### PR TITLE
fix(auth): break login loop by checking ~/.claude/.credentials.json

### DIFF
--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -85,6 +85,13 @@ describe('hasApiCredentials', () => {
     expect(hasApiCredentials()).toBe(true);
   });
 
+  it('returns true when ~/.claude/.credentials.json has a valid OAuth token', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-from-file' } }),
+    );
+    expect(hasApiCredentials()).toBe(true);
+  });
+
   it('returns false when no credentials are configured', () => {
     expect(hasApiCredentials()).toBe(false);
   });

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -16,6 +16,20 @@ import { readEnvFile } from './env.js';
 
 const DEUS_CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 const MEMORY_DB_PATH = path.join(HOME_DIR, '.deus', 'memory.db');
+const CLAUDE_CREDENTIALS_PATH = path.join(HOME_DIR, '.claude', '.credentials.json');
+
+/** Check if ~/.claude/.credentials.json has a valid OAuth access token. */
+function hasClaudeCredentialsFile(): boolean {
+  try {
+    const raw = fs.readFileSync(CLAUDE_CREDENTIALS_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as {
+      claudeAiOauth?: { accessToken?: string };
+    };
+    return !!parsed?.claudeAiOauth?.accessToken;
+  } catch {
+    return false;
+  }
+}
 
 /** Check if Anthropic API credentials are configured (API key or OAuth token). */
 export function hasApiCredentials(): boolean {
@@ -30,7 +44,8 @@ export function hasApiCredentials(): boolean {
     env.ANTHROPIC_AUTH_TOKEN ||
     process.env.ANTHROPIC_API_KEY ||
     process.env.CLAUDE_CODE_OAUTH_TOKEN ||
-    process.env.ANTHROPIC_AUTH_TOKEN
+    process.env.ANTHROPIC_AUTH_TOKEN ||
+    hasClaudeCredentialsFile()
   );
 }
 


### PR DESCRIPTION
## Summary
- `hasApiCredentials()` only checked `.env` and `process.env`, but `/login` writes the token to `~/.claude/.credentials.json`
- After idle login, the startup gate still returned false → repeated login prompts
- Added `hasClaudeCredentialsFile()` to mirror what the credential proxy already does at runtime

## Test plan
- [ ] All 28 existing checks tests pass
- [ ] New test: `returns true when ~/.claude/.credentials.json has a valid OAuth token`
- [ ] Verify after `/login`: Deus resumes without re-prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)