### PR TITLE
fix(setup): cross-platform Docker build + async setup flow

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -78,8 +78,8 @@ Run `npx tsx setup/index.ts --step environment` and parse the status block.
 - DOCKER=installed_not_running → start Docker:
   - macOS: `open -a Docker`
   - Linux: `sudo systemctl start docker`
-  - Windows: Docker Desktop auto-starts. Check the system tray icon — if it's not there, launch "Docker Desktop" from Start. Wait 15s then re-check with `docker info`.
-  - Wait 15s, re-check with `docker info`.
+  - Windows: launch Docker Desktop from Start menu if not in system tray.
+  - After starting, check once with `docker info`. If it fails, **do NOT poll in a loop** — use AskUserQuestion: "Docker is starting up. Let me know when it's ready (you'll see the Docker icon in the system tray turn solid)." Then verify with `docker info`.
 - DOCKER=not_found → Use `AskUserQuestion: Docker is required for running agents. Would you like me to install it?` If confirmed:
   - macOS: install via `brew install --cask docker`, then `open -a Docker` and wait for it to start. If brew not available, direct to Docker Desktop download at https://docker.com/products/docker-desktop
   - Linux: install with `curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker $USER`. Note: user may need to log out/in for group membership.
@@ -87,11 +87,16 @@ Run `npx tsx setup/index.ts --step environment` and parse the status block.
 
 ### 3b. Build and test (BACKGROUND)
 
-**Start the container build in the background** — it takes 3-5 minutes and doesn't need user input. Continue with steps 4-6 while it runs.
+**Start the container build in the background** — it takes 3-5 minutes (up to 10 on Windows first run) and doesn't need user input. Continue with steps 4-6 while it runs.
 
-Run in background: `npx tsx setup/index.ts --step container -- --runtime docker`
+Run in background with **10 minute timeout**: `npx tsx setup/index.ts --step container -- --runtime docker`
 
 **Do NOT wait for this to finish.** Immediately continue to step 4. You will check the result before step 7.
+
+**IMPORTANT — if build fails later:** Read the FULL error output before retrying. Common causes:
+- TypeScript compilation errors from skill agents → check which skill was staged and if it's compatible
+- Timeout → re-run with longer timeout, Docker layers are cached so retry is faster
+- Do NOT prune Docker cache unless you're certain the cache itself is the problem
 
 ## 4. Claude Authentication (No Script)
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -85,15 +85,13 @@ Run `npx tsx setup/index.ts --step environment` and parse the status block.
   - Linux: install with `curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker $USER`. Note: user may need to log out/in for group membership.
   - Windows: direct to Docker Desktop download at https://docker.com/products/docker-desktop. Requires WSL 2 (auto-offered by Docker installer). After install, start Docker Desktop from Start menu.
 
-### 3b. Build and test
+### 3b. Build and test (BACKGROUND)
 
-Run `npx tsx setup/index.ts --step container -- --runtime docker` and parse the status block.
+**Start the container build in the background** — it takes 3-5 minutes and doesn't need user input. Continue with steps 4-6 while it runs.
 
-**If BUILD_OK=false:** Read `logs/setup.log` tail for the build error.
-- Cache issue (stale layers): `docker builder prune -f`. Retry.
-- Dockerfile syntax or missing files: diagnose from the log and fix, then retry.
+Run in background: `npx tsx setup/index.ts --step container -- --runtime docker`
 
-**If TEST_OK=false but BUILD_OK=true:** The image built but won't run. Check logs — common cause is runtime not fully started. Wait a moment and retry the test.
+**Do NOT wait for this to finish.** Immediately continue to step 4. You will check the result before step 7.
 
 ## 4. Claude Authentication (No Script)
 
@@ -143,6 +141,18 @@ AskUserQuestion: Agent access to external directories?
 
 **No:** `npx tsx setup/index.ts --step mounts -- --empty`
 **Yes:** Collect paths/permissions. `npx tsx setup/index.ts --step mounts -- --json '{"allowedRoots":[...],"blockedPatterns":[],"nonMainReadOnly":true}'`
