### PR TITLE
fix(channels): Telegram polling resilience + startup hint clarity

### DIFF
--- a/packages/mcp-telegram/src/telegram.test.ts
+++ b/packages/mcp-telegram/src/telegram.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted runs before vi.mock hoisting — set env before module evaluation
+vi.hoisted(() => {
+  process.env.TELEGRAM_BOT_TOKEN = 'test-token-123';
+});
+
+// Shared state for the mock bot
+let catchHandler: Function | null = null;
+const mockStart = vi.fn((options: any) => {
+  if (options?.onStart) {
+    options.onStart({ username: 'test_bot', id: 123 });
+  }
+  return Promise.resolve();
+});
+const mockStop = vi.fn();
+const mockCommand = vi.fn();
+const mockOn = vi.fn();
+const mockCatch = vi.fn((handler: Function) => {
+  catchHandler = handler;
+});
+
+vi.mock('grammy', () => {
+  return {
+    Bot: class MockBot {
+      command = mockCommand;
+      on = mockOn;
+      catch = mockCatch;
+      start = mockStart;
+      stop = mockStop;
+      api = {
+        sendMessage: vi.fn(),
+        sendChatAction: vi.fn(),
+      };
+    },
+    Api: class {},
+  };
+});
+
+vi.mock('pino', () => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  const pinoFn: any = () => mockLogger;
+  pinoFn.destination = () => ({});
+  return { default: pinoFn };
+});
+
+import { TelegramProvider } from './telegram.js';
+
+describe('TelegramProvider', () => {
+  let provider: TelegramProvider;
+
+  beforeEach(() => {
+    catchHandler = null;
+    // Reset implementations but keep fns alive
+    mockStart.mockImplementation((options: any) => {
+      if (options?.onStart) {
+        options.onStart({ username: 'test_bot', id: 123 });
+      }
+      return Promise.resolve();
+    });
+    mockStop.mockReset();
+    mockCommand.mockReset();
+    mockOn.mockReset();
+    mockCatch.mockImplementation((handler: Function) => {
+      catchHandler = handler;
+    });
+    provider = new TelegramProvider();
+  });
+
+  describe('error tracking and polling reset', () => {
+    it('tracks consecutive errors via the catch handler', async () => {
+      await provider.connect();
+      expect(catchHandler).toBeDefined();
+
+      // Simulate errors below threshold
+      for (let i = 0; i < 3; i++) {
+        catchHandler!({ message: `error ${i}` });
+      }
+
+      // Bot should not have been stopped
+      expect(mockStop).not.toHaveBeenCalled();
+    });
+
+    it('resets polling after MAX_CONSECUTIVE_ERRORS (5) failures', async () => {
+      await provider.connect();
+
+      // Reset call counts from connect()
+      mockStop.mockClear();
+      mockStart.mockClear();
+
+      // Simulate 5 consecutive errors (the threshold)
+      for (let i = 0; i < 5; i++) {
+        catchHandler!({ message: `error ${i}` });
+      }
+
+      // Should have called stop + start to reset polling
+      expect(mockStop).toHaveBeenCalledTimes(1);
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reset polling twice while already resetting', async () => {
+      await provider.connect();
+
+      // Make start not call onStart (simulating slow restart)
+      mockStart.mockImplementationOnce(() => Promise.resolve());
+      mockStop.mockClear();
+      mockStart.mockClear();
+
+      // Trigger 5 errors to start a reset
+      for (let i = 0; i < 5; i++) {
+        catchHandler!({ message: `error ${i}` });
+      }
+
+      // Now send 5 more errors while resetting
+      for (let i = 0; i < 5; i++) {
+        catchHandler!({ message: `error ${i}` });
+      }
+
+      // Should only have triggered one reset
+      expect(mockStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleans up state on disconnect', async () => {
+      await provider.connect();
+      mockStop.mockClear();
+
+      await provider.disconnect();
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+      expect(provider.isConnected()).toBe(false);
+    });
+  });
+
+  describe('basic operations', () => {
+    it('reports connected after successful connect', async () => {
+      await provider.connect();
+      expect(provider.isConnected()).toBe(true);
+    });
+
+    it('returns correct status', async () => {
+      await provider.connect();
+      const status = provider.getStatus();
+      expect(status.connected).toBe(true);
+      expect(status.channel).toBe('telegram');
+      expect(status.identity).toBe('test_bot');
+    });
+
+    it('has name "telegram"', () => {
+      expect(provider.name).toBe('telegram');
+    });
+  });
+});

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -26,6 +26,7 @@ const logger = pino(
 );
 
 const MAX_MESSAGE_LENGTH = 4096;
+const MAX_CONSECUTIVE_ERRORS = 5;
 
 /**
  * Send a message with Telegram Markdown parse mode, falling back to plain text.
@@ -50,6 +51,8 @@ export class TelegramProvider implements ChannelProvider {
   private connectTime = 0;
   private knownChats = new Map<string, { name: string; isGroup: boolean }>();
   private botUsername?: string;
+  private consecutiveErrors = 0;
+  private resetting = false;
 
   // Set by server-base.ts
   onMessage: (msg: IncomingMessage) => void = () => {};
@@ -87,6 +90,7 @@ export class TelegramProvider implements ChannelProvider {
 
     // Handle text messages
     this.bot.on('message:text', async (ctx) => {
+      this.consecutiveErrors = 0;
       if (ctx.message.text.startsWith('/')) {
         const cmd = ctx.message.text.slice(1).split(/[\s@]/)[0].toLowerCase();
         if (BOT_COMMANDS.has(cmd)) return;
@@ -206,7 +210,15 @@ export class TelegramProvider implements ChannelProvider {
     this.bot.on('message:contact', (ctx) => storeMedia(ctx, '[Contact]'));
 
     this.bot.catch((err) => {
-      logger.error({ err: err.message }, 'Telegram bot error');
+      this.consecutiveErrors++;
+      logger.error(
+        { err: err.message, consecutiveErrors: this.consecutiveErrors },
+        'Telegram bot error',
+      );
+
+      if (this.consecutiveErrors >= MAX_CONSECUTIVE_ERRORS && !this.resetting) {
+        this.resetPolling();
+      }
     });
 
     return new Promise<void>((resolve) => {
@@ -214,6 +226,7 @@ export class TelegramProvider implements ChannelProvider {
         onStart: (botInfo) => {
           this.botUsername = botInfo.username;
           this.connectTime = Date.now();
+          this.consecutiveErrors = 0;
           logger.info(
             { username: botInfo.username, id: botInfo.id },
             'Telegram bot connected',
@@ -221,6 +234,35 @@ export class TelegramProvider implements ChannelProvider {
           resolve();
         },
       });
+    });
+  }
+
+  /**
+   * Reset the polling session after consecutive errors.
+   * Stops the bot and restarts polling to recover from a degraded state.
+   */
+  private resetPolling(): void {
+    if (!this.bot || this.resetting) return;
+    this.resetting = true;
+    logger.warn(
+      { consecutiveErrors: this.consecutiveErrors },
+      'Too many consecutive errors, resetting Telegram polling session',
+    );
+
+    const bot = this.bot;
+    bot.stop();
+    this.consecutiveErrors = 0;
+
+    bot.start({
+      onStart: (botInfo) => {
+        this.botUsername = botInfo.username;
+        this.connectTime = Date.now();
+        this.resetting = false;
+        logger.info(
+          { username: botInfo.username, id: botInfo.id },
+          'Telegram bot reconnected after polling reset',
+        );
+      },
     });
   }
 
@@ -261,6 +303,8 @@ export class TelegramProvider implements ChannelProvider {
 
   async disconnect(): Promise<void> {
     if (this.bot) {
+      this.resetting = false;
+      this.consecutiveErrors = 0;
       this.bot.stop();
       this.bot = null;
       logger.info('Telegram bot stopped');

--- a/src/startup-gate.test.ts
+++ b/src/startup-gate.test.ts
@@ -111,6 +111,33 @@ describe('runStartupChecks', () => {
     expect(suggestNames).toContain('Registered groups');
   });
 
+  it('shows setup hint when no groups and no channels configured', () => {
+    mockHasApiCredentials.mockReturnValue(true);
+    mockHasAnyChannelAuth.mockReturnValue(false);
+    mockCountRegisteredGroups.mockReturnValue(0);
+    const report = runStartupChecks();
+    const groupResult = report.suggestions.find(
+      (r) => r.name === 'Registered groups',
+    );
+    expect(groupResult).toBeDefined();
+    expect(groupResult!.hint).toContain('/add-whatsapp');
+    expect(groupResult!.hint).toContain('/add-telegram');
+    expect(groupResult!.hint).not.toContain('messages will be ignored');
+  });
+
+  it('shows channel-connected hint when channels exist but no groups registered', () => {
+    mockHasApiCredentials.mockReturnValue(true);
+    mockHasAnyChannelAuth.mockReturnValue(true);
+    mockCountRegisteredGroups.mockReturnValue(0);
+    const report = runStartupChecks();
+    const groupResult = report.suggestions.find(
+      (r) => r.name === 'Registered groups',
+    );
+    expect(groupResult).toBeDefined();
+    expect(groupResult!.hint).toContain('Channel connected');
+    expect(groupResult!.hint).toContain('/setup');
+  });
+
   it('returns all passed when everything is healthy', () => {
     mockHasApiCredentials.mockReturnValue(true);
     mockHasGeminiApiKey.mockReturnValue(true);

--- a/src/startup-gate.ts
+++ b/src/startup-gate.ts
@@ -128,12 +128,18 @@ registerStartupCheck({
 registerStartupCheck({
   name: 'Registered groups',
   level: 'suggest',
-  run: () => ({
-    name: 'Registered groups',
-    level: 'suggest',
-    ok: countRegisteredGroups() > 0,
-    hint: 'No groups registered — messages will be ignored. Run /setup → "register" to add one.',
-  }),
+  run: () => {
+    const ok = countRegisteredGroups() > 0;
+    let hint: string;
+    if (hasAnyChannelAuth()) {
+      hint =
+        'Channel connected but no chats registered. Run /setup to register a chat.';
+    } else {
+      hint =
+        'No groups registered yet. Use /add-whatsapp or /add-telegram to set up a channel, then register a chat.';
+    }
+    return { name: 'Registered groups', level: 'suggest', ok, hint };
+  },
 });
 
 // ── Runner ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Telegram polling reset**: Added consecutive error tracking to the Telegram bot's `catch` handler. After 5 consecutive middleware failures, the bot stops and restarts its polling session to recover from degraded state. Successful message processing resets the counter. The `disconnect()` method cleanly resets all resilience state.
- **Startup hint clarity**: Replaced the misleading "messages will be ignored" hint in the startup gate with context-aware messages. When channels are configured but no chats registered, it suggests `/setup`. When no channels exist, it suggests `/add-whatsapp` or `/add-telegram` first.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (487 root tests + 7 telegram package tests)
- [x] New tests for Telegram error tracking, polling reset, and disconnect cleanup
- [x] New tests for context-aware startup hint (no channels vs channels-but-no-groups)
- [x] Pre-commit hooks (eslint + prettier) pass on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)