### PR TITLE
fix(eval): resolve pytest version conflict with deepeval

### DIFF
--- a/eval/requirements.txt
+++ b/eval/requirements.txt
@@ -1,6 +1,6 @@
 # Pinned versions — update periodically with: pip install --upgrade <pkg>
 anthropic==0.49.0
 deepeval==2.5.6
-pytest==8.3.5
+pytest>=7.4.3,<8.0.0
 google-genai==1.14.0
 sqlite-vec==0.1.6


### PR DESCRIPTION
## Summary
- `deepeval==2.5.6` requires `pytest<8.0.0`, but `eval/requirements.txt` pinned `pytest==8.3.5`, causing pip resolution failure on every PR that triggers the eval workflow
- Relaxed the pytest pin to `>=7.4.3,<8.0.0` so it satisfies deepeval's constraint while staying on the latest compatible version

## Test plan
- [ ] Eval CI workflow passes pip install step without resolution errors
- [ ] Smoke tests run successfully with pytest 7.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)