### PR TITLE
Polish channel setup skills with recovery guidance and smoke tests

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -147,6 +147,32 @@ Tell the user:
 >
 > The bot should respond within a few seconds.
 
+### Smoke test
+
+After confirming the service is running, verify end-to-end delivery:
+
+```bash
+npx tsx -e "
+import { getDb } from './dist/db.js';
+const db = getDb();
+const group = db.prepare('SELECT jid, name FROM registered_groups WHERE jid LIKE \"tg:%\" LIMIT 1').get();
+if (!group) { console.log('SMOKE_TEST: no registered Telegram chat found'); process.exit(1); }
+console.log('SMOKE_TEST: sending to ' + group.name + ' (' + group.jid + ')');
+"
+```
+
+If a registered chat is found, use the MCP tool `send_message` (if available) or tell the user:
+
+> Smoke test: Send any message to your registered Telegram chat now. I'll check the logs in 5 seconds.
+
+Wait 5 seconds, then check for delivery confirmation:
+
+```bash
+tail -20 logs/deus.log | grep -i "message\|received\|processing\|telegram"
+```
+
+Report the result: if log entries show message receipt/processing, tell the user "Telegram channel is working." If no relevant log entries, suggest checking the Troubleshooting section below.
+
 ### Check logs if needed
 
 ```bash
@@ -197,6 +223,23 @@ After completing the Telegram setup, use `AskUserQuestion`:
 AskUserQuestion: Would you like to add Agent Swarm support? Without it, Agent Teams still work — they just operate behind the scenes. With Swarm support, each subagent appears as a different bot in the Telegram group so you can see who's saying what and have interactive team sessions.
 
 If they say yes, invoke the `/add-telegram-swarm` skill.
+
+## Troubleshooting: Re-authentication
+
+If the bot stops responding or the token becomes invalid:
+
+1. Verify the token is still valid:
+   ```bash
+   curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe" | grep -q '"ok":true' && echo "Token valid" || echo "Token invalid"
+   ```
+2. If the token is invalid, generate a new one via `@BotFather` > `/mybots` > select bot > **API Token** > **Revoke current token**
+3. Update the token in `.env` and sync: `mkdir -p data/env && cp .env data/env/env`
+4. Restart the service — no re-registration needed (the chat ID stays the same)
+
+Common causes of bot failure:
+- Token was revoked via BotFather
+- Bot was deleted and recreated (new token needed, chat IDs may change for private chats)
+- Telegram API rate limiting (wait a few minutes and retry)
 
 ## Removal
 

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -9,7 +9,11 @@ This skill adds WhatsApp support to Deus. It builds the local MCP packages, regi
 
 **IMPORTANT:** Do NOT add git remotes, fetch from external repos, or install npm packages from the public registry during this skill. All channel code is already in the repo under `packages/` and `src/channels/`.
 
+---
+
 ## Phase 1: Pre-flight
+
+> **Recovery:** If something goes wrong in Phase 1, simply re-run the skill from the beginning.
 
 ### Check current state
 
@@ -43,7 +47,11 @@ If they chose pairing code:
 
 AskUserQuestion: What is your phone number? (Include country code without +, e.g., 1234567890)
 
+---
+
 ## Phase 2: Build Local Packages
+
+> **Recovery:** If the build fails, fix the error and re-run from Phase 2. No need to redo Phase 1.
 
 The WhatsApp channel is a local MCP server in `packages/`. Build the packages in order (core first, then whatsapp):
 
@@ -78,7 +86,11 @@ npm run build
 
 Build must be clean before proceeding.
 
+---
+
 ## Phase 3: Authentication
+
+> **Recovery:** If authentication fails, delete `store/auth/` and re-run from Phase 3. Phases 1-2 do not need to be repeated.
 
 ### Clean previous auth state (if re-authenticating)
 
@@ -160,7 +172,11 @@ Sync to container environment:
 mkdir -p data/env && cp .env data/env/env
 ```
 
+---
+
 ## Phase 4: Registration
+
+> **Recovery:** If registration fails or you chose the wrong group, re-run from Phase 4. Authentication (Phase 3) is preserved.
 
 ### Configure trigger and channel type
 
