### PR TITLE
feat(memory): make vault Obsidian-independent

### DIFF
--- a/.claude/commands/compress.md
+++ b/.claude/commands/compress.md
@@ -1,4 +1,4 @@
-Save this Claude Code session to the Obsidian vault and update the semantic memory index.
+Save this Claude Code session to the vault and update the semantic memory index.
 
 First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
 

--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -1,4 +1,4 @@
-Load context from the Obsidian vault before starting work.
+Load context from the vault before starting work.
 
 NOTE: This is the home-mode (~/deus) version. For external projects, the user-level /resume skill at ~/.claude/skills/resume/ handles project-focused context loading automatically.
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ __pycache__/
 # Skills system (local per-installation state)
 .deus/
 
+# Project-local memory vault (alternative to external vault path)
+.vault/
+
 # Local-only skills — listed here so they're not staged into container builds
 # One skill name per line (e.g., "x-integration"). No paths, just the name.
 .local-skills

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ macOS (Apple Silicon recommended), Linux, and Windows (via Docker Desktop). Wind
 The core agent uses the Claude Agent SDK — this is architectural and not swappable. The evolution/eval judges can use Ollama (local, free) or Gemini.
 
 **Where is my data?**
-All local. Memory in SQLite, session logs optionally in an Obsidian vault, no cloud sync.
+All local. Memory in SQLite, session logs in a local vault directory, no cloud sync.
 
 **How do I add a new channel?**
 Use the skill system: `/add-whatsapp`, `/add-telegram`, `/add-slack`, `/add-discord`, `/add-gmail`. Or build your own channel skill.

--- a/assets/brand-production/DIAGRAM_PROMPTS.md
+++ b/assets/brand-production/DIAGRAM_PROMPTS.md
@@ -37,7 +37,7 @@ The flow is left-to-right with these stages:
 5. CONTAINER (Linux VM) — a rounded box with dashed border containing:
    - "Claude Agent SDK" at top
    - Below it, two tool boxes: "Calendar (gcal)" and "Filesystem"
-   - A small label: "YouTube, Obsidian, etc. via optional skills"
+   - A small label: "YouTube, etc. via optional skills"
 6. Container → "Credential Proxy (:3001)" → external "Claude API" (shown to the right of container, outside both zones). This is the OUTBOUND path for Claude API calls — the proxy injects real credentials so the container never holds secrets. Label this arrow "tokens injected outbound".
 7. Separate return arrow: CONTAINER → HOST → USER labeled "response". This is the user-facing response path — it does NOT go through the credential proxy.
 
@@ -135,7 +135,7 @@ LEFT ZONE — "Host" (orange accent):
   - "Credential Proxy (:3001)" box
   - "SQLite databases" box
   - "Mount Security Validator" box (validates additional mounts against allowlist)
-  - "Obsidian vault" box (labeled "optional mount, read-write")
+  - "Memory vault" box (labeled "optional mount, read-write")
 
 RIGHT ZONE — "Container" (teal accent, dashed border):
   - "Claude Agent SDK" box

--- a/container/skills/compress/SKILL.md
+++ b/container/skills/compress/SKILL.md
@@ -1,22 +1,30 @@
 ---
 name: compress
-description: Save the current session to the Obsidian vault. Writes a compact session log with a TL;DR frontmatter (always) and full details below (when useful).
+description: Save the current session to the vault. Writes a compact session log with a TL;DR frontmatter (always) and full details below (when useful).
 ---
 
 # /compress — Save Session
 
-Save a summary of this conversation to the Obsidian vault.
+Save a summary of this conversation to the vault.
+
+The vault is mounted at `/workspace/vault/`. If it doesn't exist, check `/workspace/extra/obsidian/Deus/` as a legacy fallback.
 
 ## Steps
 
-1. **Reflect on the conversation** — identify what's worth saving:
+1. **Resolve vault path:**
+   ```bash
+   VAULT_DIR="${DEUS_VAULT_DIR:-/workspace/vault}"
+   [ ! -d "$VAULT_DIR" ] && VAULT_DIR="/workspace/extra/obsidian/Deus"
+   ```
+
+2. **Reflect on the conversation** — identify what's worth saving:
    - Decisions made, key learnings, files modified, pending tasks, errors/workarounds
 
