### PR TITLE
feat(channels): add Discord MCP package

### DIFF
--- a/packages/mcp-discord/README.md
+++ b/packages/mcp-discord/README.md
@@ -1,0 +1,48 @@
+# @deus-ai/discord-mcp
+
+Standalone MCP server for Discord bots. Uses [discord.js](https://discord.js.org/) for the Discord API.
+
+Works with any MCP client — Claude Code, Claude Desktop, or your own application.
+
+## Quick Start
+
+```json
+{
+  "mcpServers": {
+    "discord": {
+      "command": "npx",
+      "args": ["@deus-ai/discord-mcp"],
+      "env": {
+        "DISCORD_BOT_TOKEN": "your-bot-token"
+      }
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `send_message` | Send a text message to a channel |
+| `send_typing` | Show/hide typing indicator |
+| `get_status` | Connection status and bot info |
+| `list_chats` | List known channels and DMs |
+| `get_new_messages` | Poll for incoming messages (cursor-based) |
+| `connect` / `disconnect` | Connection lifecycle |
+
+## Incoming Messages
+
+Messages are pushed in real-time via MCP logging notifications with `logger: "incoming_message"`. For clients that don't support notifications, use the `get_new_messages` polling tool.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISCORD_BOT_TOKEN` | *(required)* | Bot token from the Discord Developer Portal |
+| `ASSISTANT_NAME` | `Deus` | Name for @mention translation |
+| `LOG_LEVEL` | `info` | Pino log level |
+
+## License
+
+MIT

--- a/packages/mcp-discord/package.json
+++ b/packages/mcp-discord/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@deus-ai/discord-mcp",
+  "version": "1.0.0",
+  "description": "Discord MCP server — standalone Discord bot integration for any MCP client",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "deus-ai-discord-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@deus-ai/channel-core": "file:../mcp-channel-core",
+    "discord.js": "^14.18.0",
+    "pino": "^10.3.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/packages/mcp-discord/src/discord.test.ts
+++ b/packages/mcp-discord/src/discord.test.ts
@@ -1,0 +1,588 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted runs before vi.mock hoisting — set env before module evaluation
+vi.hoisted(() => {
+  process.env.DISCORD_BOT_TOKEN = 'test-token-123';
+});
+
+// --- discord.js mock ---
+
+type Handler = (...args: any[]) => any;
+
+const clientRef = vi.hoisted(() => ({ current: null as any }));
+
+const mockChannelFetch = vi.fn().mockResolvedValue({
+  send: vi.fn().mockResolvedValue(undefined),
+  sendTyping: vi.fn().mockResolvedValue(undefined),
+});
+
+vi.mock('discord.js', () => {
+  const Events = {
+    MessageCreate: 'messageCreate',
+    ClientReady: 'ready',
+    Error: 'error',
+  };
+
+  const GatewayIntentBits = {
+    Guilds: 1,
+    GuildMessages: 2,
+    MessageContent: 4,
+    DirectMessages: 8,
+  };
+
+  class MockClient {
+    eventHandlers = new Map<string, Handler[]>();
+    user: any = { id: '999888777', tag: 'Deus#1234' };
+    private _ready = false;
+
+    constructor(_opts: any) {
+      clientRef.current = this;
+    }
+
+    on(event: string, handler: Handler) {
+      const existing = this.eventHandlers.get(event) || [];
+      existing.push(handler);
+      this.eventHandlers.set(event, existing);
+      return this;
+    }
+
+    once(event: string, handler: Handler) {
+      return this.on(event, handler);
+    }
+
+    async login(_token: string) {
+      this._ready = true;
+      const readyHandlers = this.eventHandlers.get('ready') || [];
+      for (const h of readyHandlers) {
+        h({ user: this.user });
+      }
+    }
+
+    isReady() {
+      return this._ready;
+    }
+
+    channels = {
+      fetch: mockChannelFetch,
+    };
+
+    destroy() {
+      this._ready = false;
+    }
+  }
+
+  class TextChannel {}
+
+  return {
+    Client: MockClient,
+    Events,
+    GatewayIntentBits,
+    TextChannel,
+  };
+});
+
+vi.mock('pino', () => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+  };
+  const pinoFn: any = () => mockLogger;
+  pinoFn.destination = () => ({});
+  return { default: pinoFn };
+});
+
+import { DiscordProvider } from './discord.js';
+
+// --- Test helpers ---
+
+function currentClient() {
+  return clientRef.current;
+}
+
+function createMessage(overrides: {
+  channelId?: string;
+  content?: string;
+  authorId?: string;
+  authorUsername?: string;
+  authorDisplayName?: string;
+  memberDisplayName?: string;
+  isBot?: boolean;
+  guildName?: string;
+  channelName?: string;
+  messageId?: string;
+  createdAt?: Date;
+  attachments?: Map<string, any>;
+  reference?: { messageId?: string };
+  mentionsBotId?: boolean;
+}) {
+  const channelId = overrides.channelId ?? '1234567890123456';
+  const authorId = overrides.authorId ?? '55512345';
+  const botId = '999888777';
+
+  const mentionsMap = new Map();
+  if (overrides.mentionsBotId) {
+    mentionsMap.set(botId, { id: botId });
+  }
+
+  return {
+    channelId,
+    id: overrides.messageId ?? 'msg_001',
+    content: overrides.content ?? 'Hello everyone',
+    createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
+    author: {
+      id: authorId,
+      username: overrides.authorUsername ?? 'alice',
+      displayName: overrides.authorDisplayName ?? 'Alice',
+      bot: overrides.isBot ?? false,
+    },
+    member: overrides.memberDisplayName
+      ? { displayName: overrides.memberDisplayName }
+      : null,
+    guild: overrides.guildName ? { name: overrides.guildName } : null,
+    channel: {
+      name: overrides.channelName ?? 'general',
+      messages: {
+        fetch: vi.fn().mockResolvedValue({
+          id: 'replied_msg_id',
+          content: 'Original message',
+          author: { username: 'Bob', displayName: 'Bob' },
+          member: { displayName: 'Bob' },
+        }),
+      },
+    },
+    mentions: {
+      users: mentionsMap,
+    },
+    attachments: overrides.attachments ?? new Map(),
+    reference: overrides.reference ?? null,
+  };
+}
+
+async function triggerMessage(message: any) {
+  const handlers = currentClient().eventHandlers.get('messageCreate') || [];
+  for (const h of handlers) await h(message);
+}
+
+// --- Tests ---
+
+describe('DiscordProvider', () => {
+  let provider: DiscordProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChannelFetch.mockResolvedValue({
+      send: vi.fn().mockResolvedValue(undefined),
+      sendTyping: vi.fn().mockResolvedValue(undefined),
+    });
+    provider = new DiscordProvider();
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when client is ready', async () => {
+      await provider.connect();
+      expect(provider.isConnected()).toBe(true);
+    });
+
+    it('registers message handlers on connect', async () => {
+      await provider.connect();
+      expect(currentClient().eventHandlers.has('messageCreate')).toBe(true);
+      expect(currentClient().eventHandlers.has('error')).toBe(true);
+      expect(currentClient().eventHandlers.has('ready')).toBe(true);
+    });
+
+    it('disconnects cleanly', async () => {
+      await provider.connect();
+      expect(provider.isConnected()).toBe(true);
+
+      await provider.disconnect();
+      expect(provider.isConnected()).toBe(false);
+    });
+
+    it('isConnected() returns false before connect', () => {
+      expect(provider.isConnected()).toBe(false);
+    });
+  });
+
+  // --- Status ---
+
+  describe('status', () => {
+    it('returns correct status when connected', async () => {
+      await provider.connect();
+      const status = provider.getStatus();
+      expect(status.connected).toBe(true);
+      expect(status.channel).toBe('discord');
+      expect(status.identity).toBe('Deus#1234');
+    });
+
+    it('returns disconnected status before connect', () => {
+      const status = provider.getStatus();
+      expect(status.connected).toBe(false);
+      expect(status.channel).toBe('discord');
+      expect(status.uptime_seconds).toBe(0);
+    });
+
+    it('has name "discord"', () => {
+      expect(provider.name).toBe('discord');
+    });
+  });
+
+  // --- Text message handling ---
+
+  describe('text message handling', () => {
+    it('delivers message via onMessage callback', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: 'Hello everyone',
+        guildName: 'Test Server',
+        channelName: 'general',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'msg_001',
+          chat_id: 'dc:1234567890123456',
+          sender: '55512345',
+          sender_name: 'Alice',
+          content: 'Hello everyone',
+          is_from_me: false,
+          is_group: true,
+          chat_name: 'Test Server #general',
+        }),
+      );
+    });
+
+    it('ignores bot messages', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({ isBot: true, content: 'I am a bot' });
+      await triggerMessage(msg);
+
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it('uses member displayName when available', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: 'Hi',
+        memberDisplayName: 'Alice Nickname',
+        authorDisplayName: 'Alice Global',
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ sender_name: 'Alice Nickname' }),
+      );
+    });
+
+    it('uses sender name for DM chats (no guild)', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: 'Hello',
+        guildName: undefined,
+        authorDisplayName: 'Alice',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          is_group: false,
+          chat_name: 'Alice',
+        }),
+      );
+    });
+  });
+
+  // --- @mention translation ---
+
+  describe('@mention translation', () => {
+    it('translates <@botId> mention to @AssistantName format', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: '<@999888777> what time is it?',
+        mentionsBotId: true,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '@Deus what time is it?',
+        }),
+      );
+    });
+
+    it('handles <@!botId> (nickname mention format)', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: '<@!999888777> check this',
+        mentionsBotId: true,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '@Deus check this',
+        }),
+      );
+    });
+
+    it('does not translate when bot is not mentioned', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: 'hello everyone',
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'hello everyone',
+        }),
+      );
+    });
+  });
+
+  // --- Attachments ---
+
+  describe('attachments', () => {
+    it('stores image attachment with placeholder', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const attachments = new Map([
+        ['att1', { name: 'photo.png', contentType: 'image/png' }],
+      ]);
+      const msg = createMessage({
+        content: '',
+        attachments,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '[Image: photo.png]',
+        }),
+      );
+    });
+
+    it('includes text content with attachments', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const attachments = new Map([
+        ['att1', { name: 'photo.jpg', contentType: 'image/jpeg' }],
+      ]);
+      const msg = createMessage({
+        content: 'Check this out',
+        attachments,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'Check this out\n[Image: photo.jpg]',
+        }),
+      );
+    });
+
+    it('handles multiple attachments', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const attachments = new Map([
+        ['att1', { name: 'a.png', contentType: 'image/png' }],
+        ['att2', { name: 'b.txt', contentType: 'text/plain' }],
+      ]);
+      const msg = createMessage({
+        content: '',
+        attachments,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '[Image: a.png]\n[File: b.txt]',
+        }),
+      );
+    });
+  });
+
+  // --- Reply context ---
+
+  describe('reply context', () => {
+    it('includes reply metadata', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        content: 'I agree with that',
+        reference: { messageId: 'original_msg_id' },
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'I agree with that',
+          metadata: expect.objectContaining({
+            reply_to_message_id: 'replied_msg_id',
+            reply_to_sender_name: 'Bob',
+          }),
+        }),
+      );
+    });
+  });
+
+  // --- sendMessage ---
+
+  describe('sendMessage', () => {
+    it('sends message via channel', async () => {
+      await provider.connect();
+
+      await provider.sendMessage('dc:1234567890123456', 'Hello');
+      expect(mockChannelFetch).toHaveBeenCalledWith('1234567890123456');
+    });
+
+    it('strips dc: prefix from chat ID', async () => {
+      await provider.connect();
+
+      await provider.sendMessage('dc:9876543210', 'Test');
+      expect(mockChannelFetch).toHaveBeenCalledWith('9876543210');
+    });
+
+    it('handles send failure gracefully', async () => {
+      await provider.connect();
+
+      mockChannelFetch.mockRejectedValueOnce(new Error('Channel not found'));
+
+      await expect(
+        provider.sendMessage('dc:1234567890123456', 'Will fail'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does nothing when client is not initialized', async () => {
+      await provider.sendMessage('dc:1234567890123456', 'No client');
+      // No error, no API call
+      expect(mockChannelFetch).not.toHaveBeenCalled();
+    });
+
+    it('splits messages exceeding 2000 characters', async () => {
+      await provider.connect();
+
+      const mockSend = vi.fn().mockResolvedValue(undefined);
+      mockChannelFetch.mockResolvedValue({
+        send: mockSend,
+        sendTyping: vi.fn(),
+      });
+
+      const longText = 'x'.repeat(3000);
+      await provider.sendMessage('dc:1234567890123456', longText);
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(mockSend).toHaveBeenNthCalledWith(1, 'x'.repeat(2000));
+      expect(mockSend).toHaveBeenNthCalledWith(2, 'x'.repeat(1000));
+    });
+  });
+
+  // --- setTyping ---
+
+  describe('setTyping', () => {
+    it('sends typing indicator when isTyping is true', async () => {
+      await provider.connect();
+
+      const mockSendTyping = vi.fn().mockResolvedValue(undefined);
+      mockChannelFetch.mockResolvedValue({
+        send: vi.fn(),
+        sendTyping: mockSendTyping,
+      });
+
+      await provider.setTyping('dc:1234567890123456', true);
+      expect(mockSendTyping).toHaveBeenCalled();
+    });
+
+    it('does nothing when isTyping is false', async () => {
+      await provider.connect();
+
+      await provider.setTyping('dc:1234567890123456', false);
+      expect(mockChannelFetch).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when client is not initialized', async () => {
+      await provider.setTyping('dc:1234567890123456', true);
+      // No error
+    });
+  });
+
+  // --- listChats ---
+
+  describe('listChats', () => {
+    it('returns empty list initially', async () => {
+      const chats = await provider.listChats();
+      expect(chats).toEqual([]);
+    });
+
+    it('tracks chats from incoming messages', async () => {
+      const onMessage = vi.fn();
+      provider.onMessage = onMessage;
+      await provider.connect();
+
+      const msg = createMessage({
+        guildName: 'My Server',
+        channelName: 'general',
+      });
+      await triggerMessage(msg);
+
+      const chats = await provider.listChats();
+      expect(chats).toEqual([
+        {
+          id: 'dc:1234567890123456',
+          name: 'My Server #general',
+          is_group: true,
+        },
+      ]);
+    });
+  });
+
+  // --- hasToken ---
+
+  describe('hasToken', () => {
+    it('returns true when DISCORD_BOT_TOKEN is set', () => {
+      expect(provider.hasToken()).toBe(true);
+    });
+  });
+});

