### PR TITLE
fix(channels): auto-import all channel factories to prevent git pull breakage

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -13,7 +13,7 @@ This skill adds Telegram support to Deus, then walks through interactive setup.
 
 ### Check if already applied
 
-Check if `src/channels/index.ts` already imports `./mcp-telegram.js`. If it does, skip to Phase 3 (Setup).
+Check if Telegram is already configured. If `TELEGRAM_BOT_TOKEN` exists in `.env`, skip to Phase 4 (Registration) or Phase 5 (Verify).
 
 ### Ask the user
 
@@ -31,16 +31,6 @@ The Telegram channel is a local MCP server in `packages/`. Build the packages in
 cd packages/mcp-channel-core && npm install && npm run build && cd ../..
 cd packages/mcp-telegram && npm install && npm run build && cd ../..
 ```
-
-### Register the channel import
-
-Add the Telegram import to `src/channels/index.ts`:
-
-```typescript
-import './mcp-telegram.js';
-```
-
-The factory file `src/channels/mcp-telegram.ts` already exists in the codebase.
 
 ### Validate
 

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -60,16 +60,6 @@ cd packages/mcp-channel-core && npm install && npm run build && cd ../..
 cd packages/mcp-whatsapp && npm install && npm run build && cd ../..
 ```
 
-### Register the channel import
-
-Check if `src/channels/index.ts` already imports `./mcp-whatsapp.js`. If not, add it:
-
-```typescript
-import './mcp-whatsapp.js';
-```
-
-The factory file `src/channels/mcp-whatsapp.ts` already exists in the codebase.
-
 ### Configure environment
 
 Add `ASSISTANT_HAS_OWN_NUMBER` to `.env` if not already present:

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,6 +1,7 @@
 // Channel self-registration barrel file.
-// Each channel skill adds its import here when installed (e.g., /add-whatsapp, /add-telegram).
-// A fresh clone has no channels — that's by design.
-//
-// Example (added by /add-whatsapp):
-//   import './whatsapp.js';
+// All channel factories are imported unconditionally — each one checks for
+// credentials and returns null if not configured, so unused channels are
+// automatically disabled. This prevents git pulls from breaking active channels.
+
+import './mcp-whatsapp.js';
+import './mcp-telegram.js';


### PR DESCRIPTION
## Summary
- Import all channel factories unconditionally in `src/channels/index.ts`
- Each factory already returns `null` when credentials are missing, so unconfigured channels are safely skipped
- Removes the manual "add import" step from `/add-whatsapp` and `/add-telegram` skills
- Prevents git pulls from silently disabling active channels

## Test plan
- [x] Build passes
- [x] All 495 tests pass
- [x] Verified WhatsApp reconnects after service restart
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)