### PR TITLE
refactor(evolution): add JudgeProvider registry pattern for centralized judge config

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ scripts/
 seeds/
   reflections.json        # Curated seed reflections for onboarding
 evolution/
-  judge/                  # OllamaJudge + GeminiJudge (DeepEvalBaseLLM wrappers)
+  judge/                  # Provider/registry pattern for judge backends (Ollama, Gemini, Mock, Claude)
   reflexion/              # Reflexion + positive patterns + principles extraction
   optimizer/              # DSPy optimizer: per-domain prompt tuning
   ilog/                   # Interaction log: domain-tagged scored interactions
@@ -277,7 +277,7 @@ evolution/
   cli.py                  # CLI: status, optimize, principles (with --domain)
 eval/
   conftest.py             # Fixtures: agent cache, parallel pre-warm, dynamic concurrency
-  judge_model.py          # make_judge(): auto-detect Ollama → Gemini → ClaudeProxy
+  judge_model.py          # make_judge(): delegates to JudgeRegistry for provider resolution
   test_core_qa.py         # Factual Q&A tests
   test_tool_use.py        # Tool-calling tests
   test_safety.py          # Refusal and safety tests

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -72,6 +72,7 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `EVOLUTION_REFLECTION_THRESHOLD` | `0.6` | Interactions scoring below this trigger corrective reflections |
 | `EVOLUTION_POSITIVE_THRESHOLD` | `0.85` | Interactions scoring above this trigger positive pattern extraction |
 | `EVOLUTION_JUDGE_MODEL` | `models/gemini-3.1-flash-lite-preview` | Gemini model used for judging and principle extraction |
+| `EVOLUTION_JUDGE_PROVIDER` | (auto-detect) | Force a specific judge provider: `ollama`, `gemini`, `claude`, `mock` |
 | `EVOLUTION_MAX_REFLECTIONS` | `3` | Max reflections retrieved per agent query |
 | `EVOLUTION_REFLECTION_DEDUP_L2` | `0.4` | L2 distance threshold for deduplicating similar reflections |
 | `DEUS_EVAL_CONCURRENT` | — | Override eval pre-warm concurrency |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,12 +329,18 @@ Commands:
 
 ### Judges
 
-| Judge | Use Case | Model |
-|-------|----------|-------|
-| `GeminiRuntimeJudge` | Production scoring | Gemini (cloud) |
-| `OllamaJudge` | Eval runs (no API quota) | `gemma4:e4b` (local) |
+Uses a **provider/registry pattern** (`evolution/judge/provider.py`). Each backend implements `JudgeProvider` and self-registers at import time. The registry resolves the best available backend by priority.
 
-Auto-detection: pings `localhost:11434`. Uses Ollama if reachable, Gemini otherwise. Override with `EVAL_JUDGE=ollama|gemini`.
+| Provider | Priority | Judge Classes | Model |
+|----------|----------|---------------|-------|
+| `ollama` | 10 | `OllamaJudge`, `OllamaRuntimeJudge` | `gemma4:e4b` (local) |
+| `gemini` | 20 | `GeminiJudge`, `GeminiRuntimeJudge` | Gemini (cloud) |
+| `claude` | 30 | `ClaudeProxyJudge` | Claude (proxy, blocked) |
+| `mock` | 0 | `MockJudge`, `MockRuntimeJudge` | Fixed score (CI only) |
+
+Auto-detection: lowest priority available provider wins. Override with `EVAL_JUDGE=ollama|gemini|mock` or `EVOLUTION_JUDGE_PROVIDER=<name>`.
+
+Adding a new backend: implement `JudgeProvider` in `evolution/judge/providers/`, register in `providers/__init__.py`.
 
 ### CLI (`evolution/cli.py`)
 

