### PR TITLE
feat: external environment mode — project registry, CLI mode, context-aware resume

### DIFF
--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -1,5 +1,7 @@
 Load context from the Obsidian vault before starting work.
 
+NOTE: This is the home-mode (~/deus) version. For external projects, the user-level /resume skill at ~/.claude/skills/resume/ handles project-focused context loading automatically.
+
 First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
 
 1. Always read core memory:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A personal AI assistant that lives in your messaging apps, remembers everything,
 8. **Self-improvement** — Scores its own responses over time and learns from both failures and successes. Low-scoring responses generate corrective reflections; high-scoring ones extract positive patterns. Uses DSPy to optimize its own system prompt per domain once enough samples accumulate.
 9. **Domain presets** — Lightweight topic-specific guidance (marketing, engineering, study, writing, strategy) that activates automatically based on your message. Presets are user-editable markdown files and improve over time through the self-improvement loop.
 10. **Sandboxed & secure** — Every conversation runs in an isolated Linux container. The AI can't access your host system beyond what you explicitly allow.
+11. **External projects** — Run `deus` in any project directory to get a coding agent with your full Deus memory and preferences. Or register a project and work on it through your messaging apps — Deus mounts it into an isolated container, auto-detects the tech stack, and shadows sensitive files automatically.
 
 ---
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -431,6 +431,30 @@ async function runQuery(
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
 
+  // Detect external project mount: if /workspace/project exists and has content,
+  // use it as the primary cwd. The agent works in the user's project directory
+  // while /workspace/group stays available as an additional directory for
+  // Deus-specific memory, conversation archives, and CLAUDE.md.
+  const projectDir = '/workspace/project';
+  let hasProject = false;
+  try {
+    // Validate the project dir is a real directory (not a symlink to elsewhere).
+    // The host already validates this, but defense-in-depth inside the container.
+    const stat = fs.statSync(projectDir);
+    if (stat.isDirectory()) {
+      const realProjectDir = fs.realpathSync(projectDir);
+      hasProject = realProjectDir.startsWith('/workspace/') &&
+        fs.readdirSync(projectDir).some(f => !f.startsWith('.'));
+    }
+  } catch {
+    // projectDir doesn't exist — not an error, just no project mounted
+  }
+  const cwd = hasProject ? projectDir : '/workspace/group';
+
+  if (hasProject) {
+    log(`External project detected at ${projectDir}, using as cwd`);
+  }
+
   // Discover additional directories mounted at /workspace/extra/*
   // These are passed to the SDK so their CLAUDE.md files are loaded automatically
   const extraDirs: string[] = [];
@@ -443,6 +467,13 @@ async function runQuery(
       }
     }
   }
+
+  // When working on an external project, add /workspace/group as an additional
+  // directory so the SDK loads its CLAUDE.md (Deus-specific memory for this group)
+  if (hasProject) {
+    extraDirs.push('/workspace/group');
+  }
+
   if (extraDirs.length > 0) {
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
@@ -450,7 +481,7 @@ async function runQuery(
   for await (const message of query({
     prompt: stream,
     options: {
-      cwd: '/workspace/group',
+      cwd,
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: resumeAt,

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1,5 +1,311 @@
 #!/bin/zsh
 PLIST="$HOME/Library/LaunchAgents/com.deus.plist"
+DEUS_PROJECTS_DIR="$HOME/.config/deus/projects"
+DEUS_SKILLS_DIR="$HOME/.claude/skills"
+
+# ─── Project Config Helpers ───
+# Config stored at ~/.config/deus/projects/<md5-of-path>.json
+# Outside both the project dir (no pollution) and the Deus repo (no cross-user leakage).
+
+_project_config_path() {
+  local dir_hash
+  dir_hash=$(echo -n "$1" | md5 -q 2>/dev/null || echo -n "$1" | md5sum | cut -d' ' -f1)
+  echo "$DEUS_PROJECTS_DIR/${dir_hash}.json"
+}
+
+_read_project_config() {
+  local config_file
+  config_file=$(_project_config_path "$1")
+  [ -f "$config_file" ] && cat "$config_file" || echo ""
+}
+
+_write_project_config() {
+  local dir="$1" level="$2" summaries="$3"
+  mkdir -p "$DEUS_PROJECTS_DIR"
+  local config_file
+  config_file=$(_project_config_path "$dir")
+  local name
+  name=$(basename "$dir")
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  (umask 077 && cat > "$config_file" <<PROJEOF
+{
+  "path": "$dir",
+  "name": "$name",
+  "memory_level": "$level",
+  "save_summaries": $summaries,
+  "created_at": "$now",
+  "last_accessed": "$now"
+}
+PROJEOF
+  )
+}
+
+_update_project_access() {
+  local config_file
+  config_file=$(_project_config_path "$1")
+  [ -f "$config_file" ] || return
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  # Update last_accessed timestamp
+  python3 -c "
+import json, sys
+with open(sys.argv[1], 'r+') as f:
+    d = json.load(f)
+    d['last_accessed'] = sys.argv[2]
+    f.seek(0); json.dump(d, f, indent=2); f.truncate()
+" "$config_file" "$now" 2>/dev/null
+}
+
+# ─── First-Run Onboarding ───
+
+_run_onboarding() {
+  local dir="$1"
+  local name
+  name=$(basename "$dir")
+  echo ""
+  echo "  Welcome to $name! First time here with Deus."
+  echo ""
+  echo "  How should I handle this project's data?"
+  echo ""
+  echo "  Memory level:"
+  echo "    [F] Full      — Remember everything. Best for personal/open-source projects."
+  echo "    [S] Standard  — Remember decisions & architecture, skip code details. (default)"
+  echo "    [R] Restricted — Nothing persists between sessions. Best for NDA/client work."
+  echo ""
+  printf "  Choice [F/S/R]: "
+  read -r choice
+  case "$choice" in
+    [Ff]) level="full" ;;
+    [Rr]) level="restricted" ;;
+    *)    level="standard" ;;
+  esac
+
+  local summaries="true"
+  if [ "$level" = "restricted" ]; then
+    summaries="false"
+  else
+    echo ""
+    echo "  Save session summaries to your Deus vault?"
+    echo "  (Contains topic + decisions, never code.)"
+    printf "  [Y/n]: "
+    read -r sum_choice
+    case "$sum_choice" in
+      [Nn]) summaries="false" ;;
+      *)    summaries="true" ;;
+    esac
+  fi
+
+  _write_project_config "$dir" "$level" "$summaries"
+  echo ""
+  echo "  Saved: memory=$level, summaries=$( [ "$summaries" = "true" ] && echo "on" || echo "off" )"
+  echo "  Change anytime with /project-settings"
+  echo ""
+}
+
+# ─── Install /resume skill (user-level, context-aware) ───
+
+_ensure_resume_skill() {
+  local skill_dir="$DEUS_SKILLS_DIR/resume"
+  local marker="$skill_dir/.deus-version"
+  local current_version="2"
+  if [ -f "$marker" ] && [ "$(cat "$marker")" = "$current_version" ]; then
+    return
+  fi
+  mkdir -p "$skill_dir"
+  cat > "$skill_dir/skill.md" <<'SKILLEOF'
+---
+name: resume
+description: Load context and catch up on recent work — adapts to home mode vs external project mode
+user_invocable: true
+---
+
+# /resume
+
+Context-aware session resume. Behavior depends on whether you're in the Deus home directory or an external project.
+
+## Detect mode
+
+Check if the current working directory is the Deus home directory (`~/deus`). If it is → **Home Mode**. Otherwise → **External Project Mode**.
+
+## Home Mode (~/deus)
+
+Load context from the Obsidian vault before starting work.
+
+First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+
+1. Always read core memory:
+   $VAULT/CLAUDE.md
+
+2. Based on likely task context, also read:
+   - Study session → $VAULT/STUDY.md
+   - NanoClaw / tools / infra session → $VAULT/INFRA.md
+   - If unclear → read both (they're small, ~10 lines each)
+
+3. Check for a mid-session checkpoint from today:
+   Run: find "$VAULT/Checkpoints" -name "$(date +%Y-%m-%d)-*.md" 2>/dev/null | xargs ls -t 2>/dev/null | head -1
+   If a file is found → read it fully. Note "resuming mid-session checkpoint" in the summary.
+
+4a. Load warm tier — recent sessions (no API cost):
+    Run: python3 scripts/memory_indexer.py --recent 3
+    This returns the 3 most recent session frontmatters by date. Include as "Recent Sessions" context.
+
+    FALLBACK — if the script fails, fall back to:
+    find "$VAULT/Session-Logs" -name "*.md" -not -path "*/.obsidian/*" | xargs ls -t 2>/dev/null | head -3
+    Then read frontmatter only (lines between the two --- markers) of those 3 files.
+
+4b. Load cold tier — semantically relevant older sessions:
+    Formulate a 1-sentence query based on the loaded context from steps 1–3.
+    Run: python3 scripts/memory_indexer.py --query "<your query>" --top 2 --recency-boost
+    Include the output as additional context. Deduplicate: skip any session that already appeared in step 4a.
+    If the script fails or returns nothing, skip silently — warm tier already provides continuity.
+
+5. If a search term was passed as argument, grep session logs for it and read frontmatters of matches.
+
+6. Summarize in 2–3 lines: ongoing context, pending tasks, ready to continue.
+   If a checkpoint was loaded, prepend: "Resuming mid-session: [checkpoint next_action]"
+
+## External Project Mode
+
+Resume work on the current external project by gathering project-specific context.
+
+### Step 1 — Project config
+
+Compute MD5 hash of the current working directory and read `~/.config/deus/projects/<hash>.json`.
+Note the memory level. If restricted, skip steps that involve reading saved memory.
+
+### Step 2 — Git context (always, regardless of memory level)
+
+Run these commands and present the results:
+
+```bash
+# Current branch and status
+git branch --show-current
+git status --short
+
+# Recent commits on this branch (last 10)
+git log --oneline -10
+
+# Any stashed work
+git stash list 2>/dev/null | head -3
+
+# Open branches with recent activity
+git branch --sort=-committerdate --format='%(refname:short) (%(committerdate:relative))' | head -5
+```
+
+### Step 3 — Open PRs (if gh is available)
+
+```bash
+gh pr list --limit 5 2>/dev/null
+```
+
+If gh fails or isn't installed, skip silently.
+
+### Step 4 — Claude auto-memory (standard/full only)
+
+Check if Claude Code has auto-memory for this project:
+- Compute the project path encoding (replace / with - , prepend -)
+- Check `~/.claude/projects/<encoded-path>/memory/MEMORY.md`
+- If it exists, read it and note any saved context
+
+### Step 5 — Project CLAUDE.md
+
+Read the project's own CLAUDE.md if it exists (at the repo root). This contains project-specific instructions and context.
+
+### Step 6 — Summarize
+
+Present a concise project status:
+
+```
+Project: <name> (<branch>)
+Memory: <level> | Last session: <date from config>
+
+Recent activity:
+• <1-2 lines about recent commits>
+• <uncommitted changes if any>
+• <open PRs if any>
+
+<any auto-memory context, 2-3 lines max>
+```
+
+Then: "What would you like to work on?"
+SKILLEOF
+  echo "$current_version" > "$marker"
+}
+
+# ─── Install /project-settings skill ───
+
+_ensure_project_settings_skill() {
+  local skill_dir="$DEUS_SKILLS_DIR/project-settings"
+  # Only install if missing or outdated
+  local marker="$skill_dir/.deus-version"
+  local current_version="1"
+  if [ -f "$marker" ] && [ "$(cat "$marker")" = "$current_version" ]; then
+    return
+  fi
+  mkdir -p "$skill_dir"
+  cat > "$skill_dir/skill.md" <<'SKILLEOF'
+---
+name: project-settings
+description: View or modify Deus external project settings (memory level, session summaries)
+user_invocable: true
+---
+
+# /project-settings
+
+Manage Deus data handling settings for the current external project.
+
+## Config location
+
+Project configs are stored at `~/.config/deus/projects/<hash>.json`. To find the config for the current directory, compute the MD5 hash of the absolute path of the current working directory and look for that file.
+
+## When invoked with no arguments
+
+Read the config file and display current settings in this format:
+
+```
+Project: <name> (<path>)
+Memory level: <full|standard|restricted>
+Session summaries: <on|off>
+Created: <date>
+Last accessed: <date>
+```
+
+Then show available commands:
+- `/project-settings memory full|standard|restricted` — change memory level
+- `/project-settings summaries on|off` — toggle session summaries
+- `/project-settings delete` — delete all Deus data for this project
+
+## When invoked with arguments
+
+Parse the argument and update the config JSON file accordingly.
+
+### `memory full|standard|restricted`
+
+Update the `memory_level` field. If changing to `restricted`, also set `save_summaries` to false and inform the user.
+
+Memory level descriptions:
+- **full**: Remember everything. Claude auto-memory enabled. Session summaries saved to vault.
+- **standard**: Remember decisions and architecture, skip code details. Auto-memory enabled with guidance. Summaries saved but redacted.
+- **restricted**: Nothing persists. Auto-memory disabled. No summaries.
+
+### `summaries on|off`
+
+Update the `save_summaries` field. If memory level is `restricted` and user tries to enable summaries, warn that restricted mode doesn't support summaries.
+
+### `delete`
+
+Ask for confirmation, then delete the config file. Inform the user that Claude Code's own session data at `~/.claude/projects/` is not affected (that's managed by Claude Code itself).
+
+## Important
+
+- The config file uses the MD5 hash of the current working directory's absolute path as filename
+- Use `md5 -q` on macOS or `md5sum | cut -d' ' -f1` on Linux to compute the hash
+- Always use `umask 077` when writing config files (they may contain path information)
+- After modifying settings, confirm the change and remind the user the new settings take effect on the next message
+SKILLEOF
+  echo "$current_version" > "$marker"
+}
 
 case "$1" in
   on)
