### PR TITLE
fix(cli): fix system prompt arg splitting on Windows

### DIFF
--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -172,7 +172,7 @@ This repo (~/deus) is the infrastructure that powers you. See README.md for phil
     if (-not $vault) {
         Write-Host "Warning: No vault configured. Set DEUS_VAULT_PATH or vault_path in ~/.config/deus/config.json" -ForegroundColor Yellow
         Set-Location $WorkDir
-        Invoke-Claude --append-system-prompt $startupInstruction
+        Invoke-Claude @("--append-system-prompt", $startupInstruction)
         return
     }
 
@@ -224,7 +224,7 @@ This repo (~/deus) is the infrastructure that powers you. See README.md for phil
     $fullPrompt += $startupInstruction
 
     Set-Location $WorkDir
-    Invoke-Claude --append-system-prompt $fullPrompt
+    Invoke-Claude @("--append-system-prompt", $fullPrompt)
 }
 
 # -- Commands -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `--append-system-prompt` and the prompt value were being split into separate tokens by PowerShell, causing `argument missing` error
- Fix: pass as explicit array `@("--append-system-prompt", $value)` so PowerShell forwards both as a pair

## Test plan
- [x] Build + tests pass
- [x] ASCII check passes
- [ ] Yonatan: `deus home` should launch without arg error

🤖 Generated with [Claude Code](https://claude.com/claude-code)