### PR TITLE
feat(cli): add `deus listen` — mic-to-text via whisper.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ Commands require admin access (sent from the owner account, or from any sender i
 
 ---
 
+## CLI Commands
+
+| Command | What it does |
+|---|---|
+| `deus` | Launch Claude Code in the current directory (external project mode if not `~/deus`) |
+| `deus home` | Launch in home mode (`~/deus`) regardless of current directory |
+| `deus auth` | Rebuild and restart background services |
+| `deus listen` | Record from mic, transcribe with whisper.cpp, copy to clipboard |
+
+`deus listen` requires `sox`, `whisper-cpp`, and `ffmpeg`. On first run it auto-downloads the base Whisper model. Configure language and model path via `WHISPER_LANG` and `WHISPER_MODEL` environment variables.
+
+---
+
 ## Design Principles
 
 | Principle | What it means |

--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -241,13 +241,80 @@ switch ($Command.ToLower()) {
         }
     }
 
+    "listen" {
+        # Record from mic, transcribe with whisper.cpp, copy to clipboard.
+        # Uses sox for recording and whisper-cli for transcription.
+        $whisperBin = if ($env:WHISPER_BIN) { $env:WHISPER_BIN } else { "whisper-cli" }
+        $whisperModel = if ($env:WHISPER_MODEL) { $env:WHISPER_MODEL } else { "$DeusHome\data\models\ggml-base.bin" }
+        $whisperLang = if ($env:WHISPER_LANG) { $env:WHISPER_LANG } else { "en" }
+        $modelUrl = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"
+
+        # Check dependencies
+        $deps = @("sox", $whisperBin, "ffmpeg")
+        $missingDeps = $deps | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) }
+        if ($missingDeps) {
+            Write-Host "Missing dependencies: $($missingDeps -join ', ')" -ForegroundColor Red
+            Write-Host "Install with: choco install sox.portable ffmpeg"
+            Write-Host "whisper-cpp: download from https://github.com/ggerganov/whisper.cpp/releases"
+            exit 1
+        }
+
+        # Auto-download model
+        if (-not (Test-Path $whisperModel)) {
+            Write-Host "Whisper model not found. Downloading ggml-base.bin (148 MB)..."
+            $modelDir = Split-Path $whisperModel -Parent
+            if (-not (Test-Path $modelDir)) { New-Item -ItemType Directory -Path $modelDir -Force | Out-Null }
+            Invoke-WebRequest -Uri $modelUrl -OutFile $whisperModel -UseBasicParsing
+            Write-Host "Download complete."
+        }
+
+        # Record
+        $tmpFile = Join-Path $env:TEMP "deus-voice-$(Get-Date -Format 'yyyyMMddHHmmss').wav"
+        Write-Host ""
+        Write-Host "  Recording... (press Ctrl+C to stop)" -ForegroundColor Cyan
+        Write-Host ""
+
+        try {
+            # rec from sox: 16kHz mono WAV
+            & sox -d -q -r 16000 -c 1 -b 16 $tmpFile
+        } catch { }
+
+        if (-not (Test-Path $tmpFile) -or (Get-Item $tmpFile).Length -lt 16000) {
+            Write-Host "  Recording too short or failed. Try again." -ForegroundColor Yellow
+            if (Test-Path $tmpFile) { Remove-Item $tmpFile -Force }
+            exit 1
+        }
+
+        # Transcribe
+        Write-Host "  Transcribing..." -ForegroundColor Cyan
+        $transcript = & $whisperBin -m $whisperModel -f $tmpFile --no-timestamps -nt -l $whisperLang 2>$null
+        $transcript = ($transcript | Where-Object { $_.Trim() -ne "" }) -join " "
+        $transcript = $transcript.Trim()
+
+        # Cleanup
+        Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+
+        if (-not $transcript) {
+            Write-Host "  Could not transcribe audio. Try speaking louder or longer." -ForegroundColor Yellow
+            exit 1
+        }
+
+        Write-Host ""
+        Write-Host "  $transcript"
+        Write-Host ""
+        Set-Clipboard -Value $transcript
+        Write-Host "  Copied to clipboard. Paste with Ctrl+V." -ForegroundColor Green
+        Write-Host ""
+    }
+
     default {
-        Write-Host "Usage: deus [home|auth|status|logs]"
+        Write-Host "Usage: deus [home|auth|status|logs|listen]"
         Write-Host ""
         Write-Host "  deus        Launch in current directory (external project mode if not ~\deus)"
         Write-Host "  deus home   Launch in home mode (~\deus) regardless of current directory"
         Write-Host "  deus auth   Rebuild dist/ and restart background service"
         Write-Host "  deus status Show service status (NSSM or Servy)"
         Write-Host "  deus logs   Tail the Deus service log"
+        Write-Host "  deus listen Record from mic, transcribe, and copy to clipboard"
     }
 }

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -856,11 +856,17 @@ $STARTUP_INSTRUCTION" "Catch me up."
       cd "$HOME/deus" && exec claude --dangerously-skip-permissions
     fi
     ;;