--- a/eval/judge_model.py
+++ b/eval/judge_model.py
@@ -1,12 +1,8 @@
 """
 DeepEval judge model for Deus eval suites.
 
-Priority order:
-0. MockJudge   — fixed score, no API calls; for CI smoke tests (EVAL_JUDGE=mock).
-1. GeminiJudge  — uses GEMINI_API_KEY; same Gemini client as memory_indexer.
-2. ClaudeProxyJudge — OAuth Bearer via localhost:3001 credential proxy.
-                      Blocked on Anthropic API (returns 401); kept as fallback
-                      in case the auth issue is resolved.
+Uses the JudgeRegistry provider pattern to resolve the best available backend.
+Supports EVAL_JUDGE env var for explicit selection (mock/ollama/gemini/claude).
 
 Usage:
     from judge_model import make_judge
@@ -15,146 +11,36 @@ Usage:
 import os
 import sys
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Optional
 
 from deepeval.models import DeepEvalBaseLLM
-
-
-# ── Mock judge (CI / PR gate) ────────────────────────────────────────────────
-
-class MockJudge(DeepEvalBaseLLM):
-    """
-    Returns a fixed score without calling any external API.
-    Useful for CI smoke tests where you want to validate the eval pipeline
-    without burning API credits.  Activated via EVAL_JUDGE=mock.
-    """
-
-    def __init__(self, score: float = 0.75):
-        self._score = score
-
-    def load_model(self):
-        return None
-
-    def generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
-        return str(self._score), self._score
-
-    async def a_generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
-        return str(self._score), self._score
-
-    def get_model_name(self) -> str:
-        return f"mock:{self._score}"
-
-
-# ── Gemini judge ───────────────────────────────────────────────────────────────
 
 # Add project root to path so `evolution` package is importable from eval/
 _PROJECT_ROOT = Path(__file__).parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-try:
-    from evolution.judge.gemini_judge import GeminiJudge
-    _GEMINI_AVAILABLE = True
-except ImportError:
-    _GEMINI_AVAILABLE = False
-    GeminiJudge = None  # type: ignore
+from evolution.judge import JudgeRegistry, NoProviderAvailableError  # noqa: E402
 
-try:
-    from evolution.judge.ollama_judge import OllamaJudge, is_ollama_available
-    _OLLAMA_IMPORTABLE = True
-except ImportError:
-    _OLLAMA_IMPORTABLE = False
-    OllamaJudge = None  # type: ignore
-    def is_ollama_available() -> bool:  # type: ignore
-        return False
-
-# ── Claude proxy judge (fallback) ─────────────────────────────────────────────
-
-PROXY_BASE_URL = os.environ.get("CREDENTIAL_PROXY_URL", "http://localhost:3001")
-JUDGE_MODEL = os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5")
-
-
-class ClaudeProxyJudge(DeepEvalBaseLLM):
-    """
-    Claude judge model routed through the Deus credential proxy.
-    NOTE: currently blocked — Anthropic messages API rejects OAuth Bearer auth.
-    Kept as fallback; use GeminiJudge for working evaluations.
-    """
-
-    def __init__(self, model: str = JUDGE_MODEL):
-        self.model = model
-        self._client = None
-
-    def _get_client(self):
-        if self._client is None:
-            import anthropic
-            self._client = anthropic.Anthropic(
-                auth_token="placeholder",
-                base_url=PROXY_BASE_URL,
-            )
-        return self._client
-
-    def load_model(self):
-        return self._get_client()
-
-    def generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
-        client = self._get_client()
-        response = client.messages.create(
-            model=self.model,
-            max_tokens=1024,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        return response.content[0].text, 0.0
-
-    async def a_generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
-        import anthropic
-        client = anthropic.AsyncAnthropic(
-            auth_token="placeholder",
-            base_url=PROXY_BASE_URL,
-        )
-        response = await client.messages.create(
-            model=self.model,
-            max_tokens=1024,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        return response.content[0].text, 0.0
-
-    def get_model_name(self) -> str:
-        return f"claude-proxy:{self.model}"
-
-
-# ── Factory ────────────────────────────────────────────────────────────────────
 
 def make_judge(model: Optional[str] = None) -> DeepEvalBaseLLM:
     """
