### PR TITLE
refactor(cleanup): orchestration tests, container-mounter split, isMain rename, contribution guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,206 @@
+# Contributing to Deus
+
+This guide explains how to add new features to Deus without breaking existing behavior.
+For cross-platform rules, see [CROSS_PLATFORM.md](CROSS_PLATFORM.md).
+For architecture decisions, see [decisions/INDEX.md](decisions/INDEX.md).
+
+---
+
+## How to add a new messaging channel
+
+A channel is a source of inbound messages and a sink for outbound responses (WhatsApp, Telegram, Slack, etc.).
+
+**Files involved:**
+
+| File | Purpose |
+|------|---------|
+| `src/channels/<name>.ts` | Channel implementation |
+| `src/channels/index.ts` | Self-registration barrel |
+| `src/channels/<name>.test.ts` | Unit tests |
+
+**Steps:**
+
+1. Implement the `Channel` interface from `src/types.ts`:
+
+```typescript
+// src/channels/myplatform.ts
+import { registerChannel } from './registry.js';
+import type { Channel, ChannelOptions } from './registry.js';
+
+function createMyPlatformChannel(opts: ChannelOptions): Channel | null {
+  const token = process.env.MYPLATFORM_BOT_TOKEN;
+  if (!token) return null; // credentials missing → skip silently
+
+  return {
+    name: 'myplatform',
+    async connect() { /* authenticate, register webhook/polling */ },
+    async disconnect() { /* clean up */ },
+    isConnected() { return /* ... */; },
+    ownsJid(jid) { return jid.startsWith('mp:'); }, // unique JID prefix
+    async sendMessage(jid, text) { /* send via platform API */ },
+    // Optional:
+    async setTyping(jid, isTyping) { /* ... */ },
+    async syncGroups(force) { /* ... */ },
+  };
+}
+
+registerChannel('myplatform', createMyPlatformChannel);
+```
+
+2. Add a barrel import in `src/channels/index.ts`:
+
+```typescript
+import './myplatform.js';
+```
+
+3. On inbound messages, call `opts.onMessage(jid, msg)` with a `NewMessage` object.
+   Use a JID format unique to your platform (e.g., `mp:<chat_id>`).
+
+4. Add credentials to `.env.example` with a comment explaining where to get them.
+
+5. Add a setup skill at `.claude/skills/add-myplatform/SKILL.md` documenting the auth flow.
+
+---
+
+## How to add a new session command
+
+Session commands are slash commands that users send from a messaging channel to control the agent (e.g., `/compact`, `/reset`, `/help`). They are intercepted before the agent runs.
+
+**File:** `src/session-commands.ts`
+
+**Steps:**
+
+1. Find the `handleSessionCommand` function. Add your command to the `switch` or `if` chain:
+
+```typescript
+// In session-commands.ts, inside handleSessionCommand:
+if (command === '/mycommand') {
+  await deps.sendMessage('Processing...');
+  // do the thing
+  await deps.advanceCursor(cmdMsg.timestamp);
+  return { handled: true, success: true };
+}
+```
+
+2. Constraints:
+   - Always call `deps.advanceCursor(cmdMsg.timestamp)` when the command succeeds, so the DB cursor advances past this message.
+   - Return `{ handled: true, success: false }` if the command fails and the message should be retried.
+   - If the command needs to run the agent, use `deps.runAgent(prompt, onOutput)` — do not call `runContainerAgent` directly.
+   - Authorization: commands from non-control-group senders are already blocked by `isSessionCommandAllowed` before `handleSessionCommand` is called.
+
+3. Add tests in `src/session-commands.test.ts`.
+
+---
+
+## How to add a new IPC message type
+
+IPC messages are JSON files that the container agent writes to `/workspace/ipc/messages/` to request host-side actions (register a group, schedule a task, send a message, etc.).
+
+**File:** `src/ipc.ts`
+
+**Steps:**
+
+1. Add a new type to the discriminated union in `ipc.ts`:
+
+```typescript
+// In the IpcMessage union:
+| { type: 'my_action'; param1: string; param2?: number }
+```
+
+2. Add a handler in the `processIpcMessage` function:
+
+```typescript
+case 'my_action': {
+  // validate required fields
+  if (!msg.param1) {
+    logger.warn('my_action: missing param1');
+    return;
+  }
+  // do the action
+  break;
+}
+```
+
+3. Update the container-side type definitions in `container/agent-runner/src/ipc-types.ts` (kept in sync manually — see the SYNC-REQUIRED comment at the top of that file).
+
+4. Add tests in `src/ipc.integration.test.ts`.
+
+---
+
+## How to add a new startup check
+
+Startup checks run before the service accepts messages. They validate prerequisites and print warnings or fatals.
+
+**File:** `src/startup-gate.ts`
+
+**Steps:**
+
+1. Implement the check function in `src/checks.ts` if it needs system inspection (credentials, files, processes). Return a typed result.
+
+2. Register the check at the bottom of `src/startup-gate.ts`:
+
+```typescript
+registerStartupCheck({
+  name: 'My check',
+  level: 'warn',        // 'fatal' blocks startup; 'warn' allows degraded startup; 'suggest' is informational
+  run: () => ({
+    name: 'My check',
+    level: 'warn',
+    ok: myCheckFunction(),
+    hint: 'What to do if this fails.',
+  }),
+});
+```
+
+3. Add tests in `src/startup-gate.test.ts`.
+
+**Before changing `startup-gate.ts` or `checks.ts`:** read `docs/decisions/INDEX.md` — there are non-obvious constraints documented there.
+
+---
+
+## Architecture map
+
+```
+index.ts            — thin startup: DB init, channel connect, subsystem start
+message-orchestrator.ts — poll loop, trigger detection, cursor management, agent dispatch
+router-state.ts     — mutable router state (lastTimestamp, sessions, registeredGroups)
+container-mounter.ts — volume mount assembly (security-critical, tested independently)
+container-runner.ts — container spawn, stdout streaming, evolution logging, snapshots
+container-runtime.ts — runtime abstraction (docker/podman binary, host gateway)
+channels/           — messaging channel implementations (WhatsApp, Telegram, ...)
+ipc.ts              — host-side IPC: handles agent → host requests
+session-commands.ts — slash command interception (/compact, /reset, /help, ...)
+startup-gate.ts     — prerequisite checks with check registry
+db.ts               — SQLite persistence (messages, groups, sessions, tasks)
+group-queue.ts      — per-group serialization queue + container lifecycle tracking
+task-scheduler.ts   — cron/interval/once task scheduling loop
+remote-control.ts   — Claude Code remote control session management
+```
+
+### Key invariants
+
+- **`isControlGroup`**: A group with `isControlGroup: true` has no trigger requirement and can see all groups, all tasks, and the project root. There should be exactly one per deployment.
+- **Cursor management**: `lastAgentTimestamp[jid]` tracks the last message sent to the agent. It is advanced before the agent runs and rolled back on error (unless output was already sent). Never advance the cursor without running the agent.
+- **Session IDs**: Each group has an isolated Claude Code session stored in `sessions[folder]`. Session IDs are persisted to DB on every update.
+- **IPC isolation**: Each group's IPC directory (`/workspace/ipc`) is namespaced by `group.folder`. Containers cannot read other groups' IPC files.
+
+---
+
+## Commit and PR conventions
+
+```
+feat(scope): add X        — new capability
+fix(scope): fix Y         — bug fix
+refactor(scope): extract Z — code restructure, no behavior change
+test(scope): add tests for W
+docs(scope): update D
+```
+
+Scope is the module name (e.g., `channels`, `ipc`, `startup-gate`, `container`, `orchestration`).
+
+**Pre-PR checklist:**
+- [ ] `npm run build` passes
+- [ ] `npm test` passes (all 569+ tests)
+- [ ] Cross-platform rules followed (see [CROSS_PLATFORM.md](CROSS_PLATFORM.md))
+- [ ] ADR index consulted for changed modules (see [decisions/INDEX.md](decisions/INDEX.md))
+- [ ] New credentials added to `.env.example` with comments (never in code)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,17 +1,20 @@
 # Development Reference
 
