### PR TITLE
fix(windows): complete cross-platform gaps

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -75,10 +75,15 @@ Run `npx tsx setup/index.ts --step environment` and parse the status block.
 ### 3a. Install Docker
 
 - DOCKER=running → continue to 3b
-- DOCKER=installed_not_running → start Docker: `open -a Docker` (macOS) or `sudo systemctl start docker` (Linux). Wait 15s, re-check with `docker info`.
+- DOCKER=installed_not_running → start Docker:
+  - macOS: `open -a Docker`
+  - Linux: `sudo systemctl start docker`
+  - Windows: Docker Desktop auto-starts. Check the system tray icon — if it's not there, launch "Docker Desktop" from Start. Wait 15s then re-check with `docker info`.
+  - Wait 15s, re-check with `docker info`.
 - DOCKER=not_found → Use `AskUserQuestion: Docker is required for running agents. Would you like me to install it?` If confirmed:
   - macOS: install via `brew install --cask docker`, then `open -a Docker` and wait for it to start. If brew not available, direct to Docker Desktop download at https://docker.com/products/docker-desktop
   - Linux: install with `curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker $USER`. Note: user may need to log out/in for group membership.
+  - Windows: direct to Docker Desktop download at https://docker.com/products/docker-desktop. Requires WSL 2 (auto-offered by Docker installer). After install, start Docker Desktop from Start menu.
 
 ### 3b. Build and test
 
@@ -92,11 +97,11 @@ Run `npx tsx setup/index.ts --step container -- --runtime docker` and parse the 
 
 ## 4. Claude Authentication (No Script)
 