-    Return the best available judge:
-    - EVAL_JUDGE=mock   → MockJudge (fixed score, no API calls)
-    - EVAL_JUDGE=ollama → OllamaJudge
-    - EVAL_JUDGE=gemini → GeminiJudge
-    - If not set, auto-detect: Ollama if reachable, then Gemini, then ClaudeProxy
+    Return the best available judge.
+
+    - EVAL_JUDGE=mock   -> MockProvider
+    - EVAL_JUDGE=ollama -> OllamaProvider
+    - EVAL_JUDGE=gemini -> GeminiProvider
+    - EVAL_JUDGE=claude -> ClaudeProxyProvider
+    - If not set, auto-detect by priority (ollama > gemini > claude)
     """
     eval_judge = os.environ.get("EVAL_JUDGE", "").lower()
+    preference = eval_judge if eval_judge else None
 
-    if eval_judge == "mock":
-        return MockJudge()
-
-    if eval_judge == "ollama":
-        if not _OLLAMA_IMPORTABLE:
-            raise RuntimeError("OllamaJudge not importable — check evolution package")
-        return OllamaJudge(model=model or os.environ.get("OLLAMA_MODEL", "gemma4:e4b"))
-
-    if eval_judge == "gemini":
-        if not _GEMINI_AVAILABLE:
-            raise RuntimeError("GeminiJudge not importable — check google-genai package")
-        from evolution.config import JUDGE_MODEL as GEMINI_JUDGE_MODEL
-        return GeminiJudge(model=model or GEMINI_JUDGE_MODEL)
-
-    # Auto-detect: try Ollama first, then Gemini, then Claude proxy
-    if _OLLAMA_IMPORTABLE and is_ollama_available():
-        return OllamaJudge(model=model or os.environ.get("OLLAMA_MODEL", "gemma4:e4b"))
-
-    if _GEMINI_AVAILABLE:
-        from evolution.config import JUDGE_MODEL as GEMINI_JUDGE_MODEL
-        return GeminiJudge(model=model or GEMINI_JUDGE_MODEL)
-
-    return ClaudeProxyJudge(model=model or JUDGE_MODEL)
+    try:
+        registry = JudgeRegistry.default()
+        provider = registry.resolve(preference)
+        return provider.make_deepeval_judge(model)
+    except NoProviderAvailableError:
+        # Last resort: Claude proxy (kept for legacy compatibility)
+        from evolution.judge.providers.claude_proxy import ClaudeProxyJudge
+        return ClaudeProxyJudge(model=model or os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5"))

--- a/evolution/backfill.py
+++ b/evolution/backfill.py
@@ -28,7 +28,7 @@ from typing import Iterator
 from .config import REFLECTION_THRESHOLD
 from .db import open_db
 from .ilog.interaction_log import log_interaction, update_score
-from .judge.gemini_judge import make_runtime_judge
+from .judge import make_runtime_judge
 from .reflexion.generator import generate_reflection
 from .reflexion.store import save_reflection
 

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -199,7 +199,7 @@ def cmd_log_interaction(json_str: str) -> None:
         return
 
     from .ilog.interaction_log import log_interaction
-    from .judge.gemini_judge import make_runtime_judge
+    from .judge import make_runtime_judge
     from .ilog.interaction_log import update_score
     from .reflexion.generator import generate_reflection
     from .reflexion.store import save_reflection

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -12,6 +12,11 @@ ARTIFACTS_DIR = EVOLUTION_DIR / "artifacts"
 DB_PATH = Path(os.environ.get("DEUS_DB", "~/.deus/memory.db")).expanduser()
 CONFIG_ENV = Path(__file__).resolve().parent.parent / ".env"
 
+# ── Ollama ────────────────────────────────────────────────────────────────────
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
+
 # ── Gemini ────────────────────────────────────────────────────────────────────
 
 EMBED_DIM = 768
@@ -34,6 +39,9 @@ MAX_REFLECTIONS_PER_QUERY = int(os.environ.get("EVOLUTION_MAX_REFLECTIONS", "3")
 REFLECTION_DEDUP_L2 = float(os.environ.get("EVOLUTION_REFLECTION_DEDUP_L2", "0.4"))
 
 # ── DSPy Optimizer ────────────────────────────────────────────────────────────
+
+# DSPy uses its own env var for independent tuning, but shares the default.
+DSPY_OLLAMA_MODEL = os.environ.get("DSPY_OLLAMA_MODEL", OLLAMA_MODEL)
 
 DSPY_MIN_SAMPLES = int(os.environ.get("EVOLUTION_DSPY_MIN_SAMPLES", "20"))
 DSPY_MIN_DOMAIN_SAMPLES = int(os.environ.get("EVOLUTION_DSPY_MIN_DOMAIN_SAMPLES", "10"))

--- a/evolution/judge/__init__.py
+++ b/evolution/judge/__init__.py
@@ -1,10 +1,31 @@
-from .gemini_judge import GeminiJudge, GeminiRuntimeJudge, make_deepeval_judge, make_runtime_judge
-from .ollama_judge import OllamaJudge, OllamaRuntimeJudge, is_ollama_available
 from .base import BaseJudge, JudgeResult
+from .provider import JudgeProvider, JudgeRegistry, NoProviderAvailableError
+
+# Legacy exports (backward compat)
+from .gemini_judge import GeminiJudge, GeminiRuntimeJudge
+from .ollama_judge import OllamaJudge, OllamaRuntimeJudge, is_ollama_available
+
+# Register built-in providers on import
+from . import providers as _providers  # noqa: F401
+
+from typing import Optional
+from deepeval.models import DeepEvalBaseLLM
+
+
+def make_deepeval_judge(model: Optional[str] = None, provider: Optional[str] = None) -> DeepEvalBaseLLM:
+    """Resolve best provider and return a DeepEval judge."""
+    return JudgeRegistry.default().resolve(provider).make_deepeval_judge(model)
+
+
+def make_runtime_judge(model: Optional[str] = None, provider: Optional[str] = None) -> BaseJudge:
+    """Resolve best provider and return a runtime judge."""
+    return JudgeRegistry.default().resolve(provider).make_runtime_judge(model)
+
 
 __all__ = [
+    "BaseJudge", "JudgeResult",
+    "JudgeProvider", "JudgeRegistry", "NoProviderAvailableError",
     "GeminiJudge", "GeminiRuntimeJudge",
     "OllamaJudge", "OllamaRuntimeJudge", "is_ollama_available",
     "make_deepeval_judge", "make_runtime_judge",
-    "BaseJudge", "JudgeResult",
 ]

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -19,9 +19,7 @@ from deepeval.models import DeepEvalBaseLLM
 
 from .base import BaseJudge, JudgeResult
 from .criteria import RUBRIC, compose_score
-
-OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
-OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
+from ..config import OLLAMA_HOST, OLLAMA_MODEL
 
 
 def _ollama_url(path: str) -> str:

--- a/evolution/judge/provider.py
+++ b/evolution/judge/provider.py
@@ -1,0 +1,146 @@
+"""
+Provider/strategy pattern for judge backends.
+
+Each backend (Ollama, Gemini, Mock, ClaudeProxy) implements JudgeProvider.
+JudgeRegistry resolves the best available backend at runtime.
+"""
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from deepeval.models import DeepEvalBaseLLM
+
+from .base import BaseJudge
+
+
+class NoProviderAvailableError(RuntimeError):
+    """Raised when no judge provider is available."""
+    pass
+
+
+class JudgeProvider(ABC):
+    """
+    A backend that can produce both DeepEval and runtime judges.
+
+    Subclass this for each backend (Ollama, Gemini, Mock, ClaudeProxy).
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique provider name, e.g. 'ollama', 'gemini', 'mock'."""
+        ...
+
+    @property
+    @abstractmethod
+    def priority(self) -> int:
+        """Lower = preferred during auto-detection."""
+        ...
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True if this backend can serve requests right now."""
+        ...
+
+    @abstractmethod
+    def make_deepeval_judge(self, model: Optional[str] = None) -> DeepEvalBaseLLM:
+        """Create a DeepEval-compatible judge instance."""
+        ...
+
+    @abstractmethod
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        """Create a runtime judge instance for scoring interactions."""
+        ...
+
+    @property
+    @abstractmethod
+    def default_model(self) -> str:
+        """The default model identifier for this backend."""
+        ...
+
+
+class JudgeRegistry:
+    """
+    Central registry of judge providers.
+
+    Usage:
+        registry = JudgeRegistry.default()
+        provider = registry.resolve()              # auto-detect best
+        provider = registry.resolve("ollama")      # explicit choice
+        judge = provider.make_runtime_judge()
+    """
+
+    _instance: Optional["JudgeRegistry"] = None
+
+    def __init__(self):
+        self._providers: dict[str, JudgeProvider] = {}
+
+    @classmethod
+    def default(cls) -> "JudgeRegistry":
+        """Return the singleton registry, creating it on first call."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset singleton — for testing only."""
+        cls._instance = None
+
+    def register(self, provider: JudgeProvider) -> None:
+        """Register a provider. Last-write-wins for same name."""
+        self._providers[provider.name] = provider
+
+    def unregister(self, name: str) -> None:
+        """Remove a provider by name."""
+        self._providers.pop(name, None)
+
+    def get(self, name: str) -> JudgeProvider:
+        """Get a provider by exact name. Raises KeyError if not found."""
+        return self._providers[name]
+
+    def list_providers(self) -> list[str]:
+        """Return registered provider names sorted by priority."""
+        return [
+            p.name for p in sorted(self._providers.values(), key=lambda p: p.priority)
+        ]
+
+    def resolve(self, preference: Optional[str] = None) -> JudgeProvider:
+        """
+        Resolve the best available provider.
+
+        Resolution order:
+        1. EVOLUTION_JUDGE_PROVIDER env var (if set)
+        2. Explicit preference argument
+        3. Auto-detect: lowest priority number among available providers
+
+        Raises NoProviderAvailableError if nothing works.
+        """
+        import os
+
+        # 1. Env var override
+        env_pref = os.environ.get("EVOLUTION_JUDGE_PROVIDER", "").lower()
+        effective = env_pref or (preference.lower() if preference else None)
+
+        # 2. Explicit preference
+        if effective:
+            if effective not in self._providers:
+                raise NoProviderAvailableError(
+                    f"Provider '{effective}' not registered. "
+                    f"Available: {self.list_providers()}"
+                )
+            provider = self._providers[effective]
+            if not provider.is_available():
+                raise NoProviderAvailableError(
+                    f"Provider '{effective}' is registered but not available."
+                )
+            return provider
+
+        # 3. Auto-detect by priority
+        candidates = sorted(self._providers.values(), key=lambda p: p.priority)
+        for provider in candidates:
+            if provider.is_available():
+                return provider
+
+        raise NoProviderAvailableError(
+            f"No judge provider available. Registered: {self.list_providers()}"
+        )

