### PR TITLE
fix(setup): add /opt/homebrew/bin to launchd plist PATH

### DIFF
--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -34,7 +34,7 @@ function generatePlist(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>
@@ -100,6 +100,15 @@ describe('plist generation', () => {
     expect(plist).toContain('/home/user/deus/dist/index.js');
   });
 
+  it('includes /opt/homebrew/bin in PATH for Apple Silicon', () => {
+    const plist = generatePlist(
+      '/usr/local/bin/node',
+      '/home/user/deus',
+      '/home/user',
+    );
+    expect(plist).toContain('/opt/homebrew/bin');
+  });
+
   it('sets log paths', () => {
     const plist = generatePlist(
       '/usr/local/bin/node',
@@ -160,9 +169,7 @@ describe('systemd unit generation', () => {
       '/home/user',
       false,
     );
-    expect(unit).toContain(
-      'ExecStart=/usr/bin/node /srv/deus/dist/index.js',
-    );
+    expect(unit).toContain('ExecStart=/usr/bin/node /srv/deus/dist/index.js');
   });
 });
 

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -104,7 +104,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>
@@ -348,10 +348,14 @@ function setupNssm(
   // Remove existing service if present (ignore errors — may not exist)
   try {
     execSync(`nssm stop ${svc}`, { stdio: 'ignore', timeout: 10000 });
-  } catch { /* not running */ }
+  } catch {
+    /* not running */
+  }
   try {
     execSync(`nssm remove ${svc} confirm`, { stdio: 'ignore', timeout: 10000 });
-  } catch { /* does not exist */ }
+  } catch {
+    /* does not exist */
+  }
 
   // Install and configure
   execSync(
@@ -380,7 +384,9 @@ function setupNssm(
       stdio: 'pipe',
     });
     serviceLoaded = out.trim() === 'SERVICE_RUNNING';
-  } catch { /* status check failed */ }
+  } catch {
+    /* status check failed */
+  }
 
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: 'windows-nssm',
@@ -408,13 +414,17 @@ function setupServy(
       stdio: 'ignore',
       timeout: 10000,
     });
-  } catch { /* not running */ }
+  } catch {
+    /* not running */
+  }
   try {
     execSync(`servy-cli uninstall --name="${svc}" --quiet`, {
       stdio: 'ignore',
       timeout: 10000,
     });
-  } catch { /* does not exist */ }
+  } catch {
+    /* does not exist */
+  }
 
   // Install with crash recovery via health monitor
   execSync(
@@ -454,7 +464,9 @@ function setupServy(
       stdio: 'pipe',
     });
     serviceLoaded = out.trim() === 'Running';
-  } catch { /* status check failed */ }
+  } catch {
+    /* status check failed */
+  }
 
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: 'windows-servy',


### PR DESCRIPTION
## Summary
- New users running `/setup` on Apple Silicon Macs got a launchd plist without `/opt/homebrew/bin` in PATH
- This caused `docker`, `python3`, `whisper-cli`, and other Homebrew-installed tools to be unreachable from the service context
- Added test to prevent regression

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 496 tests pass (1 new)
- [x] Verified launchd service restarts cleanly with updated build

🤖 Generated with [Claude Code](https://claude.com/claude-code)