### PR TITLE
fix(setup): use platform-aware shell and bash for Windows container builds

### DIFF
--- a/setup/container.test.ts
+++ b/setup/container.test.ts
@@ -1,0 +1,43 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import os from 'os';
+import fs from 'fs';
+
+import { resolveBash } from './container.js';
+
+describe('resolveBash', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns "bash" on non-Windows platforms', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    expect(resolveBash()).toBe('bash');
+  });
+
+  it('returns "bash" on linux', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    expect(resolveBash()).toBe('bash');
+  });
+
+  it('returns Git Bash path on Windows when found', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      return p === 'C:\\Program Files\\Git\\bin\\bash.exe';
+    });
+    expect(resolveBash()).toBe('C:\\Program Files\\Git\\bin\\bash.exe');
+  });
+
+  it('returns Git Bash x86 path on Windows when 64-bit not found', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      return p === 'C:\\Program Files (x86)\\Git\\bin\\bash.exe';
+    });
+    expect(resolveBash()).toBe('C:\\Program Files (x86)\\Git\\bin\\bash.exe');
+  });
+
+  it('falls back to "bash" on Windows when Git Bash not found', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    expect(resolveBash()).toBe('bash');
+  });
+});

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -105,6 +105,22 @@ function cleanupStaging(projectRoot: string): void {
   }
 }
 
+/**
+ * Resolve the path to a bash executable.
+ * On Windows, bash isn't guaranteed to be in PATH — look in common Git install paths.
+ * On macOS/Linux, plain `bash` is always available.
+ */
+export function resolveBash(): string {
+  if (process.platform === 'win32') {
+    const gitBashPaths = [
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+    ];
+    return gitBashPaths.find((p) => fs.existsSync(p)) || 'bash';
+  }
+  return 'bash';
+}
+
 export async function run(args: string[]): Promise<void> {
   const projectRoot = process.cwd();
   const { runtime } = parseArgs(args);
@@ -180,8 +196,9 @@ export async function run(args: string[]): Promise<void> {
       });
       cleanupStaging(projectRoot);
     } else {
-      // macOS/Linux: use build.sh which handles staging + build
-      execSync(`bash container/build.sh`, {
+      // macOS/Linux/WSL: use build.sh which handles staging + build
+      const bash = resolveBash();
+      execSync(`"${bash}" container/build.sh`, {
         cwd: projectRoot,
         stdio: ['ignore', 'pipe', 'pipe'],
       });

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -200,8 +200,8 @@ export async function run(args: string[]): Promise<void> {
     logger.info('Testing container');
     try {
       const output = execSync(
-        `echo '{}' | docker run -i --rm --entrypoint /bin/echo ${image} "Container OK"`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+        `docker run -i --rm --entrypoint /bin/echo ${image} "Container OK"`,
+        { input: '{}', encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
       );
       testOk = output.includes('Container OK');
       logger.info({ testOk }, 'Container test result');


### PR DESCRIPTION
## Summary
- **Shell pipe removal**: Replace `echo '{}' | docker run ...` with the `input` option of `execSync`, removing the dependency on a shell interpreter for pipe handling. This fixes container test verification on Windows where `echo` and `|` behave differently.
- **Bash path resolution**: Add `resolveBash()` helper that checks common Git for Windows install paths (`Program Files\Git\bin\bash.exe`) before falling back to plain `bash`. Ensures `container/build.sh` can be invoked even when bash isn't on the system PATH.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (490/490 tests, including new `resolveBash` unit tests)
- [ ] Verify container test command works on Windows with Docker Desktop
- [ ] Verify `resolveBash()` finds Git Bash on a Windows machine with Git installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)