--- a/evolution/judge/providers/__init__.py
+++ b/evolution/judge/providers/__init__.py
@@ -1,0 +1,15 @@
+"""Built-in judge providers. Importing this package registers them all."""
+from ..provider import JudgeRegistry
+
+from .ollama import OllamaProvider
+from .gemini import GeminiProvider
+from .mock import MockProvider
+from .claude_proxy import ClaudeProxyProvider
+
+_registry = JudgeRegistry.default()
+_registry.register(OllamaProvider())
+_registry.register(GeminiProvider())
+_registry.register(MockProvider())
+_registry.register(ClaudeProxyProvider())
+
+__all__ = ["OllamaProvider", "GeminiProvider", "MockProvider", "ClaudeProxyProvider"]

--- a/evolution/judge/providers/claude_proxy.py
+++ b/evolution/judge/providers/claude_proxy.py
@@ -1,0 +1,112 @@
+"""Claude proxy judge provider — last-resort fallback."""
+import os
+import urllib.request
+import urllib.error
+from typing import Any, Optional, Tuple
+
+from deepeval.models import DeepEvalBaseLLM
+
+from ..base import BaseJudge, JudgeResult
+from ..provider import JudgeProvider
+
+PROXY_BASE_URL = os.environ.get("CREDENTIAL_PROXY_URL", "http://localhost:3001")
+CLAUDE_JUDGE_MODEL = os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5")
+
+
+class ClaudeProxyJudge(DeepEvalBaseLLM):
+    """
+    Claude judge model routed through the Deus credential proxy.
+    NOTE: currently blocked — Anthropic messages API rejects OAuth Bearer auth.
+    Kept as fallback.
+    """
+
+    def __init__(self, model: str = CLAUDE_JUDGE_MODEL):
+        self.model = model
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            import anthropic
+            self._client = anthropic.Anthropic(
+                auth_token="placeholder",
+                base_url=PROXY_BASE_URL,
+            )
+        return self._client
+
+    def load_model(self):
+        return self._get_client()
+
+    def generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
+        client = self._get_client()
+        response = client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text, 0.0
+
+    async def a_generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
+        import anthropic
+        client = anthropic.AsyncAnthropic(
+            auth_token="placeholder",
+            base_url=PROXY_BASE_URL,
+        )
+        response = await client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text, 0.0
+
+    def get_model_name(self) -> str:
+        return f"claude-proxy:{self.model}"
+
+
+class ClaudeProxyRuntimeJudge(BaseJudge):
+    """Runtime judge via Claude proxy — returns neutral scores (blocked)."""
+
+    def evaluate(
+        self,
+        prompt: str,
+        response: str,
+        tools_used: Optional[list[str]] = None,
+        context: Optional[str] = None,
+    ) -> JudgeResult:
+        return JudgeResult(
+            score=0.5,
+            quality=0.5,
+            safety=1.0,
+            tool_use=1.0,
+            personalization=0.5,
+            rationale="Claude proxy judge — blocked, returning neutral score",
+        )
+
+
+class ClaudeProxyProvider(JudgeProvider):
+    """Claude proxy — last resort, currently blocked."""
+
+    @property
+    def name(self) -> str:
+        return "claude"
+
+    @property
+    def priority(self) -> int:
+        return 30
+
+    @property
+    def default_model(self) -> str:
+        return CLAUDE_JUDGE_MODEL
+
+    def is_available(self) -> bool:
+        try:
+            req = urllib.request.Request(f"{PROXY_BASE_URL}/health")
+            urllib.request.urlopen(req, timeout=2)
+            return True
+        except (urllib.error.URLError, OSError):
+            return False
+
+    def make_deepeval_judge(self, model: Optional[str] = None) -> DeepEvalBaseLLM:
+        return ClaudeProxyJudge(model=model or self.default_model)
+
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        return ClaudeProxyRuntimeJudge()