-If HAS_ENV=true from step 2, read `.env` and check for `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. If present, confirm with user: keep or reconfigure?
+If HAS_ENV=true from step 2, read `.env` and check for `ANTHROPIC_API_KEY`. If present, confirm with user: keep or reconfigure?
 
 AskUserQuestion: Claude subscription (Pro/Max) vs Anthropic API key?
 
-**Subscription:** Tell user to run `claude setup-token` in another terminal, copy the token, add `CLAUDE_CODE_OAUTH_TOKEN=<token>` to `.env`. Do NOT collect the token in chat.
+**Subscription (OAuth):** The credential proxy reads `~/.claude/.credentials.json` directly — no `.env` entry needed. Just ensure the user is logged in: `claude` (launches Claude Code, which authenticates). Do NOT add `CLAUDE_CODE_OAUTH_TOKEN` to `.env` — writing it there freezes it and causes a login loop when the token auto-rotates.
 
 **API key:** Tell user to add `ANTHROPIC_API_KEY=<key>` to `.env`.
 
@@ -141,13 +146,17 @@ AskUserQuestion: Agent access to external directories?
 
 ## 7. Start Service
 
-If service already running: unload first.
+If service already running: stop first.
 - macOS: `launchctl unload ~/Library/LaunchAgents/com.deus.plist`
 - Linux: `systemctl --user stop deus` (or `systemctl stop deus` if root)
+- Windows (NSSM): `nssm stop deus`
+- Windows (Servy): `servy-cli stop --name=deus`
 
 Run `npx tsx setup/index.ts --step service` and parse the status block.
 
 **If FALLBACK=wsl_no_systemd:** WSL without systemd detected. Tell user they can either enable systemd in WSL (`echo -e "[boot]\nsystemd=true" | sudo tee /etc/wsl.conf` then restart WSL) or use the generated `start-deus.sh` wrapper.
+
+**If PLATFORM=windows and FALLBACK=batch:** Windows without NSSM/Servy — a `start-deus.bat` launcher was generated. Tell user: run it from PowerShell as `.\start-deus.bat` or double-click it. For auto-start on login, add a shortcut to `shell:startup`.
 
 **If DOCKER_GROUP_STALE=true:** The user was added to the docker group after their session started — the systemd service can't reach the Docker socket. Ask user to run these two commands:
 
@@ -174,7 +183,12 @@ Replace `USERNAME` with the actual username (from `whoami`). Run the two `sudo` 
 Run `npx tsx setup/index.ts --step verify` and parse the status block.
 
 **If STATUS=failed, fix each:**
-- SERVICE=stopped → `npm run build`, then restart: `launchctl kickstart -k gui/$(id -u)/com.deus` (macOS) or `systemctl --user restart deus` (Linux) or `bash start-deus.sh` (WSL nohup)
+- SERVICE=stopped → `npm run build`, then restart:
+  - macOS: `launchctl kickstart -k gui/$(id -u)/com.deus`
+  - Linux: `systemctl --user restart deus`
+  - Windows (NSSM): `nssm restart deus`
+  - Windows (Servy): `servy-cli restart --name=deus`
+  - WSL nohup fallback: `bash start-deus.sh`
 - SERVICE=not_found → re-run step 7
 - CREDENTIALS=missing → re-run step 4
 - CHANNEL_AUTH shows `not_found` for any channel → re-invoke that channel's skill (e.g. `/add-telegram`)

--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,20 @@ groups/*/CLAUDE.md
 !groups/*/CLAUDE.md.template
 
 # Secrets — never commit credentials, tokens, or keys
-*.keys.json
+# RULE: this project is designed to be public — treat every commit as if it will be public
 .env
 .env.local
+.env.*
+!.env.example        # allow .env.example (no real values)
+*.keys.json
+*.credentials.json   # catch any stray credentials file
+*.token              # raw token files
+*.pem                # TLS/SSH private keys
+*.p12
+*.pfx
 integrations/gcal/credentials.json
 integrations/gcal/tokens.json
+config.local.json    # local config overrides that may contain secrets
 
 # Personal/one-time scripts
 scripts/rename-repo.sh

--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -1,0 +1,253 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Deus CLI for Windows — mirrors deus-cmd.sh on macOS/Linux.
+
+.DESCRIPTION
+    Usage:
+      deus              Launch Claude Code in current directory (external project mode)
+      deus home         Launch Claude Code in home mode (~\deus)
+      deus auth         Rebuild dist/ and restart the background service
+      deus status       Show service status
+      deus logs         Tail the Deus service log
+
+    The Deus background service runs under NSSM or Servy.
+    Credential proxy reads ~/.claude/.credentials.json directly — do NOT
+    write CLAUDE_CODE_OAUTH_TOKEN to .env (causes login loop on token rotation).
+#>
+
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = ""
+)
+
+$DeusHome = "$env:USERPROFILE\deus"
+$ServiceName = "deus"
+$LogFile = "$DeusHome\logs\deus.log"
+$ErrorLog = "$DeusHome\logs\deus.error.log"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Get-ServiceManager {
+    if (Get-Command "servy-cli" -ErrorAction SilentlyContinue) { return "servy" }
+    if (Get-Command "nssm" -ErrorAction SilentlyContinue) { return "nssm" }
+    return "none"
+}
+
+function Restart-DeusService {
+    $mgr = Get-ServiceManager
+    switch ($mgr) {
+        "servy" {
+            & servy-cli restart --name=$ServiceName
+        }
+        "nssm" {
+            & nssm restart $ServiceName
+        }
+        "none" {
+            Write-Host "No service manager found. Start Deus manually: node $DeusHome\dist\index.js" -ForegroundColor Yellow
+            Write-Host "Install NSSM: choco install nssm" -ForegroundColor Yellow
+        }
+    }
+}
+
+function Get-DeusServiceStatus {
+    $mgr = Get-ServiceManager
+    switch ($mgr) {
+        "servy" {
+            & servy-cli status --name=$ServiceName
+        }
+        "nssm" {
+            & nssm status $ServiceName
+        }
+        "none" {
+            # Fall back to checking if the process is running
+            $proc = Get-Process -Name "node" -ErrorAction SilentlyContinue |
+                Where-Object { $_.MainModule.FileName -like "*\deus\*" }
+            if ($proc) {
+                Write-Host "Deus is running (PID $($proc.Id))" -ForegroundColor Green
+            } else {
+                Write-Host "Deus does not appear to be running." -ForegroundColor Yellow
+            }
+        }
+    }
+}
+
+function Build-Deus {
+    Write-Host "  Building..." -NoNewline
+    Push-Location $DeusHome
+    try {
+        & npm run build --silent
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host " FAILED" -ForegroundColor Red
+            Write-Error "Build failed — not restarting."
+            return $false
+        }
+    } finally {
+        Pop-Location
+    }
+    Write-Host " OK" -ForegroundColor Green
+    return $true
+}
+
+function Read-VaultFile {
+    param([string]$Path)
+    if (Test-Path $Path) { return Get-Content $Path -Raw } else { return "" }
+}
+
+function Get-VaultPath {
+    $envVault = $env:DEUS_VAULT_PATH
+    if ($envVault) { return $envVault }
+    $configPath = "$env:USERPROFILE\.config\deus\config.json"
+    if (Test-Path $configPath) {
+        try {
+            $cfg = Get-Content $configPath -Raw | ConvertFrom-Json
+            return $cfg.vault_path
+        } catch { }
+    }
+    return ""
+}
+
+function Invoke-ClaudeWithContext {
+    param([string]$WorkDir)
+
+    # Load token for current shell session (service uses credentials.json directly)
+    $credPath = "$env:USERPROFILE\.claude\.credentials.json"
+    if (Test-Path $credPath) {
+        try {
+            $creds = Get-Content $credPath -Raw | ConvertFrom-Json
+            $token = $creds.claudeAiOauth.accessToken
+            if ($token) { $env:CLAUDE_CODE_OAUTH_TOKEN = $token }
+        } catch { }
+    }
+
+    $vault = Get-VaultPath
+    if (-not $vault) {
+        Write-Host "Warning: No vault configured. Set DEUS_VAULT_PATH or vault_path in ~/.config/deus/config.json" -ForegroundColor Yellow
+        Set-Location $WorkDir
+        & claude --dangerously-skip-permissions
+        return
+    }
+
+    # ── Load context (mirrors deus-cmd.sh context loading) ──────────────────
+    Write-Host "  Reading vault...`r" -NoNewline
+    $claudeMd  = Read-VaultFile "$vault\CLAUDE.md"
+    $studyMd   = Read-VaultFile "$vault\STUDY.md"
+    $infraMd   = Read-VaultFile "$vault\INFRA.md"
+
+    $context = ""
+    if ($claudeMd) { $context += "=== VAULT: CLAUDE.md ===`n$claudeMd" }
+    if ($studyMd)  { $context += "`n`n=== VAULT: STUDY.md ===`n$studyMd" }
+    if ($infraMd)  { $context += "`n`n=== VAULT: INFRA.md ===`n$infraMd" }
+
+    # Checkpoint (today's)
+    Write-Host "  Checking checkpoints...`r" -NoNewline
+    $today = Get-Date -Format "yyyy-MM-dd"
+    $checkpointDir = "$vault\Checkpoints"
+    if (Test-Path $checkpointDir) {
+        $cpFile = Get-ChildItem $checkpointDir -Filter "$today-*.md" |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($cpFile) {
+            $cp = Get-Content $cpFile.FullName -Raw
+            if ($cp) { $context += "`n`n=== MID-SESSION CHECKPOINT ===`n$cp" }
+        }
+    }
+
+    # Recent sessions (via memory_indexer.py)
+    Write-Host "  Loading recent sessions...`r" -NoNewline
+    $pythonCmd = if (Get-Command "python3" -ErrorAction SilentlyContinue) { "python3" } else { "python" }
+    $indexerPath = "$DeusHome\scripts\memory_indexer.py"
+    if ((Get-Command $pythonCmd -ErrorAction SilentlyContinue) -and (Test-Path $indexerPath)) {
+        $recent = & $pythonCmd $indexerPath --recent 3 2>$null
+        if ($recent) { $context += "`n`n=== RECENT SESSIONS ===`n$recent" }
+    }
+
+    # Query memory for related sessions
+    $related = ""
+    if ((Get-Command $pythonCmd -ErrorAction SilentlyContinue) -and (Test-Path $indexerPath)) {
+        $related = & $pythonCmd $indexerPath --query --top 2 --recency-boost 2>$null
+        if ($related) { $context += "`n`n=== RELATED SESSIONS ===`n$related" }
+    }
+
+    # Git status for context
+    Write-Host "  Loading git status...`r" -NoNewline
+    $gitStatus = ""
+    Push-Location $WorkDir
+    try {
+        $branch    = & git rev-parse --abbrev-ref HEAD 2>$null
+        $mainBranch = "main"
+        $status    = & git status --short 2>$null
+        $log       = & git log --oneline -5 2>$null
+        if ($branch) {
+            $gitStatus  = "Current branch: $branch`n`nMain branch (you will usually use this for PRs): $mainBranch`n`n"
+            $gitStatus += "Status:`n$(if ($status) { $status } else { '(clean)' })`n`nRecent commits:`n$($log -join "`n")"
+        }
+    } catch { } finally { Pop-Location }
+    if ($gitStatus) { $context += "`n`n=== GIT STATUS ===`n$gitStatus" }
+
+    Write-Host "  " + (" " * 40) + "`r" -NoNewline  # clear line
+
+    # Launch Claude with system prompt
+    $env:CLAUDE_SYSTEM_PROMPT = $context
+    Set-Location $WorkDir
+    & claude --dangerously-skip-permissions
+}
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+
+switch ($Command.ToLower()) {
+    "auth" {
+        # Validate credentials before restarting
+        $credPath = "$env:USERPROFILE\.claude\.credentials.json"
+        if (-not (Test-Path $credPath)) {
+            Write-Error "Error: ~/.claude/.credentials.json not found. Run 'claude' to authenticate first."
+            exit 1
+        }
+        try {
+            $creds = Get-Content $credPath -Raw | ConvertFrom-Json
+            if (-not $creds.claudeAiOauth.accessToken) { throw "no token" }
+        } catch {
+            Write-Error "Error: could not read token from ~/.claude/.credentials.json"
+            exit 1
+        }
+
+        # Rebuild then restart
+        if (-not (Build-Deus)) { exit 1 }
+        Restart-DeusService
+        Write-Host "Deus built and restarted."
+    }
+
+    "status" {
+        Get-DeusServiceStatus
+    }
+
+    "logs" {
+        if (Test-Path $LogFile) {
+            Get-Content $LogFile -Wait -Tail 50
+        } else {
+            Write-Host "Log file not found: $LogFile" -ForegroundColor Yellow
+        }
+    }
+
+    "home" {
+        Invoke-ClaudeWithContext -WorkDir $DeusHome
+    }
+
+    { $_ -eq "" -or $_ -eq "." } {
+        $currentDir = (Get-Location).Path
+        if ($currentDir -eq $DeusHome) {
+            Invoke-ClaudeWithContext -WorkDir $DeusHome
+        } else {
+            Invoke-ClaudeWithContext -WorkDir $currentDir
+        }
+    }
+
+    default {
+        Write-Host "Usage: deus [home|auth|status|logs]"
+        Write-Host ""
+        Write-Host "  deus        Launch in current directory (external project mode if not ~\deus)"
+        Write-Host "  deus home   Launch in home mode (~\deus) regardless of current directory"
+        Write-Host "  deus auth   Rebuild dist/ and restart background service"
+        Write-Host "  deus status Show service status (NSSM or Servy)"
+        Write-Host "  deus logs   Tail the Deus service log"
+    }
+}

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -644,8 +644,14 @@ case "$1" in
     # Do NOT write token to .env — the credential proxy reads credentials.json
     # directly via getDynamicOAuthToken() with a 5-min cache. Writing to .env
     # would permanently freeze the token and cause a login loop on next refresh.
+    #
+    # Always rebuild before restarting — prevents silent dist/src drift where
+    # a source fix is present but the running binary is stale (root cause of
+    # the login loop regression: fix was in src but never compiled into dist).
+    printf "  Building...\r"
+    (cd "$HOME/deus" && npm run build --silent) || { echo "Build failed — not restarting."; exit 1; }
     launchctl kickstart -k "gui/$(id -u)/com.deus" 2>/dev/null
-    echo "Deus restarted (credential proxy reads ~/.claude/.credentials.json directly)."
+    echo "Deus built and restarted."
     ;;
   home|"")
     TOKEN=$(python3 -c 'import sys,json; print(json.load(open(sys.argv[1]))["claudeAiOauth"]["accessToken"])' "$HOME/.claude/.credentials.json" 2>/dev/null)

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -1,0 +1,257 @@
+# Cross-Platform Guide
+
+Deus runs on **macOS, Linux, and Windows** (via Docker Desktop + WSL2). Every change to the codebase must work on all three platforms. This document explains what to avoid, what to use instead, and provides a checklist to run before opening a PR.
+
+---
+
+## The Rule
+
+> If your code contains a shell string, a Unix path, or a platform-specific binary, it's probably broken on at least one OS. Check the table below before merging.
+
+---
+
+## Patterns to Avoid (and Their Replacements)
+
+### 1. Shell redirections in `execSync` strings
+
+`2>/dev/null` and `>/dev/null` are Bash/Zsh syntax. Windows `cmd.exe` doesn't understand them.
+
+```ts
+// BAD — 2>/dev/null is shell syntax; breaks on Windows
+execSync(`docker image inspect deus-agent 2>/dev/null`, { stdio: 'pipe' });
+
+// GOOD — stdio: 'pipe' already captures/suppresses stderr at the Node level
+execSync(`docker image inspect deus-agent`, { stdio: 'pipe' });
+```
+
+**Rule:** Never put shell redirect syntax in an `execSync` string. Use `stdio: 'pipe'` or `stdio: ['pipe','pipe','pipe']` instead — they silence stderr at the Node.js level and work everywhere.
+
+---
+
+### 2. Single quotes in shell strings passed to `execSync`
+
+Windows `cmd.exe` does not interpret single quotes. They are passed literally to the subprocess, breaking Go templates, Python `-c` args, and similar patterns.
+
+```ts
+// BAD — single quotes break on Windows cmd.exe
+execSync(`docker ps --format '{{.Names}}'`);
+
+// GOOD — no quoting needed when there are no spaces
+execSync(`docker ps --format {{.Names}}`);
+
+// GOOD — use execFileSync with args array to avoid all shell quoting issues
+import { execFileSync } from 'child_process';
+execFileSync('docker', ['ps', '--format', '{{.Names}}'], { stdio: 'pipe' });
+```
+
+**Rule:** Prefer `execFileSync(binary, [args])` over `execSync(shellString)`. With an args array, the shell is never involved and quoting is not an issue.
+
+---
+
+### 3. Hardcoded `/dev/null`
+
+```ts
+// BAD — /dev/null doesn't exist on Windows
+hostPath: '/dev/null'
+
+// GOOD — os.devNull is '/dev/null' on Unix, '\\.\nul' on Windows
+import os from 'os';
+hostPath: os.devNull
+```
+
+---
+
+### 4. SIGTERM / negative PID kills
+
+`SIGTERM` is not delivered on Windows and negative PIDs (process groups) are a Unix concept.
+
+```ts
+// BAD — broken on Windows
+process.kill(-pid, 'SIGTERM');
+process.kill(pid, 'SIGTERM');
+
+// GOOD — platform-aware (see src/remote-control.ts for the full killProcess() helper)
+import os from 'os';
+import { execSync } from 'child_process';
+
+function killProcess(pid: number): void {
+  if (os.platform() === 'win32') {
+    try { execSync(`taskkill /F /T /PID ${pid}`, { stdio: 'pipe' }); } catch {}
+    return;
+  }
+  try { process.kill(-pid, 'SIGTERM'); } catch {
+    try { process.kill(pid, 'SIGTERM'); } catch {}
+  }
+}
+```
+
+**Rule:** Never send signals directly without a platform check. Use the shared `killProcess()` helper in `src/remote-control.ts` or copy its pattern.
+
+---
+
+### 5. Hardcoded Unix paths in TypeScript/JavaScript
+
+```ts
+// BAD — Unix absolute paths
+fs.readFileSync('/proc/version');        // Linux only
+const home = '/Users/liam/deus';        // macOS only
+const nullDev = '/dev/null';            // Unix only
+
+// GOOD
+import os from 'os';
+import path from 'path';
+const home = os.homedir();                           // cross-platform
+const configDir = path.join(home, '.config', 'deus'); // correct separators
+const nullDev = os.devNull;                           // cross-platform
+// /proc paths: always wrap in try-catch with platform check
+if (os.platform() === 'linux') { /* /proc access */ }
+```
+
+**Rule:** Never hardcode `/Users/`, `/home/`, `/proc/`, `/dev/`, `/etc/`. Always use `os.homedir()`, `os.tmpdir()`, `os.devNull`, or `path.join()`.
+
+---
+
+### 6. Unix-only environment variables
+
+```ts
+// BAD — HOME is not set on Windows (USERPROFILE is)
+const home = process.env.HOME;
+
+// GOOD — always falls back correctly
+const home = process.env.HOME || os.homedir();  // os.homedir() handles Windows
+```
+
+---
+
+### 7. Unix-only process APIs
+
+```ts
+// BAD — process.getuid() / process.getgid() don't exist on Windows
+const isRoot = process.getuid() === 0;
+
+// GOOD — use optional chaining; undefined means non-root on Windows
+const isRoot = process.getuid?.() === 0;
+```
+
+---
+
+### 8. Shell-specific scripts called from Node
+
+```ts
+// BAD — .sh scripts don't run on Windows
+execSync('./scripts/setup.sh');
+execSync('bash container/build.sh');
+
+// GOOD — either use the TypeScript equivalent, or document the Windows alternative
+// See: setup/service.ts for examples of platform-branched setup code
+```
+
+If a script is macOS/Linux-only by design (e.g. `deus-cmd.sh`), document it clearly and provide the Windows equivalent (e.g. `deus-cmd.ps1`).
+
+---
+
+### 9. Platform branches missing Windows
+
+```ts
+// BAD — handles darwin and linux but silently does nothing on Windows
+if (platform === 'macos') { /* macOS path */ }
+else if (platform === 'linux') { /* Linux path */ }
+// Windows falls through with no action and no error
+
+// GOOD — always include a Windows branch or an explicit default
+if (platform === 'macos') { /* ... */ }
+else if (platform === 'linux') { /* ... */ }
+else if (platform === 'windows') { /* Windows path */ }
+else { throw new Error(`Unsupported platform: ${platform}`); }
+```
+
+---
+
+### 10. PATH separator assumptions
+
+```ts
+// BAD — : separator is Unix-only
+const PATH = `/usr/local/bin:/usr/bin:${home}/.local/bin`;
+
+// GOOD — use path.delimiter
+import path from 'path';
+const paths = ['/usr/local/bin', '/usr/bin', customBin];
+const PATH = paths.join(path.delimiter);  // ':' on Unix, ';' on Windows
+```
+
+---
+
+## Platform Detection Reference
+
+```ts
+import os from 'os';
+import { getPlatform, isWSL } from './setup/platform.js'; // for setup code
+
+// Raw Node.js
+os.platform()     // 'darwin' | 'linux' | 'win32'
+os.homedir()      // /Users/name | /home/name | C:\Users\name
+os.tmpdir()       // /tmp | C:\Users\name\AppData\Local\Temp
+os.devNull        // /dev/null | \\.\nul
+path.sep          // '/' | '\'
+path.delimiter    // ':' | ';'
+
+// Deus helpers (setup code only)
+getPlatform()     // 'macos' | 'linux' | 'windows' | 'unknown'
+isWSL()           // true if running inside WSL2
+```
+
+---
+
+## Known Platform-Specific Files
+
+These files are intentionally platform-specific and are **not** expected to be cross-platform:
+
+| File | Platform | Notes |
+|------|----------|-------|
+| `deus-cmd.sh` | macOS/Linux | CLI launcher; Windows equivalent is `deus-cmd.ps1` |
+| `deus-cmd.ps1` | Windows | CLI launcher; install via the setup skill |
+| `scripts/rename-repo.sh` | macOS/Linux | One-time repo renaming utility; not part of the runtime |
+| `container/build.sh` | macOS/Linux | Use `docker build -t deus-agent ./container` on Windows |
+| `setup.sh` | macOS/Linux | Initial bootstrap; use `npm run setup` on Windows |
+
+---
+
+## PR Checklist: Cross-Platform Review
+
+Before opening a PR, run through this checklist for every file you changed:
+
+```
+[ ] No shell redirect syntax in execSync strings (2>/dev/null, >/dev/null)
+[ ] No single-quoted strings in shell commands run via execSync
+[ ] No hardcoded /dev/null — use os.devNull
+[ ] No SIGTERM/process.kill without platform check — use killProcess() helper
+[ ] No hardcoded Unix paths (/Users/, /home/, /proc/, /dev/, /etc/)
+[ ] No process.getuid() without optional chaining (?.)
+[ ] No process.env.HOME without os.homedir() fallback
+[ ] No platform branches that handle darwin+linux but skip win32
+[ ] No PATH strings using ':' separator — use path.delimiter
+[ ] No .sh scripts invoked from Node.js without a Windows alternative
+[ ] New exec calls use execFileSync(binary, args) not execSync(shellString)
+```
+
+---
+
+## Testing on Multiple Platforms
+
+The CI runs on `ubuntu-latest`, `macos-latest`, and `windows-latest`. If your change touches anything in the checklist above, you should:
+
+1. Look at the CI output for the `windows-latest` job in your PR
+2. If you don't have a Windows machine, annotate your PR with `needs-windows-test` and describe what you expect might fail
+
+For the Windows service path (NSSM/Servy integration), a real Windows machine smoke test is required — see `docs/windows-setup.md`.
+
+---
+
+## Adding a New Platform-Specific Feature
+
+If you're adding a feature that truly requires different implementations per platform:
+
+1. Add a branch in `setup/platform.ts` — that's the single source of truth for platform detection
+2. Add the Windows case in `setup/service.ts` if it's service-related
+3. Update this document with the new pattern
+4. Add tests for each platform branch (see `src/checks.test.ts` for examples of mocking `os.platform()`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,5 +1,7 @@
 # Development Reference
 
+> **Contributing?** Read [`docs/CROSS_PLATFORM.md`](CROSS_PLATFORM.md) before opening a PR — every change must work on macOS, Linux, and Windows.
+
 ## Key Files
 
 | File | Purpose |

--- a/setup/memory.ts
+++ b/setup/memory.ts
@@ -14,6 +14,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { HOME_DIR, CONFIG_DIR } from '../src/config.js';
+import { resolvePython } from '../src/checks.js';
 import { logger } from '../src/logger.js';
 import { emitStatus } from './status.js';
 
@@ -33,9 +34,19 @@ export async function run(args: string[]): Promise<void> {
   logger.info('Starting memory system setup');
 
   // ── 1. Check Python ──────────────────────────────────────────────────────
+  // Resolve python3 or python (Windows may only have `python` in PATH)
+  const pythonCmd = resolvePython();
+  if (!pythonCmd) {
+    emitStatus('MEMORY', {
+      STATUS: 'failed',
+      ERROR: 'Python 3 not found. Install Python 3.11+ to enable the memory system.',
+      STEP: 'python_check',
+    });
+    return;
+  }
   let pythonVersion = '';
   try {
-    pythonVersion = execSync('python3 --version', {
+    pythonVersion = execSync(`${pythonCmd} --version`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
@@ -54,12 +65,12 @@ export async function run(args: string[]): Promise<void> {
   // ── 2. Check/install Python dependencies ─────────────────────────────────
   const missing: string[] = [];
   try {
-    execSync('python3 -c "import sqlite_vec"', { stdio: 'pipe', timeout: 5000 });
+    execSync('${pythonCmd} -c "import sqlite_vec"', { stdio: 'pipe', timeout: 5000 });
   } catch {
     missing.push('sqlite-vec');
   }
   try {
-    execSync('python3 -c "from google import genai"', { stdio: 'pipe', timeout: 5000 });
+    execSync('${pythonCmd} -c "from google import genai"', { stdio: 'pipe', timeout: 5000 });
   } catch {
     missing.push('google-genai');
   }
@@ -97,12 +108,12 @@ export async function run(args: string[]): Promise<void> {
     // Re-check after install.
     const stillMissing: string[] = [];
     try {
-      execSync('python3 -c "import sqlite_vec"', { stdio: 'pipe', timeout: 5000 });
+      execSync('${pythonCmd} -c "import sqlite_vec"', { stdio: 'pipe', timeout: 5000 });
     } catch {
       stillMissing.push('sqlite-vec');
     }
     try {
-      execSync('python3 -c "from google import genai"', { stdio: 'pipe', timeout: 5000 });
+      execSync('${pythonCmd} -c "from google import genai"', { stdio: 'pipe', timeout: 5000 });
     } catch {
       stillMissing.push('google-genai');
     }
@@ -179,7 +190,7 @@ export async function run(args: string[]): Promise<void> {
   // ── 5. Initialize memory database ────────────────────────────────────────
   try {
     execSync(
-      `python3 "${MEMORY_INDEXER}" --rebuild`,
+      `${pythonCmd} "${MEMORY_INDEXER}" --rebuild`,
       {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -185,9 +185,10 @@ describe('hasPythonDeps', () => {
     expect(result.missing).toHaveLength(0);
   });
 
-  it('returns ok=false with python3 missing when python3 check fails', () => {
+  it('returns ok=false with python3 missing when both python3 and python are absent', () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (String(cmd).includes('python3 --version')) {
+      // Both python3 and python unavailable (Windows without Python in PATH)
+      if (String(cmd).includes('--version')) {
         throw new Error('not found');
       }
       return Buffer.from('');

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -167,7 +167,7 @@ export function hasContainerImage(): boolean {
   const runtime = process.env.CONTAINER_RUNTIME || 'docker';
   const bin = runtime === 'container' ? 'container' : 'docker';
   try {
-    execSync(`${bin} image inspect deus-agent 2>/dev/null`, {
+    execSync(`${bin} image inspect deus-agent`, {
       stdio: 'pipe',
       timeout: 5000,
     });
@@ -186,7 +186,7 @@ export function countRegisteredGroups(): number {
     // Dynamic import avoidance: use execSync to query without loading better-sqlite3
     // into the main process before initDatabase() runs.
     const result = execSync(
-      `sqlite3 "${dbPath}" "SELECT COUNT(*) FROM registered_groups;" 2>/dev/null`,
+      `sqlite3 "${dbPath}" "SELECT COUNT(*) FROM registered_groups;"`,
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 },
     );
     return parseInt(result.trim(), 10) || 0;

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -89,20 +89,35 @@ export function hasMemoryVault(): { ok: boolean; path: string | null } {
   return { ok: true, path: resolved };
 }
 
+/**
+ * Resolve the Python executable name.
+ * Tries `python3` first (Unix standard), then `python` (Windows / some envs).
+ * Returns the working command, or null if Python is not available.
+ */
+export function resolvePython(): string | null {
+  for (const cmd of ['python3', 'python']) {
+    try {
+      execSync(`${cmd} --version`, { stdio: 'pipe', timeout: 5000 });
+      return cmd;
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}
+
 /** Check if Python 3 and required packages (sqlite-vec, google-genai) are available. */
 export function hasPythonDeps(): { ok: boolean; missing: string[] } {
   const missing: string[] = [];
 
-  // Check Python 3 exists
-  try {
-    execSync('python3 --version', { stdio: 'pipe', timeout: 5000 });
-  } catch {
+  const python = resolvePython();
+  if (!python) {
     return { ok: false, missing: ['python3'] };
   }
 
   // Check sqlite-vec
   try {
-    execSync('python3 -c "import sqlite_vec"', {
+    execSync(`${python} -c "import sqlite_vec"`, {
       stdio: 'pipe',
       timeout: 5000,
     });
@@ -112,7 +127,7 @@ export function hasPythonDeps(): { ok: boolean; missing: string[] } {
 
   // Check google-genai
   try {
-    execSync('python3 -c "from google import genai"', {
+    execSync(`${python} -c "from google import genai"`, {
       stdio: 'pipe',
       timeout: 5000,
     });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, execFile, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -87,10 +88,11 @@ function buildVolumeMounts(
 
     // Shadow .env so the agent cannot read secrets from the mounted project root.
     // Credentials are injected by the credential proxy, never exposed to containers.
+    // os.devNull is '/dev/null' on Unix and '\\.\nul' on Windows.
     const envFile = path.join(projectRoot, '.env');
     if (fs.existsSync(envFile)) {
       mounts.push({
-        hostPath: '/dev/null',
+        hostPath: os.devNull,
         containerPath: '/workspace/project/.env',
         readonly: true,
       });

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -93,8 +93,10 @@ export function ensureContainerRuntimeRunning(): void {
 /** Kill orphaned Deus containers from previous runs. */
 export function cleanupOrphans(): void {
   try {
+    // No shell quoting around the Go template: single quotes don't work on
+    // Windows cmd.exe and are unnecessary here since there are no spaces.
     const output = execSync(
-      `${CONTAINER_RUNTIME_BIN} ps --filter name=deus- --format '{{.Names}}'`,
+      `${CONTAINER_RUNTIME_BIN} ps --filter name=deus- --format {{.Names}}`,
       { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
     );
     const orphans = output.trim().split('\n').filter(Boolean);

--- a/src/remote-control.test.ts
+++ b/src/remote-control.test.ts
@@ -261,7 +261,8 @@ describe('remote-control', () => {
 
       const result = stopRemoteControl();
       expect(result).toEqual({ ok: true });
-      expect(killSpy).toHaveBeenCalledWith(55555, 'SIGTERM');
+      // Unix: killProcess sends SIGTERM to process group (-pid) first
+      expect(killSpy).toHaveBeenCalledWith(-55555, 'SIGTERM');
       expect(unlinkSyncSpy).toHaveBeenCalledWith(STATE_FILE);
       expect(getActiveSession()).toBeNull();
     });
@@ -362,7 +363,8 @@ describe('remote-control', () => {
 
       const result = stopRemoteControl();
       expect(result).toEqual({ ok: true });
-      expect(killSpy).toHaveBeenCalledWith(77777, 'SIGTERM');
+      // Unix: killProcess sends SIGTERM to process group (-pid) first
+      expect(killSpy).toHaveBeenCalledWith(-77777, 'SIGTERM');
       expect(unlinkSyncSpy).toHaveBeenCalled();
       expect(getActiveSession()).toBeNull();
     });

--- a/src/remote-control.ts
+++ b/src/remote-control.ts
@@ -1,5 +1,6 @@
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { DATA_DIR } from './config.js';
@@ -41,6 +42,32 @@ function isProcessAlive(pid: number): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Terminate a process cross-platform.
+ * - Unix: sends SIGTERM to the process group first (-pid), falls back to SIGTERM on the PID.
+ * - Windows: SIGTERM is unsupported; uses `taskkill /F /T /PID` to kill the process tree.
+ */
+function killProcess(pid: number): void {
+  if (os.platform() === 'win32') {
+    try {
+      execSync(`taskkill /F /T /PID ${pid}`, { stdio: 'pipe' });
+    } catch {
+      // already dead
+    }
+    return;
+  }
+  // Unix: try process group first, then individual PID
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // already dead
+    }
   }
 }
 
@@ -179,15 +206,7 @@ export async function startRemoteControl(
 
       // Timeout check
       if (Date.now() - startTime >= URL_TIMEOUT_MS) {
-        try {
-          process.kill(-pid, 'SIGTERM');
-        } catch {
-          try {
-            process.kill(pid, 'SIGTERM');
-          } catch {
-            // already dead
-          }
-        }
+        killProcess(pid);
         resolve({
           ok: false,
           error: 'Timed out waiting for Remote Control URL',
@@ -212,11 +231,7 @@ export function stopRemoteControl():
   }
 
   const { pid } = activeSession;
-  try {
-    process.kill(pid, 'SIGTERM');
-  } catch {
-    // already dead
-  }
+  killProcess(pid);
   activeSession = null;
   clearState();
   logger.info({ pid }, 'Remote Control session stopped');

--- a/src/startup-gate.ts
+++ b/src/startup-gate.ts
@@ -10,6 +10,8 @@
  *   suggest — allows startup, one-line hint (e.g., Gemini API key, channels)
  */
 
+import os from 'os';
+
 import {
   hasApiCredentials,
   hasGeminiApiKey,
@@ -94,7 +96,9 @@ registerStartupCheck({
     name: 'Agent container image',
     level: 'warn',
     ok: hasContainerImage(),
-    hint: 'Agent container image not built. Run: ./container/build.sh',
+    hint: os.platform() === 'win32'
+      ? 'Agent container image not built. Run: docker build -t deus-agent ./container'
+      : 'Agent container image not built. Run: ./container/build.sh',
   }),
 });
 


### PR DESCRIPTION
## Summary

Addresses all gaps found in a full Windows cross-platform audit after PR #4 (Windows support):

- **`deus-cmd.ps1`** — Windows PowerShell CLI equivalent of `deus-cmd.sh`. Supports `auth` (rebuild + restart NSSM/Servy), `home`, `status`, `logs`, `help`. Reads `credentials.json` directly (never writes to `.env`).
- **Python fallback** — `resolvePython()` in `checks.ts` tries `python3` then `python` (Windows may only have `python` in PATH). Reused in `setup/memory.ts` for all Python invocations.
- **Platform-aware container hint** — startup gate shows `docker build -t deus-agent ./container` on Windows instead of `./container/build.sh`.
- **`deus auth` rebuild step** — `deus-cmd.sh` now runs `npm run build` before restarting the service, preventing silent `dist/src` drift (root cause of the 2026-04-02 login loop regression).
- **Setup skill Windows guidance** — Docker Desktop startup (Step 3a), NSSM/Servy service commands (Steps 7 & 8), correct OAuth flow (do NOT write token to `.env`).
- **`.gitignore` hardened** — adds `*.credentials.json`, `*.token`, `*.pem`, `config.local.json`, `.env.*` with `!.env.example` carve-out.

## Test plan

- [ ] All 552 existing tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] `deus auth` on macOS: builds and restarts service cleanly
- [ ] Windows (real machine): `deus-cmd.ps1 auth` — rebuilds, restarts NSSM/Servy service
- [ ] Windows (real machine): `python` fallback works when `python3` is absent from PATH
- [ ] Startup gate shows correct `docker build` hint on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)