### PR TITLE
feat(memory): improve /resume session loading, learnings, and UX

### DIFF
--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -25,7 +25,12 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
     find "$VAULT/Session-Logs" -name "*.md" -not -path "*/.obsidian/*" | xargs ls -t 2>/dev/null | head -6
     Then read frontmatter only (lines between the two --- markers) of those files.
 
-4b. Load cold tier — semantically relevant older sessions:
+4b. Load learnings — what's new since last /resume (no API cost):
+    Run: python3 scripts/memory_indexer.py --learnings --since 7 --top 3
+    If output is non-empty, include it as a "What's Emerging" section after recent sessions.
+    If no output (nothing new), skip silently — silence signals stability.
+
+4c. Load cold tier — semantically relevant older sessions:
     Formulate a 1-sentence query based on the loaded context from steps 1–3 (e.g. "linear algebra exam prep" or "nanoclaw whatsapp debugging").
     Run: python3 scripts/memory_indexer.py --query "<your query>" --top 2 --recency-boost
     Include the output as additional context. Deduplicate: skip any session that already appeared in step 4a (compare by filename).

--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -17,18 +17,20 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
    If a file is found → read it fully. Note "resuming mid-session checkpoint" in the summary.
 
 4a. Load warm tier — recent sessions (no API cost):
-    Run: python3 scripts/memory_indexer.py --recent 3
-    This returns the 3 most recent session frontmatters by date. Include as "Recent Sessions" context.
+    Run: python3 scripts/memory_indexer.py --recent-days 3
+    This returns ALL sessions from the last 3 calendar days, sorted newest-first.
+    Include as "Recent Sessions" context.
 
     FALLBACK — if the script fails, fall back to:
-    find "$VAULT/Session-Logs" -name "*.md" -not -path "*/.obsidian/*" | xargs ls -t 2>/dev/null | head -3
-    Then read frontmatter only (lines between the two --- markers) of those 3 files.
+    find "$VAULT/Session-Logs" -name "*.md" -not -path "*/.obsidian/*" | xargs ls -t 2>/dev/null | head -6
+    Then read frontmatter only (lines between the two --- markers) of those files.
 
 4b. Load cold tier — semantically relevant older sessions:
     Formulate a 1-sentence query based on the loaded context from steps 1–3 (e.g. "linear algebra exam prep" or "nanoclaw whatsapp debugging").
     Run: python3 scripts/memory_indexer.py --query "<your query>" --top 2 --recency-boost
-    Include the output as additional context. Deduplicate: skip any session that already appeared in step 4a.
+    Include the output as additional context. Deduplicate: skip any session that already appeared in step 4a (compare by filename).
     If the script fails or returns nothing, skip silently — warm tier already provides continuity.
+    NOTE: Since warm tier now returns all sessions from 3 days, cold tier is purely for older context.
 
 5. If a search term was passed as argument, grep session logs for it and read frontmatters of matches.
 

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -259,8 +259,13 @@ def cmd_add(path_str: str):
     print(f"Indexed {indexed} chunk(s) from {path.name}")
 
 
-def cmd_recent(n: int = 3):
-    """Return the last N session frontmatters by date. Pure filesystem — no API calls."""
+def cmd_recent(n: int = 3, days: bool = False):
+    """Return recent session frontmatters. Pure filesystem — no API calls.
+
+    When days=False (legacy): return last N sessions, sorted by date then mtime.
+    When days=True: return ALL sessions from the last N calendar days, sorted by
+    date descending then mtime descending (newest first within each day).
+    """
     if not VAULT_SESSION_LOGS.exists():
         print(f"ERROR: session logs not found at {VAULT_SESSION_LOGS}", file=sys.stderr)
         sys.exit(1)
@@ -276,10 +281,24 @@ def cmd_recent(n: int = 3):
         return fm.get("date", "0000-00-00")
 
     dated = [(get_date(f), f) for f in log_files]