--- a/evolution/judge/providers/gemini.py
+++ b/evolution/judge/providers/gemini.py
@@ -1,0 +1,40 @@
+"""Gemini judge provider."""
+from typing import Optional
+
+from deepeval.models import DeepEvalBaseLLM
+
+from ..base import BaseJudge
+from ..provider import JudgeProvider
+
+
+class GeminiProvider(JudgeProvider):
+    """Gemini API — fallback when Ollama is unavailable."""
+
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    @property
+    def priority(self) -> int:
+        return 20
+
+    @property
+    def default_model(self) -> str:
+        from ...config import JUDGE_MODEL
+        return JUDGE_MODEL
+
+    def is_available(self) -> bool:
+        try:
+            from ...config import load_api_key
+            load_api_key()
+            return True
+        except (RuntimeError, ImportError):
+            return False
+
+    def make_deepeval_judge(self, model: Optional[str] = None) -> DeepEvalBaseLLM:
+        from ..gemini_judge import GeminiJudge
+        return GeminiJudge(model=model or self.default_model)
+
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        from ..gemini_judge import GeminiRuntimeJudge
+        return GeminiRuntimeJudge(model=model or self.default_model)

--- a/evolution/judge/providers/mock.py
+++ b/evolution/judge/providers/mock.py
@@ -1,0 +1,75 @@
+"""Mock judge provider — for CI smoke tests."""
+import os
+from typing import Any, Optional, Tuple
+
+from deepeval.models import DeepEvalBaseLLM
+
+from ..base import BaseJudge, JudgeResult
+from ..provider import JudgeProvider
+
+
+class MockJudge(DeepEvalBaseLLM):
+    """Returns a fixed score without calling any external API."""
+
+    def __init__(self, score: float = 0.75):
+        self._score = score
+
+    def load_model(self):
+        return None
+
+    def generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
+        return str(self._score), self._score
+
+    async def a_generate(self, prompt: str, schema: Optional[Any] = None) -> Tuple[str, float]:
+        return str(self._score), self._score
+
+    def get_model_name(self) -> str:
+        return f"mock:{self._score}"
+
+
+class MockRuntimeJudge(BaseJudge):
+    """Returns fixed scores for runtime evaluation."""
+
+    def __init__(self, score: float = 0.75):
+        self._score = score
+
+    def evaluate(
+        self,
+        prompt: str,
+        response: str,
+        tools_used: Optional[list[str]] = None,
+        context: Optional[str] = None,
+    ) -> JudgeResult:
+        return JudgeResult(
+            score=self._score,
+            quality=self._score,
+            safety=1.0,
+            tool_use=1.0,
+            personalization=self._score,
+            rationale="Mock judge — fixed score",
+        )
+
+
+class MockProvider(JudgeProvider):
+    """Mock provider — only available when explicitly requested via EVAL_JUDGE=mock."""
+
+    @property
+    def name(self) -> str:
+        return "mock"
+
+    @property
+    def priority(self) -> int:
+        return 0
+
+    @property
+    def default_model(self) -> str:
+        return "mock:0.75"
+
+    def is_available(self) -> bool:
+        return os.environ.get("EVAL_JUDGE", "").lower() == "mock"
+
+    def make_deepeval_judge(self, model: Optional[str] = None) -> DeepEvalBaseLLM:
+        return MockJudge()
+
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        return MockRuntimeJudge()

