### PR TITLE
fix(setup): update channel skills for MCP architecture

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -7,11 +7,13 @@ description: Add Telegram as a channel. Can replace WhatsApp entirely or run alo
 
 This skill adds Telegram support to Deus, then walks through interactive setup.
 
+**IMPORTANT:** Do NOT add git remotes, fetch from external repos, or install npm packages from the public registry during this skill. All channel code is already in the repo under `packages/` and `src/channels/`.
+
 ## Phase 1: Pre-flight
 
 ### Check if already applied
 
-Check if `src/channels/telegram.ts` exists. If it does, skip to Phase 3 (Setup). The code changes are already in place.
+Check if `src/channels/index.ts` already imports `./mcp-telegram.js`. If it does, skip to Phase 3 (Setup).
 
 ### Ask the user
 
@@ -21,19 +23,16 @@ AskUserQuestion: Do you have a Telegram bot token, or do you need to create one?
 
 If they have one, collect it now. If not, we'll create one in Phase 3.
 
-## Phase 2: Apply Code Changes
+## Phase 2: Build Local Packages
 
-Check if `src/channels/mcp-telegram.ts` already exists in the channel barrel imports. If it does, skip to Phase 3 (Setup).
-
-### Install the Telegram MCP server package
+The Telegram channel is a local MCP server in `packages/`. Build the packages in order (core first, then telegram):
 
 ```bash
-npm install deus-mcp-telegram
+cd packages/mcp-channel-core && npm install && npm run build && cd ../..
+cd packages/mcp-telegram && npm install && npm run build && cd ../..
 ```
 
-This installs the standalone Telegram MCP server, which runs as a separate process and communicates via stdio.
-
-### Register the channel
+### Register the channel import
 
 Add the Telegram import to `src/channels/index.ts`:
 
@@ -41,9 +40,9 @@ Add the Telegram import to `src/channels/index.ts`:
 import './mcp-telegram.js';
 ```
 
-The `src/channels/mcp-telegram.ts` factory is already in the codebase — it spawns the MCP server and bridges it to the Deus Channel interface.
+The factory file `src/channels/mcp-telegram.ts` already exists in the codebase.
 
-### Validate code changes
+### Validate
 
 ```bash
 npm run build
@@ -101,9 +100,12 @@ Tell the user:
 
 ```bash
 npm run build
-launchctl kickstart -k gui/$(id -u)/com.deus  # macOS
-# Linux: systemctl --user restart deus
 ```
+
+Restart the service (platform-specific):
+- macOS: `launchctl kickstart -k gui/$(id -u)/com.deus`
+- Linux: `systemctl --user restart deus`
+- Windows: `nssm restart deus` or `servy-cli restart --name=deus`
 
 ## Phase 4: Registration
 
@@ -200,9 +202,7 @@ If they say yes, invoke the `/add-telegram-swarm` skill.
 
 To remove Telegram integration:
 
-1. Delete `src/channels/telegram.ts` and `src/channels/telegram.test.ts`
-2. Remove `import './telegram.js'` from `src/channels/index.ts`
-3. Remove `TELEGRAM_BOT_TOKEN` from `.env`
-4. Remove Telegram registrations from SQLite: `sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE 'tg:%'"`
-5. Uninstall: `npm uninstall grammy`
-6. Rebuild: `npm run build && launchctl kickstart -k gui/$(id -u)/com.deus` (macOS) or `npm run build && systemctl --user restart deus` (Linux)
+1. Remove import from `src/channels/index.ts`
+2. Remove `TELEGRAM_BOT_TOKEN` from `.env`
+3. Remove Telegram registrations: `sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE 'tg:%'"`
+4. Rebuild and restart

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -5,7 +5,9 @@ description: Add WhatsApp as a channel. Can replace other channels entirely or r
 
 # Add WhatsApp Channel
 
