### PR TITLE
ci(packages): add CI test job for MCP channel packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,28 @@ jobs:
         with:
           configFile: commitlint.config.mjs
 
+  test-packages:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            packages:
+              - 'packages/**'
+      - uses: actions/setup-node@v6
+        if: steps.filter.outputs.packages == 'true'
+        with:
+          node-version: 20
+      - name: Build and test packages
+        if: steps.filter.outputs.packages == 'true'
+        run: |
+          cd packages/mcp-channel-core && npm ci && npm run build && npm test && cd ../..
+          cd packages/mcp-whatsapp && npm ci && npm run build && npm test && cd ../..
+          cd packages/mcp-telegram && npm ci && npm run build && npm test
+
   test-windows:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds a `test-packages` job to the existing CI workflow
- Uses `dorny/paths-filter` to only run when `packages/**` files change
- Builds and tests all 3 packages in dependency order: core first, then whatsapp & telegram
- Runs on ubuntu-latest with Node 20

## Test plan
- [ ] Verify the job is skipped on PRs that don't touch `packages/`
- [ ] Verify the job runs and passes on PRs that modify files in `packages/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)