-2. **Determine a short topic slug** from the main theme (e.g. `google-calendar-setup`, `ui-debugging`).
+3. **Determine a short topic slug** from the main theme (e.g. `google-calendar-setup`, `ui-debugging`).
 
-3. **Write the session log:**
+4. **Write the session log:**
    ```
-   /workspace/extra/obsidian/Deus/Session-Logs/YYYY-MM-DD-{topic}.md
+   $VAULT_DIR/Session-Logs/YYYY-MM-DD-{topic}.md
    ```
 
    Use this format — the `tldr` frontmatter field is **mandatory**; full sections are optional:
@@ -50,8 +58,8 @@ Save a summary of this conversation to the Obsidian vault.
    Keep `tldr` to 2–3 lines max — this is what gets loaded every session.
    Skip any full section that has no content.
 
-4. **Update pending tasks in CLAUDE.md** if there are carry-forward items:
-   - Read `/workspace/extra/obsidian/Deus/CLAUDE.md`
+5. **Update pending tasks in CLAUDE.md** if there are carry-forward items:
+   - Read `$VAULT_DIR/CLAUDE.md`
    - Update the `pending:` block
    - Write it back
 

--- a/container/skills/preserve/SKILL.md
+++ b/container/skills/preserve/SKILL.md
@@ -5,14 +5,18 @@ description: Scan the current conversation and silently save anything worth perm
 
 # /preserve — Update Permanent Memory
 
-Silently extract and save lasting knowledge from this conversation to `/workspace/extra/obsidian/Deus/CLAUDE.md`.
+Silently extract and save lasting knowledge from this conversation to the vault's CLAUDE.md.
+
+The vault is mounted at `/workspace/vault/`. If it doesn't exist, check `/workspace/extra/obsidian/Deus/` as a legacy fallback.
 
 ## Steps
 
 1. **Read the current CLAUDE.md:**
    ```bash
-   cat /workspace/extra/obsidian/Deus/CLAUDE.md
-   wc -l /workspace/extra/obsidian/Deus/CLAUDE.md
+   VAULT_DIR="${DEUS_VAULT_DIR:-/workspace/vault}"
+   [ ! -d "$VAULT_DIR" ] && VAULT_DIR="/workspace/extra/obsidian/Deus"
+   cat "$VAULT_DIR/CLAUDE.md"
+   wc -l "$VAULT_DIR/CLAUDE.md"
    ```
 
 2. **Review the conversation** — identify what's genuinely worth permanent memory:
@@ -30,7 +34,7 @@ Silently extract and save lasting knowledge from this conversation to `/workspac
    - Write as data, not narrative
 
 4. **Auto-archive if file exceeds 200 lines:**
-   - Move completed projects and old decisions to `/workspace/extra/obsidian/Deus/CLAUDE-Archive.md`
+   - Move completed projects and old decisions to `$VAULT_DIR/CLAUDE-Archive.md`
    - Keep core blocks: identity line, tools, projects, pending, decisions
 
 5. **Confirm briefly** what was added, or "Nothing new worth preserving." if nothing qualified.

--- a/container/skills/resume/SKILL.md
+++ b/container/skills/resume/SKILL.md
@@ -5,18 +5,22 @@ description: Load context from permanent memory and recent session logs. Tiered 
 
 # /resume — Load Context
 
-Load persistent context from the Obsidian vault.
+Load persistent context from the vault.
+
+The vault is mounted at `/workspace/vault/`. If it doesn't exist, check `/workspace/extra/obsidian/Deus/` as a legacy fallback.
 
 ## Steps
 
-1. **Read permanent memory (full — it's compact):**
+1. **Resolve vault path and read permanent memory (full — it's compact):**
    ```bash
-   cat /workspace/extra/obsidian/Deus/CLAUDE.md
+   VAULT_DIR="${DEUS_VAULT_DIR:-/workspace/vault}"
+   [ ! -d "$VAULT_DIR" ] && VAULT_DIR="/workspace/extra/obsidian/Deus"
+   cat "$VAULT_DIR/CLAUDE.md"
    ```
 
 2. **Find recent session logs** (default: last 3, or use number given as argument):
    ```bash
