### PR TITLE
fix(startup): normalize process.cwd() for MSYS2 path compatibility

### DIFF
--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -28,7 +28,7 @@ function parseArgs(args: string[]): { list: boolean; limit: number } {
 }
 
 export async function run(args: string[]): Promise<void> {
-  const projectRoot = process.cwd();
+  const projectRoot = path.resolve(process.cwd());
   const { list, limit } = parseArgs(args);
 
   if (list) {

--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('./config.js', () => ({
   HOME_DIR: '/home/testuser',
   CONFIG_DIR: '/home/testuser/.config/deus',
+  STORE_DIR: '/project/store',
 }));
 
 vi.mock('./logger.js', () => ({

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -11,7 +11,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import { HOME_DIR, CONFIG_DIR } from './config.js';
+import { HOME_DIR, CONFIG_DIR, STORE_DIR } from './config.js';
 import { readEnvFile } from './env.js';
 
 const DEUS_CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
@@ -149,8 +149,7 @@ export function hasAnyChannelAuth(): boolean {
   // Each skill leaves credentials on disk. Check for known credential patterns.
   const checks: Array<() => boolean> = [
     // WhatsApp: store/auth/creds.json
-    () =>
-      fs.existsSync(path.join(process.cwd(), 'store', 'auth', 'creds.json')),
+    () => fs.existsSync(path.join(STORE_DIR, 'auth', 'creds.json')),
     // Token-based channels (Telegram, Slack, Discord, etc.)
     () => {
       const env = readEnvFile([
@@ -185,7 +184,7 @@ export function hasContainerImage(): boolean {
 
 /** Count registered groups in the database (opens readonly, safe before initDatabase). */
 export function countRegisteredGroups(): number {
-  const dbPath = path.join(process.cwd(), 'store', 'messages.db');
+  const dbPath = path.join(STORE_DIR, 'messages.db');
   if (!fs.existsSync(dbPath)) return 0;
 
   try {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+
+import { STORE_DIR, GROUPS_DIR, DATA_DIR } from './config.js';
+
+describe('config paths', () => {
+  it('STORE_DIR is an absolute path ending with store', () => {
+    expect(path.isAbsolute(STORE_DIR)).toBe(true);
+    expect(STORE_DIR).toMatch(/store$/);
+  });
+
+  it('GROUPS_DIR is an absolute path ending with groups', () => {
+    expect(path.isAbsolute(GROUPS_DIR)).toBe(true);
+    expect(GROUPS_DIR).toMatch(/groups$/);
+  });
+
+  it('DATA_DIR is an absolute path ending with data', () => {
+    expect(path.isAbsolute(DATA_DIR)).toBe(true);
+    expect(DATA_DIR).toMatch(/data$/);
+  });
+
+  it('PROJECT_ROOT uses path.resolve so paths are normalized', () => {
+    // STORE_DIR = path.resolve(PROJECT_ROOT, 'store')
+    // If PROJECT_ROOT were not normalized, paths could contain duplicated segments.
+    // Verify no segment duplication (e.g. "DeusDeusstore" pattern).
+    const segments = STORE_DIR.split(path.sep);
+    // Check that 'store' appears only as the last segment, not fused into another
+    expect(segments[segments.length - 1]).toBe('store');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export const POLL_INTERVAL = 2000;
 export const SCHEDULER_POLL_INTERVAL = 60000;
 
 // Absolute paths needed for container mounts
-const PROJECT_ROOT = process.cwd();
+const PROJECT_ROOT = path.resolve(process.cwd());
 export const HOME_DIR = process.env.HOME || os.homedir();
 export const CONFIG_DIR = path.join(HOME_DIR, '.config', 'deus');
 


### PR DESCRIPTION
## Summary
- Wrap `process.cwd()` with `path.resolve()` in `src/config.ts` to normalize POSIX-style paths returned by MSYS2 on Windows, preventing mangled paths like `DeusDeusstoremessages.db`
- Replace raw `process.cwd()` calls in `src/checks.ts` with the centralized `STORE_DIR` constant from config, eliminating duplicated path logic
- Normalize `process.cwd()` in `setup/groups.ts` for the same MSYS2 compatibility reason
- Add `src/config.test.ts` with path normalization assertions

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (489 tests, 35 files)
- [ ] Verify on Windows with Git Bash that paths resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)