-> **Contributing?** Read [`docs/CROSS_PLATFORM.md`](CROSS_PLATFORM.md) before opening a PR — every change must work on macOS, Linux, and Windows.
+> **Contributing?** Read [`docs/CONTRIBUTING.md`](CONTRIBUTING.md) for how to add channels, commands, and IPC types. Read [`docs/CROSS_PLATFORM.md`](CROSS_PLATFORM.md) before opening a PR — every change must work on macOS, Linux, and Windows.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/index.ts` | Orchestrator: state, message loop, agent invocation |
+| `src/index.ts` | Thin startup: DB init, channel connect, subsystem wiring |
+| `src/message-orchestrator.ts` | Poll loop, trigger detection, cursor management, agent dispatch |
+| `src/router-state.ts` | Mutable router state (timestamps, sessions, registered groups) |
+| `src/container-mounter.ts` | Volume mount assembly (security-critical) |
+| `src/container-runner.ts` | Container spawn, stdout streaming, evolution logging |
 | `src/channels/registry.ts` | Channel registry (self-registration at startup) |
 | `src/ipc.ts` | IPC watcher and task processing |
 | `src/router.ts` | Message formatting and outbound routing |
 | `src/config.ts` | Trigger pattern, paths, intervals |
-| `src/container-runner.ts` | Spawns agent containers with mounts |
 | `src/task-scheduler.ts` | Runs scheduled tasks |
 | `src/db.ts` | SQLite operations |
 | `groups/{name}/CLAUDE.md` | Per-group memory (isolated) |

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -20,7 +20,7 @@ interface RegisterArgs {
   folder: string;
   channel: string;
   requiresTrigger: boolean;
-  isMain: boolean;
+  isControlGroup: boolean;
   assistantName: string;
 }
 
@@ -32,7 +32,7 @@ function parseArgs(args: string[]): RegisterArgs {
     folder: '',
     channel: 'whatsapp', // backward-compat: pre-refactor installs omit --channel
     requiresTrigger: true,
-    isMain: false,
+    isControlGroup: false,
     assistantName: 'Deus',
   };
 
@@ -57,7 +57,7 @@ function parseArgs(args: string[]): RegisterArgs {
         result.requiresTrigger = false;
         break;
       case '--is-main':
-        result.isMain = true;
+        result.isControlGroup = true;
         break;
       case '--assistant-name':
         result.assistantName = args[++i] || 'Deus';
@@ -145,7 +145,7 @@ export async function run(args: string[]): Promise<void> {
     trigger: parsed.trigger,
     added_at: new Date().toISOString(),
     requiresTrigger: parsed.requiresTrigger,
-    isMain: parsed.isMain,
+    isControlGroup: parsed.isControlGroup,
   });
 
   logger.info('Wrote registration to SQLite');

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -1,0 +1,295 @@
+/**
+ * Volume mount assembly for Deus agent containers.
+ *
+ * Builds the list of bind mounts for a container run. This is the
+ * security-critical layer: every host path that enters the container is
+ * decided here, including credential shadowing and TOCTOU defenses.
+ *
+ * Separation rationale: mounting logic is complex, security-sensitive, and
+ * independently testable. Keeping it in a dedicated module makes security
+ * audits and contributor changes easier to reason about.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { DATA_DIR, GROUPS_DIR } from './config.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import { getProjectById } from './db.js';
+import {
+  SENSITIVE_FILE_PATTERNS,
+  SENSITIVE_DIR_PATTERNS,
+} from './project-registry.js';
+import { validateAdditionalMounts } from './mount-security.js';
+import { RegisteredGroup } from './types.js';
+
+export interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+}
+
+export function buildVolumeMounts(
+  group: RegisteredGroup,
+  isControlGroup: boolean,
+): VolumeMount[] {
+  const mounts: VolumeMount[] = [];
+  const projectRoot = process.cwd();
+  const groupDir = resolveGroupFolderPath(group.folder);
+
+  if (isControlGroup) {
+    // Main gets the project root read-only. Writable paths the agent needs
+    // (group folder, IPC, .claude/) are mounted separately below.
+    // Read-only prevents the agent from modifying host application code
+    // (src/, dist/, package.json, etc.) which would bypass the sandbox
+    // entirely on next restart.
+    mounts.push({
+      hostPath: projectRoot,
+      containerPath: '/workspace/project',
+      readonly: true,
+    });
+
+    // Shadow .env so the agent cannot read secrets from the mounted project root.
+    // Credentials are injected by the credential proxy, never exposed to containers.
+    // os.devNull is '/dev/null' on Unix and '\\.\nul' on Windows.
+    const envFile = path.join(projectRoot, '.env');
+    if (fs.existsSync(envFile)) {
+      mounts.push({
+        hostPath: os.devNull,
+        containerPath: '/workspace/project/.env',
+        readonly: true,
+      });
+    }
+
+    // Main also gets its group folder as the working directory
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+  } else {
+    // Other groups only get their own folder
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+
+    // Global memory directory (read-only for non-main)
+    // Only directory mounts are supported, not file mounts
+    const globalDir = path.join(GROUPS_DIR, 'global');
+    if (fs.existsSync(globalDir)) {
+      mounts.push({
+        hostPath: globalDir,
+        containerPath: '/workspace/global',
+        readonly: true,
+      });
+    }
+  }
+
+  // External project mount: when a group has an associated project,
+  // mount it at /workspace/project so the agent works on the external codebase.
+  // Security: project path was validated against mount-allowlist at registration time.
+  // We re-validate the real path hasn't changed (symlink TOCTOU defense) and
+  // shadow sensitive files to prevent credential exfiltration.
+  if (group.projectId) {
+    const project = getProjectById(group.projectId);
+    if (project && fs.existsSync(project.path)) {
+      // TOCTOU defense: re-resolve symlinks at mount time.
+      // The path was validated at registration, but a symlink target
+      // could have been swapped between registration and now.
+      let realProjectPath: string;
+      try {
+        realProjectPath = fs.realpathSync(project.path);
+      } catch {
+        logger.warn(
+          { projectId: group.projectId, path: project.path },
+          'Project path no longer resolvable, skipping mount',
+        );
+        realProjectPath = ''; // Will skip the mount below
+      }
+
+      if (realProjectPath && realProjectPath === project.path) {
+        // Determine effective readonly: project config + non-main override
+        const effectiveReadonly = project.readonly || !isControlGroup;
+
+        mounts.push({
+          hostPath: realProjectPath,
+          containerPath: '/workspace/project',
+          readonly: effectiveReadonly,
+        });
+
+        // Shadow sensitive files to prevent credential leakage.
+        // The container will see /dev/null instead of the real file.
+        for (const pattern of SENSITIVE_FILE_PATTERNS) {
+          const filePath = path.join(realProjectPath, pattern);
+          if (fs.existsSync(filePath)) {
+            mounts.push({
+              hostPath: '/dev/null',
+              containerPath: `/workspace/project/${pattern}`,
+              readonly: true,
+            });
+          }
+        }
+
+        // Shadow sensitive directories
+        for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
+          const dirPath = path.join(realProjectPath, dirPattern);
+          if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+            // Can't shadow a directory with /dev/null — use an empty tmpdir instead.
+            // Create a project-specific empty dir that persists across runs.
+            const shadowDir = path.join(
+              DATA_DIR,
+              'project-shadows',
+              group.projectId!,
+              dirPattern,
+            );
+            fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
+            mounts.push({
+              hostPath: shadowDir,
+              containerPath: `/workspace/project/${dirPattern}`,
+              readonly: true,
+            });
+          }
+        }
+
+        // Security note: symlinks WITHIN the mounted project can escape the
+        // project boundary (e.g., project/data -> /etc/passwd). Docker/Apple
+        // Container bind mounts follow symlinks by default. This is mitigated
+        // by container isolation (the container process can only access
+        // what's mounted) and the mount-allowlist blocking sensitive roots
+        // (.ssh, .gnupg, .aws, etc). For maximum safety, users should:
+        // 1. Only register trusted project directories
+        // 2. Use readonly mode for untrusted projects
+        // 3. Review projects for suspicious symlinks before registering
+
+        logger.info(
+          {
+            group: group.name,
+            projectId: group.projectId,
+            projectName: project.name,
+            readonly: effectiveReadonly,
+          },
+          'Project mounted as primary workspace',
+        );
+      } else if (realProjectPath) {
+        // Symlink target changed since registration — block the mount.
+        // This prevents an attack where someone registers ~/projects/legit,
+        // then replaces it with a symlink to /etc or ~/.ssh before the next run.
+        logger.error(
+          {
+            projectId: group.projectId,
+            registeredPath: project.path,
+            currentRealPath: realProjectPath,
+          },
+          'Project real path changed since registration — mount BLOCKED (possible symlink swap attack)',
+        );
+      }
+    } else if (project) {
+      logger.warn(
+        { projectId: group.projectId, path: project.path },
+        'Associated project path does not exist, skipping mount',
+      );
+    }
+  }
+
+  // Per-group Claude sessions directory (isolated from other groups)
+  // Each group gets their own .claude/ to prevent cross-group session access
+  const groupSessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+  );
+  fs.mkdirSync(groupSessionsDir, { recursive: true });
+  const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  if (!fs.existsSync(settingsFile)) {
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify(
+        {
+          env: {
+            // Enable agent swarms (subagent orchestration)
+            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+            // Load CLAUDE.md from additional mounted directories
+            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+            // Enable Claude's memory feature (persists user preferences between sessions)
+            // https://code.claude.com/docs/en/memory#manage-auto-memory
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+
+  // Sync skills from container/skills/ into each group's .claude/skills/
+  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
+  const skillsDst = path.join(groupSessionsDir, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    for (const skillDir of fs.readdirSync(skillsSrc)) {
+      const srcDir = path.join(skillsSrc, skillDir);
+      if (!fs.statSync(srcDir).isDirectory()) continue;
+      const dstDir = path.join(skillsDst, skillDir);
+      fs.cpSync(srcDir, dstDir, { recursive: true });
+    }
+  }
+  mounts.push({
+    hostPath: groupSessionsDir,
+    containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Per-group IPC namespace: each group gets its own IPC directory
+  // This prevents cross-group privilege escalation via IPC
+  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  mounts.push({
+    hostPath: groupIpcDir,
+    containerPath: '/workspace/ipc',
+    readonly: false,
+  });
+
+  // Copy agent-runner source into a per-group writable location so agents
+  // can customize it (add tools, change behavior) without affecting other
+  // groups. Recompiled on container startup via entrypoint.sh.
+  const agentRunnerSrc = path.join(
+    projectRoot,
+    'container',
+    'agent-runner',
+    'src',
+  );
+  const groupAgentRunnerDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    'agent-runner-src',
+  );
+  if (fs.existsSync(agentRunnerSrc)) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  }
+  mounts.push({
+    hostPath: groupAgentRunnerDir,
+    containerPath: '/app/src',
+    readonly: true,
+  });
+
+  // Additional mounts validated against external allowlist (tamper-proof from containers)
+  if (group.containerConfig?.additionalMounts) {
+    const validatedMounts = validateAdditionalMounts(
+      group.containerConfig.additionalMounts,
+      group.name,
+      isControlGroup,
+    );
+    mounts.push(...validatedMounts);
+  }
+
+  return mounts;
+}

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -137,7 +137,7 @@ const testInput = {
   prompt: 'Hello',
   groupFolder: 'test-group',
   chatJid: 'test@g.us',
-  isMain: false,
+  isControlGroup: false,
 };
 
 function emitOutputMarker(
@@ -329,7 +329,7 @@ function parseMountsFromSpawnArgs(
 // to resolve the promise without waiting for a real container.
 async function runAndCaptureMounts(
   group: RegisteredGroup,
-  isMain: boolean,
+  isControlGroup: boolean,
 ): Promise<
   Array<{ hostPath: string; containerPath: string; readonly: boolean }>
 > {
@@ -349,7 +349,7 @@ async function runAndCaptureMounts(
     prompt: 'test',
     groupFolder: group.folder,
     chatJid: 'test@g.us',
-    isMain,
+    isControlGroup,
   };
 
   await runContainerAgent(group, input, () => {});
@@ -393,7 +393,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
       folder: 'main-group',
       trigger: '@Deus',
       added_at: new Date().toISOString(),
-      isMain: true,
+      isControlGroup: true,
     };
 
     const mounts = await runAndCaptureMounts(group, true);
@@ -412,7 +412,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
       folder: 'main-group',
       trigger: '@Deus',
       added_at: new Date().toISOString(),
-      isMain: true,
+      isControlGroup: true,
     };
 
     const mounts = await runAndCaptureMounts(group, true);
@@ -437,7 +437,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
       folder: 'main-group',
       trigger: '@Deus',
       added_at: new Date().toISOString(),
-      isMain: true,
+      isControlGroup: true,
     };
 
     const mounts = await runAndCaptureMounts(group, true);
@@ -456,7 +456,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
       folder: 'main-group',
       trigger: '@Deus',
       added_at: new Date().toISOString(),
-      isMain: true,
+      isControlGroup: true,
     };
 
     // existsSync returns false by default (set in beforeEach)
@@ -478,7 +478,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
       folder: 'main-group',
       trigger: '@Deus',
       added_at: new Date().toISOString(),
-      isMain: true,
+      isControlGroup: true,
     };
 
     fakeProc = createFakeProcess();
@@ -493,7 +493,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
         prompt: 'test',
         groupFolder: group.folder,
         chatJid: 'x@g.us',
-        isMain: true,
+        isControlGroup: true,
       },
       () => {},
     );
@@ -540,7 +540,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
       folder: 'main-group',
       trigger: '@Deus',
       added_at: new Date().toISOString(),
-      isMain: true,
+      isControlGroup: true,
     };
 
     fakeProc = createFakeProcess();
@@ -555,7 +555,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — main group', () => {
         prompt: 'test',
         groupFolder: group.folder,
         chatJid: 'x@g.us',
-        isMain: true,
+        isControlGroup: true,
       },
       () => {},
     );
@@ -689,7 +689,7 @@ describe.skipIf(onWindows)('buildVolumeMounts — non-main group', () => {
         prompt: 'test',
         groupFolder: group.folder,
         chatJid: 'x@g.us',
-        isMain: false,
+        isControlGroup: false,
       },
       () => {},
     );
@@ -771,7 +771,7 @@ describe.skipIf(onWindows)(
         projectId: 'proj-1',
       };
 
-      // Use isMain: false — non-main groups don't mount process.cwd() at
+      // Use isControlGroup: false — non-main groups don't mount process.cwd() at
       // /workspace/project, so the only /workspace/project entry comes from
       // the external project mount. This keeps the assertion unambiguous.
       const mounts = await runAndCaptureMounts(group, false);
@@ -809,7 +809,7 @@ describe.skipIf(onWindows)(
         projectId: 'proj-symlink',
       };
 
-      // Use isMain: false so we can assert no external project at /workspace/project
+      // Use isControlGroup: false so we can assert no external project at /workspace/project
       const mounts = await runAndCaptureMounts(group, false);
 
       // Mount should be blocked — no /workspace/project with the symlink target
@@ -842,7 +842,7 @@ describe.skipIf(onWindows)(
         projectId: 'proj-missing',
       };
 
-      // Use isMain: false to avoid the main group's process.cwd() mount
+      // Use isControlGroup: false to avoid the main group's process.cwd() mount
       const mounts = await runAndCaptureMounts(group, false);
 
       const projectMount = mounts.find(
@@ -1031,7 +1031,7 @@ describe.skipIf(onWindows)(
           prompt: 'test',
           groupFolder: group.folder,
           chatJid: 'x@g.us',
-          isMain: true,
+          isControlGroup: true,
         },
         () => {},
       );
@@ -1115,7 +1115,7 @@ describe.skipIf(onWindows)(
           prompt: 'test',
           groupFolder: group.folder,
           chatJid: 'x@g.us',
-          isMain: true,
+          isControlGroup: true,
         },
         () => {},
       );

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1,10 +1,11 @@
 /**
  * Container Runner for Deus
  * Spawns agent execution in containers and handles IPC
+ *
+ * Mount assembly lives in container-mounter.ts.
  */
 import { ChildProcess, execFile, spawn } from 'child_process';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 
 import {
@@ -12,8 +13,6 @@ import {
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
   CREDENTIAL_PROXY_PORT,
-  DATA_DIR,
-  GROUPS_DIR,
   IDLE_TIMEOUT,
   TIMEZONE,
 } from './config.js';
@@ -26,16 +25,12 @@ import {
   readonlyMountArgs,
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
-import { validateAdditionalMounts } from './mount-security.js';
-import { getProjectById } from './db.js';
-import {
-  SENSITIVE_FILE_PATTERNS,
-  SENSITIVE_DIR_PATTERNS,
-} from './project-registry.js';
+import { buildVolumeMounts } from './container-mounter.js';
 import { RegisteredGroup } from './types.js';
 import { detectDomains } from './domain-presets.js';
 import { getReflections, logInteraction } from './evolution-client.js';
 import { detectUserSignal } from './user-signal.js';
+import { getProjectById } from './db.js';
 
 // SYNC-REQUIRED: Duplicated in container/agent-runner/src/index.ts.
 // Cannot be shared via import — agent-runner is a separate package inside an isolated container.
@@ -47,7 +42,7 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
-  isMain: boolean;
+  isControlGroup: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
@@ -60,277 +55,8 @@ export interface ContainerOutput {
   error?: string;
 }
 
-interface VolumeMount {
-  hostPath: string;
-  containerPath: string;
-  readonly: boolean;
-}
-
-function buildVolumeMounts(
-  group: RegisteredGroup,
-  isMain: boolean,
-): VolumeMount[] {
-  const mounts: VolumeMount[] = [];
-  const projectRoot = process.cwd();
-  const groupDir = resolveGroupFolderPath(group.folder);
-
-  if (isMain) {
-    // Main gets the project root read-only. Writable paths the agent needs
-    // (group folder, IPC, .claude/) are mounted separately below.
-    // Read-only prevents the agent from modifying host application code
-    // (src/, dist/, package.json, etc.) which would bypass the sandbox
-    // entirely on next restart.
-    mounts.push({
-      hostPath: projectRoot,
-      containerPath: '/workspace/project',
-      readonly: true,
-    });
-
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the credential proxy, never exposed to containers.
-    // os.devNull is '/dev/null' on Unix and '\\.\nul' on Windows.
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
-      mounts.push({
-        hostPath: os.devNull,
-        containerPath: '/workspace/project/.env',
-        readonly: true,
-      });
-    }
-
-    // Main also gets its group folder as the working directory
-    mounts.push({
-      hostPath: groupDir,
-      containerPath: '/workspace/group',
-      readonly: false,
-    });
-  } else {
-    // Other groups only get their own folder
-    mounts.push({
-      hostPath: groupDir,
-      containerPath: '/workspace/group',
-      readonly: false,
-    });
-
-    // Global memory directory (read-only for non-main)
-    // Only directory mounts are supported, not file mounts
-    const globalDir = path.join(GROUPS_DIR, 'global');
-    if (fs.existsSync(globalDir)) {
-      mounts.push({
-        hostPath: globalDir,
-        containerPath: '/workspace/global',
-        readonly: true,
-      });
-    }
-  }
-
-  // External project mount: when a group has an associated project,
-  // mount it at /workspace/project so the agent works on the external codebase.
-  // Security: project path was validated against mount-allowlist at registration time.
-  // We re-validate the real path hasn't changed (symlink TOCTOU defense) and
-  // shadow sensitive files to prevent credential exfiltration.
-  if (group.projectId) {
-    const project = getProjectById(group.projectId);
-    if (project && fs.existsSync(project.path)) {
-      // TOCTOU defense: re-resolve symlinks at mount time.
-      // The path was validated at registration, but a symlink target
-      // could have been swapped between registration and now.
-      let realProjectPath: string;
-      try {
-        realProjectPath = fs.realpathSync(project.path);
-      } catch {
-        logger.warn(
-          { projectId: group.projectId, path: project.path },
-          'Project path no longer resolvable, skipping mount',
-        );
-        realProjectPath = ''; // Will skip the mount below
-      }
-
-      if (realProjectPath && realProjectPath === project.path) {
-        // Determine effective readonly: project config + non-main override
-        const effectiveReadonly = project.readonly || !isMain;
-
-        mounts.push({
-          hostPath: realProjectPath,
-          containerPath: '/workspace/project',
-          readonly: effectiveReadonly,
-        });
-
-        // Shadow sensitive files to prevent credential leakage.
-        // The container will see /dev/null instead of the real file.
-        for (const pattern of SENSITIVE_FILE_PATTERNS) {
-          const filePath = path.join(realProjectPath, pattern);
-          if (fs.existsSync(filePath)) {
-            mounts.push({
-              hostPath: '/dev/null',
-              containerPath: `/workspace/project/${pattern}`,
-              readonly: true,
-            });
-          }
-        }
-
-        // Shadow sensitive directories
-        for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
-          const dirPath = path.join(realProjectPath, dirPattern);
-          if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
-            // Can't shadow a directory with /dev/null — use an empty tmpdir instead.
-            // Create a project-specific empty dir that persists across runs.
-            const shadowDir = path.join(
-              DATA_DIR,
-              'project-shadows',
-              group.projectId!,
-              dirPattern,
-            );
-            fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
-            mounts.push({
-              hostPath: shadowDir,
-              containerPath: `/workspace/project/${dirPattern}`,
-              readonly: true,
-            });
-          }
-        }
-
-        // Security note: symlinks WITHIN the mounted project can escape the
-        // project boundary (e.g., project/data -> /etc/passwd). Docker/Apple
-        // Container bind mounts follow symlinks by default. This is mitigated
-        // by container isolation (the container process can only access
-        // what's mounted) and the mount-allowlist blocking sensitive roots
-        // (.ssh, .gnupg, .aws, etc). For maximum safety, users should:
-        // 1. Only register trusted project directories
-        // 2. Use readonly mode for untrusted projects
-        // 3. Review projects for suspicious symlinks before registering
-
-        logger.info(
-          {
-            group: group.name,
-            projectId: group.projectId,
-            projectName: project.name,
-            readonly: effectiveReadonly,
-          },
-          'Project mounted as primary workspace',
-        );
-      } else if (realProjectPath) {
-        // Symlink target changed since registration — block the mount.
-        // This prevents an attack where someone registers ~/projects/legit,
-        // then replaces it with a symlink to /etc or ~/.ssh before the next run.
-        logger.error(
-          {
-            projectId: group.projectId,
-            registeredPath: project.path,
-            currentRealPath: realProjectPath,
-          },
-          'Project real path changed since registration — mount BLOCKED (possible symlink swap attack)',
-        );
-      }
-    } else if (project) {
-      logger.warn(
-        { projectId: group.projectId, path: project.path },
-        'Associated project path does not exist, skipping mount',
-      );
-    }
-  }
-
-  // Per-group Claude sessions directory (isolated from other groups)
-  // Each group gets their own .claude/ to prevent cross-group session access
-  const groupSessionsDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
-    '.claude',
-  );
-  fs.mkdirSync(groupSessionsDir, { recursive: true });
-  const settingsFile = path.join(groupSessionsDir, 'settings.json');
-  if (!fs.existsSync(settingsFile)) {
-    fs.writeFileSync(
-      settingsFile,
-      JSON.stringify(
-        {
-          env: {
-            // Enable agent swarms (subagent orchestration)
-            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
-            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-            // Load CLAUDE.md from additional mounted directories
-            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
-            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-            // Enable Claude's memory feature (persists user preferences between sessions)
-            // https://code.claude.com/docs/en/memory#manage-auto-memory
-            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-          },
-        },
-        null,
-        2,
-      ) + '\n',
-    );
-  }
-
-  // Sync skills from container/skills/ into each group's .claude/skills/
-  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
-  const skillsDst = path.join(groupSessionsDir, 'skills');
-  if (fs.existsSync(skillsSrc)) {
-    for (const skillDir of fs.readdirSync(skillsSrc)) {
-      const srcDir = path.join(skillsSrc, skillDir);
-      if (!fs.statSync(srcDir).isDirectory()) continue;
-      const dstDir = path.join(skillsDst, skillDir);
-      fs.cpSync(srcDir, dstDir, { recursive: true });
-    }
-  }
-  mounts.push({
-    hostPath: groupSessionsDir,
-    containerPath: '/home/node/.claude',
-    readonly: false,
-  });
-
-  // Per-group IPC namespace: each group gets its own IPC directory
-  // This prevents cross-group privilege escalation via IPC
-  const groupIpcDir = resolveGroupIpcPath(group.folder);
-  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
-  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
-  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
-  mounts.push({
-    hostPath: groupIpcDir,
-    containerPath: '/workspace/ipc',
-    readonly: false,
-  });
-
-  // Copy agent-runner source into a per-group writable location so agents
-  // can customize it (add tools, change behavior) without affecting other
-  // groups. Recompiled on container startup via entrypoint.sh.
-  const agentRunnerSrc = path.join(
-    projectRoot,
-    'container',
-    'agent-runner',
-    'src',
-  );
-  const groupAgentRunnerDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
-    'agent-runner-src',
-  );
-  if (fs.existsSync(agentRunnerSrc)) {
-    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
-  }
-  mounts.push({
-    hostPath: groupAgentRunnerDir,
-    containerPath: '/app/src',
-    readonly: true,
-  });
-
-  // Additional mounts validated against external allowlist (tamper-proof from containers)
-  if (group.containerConfig?.additionalMounts) {
-    const validatedMounts = validateAdditionalMounts(
-      group.containerConfig.additionalMounts,
-      group.name,
-      isMain,
-    );
-    mounts.push(...validatedMounts);
-  }
-
-  return mounts;
-}
-
 function buildContainerArgs(
-  mounts: VolumeMount[],
+  mounts: ReturnType<typeof buildVolumeMounts>,
   containerName: string,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
@@ -424,7 +150,7 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
+  const mounts = buildVolumeMounts(group, input.isControlGroup);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `deus-${safeName}-${Date.now()}`;
   const containerArgs = buildContainerArgs(mounts, containerName);
@@ -447,7 +173,7 @@ export async function runContainerAgent(
       group: group.name,
       containerName,
       mountCount: mounts.length,
-      isMain: input.isMain,
+      isControlGroup: input.isControlGroup,
     },
     'Spawning container agent',
   );
@@ -649,7 +375,7 @@ export async function runContainerAgent(
         `=== Container Run Log ===`,
         `Timestamp: ${new Date().toISOString()}`,
         `Group: ${group.name}`,
-        `IsMain: ${input.isMain}`,
+        `IsControlGroup: ${input.isControlGroup}`,
         `Duration: ${duration}ms`,
         `Exit Code: ${code}`,
         `Stdout Truncated: ${stdoutTruncated}`,
@@ -842,7 +568,7 @@ export async function runContainerAgent(
 
 export function writeTasksSnapshot(
   groupFolder: string,
-  isMain: boolean,
+  isControlGroup: boolean,
   tasks: Array<{
     id: string;
     groupFolder: string;
@@ -858,7 +584,7 @@ export function writeTasksSnapshot(
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   // Main sees all tasks, others only see their own
-  const filteredTasks = isMain
+  const filteredTasks = isControlGroup
     ? tasks
     : tasks.filter((t) => t.groupFolder === groupFolder);
 
@@ -880,7 +606,7 @@ export interface AvailableGroup {
  */
 export function writeGroupsSnapshot(
   groupFolder: string,
-  isMain: boolean,
+  isControlGroup: boolean,
   groups: AvailableGroup[],
   registeredJids: Set<string>,
 ): void {
@@ -888,7 +614,7 @@ export function writeGroupsSnapshot(
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   // Main sees all groups; others see nothing (they can't activate groups)
-  const visibleGroups = isMain ? groups : [];
+  const visibleGroups = isControlGroup ? groups : [];
 
   const groupsFile = path.join(groupIpcDir, 'available_groups.json');
   fs.writeFileSync(

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -449,26 +449,26 @@ describe('message query LIMIT', () => {
   });
 });
 
-// --- RegisteredGroup isMain round-trip ---
+// --- RegisteredGroup isControlGroup round-trip ---
 
-describe('registered group isMain', () => {
-  it('persists isMain=true through set/get round-trip', () => {
+describe('registered group isControlGroup', () => {
+  it('persists isControlGroup=true through set/get round-trip', () => {
     setRegisteredGroup('main@s.whatsapp.net', {
       name: 'Main Chat',
       folder: 'whatsapp_main',
       trigger: '@Deus',
       added_at: '2024-01-01T00:00:00.000Z',
-      isMain: true,
+      isControlGroup: true,
     });
 
     const groups = getAllRegisteredGroups();
     const group = groups['main@s.whatsapp.net'];
     expect(group).toBeDefined();
-    expect(group.isMain).toBe(true);
+    expect(group.isControlGroup).toBe(true);
     expect(group.folder).toBe('whatsapp_main');
   });
 
-  it('omits isMain for non-main groups', () => {
+  it('omits isControlGroup for non-main groups', () => {
     setRegisteredGroup('group@g.us', {
       name: 'Family Chat',
       folder: 'whatsapp_family-chat',
@@ -479,6 +479,6 @@ describe('registered group isMain', () => {
     const groups = getAllRegisteredGroups();
     const group = groups['group@g.us'];
     expect(group).toBeDefined();
-    expect(group.isMain).toBeUndefined();
+    expect(group.isControlGroup).toBeUndefined();
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -607,7 +607,7 @@ export function getRegisteredGroup(
       : undefined,
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-    isMain: row.is_main === 1 ? true : undefined,
+    isControlGroup: row.is_main === 1 ? true : undefined,
     projectId: row.project_id ?? undefined,
   };
 }
@@ -627,7 +627,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.added_at,
     group.containerConfig ? JSON.stringify(group.containerConfig) : null,
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
-    group.isMain ? 1 : 0,
+    group.isControlGroup ? 1 : 0,
     group.projectId ?? null,
   );
 }
@@ -663,7 +663,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
         : undefined,
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-      isMain: row.is_main === 1 ? true : undefined,
+      isControlGroup: row.is_main === 1 ? true : undefined,
       projectId: row.project_id ?? undefined,
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ async function main(): Promise<void> {
     msg: NewMessage,
   ): Promise<void> {
     const group = state.registeredGroups[chatJid];
-    if (!group?.isMain) {
+    if (!group?.isControlGroup) {
       logger.warn(
         { chatJid, sender: msg.sender },
         'Remote control rejected: not main group',
@@ -271,7 +271,7 @@ async function main(): Promise<void> {
         next_run: t.next_run,
       }));
       for (const group of Object.values(state.registeredGroups)) {
-        writeTasksSnapshot(group.folder, group.isMain === true, taskRows);
+        writeTasksSnapshot(group.folder, group.isControlGroup === true, taskRows);
       }
     },
   });

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -17,7 +17,7 @@ const MAIN_GROUP: RegisteredGroup = {
   folder: 'whatsapp_main',
   trigger: 'always',
   added_at: '2024-01-01T00:00:00.000Z',
-  isMain: true,
+  isControlGroup: true,
 };
 
 const OTHER_GROUP: RegisteredGroup = {
@@ -384,18 +384,18 @@ describe('refresh_groups authorization', () => {
 
 // --- IPC message authorization ---
 // Tests the authorization pattern from startIpcWatcher (ipc.ts).
-// The logic: isMain || (targetGroup && targetGroup.folder === sourceGroup)
+// The logic: isControlGroup || (targetGroup && targetGroup.folder === sourceGroup)
 
 describe('IPC message authorization', () => {
   // Replicate the exact check from the IPC watcher
   function isMessageAuthorized(
     sourceGroup: string,
-    isMain: boolean,
+    isControlGroup: boolean,
     targetChatJid: string,
     registeredGroups: Record<string, RegisteredGroup>,
   ): boolean {
     const targetGroup = registeredGroups[targetChatJid];
-    return isMain || (!!targetGroup && targetGroup.folder === sourceGroup);
+    return isControlGroup || (!!targetGroup && targetGroup.folder === sourceGroup);
   }
 
   it('main group can send to any group', () => {

--- a/src/ipc.integration.test.ts
+++ b/src/ipc.integration.test.ts
@@ -68,7 +68,7 @@ const MAIN_GROUP: RegisteredGroup = {
   folder: 'whatsapp_main',
   trigger: 'always',
   added_at: '2024-01-01T00:00:00.000Z',
-  isMain: true,
+  isControlGroup: true,
 };
 
 const OTHER_GROUP: RegisteredGroup = {
@@ -328,11 +328,11 @@ describe('processTaskIpc: authorization', () => {
 describe('IPC authorization logic (replicated from startIpcWatcher)', () => {
   function isMessageAuthorized(
     sourceGroup: string,
-    isMain: boolean,
+    isControlGroup: boolean,
     targetChatJid: string,
   ): boolean {
     const targetGroup = groups[targetChatJid];
-    return isMain || (!!targetGroup && targetGroup.folder === sourceGroup);
+    return isControlGroup || (!!targetGroup && targetGroup.folder === sourceGroup);
   }
 
   it('main group can send to any chat JID', () => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -26,7 +26,7 @@ export interface IpcDeps {
   getAvailableGroups: () => AvailableGroup[];
   writeGroupsSnapshot: (
     groupFolder: string,
-    isMain: boolean,
+    isControlGroup: boolean,
     availableGroups: AvailableGroup[],
     registeredJids: Set<string>,
   ) => void;
@@ -61,14 +61,14 @@ export function startIpcWatcher(deps: IpcDeps): void {
 
     const registeredGroups = deps.registeredGroups();
 
-    // Build folder→isMain lookup from registered groups
+    // Build folder→isControlGroup lookup from registered groups
     const folderIsMain = new Map<string, boolean>();
     for (const group of Object.values(registeredGroups)) {
-      if (group.isMain) folderIsMain.set(group.folder, true);
+      if (group.isControlGroup) folderIsMain.set(group.folder, true);
     }
 
     for (const sourceGroup of groupFolders) {
-      const isMain = folderIsMain.get(sourceGroup) === true;
+      const isControlGroup = folderIsMain.get(sourceGroup) === true;
       const messagesDir = path.join(ipcBaseDir, sourceGroup, 'messages');
       const tasksDir = path.join(ipcBaseDir, sourceGroup, 'tasks');
 
@@ -86,7 +86,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
                 // Authorization: verify this group can send to this chatJid
                 const targetGroup = registeredGroups[data.chatJid];
                 if (
-                  isMain ||
+                  isControlGroup ||
                   (targetGroup && targetGroup.folder === sourceGroup)
                 ) {
                   await deps.sendMessage(data.chatJid, data.text);
@@ -134,7 +134,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               // Pass source group identity to processTaskIpc for authorization
-              await processTaskIpc(data, sourceGroup, isMain, deps);
+              await processTaskIpc(data, sourceGroup, isControlGroup, deps);
               fs.unlinkSync(filePath);
             } catch (err) {
               logger.error(
@@ -186,7 +186,7 @@ export async function processTaskIpc(
     readonly?: boolean;
   },
   sourceGroup: string, // Verified identity from IPC directory
-  isMain: boolean, // Verified from directory path
+  isControlGroup: boolean, // Verified from directory path
   deps: IpcDeps,
 ): Promise<void> {
   const registeredGroups = deps.registeredGroups();
@@ -214,7 +214,7 @@ export async function processTaskIpc(
         const targetFolder = targetGroupEntry.folder;
 
         // Authorization: non-main groups can only schedule for themselves
-        if (!isMain && targetFolder !== sourceGroup) {
+        if (!isControlGroup && targetFolder !== sourceGroup) {
           logger.warn(
             { sourceGroup, targetFolder },
             'Unauthorized schedule_task attempt blocked',
@@ -290,7 +290,7 @@ export async function processTaskIpc(
     case 'pause_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
+        if (task && (isControlGroup || task.group_folder === sourceGroup)) {
           updateTask(data.taskId, { status: 'paused' });
           logger.info(
             { taskId: data.taskId, sourceGroup },
@@ -309,7 +309,7 @@ export async function processTaskIpc(
     case 'resume_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
+        if (task && (isControlGroup || task.group_folder === sourceGroup)) {
           updateTask(data.taskId, { status: 'active' });
           logger.info(
             { taskId: data.taskId, sourceGroup },
@@ -328,7 +328,7 @@ export async function processTaskIpc(
     case 'cancel_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
+        if (task && (isControlGroup || task.group_folder === sourceGroup)) {
           deleteTask(data.taskId);
           logger.info(
             { taskId: data.taskId, sourceGroup },
@@ -354,7 +354,7 @@ export async function processTaskIpc(
           );
           break;
         }
-        if (!isMain && task.group_folder !== sourceGroup) {
+        if (!isControlGroup && task.group_folder !== sourceGroup) {
           logger.warn(
             { taskId: data.taskId, sourceGroup },
             'Unauthorized task update attempt',
@@ -411,7 +411,7 @@ export async function processTaskIpc(
 
     case 'refresh_groups':
       // Only main group can request a refresh
-      if (isMain) {
+      if (isControlGroup) {
         logger.info(
           { sourceGroup },
           'Group metadata refresh requested via IPC',
@@ -435,7 +435,7 @@ export async function processTaskIpc(
 
     case 'register_group':
       // Only main group can register new groups
-      if (!isMain) {
+      if (!isControlGroup) {
         logger.warn(
           { sourceGroup },
           'Unauthorized register_group attempt blocked',
@@ -450,7 +450,7 @@ export async function processTaskIpc(
           );
           break;
         }
-        // Defense in depth: agent cannot set isMain via IPC
+        // Defense in depth: agent cannot set isControlGroup via IPC
         deps.registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
@@ -471,7 +471,7 @@ export async function processTaskIpc(
       // Main-only: register an external project for container mounting.
       // The agent provides a name and host path; we validate against the
       // mount allowlist and detect the project type.
-      if (!isMain) {
+      if (!isControlGroup) {
         logger.warn(
           { sourceGroup },
           'Unauthorized register_project attempt blocked',
@@ -503,7 +503,7 @@ export async function processTaskIpc(
 
     case 'associate_project':
       // Main-only: link a project to a group so its container mounts the project.
-      if (!isMain) {
+      if (!isControlGroup) {
         logger.warn(
           { sourceGroup },
           'Unauthorized associate_project attempt blocked',
@@ -533,7 +533,7 @@ export async function processTaskIpc(
 
     case 'dissociate_project':
       // Main-only: remove project association from a group.
-      if (!isMain) {
+      if (!isControlGroup) {
         logger.warn(
           { sourceGroup },
           'Unauthorized dissociate_project attempt blocked',
@@ -551,7 +551,7 @@ export async function processTaskIpc(
 
     case 'delete_project':
       // Main-only: unregister a project (dissociates all groups automatically).
-      if (!isMain) {
+      if (!isControlGroup) {
         logger.warn(
           { sourceGroup },
           'Unauthorized delete_project attempt blocked',
@@ -574,7 +574,7 @@ export async function processTaskIpc(
     case 'list_projects':
       // Main-only: list all registered projects.
       // Response written to IPC output for the agent to read.
-      if (!isMain) {
+      if (!isControlGroup) {
         logger.warn(
           { sourceGroup },
           'Unauthorized list_projects attempt blocked',

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -1,0 +1,624 @@
+/**
+ * Unit tests for message-orchestrator.ts
+ *
+ * Tests the core orchestration behaviours:
+ *   - Cursor advancement and rollback on agent error
+ *   - Trigger gating for non-main groups
+ *   - Session command interception
+ *   - Startup recovery (recoverPendingMessages)
+ *   - Message loop routing (pipe vs enqueue)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Module mocks (hoisted) ───────────────────────────────────────────────────
+
+vi.mock('./config.js', () => ({
+  ASSISTANT_NAME: 'Deus',
+  IDLE_TIMEOUT: 30_000,
+  POLL_INTERVAL: 1_000,
+  TIMEZONE: 'UTC',
+  TRIGGER_PATTERN: /^@deus\b/i,
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock('./db.js', () => ({
+  getMessagesSince: vi.fn(() => []),
+  getNewMessages: vi.fn(() => ({ messages: [], newTimestamp: '' })),
+  getAllTasks: vi.fn(() => []),
+  setSession: vi.fn(),
+}));
+
+vi.mock('./container-runner.js', () => ({
+  runContainerAgent: vi.fn(async (_g: unknown, _i: unknown, _op: unknown, onOutput: ((...args: unknown[]) => Promise<void>) | undefined) => {
+    if (onOutput) {
+      await onOutput({ status: 'success', result: 'Agent response', newSessionId: 'sess-1' });
+    }
+    return { status: 'success', result: 'Agent response', newSessionId: 'sess-1' };
+  }),
+  writeTasksSnapshot: vi.fn(),
+  writeGroupsSnapshot: vi.fn(),
+}));
+
+vi.mock('./router.js', () => ({
+  findChannel: vi.fn(),
+  formatMessages: vi.fn(() => 'formatted prompt'),
+}));
+
+vi.mock('./session-commands.js', () => ({
+  handleSessionCommand: vi.fn(async () => ({ handled: false, success: false })),
+  extractSessionCommand: vi.fn(() => null),
+  isSessionCommandAllowed: vi.fn(() => true),
+}));
+
+vi.mock('./sender-allowlist.js', () => ({
+  loadSenderAllowlist: vi.fn(() => ({})),
+  isTriggerAllowed: vi.fn(() => true),
+}));
+
+vi.mock('./image.js', () => ({
+  parseImageReferences: vi.fn(() => []),
+}));
+
+vi.mock('./router-state.js', () => ({
+  getAvailableGroups: vi.fn(() => []),
+}));
+
+vi.mock('./evolution-client.js', () => ({
+  getReflections: vi.fn(async () => ({ block: '', reflectionIds: [] })),
+  logInteraction: vi.fn(),
+}));
+
+vi.mock('./user-signal.js', () => ({
+  detectUserSignal: vi.fn(() => null),
+}));
+
+vi.mock('./domain-presets.js', () => ({
+  detectDomains: vi.fn(() => []),
+}));
+
+vi.mock('./project-registry.js', () => ({
+  SENSITIVE_FILE_PATTERNS: [],
+  SENSITIVE_DIR_PATTERNS: [],
+  getProjectById: vi.fn(() => null),
+}));
+
+vi.mock('./mount-security.js', () => ({
+  validateAdditionalMounts: vi.fn(() => []),
+}));
+
+vi.mock('./group-folder.js', () => ({
+  resolveGroupFolderPath: vi.fn((f: string) => `/tmp/groups/${f}`),
+  resolveGroupIpcPath: vi.fn((f: string) => `/tmp/ipc/${f}`),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => false),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      readdirSync: vi.fn(() => []),
+      statSync: vi.fn(() => ({ isDirectory: () => false })),
+      cpSync: vi.fn(),
+    },
+  };
+});
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { createMessageOrchestrator } from './message-orchestrator.js';
+import { getMessagesSince, getNewMessages } from './db.js';
+import { runContainerAgent } from './container-runner.js';
+import type { ContainerOutput } from './container-runner.js';
+import { findChannel } from './router.js';
+import { handleSessionCommand, extractSessionCommand } from './session-commands.js';
+import type { RegisteredGroup } from './types.js';
+
+const mockGetMessagesSince = vi.mocked(getMessagesSince);
+const mockGetNewMessages = vi.mocked(getNewMessages);
+const mockRunContainerAgent = vi.mocked(runContainerAgent);
+const mockFindChannel = vi.mocked(findChannel);
+const mockHandleSessionCommand = vi.mocked(handleSessionCommand);
+const mockExtractSessionCommand = vi.mocked(extractSessionCommand);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const MAIN_GROUP: RegisteredGroup = {
+  name: 'Main',
+  folder: 'whatsapp_main',
+  trigger: 'always',
+  added_at: '2024-01-01T00:00:00.000Z',
+  isControlGroup: true,
+};
+
+const NON_MAIN_GROUP: RegisteredGroup = {
+  name: 'Support',
+  folder: 'whatsapp_support',
+  trigger: '@Deus',
+  added_at: '2024-01-01T00:00:00.000Z',
+  requiresTrigger: true,
+};
+
+function makeMsg(
+  override: Partial<{
+    id: string;
+    timestamp: string;
+    content: string;
+    sender: string;
+    is_from_me: boolean;
+  }> = {},
+) {
+  return {
+    id: override.id ?? 'msg-1',
+    chat_jid: 'group@g.us',
+    sender: override.sender ?? 'alice@s.whatsapp.net',
+    sender_name: 'Alice',
+    content: override.content ?? 'hello',
+    timestamp: override.timestamp ?? '2024-01-01T00:00:01.000Z',
+    is_from_me: override.is_from_me ?? false,
+    is_bot_message: false,
+  };
+}
+
+/** Minimal RouterState mock. Tracks cursor calls so tests can assert on them. */
+function makeState(group: RegisteredGroup, initialCursor = '') {
+  let cursor = initialCursor;
+  return {
+    registeredGroups: { 'group@g.us': group } as Record<string, RegisteredGroup>,
+    getLastAgentTimestamp: vi.fn(() => cursor),
+    setLastAgentTimestamp: vi.fn((_jid: string, ts: string) => {
+      cursor = ts;
+    }),
+    save: vi.fn(),
+    getSession: vi.fn(() => undefined as string | undefined),
+    setSession: vi.fn(),
+    get lastTimestamp() {
+      return '';
+    },
+    set lastTimestamp(_: string) {},
+    sessions: {} as Record<string, string>,
+  };
+}
+
+/** Minimal GroupQueue mock. */
+function makeQueue() {
+  return {
+    closeStdin: vi.fn(),
+    notifyIdle: vi.fn(),
+    enqueueMessageCheck: vi.fn(),
+    sendMessage: vi.fn(() => false as boolean),
+    registerProcess: vi.fn(),
+  };
+}
+
+/** Minimal Channel mock that owns all JIDs. */
+function makeChannel() {
+  return {
+    ownsJid: vi.fn(() => true),
+    isConnected: vi.fn(() => true),
+    sendMessage: vi.fn(async () => {}),
+    setTyping: vi.fn(async () => {}),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // Restore default behaviours after reset
+  mockGetMessagesSince.mockReturnValue([]);
+  mockGetNewMessages.mockReturnValue({ messages: [], newTimestamp: '' });
+  mockHandleSessionCommand.mockResolvedValue({ handled: false });
+  mockExtractSessionCommand.mockReturnValue(null);
+  mockRunContainerAgent.mockImplementation(
+    async (_g: unknown, _i: unknown, _op: unknown, onOutput: ((output: ContainerOutput) => Promise<void>) | undefined) => {
+      if (onOutput) {
+        await onOutput({ status: 'success', result: 'Agent response', newSessionId: 'sess-1' });
+      }
+      return { status: 'success', result: 'Agent response', newSessionId: 'sess-1' };
+    },
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ── processGroupMessages ─────────────────────────────────────────────────────
+
+describe('processGroupMessages', () => {
+  it('returns true immediately when group is not registered', async () => {
+    const state = makeState(MAIN_GROUP);
+    state.registeredGroups = {}; // JID not in map
+    const queue = makeQueue();
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    expect(mockGetMessagesSince).not.toHaveBeenCalled();
+  });
+
+  it('returns true immediately when no missed messages', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([]);
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    expect(mockRunContainerAgent).not.toHaveBeenCalled();
+  });
+
+  it('advances cursor then rolls back on agent error with no output sent', async () => {
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+    // Agent errors, never calls onOutput
+    mockRunContainerAgent.mockResolvedValue({
+      status: 'error',
+      result: null,
+      error: 'Container crashed',
+    });
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(false);
+    // First advance to ts-1, then roll back to ts-prev
+    expect(state.setLastAgentTimestamp).toHaveBeenNthCalledWith(1, 'group@g.us', 'ts-1');
+    expect(state.setLastAgentTimestamp).toHaveBeenNthCalledWith(2, 'group@g.us', 'ts-prev');
+  });
+
+  it('does NOT roll back cursor when output was already sent to the user', async () => {
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+    // Agent sends output first, then errors
+    mockRunContainerAgent.mockImplementation(
+      async (_g, _i, _op, onOutput) => {
+        if (onOutput) {
+          await onOutput({ status: 'success', result: 'Partial response', newSessionId: undefined });
+        }
+        return { status: 'error', result: null, error: 'crashed after output' };
+      },
+    );
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // success because output was sent
+    // Cursor advanced to ts-1 — no rollback
+    expect(state.setLastAgentTimestamp).toHaveBeenCalledWith('group@g.us', 'ts-1');
+    expect(state.setLastAgentTimestamp).toHaveBeenCalledTimes(1);
+    expect(channel.sendMessage).toHaveBeenCalledWith('group@g.us', 'Partial response');
+  });
+
+  it('skips non-main group when trigger is required but not present', async () => {
+    const state = makeState(NON_MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: 'just a regular message, no trigger' }),
+    ]);
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    expect(mockRunContainerAgent).not.toHaveBeenCalled();
+  });
+
+  it('processes non-main group when trigger message is present', async () => {
+    const state = makeState(NON_MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: '@Deus please help' }),
+    ]);
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    expect(mockRunContainerAgent).toHaveBeenCalled();
+  });
+
+  it('main group processes messages without trigger check', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: 'no trigger here, just a regular message' }),
+    ]);
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    expect(mockRunContainerAgent).toHaveBeenCalled();
+  });
+
+  it('returns session command result without running agent when handled', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ content: '@Deus /compact' })]);
+    mockHandleSessionCommand.mockResolvedValue({ handled: true, success: true });
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    expect(mockRunContainerAgent).not.toHaveBeenCalled();
+  });
+
+  it('sends agent output to the channel', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+    mockRunContainerAgent.mockImplementation(async (_g, _i, _op, onOutput) => {
+      if (onOutput) await onOutput({ status: 'success', result: 'Hello user!', newSessionId: undefined });
+      return { status: 'success', result: 'Hello user!', newSessionId: undefined };
+    });
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    await orchestrator.processGroupMessages('group@g.us');
+    expect(channel.sendMessage).toHaveBeenCalledWith('group@g.us', 'Hello user!');
+  });
+
+  it('strips <internal> blocks before sending to user', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+    mockRunContainerAgent.mockImplementation(async (_g, _i, _op, onOutput) => {
+      if (onOutput) {
+        await onOutput({
+          status: 'success',
+          result: '<internal>thinking...</internal>Visible reply',
+          newSessionId: undefined,
+        });
+      }
+      return { status: 'success', result: null, newSessionId: undefined };
+    });
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    await orchestrator.processGroupMessages('group@g.us');
+    expect(channel.sendMessage).toHaveBeenCalledWith('group@g.us', 'Visible reply');
+  });
+});
+
+// ── recoverPendingMessages ───────────────────────────────────────────────────
+
+describe('recoverPendingMessages', () => {
+  it('enqueues groups that have pending messages', () => {
+    const state = makeState(MAIN_GROUP, 'ts-cursor');
+    // Pending messages exist after the cursor
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-new' })]);
+
+    const queue = makeQueue();
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [],
+    });
+
+    orchestrator.recoverPendingMessages();
+    expect(queue.enqueueMessageCheck).toHaveBeenCalledWith('group@g.us');
+  });
+
+  it('does not enqueue groups with no pending messages', () => {
+    const state = makeState(MAIN_GROUP, 'ts-cursor');
+    mockGetMessagesSince.mockReturnValue([]); // nothing pending
+
+    const queue = makeQueue();
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [],
+    });
+
+    orchestrator.recoverPendingMessages();
+    expect(queue.enqueueMessageCheck).not.toHaveBeenCalled();
+  });
+});
+
+// ── startMessageLoop ─────────────────────────────────────────────────────────
+
+describe('startMessageLoop', () => {
+  it('advances lastTimestamp when new messages arrive', async () => {
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    let lastTs = '';
+    Object.defineProperty(state, 'lastTimestamp', {
+      get: () => lastTs,
+      set: (v) => { lastTs = v; },
+    });
+
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetNewMessages.mockReturnValueOnce({
+      messages: [{ ...makeMsg(), chat_jid: 'group@g.us' }],
+      newTimestamp: 'ts-new',
+    }).mockReturnValue({ messages: [], newTimestamp: '' });
+
+    const queue = makeQueue();
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [channel as any],
+    });
+
+    const loopPromise = orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(lastTs).toBe('ts-new');
+    expect(state.save).toHaveBeenCalled();
+
+    // Cleanup: second invocation should no-op
+    await vi.advanceTimersByTimeAsync(10);
+    loopPromise; // don't await — it's infinite
+  });
+
+  it('pipes message to active container if one exists', async () => {
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetNewMessages.mockReturnValueOnce({
+      messages: [{ ...makeMsg(), chat_jid: 'group@g.us' }],
+      newTimestamp: 'ts-1',
+    }).mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([makeMsg()]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true); // active container exists
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [channel as any],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.sendMessage).toHaveBeenCalled();
+    expect(queue.enqueueMessageCheck).not.toHaveBeenCalled();
+  });
+
+  it('enqueues message check when no active container', async () => {
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetNewMessages.mockReturnValueOnce({
+      messages: [{ ...makeMsg(), chat_jid: 'group@g.us' }],
+      newTimestamp: 'ts-1',
+    }).mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([makeMsg()]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(false); // no active container
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [channel as any],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.enqueueMessageCheck).toHaveBeenCalledWith('group@g.us');
+  });
+
+  it('intercepts session command: closes stdin and enqueues instead of piping', async () => {
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetNewMessages.mockReturnValueOnce({
+      messages: [{ ...makeMsg({ content: '@Deus /compact' }), chat_jid: 'group@g.us' }],
+      newTimestamp: 'ts-1',
+    }).mockReturnValue({ messages: [], newTimestamp: '' });
+    mockExtractSessionCommand.mockReturnValue('/compact' as any);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true);
+
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [channel as any],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.closeStdin).toHaveBeenCalledWith('group@g.us');
+    expect(queue.enqueueMessageCheck).toHaveBeenCalledWith('group@g.us');
+    expect(queue.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not start a second loop if already running', async () => {
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    mockGetNewMessages.mockReturnValue({ messages: [], newTimestamp: '' });
+
+    const queue = makeQueue();
+    const orchestrator = createMessageOrchestrator({
+      state: state as any,
+      queue: queue as any,
+      channels: [],
+    });
+
+    orchestrator.startMessageLoop();
+    orchestrator.startMessageLoop(); // second call should no-op
+
+    await vi.advanceTimersByTimeAsync(10);
+    // getNewMessages called once (from first loop), not twice
+    expect(mockGetNewMessages.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -62,13 +62,13 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
     imageAttachments: Array<{ relativePath: string; mediaType: string }>,
     onOutput?: (output: ContainerOutput) => Promise<void>,
   ): Promise<'success' | 'error'> {
-    const isMain = group.isMain === true;
+    const isControlGroup = group.isControlGroup === true;
     const sessionId = state.getSession(group.folder);
 
     const tasks = getAllTasks();
     writeTasksSnapshot(
       group.folder,
-      isMain,
+      isControlGroup,
       tasks.map((t) => ({
         id: t.id,
         groupFolder: t.group_folder,
@@ -83,7 +83,7 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
     const availableGroups = getAvailableGroups(state.registeredGroups);
     writeGroupsSnapshot(
       group.folder,
-      isMain,
+      isControlGroup,
       availableGroups,
       new Set(Object.keys(state.registeredGroups)),
     );
@@ -106,7 +106,7 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
           sessionId,
           groupFolder: group.folder,
           chatJid,
-          isMain,
+          isControlGroup,
           assistantName: ASSISTANT_NAME,
           ...(imageAttachments.length > 0 && { imageAttachments }),
         },
@@ -149,7 +149,7 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       return true;
     }
 
-    const isMainGroup = group.isMain === true;
+    const isMainGroup = group.isControlGroup === true;
     const sinceTimestamp = state.getLastAgentTimestamp(chatJid);
     const missedMessages = getMessagesSince(
       chatJid,
@@ -348,7 +348,7 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
               continue;
             }
 
-            const isMainGroup = group.isMain === true;
+            const isMainGroup = group.isControlGroup === true;
 
             // --- Session command interception (message loop) ---
             // Scan ALL messages in the batch for a session command.

--- a/src/mount-security.test.ts
+++ b/src/mount-security.test.ts
@@ -234,7 +234,7 @@ describe('validateMount', () => {
     setupAllowlist({ nonMainReadOnly: true });
     const result = validateMount(
       { hostPath: '/home/testuser/projects/myapp', readonly: false },
-      false, // isMain=false
+      false, // isControlGroup=false
     );
     expect(result.allowed).toBe(true);
     expect(result.effectiveReadonly).toBe(true);

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -233,7 +233,7 @@ export interface MountValidationResult {
  */
 export function validateMount(
   mount: AdditionalMount,
-  isMain: boolean,
+  isControlGroup: boolean,
 ): MountValidationResult {
   const allowlist = loadMountAllowlist();
 
@@ -295,7 +295,7 @@ export function validateMount(
   let effectiveReadonly = true; // Default to readonly
 
   if (requestedReadWrite) {
-    if (!isMain && allowlist.nonMainReadOnly) {
+    if (!isControlGroup && allowlist.nonMainReadOnly) {
       // Non-main groups forced to read-only
       effectiveReadonly = true;
       logger.info(
@@ -337,7 +337,7 @@ export function validateMount(
 export function validateAdditionalMounts(
   mounts: AdditionalMount[],
   groupName: string,
-  isMain: boolean,
+  isControlGroup: boolean,
 ): Array<{
   hostPath: string;
   containerPath: string;
@@ -350,7 +350,7 @@ export function validateAdditionalMounts(
   }> = [];
 
   for (const mount of mounts) {
-    const result = validateMount(mount, isMain);
+    const result = validateMount(mount, isControlGroup);
 
     if (result.allowed) {
       validatedMounts.push({

--- a/src/pipeline.integration.test.ts
+++ b/src/pipeline.integration.test.ts
@@ -129,7 +129,7 @@ const MAIN_GROUP: RegisteredGroup = {
   folder: 'whatsapp_main',
   trigger: 'always',
   added_at: '2024-01-01T00:00:00.000Z',
-  isMain: true,
+  isControlGroup: true,
 };
 
 const OTHER_GROUP: RegisteredGroup = {
@@ -300,7 +300,7 @@ describe('runContainerAgent mock: response handling', () => {
         prompt: 'Test prompt',
         groupFolder: 'main',
         chatJid: 'main@g.us',
-        isMain: true,
+        isControlGroup: true,
       },
       () => {},
     );
@@ -329,7 +329,7 @@ describe('runContainerAgent mock: response handling', () => {
     const onOutput = vi.fn(async () => {});
     await runContainerAgent(
       MAIN_GROUP,
-      { prompt: 'Hi', groupFolder: 'main', chatJid: 'main@g.us', isMain: true },
+      { prompt: 'Hi', groupFolder: 'main', chatJid: 'main@g.us', isControlGroup: true },
       () => {},
       onOutput,
     );
@@ -350,7 +350,7 @@ describe('runContainerAgent mock: response handling', () => {
         prompt: 'Test',
         groupFolder: 'main',
         chatJid: 'main@g.us',
-        isMain: true,
+        isControlGroup: true,
       },
       () => {},
     );
@@ -470,7 +470,7 @@ describe('Full pipeline simulation', () => {
         prompt: 'msg content',
         groupFolder: 'main',
         chatJid: 'main@g.us',
-        isMain: true,
+        isControlGroup: true,
       },
       () => {},
       onOutput,

--- a/src/project-registry.ts
+++ b/src/project-registry.ts
@@ -196,11 +196,11 @@ export function registerProject(
   const realPath = fs.realpathSync(resolvedPath);
 
   // Validate against mount allowlist (reuse existing security infrastructure).
-  // We check as isMain=true because project registration is main-only,
+  // We check as isControlGroup=true because project registration is main-only,
   // but the effective readonly is determined per-group at mount time.
   const validation = validateMount(
     { hostPath: realPath, readonly: options?.readonly ?? false },
-    true, // isMain — registration requires main privileges
+    true, // isControlGroup — registration requires main privileges
   );
 
   if (!validation.allowed) {

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -130,11 +130,11 @@ async function runTask(
   }
 
   // Update tasks snapshot for container to read (filtered by group)
-  const isMain = group.isMain === true;
+  const isControlGroup = group.isControlGroup === true;
   const tasks = getAllTasks();
   writeTasksSnapshot(
     task.group_folder,
-    isMain,
+    isControlGroup,
     tasks.map((t) => ({
       id: t.id,
       groupFolder: t.group_folder,
@@ -176,7 +176,7 @@ async function runTask(
         sessionId,
         groupFolder: task.group_folder,
         chatJid: task.chat_jid,
-        isMain,
+        isControlGroup,
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export interface RegisteredGroup {
   added_at: string;
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
-  isMain?: boolean; // True for the main control group (no trigger, elevated privileges)
+  isControlGroup?: boolean; // True for the control group (no trigger required, elevated privileges)
   projectId?: string; // Associated project for external environment mode
 }
 


### PR DESCRIPTION
## Summary

- **`src/message-orchestrator.test.ts`** (new, 17 tests): unit tests covering cursor rollback, cursor no-rollback after output, trigger gating, session command interception, `<internal>` stripping, `recoverPendingMessages`, and `startMessageLoop` routing (pipe vs enqueue, session command dedup)

- **`src/container-mounter.ts`** (new): extracted `buildVolumeMounts` from `container-runner.ts` — the security-critical mount assembly layer is now independently readable (~260 lines). `container-runner.ts` down from 905 → 640 lines

- **`isMain` → `isControlGroup`**: renamed across all TypeScript source files. DB column `is_main` is unchanged. `ContainerInput` in the agent-runner container kept in sync (SYNC-REQUIRED)

- **`docs/CONTRIBUTING.md`** (new): "how to add X" guide covering channels, session commands, IPC message types, startup checks, architecture map, and key invariants (cursor management, control group, IPC isolation)

- **`docs/DEVELOPMENT.md`**: updated key files table to reflect new modules, added link to CONTRIBUTING.md

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 569/569 passing (17 new orchestration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)