### PR TITLE
fix(channels): enable MCP logging capability for message delivery

### DIFF
--- a/packages/mcp-discord/src/index.ts
+++ b/packages/mcp-discord/src/index.ts
@@ -18,10 +18,10 @@ import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { DiscordProvider } from './discord.js';
 
-const server = new McpServer({
-  name: '@deus-ai/discord-mcp',
-  version: '1.0.0',
-});
+const server = new McpServer(
+  { name: '@deus-ai/discord-mcp', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
 
 const provider = new DiscordProvider();
 

--- a/packages/mcp-gmail/src/index.ts
+++ b/packages/mcp-gmail/src/index.ts
@@ -19,10 +19,10 @@ import { z } from 'zod';
 
 import { GmailProvider } from './gmail.js';
 
-const server = new McpServer({
-  name: '@deus-ai/gmail-mcp',
-  version: '1.0.0',
-});
+const server = new McpServer(
+  { name: '@deus-ai/gmail-mcp', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
 
 const provider = new GmailProvider();
 

--- a/packages/mcp-slack/src/index.ts
+++ b/packages/mcp-slack/src/index.ts
@@ -21,10 +21,10 @@ import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { SlackProvider } from './slack.js';
 
-const server = new McpServer({
-  name: '@deus-ai/slack-mcp',
-  version: '1.0.0',
-});
+const server = new McpServer(
+  { name: '@deus-ai/slack-mcp', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
 
 const provider = new SlackProvider();
 

--- a/packages/mcp-telegram/src/index.ts
+++ b/packages/mcp-telegram/src/index.ts
@@ -18,10 +18,10 @@ import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { TelegramProvider } from './telegram.js';
 
-const server = new McpServer({
-  name: '@deus-ai/telegram-mcp',
-  version: '1.0.0',
-});
+const server = new McpServer(
+  { name: '@deus-ai/telegram-mcp', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
 
 const provider = new TelegramProvider();
 

--- a/packages/mcp-whatsapp/src/index.ts
+++ b/packages/mcp-whatsapp/src/index.ts
@@ -20,10 +20,10 @@ import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { WhatsAppProvider } from './whatsapp.js';
 
-const server = new McpServer({
-  name: '@deus-ai/whatsapp-mcp',
-  version: '1.0.0',
-});
+const server = new McpServer(
+  { name: '@deus-ai/whatsapp-mcp', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
 
 const provider = new WhatsAppProvider();
 


### PR DESCRIPTION
## Summary
- All 5 channel MCP servers were missing the `logging` capability declaration
- Without it, `McpServer.sendLoggingMessage()` silently drops all notifications (gated by `if (this._capabilities.logging)`)
- This broke all channel message delivery since the MCP conversion on Apr 5 — channels connected fine but incoming messages never reached the host process

## Root Cause
The MCP SDK v1.29.0 `Server.sendLoggingMessage()` checks `this._capabilities.logging` before sending. When `McpServer` is constructed without `capabilities: { logging: {} }`, the capability defaults to `undefined`, and all logging notifications are silently discarded.

## Fix
Added `{ capabilities: { logging: {} } }` as the second argument to `new McpServer()` in all 5 channel packages:
- `packages/mcp-whatsapp/src/index.ts`
- `packages/mcp-telegram/src/index.ts`
- `packages/mcp-discord/src/index.ts`
- `packages/mcp-gmail/src/index.ts`
- `packages/mcp-slack/src/index.ts`

## Test plan
- [x] Sent WhatsApp self-chat message — arrived in DB and got a response
- [x] Verified MCP notification handler fires in host process
- [ ] Verify Telegram message delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)