@@ -48,9 +354,21 @@ case "$1" in
     export CLAUDE_CODE_OAUTH_TOKEN="$TOKEN"
     # Resolve vault path from config (DEUS_VAULT_PATH env var → ~/.config/deus/config.json)
     VAULT="${DEUS_VAULT_PATH:-$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('~/.config/deus/config.json').expanduser().read_text()).get('vault_path',''))" 2>/dev/null)}"
+
+    DEUS_HOME="$HOME/deus"
+    CURRENT_DIR="$(pwd)"
+
+    # ─── SHARED CONTEXT LOADING ───
+    # Full vault + memory + sessions loaded identically regardless of mode.
+    # The only difference between home mode and external project mode is
+    # the working directory and the startup instruction.
     if [ -z "$VAULT" ]; then
       echo "Warning: No vault configured. Set DEUS_VAULT_PATH or vault_path in ~/.config/deus/config.json"
-      cd "$HOME/deus" && exec claude --dangerously-skip-permissions
+      if [ "$CURRENT_DIR" != "$DEUS_HOME" ]; then
+        exec claude --dangerously-skip-permissions
+      else
+        cd "$HOME/deus" && exec claude --dangerously-skip-permissions
+      fi
     fi
     CONTEXT=""
 
@@ -93,6 +411,110 @@ case "$1" in
 
     printf "✓ Ready.                        \n"
 
