### PR TITLE
fix(skills): only add upstream remote when user owns origin repo

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -41,14 +41,24 @@ If continue without fork: add upstream so they can still pull updates:
 git remote add upstream https://github.com/qwibitai/nanoclaw.git
 ```
 
-**Case B — `origin` points to user's fork (NOT qwibitai/nanoclaw), no `upstream` remote:**
+**Case B — `origin` points to a non-qwibitai repo, no `upstream` remote:**
 
-First, check if this is a genuine fork or the source repo itself. Use `gh repo view --json parent` to check if origin has a parent repo. If it does → it's a fork, add upstream pointing to the parent. If it doesn't → it's the source repo (e.g. `sliamh11/Deus`), do NOT add upstream.
+Determine if the user owns the origin repo (it's their fork) or if they cloned someone else's repo:
 
-For forks only:
-```bash
-git remote add upstream https://github.com/qwibitai/nanoclaw.git
-```
+1. Get the authenticated GitHub user: `gh api user --jq .login`
+2. Extract the owner from the origin URL (e.g. `sliamh11` from `sliamh11/Deus`)
+3. Compare them.
+
+**If the user OWNS origin** (their GitHub username matches origin owner):
+  - Check if origin is a fork: `gh repo view --json parent --jq '.parent.owner.login + "/" + .parent.name'`
+  - If it's a fork → add the parent as upstream:
+    ```bash
+    git remote add upstream https://github.com/<parent-owner>/<parent-name>.git
+    ```
+  - If it's NOT a fork → this is the source repo. No upstream needed (Case D).
+
+**If the user does NOT own origin** (they cloned someone else's repo):
+  - They're using that repo as their source of truth. Do NOT add upstream. Their `origin` is already their update source.
 
 **Case C — both `origin` and `upstream` exist:**
 


### PR DESCRIPTION
## Summary
- Fix /setup step 0 incorrectly adding `upstream` remote to `qwibitai/nanoclaw` when user clones a fork (e.g. `sliamh11/Deus`)
- Root cause: `gh repo view --json parent` returns the grandparent repo, so any clone of a fork gets the wrong upstream
- New logic: compare authenticated GitHub user with origin repo owner. Only add upstream if user owns origin (it's their fork). If they cloned someone else's repo, that repo IS their source — no upstream needed.

## Context
Yonatan cloned `sliamh11/Deus` and /setup added `qwibitai/nanoclaw` as upstream, causing `git fetch` to pull from both repos.

## Test plan
- [ ] Clone `sliamh11/Deus` as non-owner → verify no upstream added
- [ ] Fork `sliamh11/Deus` as owner → verify upstream points to `sliamh11/Deus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)