--- a/evolution/judge/providers/ollama.py
+++ b/evolution/judge/providers/ollama.py
@@ -1,0 +1,36 @@
+"""Ollama judge provider."""
+from typing import Optional
+
+from deepeval.models import DeepEvalBaseLLM
+
+from ..base import BaseJudge
+from ..provider import JudgeProvider
+
+
+class OllamaProvider(JudgeProvider):
+    """Local Ollama — preferred when available (free, no quota)."""
+
+    @property
+    def name(self) -> str:
+        return "ollama"
+
+    @property
+    def priority(self) -> int:
+        return 10
+
+    @property
+    def default_model(self) -> str:
+        from ...config import OLLAMA_MODEL
+        return OLLAMA_MODEL
+
+    def is_available(self) -> bool:
+        from ..ollama_judge import is_ollama_available
+        return is_ollama_available()
+
+    def make_deepeval_judge(self, model: Optional[str] = None) -> DeepEvalBaseLLM:
+        from ..ollama_judge import OllamaJudge
+        return OllamaJudge(model=model or self.default_model)
+
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        from ..ollama_judge import OllamaRuntimeJudge
+        return OllamaRuntimeJudge(model=model or self.default_model)

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     _MCP_AVAILABLE = False
 
-from .judge.gemini_judge import make_runtime_judge
+from .judge import make_runtime_judge
 from .ilog.interaction_log import log_interaction, update_score
 from .reflexion.generator import generate_reflection
 from .reflexion.retriever import format_reflections_block, get_reflections

--- a/evolution/optimizer/dspy_optimizer.py
+++ b/evolution/optimizer/dspy_optimizer.py
@@ -14,6 +14,7 @@ from ..config import (
     DSPY_MAX_LABELED,
     DSPY_MIN_DOMAIN_SAMPLES,
     DSPY_MIN_SAMPLES,
+    DSPY_OLLAMA_MODEL,
     JUDGE_MODEL,
     load_api_key,
 )
@@ -27,20 +28,19 @@ def _setup_dspy(model: str = JUDGE_MODEL) -> None:
     import dspy
     import os
     # Prefer Ollama (no quota) for optimizer; fall back to Gemini.
-    # gemma4:e4b — best accuracy/speed tradeoff per benchmark (Round 3 clean dataset).
-    ollama_model = os.environ.get("DSPY_OLLAMA_MODEL", "gemma4:e4b")
+    from ..judge.provider import JudgeRegistry
     try:
-        import httpx
-        r = httpx.get("http://localhost:11434/api/tags", timeout=2)
-        if r.status_code == 200:
+        ollama_provider = JudgeRegistry.default().get("ollama")
+        if ollama_provider.is_available():
+            from ..config import OLLAMA_HOST
             lm = dspy.LM(
-                f"ollama/{ollama_model}",
-                api_base="http://localhost:11434",
+                f"ollama/{DSPY_OLLAMA_MODEL}",
+                api_base=OLLAMA_HOST,
                 think=False,
             )
             dspy.configure(lm=lm)
             return
-    except Exception:
+    except KeyError:
         pass
     # Fallback: Gemini
     os.environ.setdefault("GEMINI_API_KEY", load_api_key())

--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -39,7 +39,7 @@ def mock_judge(monkeypatch):
     judge_mock.a_evaluate = AsyncMock(return_value=result)
 
     monkeypatch.setattr(
-        "evolution.judge.gemini_judge.make_runtime_judge",
+        "evolution.judge.make_runtime_judge",
         lambda *args, **kwargs: judge_mock,
     )
     return judge_mock, result
@@ -60,7 +60,7 @@ def mock_low_score_judge(monkeypatch):
     judge_mock.a_evaluate = AsyncMock(return_value=result)
 
     monkeypatch.setattr(
-        "evolution.judge.gemini_judge.make_runtime_judge",
+        "evolution.judge.make_runtime_judge",
         lambda *args, **kwargs: judge_mock,
     )
     return judge_mock, result
@@ -228,7 +228,7 @@ def mock_high_score_judge(monkeypatch):
     judge_mock = MagicMock()
     judge_mock.a_evaluate = AsyncMock(return_value=result)
     monkeypatch.setattr(
-        "evolution.judge.gemini_judge.make_runtime_judge",
+        "evolution.judge.make_runtime_judge",
         lambda *args, **kwargs: judge_mock,
     )
     return judge_mock, result
@@ -248,7 +248,7 @@ def mock_mid_score_judge(monkeypatch):
     judge_mock = MagicMock()
     judge_mock.a_evaluate = AsyncMock(return_value=result)
     monkeypatch.setattr(
-        "evolution.judge.gemini_judge.make_runtime_judge",
+        "evolution.judge.make_runtime_judge",
         lambda *args, **kwargs: judge_mock,
     )
     return judge_mock, result
