### PR TITLE
fix(cli): guard against overwriting foreign binaries at CLI path

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -247,6 +247,8 @@ This creates a global `deus` command so the user can type `deus` from any termin
 - macOS/Linux: symlinks `deus-cmd.sh` → `~/.local/bin/deus`
 - Windows: creates `deus.cmd` shim → `%USERPROFILE%\.local\bin\` and adds it to user PATH
 
+**If STATUS=conflict and EXISTING=foreign:** A non-Deus binary named `deus` already exists at the CLI path. Ask the user: "A file already exists at `<LINK_PATH>` that doesn't appear to be a Deus installation. Should I replace it with the Deus CLI? (The existing file will be deleted.)" If they confirm, delete the file and re-run `npx tsx setup/index.ts --step cli`. If they decline, skip CLI registration and tell them they can run Deus directly with `./deus-cmd.sh` from the repo directory.
+
 **If IN_PATH=false:** The setup step auto-appends `~/.local/bin` to the user's shell config. If it couldn't (permissions, etc.), tell user to add it manually:
 
 ```bash

--- a/setup/cli.test.ts
+++ b/setup/cli.test.ts
@@ -27,7 +27,7 @@ vi.mock('../src/logger.js', () => ({
 }));
 
 import { getPlatform } from './platform.js';
