### PR TITLE
ci(sponsors): auto-populate sponsors in README

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -1,0 +1,24 @@
+name: Update Sponsors README
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday midnight UTC
+  workflow_dispatch:
+
+jobs:
+  update-sponsors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: JamesIves/github-sponsors-readme-action@v1
+        with:
+          token: ${{ secrets.PAT }}
+          file: README.md
+          fallback: 'Become the first sponsor — [github.com/sponsors/sliamh11](https://github.com/sponsors/sliamh11)'
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update sponsors in README'

--- a/README.md
+++ b/README.md
@@ -309,9 +309,7 @@ Sponsorships go toward full-time development during breaks, CI/infrastructure co
 
 ### Sponsors
 
-<!-- sponsors:start -->
-*Become the first sponsor — [github.com/sponsors/sliamh11](https://github.com/sponsors/sliamh11)*
-<!-- sponsors:end -->
+<!-- sponsors --><!-- sponsors -->
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- Add `sponsors.yml` workflow using [JamesIves/github-sponsors-readme-action](https://github.com/JamesIves/github-sponsors-readme-action)
- Runs weekly (Sunday midnight UTC) + manual dispatch
- Renders sponsor avatars between `<!-- sponsors -->` markers in README
- Falls back to "become the first sponsor" link when empty
- Update README markers from `sponsors:start/end` to action's expected format

## Setup required
Add a **PAT** repository secret with `user:read` scope:
1. Go to [github.com/settings/tokens](https://github.com/settings/tokens) → Generate new token (classic)
2. Select scope: `read:user`
3. Copy the token
4. Go to repo Settings → Secrets and variables → Actions → New repository secret
5. Name: `PAT`, Value: the token

## Test plan
- [ ] Add PAT secret
- [ ] Trigger workflow manually via Actions → Update Sponsors README → Run workflow
- [ ] Verify README updates (fallback text if no sponsors yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)