### PR TITLE
fix(auth): move OAuth credentials into session dir

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -59,9 +59,7 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
-# .claude dir is needed for SDK credentials/settings (mounted at runtime)
-RUN chown -R node:node /workspace && chmod 777 /home/node \
-    && mkdir -p /home/node/.claude && chown node:node /home/node/.claude
+RUN chown -R node:node /workspace && chmod 777 /home/node
 
 # Switch to non-root user (required for --dangerously-skip-permissions)
 USER node

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -18,6 +18,7 @@ import { DATA_DIR, GROUPS_DIR } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
 import { getProjectById } from './db.js';
+import { detectAuthMode } from './credential-proxy.js';
 import {
   SENSITIVE_FILE_PATTERNS,
   SENSITIVE_DIR_PATTERNS,
@@ -225,6 +226,31 @@ export function buildVolumeMounts(
         null,
         2,
       ) + '\n',
+    );
+  }
+
+  // OAuth session auth: write placeholder credentials so the SDK uses
+  // session-based auth (Bearer token). The credential proxy swaps the
+  // placeholder with the real token. Written into the session .claude dir
+  // (which is already mounted at /home/node/.claude) to avoid Docker
+  // mount conflicts with overlapping bind mounts.
+  if (detectAuthMode() === 'oauth') {
+    const credsFile = path.join(groupSessionsDir, '.credentials.json');
+    fs.writeFileSync(
+      credsFile,
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'placeholder',
+          expiresAt: 4102444800000, // 2100-01-01
+          scopes: [
+            'user:file_upload',
+            'user:inference',
+            'user:mcp_servers',
+            'user:profile',
+            'user:sessions:claude_code',
+          ],
+        },
+      }),
     );
   }
 

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1152,30 +1152,6 @@ describe.skipIf(onWindows)('OAuth session-based auth', () => {
     );
   });
 