-import { run, cleanStaleLegacySymlink } from './cli.js';
+import { run, cleanStaleLegacySymlink, checkExistingCli } from './cli.js';
 
 describe('setup/cli', () => {
   const originalCwd = process.cwd();
@@ -79,10 +79,10 @@ describe('setup/cli', () => {
     expect(emitStatusCalls[0].data.ERROR).toBe('deus-cmd.sh not found');
   });
 
-  it('replaces existing symlink', async () => {
+  it('replaces existing dead symlink', async () => {
     vi.mocked(getPlatform).mockReturnValue('macos');
 
-    // Create an existing symlink pointing elsewhere
+    // Create an existing dead symlink
     const binDir = path.join(os.homedir(), '.local', 'bin');
     const linkPath = path.join(binDir, 'deus');
     fs.mkdirSync(binDir, { recursive: true });
@@ -91,7 +91,7 @@ describe('setup/cli', () => {
     } catch {
       // doesn't exist
     }
-    fs.symlinkSync('/tmp/old-deus', linkPath);
+    fs.symlinkSync('/tmp/old-deus-nonexistent', linkPath);
 
     await run([]);
 
@@ -102,6 +102,93 @@ describe('setup/cli', () => {
 
     // Clean up
     fs.unlinkSync(linkPath);
+  });
+
+  it('replaces existing Deus symlink from different install path', async () => {
+    vi.mocked(getPlatform).mockReturnValue('macos');
+
+    const binDir = path.join(os.homedir(), '.local', 'bin');
+    const linkPath = path.join(binDir, 'deus');
+    fs.mkdirSync(binDir, { recursive: true });
+    try {
+      fs.unlinkSync(linkPath);
+    } catch {
+      // doesn't exist
+    }
+    // Symlink pointing to our own deus-cmd.sh (current dir)
+    fs.symlinkSync(path.join(tmpDir, 'deus-cmd.sh'), linkPath);
+
+    await run([]);
+
+    expect(emitStatusCalls[0].data.STATUS).toBe('success');
+
+    // Clean up
+    fs.unlinkSync(linkPath);
+  });
+
+  it('skips symlink creation when foreign binary exists', async () => {
+    vi.mocked(getPlatform).mockReturnValue('macos');
+
+    const binDir = path.join(os.homedir(), '.local', 'bin');
+    const linkPath = path.join(binDir, 'deus');
+    fs.mkdirSync(binDir, { recursive: true });
+    try {
+      fs.unlinkSync(linkPath);
+    } catch {
+      // doesn't exist
+    }
+    // Create a regular file (foreign binary)
+    fs.writeFileSync(linkPath, '#!/bin/sh\necho "different deus tool"');
+
+    await run([]);
+
+    expect(emitStatusCalls[0].data.STATUS).toBe('conflict');
+    expect(emitStatusCalls[0].data.EXISTING).toBe('foreign');
+    // Foreign file should still be intact
+    expect(fs.readFileSync(linkPath, 'utf-8')).toContain('different deus tool');
+
+    // Clean up
+    fs.unlinkSync(linkPath);
+  });
+
+  describe('checkExistingCli', () => {
+    let checkDir: string;
+
+    beforeEach(() => {
+      checkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-check-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(checkDir, { recursive: true, force: true });
+    });
+
+    it('returns none when path does not exist', () => {
+      expect(checkExistingCli(path.join(checkDir, 'deus'))).toBe('none');
+    });
+
+    it('returns ours when symlink points to deus-cmd.sh', () => {
+      const target = path.join(checkDir, 'deus-cmd.sh');
+      fs.writeFileSync(target, '#!/bin/sh');
+      fs.symlinkSync(target, path.join(checkDir, 'deus'));
+      expect(checkExistingCli(path.join(checkDir, 'deus'))).toBe('ours');
+    });
+
+    it('returns dead when symlink target does not exist', () => {
+      fs.symlinkSync('/tmp/nonexistent-xyz', path.join(checkDir, 'deus'));
+      expect(checkExistingCli(path.join(checkDir, 'deus'))).toBe('dead');
+    });
+
+    it('returns foreign for symlink to non-deus target', () => {
+      const target = path.join(checkDir, 'other-tool');
+      fs.writeFileSync(target, '#!/bin/sh');
+      fs.symlinkSync(target, path.join(checkDir, 'deus'));
+      expect(checkExistingCli(path.join(checkDir, 'deus'))).toBe('foreign');
+    });
+
+    it('returns foreign for regular file', () => {
+      fs.writeFileSync(path.join(checkDir, 'deus'), '#!/bin/sh\necho hi');
+      expect(checkExistingCli(path.join(checkDir, 'deus'))).toBe('foreign');
+    });
   });
 
   describe('cleanStaleLegacySymlink', () => {

--- a/setup/cli.ts
+++ b/setup/cli.ts
@@ -47,7 +47,24 @@ function setupUnixCli(projectRoot: string, homeDir: string): void {
 
   fs.mkdirSync(binDir, { recursive: true });
 
-  // Remove existing symlink/file if present
+  // Check what exists at the target path before overwriting
+  const existing = checkExistingCli(linkPath);
+  if (existing === 'foreign') {
+    logger.warn(
+      { linkPath },
+      'A non-Deus binary already exists at the CLI path. Skipping symlink creation to avoid data loss.',
+    );
+    emitStatus('SETUP_CLI', {
+      STATUS: 'conflict',
+      LINK_PATH: linkPath,
+      SCRIPT_PATH: scriptPath,
+      EXISTING: 'foreign',
+      IN_PATH: false,
+    });
+    return;
+  }
+
+  // Safe to replace: either nothing, a dead symlink, or our own deus-cmd.sh symlink
   try {
     fs.unlinkSync(linkPath);
   } catch {
@@ -104,6 +121,36 @@ function setupUnixCli(projectRoot: string, homeDir: string): void {
     SCRIPT_PATH: scriptPath,
     IN_PATH: inPath,
   });
+}
+
+/**
+ * Check what exists at the CLI symlink path.
+ * Returns:
+ * - 'none'    — nothing exists, safe to create
+ * - 'ours'    — symlink pointing to a deus-cmd.sh, safe to replace
+ * - 'dead'    — dead symlink, safe to replace
+ * - 'foreign' — something else (different binary, regular file), DO NOT replace
+ */
+export function checkExistingCli(
+  linkPath: string,
+): 'none' | 'ours' | 'dead' | 'foreign' {
+  try {
+    const stat = fs.lstatSync(linkPath);
+
+    if (stat.isSymbolicLink()) {
+      const target = fs.readlinkSync(linkPath);
+      // Check if target is alive
+      if (!fs.existsSync(linkPath)) return 'dead';
+      // Check if it points to any deus-cmd.sh (ours, possibly different install path)
+      if (path.basename(target) === 'deus-cmd.sh') return 'ours';
+      return 'foreign';
+    }
+
+    // Regular file or directory — not ours
+    return 'foreign';
+  } catch {
+    return 'none';
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- `setup/cli.ts` now checks what exists at `~/.local/bin/deus` before creating the symlink
- If a non-Deus binary is found, emits `STATUS: conflict` instead of silently overwriting
- `/setup` skill updated to ask the user for confirmation on conflict
- Dead symlinks and existing Deus symlinks are still replaced automatically

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 507 tests pass (7 new: 5 for `checkExistingCli`, 2 updated integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)