+
+## 6b. Wait for Container Build
+
+**Before proceeding to step 7, check the container build from step 3b.**
+
+If the background build is still running, wait for it to finish. Parse the status block.
+
+**If BUILD_OK=false:** Read `logs/setup.log` tail for the build error.
+- Cache issue (stale layers): `docker builder prune -f`. Retry.
+- Dockerfile syntax or missing files: diagnose from the log and fix, then retry.
+
+**If TEST_OK=false but BUILD_OK=true:** The image built but won't run. Check logs — common cause is runtime not fully started. Wait a moment and retry the test.
 
 ## 7. Start Service
 

--- a/container/build.sh
+++ b/container/build.sh
@@ -22,9 +22,22 @@ rm -rf "$STAGING_DIR"
 mkdir -p "$STAGING_DIR"
 
 if [ -d ".claude/skills" ]; then
+  # Read local-only skills from .git/info/exclude (lines matching .claude/skills/<name>)
+  LOCAL_ONLY_SKILLS=""
+  if [ -f ".git/info/exclude" ]; then
+    LOCAL_ONLY_SKILLS=$(grep -oP '\.claude/skills/\K[^/]+' .git/info/exclude 2>/dev/null || true)
+  fi
+
   for skill_dir in .claude/skills/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name=$(basename "$skill_dir")