@@ -202,14 +218,27 @@ node -e "const c=JSON.parse(require('fs').readFileSync('store/auth/creds.json','
 
 **DM with bot:** Ask for the bot's phone number. JID = `NUMBER@s.whatsapp.net`
 
-**Group (solo, existing):** Run group sync and list available groups:
+**Group (solo, existing):** Run group sync first:
 
 ```bash
 npx tsx setup/index.ts --step groups
-npx tsx setup/index.ts --step groups --list
 ```
 
-The output shows `JID|GroupName` pairs. Present candidates as AskUserQuestion (names only, not JIDs).
+Then use a search-based picker (group lists can have 300+ entries):
+
+1. AskUserQuestion: Type the name (or part of the name) of the WhatsApp group you want to register.
+
+2. Filter groups using the search term:
+
+```bash
+npx tsx setup/index.ts --step groups --list | grep -i "<search-term>" | head -10
+```
+
+3. Present the top 10 matching groups as AskUserQuestion options (names only, not JIDs). Include two extra options at the bottom:
+   - **Show more results** — re-run the filter with `head -20` to show the next batch
+   - **Search again** — ask for a different search term and repeat from step 1
+
+4. Once the user picks a group, extract the JID from the matching line.
 
 ### Register the chat
 
@@ -236,7 +265,11 @@ npx tsx setup/index.ts --step register \
   --channel whatsapp
 ```
 
+---
+
 ## Phase 5: Verify
+
+> **Recovery:** If verification fails, check logs (`tail -50 logs/deus.log`). For service issues, re-run from Phase 5. For auth issues, re-run from Phase 3. For registration issues, re-run from Phase 4.
 
 ### Build and restart
 
@@ -267,6 +300,32 @@ Tell the user:
 > - For groups: Use the trigger word (e.g., "@Deus hello")
 >
 > The assistant should respond within a few seconds.
+
+### Smoke test
+
+After confirming the service is running, send a programmatic test message to verify end-to-end delivery:
+
+```bash
+npx tsx -e "
+import { getDb } from './dist/db.js';
+const db = getDb();
+const group = db.prepare('SELECT jid, name FROM registered_groups WHERE jid LIKE \"%@s.whatsapp.net\" OR jid LIKE \"%@g.us\" LIMIT 1').get();
+if (!group) { console.log('SMOKE_TEST: no registered WhatsApp chat found'); process.exit(1); }
+console.log('SMOKE_TEST: sending to ' + group.name + ' (' + group.jid + ')');
+"
+```
+
+If a registered chat is found, use the MCP tool `send_message` (if available) or tell the user:
+
+> Smoke test: Send any message to your registered chat now. I'll check the logs in 5 seconds.
+
+Wait 5 seconds, then check for delivery confirmation:
+
+```bash
+tail -20 logs/deus.log | grep -i "message\|received\|processing"
+```
+
+Report the result: if log entries show message receipt/processing, tell the user "WhatsApp channel is working." If no relevant log entries, suggest checking the Troubleshooting section below.
 
 ### Check logs if needed
 
@@ -340,6 +399,19 @@ launchctl load ~/Library/LaunchAgents/com.deus.plist
 # npm run dev
 # systemctl --user start deus
 ```
+
+## Troubleshooting: Re-authentication
+
+If WhatsApp disconnects (session revoked, "logged out" error in logs, or `store/auth/creds.json` becomes invalid):
+
+1. Delete the auth state: `rm -rf store/auth/`
+2. Re-run Phase 3 (Authentication) — Phases 1-2 do not need to be repeated
+3. After re-authentication, restart the service — no re-registration needed (the JID stays the same)
+
+Common causes of disconnection:
+- Linked the same WhatsApp account to another instance of Deus or another Baileys client
+- Manually removed the linked device from WhatsApp Settings > Linked Devices
+- WhatsApp server-side session expiry (rare, ~14 days of inactivity)
 
 ## Removal
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -189,7 +189,37 @@ Run `npx tsx setup/index.ts --step service` and parse the status block.
 
 **If FALLBACK=wsl_no_systemd:** WSL without systemd detected. Tell user they can either enable systemd in WSL (`echo -e "[boot]\nsystemd=true" | sudo tee /etc/wsl.conf` then restart WSL) or use the generated `start-deus.sh` wrapper.
 
