### PR TITLE
docs(readme): add sponsor tiers and sponsors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,25 @@ Commit messages, formatting, and PR conventions are enforced automatically by pr
 
 ## Support
 
-If Deus is useful to you, consider sponsoring the project — it helps fund continued development, new channel integrations, and documentation.
+Deus is built and maintained solo — no company, no funding, just one developer and a lot of coffee. If it's useful to you, sponsoring helps keep it independent and actively developed.
 
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=github)](https://github.com/sponsors/sliamh11)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-Support-ff5e5b?logo=ko-fi)](https://ko-fi.com/liamsteiner)
+
+| Tier | What you get |
+|------|-------------|
+| **Supporter** ($3/mo) | Your name in the sponsors list below |
+| **Backer** ($10/mo) | Supporter perks + priority issue responses |
+| **Sponsor** ($25/mo) | Backer perks + quarterly roadmap input + early access to new features |
+| **Gold Sponsor** ($50/mo) | Sponsor perks + logo below + direct access for feature requests |
+
+Sponsorships go toward full-time development during breaks, CI/infrastructure costs, and keeping the project open-source.
+
+### Sponsors
+
+<!-- sponsors:start -->
+*Become the first sponsor — [github.com/sponsors/sliamh11](https://github.com/sponsors/sliamh11)*
+<!-- sponsors:end -->
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- Expand Support section with tier descriptions (Supporter/Backer/Sponsor/Gold)
- Add sponsors placeholder with `<!-- sponsors:start/end -->` markers for future automation
- Update sponsorship rationale copy

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm sponsor tier table displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)