-   ls -t /workspace/extra/obsidian/Deus/Session-Logs/*.md 2>/dev/null | head -${args:-3}
+   ls -t "$VAULT_DIR"/Session-Logs/*.md 2>/dev/null | head -${args:-3}
    ```
 
 3. **For each session log: read frontmatter only** (the YAML block between the two `---` lines):
@@ -28,7 +32,7 @@ Load persistent context from the Obsidian vault.
 
 4. **If a search term was given** (e.g. `/resume auth`), grep logs and read frontmatter of matches:
    ```bash
-   grep -ril "<term>" /workspace/extra/obsidian/Deus/Session-Logs/ 2>/dev/null
+   grep -ril "<term>" "$VAULT_DIR/Session-Logs/" 2>/dev/null
    ```
 
 5. **Summarize in 2–3 lines:** ongoing context, pending tasks, ready to continue.

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -133,7 +133,7 @@ Check if the current working directory is the Deus home directory (`~/deus`). If
 
 ## Home Mode (~/deus)
 
-Load context from the Obsidian vault before starting work.
+Load context from the vault before starting work.
 
 First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
 
@@ -456,7 +456,7 @@ _ensure_compress_skill() {
   cat > "$skill_dir/skill.md" <<'SKILLEOF'
 ---
 name: compress
-description: Save this session to the Obsidian vault and update the semantic memory index
+description: Save this session to the vault and update the semantic memory index
 user_invocable: true
 ---
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -102,7 +102,7 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DEUS_VAULT_PATH` | — | Obsidian vault path for session logs and memory |
+| `DEUS_VAULT_PATH` | — | Vault directory path for session logs and memory |
 
 ## Sessions
 

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -21,6 +21,6 @@ This lock-in is a deliberate trade-off: the Claude Agent SDK provides session ma
 
 While Linux is supported, several features work best on macOS:
 - **Whisper transcription** — Metal acceleration on Apple Silicon
-- **Obsidian vault sync** — assumes local filesystem access
+- **Vault sync** — assumes local filesystem access
 
 Linux users can use Docker and skip voice transcription if Whisper Metal isn't available.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ Deus is a personal AI assistant. A single Node.js host process orchestrates cont
               │                   MEMORY LAYER                           │
               │                                                          │
               │   Session Logs ──▶ Memory Indexer (scripts/)             │
-              │   (Obsidian vault)   sqlite-vec + Gemini embeddings      │
+              │   (vault directory)  sqlite-vec + Gemini embeddings      │
               │                         │                                │
               │              Tiered retrieval:                           │
               │              warm (last N sessions, free)                │
@@ -289,7 +289,7 @@ At startup, `index.ts` iterates over registered channel names, calls each factor
 
 - **SQLite vector database**: `~/.deus/memory.db` using `sqlite-vec` extension for vector similarity search
 - **Embeddings**: Gemini `text-embedding-004` model (768-dimensional vectors)
-- **Session logs**: Markdown files stored in an Obsidian vault (path configured via `DEUS_VAULT_PATH` or `~/.config/deus/config.json`)
+- **Session logs**: Markdown files stored in a vault directory (path configured via `DEUS_VAULT_PATH` or `~/.config/deus/config.json`, defaults to `~/.deus/vault/`)
 
 ### Memory Indexer (`scripts/memory_indexer.py`)
 
@@ -310,7 +310,7 @@ Commands:
 
 ### Session Lifecycle
 
-1. **Stop hook** (`scripts/stop_hook.py`): auto-saves a checkpoint to the Obsidian vault at the end of each Claude Code session. No LLM calls.
+1. **Stop hook** (`scripts/stop_hook.py`): auto-saves a checkpoint to the vault at the end of each Claude Code session. No LLM calls.
 2. **`/compress`**: saves the current session and updates the semantic index.
 3. **`/resume`**: loads core memory + warm tier + cold tier before starting work.
 
@@ -453,7 +453,7 @@ See [`docs/ENVIRONMENT.md`](ENVIRONMENT.md) for the full reference. Key variable
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (alternative to API key) |
 | `GEMINI_API_KEY` | Gemini API key for memory embeddings and production judge |
 | `CONTAINER_RUNTIME` | Container binary: `docker`, `container`, `podman` |
-| `DEUS_VAULT_PATH` | Obsidian vault path for session logs |
+| `DEUS_VAULT_PATH` | Vault directory path for session logs |
 | `EVOLUTION_ENABLED` | Enable/disable evolution loop (default: enabled) |
 | `EVOLUTION_REFLECTION_THRESHOLD` | Score threshold for reflexion (default: 0.6) |
 | `EVAL_JUDGE` | Force judge: `ollama` or `gemini` |

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -61,7 +61,7 @@ def _load_vault_path() -> Path:
     print(
         "ERROR: Memory vault not configured.\n"
         "Set DEUS_VAULT_PATH or add vault_path to ~/.config/deus/config.json\n"
-        "Run /setup → 'memory' in Claude Code to configure.",
+        "Run `deus setup` or /setup in Claude Code to configure.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -2,8 +2,8 @@
 """
 Deus Stop Hook
 Fires when Claude Code finishes a turn. Extracts the last few exchanges
-from the transcript and writes a lightweight checkpoint to the Obsidian
-vault so /resume can restore context across sessions or after /compact.
+from the transcript and writes a lightweight checkpoint to the vault
+so /resume can restore context across sessions or after /compact.
 
 No LLM calls — works offline, no quota risk, fast.
 Throttled: at most one checkpoint per 30 minutes.

--- a/setup/memory.ts
+++ b/setup/memory.ts
@@ -21,6 +21,7 @@ import { emitStatus } from './status.js';
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 const DEUS_ENV_PATH = path.join(process.cwd(), '.env');
 const DEFAULT_VAULT_PATH = path.join(HOME_DIR, '.deus', 'vault');
+const PROJECT_LOCAL_VAULT_PATH = path.join(process.cwd(), '.vault');
 const MEMORY_INDEXER = path.join(process.cwd(), 'scripts', 'memory_indexer.py');
 
 const VAULT_SUBDIRS = ['Session-Logs', 'Atoms', 'Checkpoints', 'Persona'];
@@ -154,11 +155,25 @@ export async function run(args: string[]): Promise<void> {
     // No existing config
   }
 
-  // If vault_path is provided as arg, use it; otherwise check config; otherwise default
-  const vaultArg = args.find((a) => a.startsWith('--vault-path='));
-  let vaultPath = vaultArg
-    ? vaultArg.split('=', 2)[1]
-    : (config.vault_path as string | undefined) || DEFAULT_VAULT_PATH;
+  // Vault location options:
+  //   --vault-path=<path>   Explicit path (Obsidian vault, NAS, Dropbox, etc.)
+  //   --vault-mode=local    Project-local vault at .vault/ (gitignored, portable)
+  //   --vault-mode=default  Standard location at ~/.deus/vault/ (default)
+  //   (no args)             Use existing config, or default
+  const vaultPathArg = args.find((a) => a.startsWith('--vault-path='));
+  const vaultModeArg = args.find((a) => a.startsWith('--vault-mode='));
+  const vaultMode = vaultModeArg?.split('=', 2)[1];
+
+  let vaultPath: string;
+  if (vaultPathArg) {
+    vaultPath = vaultPathArg.split('=', 2)[1];
+  } else if (vaultMode === 'local') {
+    vaultPath = PROJECT_LOCAL_VAULT_PATH;
+  } else if (vaultMode === 'default') {
+    vaultPath = DEFAULT_VAULT_PATH;
+  } else {
+    vaultPath = (config.vault_path as string | undefined) || DEFAULT_VAULT_PATH;
+  }
 
   // Expand ~ if needed
   if (vaultPath.startsWith('~')) {
@@ -229,10 +244,18 @@ export async function run(args: string[]): Promise<void> {
     // File doesn't exist
   }
 
+  const vaultLocation =
+    vaultPath === path.resolve(PROJECT_LOCAL_VAULT_PATH)
+      ? 'project-local (.vault/)'
+      : vaultPath === path.resolve(DEFAULT_VAULT_PATH)
+        ? 'default (~/.deus/vault/)'
+        : 'custom';
+
   emitStatus('MEMORY', {
     STATUS: 'success',
     PYTHON_VERSION: pythonVersion,
     VAULT_PATH: vaultPath,
+    VAULT_LOCATION: vaultLocation,
     CONFIG_PATH: CONFIG_PATH,
     HAS_GEMINI_KEY: hasGeminiKey,
     GEMINI_KEY_HINT: hasGeminiKey

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -14,7 +14,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { DATA_DIR, GROUPS_DIR } from './config.js';
+import { DATA_DIR, GROUPS_DIR, HOME_DIR, CONFIG_DIR } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
 import { getProjectById } from './db.js';
@@ -30,6 +30,36 @@ export interface VolumeMount {
   hostPath: string;
   containerPath: string;
   readonly: boolean;
+}
+
+/**
+ * Resolve the vault path from env var or config file.
+ * Returns null if no vault is configured.
+ */
+function resolveVaultPath(): string | null {
+  // 1. Environment variable
+  const envPath = process.env.DEUS_VAULT_PATH;
+  if (envPath) {
+    const resolved = envPath.startsWith('~')
+      ? path.join(HOME_DIR, envPath.slice(1))
+      : envPath;
+    return path.resolve(resolved);
+  }
+  // 2. Config file
+  const configPath = path.join(CONFIG_DIR, 'config.json');
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if (cfg.vault_path) {
+      const vp = cfg.vault_path as string;
+      const resolved = vp.startsWith('~')
+        ? path.join(HOME_DIR, vp.slice(1))
+        : vp;
+      return path.resolve(resolved);
+    }
+  } catch {
+    // No config file or parse error
+  }
+  return null;
 }
 
 export function buildVolumeMounts(
@@ -306,6 +336,23 @@ export function buildVolumeMounts(
     containerPath: '/app/src',
     readonly: true,
   });