-    dated.sort(key=lambda x: x[0], reverse=True)
+    # Sort by date descending, then mtime descending (newest file first within same day)
+    dated.sort(key=lambda x: (x[0], x[1].stat().st_mtime), reverse=True)
+
+    if days:
+        # Collect all unique dates, take the first N, return all sessions from those days
+        seen_dates: list[str] = []
+        for date, _ in dated:
+            if date not in seen_dates:
+                seen_dates.append(date)
+            if len(seen_dates) > n:
+                break
+        target_dates = set(seen_dates[:n])
+        selected = [(d, p) for d, p in dated if d in target_dates]
+    else:
+        selected = dated[:n]
 
     lines = ["## Recent Sessions"]
-    for date, path in dated[:n]:
+    for date, path in selected:
         content = path.read_text(encoding="utf-8")
         fm = extract_frontmatter(content)
         name = path.stem.replace("-", " ")
@@ -798,6 +817,8 @@ def main():
                        help="Extract atomic facts from a session log (uses Gemini Flash)")
     group.add_argument("--recent", type=int, metavar="N",
                        help="Return last N session frontmatters by date (no API call)")
+    group.add_argument("--recent-days", type=int, metavar="N",
+                       help="Return ALL sessions from the last N calendar days (no API call)")
     parser.add_argument("--top", type=int, default=3, help="Number of results for --query")
     parser.add_argument("--steps", type=int, default=3, help="Activation steps for --wander")
     parser.add_argument("--recency-boost", action="store_true",
@@ -811,6 +832,9 @@ def main():
         return
     if args.recent is not None:
         cmd_recent(args.recent)
+        return
+    if args.recent_days is not None:
+        cmd_recent(args.recent_days, days=True)
         return
 
     _client = genai.Client(api_key=load_api_key())

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -298,16 +298,76 @@ def cmd_recent(n: int = 3, days: bool = False):
     else:
         selected = dated[:n]
 
-    lines = ["## Recent Sessions"]
+    # Group sessions by date for clustering on busy days
+    from collections import OrderedDict
+    by_date: OrderedDict[str, list[tuple[str, Path, dict]]] = OrderedDict()
     for date, path in selected:
         content = path.read_text(encoding="utf-8")
         fm = extract_frontmatter(content)
-        name = path.stem.replace("-", " ")
-        tldr = (fm.get("tldr", "") or "").split(".")[0][:80]
-        decisions = fm.get("decisions", "") or ""
-        dec_part = f" | {decisions}" if decisions else ""
-        lines.append(f"- [{date} | {name}]{dec_part} — {tldr}")
-        lines.append(f"  (full log: {path})")
+        by_date.setdefault(date, []).append((date, path, fm))
+
+    lines = ["## Recent Sessions"]
+
+    for date, sessions in by_date.items():
+        if len(sessions) >= 4:
+            # Cluster by topics when 4+ sessions on the same day
+            clusters: dict[str, list[tuple[Path, dict]]] = {}
+            for _, path, fm in sessions:
+                topics = fm.get("topics", "") or ""
+                # Use first topic as cluster key, fallback to "General"
+                first_topic = topics.split(",")[0].strip() if topics else "General"
+                first_topic = first_topic.strip("[] ")
+                if not first_topic:
+                    first_topic = "General"
+                clusters.setdefault(first_topic, []).append((path, fm))
+
+            for topic, items in clusters.items():
+                if len(items) >= 2:
+                    # Clustered: group header + indented items
+                    lines.append(f"- [{date} | {topic}] ({len(items)} sessions)")
+                    for path, fm in items:
+                        name = path.stem.replace("-", " ")
+                        tldr = (fm.get("tldr", "") or "").split(".")[0][:80]
+                        lines.append(f"  - {name} — {tldr}")
+                        lines.append(f"    (full log: {path})")
+                else:
+                    # Single item — flat format
+                    path, fm = items[0]
+                    name = path.stem.replace("-", " ")
+                    tldr = (fm.get("tldr", "") or "").split(".")[0][:80]
+                    decisions = fm.get("decisions", "") or ""
+                    dec_part = f" | {decisions}" if decisions else ""
+                    lines.append(f"- [{date} | {name}]{dec_part} — {tldr}")
+                    lines.append(f"  (full log: {path})")
+        else:
+            for _, path, fm in sessions:
+                name = path.stem.replace("-", " ")
+                tldr = (fm.get("tldr", "") or "").split(".")[0][:80]
+                decisions = fm.get("decisions", "") or ""
+                dec_part = f" | {decisions}" if decisions else ""
+                lines.append(f"- [{date} | {name}]{dec_part} — {tldr}")
+                lines.append(f"  (full log: {path})")
+
+    # Continuity indicator
+    total_sessions = len(list(VAULT_SESSION_LOGS.rglob("*.md"))) if VAULT_SESSION_LOGS.exists() else 0
+    total_atoms = len(list(VAULT_ATOMS.glob("*.md"))) if VAULT_ATOMS.exists() else 0
+    total_days = len(by_date)
+    parts = [f"{len(selected)} sessions across {total_days} day{'s' if total_days != 1 else ''}"]
+    if total_atoms > 0:
+        parts.append(f"{total_atoms} atoms")
+    # Check for reflections in shared DB (optional — evolution may not be set up)
+    try:
+        if DB_PATH.exists():
+            _db = sqlite3.connect(DB_PATH)
+            reflection_count = _db.execute(
+                "SELECT COUNT(*) FROM reflections WHERE archived = 0"
+            ).fetchone()[0]
+            _db.close()
+            if reflection_count > 0:
+                parts.append(f"{reflection_count} active reflections")
+    except (sqlite3.OperationalError, Exception):
+        pass
+    lines.append(f"\nContinuity: {' · '.join(parts)} (total: {total_sessions} sessions, {total_atoms} atoms)")
 
     print("\n".join(lines))
 
@@ -318,7 +378,10 @@ def cmd_learnings(since_days: int = 7, max_items: int = 3):
     Delta tracking: compares against ~/.deus/last_resume_learnings.txt to avoid
     showing the same learnings twice. Outputs nothing if no new learnings exist.
     """
-    if not VAULT_ATOMS.exists():
+    atom_count = len(list(VAULT_ATOMS.glob("*.md"))) if VAULT_ATOMS.exists() else 0
+    if atom_count == 0:
+        print("## What's Emerging\n- Your learnings will appear here as you use Deus. "
+              "Each session extracts atomic facts that grow stronger through corroboration.")
         return
 
     from datetime import date as _date, timedelta

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -40,6 +40,7 @@ from evolution.config import (
 
 CONFIG_PATH = Path("~/.config/deus/config.json").expanduser()
 DB_PATH = Path("~/.deus/memory.db").expanduser()
+LAST_RESUME_LEARNINGS = Path("~/.deus/last_resume_learnings.txt").expanduser()
 
 
 def _load_vault_path() -> Path:
@@ -309,6 +310,129 @@ def cmd_recent(n: int = 3, days: bool = False):
         lines.append(f"  (full log: {path})")
 
     print("\n".join(lines))
+
+
+def cmd_learnings(since_days: int = 7, max_items: int = 3):
+    """Surface recently strengthened or new high-confidence atoms since last /resume.
+
+    Delta tracking: compares against ~/.deus/last_resume_learnings.txt to avoid
+    showing the same learnings twice. Outputs nothing if no new learnings exist.
+    """
+    if not VAULT_ATOMS.exists():
+        return
+
+    from datetime import date as _date, timedelta
+    today = _date.today()
+    cutoff = today - timedelta(days=since_days)
+
+    # Load previously shown learnings for delta tracking
+    previously_shown: set[str] = set()
+    if LAST_RESUME_LEARNINGS.exists():
+        previously_shown = set(LAST_RESUME_LEARNINGS.read_text().strip().splitlines())
+
+    # Scan all atoms
+    candidates: list[dict] = []
+    for atom_path in VAULT_ATOMS.glob("*.md"):
+        content = atom_path.read_text(encoding="utf-8")
+        fm = extract_frontmatter(content)
+        if not fm:
+            continue
+
+        created_at = fm.get("date") or fm.get("raw", "")
+        updated_at = ""
+        corroborations = 1
+        confidence = 0.5
+        category = "fact"
+        expired = False
+
+        # Parse frontmatter fields from raw block
+        raw = fm.get("raw", "")
+        for line in raw.splitlines():
+            if line.startswith("created_at:"):
+                created_at = line.split(":", 1)[1].strip()
+            elif line.startswith("updated_at:"):
+                updated_at = line.split(":", 1)[1].strip()
+            elif line.startswith("corroborations:"):
+                try:
+                    corroborations = int(line.split(":", 1)[1].strip())
+                except ValueError:
+                    pass
+            elif line.startswith("confidence:"):
+                try:
+                    confidence = float(line.split(":", 1)[1].strip())
+                except ValueError:
+                    pass
+            elif line.startswith("category:"):
+                category = line.split(":", 1)[1].strip()
+            elif line.startswith("ttl_days:"):
+                ttl_str = line.split(":", 1)[1].strip()
+                if ttl_str not in ("null", ""):
+                    try:
+                        ttl = int(ttl_str)
+                        if created_at and (today - _date.fromisoformat(created_at)).days > ttl:
+                            expired = True
+                    except (ValueError, TypeError):
+                        pass
+
+        if expired:
+            continue
+
+        if not updated_at:
+            updated_at = created_at
+
+        try:
+            update_date = _date.fromisoformat(updated_at)
+        except (ValueError, TypeError):
+            continue
+
+        if update_date < cutoff:
+            continue
+
+        # Extract body text (after second ---)
+        body = ""
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2].strip()
+        if not body:
+            continue
+
+        # Skip if already shown in a previous /resume
+        if atom_path.name in previously_shown:
+            continue
+
+        # Classify: strengthened (updated > created, 2+ corroborations) vs new insight
+        is_strengthened = (updated_at != created_at) and corroborations >= 2
+
+        candidates.append({
+            "path": atom_path,
+            "name": atom_path.name,
+            "body": body,
+            "category": category,
+            "corroborations": corroborations,
+            "confidence": confidence,
+            "is_strengthened": is_strengthened,
+            "updated_at": updated_at,
+        })
+
+    if not candidates:
+        return
+
+    # Sort: strengthened patterns first, then by confidence desc, then recency
+    candidates.sort(key=lambda x: (x["is_strengthened"], x["confidence"], x["updated_at"]), reverse=True)
+    selected = candidates[:max_items]
+
+    lines = ["## What's Emerging"]
+    for item in selected:
+        prefix = "Pattern confirmed" if item["is_strengthened"] else "New insight"
+        suffix = f" (seen across {item['corroborations']} sessions)" if item["corroborations"] >= 2 else ""
+        lines.append(f"- {prefix}: {item['body']}{suffix}")
+
+    print("\n".join(lines))
+
+    # Update delta tracking file
+    LAST_RESUME_LEARNINGS.parent.mkdir(parents=True, exist_ok=True)
+    shown_names = previously_shown | {item["name"] for item in selected}
+    LAST_RESUME_LEARNINGS.write_text("\n".join(sorted(shown_names)) + "\n")
 
 
 def cmd_query(query: str, top: int = 3, recency_boost: bool = False):
@@ -819,7 +943,11 @@ def main():
                        help="Return last N session frontmatters by date (no API call)")
     group.add_argument("--recent-days", type=int, metavar="N",
                        help="Return ALL sessions from the last N calendar days (no API call)")
+    group.add_argument("--learnings", action="store_true",
+                       help="Surface recently strengthened/new atoms since last /resume (no API call)")
     parser.add_argument("--top", type=int, default=3, help="Number of results for --query")
+    parser.add_argument("--since", type=int, default=7,
+                        help="Lookback window in days for --learnings (default: 7)")
     parser.add_argument("--steps", type=int, default=3, help="Activation steps for --wander")
     parser.add_argument("--recency-boost", action="store_true",
                         help="Boost recent results in --query (last 7d strong, 30d moderate)")
@@ -835,6 +963,9 @@ def main():
         return
     if args.recent_days is not None:
         cmd_recent(args.recent_days, days=True)
+        return
+    if args.learnings:
+        cmd_learnings(since_days=args.since, max_items=args.top)
         return
 
     _client = genai.Client(api_key=load_api_key())

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -267,6 +267,56 @@ def test_cmd_recent_days_spans_multiple_days(mi, fresh_vault, capsys):
     assert "ancient-session" not in output
 
 
+def test_cmd_recent_continuity_indicator(mi, fresh_vault, capsys):
+    """Output should include a continuity summary line."""
+    _create_session(fresh_vault, "2024-06-15", "session-a", "a", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "session-b", "b", mtime_offset=200)
+    # Create an atom so we can verify atom count
+    atoms_dir = fresh_vault / "Atoms"
+    atoms_dir.mkdir(exist_ok=True)
+    (atoms_dir / "test-atom.md").write_text("---\ntype: atom\n---\nTest atom\n")
+
+    mi.cmd_recent(1, days=True)
+    output = capsys.readouterr().out
+    assert "Continuity:" in output
+    assert "2 sessions across 1 day" in output
+    assert "1 atoms" in output
+
+
+def test_cmd_recent_clustering_on_busy_days(mi, fresh_vault, capsys):
+    """When 4+ sessions share a day, sessions with matching topics are clustered."""
+    _create_session(fresh_vault, "2024-06-15", "auth-login", "login fix", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "auth-oauth", "oauth fix", mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "ui-dashboard", "dashboard", mtime_offset=300)
+    _create_session(fresh_vault, "2024-06-15", "ui-sidebar", "sidebar", mtime_offset=400)
+
+    # Patch the sessions to have topics
+    for name, topics in [("auth-login", "auth, security"), ("auth-oauth", "auth, oauth"),
+                         ("ui-dashboard", "ui, dashboard"), ("ui-sidebar", "ui, layout")]:
+        p = fresh_vault / "Session-Logs" / "2024-06-15" / f"{name}.md"
+        p.write_text(
+            f"---\ntype: session\ndate: 2024-06-15\ntldr: {name} work\ntopics: [{topics}]\n---\n## Summary\n"
+        )
+
+    mi.cmd_recent(1, days=True)
+    output = capsys.readouterr().out
+    # Should have at least one cluster header with "(2 sessions)"
+    assert "(2 sessions)" in output
+
+
+def test_cmd_recent_no_clustering_under_threshold(mi, fresh_vault, capsys):
+    """Fewer than 4 sessions on a day should NOT cluster."""
+    _create_session(fresh_vault, "2024-06-15", "session-a", "a", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "session-b", "b", mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "session-c", "c", mtime_offset=300)
+
+    mi.cmd_recent(1, days=True)
+    output = capsys.readouterr().out
+    # No clustering — flat format
+    assert "(2 sessions)" not in output
+    assert "session a" in output
+
+
 def test_cmd_recent_days_mtime_order_within_day(mi, fresh_vault, capsys):
     """Within a day, sessions should be ordered newest-first by mtime."""
     _create_session(fresh_vault, "2024-06-15", "early", "e", mtime_offset=100)
@@ -366,6 +416,15 @@ def test_cmd_learnings_empty_when_nothing_new(mi, fresh_vault, capsys, tmp_path,
     mi.cmd_learnings(since_days=7, max_items=3)
     output = capsys.readouterr().out
     assert output == ""
+
+
+def test_cmd_learnings_cold_start_welcome(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """When no atoms exist, show a welcome message."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    # fresh_vault has empty Atoms dir
+    mi.cmd_learnings(since_days=7, max_items=3)
+    output = capsys.readouterr().out
+    assert "Your learnings will appear here" in output
 
 
 def test_cmd_learnings_skips_expired_atoms(mi, fresh_vault, capsys, tmp_path, monkeypatch):

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -281,3 +281,105 @@ def test_cmd_recent_days_mtime_order_within_day(mi, fresh_vault, capsys):
     assert "late" in lines[0]
     assert "middle" in lines[1]
     assert "early" in lines[2]
+
+
+# ── cmd_learnings ────────────────────────────────────────────────────────
+
+
+def _create_atom(vault, name: str, body: str, category: str = "decision",
+                 corroborations: int = 1, confidence: float = 0.5,
+                 created_at: str = "2024-06-10", updated_at: str = "2024-06-15",
+                 ttl_days: str = "null"):
+    """Helper to create an atom file."""
+    atoms_dir = vault / "Atoms"
+    atoms_dir.mkdir(exist_ok=True)
+    p = atoms_dir / name
+    p.write_text(
+        f"---\ntype: atom\ncategory: {category}\ntags: []\n"
+        f"confidence: {confidence}\ncorroborations: {corroborations}\n"
+        f"source: /test/session.md\ncreated_at: {created_at}\n"
+        f"updated_at: {updated_at}\nttl_days: {ttl_days}\n---\n{body}\n"
+    )
+    return p
+
+
+def test_cmd_learnings_surfaces_strengthened_atoms(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """Atoms with updated_at > created_at and corroborations >= 2 show as 'Pattern confirmed'."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    from datetime import date, timedelta
+    today = date.today()
+    _create_atom(fresh_vault, "decision-branches.md", "Always use feature branches",
+                 corroborations=3, confidence=0.80,
+                 created_at=str(today - timedelta(days=10)),
+                 updated_at=str(today - timedelta(days=1)))
+
+    mi.cmd_learnings(since_days=7, max_items=3)
+    output = capsys.readouterr().out
+    assert "Pattern confirmed" in output
+    assert "feature branches" in output
+    assert "seen across 3 sessions" in output
+
+
+def test_cmd_learnings_surfaces_new_insights(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """Atoms created recently with 1 corroboration show as 'New insight'."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    from datetime import date, timedelta
+    today = date.today()
+    _create_atom(fresh_vault, "fact-new-thing.md", "Playwright needs interactive stdin",
+                 category="fact", corroborations=1, confidence=0.50,
+                 created_at=str(today - timedelta(days=2)),
+                 updated_at=str(today - timedelta(days=2)))
+
+    mi.cmd_learnings(since_days=7, max_items=3)
+    output = capsys.readouterr().out
+    assert "New insight" in output
+    assert "Playwright" in output
+
+
+def test_cmd_learnings_delta_tracking(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """Second run skips atoms already shown in first run."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    from datetime import date, timedelta
+    today = date.today()
+    _create_atom(fresh_vault, "decision-only-one.md", "Use sqlite-vec for search",
+                 corroborations=2, confidence=0.70,
+                 created_at=str(today - timedelta(days=5)),
+                 updated_at=str(today - timedelta(days=1)))
+
+    # First run — should show it
+    mi.cmd_learnings(since_days=7, max_items=3)
+    first_output = capsys.readouterr().out
+    assert "sqlite-vec" in first_output
+
+    # Second run — should NOT show it (delta tracking)
+    mi.cmd_learnings(since_days=7, max_items=3)
+    second_output = capsys.readouterr().out
+    assert "sqlite-vec" not in second_output
+
+
+def test_cmd_learnings_empty_when_nothing_new(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """No output when no atoms qualify (old atoms only)."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    _create_atom(fresh_vault, "decision-old.md", "Old decision",
+                 created_at="2020-01-01", updated_at="2020-01-01")
+
+    mi.cmd_learnings(since_days=7, max_items=3)
+    output = capsys.readouterr().out
+    assert output == ""
+
+
+def test_cmd_learnings_skips_expired_atoms(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """Atoms past their TTL should not appear."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    from datetime import date, timedelta
+    today = date.today()
+    # Created 400 days ago with 365-day TTL — expired
+    _create_atom(fresh_vault, "constraint-expired.md", "Expired constraint",
+                 category="constraint", corroborations=5, confidence=0.90,
+                 created_at=str(today - timedelta(days=400)),
+                 updated_at=str(today - timedelta(days=1)),
+                 ttl_days="365")
+
+    mi.cmd_learnings(since_days=7, max_items=3)
+    output = capsys.readouterr().out
+    assert "Expired constraint" not in output

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -197,3 +197,87 @@ def test_delete_entries_removes_rows(mi):
     mi.delete_entries(db, "/test/path.md")
     assert not mi.entry_exists(db, "/test/path.md")
     db.close()
+
+
+# ── cmd_recent ───────────────────────────────────────────────────────────
+
+
+def _create_session(vault, date_folder: str, name: str, tldr: str, mtime_offset: float = 0):
+    """Helper to create a session log file with controlled mtime."""
+    day_dir = vault / "Session-Logs" / date_folder
+    day_dir.mkdir(parents=True, exist_ok=True)
+    p = day_dir / f"{name}.md"
+    p.write_text(
+        f"---\ntype: session\ndate: {date_folder}\ntldr: {tldr}\n---\n## Summary\n"
+    )
+    # Set mtime: base + offset (higher offset = newer)
+    import time
+    base_mtime = time.time() - 10000 + mtime_offset
+    os.utime(p, (base_mtime, base_mtime))
+    return p
+
+
+def test_cmd_recent_mtime_tiebreaker(mi, fresh_vault, capsys):
+    """Sessions on the same day should be ordered by mtime, newest first."""
+    _create_session(fresh_vault, "2024-06-15", "session-a", "first session", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "session-b", "second session", mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "session-c", "third session", mtime_offset=300)
+
+    mi.cmd_recent(2)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    assert len(lines) == 2
+    # session-c (newest mtime) should be first, then session-b
+    assert "session c" in lines[0]
+    assert "session b" in lines[1]
+
+
+def test_cmd_recent_days_returns_all_from_day(mi, fresh_vault, capsys):
+    """--recent-days N should return ALL sessions from the last N calendar days."""
+    # 3 sessions on the same day
+    _create_session(fresh_vault, "2024-06-15", "session-a", "a", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "session-b", "b", mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "session-c", "c", mtime_offset=300)
+    # 1 session on a different day
+    _create_session(fresh_vault, "2024-06-14", "session-old", "old", mtime_offset=50)
+
+    mi.cmd_recent(1, days=True)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    # Should return all 3 from 2024-06-15, NOT the one from 2024-06-14
+    assert len(lines) == 3
+    assert "session old" not in output
+
+
+def test_cmd_recent_days_spans_multiple_days(mi, fresh_vault, capsys):
+    """--recent-days 2 should return sessions from 2 distinct calendar days."""
+    _create_session(fresh_vault, "2024-06-15", "today-a", "a", mtime_offset=300)
+    _create_session(fresh_vault, "2024-06-15", "today-b", "b", mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-14", "yesterday", "y", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-13", "ancient-session", "o", mtime_offset=50)
+
+    mi.cmd_recent(2, days=True)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    # 2 from Jun 15 + 1 from Jun 14 = 3
+    assert len(lines) == 3
+    assert "ancient-session" not in output
+
+
+def test_cmd_recent_days_mtime_order_within_day(mi, fresh_vault, capsys):
+    """Within a day, sessions should be ordered newest-first by mtime."""
+    _create_session(fresh_vault, "2024-06-15", "early", "e", mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "middle", "m", mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "late", "l", mtime_offset=300)
+
+    mi.cmd_recent(1, days=True)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    assert len(lines) == 3
+    assert "late" in lines[0]
+    assert "middle" in lines[1]
+    assert "early" in lines[2]


### PR DESCRIPTION
## Summary

Three commits improving the `/resume` experience:

**1. Session ordering fix + --recent-days flag**
- `cmd_recent()` sorted by date-folder only — arbitrary order on busy days, silently dropping sessions
- Now sorts by `(date, st_mtime)` descending. Added `--recent-days N` to return ALL sessions from the last N calendar days
- `/resume` warm tier updated from `--recent 3` to `--recent-days 3`

**2. "What's Emerging" learnings section**
- New `--learnings` flag surfaces recently strengthened or new atoms
- Delta tracking via `~/.deus/last_resume_learnings.txt` — each `/resume` shows only what's new since last time
- Narrative framing: "Pattern confirmed" vs "New insight"
- Skips expired atoms (TTL), caps at 3 items, silent when nothing new
- Cold start welcome for new users with no atoms yet

**3. Session clustering + continuity indicator**
- Groups sessions by topic when 4+ sessions share a day (clusters of 2+ get grouped, singles stay flat)
- Continuity indicator: one-liner showing session/atom/reflection counts as a knowledge base pulse
- Reads reflection count from shared evolution DB if available

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 571 tests pass
- [x] `python3 -m pytest scripts/tests/test_memory_indexer.py` — 27 tests pass (13 new)
- [x] Manual: `--recent-days 1` returns all 6 today sessions, clustered by topic, with continuity line
- [x] Manual: `--learnings` shows emerging patterns with delta tracking (each run shows new items)
- [x] Manual: expired atoms filtered, cold start welcome shown on empty atom dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)