+
+    # Skip local-only skills (not committed, would break container build)
+    if echo "$LOCAL_ONLY_SKILLS" | grep -qx "$skill_name" 2>/dev/null; then
+      echo "  Skipped local-only skill: $skill_name"
+      continue
+    fi
+
     if [ -f "$skill_dir/agent.ts" ]; then
       mkdir -p "$STAGING_DIR/$skill_name"
       cp "$skill_dir/agent.ts" "$STAGING_DIR/$skill_name/"

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -23,8 +23,28 @@ function parseArgs(args: string[]): { runtime: string } {
 }
 
 /**
+ * Read local-only skill names from .git/info/exclude.
+ * These are skills that exist locally but aren't committed (e.g. x-integration).
+ * They should NOT be staged into the container — their dependencies aren't available.
+ */
+function getLocalOnlySkills(projectRoot: string): Set<string> {
+  const excludePath = path.join(projectRoot, '.git', 'info', 'exclude');
+  const localOnly = new Set<string>();
+  if (!fs.existsSync(excludePath)) return localOnly;
+
+  const content = fs.readFileSync(excludePath, 'utf-8');
+  const pattern = /\.claude\/skills\/([^/\s]+)/g;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    localOnly.add(match[1]);
+  }
+  return localOnly;
+}
+
+/**
  * Stage skill agent files into container/skill-agents/ for the Docker build.
  * This replicates the staging logic from build.sh in a cross-platform way.
+ * Skips local-only skills listed in .git/info/exclude.
  */
 function stageSkillAgents(projectRoot: string): void {
   const stagingDir = path.join(projectRoot, 'container', 'skill-agents');
@@ -38,7 +58,14 @@ function stageSkillAgents(projectRoot: string): void {
   const skillsDir = path.join(projectRoot, '.claude', 'skills');
   if (!fs.existsSync(skillsDir)) return;
 
+  const localOnly = getLocalOnlySkills(projectRoot);
+
   for (const skillName of fs.readdirSync(skillsDir)) {
+    if (localOnly.has(skillName)) {
+      logger.info({ skill: skillName }, 'Skipped local-only skill');
+      continue;
+    }
+
     const skillDir = path.join(skillsDir, skillName);
     if (!fs.statSync(skillDir).isDirectory()) continue;
 

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -1,8 +1,9 @@
 /**
  * Step: container — Build container image and verify with test run.
- * Replaces 03-setup-container.sh
+ * Cross-platform: uses build.sh on macOS/Linux, replicates staging logic on Windows.
  */
 import { execSync } from 'child_process';
+import fs from 'fs';
 import path from 'path';
 
 import { CONTAINER_IMAGE } from '../src/config.js';
@@ -21,11 +22,50 @@ function parseArgs(args: string[]): { runtime: string } {
   return { runtime };
 }
 
+/**
+ * Stage skill agent files into container/skill-agents/ for the Docker build.
+ * This replicates the staging logic from build.sh in a cross-platform way.
+ */
+function stageSkillAgents(projectRoot: string): void {
+  const stagingDir = path.join(projectRoot, 'container', 'skill-agents');
+
+  // Clean previous staging
+  if (fs.existsSync(stagingDir)) {
+    fs.rmSync(stagingDir, { recursive: true });
+  }
+  fs.mkdirSync(stagingDir, { recursive: true });
+
+  const skillsDir = path.join(projectRoot, '.claude', 'skills');
+  if (!fs.existsSync(skillsDir)) return;
+
+  for (const skillName of fs.readdirSync(skillsDir)) {
+    const skillDir = path.join(skillsDir, skillName);
+    if (!fs.statSync(skillDir).isDirectory()) continue;
+
+    const agentFile = path.join(skillDir, 'agent.ts');
+    if (fs.existsSync(agentFile)) {
+      const destDir = path.join(stagingDir, skillName);
+      fs.mkdirSync(destDir, { recursive: true });
+      fs.copyFileSync(agentFile, path.join(destDir, 'agent.ts'));
+      logger.info({ skill: skillName }, 'Staged skill agent');
+    }
+  }
+}
+
+/**
+ * Clean up staging directory after build.
+ */
+function cleanupStaging(projectRoot: string): void {
+  const stagingDir = path.join(projectRoot, 'container', 'skill-agents');
+  if (fs.existsSync(stagingDir)) {
+    fs.rmSync(stagingDir, { recursive: true });
+  }
+}
+
 export async function run(args: string[]): Promise<void> {
   const projectRoot = process.cwd();
   const { runtime } = parseArgs(args);
   const image = CONTAINER_IMAGE;
-  const logFile = path.join(projectRoot, 'logs', 'setup.log');
 
   if (!runtime) {
     emitStatus('SETUP_CONTAINER', {
@@ -40,7 +80,6 @@ export async function run(args: string[]): Promise<void> {
     process.exit(4);
   }
 
-  // Validate runtime availability
   if (runtime !== 'docker') {
     emitStatus('SETUP_CONTAINER', {
       RUNTIME: runtime,
@@ -82,21 +121,34 @@ export async function run(args: string[]): Promise<void> {
     process.exit(2);
   }
 
-  const buildCmd = 'docker build';
-  const runCmd = 'docker';
-
-  // Build
+  // Build — use build.sh on unix, manual staging on Windows
   let buildOk = false;
   logger.info({ runtime }, 'Building container');
+
+  const isWindows = process.platform === 'win32';
+
   try {
-    execSync(`${buildCmd} -t ${image} .`, {
-      cwd: path.join(projectRoot, 'container'),
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    if (isWindows) {
+      // Windows: stage skills and run docker build from project root
+      stageSkillAgents(projectRoot);
+      execSync(`docker build -t ${image} -f container/Dockerfile .`, {
+        cwd: projectRoot,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      cleanupStaging(projectRoot);
+    } else {
+      // macOS/Linux: use build.sh which handles staging + build
+      execSync(`bash container/build.sh`, {
+        cwd: projectRoot,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    }
     buildOk = true;
     logger.info('Container build succeeded');
   } catch (err) {
     logger.error({ err }, 'Container build failed');
+    // Clean up staging on failure too
+    if (isWindows) cleanupStaging(projectRoot);
   }
 
   // Test
@@ -105,7 +157,7 @@ export async function run(args: string[]): Promise<void> {
     logger.info('Testing container');
     try {
       const output = execSync(
-        `echo '{}' | ${runCmd} run -i --rm --entrypoint /bin/echo ${image} "Container OK"`,
+        `echo '{}' | docker run -i --rm --entrypoint /bin/echo ${image} "Container OK"`,
         { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
       );
       testOk = output.includes('Container OK');


### PR DESCRIPTION
## Summary
- **Windows Docker fix:** `setup/container.ts` was running `docker build` with `cwd: container/` — Docker's build context didn't match the Dockerfile's COPY paths (`container/agent-runner/`, `container/skill-agents/`). Also never staged skill agents. Now uses `build.sh` on macOS/Linux and replicates the staging logic cross-platform on Windows.
- **Async setup:** Docker build (3-5 min) now runs in the background during step 3b while the user continues with auth, channels, and mounts. Result is checked at step 6b before starting the service.

## Test plan
- [x] TypeScript compiles (`npm run build`)
- [x] All 482 tests pass (`npm test`)
- [ ] Smoke test: run `/setup` on Windows with Docker Desktop
- [ ] Verify skill agents are staged and included in container image

🤖 Generated with [Claude Code](https://claude.com/claude-code)