+    # ─── EXTERNAL PROJECT MODE ───
+    # Same full Deus brain, different working directory and startup.
+    # Memory level controls how much project data persists between sessions.
+    if [ "$CURRENT_DIR" != "$DEUS_HOME" ]; then
+
+      # Ensure skills are installed
+      _ensure_project_settings_skill
+      _ensure_resume_skill
+
+      # Check for existing project config or run onboarding
+      PROJECT_CONFIG=$(_read_project_config "$CURRENT_DIR")
+      if [ -z "$PROJECT_CONFIG" ]; then
+        _run_onboarding "$CURRENT_DIR"
+        PROJECT_CONFIG=$(_read_project_config "$CURRENT_DIR")
+      else
+        _update_project_access "$CURRENT_DIR"
+      fi
+
+      # Parse memory level and summaries from config
+      MEMORY_LEVEL=$(echo "$PROJECT_CONFIG" | python3 -c "import sys,json; print(json.load(sys.stdin).get('memory_level','standard'))" 2>/dev/null)
+      [ -z "$MEMORY_LEVEL" ] && MEMORY_LEVEL="standard"
+
+      # Build env vars based on memory level
+      EXTRA_ENV=""
+      if [ "$MEMORY_LEVEL" = "restricted" ]; then
+        EXTRA_ENV="CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"
+      fi
+
+      # Build memory-level-specific system prompt instructions
+      MEMORY_INSTRUCTION=""
+      case "$MEMORY_LEVEL" in
+        full)
+          MEMORY_INSTRUCTION="Memory level: FULL. You may remember anything about this project freely — architecture, decisions, code patterns, team context. Treat this project as part of your core working memory." ;;
+        standard)
+          MEMORY_INSTRUCTION="Memory level: STANDARD. Remember architectural decisions, team context, project conventions, and what was tried/researched. Do NOT memorize specific code contents, file paths, line numbers, or implementation details — read those fresh each session. When saving to memory, focus on the 'what and why' not the 'where and how'." ;;
+        restricted)
+          MEMORY_INSTRUCTION="Memory level: RESTRICTED. This is a privacy-sensitive project. Do NOT save any project-specific information to memory. Each session starts fresh. Do not reference prior sessions or accumulated knowledge about this codebase. Auto-memory is disabled." ;;
+      esac
+
+      # Gather git context for returning users (lightweight, always safe)
+      GIT_CONTEXT=""
+      if [ -d "$CURRENT_DIR/.git" ] || git -C "$CURRENT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+        printf "  Gathering project context...\r"
+        GIT_BRANCH=$(git -C "$CURRENT_DIR" branch --show-current 2>/dev/null)
+        GIT_STATUS=$(git -C "$CURRENT_DIR" status --short 2>/dev/null | head -20)
+        GIT_LOG=$(git -C "$CURRENT_DIR" log --oneline -8 2>/dev/null)
+        GIT_STASH=$(git -C "$CURRENT_DIR" stash list 2>/dev/null | head -3)
+        GIT_CONTEXT="=== PROJECT GIT STATE ===
+Branch: ${GIT_BRANCH:-detached}
+Recent commits:
+${GIT_LOG:-  (no commits)}
+$([ -n "$GIT_STATUS" ] && echo "
+Uncommitted changes:
+$GIT_STATUS")$([ -n "$GIT_STASH" ] && echo "
+Stashed work:
+$GIT_STASH")"
+      fi
+
+      # Determine if this is a first-run or returning session
+      IS_RETURNING="false"
+      LAST_ACCESSED=$(echo "$PROJECT_CONFIG" | python3 -c "import sys,json; print(json.load(sys.stdin).get('last_accessed',''))" 2>/dev/null)
+      [ -n "$LAST_ACCESSED" ] && IS_RETURNING="true"
+
+      if [ "$IS_RETURNING" = "true" ]; then
+        STARTUP_GREETING="Greet the user with a brief project status based on the git state provided above. Format:
+
+Project: <name> (<branch>) | Memory: $MEMORY_LEVEL
+• <1-2 lines about recent commits or uncommitted changes>
+
+Then ask what they'd like to work on. Use /resume for a deeper context reload."
+      else
+        STARTUP_GREETING="Greet the user briefly: identify the project (from CLAUDE.md, package.json, or directory name), state the memory level ($MEMORY_LEVEL), and wait for instructions."
+      fi
+
+      STARTUP_INSTRUCTION="STARTUP INSTRUCTION: You are Deus, operating in EXTERNAL PROJECT MODE. The current directory is an external codebase at $CURRENT_DIR — not the Deus project. You have your full memory, preferences, and capabilities. Focus on this codebase while applying all your behavioral rules and knowledge. The project may have its own CLAUDE.md — follow it alongside yours.
+
+$MEMORY_INSTRUCTION
+
+Available commands: /project-settings (data handling) | /resume (deep context reload)
+
+$GIT_CONTEXT
+
+$STARTUP_GREETING"
+
+      # Launch claude with appropriate env vars
+      if [ -n "$EXTRA_ENV" ]; then
+        export $EXTRA_ENV
+      fi
+
+      if [ -n "$CONTEXT" ]; then
+        exec claude --dangerously-skip-permissions --append-system-prompt "$(printf '%s' "$CONTEXT")
+
+$STARTUP_INSTRUCTION"
+      else
+        exec claude --dangerously-skip-permissions --append-system-prompt "$STARTUP_INSTRUCTION"
+      fi
+    fi
+
+    # ─── HOME MODE ───
+    # Ensure /resume skill is available globally (home mode uses project command,
+    # but the skill provides the external-project-aware version for other dirs)
+    _ensure_resume_skill
+
+    # Running from ~/deus — full startup with catch-me-up greeting.
     STARTUP_INSTRUCTION="STARTUP INSTRUCTION: Context from the memory vault has been pre-loaded above. Catch the user up using exactly this format:
 
 • Previous session: [1-2 lines of ongoing context and last session topic]

--- a/docs/research/cli-mode-data-management.md
+++ b/docs/research/cli-mode-data-management.md
@@ -1,0 +1,314 @@
+# CLI Mode Data Management: Research & Design
+
+How Deus should handle memory, privacy, and data when operating in external project directories via CLI.
+
+**Date:** 2026-03-31
+**Status:** Research / Pre-Implementation
+**Author:** Research collaboration (Liam + Claude)
+
+---
+
+## Table of Contents
+
+1. [How Other Tools Handle This](#1-how-other-tools-handle-this)
+2. [The Three-Tier Memory Model](#2-the-three-tier-memory-model)
+3. [What Deus Should Remember vs Not](#3-what-deus-should-remember-vs-not)
+4. [Privacy and Compliance Concerns](#4-privacy-and-compliance-concerns)
+5. [Design: Project Onboarding + Memory Levels](#5-design-project-onboarding--memory-levels)
+6. [Implementation Plan](#6-implementation-plan)
+
+---
+
+## 1. How Other Tools Handle This
+
+### Claude Code (our foundation)
+
+Claude Code already provides per-project memory isolation. When running in any directory:
+- **Auto-memory** saved to `~/.claude/projects/<path-encoded>/memory/` — local, editable, project-scoped
+- **CLAUDE.md** in the repo is loaded automatically — project instructions
+- **Session transcripts** stored as `.jsonl` files in the project directory
+- **Three scopes**: user-level (`~/.claude/CLAUDE.md`), project-level (repo root), folder-level (nested)
+- **No cross-project leakage** — sessions from different projects never mix
+
+**Key insight:** When `deus` runs in `~/projects/foo`, Claude Code automatically creates isolated memory at `~/.claude/projects/-Users-liam10play-projects-foo/memory/`. This native isolation is our starting point — Deus doesn't need to build a separate memory system.
+
+### Cursor
+
+- `.cursorrules` and `.cursor/rules/` for project-specific instructions (committed to repo)
+- Native "Memories" feature was introduced mid-2025 then **removed in v2.1.x** — partly due to user concerns about uncontrolled accumulation
+- No built-in cross-session memory; community uses "Memory Bank" markdown files or MCP-based external memory
+- Privacy Mode available (disables telemetry, no server-side code storage)
+
+### Windsurf (Codeium)
+
+- Auto-generated memories created during conversations, stored at `~/.codeium/windsurf/memories/`
+- **Workspace-scoped** — memories from one workspace are unavailable in another
+- Memories Panel UI for viewing, editing, deleting
+- Rules can be global or workspace-specific
+
+### GitHub Copilot
+
+- Custom instructions via `.github/copilot-instructions.md` (committed to repo)
+- **Agentic Memory** (public preview) — auto-generates memories per repository
+- **Memories auto-expire after 28 days** — time-bounded decay prevents accumulation
+- Enterprise customers can disable features, control data retention, opt out of training
+
+### Devin
+
+- Cloud-hosted session state, playbooks, and knowledge
+- Enterprise tier offers VPC deployment (data stays in customer-controlled environment)
+- SOC 2 posture (details behind NDA)
+- Per-workspace/team isolation
+
+### aider
+
+- Chat history (`.aider.chat.history.md`), input history, optional LLM log — all in project directory
+- Configuration via `.aider.conf.yml` (project) or `~/.aider.conf.yml` (global)
+- **Git commits as the primary persistence** — code changes tracked as commits, not memory
+- Fully local, no vendor-hosted state, no telemetry by default
+
+### Continue.dev
+
+- `.continuerules` for project instructions
+- No built-in cross-session memory yet; MCP-based memory is opt-in
+- Open-source, runs locally, user chooses LLM provider
+
+---
+
+## 2. The Three-Tier Memory Model
+
+The industry is converging on three tiers:
+
+| Tier | Scope | Lifetime | What's in it |
+|------|-------|----------|-------------|
+| **Global** | All projects | Permanent | User identity, coding style, behavioral rules, tool preferences |
+| **Project** | Single repo/workspace | Project lifetime | Architecture decisions, conventions, build commands, team info |
+| **Session** | Single conversation | Ephemeral | Current task context, working memory, file contents |
+
+Claude Code's existing system already maps to this:
+- **Global**: `~/.claude/CLAUDE.md` (user-level instructions)
+- **Project**: `<repo>/CLAUDE.md` + `~/.claude/projects/<path>/memory/` (auto-memory)
+- **Session**: Conversation context (lost on exit unless compacted)
+
+Deus adds a **fourth layer** on top: the Deus vault (user preferences, behavioral rules, session logs, semantic memory). This is cross-project knowledge about the USER, not about any specific project.
+
+### Copilot's 28-Day TTL
+
+GitHub Copilot's approach of auto-expiring memories after 28 days is notable. It prevents unbounded accumulation while keeping recent context fresh. Worth considering for Deus's project-level memory.
+
+---
+
+## 3. What Deus Should Remember vs Not
+
+Based on the "team member" analogy: a new colleague naturally accumulates project understanding, but would never carry proprietary code verbatim from one client to another.
+
+### Always Remember (Global Tier — Deus Vault)
+
+These are about the USER, not the project:
+- Coding style preferences ("functional over OOP", "always use feature branches")
+- Tool preferences ("use pnpm not npm", "prefer vitest over jest")
+- Communication style ("be concise", "no emojis")
+- Behavioral rules ("always wait for approval before executing")
+- Study/personal context (it's the same Deus everywhere)
+
+### Remember Per-Project (Project Tier — Local)
+
+These are about THIS project and stay isolated:
+- Architecture decisions ("we chose Postgres because X")
+- Team info ("Bob is the PM, Alice handles frontend")
+- Client context ("fintech domain, regulatory constraints apply")
+- What was tried and why ("migrated from REST to GraphQL on 2026-03-15")
+- Build/test/deploy commands
+- Project conventions
+
+### Never Remember (Ephemeral Only)
+
+These should NOT persist beyond the session:
+- Specific code contents (the code IS the source of truth — read it fresh)
+- File paths and line numbers (they change constantly)
+- Debugging session details (stack traces, error logs)
+- Specific variable names, function signatures (grep is better than memory)
+- Credentials, tokens, API keys, environment variables
+
+### The Gray Area
+
+Some things could go either way depending on user preference:
+- Session summaries ("today we refactored the auth module") — useful for continuity but could leak project details
+- Code patterns and idioms specific to this project — useful but project-specific
+- Bug reports and issue references — useful but tied to the project
+
+---
+
+## 4. Privacy and Compliance Concerns
+
+### What Enterprises Worry About
+
+- **Code leakage to training**: Most vendors promise "no training on your code" but this is policy, not technical guarantee
+- **Cross-client contamination**: AI remembers Client A's architecture and surfaces it while working on Client B — compliance nightmare
+- **Persistent artifact risk**: Memories, embeddings, indexes that persist after disengagement could be discoverable
+- **SOC 2 / GDPR**: Require defined data retention policies, access controls, right to deletion, data minimization
+- **Audit trail**: What does the AI "know" and when did it learn it?
+
+### Deus-Specific Risks
+
+1. **Vault leakage**: The Deus vault is injected into every session. If the vault contains details about Project A, those details are now in Project B's context. **Mitigation**: The vault contains USER preferences, not project details. Project-specific data stays in project-local memory.
+
+2. **Session log leakage**: If `/compress` saves session summaries to the Deus vault, summaries from Client A's project could surface in Client B's session. **Mitigation**: Session logs from external projects should either (a) not be saved to the vault, or (b) be tagged with the project and filtered when loading context for a different project.
+
+3. **Auto-memory cross-pollination**: Claude Code's auto-memory is already project-isolated. Deus doesn't break this — it only adds vault context (user-level) via system prompt. No risk here.
+
+4. **Memory index pollution**: The Deus memory indexer (`scripts/memory_indexer.py`) indexes session logs for semantic search. If external project sessions are indexed, they could surface in unrelated contexts. **Mitigation**: Either don't index external project sessions, or tag them with the project path and filter at query time.
+
+### The Key Realization
+
+**Deus's vault is about the USER. Project memory is about the PROJECT. These are different systems with different lifetimes and isolation boundaries.**
+
+As long as we maintain this separation, privacy is preserved:
+- Vault (global): user identity, preferences, behavioral rules — safe to inject everywhere
+- Project memory (local): architecture, decisions, team info — stays in `~/.claude/projects/<path>/`
+- Session (ephemeral): code details, debugging — gone when session ends
+
+The only bridge between them is: **should Deus save a session summary from an external project to the vault?** This is the user's choice.
+
+---
+
+## 5. Design: Project Onboarding + Memory Levels
+
+### First-Run Questionnaire
+
+When Deus detects it's running in a new external directory for the first time, it should run a brief onboarding:
+
+```
+Welcome to ~/projects/client-api! First time here.
+
+Quick setup — tell me how to handle this project's data:
+
+1. Memory level:
+   [F] Full — Remember everything. Best for personal projects.
+   [S] Standard — Remember decisions and architecture, skip code details.
+       Best for team/work projects. (default)
+   [R] Restricted — Nothing persists between sessions. 
+       Best for NDA/client projects or one-off tasks.
+
+2. Save session summaries to your Deus vault? (topic + decisions, never code)
+   [Y] Yes  [N] No  (default: Yes for Full/Standard, No for Restricted)
+
+You can change this anytime with /project-settings.
+```
+
+### Memory Levels Explained
+
+| Level | Claude Auto-Memory | Session Summaries to Vault | Memory Indexer | When to Use |
+|-------|-------------------|---------------------------|----------------|-------------|
+| **Full** | Enabled (default Claude behavior) | Yes — full summaries | Indexed | Personal projects, open-source, your own repos |
+| **Standard** | Enabled with guardrails | Yes — redacted summaries (decisions only, no code) | Indexed (summaries only) | Work projects, team repos, internal tools |
+| **Restricted** | Disabled (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`) | No | Not indexed | Client projects, NDA work, compliance-sensitive repos |
+
+### How Each Level Works
+
+**Full**: Identical to home mode. Claude Code auto-memory enabled, session summaries saved to vault, sessions indexed for semantic search. The project is treated as part of Deus's core memory. Best for repos the user owns or contributes to long-term.
+
+**Standard** (default): Claude Code auto-memory is enabled but guided. A system prompt instruction tells Claude to remember only decisions, architecture, and team context — not code patterns or implementation details. Session summaries saved to vault but automatically redacted (topic + decisions only, no code references, no file paths, no function names). Indexed for semantic search but with the project tag, so they only surface when relevant.
+
+**Restricted**: Claude Code auto-memory is disabled entirely (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`). No session summaries saved to vault. No indexing. Each session starts completely fresh (except for Deus's global user context). The only persistence is what Claude Code stores natively in its session transcript (`.jsonl` files in `~/.claude/projects/`).
+
+### Config Storage
+
+Project settings stored at `~/.config/deus/projects/<path-hash>.json`:
+
+```json
+{
+  "path": "/Users/liam/projects/client-api",
+  "name": "client-api",
+  "memory_level": "standard",
+  "save_summaries": true,
+  "created_at": "2026-03-31T10:00:00Z",
+  "last_accessed": "2026-03-31T10:00:00Z"
+}
+```
+
+This is outside the project directory (no pollution) and outside the Deus repo (no cross-user leakage).
+
+### /project-settings Command
+
+A slash command available in external project mode to adjust settings mid-session:
+- `/project-settings` — show current settings
+- `/project-settings memory full|standard|restricted` — change memory level
+- `/project-settings summaries on|off` — toggle session summaries
+- `/project-settings reset` — reset to defaults
+- `/project-settings delete` — delete all Deus data for this project
+
+### What Changes at Runtime
+
+The `deus` CLI script reads the project config (or triggers onboarding) and adjusts:
+
+1. **System prompt additions** based on memory level:
+   - Full: no restrictions
+   - Standard: "Remember architectural decisions and team context. Do not memorize specific code, file paths, or implementation details."
+   - Restricted: "This is a restricted project. Do not save any project-specific information to memory."
+
+2. **Environment variables**:
+   - Restricted: `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`
+
+3. **Post-session hooks** (if save_summaries is true):
+   - On session end, offer to save a summary to vault
+   - Standard: auto-redact code references before saving
+   - Restricted: skip entirely
+
+---
+
+## 6. Implementation Plan
+
+### Phase 1: First-Run Onboarding + Memory Levels (this commit)
+
+1. **Project config system** (~50 lines, shell functions in `deus-cmd.sh`)
+   - `~/.config/deus/projects/` directory
+   - Read/write project config JSON
+   - Path-based lookup (hash of absolute path as filename)
+
+2. **First-run detection + questionnaire** (~30 lines in `deus-cmd.sh`)
+   - Check if config exists for current directory
+   - If not, run interactive onboarding
+   - Save config
+
+3. **Memory level enforcement** (~20 lines in `deus-cmd.sh`)
+   - Read memory level from config
+   - Set env vars (`CLAUDE_CODE_DISABLE_AUTO_MEMORY` for restricted)
+   - Inject memory-level-specific instructions into system prompt
+
+4. **Full context loading** (already implemented)
+   - Load vault + sessions + semantic search (identical to home mode)
+   - Add project-mode startup instruction
+
+### Phase 2: /project-settings command (follow-up)
+
+- Container skill that reads/writes the project config
+- Available in external project mode sessions
+
+### Phase 3: Session summary saving (follow-up)
+
+- Pre-compact hook that extracts a summary
+- Auto-redaction for standard mode (strip code references)
+- Save to vault with project tag
+- Memory indexer integration with project filtering
+
+### What's NOT Needed
+
+- **Separate memory system** — Claude Code's native auto-memory handles project-level persistence
+- **Code indexing/embedding** — Claude Code reads files on demand; Deus doesn't need to duplicate this
+- **Project-specific reflections/evolution** — The evolution loop is a messaging-channel feature; CLI mode doesn't need it yet
+
+---
+
+## References
+
+### Tool Research
+- [Claude Code Memory Docs](https://code.claude.com/docs/en/memory) — CLAUDE.md tiers, auto-memory, project isolation
+- [Anatomy of the .claude/ Folder](https://blog.dailydoseofds.com/p/anatomy-of-the-claude-folder) — internal storage structure
+- [Cursor Memory Across Conversations](https://www.blockchain-council.org/ai/cursor-ai-track-memory-across-conversations/) — memory feature added then removed
+- [Windsurf Cascade Memories](https://docs.windsurf.com/windsurf/cascade/memories) — workspace-scoped memories
+- [GitHub Copilot Agentic Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory) — 28-day TTL
+- [Aider Configuration](https://aider.chat/docs/config/aider_conf.html) — plain-text, git-native persistence
+- [SOC 2 Ready AI Coding Tools](https://www.augmentcode.com/guides/7-soc-2-ready-ai-coding-tools-for-enterprise-security) — enterprise compliance
+- [AI Coding Compliance Gap](https://pinklime.io/blog/ai-coding-compliance-gdpr-soc2-hipaa) — GDPR, HIPAA considerations
+- [Top AI Memory Products 2026](https://medium.com/@bumurzaqov2/top-10-ai-memory-products-2026-09d7900b5ab1) — Mem0, Zep, Letta frameworks

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -26,6 +26,11 @@ import {
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
+import { getProjectById } from './db.js';
+import {
+  SENSITIVE_FILE_PATTERNS,
+  SENSITIVE_DIR_PATTERNS,
+} from './project-registry.js';
 import { RegisteredGroup } from './types.js';
 import { detectAndLoad } from './domain-presets.js';
 import { getReflections, logInteraction } from './evolution-client.js';
@@ -114,6 +119,112 @@ function buildVolumeMounts(
         containerPath: '/workspace/global',
         readonly: true,
       });
+    }
+  }
+
+  // External project mount: when a group has an associated project,
+  // mount it at /workspace/project so the agent works on the external codebase.
+  // Security: project path was validated against mount-allowlist at registration time.
+  // We re-validate the real path hasn't changed (symlink TOCTOU defense) and
+  // shadow sensitive files to prevent credential exfiltration.
+  if (group.projectId) {
+    const project = getProjectById(group.projectId);
+    if (project && fs.existsSync(project.path)) {
+      // TOCTOU defense: re-resolve symlinks at mount time.
+      // The path was validated at registration, but a symlink target
+      // could have been swapped between registration and now.
+      let realProjectPath: string;
+      try {
+        realProjectPath = fs.realpathSync(project.path);
+      } catch {
+        logger.warn(
+          { projectId: group.projectId, path: project.path },
+          'Project path no longer resolvable, skipping mount',
+        );
+        realProjectPath = ''; // Will skip the mount below
+      }
+
+      if (realProjectPath && realProjectPath === project.path) {
+        // Determine effective readonly: project config + non-main override
+        const effectiveReadonly = project.readonly || (!isMain);
+
+        mounts.push({
+          hostPath: realProjectPath,
+          containerPath: '/workspace/project',
+          readonly: effectiveReadonly,
+        });
+
+        // Shadow sensitive files to prevent credential leakage.
+        // The container will see /dev/null instead of the real file.
+        for (const pattern of SENSITIVE_FILE_PATTERNS) {
+          const filePath = path.join(realProjectPath, pattern);
+          if (fs.existsSync(filePath)) {
+            mounts.push({
+              hostPath: '/dev/null',
+              containerPath: `/workspace/project/${pattern}`,
+              readonly: true,
+            });
+          }
+        }
+
+        // Shadow sensitive directories
+        for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
+          const dirPath = path.join(realProjectPath, dirPattern);
+          if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+            // Can't shadow a directory with /dev/null — use an empty tmpdir instead.
+            // Create a project-specific empty dir that persists across runs.
+            const shadowDir = path.join(
+              DATA_DIR,
+              'project-shadows',
+              group.projectId!,
+              dirPattern,
+            );
+            fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
+            mounts.push({
+              hostPath: shadowDir,
+              containerPath: `/workspace/project/${dirPattern}`,
+              readonly: true,
+            });
+          }
+        }
+
+        // Security note: symlinks WITHIN the mounted project can escape the
+        // project boundary (e.g., project/data -> /etc/passwd). Docker/Apple
+        // Container bind mounts follow symlinks by default. This is mitigated
+        // by container isolation (the container process can only access
+        // what's mounted) and the mount-allowlist blocking sensitive roots
+        // (.ssh, .gnupg, .aws, etc). For maximum safety, users should:
+        // 1. Only register trusted project directories
+        // 2. Use readonly mode for untrusted projects
+        // 3. Review projects for suspicious symlinks before registering
+
+        logger.info(
+          {
+            group: group.name,
+            projectId: group.projectId,
+            projectName: project.name,
+            readonly: effectiveReadonly,
+          },
+          'Project mounted as primary workspace',
+        );
+      } else if (realProjectPath) {
+        // Symlink target changed since registration — block the mount.
+        // This prevents an attack where someone registers ~/projects/legit,
+        // then replaces it with a symlink to /etc or ~/.ssh before the next run.
+        logger.error(
+          {
+            projectId: group.projectId,
+            registeredPath: project.path,
+            currentRealPath: realProjectPath,
+          },
+          'Project real path changed since registration — mount BLOCKED (possible symlink swap attack)',
+        );
+      }
+    } else if (project) {
+      logger.warn(
+        { projectId: group.projectId, path: project.path },
+        'Associated project path does not exist, skipping mount',
+      );
     }
   }
 
@@ -293,6 +404,24 @@ export async function runContainerAgent(
   const { domains, presetBlock } = detectAndLoad(input.prompt);
   if (presetBlock) {
     input = { ...input, prompt: `${presetBlock}\n\n${input.prompt}` };
+  }
+
+  // Pre-dispatch: inject project type hint if group has an associated project.
+  // This gives the agent immediate context about the project without waiting
+  // for it to inspect files. The hint is kept brief to minimize token overhead.
+  if (group.projectId) {
+    const project = getProjectById(group.projectId);
+    if (project?.type) {
+      const parts = [project.type.language];
+      if (project.type.framework) parts.push(project.type.framework);
+      if (project.type.packageManager) parts.push(`pkg:${project.type.packageManager}`);
+      if (project.type.testRunner) parts.push(`test:${project.type.testRunner}`);
+      const hint = `[Project: ${project.name} (${parts.join(', ')}) at /workspace/project${project.readonly ? ' — READ-ONLY' : ''}]`;
+      input = { ...input, prompt: `${hint}\n\n${input.prompt}` };
+    } else if (project) {
+      const hint = `[Project: ${project.name} at /workspace/project${project.readonly ? ' — READ-ONLY' : ''}]`;
+      input = { ...input, prompt: `${hint}\n\n${input.prompt}` };
+    }
   }
 
   const groupDir = resolveGroupFolderPath(group.folder);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -146,7 +146,7 @@ function buildVolumeMounts(
 
       if (realProjectPath && realProjectPath === project.path) {
         // Determine effective readonly: project config + non-main override
-        const effectiveReadonly = project.readonly || (!isMain);
+        const effectiveReadonly = project.readonly || !isMain;
 
         mounts.push({
           hostPath: realProjectPath,
@@ -414,8 +414,10 @@ export async function runContainerAgent(
     if (project?.type) {
       const parts = [project.type.language];
       if (project.type.framework) parts.push(project.type.framework);
-      if (project.type.packageManager) parts.push(`pkg:${project.type.packageManager}`);
-      if (project.type.testRunner) parts.push(`test:${project.type.testRunner}`);
+      if (project.type.packageManager)
+        parts.push(`pkg:${project.type.packageManager}`);
+      if (project.type.testRunner)
+        parts.push(`test:${project.type.testRunner}`);
       const hint = `[Project: ${project.name} (${parts.join(', ')}) at /workspace/project${project.readonly ? ' — READ-ONLY' : ''}]`;
       input = { ...input, prompt: `${hint}\n\n${input.prompt}` };
     } else if (project) {

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -13,7 +13,6 @@
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
-
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 
@@ -109,12 +108,32 @@ export function startCredentialProxy(
       });
     });
 
-    server.listen(port, host, () => {
-      logger.info({ port, host, authMode }, 'Credential proxy started');
-      resolve(server);
+    let retries = 0;
+    const maxRetries = 10;
+    const retryDelay = 2000;
+
+    const tryListen = () => {
+      server.listen(port, host, () => {
+        logger.info({ port, host, authMode }, 'Credential proxy started');
+        resolve(server);
+      });
+    };
+
+    server.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE' && retries < maxRetries) {
+        retries++;
+        logger.warn(
+          { port, attempt: retries, maxRetries },
+          'Port in use, retrying...',
+        );
+        server.close();
+        setTimeout(tryListen, retryDelay);
+      } else {
+        reject(err);
+      }
     });
 
-    server.on('error', reject);
+    tryListen();
   });
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,6 +7,7 @@ import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
   NewMessage,
+  ProjectConfig,
   RegisteredGroup,
   ScheduledTask,
   TaskRunLog,
@@ -82,6 +83,15 @@ function createSchema(database: Database.Database): void {
       container_config TEXT,
       requires_trigger INTEGER DEFAULT 1
     );
+
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      type TEXT,
+      readonly INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL
+    );
   `);
 
   // Add context_mode column if it doesn't exist (migration for existing DBs)
@@ -118,6 +128,27 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* column already exists */
   }
+
+  // Add project_id column to registered_groups (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE registered_groups ADD COLUMN project_id TEXT REFERENCES projects(id)`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Create projects table if it doesn't exist (migration for existing DBs)
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      type TEXT,
+      readonly INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL
+    );
+  `);
 
   // Add channel and is_group columns if they don't exist (migration for existing DBs)
   try {
@@ -554,6 +585,7 @@ export function getRegisteredGroup(
         container_config: string | null;
         requires_trigger: number | null;
         is_main: number | null;
+        project_id: string | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -576,6 +608,7 @@ export function getRegisteredGroup(
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     isMain: row.is_main === 1 ? true : undefined,
+    projectId: row.project_id ?? undefined,
   };
 }
 
@@ -584,8 +617,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, project_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -595,6 +628,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.containerConfig ? JSON.stringify(group.containerConfig) : null,
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
     group.isMain ? 1 : 0,
+    group.projectId ?? null,
   );
 }
 
@@ -608,6 +642,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     container_config: string | null;
     requires_trigger: number | null;
     is_main: number | null;
+    project_id: string | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -629,9 +664,110 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
       isMain: row.is_main === 1 ? true : undefined,
+      projectId: row.project_id ?? undefined,
     };
   }
   return result;
+}
+
+// --- Project accessors ---
+
+export function createProject(project: ProjectConfig): void {
+  db.prepare(
+    `INSERT INTO projects (id, name, path, type, readonly, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    project.id,
+    project.name,
+    project.path,
+    project.type ? JSON.stringify(project.type) : null,
+    project.readonly ? 1 : 0,
+    project.created_at,
+  );
+}
+
+export function getProjectById(id: string): ProjectConfig | undefined {
+  const row = db
+    .prepare('SELECT * FROM projects WHERE id = ?')
+    .get(id) as
+    | {
+        id: string;
+        name: string;
+        path: string;
+        type: string | null;
+        readonly: number;
+        created_at: string;
+      }
+    | undefined;
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    name: row.name,
+    path: row.path,
+    type: row.type ? JSON.parse(row.type) : null,
+    readonly: row.readonly === 1,
+    created_at: row.created_at,
+  };
+}
+
+export function getProjectByPath(hostPath: string): ProjectConfig | undefined {
+  const row = db
+    .prepare('SELECT * FROM projects WHERE path = ?')
+    .get(hostPath) as
+    | {
+        id: string;
+        name: string;
+        path: string;
+        type: string | null;
+        readonly: number;
+        created_at: string;
+      }
+    | undefined;
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    name: row.name,
+    path: row.path,
+    type: row.type ? JSON.parse(row.type) : null,
+    readonly: row.readonly === 1,
+    created_at: row.created_at,
+  };
+}
+
+export function getAllProjects(): ProjectConfig[] {
+  const rows = db.prepare('SELECT * FROM projects ORDER BY created_at DESC').all() as Array<{
+    id: string;
+    name: string;
+    path: string;
+    type: string | null;
+    readonly: number;
+    created_at: string;
+  }>;
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    path: row.path,
+    type: row.type ? JSON.parse(row.type) : null,
+    readonly: row.readonly === 1,
+    created_at: row.created_at,
+  }));
+}
+
+export function deleteProject(id: string): void {
+  // Dissociate all groups first
+  db.prepare(
+    `UPDATE registered_groups SET project_id = NULL WHERE project_id = ?`,
+  ).run(id);
+  db.prepare('DELETE FROM projects WHERE id = ?').run(id);
+}
+
+export function setGroupProject(
+  groupFolder: string,
+  projectId: string | null,
+): void {
+  db.prepare(
+    `UPDATE registered_groups SET project_id = ? WHERE folder = ?`,
+  ).run(projectId, groupFolder);
 }
 
 // --- JSON migration ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -687,9 +687,7 @@ export function createProject(project: ProjectConfig): void {
 }
 
 export function getProjectById(id: string): ProjectConfig | undefined {
-  const row = db
-    .prepare('SELECT * FROM projects WHERE id = ?')
-    .get(id) as
+  const row = db.prepare('SELECT * FROM projects WHERE id = ?').get(id) as
     | {
         id: string;
         name: string;
@@ -735,7 +733,9 @@ export function getProjectByPath(hostPath: string): ProjectConfig | undefined {
 }
 
 export function getAllProjects(): ProjectConfig[] {
-  const rows = db.prepare('SELECT * FROM projects ORDER BY created_at DESC').all() as Array<{
+  const rows = db
+    .prepare('SELECT * FROM projects ORDER BY created_at DESC')
+    .all() as Array<{
     id: string;
     name: string;
     path: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -582,6 +582,18 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 
+  // Debug: log any unexpected exits
+  process.on('exit', (code) => {
+    logger.info({ code }, 'Process exiting');
+  });
+  process.on('uncaughtException', (err) => {
+    logger.error({ err }, 'Uncaught exception');
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (reason) => {
+    logger.error({ reason }, 'Unhandled rejection');
+  });
+
   // Handle /remote-control and /remote-control-end commands
   async function handleRemoteControl(
     command: string,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -8,6 +8,14 @@ import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
+import {
+  registerProject,
+  associateProject,
+  dissociateProject,
+  removeProject,
+  getAllProjects,
+  getProjectById,
+} from './project-registry.js';
 import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
@@ -172,6 +180,10 @@ export async function processTaskIpc(
     trigger?: string;
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
+    // For project management
+    projectPath?: string;
+    projectId?: string;
+    readonly?: boolean;
   },
   sourceGroup: string, // Verified identity from IPC directory
   isMain: boolean, // Verified from directory path
@@ -451,6 +463,135 @@ export async function processTaskIpc(
         logger.warn(
           { data },
           'Invalid register_group request - missing required fields',
+        );
+      }
+      break;
+
+    case 'register_project':
+      // Main-only: register an external project for container mounting.
+      // The agent provides a name and host path; we validate against the
+      // mount allowlist and detect the project type.
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized register_project attempt blocked',
+        );
+        break;
+      }
+      if (data.name && data.projectPath) {
+        try {
+          const project = registerProject(data.name, data.projectPath, {
+            readonly: data.readonly,
+          });
+          logger.info(
+            { projectId: project.id, name: project.name, path: project.path },
+            'Project registered via IPC',
+          );
+        } catch (err) {
+          logger.error(
+            { name: data.name, path: data.projectPath, err },
+            'Failed to register project via IPC',
+          );
+        }
+      } else {
+        logger.warn({ data }, 'Invalid register_project request - missing name or path');
+      }
+      break;
+
+    case 'associate_project':
+      // Main-only: link a project to a group so its container mounts the project.
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized associate_project attempt blocked',
+        );
+        break;
+      }
+      if (data.projectId && data.folder) {
+        try {
+          associateProject(data.projectId, data.folder);
+          logger.info(
+            { projectId: data.projectId, folder: data.folder },
+            'Project associated with group via IPC',
+          );
+        } catch (err) {
+          logger.error(
+            { projectId: data.projectId, folder: data.folder, err },
+            'Failed to associate project via IPC',
+          );
+        }
+      } else {
+        logger.warn(
+          { data },
+          'Invalid associate_project request - missing projectId or folder',
+        );
+      }
+      break;
+
+    case 'dissociate_project':
+      // Main-only: remove project association from a group.
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized dissociate_project attempt blocked',
+        );
+        break;
+      }
+      if (data.folder) {
+        dissociateProject(data.folder);
+        logger.info(
+          { folder: data.folder },
+          'Project dissociated from group via IPC',
+        );
+      }
+      break;
+
+    case 'delete_project':
+      // Main-only: unregister a project (dissociates all groups automatically).
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized delete_project attempt blocked',
+        );
+        break;
+      }
+      if (data.projectId) {
+        try {
+          removeProject(data.projectId);
+          logger.info(
+            { projectId: data.projectId },
+            'Project deleted via IPC',
+          );
+        } catch (err) {
+          logger.error(
+            { projectId: data.projectId, err },
+            'Failed to delete project via IPC',
+          );
+        }
+      }
+      break;
+
+    case 'list_projects':
+      // Main-only: list all registered projects.
+      // Response written to IPC output for the agent to read.
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized list_projects attempt blocked',
+        );
+        break;
+      }
+      {
+        const projects = getAllProjects();
+        const ipcDir = path.join(DATA_DIR, 'ipc', sourceGroup);
+        fs.mkdirSync(ipcDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(ipcDir, 'projects.json'),
+          JSON.stringify({ projects }, null, 2),
+        );
+        logger.info(
+          { count: projects.length },
+          'Projects list written to IPC',
         );
       }
       break;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -494,7 +494,10 @@ export async function processTaskIpc(
           );
         }
       } else {
-        logger.warn({ data }, 'Invalid register_project request - missing name or path');
+        logger.warn(
+          { data },
+          'Invalid register_project request - missing name or path',
+        );
       }
       break;
 