-  it('mounts placeholder credentials file in OAuth mode', async () => {
-    const { detectAuthMode } = await import('./credential-proxy.js');
-    vi.mocked(detectAuthMode).mockReturnValue('oauth');
-
-    const group: RegisteredGroup = {
-      name: 'Main',
-      folder: 'main-group',
-      trigger: '@Deus',
-      added_at: new Date().toISOString(),
-      isControlGroup: true,
-    };
-
-    const mounts = await runAndCaptureMounts(group, true);
-
-    const credsMount = mounts.find(
-      (m) => m.containerPath === '/home/node/.claude/.credentials.json',
-    );
-    expect(credsMount).toBeDefined();
-    expect(credsMount!.readonly).toBe(true);
-
-    // Restore default for other tests
-    vi.mocked(detectAuthMode).mockReturnValue('api-key');
-  });
-
   it('does NOT set CLAUDE_CODE_OAUTH_TOKEN env var in OAuth mode', async () => {
     const { detectAuthMode } = await import('./credential-proxy.js');
     vi.mocked(detectAuthMode).mockReturnValue('oauth');
@@ -1209,9 +1185,8 @@ describe.skipIf(onWindows)('OAuth session-based auth', () => {
     const lastCall = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
     const args = lastCall[1] as string[];
 
-    // Should NOT contain CLAUDE_CODE_OAUTH_TOKEN
+    // Should NOT contain CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
     expect(args.join(' ')).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
-    // Should NOT contain ANTHROPIC_API_KEY (that's api-key mode)
     expect(args.join(' ')).not.toContain('ANTHROPIC_API_KEY');
 
     // Restore default

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -8,8 +8,6 @@ import { ChildProcess, execFile, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import os from 'os';
-
 import {
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
@@ -33,46 +31,6 @@ import { detectDomains } from './domain-presets.js';
 import { getReflections, logInteraction } from './evolution-client.js';
 import { detectUserSignal } from './user-signal.js';
 import { getProjectById } from './db.js';
-
-// ---------------------------------------------------------------------------
-// OAuth: placeholder credentials file for session-based auth
-// ---------------------------------------------------------------------------
-// The Claude Agent SDK supports two OAuth flows:
-//   1. CLAUDE_CODE_OAUTH_TOKEN env var → exchanges token via create_api_key
-//      endpoint (requires org:create_api_key scope — no longer granted).
-//   2. ~/.claude/.credentials.json file → uses session-based auth with Bearer
-//      token (requires user:sessions:claude_code scope — standard for Max).
-//
-// We use flow (2): mount a placeholder credentials file into the container.
-// The SDK reads it, sends "Bearer placeholder" on API calls, and the
-// credential proxy swaps it with the real token before forwarding upstream.
-// ---------------------------------------------------------------------------
-const PLACEHOLDER_CREDENTIALS = JSON.stringify({
-  claudeAiOauth: {
-    accessToken: 'placeholder',
-    expiresAt: 4102444800000, // 2100-01-01
-    scopes: [
-      'user:file_upload',
-      'user:inference',
-      'user:mcp_servers',
-      'user:profile',
-      'user:sessions:claude_code',
-    ],
-  },
-});
-
-let placeholderCredentialsPath: string | null = null;
-
-/** Write the placeholder credentials file once (lazily, on first container). */
-function ensurePlaceholderCredentials(): string {
-  if (placeholderCredentialsPath) return placeholderCredentialsPath;
-  const dir = path.join(os.tmpdir(), 'deus-oauth');
-  fs.mkdirSync(dir, { recursive: true });
-  const filePath = path.join(dir, '.credentials.json');
-  fs.writeFileSync(filePath, PLACEHOLDER_CREDENTIALS, { mode: 0o600 });
-  placeholderCredentialsPath = filePath;
-  return filePath;
-}
 
 // SYNC-REQUIRED: Duplicated in container/agent-runner/src/index.ts.
 // Cannot be shared via import — agent-runner is a separate package inside an isolated container.
@@ -114,16 +72,14 @@ function buildContainerArgs(
 
   // Mirror the host's auth method with a placeholder value.
   // API key mode: SDK sends x-api-key, proxy replaces with real key.
-  // OAuth mode:   Mount placeholder credentials file so SDK uses session-based
-  //               auth (Bearer token). Proxy swaps placeholder with real token.
+  // OAuth mode:   Placeholder .credentials.json is written into the group's
+  //               session .claude/ dir by container-mounter.ts. The SDK reads
+  //               it, sends Bearer placeholder, and the proxy swaps with the
+  //               real token. No separate mount needed (avoids Docker conflicts
+  //               with the overlapping /home/node/.claude bind mount).
   const authMode = detectAuthMode();
   if (authMode === 'api-key') {
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
-  } else {
-    const credsPath = ensurePlaceholderCredentials();
-    args.push(
-      ...readonlyMountArgs(credsPath, '/home/node/.claude/.credentials.json'),
-    );
   }
 
   // Runtime-specific args for host gateway resolution


### PR DESCRIPTION
## Summary
- Moves placeholder `.credentials.json` write from `container-runner.ts` (separate Docker file mount) into `container-mounter.ts` (writes into group's session `.claude/` dir)
- Fixes Docker "mountpoint outside of rootfs" error caused by overlapping bind mounts on `/home/node/.claude`
- Reverts unnecessary `mkdir /home/node/.claude` in Dockerfile (no longer needed)
- Removes dead code: `PLACEHOLDER_CREDENTIALS` constant, `ensurePlaceholderCredentials()`, temp file logic

## Context
PR #19 switched OAuth from `create_api_key` to session-based auth, but mounting `.credentials.json` as a separate file inside an already bind-mounted directory (`/home/node/.claude`) causes Docker to reject the mount. This fix writes the credentials directly into the session dir on the host, which is already mounted into the container.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 571 tests pass
- [x] Verified via WhatsApp test message — container spawns and authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)