### PR TITLE
fix(security): eliminate shell injection and harden input validation

### DIFF
--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -6,6 +6,7 @@ Uses a temp DB via monkeypatching evolution.db.DB_PATH.
 """
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -573,7 +574,7 @@ def test_main_status_exits_zero():
         [sys.executable, "-m", "evolution.cli", "status"],
         capture_output=True,
         text=True,
-        cwd="/Users/liam10play/deus",
+        cwd=str(Path(__file__).resolve().parents[2]),
     )
     assert result.returncode == 0, (
         f"Expected exit 0, got {result.returncode}.\nstdout={result.stdout}\nstderr={result.stderr}"
@@ -637,6 +638,6 @@ def test_main_unknown_subcommand_exits_nonzero():
         [sys.executable, "-m", "evolution.cli", "nonexistent_subcommand"],
         capture_output=True,
         text=True,
-        cwd="/Users/liam10play/deus",
+        cwd=str(Path(__file__).resolve().parents[2]),
     )
     assert result.returncode != 0

--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -60,7 +60,7 @@ vi.mock('fs', async () => {
 
 // Mock child_process (used for osascript notification)
 vi.mock('child_process', () => ({
-  exec: vi.fn(),
+  execFile: vi.fn(),
 }));
 
 // Build a fake WASocket that's an EventEmitter with the methods we need

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -91,9 +91,10 @@ export class WhatsAppChannel implements Channel {
         const msg =
           'WhatsApp authentication required. Run /setup in Claude Code.';
         logger.error(msg);
-        exec(
-          `osascript -e 'display notification "${msg}" with title "Deus" sound name "Basso"'`,
-        );
+        execFile('osascript', [
+          '-e',
+          `display notification "${msg}" with title "Deus" sound name "Basso"`,
+        ]);
         setTimeout(() => process.exit(1), 1000);
       }
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -4,6 +4,7 @@ import sharp from 'sharp';
 import type { WAMessage } from '@whiskeysockets/baileys';
 
 const MAX_DIMENSION = 1024;
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
 const IMAGE_REF_PATTERN = /\[Image: (attachments\/[^\]]+)\]/g;
 
 export interface ProcessedImage {
@@ -25,7 +26,8 @@ export async function processImage(
   groupDir: string,
   caption: string,
 ): Promise<ProcessedImage | null> {
-  if (!buffer || buffer.length === 0) return null;
+  if (!buffer || buffer.length === 0 || buffer.length > MAX_FILE_SIZE)
+    return null;
 
   const resized = await sharp(buffer)
     .resize(MAX_DIMENSION, MAX_DIMENSION, {

--- a/src/remote-control.test.ts
+++ b/src/remote-control.test.ts
@@ -12,9 +12,11 @@ vi.mock('./config.js', () => ({
 // Mock child_process
 const spawnMock = vi.fn();
 const execSyncMock = vi.fn();
+const execFileSyncMock = vi.fn();
 vi.mock('child_process', () => ({
   spawn: (...args: any[]) => spawnMock(...args),
   execSync: (...args: any[]) => execSyncMock(...args),
+  execFileSync: (...args: any[]) => execFileSyncMock(...args),
 }));
 
 import {
@@ -267,9 +269,11 @@ describe('remote-control', () => {
       const result = stopRemoteControl();
       expect(result).toEqual({ ok: true });
       if (isWindows) {
-        expect(execSyncMock).toHaveBeenCalledWith('taskkill /F /T /PID 55555', {
-          stdio: 'pipe',
-        });
+        expect(execFileSyncMock).toHaveBeenCalledWith(
+          'taskkill',
+          ['/F', '/T', '/PID', '55555'],
+          { stdio: 'pipe' },
+        );
       } else {
         expect(killSpy).toHaveBeenCalledWith(-55555, 'SIGTERM');
       }
@@ -374,9 +378,11 @@ describe('remote-control', () => {
       const result = stopRemoteControl();
       expect(result).toEqual({ ok: true });
       if (isWindows) {
-        expect(execSyncMock).toHaveBeenCalledWith('taskkill /F /T /PID 77777', {
-          stdio: 'pipe',
-        });
+        expect(execFileSyncMock).toHaveBeenCalledWith(
+          'taskkill',
+          ['/F', '/T', '/PID', '77777'],
+          { stdio: 'pipe' },
+        );
       } else {
         expect(killSpy).toHaveBeenCalledWith(-77777, 'SIGTERM');
       }

--- a/src/remote-control.ts
+++ b/src/remote-control.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from 'child_process';
+import { execFileSync, execSync, spawn } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -53,7 +53,9 @@ function isProcessAlive(pid: number): boolean {
 function killProcess(pid: number): void {
   if (os.platform() === 'win32') {
     try {
-      execSync(`taskkill /F /T /PID ${pid}`, { stdio: 'pipe' });
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], {
+        stdio: 'pipe',
+      });
     } catch {
       // already dead
     }


### PR DESCRIPTION
## Summary
- **Shell injection (osascript):** Replaced `exec()` with `execFile()` in WhatsApp notification — prevents shell metacharacter injection
- **Shell injection (taskkill):** Replaced `execSync()` with `execFileSync()` in Windows process killing — prevents PID interpolation attack
- **Image buffer hardening:** Added 50MB file size check before `sharp()` processes buffer — prevents memory exhaustion from oversized payloads
- **Hardcoded path:** Replaced `/Users/liam10play/deus` with dynamic `Path(__file__).resolve().parents[2]` in evolution tests

## Context
Pre-public-release security audit identified these patterns. Both shell injection sites had low exploitability (hardcoded msg / numeric PID from internal code), but the patterns are dangerous for a public codebase where contributors may copy them.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 577/577 tests pass (35 files)
- [x] WhatsApp test mock updated (`exec` → `execFile`)
- [x] Type-check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)