-This skill adds WhatsApp support to Deus. It installs the WhatsApp channel code, dependencies, and guides through authentication, registration, and configuration.
+This skill adds WhatsApp support to Deus. It builds the local MCP packages, registers the channel, and guides through authentication.
+
+**IMPORTANT:** Do NOT add git remotes, fetch from external repos, or install npm packages from the public registry during this skill. All channel code is already in the repo under `packages/` and `src/channels/`.
 
 ## Phase 1: Pre-flight
 
@@ -33,46 +35,42 @@ If IS_HEADLESS=true AND not WSL → AskUserQuestion: How do you want to authenti
 - **Pairing code** (Recommended) - Enter a numeric code on your phone (no camera needed, requires phone number)
 - **QR code in terminal** - Displays QR code in the terminal (can be too small on some displays)
 
-Otherwise (macOS, desktop Linux, or WSL) → AskUserQuestion: How do you want to authenticate WhatsApp?
-- **QR code in browser** (Recommended) - Opens a browser window with a large, scannable QR code
+Otherwise (macOS, desktop Linux, Windows, or WSL) → AskUserQuestion: How do you want to authenticate WhatsApp?
+- **QR code in terminal** (Recommended) - Displays QR code in the terminal
 - **Pairing code** - Enter a numeric code on your phone (no camera needed, requires phone number)
-- **QR code in terminal** - Displays QR code in the terminal (can be too small on some displays)
 
 If they chose pairing code:
 
 AskUserQuestion: What is your phone number? (Include country code without +, e.g., 1234567890)
 
-## Phase 2: Apply Code Changes
+## Phase 2: Build Local Packages
 
-Check if `src/channels/mcp-whatsapp.ts` already exists in the channel barrel imports. If it does, skip to Phase 3 (Authentication).
-
-### Install the WhatsApp MCP server package
+The WhatsApp channel is a local MCP server in `packages/`. Build the packages in order (core first, then whatsapp):
 
 ```bash
-npm install deus-mcp-whatsapp
+cd packages/mcp-channel-core && npm install && npm run build && cd ../..
+cd packages/mcp-whatsapp && npm install && npm run build && cd ../..
 ```
 
-This installs the standalone WhatsApp MCP server, which runs as a separate process and communicates via stdio.
+### Register the channel import
 
-### Register the channel
-
-Add the WhatsApp import to `src/channels/index.ts`:
+Check if `src/channels/index.ts` already imports `./mcp-whatsapp.js`. If not, add it:
 
 ```typescript
 import './mcp-whatsapp.js';
 ```
 
-The `src/channels/mcp-whatsapp.ts` factory is already in the codebase — it spawns the MCP server and bridges it to the Deus Channel interface.
+The factory file `src/channels/mcp-whatsapp.ts` already exists in the codebase.
 
 ### Configure environment
 
-Add `ASSISTANT_HAS_OWN_NUMBER` to `.env.example` if not already present:
+Add `ASSISTANT_HAS_OWN_NUMBER` to `.env` if not already present:
 
 ```
 ASSISTANT_HAS_OWN_NUMBER=false
 ```
 
-### Validate code changes
+### Validate
 
 ```bash
 npm run build
@@ -90,41 +88,32 @@ rm -rf store/auth/
 
 ### Run WhatsApp authentication
 
-For QR code in browser (recommended):
+The auth script is at `scripts/whatsapp-auth.ts`. It uses baileys from the mcp-whatsapp workspace package.
+
+**For QR code in terminal:**
 
 ```bash