@@ -506,7 +506,7 @@ def test_cmd_log_interaction_judge_exception_does_not_crash(monkeypatch, mock_em
     judge_mock = MagicMock()
     judge_mock.a_evaluate = AsyncMock(side_effect=RuntimeError("Judge API exploded"))
     monkeypatch.setattr(
-        "evolution.judge.gemini_judge.make_runtime_judge",
+        "evolution.judge.make_runtime_judge",
         lambda *args, **kwargs: judge_mock,
     )
 
@@ -603,7 +603,7 @@ def test_main_log_interaction_dispatch(monkeypatch, tmp_path):
     judge_mock = MagicMock()
     judge_mock.a_evaluate = AsyncMock(return_value=result)
     monkeypatch.setattr(
-        "evolution.judge.gemini_judge.make_runtime_judge",
+        "evolution.judge.make_runtime_judge",
         lambda *args, **kwargs: judge_mock,
     )
     monkeypatch.setattr("evolution.reflexion.generator.generate_reflection", lambda **kw: ("c", "cat"))

--- a/evolution/tests/test_judge_registry.py
+++ b/evolution/tests/test_judge_registry.py
@@ -1,0 +1,250 @@
+"""Tests for the JudgeProvider / JudgeRegistry pattern."""
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from deepeval.models import DeepEvalBaseLLM
+
+from evolution.judge.base import BaseJudge, JudgeResult
+from evolution.judge.provider import (
+    JudgeProvider,
+    JudgeRegistry,
+    NoProviderAvailableError,
+)
+
+
+# ── Test helpers ──────────────────────────────────────────────────────────────
+
+
+class FakeDeepEvalJudge(DeepEvalBaseLLM):
+    def __init__(self, name: str = "fake"):
+        self._name = name
+
+    def load_model(self):
+        return None
+
+    def generate(self, prompt, schema=None):
+        return "fake", 0.0
+
+    async def a_generate(self, prompt, schema=None):
+        return "fake", 0.0
+
+    def get_model_name(self):
+        return self._name
+
+
+class FakeRuntimeJudge(BaseJudge):
+    def evaluate(self, prompt, response, tools_used=None, context=None):
+        return JudgeResult(
+            score=0.5, quality=0.5, safety=1.0, tool_use=1.0,
+            personalization=0.5, rationale="fake",
+        )
+
+
+class FakeProvider(JudgeProvider):
+    """Configurable provider for testing."""
+
+    def __init__(self, name: str, priority: int, available: bool = True):
+        self._name = name
+        self._priority = priority
+        self._available = available
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def priority(self) -> int:
+        return self._priority
+
+    @property
+    def default_model(self) -> str:
+        return f"{self._name}:default"
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def make_deepeval_judge(self, model: Optional[str] = None) -> DeepEvalBaseLLM:
+        return FakeDeepEvalJudge(model or self.default_model)
+
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        return FakeRuntimeJudge()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Ensure each test gets a fresh registry."""
+    JudgeRegistry.reset()
+    yield
+    JudgeRegistry.reset()
+
+
+# ── Registry unit tests ──────────────────────────────────────────────────────
+
+
+class TestJudgeRegistry:
+    def test_register_and_get(self):
+        reg = JudgeRegistry.default()
+        p = FakeProvider("test", priority=10)
+        reg.register(p)
+        assert reg.get("test") is p
+
+    def test_get_unknown_raises_keyerror(self):
+        reg = JudgeRegistry.default()
+        with pytest.raises(KeyError):
+            reg.get("nonexistent")
+
+    def test_unregister(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("tmp", priority=10))
+        reg.unregister("tmp")
+        with pytest.raises(KeyError):
+            reg.get("tmp")
+
+    def test_unregister_missing_is_noop(self):
+        reg = JudgeRegistry.default()
+        reg.unregister("nonexistent")  # should not raise
+
+    def test_list_providers_sorted_by_priority(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("high", priority=30))
+        reg.register(FakeProvider("low", priority=5))
+        reg.register(FakeProvider("mid", priority=15))
+        assert reg.list_providers() == ["low", "mid", "high"]
+
+    def test_singleton(self):
+        a = JudgeRegistry.default()
+        b = JudgeRegistry.default()
+        assert a is b
+
+    def test_reset_creates_fresh_instance(self):
+        a = JudgeRegistry.default()
+        a.register(FakeProvider("x", priority=1))
+        JudgeRegistry.reset()
+        b = JudgeRegistry.default()
+        assert a is not b
+        assert b.list_providers() == []
+
+
+class TestResolve:
+    def test_resolve_auto_detect_by_priority(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("slow", priority=20, available=True))
+        reg.register(FakeProvider("fast", priority=5, available=True))
+        assert reg.resolve().name == "fast"
+
+    def test_resolve_skips_unavailable(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("down", priority=1, available=False))
+        reg.register(FakeProvider("up", priority=10, available=True))
+        assert reg.resolve().name == "up"
+
+    def test_resolve_explicit_preference(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("a", priority=1, available=True))
+        reg.register(FakeProvider("b", priority=10, available=True))
+        assert reg.resolve("b").name == "b"
+
+    def test_resolve_env_var_override(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("a", priority=1, available=True))
+        reg.register(FakeProvider("b", priority=10, available=True))
+        with patch.dict(os.environ, {"EVOLUTION_JUDGE_PROVIDER": "b"}):
+            assert reg.resolve().name == "b"
+
+    def test_resolve_env_var_takes_precedence_over_preference(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("a", priority=1, available=True))
+        reg.register(FakeProvider("b", priority=10, available=True))
+        with patch.dict(os.environ, {"EVOLUTION_JUDGE_PROVIDER": "b"}):
+            assert reg.resolve("a").name == "b"
+
+    def test_resolve_no_providers_raises(self):
+        reg = JudgeRegistry.default()
+        with pytest.raises(NoProviderAvailableError, match="No judge provider available"):
+            reg.resolve()
+
+    def test_resolve_all_unavailable_raises(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("x", priority=1, available=False))
+        reg.register(FakeProvider("y", priority=2, available=False))
+        with pytest.raises(NoProviderAvailableError, match="No judge provider available"):
+            reg.resolve()
+
+    def test_resolve_unknown_preference_raises(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("a", priority=1, available=True))
+        with pytest.raises(NoProviderAvailableError, match="not registered"):
+            reg.resolve("nonexistent")
+
+    def test_resolve_preference_unavailable_raises(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("a", priority=1, available=False))
+        with pytest.raises(NoProviderAvailableError, match="not available"):
+            reg.resolve("a")
+
+    def test_resolve_case_insensitive(self):
+        reg = JudgeRegistry.default()
+        reg.register(FakeProvider("ollama", priority=10, available=True))
+        assert reg.resolve("OLLAMA").name == "ollama"
+
+
+class TestProviderFactoryMethods:
+    def test_make_deepeval_judge_uses_default_model(self):
+        p = FakeProvider("test", priority=1)
+        judge = p.make_deepeval_judge()
+        assert judge.get_model_name() == "test:default"
+
+    def test_make_deepeval_judge_uses_custom_model(self):
+        p = FakeProvider("test", priority=1)
+        judge = p.make_deepeval_judge("custom-model")
+        assert judge.get_model_name() == "custom-model"
+
+    def test_make_runtime_judge_returns_base_judge(self):
+        p = FakeProvider("test", priority=1)
+        judge = p.make_runtime_judge()
+        assert isinstance(judge, BaseJudge)
+
+
+class TestBuiltInProviders:
+    """Smoke tests that the real providers can be instantiated."""
+
+    def test_ollama_provider_has_correct_name(self):
+        from evolution.judge.providers.ollama import OllamaProvider
+        p = OllamaProvider()
+        assert p.name == "ollama"
+        assert p.priority == 10
+
+    def test_gemini_provider_has_correct_name(self):
+        from evolution.judge.providers.gemini import GeminiProvider
+        p = GeminiProvider()
+        assert p.name == "gemini"
+        assert p.priority == 20
+
+    def test_mock_provider_has_correct_name(self):
+        from evolution.judge.providers.mock import MockProvider
+        p = MockProvider()
+        assert p.name == "mock"
+        assert p.priority == 0
+
+    def test_mock_provider_available_only_when_env_set(self):
+        from evolution.judge.providers.mock import MockProvider
+        p = MockProvider()
+        assert not p.is_available()
+        with patch.dict(os.environ, {"EVAL_JUDGE": "mock"}):
+            assert p.is_available()
+
+    def test_claude_proxy_provider_has_correct_name(self):
+        from evolution.judge.providers.claude_proxy import ClaudeProxyProvider
+        p = ClaudeProxyProvider()
+        assert p.name == "claude"
+        assert p.priority == 30
+
+    def test_default_model_reads_from_config(self):
+        from evolution.judge.providers.ollama import OllamaProvider
+        p = OllamaProvider()
+        assert p.default_model == "gemma4:e4b"  # current default in config


### PR DESCRIPTION
## Summary
- Introduce `JudgeProvider` ABC + `JudgeRegistry` singleton for seamless backend switching
- Centralize all Ollama model defaults in `evolution/config.py` (1 file instead of 4)
- Implement 4 built-in providers: Ollama (priority 10), Gemini (20), Mock (0, CI-only), ClaudeProxy (30)
- Simplify `eval/judge_model.py` from ~160 lines to ~40 by delegating to registry
- New env var `EVOLUTION_JUDGE_PROVIDER` for explicit provider selection
- Adding a new backend = 1 provider file + 1 registration line

## Test plan
- [x] 26 new tests for registry, resolution, provider instantiation (`evolution/tests/test_judge_registry.py`)
- [x] All 77 existing Python tests pass (1 pre-existing failure on `main` unrelated to this PR)
- [x] 507 TypeScript tests pass, `npm run build` clean
- [x] Verified registry loads all 4 providers: `['mock', 'ollama', 'gemini', 'claude']`
- [x] Backward compat: `EVAL_JUDGE=mock/ollama/gemini` env vars still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)