+
+  // Auto-mount the memory vault if configured.
+  // The vault stores session logs, atoms, and checkpoints — agents need read-write
+  // access for /compress, /resume, and /preserve skills.
+  // Mounted at /workspace/vault/ (standard path referenced by container skills).
+  const vaultPath = resolveVaultPath();
+  if (vaultPath && fs.existsSync(vaultPath)) {
+    mounts.push({
+      hostPath: vaultPath,
+      containerPath: '/workspace/vault',
+      readonly: false,
+    });
+    logger.info(
+      { group: group.name, vaultPath },
+      'Vault mounted at /workspace/vault',
+    );
+  }
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -18,9 +18,11 @@ vi.mock('./config.js', () => ({
   CONTAINER_IMAGE: 'deus-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min
+  CONFIG_DIR: '/tmp/deus-test-config',
   CREDENTIAL_PROXY_PORT: 3001,
   DATA_DIR: '/tmp/deus-test-data',
   GROUPS_DIR: '/tmp/deus-test-groups',
+  HOME_DIR: '/tmp/deus-test-home',
   IDLE_TIMEOUT: 1800000, // 30min
   TIMEZONE: 'America/Los_Angeles',
 }));


### PR DESCRIPTION
## Summary
- Replaced all "Obsidian vault" references with generic "vault" across docs, commands, container skills, and scripts (17 files)
- Added vault auto-mount in `container-mounter.ts` — reads `vault_path` from config and mounts at `/workspace/vault/` (container skills use this standard path with legacy fallback)
- Added `--vault-mode=local|default` option to `setup/memory.ts` for project-local `.vault/` storage (gitignored)
- Added `resolveVaultPath()` helper to container-mounter for config-based vault resolution

## Test plan
- [x] `npm run build` passes
- [x] All 495 tests pass (including updated container-runner mock)
- [ ] Manual: `deus setup` with `--vault-mode=local` creates `.vault/` in project root
- [ ] Manual: `deus setup` with `--vault-path=/custom/path` uses custom path
- [ ] Manual: container skills find vault at `/workspace/vault/` after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)