### PR TITLE
fix(ci): disable body line-length for dependabot compat

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -18,5 +18,8 @@ export default {
     ],
     'scope-empty': [1, 'never'],
     'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+    // Disable body/footer line-length — dependabot auto-generates long lines
+    'body-max-line-length': [0, 'always'],
+    'footer-max-line-length': [0, 'always'],
   },
 };


### PR DESCRIPTION
## Summary
- Disable `body-max-line-length` and `footer-max-line-length` in commitlint
- Dependabot auto-generates commit bodies with lines >100 chars (dependency URLs, changelogs)
- Since we squash-merge, the PR title becomes the final commit message — body content doesn't affect history

## Context
Blocking dependabot PRs #14, #15 from merging. This is a known compatibility issue with commitlint + dependabot.

## Test plan
- [x] Commitlint still validates subject/type/scope (only body length disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)