### PR TITLE
chore(channels): rename MCP packages to @deus-ai/* scope and add publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,46 @@
+name: Publish MCP Packages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Build and publish @deus-ai/channel-core
+        working-directory: packages/mcp-channel-core
+        run: |
+          npm ci
+          npm run build
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build and publish @deus-ai/whatsapp-mcp
+        working-directory: packages/mcp-whatsapp
+        run: |
+          npm ci
+          npm run build
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build and publish @deus-ai/telegram-mcp
+        working-directory: packages/mcp-telegram
+        run: |
+          npm ci
+          npm run build
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/mcp-channel-core/package.json
+++ b/packages/mcp-channel-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deus-mcp-channel-core",
+  "name": "@deus-ai/channel-core",
   "version": "1.0.0",
   "description": "Shared types and base server logic for Deus MCP channel servers",
   "type": "module",
@@ -20,6 +20,9 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "MIT"
 }

--- a/packages/mcp-telegram/README.md
+++ b/packages/mcp-telegram/README.md
@@ -1,4 +1,4 @@
-# deus-mcp-telegram
+# @deus-ai/telegram-mcp
 
 Standalone MCP server for Telegram bots. Uses [grammY](https://grammy.dev/) for the Telegram Bot API.
 
@@ -11,7 +11,7 @@ Works with any MCP client — Claude Code, Claude Desktop, or your own applicati
   "mcpServers": {
     "telegram": {
       "command": "npx",
-      "args": ["deus-mcp-telegram"],
+      "args": ["@deus-ai/telegram-mcp"],
       "env": {
         "TELEGRAM_BOT_TOKEN": "your-bot-token"
       }

--- a/packages/mcp-telegram/package.json
+++ b/packages/mcp-telegram/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "deus-mcp-telegram",
+  "name": "@deus-ai/telegram-mcp",
   "version": "1.0.0",
   "description": "Telegram MCP server — standalone Telegram bot integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "deus-mcp-telegram": "./dist/index.js"
+    "deus-ai-telegram-mcp": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "deus-mcp-channel-core": "file:../mcp-channel-core",
+    "@deus-ai/channel-core": "file:../mcp-channel-core",
     "grammy": "^1.39.3",
     "pino": "^10.3.1",
     "zod": "^4.3.6"
@@ -26,6 +26,9 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "MIT"
 }

--- a/packages/mcp-telegram/src/index.ts
+++ b/packages/mcp-telegram/src/index.ts
@@ -14,12 +14,12 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { registerCommonTools } from 'deus-mcp-channel-core';
+import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { TelegramProvider } from './telegram.js';
 
 const server = new McpServer({
-  name: 'deus-mcp-telegram',
+  name: '@deus-ai/telegram-mcp',
   version: '1.0.0',
 });
 
@@ -32,7 +32,7 @@ registerCommonTools(server, provider);
 
 if (provider.hasToken()) {
   provider.connect().catch((err) => {
-    console.error('[deus-mcp-telegram] Auto-connect failed:', err.message);
+    console.error('[@deus-ai/telegram-mcp] Auto-connect failed:', err.message);
   });
 }
 

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -14,7 +14,7 @@ import type {
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
-} from 'deus-mcp-channel-core';
+} from '@deus-ai/channel-core';
 
 const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Deus';
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || '';

--- a/packages/mcp-whatsapp/README.md
+++ b/packages/mcp-whatsapp/README.md
@@ -1,4 +1,4 @@
-# deus-mcp-whatsapp
+# @deus-ai/whatsapp-mcp
 
 Standalone MCP server for WhatsApp messaging. Uses [Baileys](https://github.com/WhiskeySockets/Baileys) for the WhatsApp Web API.
 
@@ -11,7 +11,7 @@ Works with any MCP client — Claude Code, Claude Desktop, or your own applicati
   "mcpServers": {
     "whatsapp": {
       "command": "npx",
-      "args": ["deus-mcp-whatsapp"],
+      "args": ["@deus-ai/whatsapp-mcp"],
       "env": {
         "WHATSAPP_AUTH_DIR": "/path/to/auth/dir"
       }

--- a/packages/mcp-whatsapp/package.json
+++ b/packages/mcp-whatsapp/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "deus-mcp-whatsapp",
+  "name": "@deus-ai/whatsapp-mcp",
   "version": "1.0.0",
   "description": "WhatsApp MCP server — standalone WhatsApp Web integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "deus-mcp-whatsapp": "./dist/index.js"
+    "deus-ai-whatsapp-mcp": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
-    "deus-mcp-channel-core": "file:../mcp-channel-core",
+    "@deus-ai/channel-core": "file:../mcp-channel-core",
     "pino": "^10.3.1",
     "qrcode-terminal": "^0.12.0",
     "zod": "^4.3.6"
@@ -28,6 +28,9 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "MIT"
 }

--- a/packages/mcp-whatsapp/src/index.ts
+++ b/packages/mcp-whatsapp/src/index.ts
@@ -16,12 +16,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { registerCommonTools } from 'deus-mcp-channel-core';
+import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { WhatsAppProvider } from './whatsapp.js';
 
 const server = new McpServer({
-  name: 'deus-mcp-whatsapp',
+  name: '@deus-ai/whatsapp-mcp',
   version: '1.0.0',
 });
 
@@ -101,7 +101,7 @@ server.tool(
 if (provider.hasAuth()) {
   provider.connect().catch((err) => {
     // Log to stderr — don't crash, stay available for auth tools
-    console.error('[deus-mcp-whatsapp] Auto-connect failed:', err.message);
+    console.error('[@deus-ai/whatsapp-mcp] Auto-connect failed:', err.message);
   });
 }
 

--- a/packages/mcp-whatsapp/src/whatsapp.ts
+++ b/packages/mcp-whatsapp/src/whatsapp.ts
@@ -33,7 +33,7 @@ import type {
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
-} from 'deus-mcp-channel-core';
+} from '@deus-ai/channel-core';
 
 // ── Config from env vars ────────────────────────────────────────────────
 

--- a/src/channels/mcp-telegram.ts
+++ b/src/channels/mcp-telegram.ts
@@ -1,5 +1,5 @@
 /**
- * Telegram channel factory — spawns deus-mcp-telegram as MCP server.
+ * Telegram channel factory — spawns @deus-ai/telegram-mcp as MCP server.
  * Registers with the channel registry so the host can use it.
  */
 