-npx tsx setup/index.ts --step whatsapp-auth -- --method qr-browser
+npx tsx scripts/whatsapp-auth.ts
 ```
 
-(Bash timeout: 150000ms)
+(Bash timeout: 120000ms)
 
 Tell the user:
 
-> A browser window will open with a QR code.
+> A QR code will appear in the terminal.
 >
 > 1. Open WhatsApp > **Settings** > **Linked Devices** > **Link a Device**
-> 2. Scan the QR code in the browser
-> 3. The page will show "Authenticated!" when done
-
-For QR code in terminal:
-
-```bash
-npx tsx setup/index.ts --step whatsapp-auth -- --method qr-terminal
-```
-
-Tell the user to run `npm run auth` in another terminal, then:
-
-> 1. Open WhatsApp > **Settings** > **Linked Devices** > **Link a Device**
 > 2. Scan the QR code displayed in the terminal
+> 3. Wait for "Authentication successful!" message
 
-For pairing code:
+**For pairing code:**
 
 Tell the user to have WhatsApp open on **Settings > Linked Devices > Link a Device**, ready to tap **"Link with phone number instead"** — the code expires in ~60 seconds and must be entered immediately.
 
 Run the auth process in the background and poll `store/pairing-code.txt` for the code:
 
 ```bash
-rm -f store/pairing-code.txt && npx tsx setup/index.ts --step whatsapp-auth -- --method pairing-code --phone <their-phone-number> > /tmp/wa-auth.log 2>&1 &
+rm -f store/pairing-code.txt && npx tsx scripts/whatsapp-auth.ts --pairing-code --phone <their-phone-number> > /tmp/wa-auth.log 2>&1 &
 ```
 
 Then immediately poll for the code (do NOT wait for the background command to finish):
@@ -258,8 +247,9 @@ launchctl kickstart -k gui/$(id -u)/com.deus
 # Linux (systemd)
 systemctl --user restart deus
 
-# Linux (nohup fallback)
-bash start-deus.sh
+# Windows (NSSM or Servy)
+nssm restart deus
+# or: servy-cli restart --name=deus
 ```
 
 ### Test the connection
@@ -282,10 +272,10 @@ tail -f logs/deus.log
 
 ### QR code expired
 
-QR codes expire after ~60 seconds. Re-run the auth command:
+QR codes expire after ~60 seconds. Re-run the auth script:
 
 ```bash
-rm -rf store/auth/ && npx tsx src/whatsapp-auth.ts
+rm -rf store/auth/ && npx tsx scripts/whatsapp-auth.ts
 ```
 
 ### Pairing code not working
@@ -293,19 +283,13 @@ rm -rf store/auth/ && npx tsx src/whatsapp-auth.ts
 Codes expire in ~60 seconds. To retry:
 
 ```bash
-rm -rf store/auth/ && npx tsx src/whatsapp-auth.ts --pairing-code --phone <phone>
+rm -rf store/auth/ && npx tsx scripts/whatsapp-auth.ts --pairing-code --phone <phone>
 ```
 
 Enter the code **immediately** when it appears. Also ensure:
 1. Phone number includes country code without `+` (e.g., `1234567890`)
 2. Phone has internet access
 3. WhatsApp is updated to the latest version
-
-If pairing code keeps failing, switch to QR-browser auth instead:
-
-```bash
-rm -rf store/auth/ && npx tsx setup/index.ts --step whatsapp-auth -- --method qr-browser
-```
 
 ### "conflict" disconnection
 
@@ -357,5 +341,6 @@ To remove WhatsApp integration:
 
 1. Delete auth credentials: `rm -rf store/auth/`
 2. Remove WhatsApp registrations: `sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE '%@g.us' OR jid LIKE '%@s.whatsapp.net'"`
