### PR TITLE
docs: add PR squash-and-merge rule to contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,16 @@ Every change — from maintainers and contributors alike — follows this workfl
 
 No direct pushes to `main`. No exceptions.
 
+## PR Scope and Squashing
+
+Each PR must contain a **single squashed commit** when merged. This means:
+
+- All commits in a PR should be squashable into one coherent change.
+- If two commits are too different to squash (different scope, different purpose), they belong in **separate PRs**.
+- Use GitHub's "Squash and merge" option when merging.
+
+This keeps `main` history clean and every commit meaningful.
+
 ## Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/). This drives automated changelogs and versioning via [release-please](https://github.com/googleapis/release-please).

--- a/docs/CONTRIBUTING-AI.md
+++ b/docs/CONTRIBUTING-AI.md
@@ -10,6 +10,10 @@ These rules apply to any AI agent (Claude Code, Deus, or other) developing in th
 4. After implementation: run `npm run build` and `npm test`. Both must pass before committing.
 5. Create a PR targeting `main`. Wait for CI to pass before requesting merge.
 
+## PR Scope and Squashing
+
+Each PR must contain a **single squashed commit** when merged. If your branch has multiple commits, they will be squashed on merge. If two commits are fundamentally different in scope or purpose, split them into separate PRs instead.
+
 ## Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) strictly. Commits that don't match this format will be rejected by the commit-msg hook and CI.


### PR DESCRIPTION
## Summary
- Require single squashed commit per PR in both contributor guides
- If commits are too different to squash, they belong in separate PRs
- Use GitHub's "Squash and merge" option when merging

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)