@@ -19,7 +19,7 @@ registerChannel('telegram', (opts) => {
   let serverPath: string;
   try {
     serverPath = import.meta
-      .resolve('deus-mcp-telegram')
+      .resolve('@deus-ai/telegram-mcp')
       .replace('file://', '');
   } catch {
     serverPath = path.join(

--- a/src/channels/mcp-whatsapp.ts
+++ b/src/channels/mcp-whatsapp.ts
@@ -1,5 +1,5 @@
 /**
- * WhatsApp channel factory — spawns deus-mcp-whatsapp as MCP server.
+ * WhatsApp channel factory — spawns @deus-ai/whatsapp-mcp as MCP server.
  * Registers with the channel registry so the host can use it.
  */
 
@@ -22,9 +22,9 @@ registerChannel('whatsapp', (opts) => {
   // Resolve the MCP server entry point
   let serverPath: string;
   try {
-    // When deus-mcp-whatsapp is installed as a dependency
+    // When @deus-ai/whatsapp-mcp is installed as a dependency
     serverPath = import.meta
-      .resolve('deus-mcp-whatsapp')
+      .resolve('@deus-ai/whatsapp-mcp')
       .replace('file://', '');
   } catch {
     // Fallback: local packages directory (monorepo dev)


### PR DESCRIPTION
## Summary
- Renamed all MCP channel packages to `@deus-ai/*` scoped names:
  - `deus-mcp-channel-core` → `@deus-ai/channel-core`
  - `deus-mcp-whatsapp` → `@deus-ai/whatsapp-mcp`
  - `deus-mcp-telegram` → `@deus-ai/telegram-mcp`
- Added `publishConfig: { access: "public" }` to all packages
- Added `.github/workflows/publish-packages.yml` — publishes to npm on GitHub Release or manual trigger
- Updated all import statements, bin entries, README docs, and host channel factories

## Test plan
- [x] All 3 packages build clean (`npm run build` in each)
- [x] Host project builds clean (`npm run build`)
- [x] All 495 tests pass (`npm test`)
- [ ] CI passes on this PR
- [ ] After merge: manually trigger publish workflow to verify npm publish works

🤖 Generated with [Claude Code](https://claude.com/claude-code)