+  listen)
+    # Record from mic, transcribe with whisper.cpp, copy to clipboard.
+    shift
+    exec "$HOME/deus/scripts/deus-listen.sh" "$@"
+    ;;
   *)
-    echo "Usage: deus [home|auth]"
+    echo "Usage: deus [home|auth|listen]"
     echo ""
     echo "  deus        Launch in current directory (external project mode if not ~/deus)"
     echo "  deus home   Launch in home mode (~/deus) regardless of current directory"
     echo "  deus auth   Restart background services (credential proxy auto-reads ~/.claude/.credentials.json)"
+    echo "  deus listen Record from mic, transcribe, and copy to clipboard"
     ;;
 esac

--- a/scripts/deus-listen.sh
+++ b/scripts/deus-listen.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# deus listen — Record from mic, transcribe with whisper.cpp, copy to clipboard.
+# Phase 1: Pure shell, cross-platform (macOS, Linux, Windows/Git Bash).
+set -euo pipefail
+
+# ── Config (env vars override defaults) ──────────────────────────────────────
+WHISPER_BIN="${WHISPER_BIN:-whisper-cli}"
+WHISPER_MODEL="${WHISPER_MODEL:-$(cd "$(dirname "$0")/.." && pwd)/data/models/ggml-base.bin}"
+WHISPER_LANG="${WHISPER_LANG:-en}"
+MODEL_URL="https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"
+NO_CLIPBOARD="${DEUS_LISTEN_NO_CLIPBOARD:-0}"
+
+# ── Dependency checks ────────────────────────────────────────────────────────
+missing=()
+command -v sox  >/dev/null 2>&1 || missing+=("sox")
+command -v "$WHISPER_BIN" >/dev/null 2>&1 || missing+=("$WHISPER_BIN")
+command -v ffmpeg >/dev/null 2>&1 || missing+=("ffmpeg")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "Missing dependencies: ${missing[*]}"
+  echo ""
+  echo "Install with:"
+  case "$(uname -s)" in
+    Darwin)  echo "  brew install sox whisper-cpp ffmpeg" ;;
+    Linux)   echo "  sudo apt install sox libsox-fmt-all ffmpeg"
+             echo "  # whisper-cpp: build from source (https://github.com/ggerganov/whisper.cpp)" ;;
+    MINGW*|MSYS*|CYGWIN*)
+             echo "  choco install sox.portable ffmpeg"
+             echo "  # whisper-cpp: download from GitHub releases" ;;
+  esac
+  exit 1
+fi
+
+# ── Auto-download model on first use ─────────────────────────────────────────
+if [ ! -f "$WHISPER_MODEL" ]; then
+  echo "Whisper model not found at: $WHISPER_MODEL"
+  echo "Downloading ggml-base.bin (148 MB)..."
+  mkdir -p "$(dirname "$WHISPER_MODEL")"
+  curl -L --progress-bar -o "$WHISPER_MODEL" "$MODEL_URL"
+  echo "Download complete."
+  echo ""
+fi
+
+# ── Clipboard helper ─────────────────────────────────────────────────────────
+copy_to_clipboard() {
+  if [ "$NO_CLIPBOARD" = "1" ]; then return 1; fi
+  case "$(uname -s)" in
+    Darwin)
+      echo -n "$1" | pbcopy && return 0 ;;
+    Linux)
+      if command -v xclip >/dev/null 2>&1; then
+        echo -n "$1" | xclip -selection clipboard && return 0
+      elif command -v xsel >/dev/null 2>&1; then
+        echo -n "$1" | xsel --clipboard --input && return 0
+      elif command -v wl-copy >/dev/null 2>&1; then
+        echo -n "$1" | wl-copy && return 0
+      fi ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo -n "$1" | clip.exe && return 0 ;;
+  esac
+  return 1
+}
+
+# ── Recording ────────────────────────────────────────────────────────────────
+TMPFILE="$(mktemp "${TMPDIR:-/tmp}/deus-voice-XXXXXX.wav")"
+cleanup() { rm -f "$TMPFILE"; }
+trap cleanup EXIT
+
+REC_PID=""
+RECORDING=true
+
+stop_recording() {
+  RECORDING=false
+  if [ -n "$REC_PID" ] && kill -0 "$REC_PID" 2>/dev/null; then
+    kill "$REC_PID" 2>/dev/null
+    wait "$REC_PID" 2>/dev/null || true
+  fi
+}
+
+# Ctrl+C stops recording (not the script)
+trap stop_recording INT
+
+echo ""
+echo "  Recording... (press Enter or Ctrl+C to stop)"
+echo ""
+
+# Start recording in background: 16kHz mono WAV (whisper.cpp format)
+# Redirect sox's progress output to /dev/null — we show our own indicator.
+rec -q -r 16000 -c 1 -b 16 "$TMPFILE" 2>/dev/null &
+REC_PID=$!
+
+# Show recording indicator with elapsed time
+START_TIME=$(date +%s)
+FRAMES=("  ●" "  ◉" "  ○" "  ◉")
+FRAME_IDX=0
+
+while $RECORDING && kill -0 "$REC_PID" 2>/dev/null; do
+  NOW=$(date +%s)
+  ELAPSED=$((NOW - START_TIME))
+  MINS=$((ELAPSED / 60))
+  SECS=$((ELAPSED % 60))
+  FRAME="${FRAMES[$FRAME_IDX]}"
+  printf "\r  %s  Recording  %d:%02d  " "$FRAME" "$MINS" "$SECS"
+  FRAME_IDX=$(( (FRAME_IDX + 1) % ${#FRAMES[@]} ))
+
+  # Check for Enter key (non-blocking read with timeout)
+  if read -t 0.4 -n 1 2>/dev/null; then
+    stop_recording
+    break
+  fi
+done
+
+# Reset the Ctrl+C trap to default
+trap - INT
+
+printf "\r  %-40s\n" ""
+
+# Check we actually recorded something
+if [ ! -f "$TMPFILE" ] || [ ! -s "$TMPFILE" ]; then
+  echo "  No audio recorded."
+  exit 1
+fi
+
+FILE_SIZE=$(wc -c < "$TMPFILE" | tr -d ' ')
+# 16kHz * 2 bytes * 1 channel = 32000 bytes/sec. 0.5s minimum.
+if [ "$FILE_SIZE" -lt 16000 ]; then
+  echo "  Recording too short (< 0.5s). Try again."
+  exit 1
+fi
+
+# ── Transcription ────────────────────────────────────────────────────────────
+echo "  Transcribing..."
+echo ""
+
+TRANSCRIPT=$("$WHISPER_BIN" -m "$WHISPER_MODEL" -f "$TMPFILE" --no-timestamps -nt -l "$WHISPER_LANG" 2>/dev/null || true)
+TRANSCRIPT=$(echo "$TRANSCRIPT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -v '^$')
+
+if [ -z "$TRANSCRIPT" ]; then
+  echo "  Could not transcribe audio. Try speaking louder or longer."
+  exit 1
+fi
+
+echo "  $TRANSCRIPT"
+echo ""
+
+# ── Clipboard ────────────────────────────────────────────────────────────────
+if copy_to_clipboard "$TRANSCRIPT"; then
+  echo "  Copied to clipboard. Paste with Cmd+V / Ctrl+V."
+else
+  echo "  (clipboard not available — copy the text above)"
+fi
+echo ""


### PR DESCRIPTION
## Summary
- New `deus listen` command: record from mic → transcribe with whisper.cpp → copy to clipboard
- Cross-platform: shell script (macOS/Linux) + PowerShell (Windows)
- Auto-downloads ggml-base.bin on first use; configurable via `WHISPER_MODEL`, `WHISPER_LANG`, `WHISPER_BIN` env vars
- Added CLI Commands section to README

## Test plan
- [ ] `brew install sox` then `deus listen` — record, press Enter, verify transcription + clipboard
- [ ] Dependency check: run without sox installed, verify helpful error message
- [x] Build passes, 572 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)