-**If PLATFORM=windows and FALLBACK=batch:** Windows without NSSM/Servy — a `start-deus.bat` launcher was generated for the background service. Tell user: the service can be started with `.\start-deus.bat` or by double-clicking it. For auto-start on login, add a shortcut to `shell:startup`. The `deus` CLI command will be set up in step 7b.
+**If PLATFORM=windows:** Detect whether NSSM is available for persistent service management:
+
+```bash
+where nssm 2>nul && echo "NSSM_AVAILABLE=true" || echo "NSSM_AVAILABLE=false"
+```
+
+**If NSSM_AVAILABLE=true:** Install and configure the Windows service with NSSM:
+
+```bash
+nssm install deus node <project-root>\dist\index.js
+nssm set deus AppDirectory <project-root>
+nssm set deus AppRestartDelay 5000
+nssm start deus
+```
+
+Replace `<project-root>` with the absolute path to the Deus project directory (from `cd` or `%CD%`).
+
+**If NSSM_AVAILABLE=false:** AskUserQuestion: NSSM is not installed. It's needed for running Deus as a persistent Windows service. How would you like to proceed?
+- **Install NSSM via winget** (Recommended) — run `winget install nssm`, then re-run this step
+- **Download NSSM manually** — download from https://nssm.cc/download and add it to your PATH, then re-run this step
+- **Use Windows Task Scheduler instead** — create a task that runs `node <project-root>\dist\index.js` at login (less reliable than NSSM for restarts)
+- **Use the batch launcher** — skip persistent service, use `.\start-deus.bat` manually
+
+If the user chose Task Scheduler: guide them to create a scheduled task:
+1. Open Task Scheduler (`taskschd.msc`)
+2. Create a Basic Task named "Deus"
+3. Trigger: "When I log on"
+4. Action: Start a Program — `node`, arguments: `<project-root>\dist\index.js`, start in: `<project-root>`
+5. Check "Run with highest privileges" if Docker requires it
+
+**If PLATFORM=windows and FALLBACK=batch (and user skipped NSSM/Task Scheduler):** A `start-deus.bat` launcher was generated for the background service. Tell user: the service can be started with `.\start-deus.bat` or by double-clicking it. For auto-start on login, add a shortcut to `shell:startup`. The `deus` CLI command will be set up in step 7b.
 
 **If DOCKER_GROUP_STALE=true:** The user was added to the docker group after their session started — the systemd service can't reach the Docker socket. Ask user to run these two commands:
 


### PR DESCRIPTION
## Summary
- **Fix 1 (P1):** Add Windows service persistence instructions to `/setup` — NSSM install/config commands, winget install guidance, Task Scheduler fallback, and batch launcher as last resort
- **Fix 2 (P2):** Replace flat group list with search-based picker in `/add-whatsapp` — asks for search term, shows top 10 matches, offers "show more" and "search again" options for 300+ group scalability
- **Fix 3 (P2):** Add phase boundary markers with explicit recovery instructions to all 5 phases of `/add-whatsapp` — each phase says exactly which earlier phase to re-run if something breaks
- **Fix 4 (P3):** Add smoke test step at end of verify phase for both `/add-whatsapp` and `/add-telegram` — checks DB for registered chat, prompts user to send test message, verifies delivery in logs
- **Fix 5 (P3):** Add "Troubleshooting: Re-authentication" section to both `/add-whatsapp` and `/add-telegram` with channel-specific recovery steps

## Test plan
- [ ] Verify no source code files were modified (only `.claude/skills/`)
- [ ] Read through each modified SKILL.md to confirm formatting and instructions are clear
- [ ] Confirm phase recovery notes reference correct phase numbers
- [ ] Verify NSSM commands use correct syntax (`nssm install`, `nssm set`)
- [ ] Confirm smoke test scripts use valid import paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)