### PR TITLE
refactor(orchestration): extract message orchestrator and router state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-
 import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
-  IDLE_TIMEOUT,
   MAX_MESSAGE_LENGTH,
-  POLL_INTERVAL,
-  TIMEZONE,
-  TRIGGER_PATTERN,
 } from './config.js';
 import { startCredentialProxy } from './credential-proxy.js';
 import './channels/index.js';
@@ -17,541 +10,42 @@ import {
   getRegisteredChannelNames,
 } from './channels/registry.js';
 import {
-  ContainerOutput,
-  runContainerAgent,
-  writeGroupsSnapshot,
-  writeTasksSnapshot,
-} from './container-runner.js';
-import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
   PROXY_BIND_HOST,
 } from './container-runtime.js';
 import {
-  getAllChats,
-  getAllRegisteredGroups,
-  getAllSessions,
-  getAllTasks,
-  getMessagesSince,
-  getNewMessages,
-  getRouterState,
   initDatabase,
-  setRegisteredGroup,
-  setRouterState,
-  setSession,
   storeChatMetadata,
   storeMessage,
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
-import { resolveGroupFolderPath } from './group-folder.js';
 import { startIpcWatcher } from './ipc.js';
-import { findChannel, formatMessages, formatOutbound } from './router.js';
+import { createMessageOrchestrator } from './message-orchestrator.js';
+import { findChannel, formatOutbound } from './router.js';
 import {
   restoreRemoteControl,
   startRemoteControl,
   stopRemoteControl,
 } from './remote-control.js';
+import { RouterState, getAvailableGroups } from './router-state.js';
 import {
   isSenderAllowed,
-  isTriggerAllowed,
   loadSenderAllowlist,
   shouldDropMessage,
 } from './sender-allowlist.js';
-import {
-  extractSessionCommand,
-  handleSessionCommand,
-  isSessionCommandAllowed,
-} from './session-commands.js';
 import { runStartupChecks, printStartupReport } from './startup-gate.js';
 import { startSchedulerLoop } from './task-scheduler.js';
-import { Channel, NewMessage, RegisteredGroup } from './types.js';
-import { parseImageReferences } from './image.js';
+import { getAllTasks } from './db.js';
+import { writeGroupsSnapshot, writeTasksSnapshot } from './container-runner.js';
+import { Channel, NewMessage } from './types.js';
 import { logger } from './logger.js';
 
-// Re-export for backwards compatibility during refactor
-export { escapeXml, formatMessages } from './router.js';
-
-let lastTimestamp = '';
-let sessions: Record<string, string> = {};
-let registeredGroups: Record<string, RegisteredGroup> = {};
-let lastAgentTimestamp: Record<string, string> = {};
-let messageLoopRunning = false;
-
-const channels: Channel[] = [];
-const queue = new GroupQueue();
-
-function loadState(): void {
-  lastTimestamp = getRouterState('last_timestamp') || '';
-  const agentTs = getRouterState('last_agent_timestamp');
-  try {
-    lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
-  } catch {
-    logger.warn('Corrupted last_agent_timestamp in DB, resetting');
-    lastAgentTimestamp = {};
-  }
-  sessions = getAllSessions();
-  registeredGroups = getAllRegisteredGroups();
-  logger.info(
-    { groupCount: Object.keys(registeredGroups).length },
-    'State loaded',
-  );
-}
-
-function saveState(): void {
-  setRouterState('last_timestamp', lastTimestamp);
-  setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
-}
-
-function registerGroup(jid: string, group: RegisteredGroup): void {
-  let groupDir: string;
-  try {
-    groupDir = resolveGroupFolderPath(group.folder);
-  } catch (err) {
-    logger.warn(
-      { jid, folder: group.folder, err },
-      'Rejecting group registration with invalid folder',
-    );
-    return;
-  }
-
-  registeredGroups[jid] = group;
-  setRegisteredGroup(jid, group);
-
-  // Create group folder
-  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
-
-  logger.info(
-    { jid, name: group.name, folder: group.folder },
-    'Group registered',
-  );
-}
-
-/**
- * Get available groups list for the agent.
- * Returns groups ordered by most recent activity.
- */
-export function getAvailableGroups(): import('./container-runner.js').AvailableGroup[] {
-  const chats = getAllChats();
-  const registeredJids = new Set(Object.keys(registeredGroups));
-
-  return chats
-    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
-    .map((c) => ({
-      jid: c.jid,
-      name: c.name,
-      lastActivity: c.last_message_time,
-      isRegistered: registeredJids.has(c.jid),
-    }));
-}
-
-/** @internal - exported for testing */
-export function _setRegisteredGroups(
-  groups: Record<string, RegisteredGroup>,
-): void {
-  registeredGroups = groups;
-}
-
-/**
- * Process all pending messages for a group.
- * Called by the GroupQueue when it's this group's turn.
- */
-async function processGroupMessages(chatJid: string): Promise<boolean> {
-  const group = registeredGroups[chatJid];
-  if (!group) return true;
-
-  const channel = findChannel(channels, chatJid);
-  if (!channel) {
-    logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
-    return true;
-  }
-
-  const isMainGroup = group.isMain === true;
-
-  const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
-  const missedMessages = getMessagesSince(
-    chatJid,
-    sinceTimestamp,
-    ASSISTANT_NAME,
-  );
-
-  if (missedMessages.length === 0) return true;
-
-  // --- Session command interception (before trigger check) ---
-  const cmdResult = await handleSessionCommand({
-    missedMessages,
-    isMainGroup,
-    groupName: group.name,
-    triggerPattern: TRIGGER_PATTERN,
-    timezone: TIMEZONE,
-    deps: {
-      sendMessage: (text) => channel.sendMessage(chatJid, text),
-      setTyping: (typing) =>
-        channel.setTyping?.(chatJid, typing) ?? Promise.resolve(),
-      runAgent: (prompt, onOutput) =>
-        runAgent(group, prompt, chatJid, [], onOutput),
-      closeStdin: () => queue.closeStdin(chatJid),
-      advanceCursor: (ts) => {
-        lastAgentTimestamp[chatJid] = ts;
-        saveState();
-      },
-      formatMessages,
-      canSenderInteract: (msg) => {
-        const hasTrigger = TRIGGER_PATTERN.test(msg.content.trim());
-        const reqTrigger = !isMainGroup && group.requiresTrigger !== false;
-        return (
-          isMainGroup ||
-          !reqTrigger ||
-          (hasTrigger &&
-            (msg.is_from_me ||
-              isTriggerAllowed(chatJid, msg.sender, loadSenderAllowlist())))
-        );
-      },
-    },
-  });
-  if (cmdResult.handled) return cmdResult.success;
-  // --- End session command interception ---
-
-  // For non-main groups, check if trigger is required and present
-  if (!isMainGroup && group.requiresTrigger !== false) {
-    const allowlistCfg = loadSenderAllowlist();
-    const hasTrigger = missedMessages.some(
-      (m) =>
-        TRIGGER_PATTERN.test(m.content.trim()) &&
-        (m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
-    );
-    if (!hasTrigger) {
-      return true;
-    }
-  }
-
-  const prompt = formatMessages(missedMessages, TIMEZONE);
-  const imageAttachments = parseImageReferences(missedMessages);
-
-  // Advance cursor so the piping path in startMessageLoop won't re-fetch
-  // these messages. Save the old cursor so we can roll back on error.
-  const previousCursor = lastAgentTimestamp[chatJid] || '';
-  lastAgentTimestamp[chatJid] =
-    missedMessages[missedMessages.length - 1].timestamp;
-  saveState();
-
-  logger.info(
-    { group: group.name, messageCount: missedMessages.length },
-    'Processing messages',
-  );
-
-  // Track idle timer for closing stdin when agent is idle
-  let idleTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const resetIdleTimer = () => {
-    if (idleTimer) clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => {
-      logger.debug(
-        { group: group.name },
-        'Idle timeout, closing container stdin',
-      );
-      queue.closeStdin(chatJid);
-    }, IDLE_TIMEOUT);
-  };
-
-  await channel.setTyping?.(chatJid, true);
-  let hadError = false;
-  let outputSentToUser = false;
-
-  const output = await runAgent(
-    group,
-    prompt,
-    chatJid,
-    imageAttachments,
-    async (result) => {
-      // Streaming output callback — called for each agent result
-      if (result.result) {
-        const raw =
-          typeof result.result === 'string'
-            ? result.result
-            : JSON.stringify(result.result);
-        // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-        logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
-        if (text) {
-          await channel.sendMessage(chatJid, text);
-          outputSentToUser = true;
-        }
-        // Only reset idle timer on actual results, not session-update markers (result: null)
-        resetIdleTimer();
-      }
-
-      if (result.status === 'success') {
-        queue.notifyIdle(chatJid);
-      }
-
-      if (result.status === 'error') {
-        hadError = true;
-      }
-    },
-  );
-
-  await channel.setTyping?.(chatJid, false);
-  if (idleTimer) clearTimeout(idleTimer);
-
-  if (output === 'error' || hadError) {
-    // If we already sent output to the user, don't roll back the cursor —
-    // the user got their response and re-processing would send duplicates.
-    if (outputSentToUser) {
-      logger.warn(
-        { group: group.name },
-        'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
-      );
-      return true;
-    }
-    // Roll back cursor so retries can re-process these messages
-    lastAgentTimestamp[chatJid] = previousCursor;
-    saveState();
-    logger.warn(
-      { group: group.name },
-      'Agent error, rolled back message cursor for retry',
-    );
-    return false;
-  }
-
-  return true;
-}
-
-async function runAgent(
-  group: RegisteredGroup,
-  prompt: string,
-  chatJid: string,
-  imageAttachments: Array<{ relativePath: string; mediaType: string }>,
-  onOutput?: (output: ContainerOutput) => Promise<void>,
-): Promise<'success' | 'error'> {
-  const isMain = group.isMain === true;
-  const sessionId = sessions[group.folder];
-
-  // Update tasks snapshot for container to read (filtered by group)
-  const tasks = getAllTasks();
-  writeTasksSnapshot(
-    group.folder,
-    isMain,
-    tasks.map((t) => ({
-      id: t.id,
-      groupFolder: t.group_folder,
-      prompt: t.prompt,
-      schedule_type: t.schedule_type,
-      schedule_value: t.schedule_value,
-      status: t.status,
-      next_run: t.next_run,
-    })),
-  );
-
-  // Update available groups snapshot (main group only can see all groups)
-  const availableGroups = getAvailableGroups();
-  writeGroupsSnapshot(
-    group.folder,
-    isMain,
-    availableGroups,
-    new Set(Object.keys(registeredGroups)),
-  );
-
-  // Wrap onOutput to track session ID from streamed results
-  const wrappedOnOutput = onOutput
-    ? async (output: ContainerOutput) => {
-        if (output.newSessionId && output.status !== 'error') {
-          sessions[group.folder] = output.newSessionId;
-          setSession(group.folder, output.newSessionId);
-        }
-        await onOutput(output);
-      }
-    : undefined;
-
-  try {
-    const output = await runContainerAgent(
-      group,
-      {
-        prompt,
-        sessionId,
-        groupFolder: group.folder,
-        chatJid,
-        isMain,
-        assistantName: ASSISTANT_NAME,
-        ...(imageAttachments.length > 0 && { imageAttachments }),
-      },
-      (proc, containerName) =>
-        queue.registerProcess(chatJid, proc, containerName, group.folder),
-      wrappedOnOutput,
-    );
-
-    if (output.newSessionId && output.status !== 'error') {
-      sessions[group.folder] = output.newSessionId;
-      setSession(group.folder, output.newSessionId);
-    }
-
-    if (output.status === 'error') {
-      logger.error(
-        { group: group.name, error: output.error },
-        'Container agent error',
-      );
-      return 'error';
-    }
-
-    return 'success';
-  } catch (err) {
-    logger.error({ group: group.name, err }, 'Agent error');
-    return 'error';
-  }
-}
-
-async function startMessageLoop(): Promise<void> {
-  if (messageLoopRunning) {
-    logger.debug('Message loop already running, skipping duplicate start');
-    return;
-  }
-  messageLoopRunning = true;
-
-  logger.info(`Deus running (trigger: @${ASSISTANT_NAME})`);
-
-  while (true) {
-    try {
-      const jids = Object.keys(registeredGroups);
-      const { messages, newTimestamp } = getNewMessages(
-        jids,
-        lastTimestamp,
-        ASSISTANT_NAME,
-      );
-
-      if (messages.length > 0) {
-        logger.info({ count: messages.length }, 'New messages');
-
-        // Advance the "seen" cursor for all messages immediately
-        lastTimestamp = newTimestamp;
-        saveState();
-
-        // Deduplicate by group
-        const messagesByGroup = new Map<string, NewMessage[]>();
-        for (const msg of messages) {
-          const existing = messagesByGroup.get(msg.chat_jid);
-          if (existing) {
-            existing.push(msg);
-          } else {
-            messagesByGroup.set(msg.chat_jid, [msg]);
-          }
-        }
-
-        for (const [chatJid, groupMessages] of messagesByGroup) {
-          const group = registeredGroups[chatJid];
-          if (!group) continue;
-
-          const channel = findChannel(channels, chatJid);
-          if (!channel) {
-            logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
-            continue;
-          }
-
-          const isMainGroup = group.isMain === true;
-
-          // --- Session command interception (message loop) ---
-          // Scan ALL messages in the batch for a session command.
-          const loopCmdMsg = groupMessages.find(
-            (m) => extractSessionCommand(m.content, TRIGGER_PATTERN) !== null,
-          );
-
-          if (loopCmdMsg) {
-            // Only close active container if the sender is authorized — otherwise an
-            // untrusted user could kill in-flight work by sending /compact (DoS).
-            // closeStdin no-ops internally when no container is active.
-            if (
-              isSessionCommandAllowed(
-                isMainGroup,
-                loopCmdMsg.is_from_me === true,
-              )
-            ) {
-              queue.closeStdin(chatJid);
-            }
-            // Enqueue so processGroupMessages handles auth + cursor advancement.
-            // Don't pipe via IPC — slash commands need a fresh container with
-            // string prompt (not MessageStream) for SDK recognition.
-            queue.enqueueMessageCheck(chatJid);
-            continue;
-          }
-          // --- End session command interception ---
-
-          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
-
-          // For non-main groups, only act on trigger messages.
-          // Non-trigger messages accumulate in DB and get pulled as
-          // context when a trigger eventually arrives.
-          if (needsTrigger) {
-            const allowlistCfg = loadSenderAllowlist();
-            const hasTrigger = groupMessages.some(
-              (m) =>
-                TRIGGER_PATTERN.test(m.content.trim()) &&
-                (m.is_from_me ||
-                  isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
-            );
-            if (!hasTrigger) continue;
-          }
-
-          // Pull all messages since lastAgentTimestamp so non-trigger
-          // context that accumulated between triggers is included.
-          const allPending = getMessagesSince(
-            chatJid,
-            lastAgentTimestamp[chatJid] || '',
-            ASSISTANT_NAME,
-          );
-          const messagesToSend =
-            allPending.length > 0 ? allPending : groupMessages;
-          const formatted = formatMessages(messagesToSend, TIMEZONE);
-
-          if (queue.sendMessage(chatJid, formatted)) {
-            logger.debug(
-              { chatJid, count: messagesToSend.length },
-              'Piped messages to active container',
-            );
-            lastAgentTimestamp[chatJid] =
-              messagesToSend[messagesToSend.length - 1].timestamp;
-            saveState();
-            // Show typing indicator while the container processes the piped message
-            channel
-              .setTyping?.(chatJid, true)
-              ?.catch((err) =>
-                logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
-              );
-          } else {
-            // No active container — enqueue for a new one
-            queue.enqueueMessageCheck(chatJid);
-          }
-        }
-      }
-    } catch (err) {
-      logger.error({ err }, 'Error in message loop');
-    }
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
-  }
-}
-
-/**
- * Startup recovery: check for unprocessed messages in registered groups.
- * Handles crash between advancing lastTimestamp and processing messages.
- */
-function recoverPendingMessages(): void {
-  for (const [chatJid, group] of Object.entries(registeredGroups)) {
-    const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
-    const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
-    if (pending.length > 0) {
-      logger.info(
-        { group: group.name, pendingCount: pending.length },
-        'Recovery: found unprocessed messages',
-      );
-      queue.enqueueMessageCheck(chatJid);
-    }
-  }
-}
-
-function ensureContainerSystemRunning(): void {
-  ensureContainerRuntimeRunning();
-  cleanupOrphans();
-}
+export { getAvailableGroups } from './router-state.js';
 
 async function main(): Promise<void> {
-  ensureContainerSystemRunning();
+  ensureContainerRuntimeRunning();
+  cleanupOrphans();
 
   // Validate prerequisites before heavy initialization.
   const startupReport = runStartupChecks();
@@ -562,7 +56,9 @@ async function main(): Promise<void> {
 
   initDatabase();
   logger.info('Database initialized');
-  loadState();
+
+  const state = new RouterState();
+  state.load();
   restoreRemoteControl();
 
   // Start credential proxy (containers route API calls through this)
@@ -570,6 +66,9 @@ async function main(): Promise<void> {
     CREDENTIAL_PROXY_PORT,
     PROXY_BIND_HOST,
   );
+
+  const channels: Channel[] = [];
+  const queue = new GroupQueue();
 
   // Graceful shutdown handlers
   const shutdown = async (signal: string) => {
@@ -582,7 +81,6 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 
-  // Debug: log any unexpected exits
   process.on('exit', (code) => {
     logger.info({ code }, 'Process exiting');
   });
@@ -600,7 +98,7 @@ async function main(): Promise<void> {
     chatJid: string,
     msg: NewMessage,
   ): Promise<void> {
-    const group = registeredGroups[chatJid];
+    const group = state.registeredGroups[chatJid];
     if (!group?.isMain) {
       logger.warn(
         { chatJid, sender: msg.sender },
@@ -657,7 +155,7 @@ async function main(): Promise<void> {
       }
 
       // Sender allowlist drop mode: discard messages from denied senders before storing
-      if (!msg.is_from_me && !msg.is_bot_message && registeredGroups[chatJid]) {
+      if (!msg.is_from_me && !msg.is_bot_message && state.registeredGroups[chatJid]) {
         const cfg = loadSenderAllowlist();
         if (
           shouldDropMessage(chatJid, cfg) &&
@@ -672,6 +170,7 @@ async function main(): Promise<void> {
           return;
         }
       }
+
       // Truncate oversized messages to prevent abuse / memory exhaustion
       if (msg.content.length > MAX_MESSAGE_LENGTH) {
         logger.warn(
@@ -696,7 +195,7 @@ async function main(): Promise<void> {
       channel?: string,
       isGroup?: boolean,
     ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
-    registeredGroups: () => registeredGroups,
+    registeredGroups: () => state.registeredGroups,
   };
 
   // Create and connect all registered channels.
@@ -722,10 +221,12 @@ async function main(): Promise<void> {
     );
   }
 
+  const orchestrator = createMessageOrchestrator({ state, queue, channels });
+
   // Start subsystems (independently of connection handler)
   startSchedulerLoop({
-    registeredGroups: () => registeredGroups,
-    getSessions: () => sessions,
+    registeredGroups: () => state.registeredGroups,
+    getSessions: () => state.sessions,
     queue,
     onProcess: (groupJid, proc, containerName, groupFolder) =>
       queue.registerProcess(groupJid, proc, containerName, groupFolder),
@@ -739,14 +240,15 @@ async function main(): Promise<void> {
       if (text) await channel.sendMessage(jid, text);
     },
   });
+
   startIpcWatcher({
     sendMessage: (jid, text) => {
       const channel = findChannel(channels, jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       return channel.sendMessage(jid, text);
     },
-    registeredGroups: () => registeredGroups,
-    registerGroup,
+    registeredGroups: () => state.registeredGroups,
+    registerGroup: (jid, group) => state.registerGroup(jid, group),
     syncGroups: async (force: boolean) => {
       await Promise.all(
         channels
@@ -754,7 +256,7 @@ async function main(): Promise<void> {
           .map((ch) => ch.syncGroups!(force)),
       );
     },
-    getAvailableGroups,
+    getAvailableGroups: () => getAvailableGroups(state.registeredGroups),
     writeGroupsSnapshot: (gf, im, ag, rj) =>
       writeGroupsSnapshot(gf, im, ag, rj),
     onTasksChanged: () => {
@@ -768,14 +270,15 @@ async function main(): Promise<void> {
         status: t.status,
         next_run: t.next_run,
       }));
-      for (const group of Object.values(registeredGroups)) {
+      for (const group of Object.values(state.registeredGroups)) {
         writeTasksSnapshot(group.folder, group.isMain === true, taskRows);
       }
     },
   });
-  queue.setProcessMessagesFn(processGroupMessages);
-  recoverPendingMessages();
-  startMessageLoop().catch((err) => {
+
+  queue.setProcessMessagesFn(orchestrator.processGroupMessages);
+  orchestrator.recoverPendingMessages();
+  orchestrator.startMessageLoop().catch((err) => {
     logger.fatal({ err }, 'Message loop crashed unexpectedly');
     process.exit(1);
   });

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -1,0 +1,463 @@
+/**
+ * Message orchestration — the core processing loop for Deus.
+ *
+ * Owns: polling for new messages, trigger detection, cursor management,
+ * session command interception, agent invocation, and startup recovery.
+ *
+ * Depends on RouterState for mutable state and GroupQueue for container
+ * lifecycle. All other dependencies are imported directly from stable modules.
+ */
+
+import {
+  ASSISTANT_NAME,
+  IDLE_TIMEOUT,
+  POLL_INTERVAL,
+  TIMEZONE,
+  TRIGGER_PATTERN,
+} from './config.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import {
+  getAllTasks,
+  getMessagesSince,
+  getNewMessages,
+  setSession,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { parseImageReferences } from './image.js';
+import { logger } from './logger.js';
+import { findChannel, formatMessages } from './router.js';
+import { RouterState, getAvailableGroups } from './router-state.js';
+import {
+  isTriggerAllowed,
+  loadSenderAllowlist,
+} from './sender-allowlist.js';
+import {
+  extractSessionCommand,
+  handleSessionCommand,
+  isSessionCommandAllowed,
+} from './session-commands.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
+
+export interface OrchestratorDeps {
+  state: RouterState;
+  queue: GroupQueue;
+  /** Mutable array — channels are pushed into it during startup before the
+   *  orchestrator starts processing, so this reference stays valid. */
+  channels: Channel[];
+}
+
+export function createMessageOrchestrator(deps: OrchestratorDeps) {
+  const { state, queue, channels } = deps;
+  let messageLoopRunning = false;
+
+  async function runAgent(
+    group: RegisteredGroup,
+    prompt: string,
+    chatJid: string,
+    imageAttachments: Array<{ relativePath: string; mediaType: string }>,
+    onOutput?: (output: ContainerOutput) => Promise<void>,
+  ): Promise<'success' | 'error'> {
+    const isMain = group.isMain === true;
+    const sessionId = state.getSession(group.folder);
+
+    const tasks = getAllTasks();
+    writeTasksSnapshot(
+      group.folder,
+      isMain,
+      tasks.map((t) => ({
+        id: t.id,
+        groupFolder: t.group_folder,
+        prompt: t.prompt,
+        schedule_type: t.schedule_type,
+        schedule_value: t.schedule_value,
+        status: t.status,
+        next_run: t.next_run,
+      })),
+    );
+
+    const availableGroups = getAvailableGroups(state.registeredGroups);
+    writeGroupsSnapshot(
+      group.folder,
+      isMain,
+      availableGroups,
+      new Set(Object.keys(state.registeredGroups)),
+    );
+
+    const wrappedOnOutput = onOutput
+      ? async (output: ContainerOutput) => {
+          if (output.newSessionId && output.status !== 'error') {
+            state.setSession(group.folder, output.newSessionId);
+            setSession(group.folder, output.newSessionId);
+          }
+          await onOutput(output);
+        }
+      : undefined;
+
+    try {
+      const output = await runContainerAgent(
+        group,
+        {
+          prompt,
+          sessionId,
+          groupFolder: group.folder,
+          chatJid,
+          isMain,
+          assistantName: ASSISTANT_NAME,
+          ...(imageAttachments.length > 0 && { imageAttachments }),
+        },
+        (proc, containerName) =>
+          queue.registerProcess(chatJid, proc, containerName, group.folder),
+        wrappedOnOutput,
+      );
+
+      if (output.newSessionId && output.status !== 'error') {
+        state.setSession(group.folder, output.newSessionId);
+        setSession(group.folder, output.newSessionId);
+      }
+
+      if (output.status === 'error') {
+        logger.error(
+          { group: group.name, error: output.error },
+          'Container agent error',
+        );
+        return 'error';
+      }
+
+      return 'success';
+    } catch (err) {
+      logger.error({ group: group.name, err }, 'Agent error');
+      return 'error';
+    }
+  }
+
+  /**
+   * Process all pending messages for a group.
+   * Called by GroupQueue when it's this group's turn.
+   */
+  async function processGroupMessages(chatJid: string): Promise<boolean> {
+    const group = state.registeredGroups[chatJid];
+    if (!group) return true;
+
+    const channel = findChannel(channels, chatJid);
+    if (!channel) {
+      logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+      return true;
+    }
+
+    const isMainGroup = group.isMain === true;
+    const sinceTimestamp = state.getLastAgentTimestamp(chatJid);
+    const missedMessages = getMessagesSince(
+      chatJid,
+      sinceTimestamp,
+      ASSISTANT_NAME,
+    );
+
+    if (missedMessages.length === 0) return true;
+
+    // --- Session command interception (before trigger check) ---
+    const cmdResult = await handleSessionCommand({
+      missedMessages,
+      isMainGroup,
+      groupName: group.name,
+      triggerPattern: TRIGGER_PATTERN,
+      timezone: TIMEZONE,
+      deps: {
+        sendMessage: (text) => channel.sendMessage(chatJid, text),
+        setTyping: (typing) =>
+          channel.setTyping?.(chatJid, typing) ?? Promise.resolve(),
+        runAgent: (prompt, onOutput) =>
+          runAgent(group, prompt, chatJid, [], onOutput),
+        closeStdin: () => queue.closeStdin(chatJid),
+        advanceCursor: (ts) => {
+          state.setLastAgentTimestamp(chatJid, ts);
+          state.save();
+        },
+        formatMessages,
+        canSenderInteract: (msg) => {
+          const hasTrigger = TRIGGER_PATTERN.test(msg.content.trim());
+          const reqTrigger = !isMainGroup && group.requiresTrigger !== false;
+          return (
+            isMainGroup ||
+            !reqTrigger ||
+            (hasTrigger &&
+              (msg.is_from_me ||
+                isTriggerAllowed(chatJid, msg.sender, loadSenderAllowlist())))
+          );
+        },
+      },
+    });
+    if (cmdResult.handled) return cmdResult.success;
+    // --- End session command interception ---
+
+    // For non-main groups, check if trigger is required and present
+    if (!isMainGroup && group.requiresTrigger !== false) {
+      const allowlistCfg = loadSenderAllowlist();
+      const hasTrigger = missedMessages.some(
+        (m) =>
+          TRIGGER_PATTERN.test(m.content.trim()) &&
+          (m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
+      );
+      if (!hasTrigger) return true;
+    }
+
+    const prompt = formatMessages(missedMessages, TIMEZONE);
+    const imageAttachments = parseImageReferences(missedMessages);
+
+    // Advance cursor so the piping path in startMessageLoop won't re-fetch
+    // these messages. Save the old cursor so we can roll back on error.
+    const previousCursor = state.getLastAgentTimestamp(chatJid);
+    state.setLastAgentTimestamp(
+      chatJid,
+      missedMessages[missedMessages.length - 1].timestamp,
+    );
+    state.save();
+
+    logger.info(
+      { group: group.name, messageCount: missedMessages.length },
+      'Processing messages',
+    );
+
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+    const resetIdleTimer = () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        logger.debug(
+          { group: group.name },
+          'Idle timeout, closing container stdin',
+        );
+        queue.closeStdin(chatJid);
+      }, IDLE_TIMEOUT);
+    };
+
+    await channel.setTyping?.(chatJid, true);
+    let hadError = false;
+    let outputSentToUser = false;
+
+    const output = await runAgent(
+      group,
+      prompt,
+      chatJid,
+      imageAttachments,
+      async (result) => {
+        if (result.result) {
+          const raw =
+            typeof result.result === 'string'
+              ? result.result
+              : JSON.stringify(result.result);
+          // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+          const text = raw
+            .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+            .trim();
+          logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
+          if (text) {
+            await channel.sendMessage(chatJid, text);
+            outputSentToUser = true;
+          }
+          // Only reset idle timer on actual results, not session-update markers
+          resetIdleTimer();
+        }
+
+        if (result.status === 'success') {
+          queue.notifyIdle(chatJid);
+        }
+
+        if (result.status === 'error') {
+          hadError = true;
+        }
+      },
+    );
+
+    await channel.setTyping?.(chatJid, false);
+    if (idleTimer) clearTimeout(idleTimer);
+
+    if (output === 'error' || hadError) {
+      // If we already sent output to the user, don't roll back the cursor —
+      // the user got their response and re-processing would send duplicates.
+      if (outputSentToUser) {
+        logger.warn(
+          { group: group.name },
+          'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
+        );
+        return true;
+      }
+      // Roll back cursor so retries can re-process these messages
+      state.setLastAgentTimestamp(chatJid, previousCursor);
+      state.save();
+      logger.warn(
+        { group: group.name },
+        'Agent error, rolled back message cursor for retry',
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /** Poll for new messages across all registered groups and route them. */
+  async function startMessageLoop(): Promise<void> {
+    if (messageLoopRunning) {
+      logger.debug('Message loop already running, skipping duplicate start');
+      return;
+    }
+    messageLoopRunning = true;
+
+    logger.info(`Deus running (trigger: @${ASSISTANT_NAME})`);
+
+    while (true) {
+      try {
+        const jids = Object.keys(state.registeredGroups);
+        const { messages, newTimestamp } = getNewMessages(
+          jids,
+          state.lastTimestamp,
+          ASSISTANT_NAME,
+        );
+
+        if (messages.length > 0) {
+          logger.info({ count: messages.length }, 'New messages');
+
+          // Advance the "seen" cursor for all messages immediately
+          state.lastTimestamp = newTimestamp;
+          state.save();
+
+          // Deduplicate by group
+          const messagesByGroup = new Map<string, NewMessage[]>();
+          for (const msg of messages) {
+            const existing = messagesByGroup.get(msg.chat_jid);
+            if (existing) {
+              existing.push(msg);
+            } else {
+              messagesByGroup.set(msg.chat_jid, [msg]);
+            }
+          }
+
+          for (const [chatJid, groupMessages] of messagesByGroup) {
+            const group = state.registeredGroups[chatJid];
+            if (!group) continue;
+
+            const channel = findChannel(channels, chatJid);
+            if (!channel) {
+              logger.warn(
+                { chatJid },
+                'No channel owns JID, skipping messages',
+              );
+              continue;
+            }
+
+            const isMainGroup = group.isMain === true;
+
+            // --- Session command interception (message loop) ---
+            // Scan ALL messages in the batch for a session command.
+            const loopCmdMsg = groupMessages.find(
+              (m) =>
+                extractSessionCommand(m.content, TRIGGER_PATTERN) !== null,
+            );
+
+            if (loopCmdMsg) {
+              // Only close active container if the sender is authorized — otherwise an
+              // untrusted user could kill in-flight work by sending /compact (DoS).
+              if (
+                isSessionCommandAllowed(
+                  isMainGroup,
+                  loopCmdMsg.is_from_me === true,
+                )
+              ) {
+                queue.closeStdin(chatJid);
+              }
+              // Enqueue so processGroupMessages handles auth + cursor advancement.
+              // Don't pipe via IPC — slash commands need a fresh container with
+              // string prompt (not MessageStream) for SDK recognition.
+              queue.enqueueMessageCheck(chatJid);
+              continue;
+            }
+            // --- End session command interception ---
+
+            const needsTrigger =
+              !isMainGroup && group.requiresTrigger !== false;
+
+            // For non-main groups, only act on trigger messages.
+            // Non-trigger messages accumulate in DB and get pulled as
+            // context when a trigger eventually arrives.
+            if (needsTrigger) {
+              const allowlistCfg = loadSenderAllowlist();
+              const hasTrigger = groupMessages.some(
+                (m) =>
+                  TRIGGER_PATTERN.test(m.content.trim()) &&
+                  (m.is_from_me ||
+                    isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
+              );
+              if (!hasTrigger) continue;
+            }
+
+            // Pull all messages since lastAgentTimestamp so non-trigger
+            // context that accumulated between triggers is included.
+            const allPending = getMessagesSince(
+              chatJid,
+              state.getLastAgentTimestamp(chatJid),
+              ASSISTANT_NAME,
+            );
+            const messagesToSend =
+              allPending.length > 0 ? allPending : groupMessages;
+            const formatted = formatMessages(messagesToSend, TIMEZONE);
+
+            if (queue.sendMessage(chatJid, formatted)) {
+              logger.debug(
+                { chatJid, count: messagesToSend.length },
+                'Piped messages to active container',
+              );
+              state.setLastAgentTimestamp(
+                chatJid,
+                messagesToSend[messagesToSend.length - 1].timestamp,
+              );
+              state.save();
+              // Show typing indicator while the container processes the piped message
+              channel
+                .setTyping?.(chatJid, true)
+                ?.catch((err) =>
+                  logger.warn(
+                    { chatJid, err },
+                    'Failed to set typing indicator',
+                  ),
+                );
+            } else {
+              // No active container — enqueue for a new one
+              queue.enqueueMessageCheck(chatJid);
+            }
+          }
+        }
+      } catch (err) {
+        logger.error({ err }, 'Error in message loop');
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+    }
+  }
+
+  /**
+   * Startup recovery: check for unprocessed messages in registered groups.
+   * Handles crash between advancing lastTimestamp and processing messages.
+   */
+  function recoverPendingMessages(): void {
+    for (const [chatJid, group] of Object.entries(state.registeredGroups)) {
+      const sinceTimestamp = state.getLastAgentTimestamp(chatJid);
+      const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+      if (pending.length > 0) {
+        logger.info(
+          { group: group.name, pendingCount: pending.length },
+          'Recovery: found unprocessed messages',
+        );
+        queue.enqueueMessageCheck(chatJid);
+      }
+    }
+  }
+
+  return {
+    processGroupMessages,
+    startMessageLoop,
+    recoverPendingMessages,
+    runAgent,
+  };
+}

--- a/src/router-state.ts
+++ b/src/router-state.ts
@@ -1,0 +1,136 @@
+/**
+ * Mutable router state — the four variables that persist across poll cycles.
+ *
+ * RouterState is the single source of truth for:
+ *   - lastTimestamp        — "seen" cursor for all incoming messages
+ *   - lastAgentTimestamp   — per-group cursor of last message sent to the agent
+ *   - sessions             — per-group Claude Code session IDs
+ *   - registeredGroups     — groups that Deus is configured to handle
+ *
+ * All persistence (DB reads/writes) is centralised here.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import {
+  getAllChats,
+  getAllRegisteredGroups,
+  getAllSessions,
+  getRouterState,
+  setRegisteredGroup,
+  setRouterState,
+} from './db.js';
+import type { AvailableGroup } from './container-runner.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { logger } from './logger.js';
+import { RegisteredGroup } from './types.js';
+
+export class RouterState {
+  private _lastTimestamp = '';
+  private _sessions: Record<string, string> = {};
+  private _registeredGroups: Record<string, RegisteredGroup> = {};
+  private _lastAgentTimestamp: Record<string, string> = {};
+
+  load(): void {
+    this._lastTimestamp = getRouterState('last_timestamp') || '';
+    const agentTs = getRouterState('last_agent_timestamp');
+    try {
+      this._lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
+    } catch {
+      logger.warn('Corrupted last_agent_timestamp in DB, resetting');
+      this._lastAgentTimestamp = {};
+    }
+    this._sessions = getAllSessions();
+    this._registeredGroups = getAllRegisteredGroups();
+    logger.info(
+      { groupCount: Object.keys(this._registeredGroups).length },
+      'State loaded',
+    );
+  }
+
+  save(): void {
+    setRouterState('last_timestamp', this._lastTimestamp);
+    setRouterState(
+      'last_agent_timestamp',
+      JSON.stringify(this._lastAgentTimestamp),
+    );
+  }
+
+  get lastTimestamp(): string {
+    return this._lastTimestamp;
+  }
+
+  set lastTimestamp(ts: string) {
+    this._lastTimestamp = ts;
+  }
+
+  getLastAgentTimestamp(jid: string): string {
+    return this._lastAgentTimestamp[jid] || '';
+  }
+
+  setLastAgentTimestamp(jid: string, ts: string): void {
+    this._lastAgentTimestamp[jid] = ts;
+  }
+
+  get sessions(): Record<string, string> {
+    return this._sessions;
+  }
+
+  getSession(folder: string): string | undefined {
+    return this._sessions[folder];
+  }
+
+  setSession(folder: string, sessionId: string): void {
+    this._sessions[folder] = sessionId;
+  }
+
+  get registeredGroups(): Record<string, RegisteredGroup> {
+    return this._registeredGroups;
+  }
+
+  registerGroup(jid: string, group: RegisteredGroup): void {
+    let groupDir: string;
+    try {
+      groupDir = resolveGroupFolderPath(group.folder);
+    } catch (err) {
+      logger.warn(
+        { jid, folder: group.folder, err },
+        'Rejecting group registration with invalid folder',
+      );
+      return;
+    }
+    this._registeredGroups[jid] = group;
+    setRegisteredGroup(jid, group);
+    fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+    logger.info(
+      { jid, name: group.name, folder: group.folder },
+      'Group registered',
+    );
+  }
+
+  /** @internal — for testing only */
+  _setRegisteredGroups(groups: Record<string, RegisteredGroup>): void {
+    this._registeredGroups = groups;
+  }
+}
+
+/**
+ * Returns all known groups available for registration, ordered by most recent
+ * activity. Pure function — takes registered groups as a parameter so callers
+ * control which state snapshot is used (easier to test).
+ */
+export function getAvailableGroups(
+  registeredGroups: Record<string, RegisteredGroup>,
+): AvailableGroup[] {
+  const chats = getAllChats();
+  const registeredJids = new Set(Object.keys(registeredGroups));
+  return chats
+    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
+    .map((c) => ({
+      jid: c.jid,
+      name: c.name,
+      lastActivity: c.last_message_time,
+      isRegistered: registeredJids.has(c.jid),
+    }));
+}

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { _initTestDatabase, getAllChats, storeChatMetadata } from './db.js';
-import { getAvailableGroups, _setRegisteredGroups } from './index.js';
+import { getAvailableGroups } from './router-state.js';
 
 beforeEach(() => {
   _initTestDatabase();
-  _setRegisteredGroups({});
 });
 
 // --- JID ownership patterns ---
@@ -50,7 +49,7 @@ describe('getAvailableGroups', () => {
       true,
     );
 
-    const groups = getAvailableGroups();
+    const groups = getAvailableGroups({});
     expect(groups).toHaveLength(2);
     expect(groups.map((g) => g.jid)).toContain('group1@g.us');
     expect(groups.map((g) => g.jid)).toContain('group2@g.us');
@@ -67,7 +66,7 @@ describe('getAvailableGroups', () => {
       true,
     );
 
-    const groups = getAvailableGroups();
+    const groups = getAvailableGroups({});
     expect(groups).toHaveLength(1);
     expect(groups[0].jid).toBe('group@g.us');
   });
@@ -88,16 +87,16 @@ describe('getAvailableGroups', () => {
       true,
     );
 
-    _setRegisteredGroups({
+    const registeredGroups = {
       'reg@g.us': {
         name: 'Registered',
         folder: 'registered',
         trigger: '@Deus',
         added_at: '2024-01-01T00:00:00.000Z',
       },
-    });
+    };
 
-    const groups = getAvailableGroups();
+    const groups = getAvailableGroups(registeredGroups);
     const reg = groups.find((g) => g.jid === 'reg@g.us');
     const unreg = groups.find((g) => g.jid === 'unreg@g.us');
 
@@ -128,7 +127,7 @@ describe('getAvailableGroups', () => {
       true,
     );
 
-    const groups = getAvailableGroups();
+    const groups = getAvailableGroups({});
     expect(groups[0].jid).toBe('new@g.us');
     expect(groups[1].jid).toBe('mid@g.us');
     expect(groups[2].jid).toBe('old@g.us');
@@ -158,13 +157,13 @@ describe('getAvailableGroups', () => {
       true,
     );
 
-    const groups = getAvailableGroups();
+    const groups = getAvailableGroups({});
     expect(groups).toHaveLength(1);
     expect(groups[0].jid).toBe('group@g.us');
   });
 
   it('returns empty array when no chats exist', () => {
-    const groups = getAvailableGroups();
+    const groups = getAvailableGroups({});
     expect(groups).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- **`src/router-state.ts`** — `RouterState` class that owns all mutable router state (`lastTimestamp`, `lastAgentTimestamp`, `sessions`, `registeredGroups`) with centralized `load()`/`save()`. `getAvailableGroups` is now a pure function (takes `registeredGroups` as param — no hidden state, easier to test)
- **`src/message-orchestrator.ts`** — `createMessageOrchestrator()` factory that owns `processGroupMessages`, `runAgent`, `startMessageLoop`, `recoverPendingMessages`
- **`src/index.ts`** — thin initialization file (298 lines, down from 795 — 63% reduction)
- **`src/routing.test.ts`** — updated to import from `router-state.ts`; `_setRegisteredGroups` removed (no longer needed since `getAvailableGroups` is pure)

## Impact

- `index.ts` is now a readable startup script, not a god object
- Orchestration logic is in one place and can receive dedicated unit tests
- `RouterState` centralizes all persistence — no scattered `saveState()` calls
- Zero behavior change: all 552 tests pass

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 552/552 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)