-3. Sync env: `mkdir -p data/env && cp .env data/env/env`
-4. Rebuild and restart: `npm run build && launchctl kickstart -k gui/$(id -u)/com.deus` (macOS) or `npm run build && systemctl --user restart deus` (Linux)
+3. Remove import from `src/channels/index.ts`
+4. Sync env: `mkdir -p data/env && cp .env data/env/env`
+5. Rebuild and restart

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -11,6 +11,8 @@ Run setup steps automatically. Only pause when user action is required (channel 
 
 **UX Note:** Use `AskUserQuestion` for all user-facing questions.
 
+**CRITICAL:** Do NOT add git remotes (`git remote add`), fetch from external repos, or install npm packages from the public registry outside of step 0. All channel code and packages are local in the repo. If something seems missing, check `packages/` and `src/channels/` before looking externally.
+
 ## 0. Git & Fork Setup
 
 Check the git remote configuration to ensure the user has a proper setup for receiving updates.

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ __pycache__/
 # Skills system (local per-installation state)
 .deus/
 
+# Local-only skills — listed here so they're not staged into container builds
+# One skill name per line (e.g., "x-integration"). No paths, just the name.
+.local-skills
+
 # Skill local dependencies (each skill manages its own node_modules)
 .claude/skills/*/node_modules/
 .claude/skills/*/package-lock.json

--- a/container/build.sh
+++ b/container/build.sh
@@ -22,9 +22,12 @@ rm -rf "$STAGING_DIR"
 mkdir -p "$STAGING_DIR"
 
 if [ -d ".claude/skills" ]; then
-  # Read local-only skills from .git/info/exclude (lines matching .claude/skills/<name>)
+  # Read local-only skills from .local-skills (one skill name per line)
+  # Falls back to .git/info/exclude for backwards compatibility
   LOCAL_ONLY_SKILLS=""
-  if [ -f ".git/info/exclude" ]; then
+  if [ -f ".local-skills" ]; then
+    LOCAL_ONLY_SKILLS=$(grep -v '^#' .local-skills 2>/dev/null | grep -v '^$' || true)
+  elif [ -f ".git/info/exclude" ]; then
     LOCAL_ONLY_SKILLS=$(grep -oP '\.claude/skills/\K[^/]+' .git/info/exclude 2>/dev/null || true)
   fi
 

--- a/scripts/whatsapp-auth.ts
+++ b/scripts/whatsapp-auth.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env npx tsx
+/**
+ * Standalone WhatsApp authentication script.
+ * Uses baileys from the mcp-whatsapp workspace package.
+ * Shows QR in terminal + writes to store/qr-data.txt for external rendering.
+ */
+import {
+  makeWASocket,
+  Browsers,
+  DisconnectReason,
+  fetchLatestWaWebVersion,
+  useMultiFileAuthState,
+} from '@whiskeysockets/baileys';
+import pino from 'pino';
+import fs from 'fs';
+import path from 'path';
+
+const AUTH_DIR = path.join(process.cwd(), 'store', 'auth');
+const QR_DATA_PATH = path.join(process.cwd(), 'store', 'qr-data.txt');
+const logger = pino({ level: 'silent' });
+
+// Parse CLI args
+const args = process.argv.slice(2);
+const usePairingCode = args.includes('--pairing-code');
+const phoneIdx = args.indexOf('--phone');
+const phone = phoneIdx !== -1 ? args[phoneIdx + 1] : undefined;
+
+if (usePairingCode && !phone) {
+  console.error('--pairing-code requires --phone <number>');
+  process.exit(1);
+}
+
+async function main() {
+  fs.mkdirSync(AUTH_DIR, { recursive: true });
+  const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
+
+  const { version } = await fetchLatestWaWebVersion({}).catch(() => ({
+    version: undefined,
+  }));
+
+  console.log('Connecting to WhatsApp...');
+
+  const sock = makeWASocket({
+    version,
+    auth: { creds: state.creds, keys: state.keys },
+    printQRInTerminal: !usePairingCode,
+    logger,
+    browser: Browsers.macOS('Chrome'),
+  });
+
+  if (usePairingCode && !sock.authState.creds.registered) {
+    // Request pairing code
+    const code = await sock.requestPairingCode(phone!);
+    console.log(`\nPAIRING_CODE: ${code}`);
+    // Write to file for polling by setup process
+    const codePath = path.join(process.cwd(), 'store', 'pairing-code.txt');
+    fs.writeFileSync(codePath, code);
+  }
+
+  sock.ev.on('connection.update', (update) => {
+    const { connection, lastDisconnect, qr } = update;
+
+    if (qr) {
+      // Write QR data to file for external rendering (browser, image, etc.)
+      fs.mkdirSync(path.dirname(QR_DATA_PATH), { recursive: true });
+      fs.writeFileSync(QR_DATA_PATH, qr);
+      console.log(`\nQR data written to ${QR_DATA_PATH}`);
+      console.log('Scan the QR code shown above with WhatsApp.');
+      console.log(
+        'Open WhatsApp > Settings > Linked Devices > Link a Device\n',
+      );
+    }
+
+    if (connection === 'close') {
+      const reason = (
+        lastDisconnect?.error as { output?: { statusCode?: number } }
+      )?.output?.statusCode;
+
+      if (reason === DisconnectReason.loggedOut) {
+        console.error('AUTH_STATUS: failed (logged_out)');
+        cleanup();
+        process.exit(1);
+      } else {
+        console.error(`Connection closed (reason: ${reason}), retrying...`);
+      }
+    } else if (connection === 'open') {
+      const id = sock.user?.id?.split(':')[0] || 'unknown';
+      console.log(`\nAUTH_STATUS: authenticated`);
+      console.log(`Phone: ${id}`);
+      console.log('WhatsApp authentication successful!');
+      cleanup();
+      setTimeout(() => process.exit(0), 2000);
+    }
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+}
+
+function cleanup() {
+  try {
+    fs.unlinkSync(QR_DATA_PATH);
+  } catch {}
+}
+
+main().catch((err) => {
+  console.error('Auth failed:', err);
+  cleanup();
+  process.exit(1);
+});

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -23,21 +23,37 @@ function parseArgs(args: string[]): { runtime: string } {
 }
 
 /**
- * Read local-only skill names from .git/info/exclude.
- * These are skills that exist locally but aren't committed (e.g. x-integration).
- * They should NOT be staged into the container — their dependencies aren't available.
+ * Read local-only skill names from .local-skills (one name per line).
+ * Falls back to .git/info/exclude for backwards compatibility.
+ * These skills should NOT be staged — their dependencies aren't in the container.
  */
 function getLocalOnlySkills(projectRoot: string): Set<string> {
-  const excludePath = path.join(projectRoot, '.git', 'info', 'exclude');
   const localOnly = new Set<string>();
-  if (!fs.existsSync(excludePath)) return localOnly;
 
-  const content = fs.readFileSync(excludePath, 'utf-8');
-  const pattern = /\.claude\/skills\/([^/\s]+)/g;
-  let match;
-  while ((match = pattern.exec(content)) !== null) {
-    localOnly.add(match[1]);
+  // Primary: .local-skills file (gitignored, works on all clones)
+  const localSkillsPath = path.join(projectRoot, '.local-skills');
+  if (fs.existsSync(localSkillsPath)) {
+    const content = fs.readFileSync(localSkillsPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        localOnly.add(trimmed);
+      }
+    }
+    return localOnly;
   }
+
+  // Fallback: .git/info/exclude (local-only, doesn't transfer to other clones)
+  const excludePath = path.join(projectRoot, '.git', 'info', 'exclude');
+  if (fs.existsSync(excludePath)) {
+    const content = fs.readFileSync(excludePath, 'utf-8');
+    const pattern = /\.claude\/skills\/([^/\s]+)/g;
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      localOnly.add(match[1]);
+    }
+  }
+
   return localOnly;
 }
 


### PR DESCRIPTION
## Summary
- **P0:** Add `scripts/whatsapp-auth.ts` — standalone auth script using baileys from workspace. No more ad-hoc script creation during setup.
- **P0:** Update `/add-whatsapp` and `/add-telegram` skills to build local `packages/` instead of trying `npm install` from registry (not published yet).
- **P1:** Replace `.git/info/exclude` approach with `.local-skills` file (gitignored) — works across all clones, not just the machine where skills were excluded.
- **P1:** Add "never add git remotes outside step 0" rule to setup SKILL.md.

## Test plan
- [x] `npm run build` clean
- [x] All 482 tests pass
- [ ] Full `/setup` on Windows with WhatsApp auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)