### PR TITLE
fix(auth): switch container OAuth to session-based auth

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -59,7 +59,9 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
-RUN chown -R node:node /workspace && chmod 777 /home/node
+# .claude dir is needed for SDK credentials/settings (mounted at runtime)
+RUN chown -R node:node /workspace && chmod 777 /home/node \
+    && mkdir -p /home/node/.claude && chown node:node /home/node/.claude
 
 # Switch to non-root user (required for --dangerously-skip-permissions)
 USER node

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1128,3 +1128,93 @@ describe.skipIf(onWindows)(
     });
   },
 );
+
+describe.skipIf(onWindows)('OAuth session-based auth', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    fakeProc = createFakeProcess();
+
+    const fsMocked = vi.mocked((fsMod as any).default as typeof fsMod);
+    fsMocked.existsSync.mockReset();
+    fsMocked.existsSync.mockReturnValue(false);
+    fsMocked.mkdirSync.mockReset();
+    fsMocked.writeFileSync.mockReset();
+    fsMocked.readdirSync.mockReset();
+    fsMocked.readdirSync.mockReturnValue([]);
+    fsMocked.statSync.mockReset();
+    fsMocked.statSync.mockReturnValue({
+      isDirectory: () => false,
+    } as ReturnType<typeof fsMod.statSync>);
+
+    vi.mocked(getProjectById).mockReturnValue(undefined);
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      fakeProc as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+  });
+
+  it('mounts placeholder credentials file in OAuth mode', async () => {
+    const { detectAuthMode } = await import('./credential-proxy.js');
+    vi.mocked(detectAuthMode).mockReturnValue('oauth');
+
+    const group: RegisteredGroup = {
+      name: 'Main',
+      folder: 'main-group',
+      trigger: '@Deus',
+      added_at: new Date().toISOString(),
+      isControlGroup: true,
+    };
+
+    const mounts = await runAndCaptureMounts(group, true);
+
+    const credsMount = mounts.find(
+      (m) => m.containerPath === '/home/node/.claude/.credentials.json',
+    );
+    expect(credsMount).toBeDefined();
+    expect(credsMount!.readonly).toBe(true);
+
+    // Restore default for other tests
+    vi.mocked(detectAuthMode).mockReturnValue('api-key');
+  });
+
+  it('does NOT set CLAUDE_CODE_OAUTH_TOKEN env var in OAuth mode', async () => {
+    const { detectAuthMode } = await import('./credential-proxy.js');
+    vi.mocked(detectAuthMode).mockReturnValue('oauth');
+
+    const group: RegisteredGroup = {
+      name: 'Main',
+      folder: 'main-group',
+      trigger: '@Deus',
+      added_at: new Date().toISOString(),
+      isControlGroup: true,
+    };
+
+    fakeProc = createFakeProcess();
+    setImmediate(() => fakeProc.emit('close', 0));
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      fakeProc as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+
+    await runContainerAgent(
+      group,
+      {
+        prompt: 'test',
+        groupFolder: group.folder,
+        chatJid: 'x@g.us',
+        isControlGroup: true,
+      },
+      () => {},
+    );
+
+    const spawnMock = vi.mocked(childProcess.spawn);
+    const lastCall = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const args = lastCall[1] as string[];
+
+    // Should NOT contain CLAUDE_CODE_OAUTH_TOKEN
+    expect(args.join(' ')).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    // Should NOT contain ANTHROPIC_API_KEY (that's api-key mode)
+    expect(args.join(' ')).not.toContain('ANTHROPIC_API_KEY');
+
+    // Restore default
+    vi.mocked(detectAuthMode).mockReturnValue('api-key');
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -8,6 +8,8 @@ import { ChildProcess, execFile, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+import os from 'os';
+
 import {
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
@@ -31,6 +33,46 @@ import { detectDomains } from './domain-presets.js';
 import { getReflections, logInteraction } from './evolution-client.js';
 import { detectUserSignal } from './user-signal.js';
 import { getProjectById } from './db.js';
+
+// ---------------------------------------------------------------------------
+// OAuth: placeholder credentials file for session-based auth
+// ---------------------------------------------------------------------------
+// The Claude Agent SDK supports two OAuth flows:
+//   1. CLAUDE_CODE_OAUTH_TOKEN env var → exchanges token via create_api_key
+//      endpoint (requires org:create_api_key scope — no longer granted).
+//   2. ~/.claude/.credentials.json file → uses session-based auth with Bearer
+//      token (requires user:sessions:claude_code scope — standard for Max).
+//
+// We use flow (2): mount a placeholder credentials file into the container.
+// The SDK reads it, sends "Bearer placeholder" on API calls, and the
+// credential proxy swaps it with the real token before forwarding upstream.
+// ---------------------------------------------------------------------------
+const PLACEHOLDER_CREDENTIALS = JSON.stringify({
+  claudeAiOauth: {
+    accessToken: 'placeholder',
+    expiresAt: 4102444800000, // 2100-01-01
+    scopes: [
+      'user:file_upload',
+      'user:inference',
+      'user:mcp_servers',
+      'user:profile',
+      'user:sessions:claude_code',
+    ],
+  },
+});
+
+let placeholderCredentialsPath: string | null = null;
+
+/** Write the placeholder credentials file once (lazily, on first container). */
+function ensurePlaceholderCredentials(): string {
+  if (placeholderCredentialsPath) return placeholderCredentialsPath;
+  const dir = path.join(os.tmpdir(), 'deus-oauth');
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, '.credentials.json');
+  fs.writeFileSync(filePath, PLACEHOLDER_CREDENTIALS, { mode: 0o600 });
+  placeholderCredentialsPath = filePath;
+  return filePath;
+}
 
 // SYNC-REQUIRED: Duplicated in container/agent-runner/src/index.ts.
 // Cannot be shared via import — agent-runner is a separate package inside an isolated container.
@@ -72,13 +114,16 @@ function buildContainerArgs(
 
   // Mirror the host's auth method with a placeholder value.
   // API key mode: SDK sends x-api-key, proxy replaces with real key.
-  // OAuth mode:   SDK exchanges placeholder token for temp API key,
-  //               proxy injects real OAuth token on that exchange request.
+  // OAuth mode:   Mount placeholder credentials file so SDK uses session-based
+  //               auth (Bearer token). Proxy swaps placeholder with real token.
   const authMode = detectAuthMode();
   if (authMode === 'api-key') {
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
   } else {
-    args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
+    const credsPath = ensurePlaceholderCredentials();
+    args.push(
+      ...readonlyMountArgs(credsPath, '/home/node/.claude/.credentials.json'),
+    );
   }
 
   // Runtime-specific args for host gateway resolution

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -318,6 +318,30 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['authorization']).toBe('Bearer refreshed-token');
   });
 
+  it('OAuth mode replaces Bearer token on session endpoints', async () => {
+    proxyPort = await startProxy({
+      CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/sessions',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+          'anthropic-beta': 'ccr-byoc-2025-07-29',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      'Bearer real-oauth-token',
+    );
+  });
+
   it('OAuth mode: no crash when credentials file is missing', async () => {
     // mockReadFileSync already throws ENOENT by default
 


### PR DESCRIPTION
## Summary
- Container auth switched from `CLAUDE_CODE_OAUTH_TOKEN` env var (broken `create_api_key` exchange) to mounted `.credentials.json` so the SDK uses session-based auth (`/v1/sessions`)
- Anthropic's OAuth login no longer grants `org:create_api_key` scope; session auth uses `user:sessions:claude_code` which is standard for Max subscriptions
- Also includes `deus listen` command: mic → whisper.cpp → clipboard (cross-platform)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 572 tests pass (including 3 new: session Bearer proxy test, OAuth credentials mount, no env var leak)
- [x] Container image rebuilt — `.claude` dir verified, mount tested
- [ ] End-to-end: restart Deus service, send message via WhatsApp, verify container authenticates
- [ ] `deus listen` smoke test after `brew install sox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)