--- a/packages/mcp-discord/src/discord.ts
+++ b/packages/mcp-discord/src/discord.ts
@@ -1,0 +1,264 @@
+/**
+ * Standalone Discord bot provider.
+ * Adapted from the Deus DiscordChannel — no Deus-specific dependencies.
+ * Config comes from env vars; all messages are forwarded to onMessage.
+ */
+
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Message,
+  TextChannel,
+} from 'discord.js';
+import pino from 'pino';
+
+import type {
+  ChannelProvider,
+  ChannelStatus,
+  ChatInfo,
+  IncomingMessage,
+} from '@deus-ai/channel-core';
+
+const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Deus';
+const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN || '';
+
+// Use stderr for logging (stdout is reserved for MCP JSON-RPC)
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
+
+const MAX_MESSAGE_LENGTH = 2000;
+
+export class DiscordProvider implements ChannelProvider {
+  readonly name = 'discord';
+
+  private client: Client | null = null;
+  private connectTime = 0;
+  private knownChats = new Map<string, { name: string; isGroup: boolean }>();
+  private botUserId?: string;
+  private botTag?: string;
+
+  // Set by channel-core registerCommonTools
+  onMessage: (msg: IncomingMessage) => void = () => {};
+
+  async connect(): Promise<void> {
+    if (!BOT_TOKEN) {
+      throw new Error('DISCORD_BOT_TOKEN not set');
+    }
+
+    this.client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.DirectMessages,
+      ],
+    });
+
+    this.client.on(Events.MessageCreate, async (message: Message) => {
+      // Ignore bot messages (including own)
+      if (message.author.bot) return;
+
+      const channelId = message.channelId;
+      const chatJid = `dc:${channelId}`;
+      let content = message.content;
+      const timestamp = message.createdAt.toISOString();
+      const senderName =
+        message.member?.displayName ||
+        message.author.displayName ||
+        message.author.username;
+      const sender = message.author.id;
+      const msgId = message.id;
+
+      // Determine chat name
+      let chatName: string;
+      const isGroup = message.guild !== null;
+      if (message.guild) {
+        const textChannel = message.channel as TextChannel;
+        chatName = `${message.guild.name} #${textChannel.name}`;
+      } else {
+        chatName = senderName;
+      }
+
+      // Track chat
+      this.knownChats.set(chatJid, { name: chatName, isGroup });
+
+      // Translate Discord @bot mentions into @AssistantName format.
+      // Discord mentions look like <@botUserId>.
+      if (this.botUserId) {
+        const botId = this.botUserId;
+        const isBotMentioned =
+          message.mentions.users.has(botId) ||
+          content.includes(`<@${botId}>`) ||
+          content.includes(`<@!${botId}>`);
+
+        if (isBotMentioned) {
+          // Strip the <@botId> mention to avoid visual clutter
+          content = content
+            .replace(new RegExp(`<@!?${botId}>`, 'g'), '')
+            .trim();
+          // Prepend @AssistantName
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Handle attachments — store placeholders
+      if (message.attachments.size > 0) {
+        const attachmentDescriptions = [...message.attachments.values()].map(
+          (att) => {
+            const contentType = att.contentType || '';
+            if (contentType.startsWith('image/')) {
+              return `[Image: ${att.name || 'image'}]`;
+            } else if (contentType.startsWith('video/')) {
+              return `[Video: ${att.name || 'video'}]`;
+            } else if (contentType.startsWith('audio/')) {
+              return `[Audio: ${att.name || 'audio'}]`;
+            } else {
+              return `[File: ${att.name || 'file'}]`;
+            }
+          },
+        );
+        if (content) {
+          content = `${content}\n${attachmentDescriptions.join('\n')}`;
+        } else {
+          content = attachmentDescriptions.join('\n');
+        }
+      }
+
+      // Handle reply context
+      let replyToMessageId: string | undefined;
+      let replyToContent: string | undefined;
+      let replyToSenderName: string | undefined;
+
+      if (message.reference?.messageId) {
+        try {
+          const repliedTo = await message.channel.messages.fetch(
+            message.reference.messageId,
+          );
+          replyToMessageId = repliedTo.id;
+          replyToContent = repliedTo.content || undefined;
+          replyToSenderName =
+            repliedTo.member?.displayName ||
+            repliedTo.author.displayName ||
+            repliedTo.author.username;
+        } catch {
+          // Referenced message may have been deleted
+        }
+      }
+
+      // Forward ALL messages
+      this.onMessage({
+        id: msgId,
+        chat_id: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+        is_group: isGroup,
+        chat_name: chatName,
+        metadata: {
+          reply_to_message_id: replyToMessageId,
+          reply_to_content: replyToContent,
+          reply_to_sender_name: replyToSenderName,
+        },
+      });
+    });
+
+    // Handle errors gracefully
+    this.client.on(Events.Error, (err) => {
+      logger.error({ err: err.message }, 'Discord client error');
+    });
+
+    return new Promise<void>((resolve) => {
+      this.client!.once(Events.ClientReady, (readyClient) => {
+        this.botUserId = readyClient.user.id;
+        this.botTag = readyClient.user.tag;
+        this.connectTime = Date.now();
+        logger.info(
+          { username: readyClient.user.tag, id: readyClient.user.id },
+          'Discord bot connected',
+        );
+        resolve();
+      });
+
+      this.client!.login(BOT_TOKEN);
+    });
+  }
+
+  async sendMessage(chatId: string, text: string): Promise<void> {
+    if (!this.client) return;
+    try {
+      const channelId = chatId.replace(/^dc:/, '');
+      const channel = await this.client.channels.fetch(channelId);
+
+      if (!channel || !('send' in channel)) {
+        logger.warn({ chatId }, 'Discord channel not found or not text-based');
+        return;
+      }
+
+      const textChannel = channel as TextChannel;
+
+      if (text.length <= MAX_MESSAGE_LENGTH) {
+        await textChannel.send(text);
+      } else {
+        for (let i = 0; i < text.length; i += MAX_MESSAGE_LENGTH) {
+          await textChannel.send(text.slice(i, i + MAX_MESSAGE_LENGTH));
+        }
+      }
+    } catch (err) {
+      logger.error({ chatId, err }, 'Failed to send Discord message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.client !== null && this.client.isReady();
+  }
+
+  getStatus(): ChannelStatus {
+    return {
+      connected: this.client !== null && this.client.isReady(),
+      channel: 'discord',
+      identity: this.botTag,
+      uptime_seconds: this.connectTime
+        ? Math.floor((Date.now() - this.connectTime) / 1000)
+        : 0,
+    };
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      this.client.destroy();
+      this.client = null;
+      logger.info('Discord bot stopped');
+    }
+  }
+
+  async setTyping(chatId: string, isTyping: boolean): Promise<void> {
+    if (!this.client || !isTyping) return;
+    try {
+      const channelId = chatId.replace(/^dc:/, '');
+      const channel = await this.client.channels.fetch(channelId);
+      if (channel && 'sendTyping' in channel) {
+        await (channel as TextChannel).sendTyping();
+      }
+    } catch {
+      // Best effort
+    }
+  }
+
+  async listChats(): Promise<ChatInfo[]> {
+    return Array.from(this.knownChats.entries()).map(([id, info]) => ({
+      id,
+      name: info.name,
+      is_group: info.isGroup,
+    }));
+  }
+
+  /** Check if a bot token is configured. */
+  hasToken(): boolean {
+    return !!BOT_TOKEN;
+  }
+}

--- a/packages/mcp-discord/src/index.ts
+++ b/packages/mcp-discord/src/index.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ * Discord MCP Server
+ *
+ * Standalone MCP server that provides Discord bot messaging tools.
+ * Communicates via stdio (JSON-RPC). Can be used by any MCP client.
+ *
+ * Config (env vars):
+ *   DISCORD_BOT_TOKEN — Discord bot token from the Developer Portal
+ *   ASSISTANT_NAME    — bot display name (default: Deus)
+ *   LOG_LEVEL         — pino log level (default: info)
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { registerCommonTools } from '@deus-ai/channel-core';
+
+import { DiscordProvider } from './discord.js';
+
+const server = new McpServer({
+  name: '@deus-ai/discord-mcp',
+  version: '1.0.0',
+});
+
+const provider = new DiscordProvider();
+
+// Register common tools (send_message, get_status, etc.)
+registerCommonTools(server, provider);
+
+// ── Auto-connect if token is configured ───────────────────────────────
+
+if (provider.hasToken()) {
+  provider.connect().catch((err) => {
+    console.error('[@deus-ai/discord-mcp] Auto-connect failed:', err.message);
+  });
+}
+
+// ── Start MCP transport ───────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp-discord/tsconfig.json
+++ b/packages/mcp-discord/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -5,3 +5,4 @@
 
 import './mcp-whatsapp.js';
 import './mcp-telegram.js';
+import './mcp-discord.js';

--- a/src/channels/mcp-discord.ts
+++ b/src/channels/mcp-discord.ts
@@ -1,0 +1,46 @@
+/**
+ * Discord channel factory — spawns @deus-ai/discord-mcp as MCP server.
+ * Registers with the channel registry so the host can use it.
+ */
+
+import path from 'path';
+
+import { ASSISTANT_NAME, PROJECT_ROOT } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { McpChannelAdapter } from './mcp-adapter.js';
+import { registerChannel } from './registry.js';
+
+registerChannel('discord', (opts) => {
+  const envVars = readEnvFile(['DISCORD_BOT_TOKEN']);
+  const token =
+    process.env.DISCORD_BOT_TOKEN || envVars.DISCORD_BOT_TOKEN || '';
+  if (!token) return null;
+
+  let serverPath: string;
+  try {
+    serverPath = import.meta
+      .resolve('@deus-ai/discord-mcp')
+      .replace('file://', '');
+  } catch {
+    serverPath = path.join(
+      PROJECT_ROOT,
+      'packages',
+      'mcp-discord',
+      'dist',
+      'index.js',
+    );
+  }
+
+  return new McpChannelAdapter({
+    name: 'discord',
+    command: 'node',
+    args: [serverPath],
+    env: {
+      DISCORD_BOT_TOKEN: token,
+      ASSISTANT_NAME: ASSISTANT_NAME,
+    },
+    onMessage: opts.onMessage,
+    onChatMetadata: opts.onChatMetadata,
+    ownsJid: (jid) => jid.startsWith('dc:'),
+  });
+});


### PR DESCRIPTION
## Summary
- Convert Discord channel to standalone MCP server package (`@deus-ai/discord-mcp`) at `packages/mcp-discord/`
- Implements `ChannelProvider` interface from `@deus-ai/channel-core` using discord.js, matching the mcp-telegram pattern
- Add factory at `src/channels/mcp-discord.ts` that spawns the MCP server and registers with the channel system

## Test plan
- [x] `packages/mcp-discord` builds cleanly (`npm run build`)
- [x] 29 unit tests pass (`vitest run`) covering connection lifecycle, message handling, @mention translation, attachments, replies, sendMessage, setTyping, listChats
- [x] Main project builds (`npm run build`)
- [x] All 495 existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)