### PR TITLE
fix(cli): replace non-ASCII chars in deus-cmd.ps1 + pre-commit guard

### DIFF
--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-    Deus CLI for Windows — mirrors deus-cmd.sh on macOS/Linux.
+    Deus CLI for Windows - mirrors deus-cmd.sh on macOS/Linux.
 
 .DESCRIPTION
     Usage:
@@ -12,7 +12,7 @@
       deus logs         Tail the Deus service log
 
     The Deus background service runs under NSSM or Servy.
-    Credential proxy reads ~/.claude/.credentials.json directly — do NOT
+    Credential proxy reads ~/.claude/.credentials.json directly - do NOT
     write CLAUDE_CODE_OAUTH_TOKEN to .env (causes login loop on token rotation).
 #>
 
@@ -27,7 +27,7 @@ $ServiceName = "deus"
 $LogFile = "$DeusHome\logs\deus.log"
 $ErrorLog = "$DeusHome\logs\deus.error.log"
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
+# -- Helpers ------------------------------------------------------------------
 
 function Get-ServiceManager {
     if (Get-Command "servy-cli" -ErrorAction SilentlyContinue) { return "servy" }
@@ -80,7 +80,7 @@ function Build-Deus {
         & npm run build --silent
         if ($LASTEXITCODE -ne 0) {
             Write-Host " FAILED" -ForegroundColor Red
-            Write-Error "Build failed — not restarting."
+            Write-Error "Build failed - not restarting."
             return $false
         }
     } finally {
@@ -129,7 +129,7 @@ function Invoke-ClaudeWithContext {
         return
     }
 
-    # ── Load context (mirrors deus-cmd.sh context loading) ──────────────────
+    # -- Load context (mirrors deus-cmd.sh context loading) ------------------
     Write-Host "  Reading vault...`r" -NoNewline
     $claudeMd  = Read-VaultFile "$vault\CLAUDE.md"
     $studyMd   = Read-VaultFile "$vault\STUDY.md"
@@ -193,7 +193,7 @@ function Invoke-ClaudeWithContext {
     & claude --dangerously-skip-permissions
 }
 
-# ── Commands ─────────────────────────────────────────────────────────────────
+# -- Commands -----------------------------------------------------------------
 
 switch ($Command.ToLower()) {
     "auth" {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "*.ts": [
       "eslint --cache --fix",
       "prettier --write"
+    ],
+    "*.ps1": [
+      "scripts/check-ascii.sh"
     ]
   },
   "engines": {

--- a/scripts/check-ascii.sh
+++ b/scripts/check-ascii.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Pre-commit check: reject non-ASCII characters in shell/PowerShell scripts.
+# Windows PowerShell 5.1 reads .ps1 files as ANSI (no UTF-8 BOM), so multi-byte
+# Unicode chars (em-dashes, smart quotes, etc.) corrupt the parser.
+
+status=0
+for file in "$@"; do
+  if LC_ALL=C grep -n '[^ -~	]' "$file"; then
+    echo "error: non-ASCII characters found in $file (see above)"
+    status=1
+  fi
+done
+exit $status


### PR DESCRIPTION
## Summary
- Replace em-dashes and box-drawing characters in `deus-cmd.ps1` with ASCII equivalents — fixes cascading "missing closing '}'" parse errors on Windows PowerShell 5.1 (reads `.ps1` as ANSI, not UTF-8)
- Add `scripts/check-ascii.sh` + lint-staged rule for `*.ps1` files to prevent non-ASCII from being committed again

## Test plan
- [x] `scripts/check-ascii.sh deus-cmd.ps1` passes
- [x] Build passes (`npm run build`)
- [x] All 485 tests pass (`npm test`)
- [x] lint-staged hook ran and validated on commit
- [ ] Yonatan: verify `deus` command runs without parse errors on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)