@@ -558,10 +561,7 @@ export async function processTaskIpc(
       if (data.projectId) {
         try {
           removeProject(data.projectId);
-          logger.info(
-            { projectId: data.projectId },
-            'Project deleted via IPC',
-          );
+          logger.info({ projectId: data.projectId }, 'Project deleted via IPC');
         } catch (err) {
           logger.error(
             { projectId: data.projectId, err },
@@ -589,10 +589,7 @@ export async function processTaskIpc(
           path.join(ipcDir, 'projects.json'),
           JSON.stringify({ projects }, null, 2),
         );
-        logger.info(
-          { count: projects.length },
-          'Projects list written to IPC',
-        );
+        logger.info({ count: projects.length }, 'Projects list written to IPC');
       }
       break;
 

--- a/src/project-registry.ts
+++ b/src/project-registry.ts
@@ -1,0 +1,268 @@
+/**
+ * Project Registry for External Environment Mode
+ *
+ * Manages registration of external projects that Deus can work on.
+ * Projects are mounted into containers as the primary workspace,
+ * replacing the default group folder as cwd.
+ *
+ * Security: project paths are validated against the mount allowlist
+ * (same system used for additionalMounts). The allowlist lives at
+ * ~/.config/deus/mount-allowlist.json — outside the project root
+ * and never mounted into containers, so agents cannot tamper with it.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  createProject,
+  deleteProject as dbDeleteProject,
+  getAllProjects,
+  getProjectById,
+  getProjectByPath,
+  setGroupProject,
+} from './db.js';
+import { HOME_DIR } from './config.js';
+import { logger } from './logger.js';
+import { validateMount } from './mount-security.js';
+import { ProjectConfig, ProjectType } from './types.js';
+
+/**
+ * Expand ~ to home directory
+ */
+function expandPath(p: string): string {
+  if (p.startsWith('~/')) return path.join(HOME_DIR, p.slice(2));
+  if (p === '~') return HOME_DIR;
+  return path.resolve(p);
+}
+
+/**
+ * Detect the project type from marker files in the directory.
+ * Returns null for unrecognized project types (still mountable, just no auto-hints).
+ */
+export function detectProjectType(projectPath: string): ProjectType | null {
+  const exists = (f: string) => fs.existsSync(path.join(projectPath, f));
+  const readJson = (f: string) => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(projectPath, f), 'utf-8'));
+    } catch {
+      return null;
+    }
+  };
+
+  // Rust
+  if (exists('Cargo.toml')) {
+    return { language: 'rust', packageManager: 'cargo', testRunner: 'cargo test' };
+  }
+
+  // Go
+  if (exists('go.mod')) {
+    return { language: 'go', testRunner: 'go test' };
+  }
+
+  // Python
+  if (exists('pyproject.toml') || exists('setup.py') || exists('requirements.txt')) {
+    const pt: ProjectType = { language: 'python' };
+    if (exists('pyproject.toml')) pt.packageManager = 'pip';
+    if (exists('Pipfile')) pt.packageManager = 'pipenv';
+    if (exists('poetry.lock')) pt.packageManager = 'poetry';
+    // Framework detection
+    const req = exists('requirements.txt')
+      ? fs.readFileSync(path.join(projectPath, 'requirements.txt'), 'utf-8')
+      : '';
+    if (req.includes('django') || exists('manage.py')) pt.framework = 'django';
+    else if (req.includes('flask')) pt.framework = 'flask';
+    else if (req.includes('fastapi')) pt.framework = 'fastapi';
+    if (exists('pytest.ini') || exists('conftest.py')) pt.testRunner = 'pytest';
+    return pt;
+  }
+
+  // Ruby
+  if (exists('Gemfile')) {
+    const pt: ProjectType = { language: 'ruby', packageManager: 'bundler' };
+    if (exists('Rakefile') || exists('config/application.rb')) pt.framework = 'rails';
+    return pt;
+  }
+
+  // Java / Kotlin
+  if (exists('pom.xml')) {
+    return { language: 'java', packageManager: 'maven', testRunner: 'maven test' };
+  }
+  if (exists('build.gradle') || exists('build.gradle.kts')) {
+    return { language: 'java', packageManager: 'gradle', testRunner: 'gradle test' };
+  }
+
+  // Node.js / TypeScript / JavaScript (checked last — many projects have package.json)
+  if (exists('package.json')) {
+    const pkg = readJson('package.json');
+    const pt: ProjectType = { language: 'javascript' };
+
+    if (exists('tsconfig.json')) pt.language = 'typescript';
+
+    // Package manager
+    if (exists('pnpm-lock.yaml')) pt.packageManager = 'pnpm';
+    else if (exists('yarn.lock')) pt.packageManager = 'yarn';
+    else if (exists('bun.lockb')) pt.packageManager = 'bun';
+    else pt.packageManager = 'npm';
+
+    // Framework detection from dependencies
+    const deps = { ...pkg?.dependencies, ...pkg?.devDependencies };
+    if (deps?.next) pt.framework = 'next.js';
+    else if (deps?.nuxt) pt.framework = 'nuxt';
+    else if (deps?.['@angular/core']) pt.framework = 'angular';
+    else if (deps?.svelte || deps?.['@sveltejs/kit']) pt.framework = 'svelte';
+    else if (deps?.vue) pt.framework = 'vue';
+    else if (deps?.react && !deps?.next) pt.framework = 'react';
+    else if (deps?.express) pt.framework = 'express';
+    else if (deps?.fastify) pt.framework = 'fastify';
+
+    // Test runner
+    if (deps?.vitest) pt.testRunner = 'vitest';
+    else if (deps?.jest) pt.testRunner = 'jest';
+    else if (deps?.mocha) pt.testRunner = 'mocha';
+
+    return pt;
+  }
+
+  return null;
+}
+
+/**
+ * Sensitive file patterns to shadow with /dev/null in project mounts.
+ * These are blocked from container access even when the project is read-write.
+ *
+ * Security rationale: a compromised or misbehaving agent could exfiltrate
+ * credentials from the user's project. Shadowing these files means the
+ * container sees /dev/null instead of the real content.
+ */
+export const SENSITIVE_FILE_PATTERNS = [
+  '.env',
+  '.env.local',
+  '.env.development',
+  '.env.production',
+  '.env.staging',
+  '.env.test',
+];
+
+/**
+ * Sensitive directory patterns to check within the project.
+ * Files matching these globs under the project root are shadowed.
+ */
+export const SENSITIVE_DIR_PATTERNS = [
+  'credentials',
+  'secrets',
+];
+
+/**
+ * Register a new external project.
+ *
+ * Validates the path against the mount allowlist before storing.
+ * This ensures only pre-approved directories can be mounted.
+ */
+export function registerProject(
+  name: string,
+  hostPath: string,
+  options?: { readonly?: boolean },
+): ProjectConfig {
+  const resolvedPath = expandPath(hostPath);
+
+  // Verify path exists and is a directory
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Path does not exist: ${hostPath} (resolved: ${resolvedPath})`);
+  }
+  if (!fs.statSync(resolvedPath).isDirectory()) {
+    throw new Error(`Path is not a directory: ${resolvedPath}`);
+  }
+
+  // Security: resolve symlinks to prevent symlink-based allowlist bypass.
+  // An attacker could create ~/projects/evil -> /etc and register it
+  // if we only checked the symlink path against the allowlist.
+  const realPath = fs.realpathSync(resolvedPath);
+
+  // Validate against mount allowlist (reuse existing security infrastructure).
+  // We check as isMain=true because project registration is main-only,
+  // but the effective readonly is determined per-group at mount time.
+  const validation = validateMount(
+    { hostPath: realPath, readonly: options?.readonly ?? false },
+    true, // isMain — registration requires main privileges
+  );
+
+  if (!validation.allowed) {
+    throw new Error(
+      `Project path not allowed by mount allowlist: ${validation.reason}. ` +
+      `Add the parent directory to ~/.config/deus/mount-allowlist.json`,
+    );
+  }
+
+  // Check for duplicate path
+  const existing = getProjectByPath(realPath);
+  if (existing) {
+    throw new Error(
+      `A project is already registered at this path: "${existing.name}" (${existing.id})`,
+    );
+  }
+
+  const projectType = detectProjectType(realPath);
+  const project: ProjectConfig = {
+    id: `proj-${crypto.randomUUID().slice(0, 8)}`,
+    name,
+    path: realPath,
+    type: projectType,
+    readonly: options?.readonly ?? false,
+    created_at: new Date().toISOString(),
+  };
+
+  createProject(project);
+  logger.info(
+    {
+      projectId: project.id,
+      name: project.name,
+      path: project.path,
+      type: project.type,
+      readonly: project.readonly,
+    },
+    'Project registered',
+  );
+
+  return project;
+}
+
+/**
+ * Associate a project with a group folder.
+ * The group's container will mount the project as its primary workspace.
+ */
+export function associateProject(
+  projectId: string,
+  groupFolder: string,
+): void {
+  const project = getProjectById(projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+  setGroupProject(groupFolder, projectId);
+  logger.info({ projectId, groupFolder }, 'Project associated with group');
+}
+
+/**
+ * Remove project association from a group.
+ */
+export function dissociateProject(groupFolder: string): void {
+  setGroupProject(groupFolder, null);
+  logger.info({ groupFolder }, 'Project dissociated from group');
+}
+
+/**
+ * Delete a project registration.
+ * Automatically dissociates all groups.
+ */
+export function removeProject(id: string): void {
+  const project = getProjectById(id);
+  if (!project) {
+    throw new Error(`Project not found: ${id}`);
+  }
+  dbDeleteProject(id);
+  logger.info({ projectId: id, name: project.name }, 'Project deleted');
+}
+
+// Re-export DB accessors for convenience
+export { getProjectById, getProjectByPath, getAllProjects };

--- a/src/project-registry.ts
+++ b/src/project-registry.ts
@@ -52,7 +52,11 @@ export function detectProjectType(projectPath: string): ProjectType | null {
 
   // Rust
   if (exists('Cargo.toml')) {
-    return { language: 'rust', packageManager: 'cargo', testRunner: 'cargo test' };
+    return {
+      language: 'rust',
+      packageManager: 'cargo',
+      testRunner: 'cargo test',
+    };
   }
 
   // Go
@@ -61,7 +65,11 @@ export function detectProjectType(projectPath: string): ProjectType | null {
   }
 
   // Python
-  if (exists('pyproject.toml') || exists('setup.py') || exists('requirements.txt')) {
+  if (
+    exists('pyproject.toml') ||
+    exists('setup.py') ||
+    exists('requirements.txt')
+  ) {
     const pt: ProjectType = { language: 'python' };
     if (exists('pyproject.toml')) pt.packageManager = 'pip';
     if (exists('Pipfile')) pt.packageManager = 'pipenv';
@@ -80,16 +88,25 @@ export function detectProjectType(projectPath: string): ProjectType | null {
   // Ruby
   if (exists('Gemfile')) {
     const pt: ProjectType = { language: 'ruby', packageManager: 'bundler' };
-    if (exists('Rakefile') || exists('config/application.rb')) pt.framework = 'rails';
+    if (exists('Rakefile') || exists('config/application.rb'))
+      pt.framework = 'rails';
     return pt;
   }
 
   // Java / Kotlin
   if (exists('pom.xml')) {
-    return { language: 'java', packageManager: 'maven', testRunner: 'maven test' };
+    return {
+      language: 'java',
+      packageManager: 'maven',
+      testRunner: 'maven test',
+    };
   }
   if (exists('build.gradle') || exists('build.gradle.kts')) {
-    return { language: 'java', packageManager: 'gradle', testRunner: 'gradle test' };
+    return {
+      language: 'java',
+      packageManager: 'gradle',
+      testRunner: 'gradle test',
+    };
   }
 
   // Node.js / TypeScript / JavaScript (checked last — many projects have package.json)
@@ -148,10 +165,7 @@ export const SENSITIVE_FILE_PATTERNS = [
  * Sensitive directory patterns to check within the project.
  * Files matching these globs under the project root are shadowed.
  */
-export const SENSITIVE_DIR_PATTERNS = [
-  'credentials',
-  'secrets',
-];
+export const SENSITIVE_DIR_PATTERNS = ['credentials', 'secrets'];
 
 /**
  * Register a new external project.
@@ -168,7 +182,9 @@ export function registerProject(
 
   // Verify path exists and is a directory
   if (!fs.existsSync(resolvedPath)) {
-    throw new Error(`Path does not exist: ${hostPath} (resolved: ${resolvedPath})`);
+    throw new Error(
+      `Path does not exist: ${hostPath} (resolved: ${resolvedPath})`,
+    );
   }
   if (!fs.statSync(resolvedPath).isDirectory()) {
     throw new Error(`Path is not a directory: ${resolvedPath}`);
@@ -190,7 +206,7 @@ export function registerProject(
   if (!validation.allowed) {
     throw new Error(
       `Project path not allowed by mount allowlist: ${validation.reason}. ` +
-      `Add the parent directory to ~/.config/deus/mount-allowlist.json`,
+        `Add the parent directory to ~/.config/deus/mount-allowlist.json`,
     );
   }
 
@@ -231,10 +247,7 @@ export function registerProject(
  * Associate a project with a group folder.
  * The group's container will mount the project as its primary workspace.
  */
-export function associateProject(
-  projectId: string,
-  groupFolder: string,
-): void {
+export function associateProject(projectId: string, groupFolder: string): void {
   const project = getProjectById(projectId);
   if (!project) {
     throw new Error(`Project not found: ${projectId}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,22 @@ export interface ContainerConfig {
   timeout?: number; // Default: 300000 (5 minutes)
 }
 
+export interface ProjectType {
+  language: string; // "typescript" | "python" | "rust" | "go" | "ruby" | "java" | "unknown"
+  framework?: string; // "next.js" | "react" | "express" | "django" | "flask" | etc.
+  packageManager?: string; // "npm" | "yarn" | "pnpm" | "pip" | "cargo" | etc.
+  testRunner?: string; // "jest" | "vitest" | "pytest" | "cargo test" | etc.
+}
+
+export interface ProjectConfig {
+  id: string;
+  name: string;
+  path: string; // Absolute host path
+  type: ProjectType | null; // Detected project type, null if unknown
+  readonly: boolean; // Whether the mount is read-only (default: false)
+  created_at: string;
+}
+
 export interface RegisteredGroup {
   name: string;
   folder: string;
@@ -40,6 +56,7 @@ export interface RegisteredGroup {
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
   isMain?: boolean; // True for the main control group (no trigger, elevated privileges)
+  projectId?: string; // Associated project for external environment mode
 }
 
 export interface NewMessage {


### PR DESCRIPTION
## Summary
- **Project Registry + Container Mounts**: Register external projects via IPC, mount into containers with security controls (symlink defense, sensitive file shadowing, TOCTOU validation)
- **CLI Mode**: Run `deus` in any directory to get a coding agent with full Deus brain — first-run onboarding (Full/Standard/Restricted memory levels), project configs, `/project-settings` command
- **Context-aware `/resume`**: Adapts to home mode (vault-based session recap) vs external project mode (git state, branches, PRs, auto-memory)
- **Smart startup**: Returning projects get auto-gathered git context in the greeting; first-run projects get onboarding questionnaire

## Test plan
- [ ] Run `deus` from ~/deus — verify home mode startup unchanged
- [ ] Run `deus` from an external git repo — verify onboarding questionnaire appears
- [ ] Return to the same external repo — verify git context in greeting
- [ ] Test `/project-settings` in external mode — view/modify memory level
- [ ] Test `/resume` in external mode — verify git-focused context loading
- [ ] Test restricted mode — verify auto-memory is disabled
- [ ] Test project registration via IPC (`register_project`, `associate_project`)
- [ ] Verify sensitive files (.env, credentials/) are shadowed in container mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)