### PR TITLE
docs(readme): simplify sponsors — remove tier table

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,15 +298,6 @@ Deus is built and maintained solo — no company, no funding, just one developer
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=github)](https://github.com/sponsors/sliamh11)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-Support-ff5e5b?logo=ko-fi)](https://ko-fi.com/liamsteiner)
 
-| Tier | What you get |
-|------|-------------|
-| **Supporter** ($3/mo) | Your name in the sponsors list below |
-| **Backer** ($10/mo) | Supporter perks + priority issue responses |
-| **Sponsor** ($25/mo) | Backer perks + quarterly roadmap input + early access to new features |
-| **Gold Sponsor** ($50/mo) | Sponsor perks + logo below + direct access for feature requests |
-
-Sponsorships go toward full-time development during breaks, CI/infrastructure costs, and keeping the project open-source.
-
 ### Sponsors
 
 <!-- sponsors --><!-- sponsors -->


### PR DESCRIPTION
## Summary
- Remove tier commitment table from Support section
- Keep badges (GitHub Sponsors + Ko-fi) and auto-populated sponsors list
- Tier ideas (priority responses, roadmap input, direct access) saved for later when project has more traction

🤖 Generated with [Claude Code](https://claude.com/claude-code)