### PR TITLE
feat(container): add Google Calendar MCP server for container agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ packages/
   mcp-discord/            # Discord channel (discord.js)
   mcp-slack/              # Slack channel (@slack/bolt)
   mcp-gmail/              # Gmail channel (googleapis + OAuth polling)
+  mcp-gcal/               # Google Calendar MCP server (tool server for container agents)
 scripts/
   memory_indexer.py       # Semantic memory: index, query, extract, wander
   import_seeds.py         # Import curated seed reflections into evolution DB
   stop_hook.py            # Auto-checkpoint on session end
-  gcal.mjs                # Google Calendar MCP server
 seeds/
   reflections.json        # Curated seed reflections for onboarding
 evolution/

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,7 +16,11 @@
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  HookCallback,
+  PreCompactHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
 interface ContainerInput {
@@ -28,7 +32,6 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
-
 }
 
 interface ImageContentBlock {
@@ -75,8 +78,14 @@ const IPC_POLL_MS = 500;
 // (TeamCreate, TeamDelete, SendMessage) are excluded from allowedTools,
 // saving ~300 tokens per call on personal-assistant queries.
 const SWARM_SIGNALS = [
-  'parallel agent', 'subagent', 'agent team', 'agent swarm',
-  'orchestrate', 'in parallel', 'multiple agents', 'spawn agent',
+  'parallel agent',
+  'subagent',
+  'agent team',
+  'agent swarm',
+  'orchestrate',
+  'in parallel',
+  'multiple agents',
+  'spawn agent',
 ];
 
 /**
@@ -119,7 +128,9 @@ class MessageStream {
         yield this.queue.shift()!;
       }
       if (this.done) return;
-      await new Promise<void>(r => { this.waiting = r; });
+      await new Promise<void>((r) => {
+        this.waiting = r;
+      });
       this.waiting = null;
     }
   }
@@ -129,7 +140,9 @@ async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
     process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
@@ -160,14 +173,19 @@ function writeOutput(output: ContainerOutput): void {
       path.join(IPC_OUTPUT_DIR, `${_outputSeq++}.json`),
       JSON.stringify(output),
     );
-  } catch { /* ignore — stdout is still the authoritative channel in production */ }
+  } catch {
+    /* ignore — stdout is still the authoritative channel in production */
+  }
 }
 
 function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
 }
 
-function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+function getSessionSummary(
+  sessionId: string,
+  transcriptPath: string,
+): string | null {
   const projectDir = path.dirname(transcriptPath);
   const indexPath = path.join(projectDir, 'sessions-index.json');
 
@@ -177,13 +195,17 @@ function getSessionSummary(sessionId: string, transcriptPath: string): string | 
   }
 
   try {
-    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-    const entry = index.entries.find(e => e.sessionId === sessionId);
+    const index: SessionsIndex = JSON.parse(
+      fs.readFileSync(indexPath, 'utf-8'),
+    );
+    const entry = index.entries.find((e) => e.sessionId === sessionId);
     if (entry?.summary) {
       return entry.summary;
     }
   } catch (err) {
-    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+    log(
+      `Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   return null;
@@ -222,12 +244,18 @@ function createPreCompactHook(assistantName?: string): HookCallback {
       const filename = `${date}-${name}.md`;
       const filePath = path.join(conversationsDir, filename);
 
-      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      const markdown = formatTranscriptMarkdown(
+        messages,
+        summary,
+        assistantName,
+      );
       fs.writeFileSync(filePath, markdown);
 
       log(`Archived conversation to ${filePath}`);
     } catch (err) {
-      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     return {};
@@ -260,9 +288,12 @@ function parseTranscript(content: string): ParsedMessage[] {
     try {
       const entry = JSON.parse(line);
       if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string'
-          ? entry.message.content
-          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content
+                .map((c: { text?: string }) => c.text || '')
+                .join('');
         if (text) messages.push({ role: 'user', content: text });
       } else if (entry.type === 'assistant' && entry.message?.content) {
         const textParts = entry.message.content
@@ -271,22 +302,26 @@ function parseTranscript(content: string): ParsedMessage[] {
         const text = textParts.join('');
         if (text) messages.push({ role: 'assistant', content: text });
       }
-    } catch {
-    }
+    } catch {}
   }
 
   return messages;
 }
 
-function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+function formatTranscriptMarkdown(
+  messages: ParsedMessage[],
+  title?: string | null,
+  assistantName?: string,
+): string {
   const now = new Date();
-  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  });
+  const formatDateTime = (d: Date) =>
+    d.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
 
   const lines: string[] = [];
   lines.push(`# ${title || 'Conversation'}`);
@@ -297,10 +332,11 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
   lines.push('');
 
   for (const msg of messages) {
-    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
-    const content = msg.content.length > 2000
-      ? msg.content.slice(0, 2000) + '...'
-      : msg.content;
+    const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
+    const content =
+      msg.content.length > 2000
+        ? msg.content.slice(0, 2000) + '...'
+        : msg.content;
     lines.push(`**${sender}**: ${content}`);
     lines.push('');
   }
@@ -313,7 +349,11 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
  */
 function shouldClose(): boolean {
   if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
-    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    try {
+      fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+    } catch {
+      /* ignore */
+    }
     return true;
   }
   return false;
@@ -326,8 +366,9 @@ function shouldClose(): boolean {
 function drainIpcInput(): string[] {
   try {
     fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
-    const files = fs.readdirSync(IPC_INPUT_DIR)
-      .filter(f => f.endsWith('.json'))
+    const files = fs
+      .readdirSync(IPC_INPUT_DIR)
+      .filter((f) => f.endsWith('.json'))
       .sort();
 
     const messages: string[] = [];
@@ -340,8 +381,14 @@ function drainIpcInput(): string[] {
           messages.push(data.text);
         }
       } catch (err) {
-        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
-        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+        log(
+          `Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        try {
+          fs.unlinkSync(filePath);
+        } catch {
+          /* ignore */
+        }
       }
     }
     return messages;
@@ -386,7 +433,11 @@ async function runQuery(
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+): Promise<{
+  newSessionId?: string;
+  lastAssistantUuid?: string;
+  closedDuringQuery: boolean;
+}> {
   const stream = new MessageStream();
   stream.push(prompt);
 
@@ -397,7 +448,10 @@ async function runQuery(
       const imgPath = path.join('/workspace/group', img.relativePath);
       try {
         const data = fs.readFileSync(imgPath).toString('base64');
-        blocks.push({ type: 'image', source: { type: 'base64', media_type: img.mediaType, data } });
+        blocks.push({
+          type: 'image',
+          source: { type: 'base64', media_type: img.mediaType, data },
+        });
       } catch (err) {
         log(`Failed to load image: ${imgPath}`);
       }
@@ -452,8 +506,9 @@ async function runQuery(
     const stat = fs.statSync(projectDir);
     if (stat.isDirectory()) {
       const realProjectDir = fs.realpathSync(projectDir);
-      hasProject = realProjectDir.startsWith('/workspace/') &&
-        fs.readdirSync(projectDir).some(f => !f.startsWith('.'));
+      hasProject =
+        realProjectDir.startsWith('/workspace/') &&
+        fs.readdirSync(projectDir).some((f) => !f.startsWith('.'));
     }
   } catch {
     // projectDir doesn't exist — not an error, just no project mounted
@@ -491,9 +546,26 @@ async function runQuery(
   // Exclude them for plain personal-assistant queries to save ~300 tokens.
   // Always include when an external project is mounted (engineering context)
   // or the prompt explicitly signals multi-agent intent.
-  const teamsNeeded = hasProject ||
-    SWARM_SIGNALS.some(kw => prompt.toLowerCase().includes(kw));
-  log(`Swarm tools: ${teamsNeeded ? 'included' : 'excluded (~300 tokens saved)'}`);
+  const teamsNeeded =
+    hasProject || SWARM_SIGNALS.some((kw) => prompt.toLowerCase().includes(kw));
+  log(
+    `Swarm tools: ${teamsNeeded ? 'included' : 'excluded (~300 tokens saved)'}`,
+  );
+
+  // Google Calendar MCP: available when the host project is mounted and gcal
+  // credentials + built package exist. The MCP server runs from the host's
+  // built dist via the read-only /workspace/project mount.
+  const gcalDistPath = '/workspace/project/packages/mcp-gcal/dist/index.js';
+  const gcalCredsPath = '/workspace/project/integrations/gcal/credentials.json';
+  const gcalTokensPath = '/workspace/project/integrations/gcal/tokens.json';
+  const hasGcalMcp =
+    hasProject &&
+    fs.existsSync(gcalDistPath) &&
+    fs.existsSync(gcalCredsPath) &&
+    fs.existsSync(gcalTokensPath);
+  if (hasGcalMcp) {
+    log('Google Calendar MCP: enabled (credentials + package found)');
+  }
 
   // CLAUDE.md probe: log fingerprint before every query() call.
   // Compare across turns in the same session — if len= appears N times for
@@ -502,7 +574,9 @@ async function runQuery(
   const claudeMdProbePath = '/workspace/group/CLAUDE.md';
   if (fs.existsSync(claudeMdProbePath)) {
     const _probeStat = fs.statSync(claudeMdProbePath);
-    log(`[claude-md-probe] turn=${sessionId ? 'resume' : 'new'} len=${_probeStat.size}B mtime=${_probeStat.mtimeMs}`);
+    log(
+      `[claude-md-probe] turn=${sessionId ? 'resume' : 'new'} len=${_probeStat.size}B mtime=${_probeStat.mtimeMs}`,
+    );
   }
 
   for await (const message of query({
@@ -513,17 +587,31 @@ async function runQuery(
       resume: sessionId,
       resumeSessionAt: resumeAt,
       systemPrompt: globalClaudeMd
-        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        ? {
+            type: 'preset' as const,
+            preset: 'claude_code' as const,
+            append: globalClaudeMd,
+          }
         : undefined,
       allowedTools: [
         'Bash',
-        'Read', 'Write', 'Edit', 'Glob', 'Grep',
-        'WebSearch', 'WebFetch',
-        'Task', 'TaskOutput', 'TaskStop',
+        'Read',
+        'Write',
+        'Edit',
+        'Glob',
+        'Grep',
+        'WebSearch',
+        'WebFetch',
+        'Task',
+        'TaskOutput',
+        'TaskStop',
         ...(teamsNeeded ? ['TeamCreate', 'TeamDelete', 'SendMessage'] : []),
-        'TodoWrite', 'ToolSearch', 'Skill',
+        'TodoWrite',
+        'ToolSearch',
+        'Skill',
         'NotebookEdit',
         'mcp__deus__*',
+        ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -539,14 +627,34 @@ async function runQuery(
             DEUS_IS_MAIN: containerInput.isMain ? '1' : '0',
           },
         },
+        // Google Calendar MCP — only available when credentials exist on the host
+        // and the project is mounted (main channel only). Runs from the host's
+        // built package via the read-only /workspace/project mount.
+        ...(hasGcalMcp
+          ? {
+              gcal: {
+                command: 'node',
+                args: ['/workspace/project/packages/mcp-gcal/dist/index.js'],
+                env: {
+                  DEUS_PROJECT_ROOT: '/workspace/project',
+                  LOG_LEVEL: process.env.LOG_LEVEL || 'info',
+                },
+              },
+            }
+          : {}),
       },
       hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+        PreCompact: [
+          { hooks: [createPreCompactHook(containerInput.assistantName)] },
+        ],
       },
-    }
+    },
   })) {
     messageCount++;
-    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    const msgType =
+      message.type === 'system'
+        ? `system/${(message as { subtype?: string }).subtype}`
+        : message.type;
     log(`[msg #${messageCount}] type=${msgType}`);
 
     if (message.type === 'assistant' && 'uuid' in message) {
@@ -558,25 +666,39 @@ async function runQuery(
       log(`Session initialized: ${newSessionId}`);
     }
 
-    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
-      const tn = message as { task_id: string; status: string; summary: string };
-      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    if (
+      message.type === 'system' &&
+      (message as { subtype?: string }).subtype === 'task_notification'
+    ) {
+      const tn = message as {
+        task_id: string;
+        status: string;
+        summary: string;
+      };
+      log(
+        `Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`,
+      );
     }
 
     if (message.type === 'result') {
       resultCount++;
-      const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      const textResult =
+        'result' in message ? (message as { result?: string }).result : null;
+      log(
+        `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
+      );
       writeOutput({
         status: 'success',
         result: textResult || null,
-        newSessionId
+        newSessionId,
       });
     }
   }
 
   ipcPolling = false;
-  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  log(
+    `Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`,
+  );
   return { newSessionId, lastAssistantUuid, closedDuringQuery };
 }
 
@@ -586,13 +708,17 @@ async function main(): Promise<void> {
   try {
     const stdinData = await readStdin();
     containerInput = JSON.parse(stdinData);
-    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    try {
+      fs.unlinkSync('/tmp/input.json');
+    } catch {
+      /* may not exist */
+    }
     log(`Received input for group: ${containerInput.groupFolder}`);
   } catch (err) {
     writeOutput({
       status: 'error',
       result: null,
-      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`,
     });
     process.exit(1);
   }
@@ -608,7 +734,11 @@ async function main(): Promise<void> {
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
   // Clean up stale _close sentinel from previous container runs
-  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+  try {
+    fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+  } catch {
+    /* ignore */
+  }
 
   // Build initial prompt (drain any pending IPC messages too)
   let prompt = containerInput.prompt;
@@ -648,13 +778,16 @@ async function main(): Promise<void> {
           allowDangerouslySkipPermissions: true,
           settingSources: ['project', 'user'] as const,
           hooks: {
-            PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+            PreCompact: [
+              { hooks: [createPreCompactHook(containerInput.assistantName)] },
+            ],
           },
         },
       })) {
-        const msgType = message.type === 'system'
-          ? `system/${(message as { subtype?: string }).subtype}`
-          : message.type;
+        const msgType =
+          message.type === 'system'
+            ? `system/${(message as { subtype?: string }).subtype}`
+            : message.type;
         log(`[slash-cmd] type=${msgType}`);
 
         if (message.type === 'system' && message.subtype === 'init') {
@@ -663,14 +796,20 @@ async function main(): Promise<void> {
         }
 
         // Observe compact_boundary to confirm compaction completed
-        if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
+        if (
+          message.type === 'system' &&
+          (message as { subtype?: string }).subtype === 'compact_boundary'
+        ) {
           compactBoundarySeen = true;
           log('Compact boundary observed — compaction completed');
         }
 
         if (message.type === 'result') {
           const resultSubtype = (message as { subtype?: string }).subtype;
-          const textResult = 'result' in message ? (message as { result?: string }).result : null;
+          const textResult =
+            'result' in message
+              ? (message as { result?: string }).result
+              : null;
 
           if (resultSubtype?.startsWith('error')) {
             hadError = true;
@@ -697,11 +836,15 @@ async function main(): Promise<void> {
       writeOutput({ status: 'error', result: null, error: errorMsg });
     }
 
-    log(`Slash command done. compactBoundarySeen=${compactBoundarySeen}, hadError=${hadError}`);
+    log(
+      `Slash command done. compactBoundarySeen=${compactBoundarySeen}, hadError=${hadError}`,
+    );
 
     // Warn if compact_boundary was never observed — compaction may not have occurred
     if (!hadError && !compactBoundarySeen) {
-      log('WARNING: compact_boundary was not observed. Compaction may not have completed.');
+      log(
+        'WARNING: compact_boundary was not observed. Compaction may not have completed.',
+      );
     }
 
     // Only emit final session marker if no result was emitted yet and no error occurred
@@ -715,7 +858,11 @@ async function main(): Promise<void> {
       });
     } else if (!hadError) {
       // Emit session-only marker so host updates session tracking
-      writeOutput({ status: 'success', result: null, newSessionId: slashSessionId });
+      writeOutput({
+        status: 'success',
+        result: null,
+        newSessionId: slashSessionId,
+      });
     }
     return;
   }
@@ -725,9 +872,18 @@ async function main(): Promise<void> {
   let resumeAt: string | undefined;
   try {
     while (true) {
-      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+      log(
+        `Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`,
+      );
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      const queryResult = await runQuery(
+        prompt,
+        sessionId,
+        mcpServerPath,
+        containerInput,
+        sdkEnv,
+        resumeAt,
+      );
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }
@@ -765,7 +921,7 @@ async function main(): Promise<void> {
       status: 'error',
       result: null,
       newSessionId: sessionId,
-      error: errorMessage
+      error: errorMessage,
     });
     process.exit(1);
   }

--- a/groups/main/CLAUDE.md.template
+++ b/groups/main/CLAUDE.md.template
@@ -13,6 +13,7 @@ You are {{ASSISTANT_NAME}}, the user's personal AI assistant. You collaborate on
 - Send messages back to the chat
 
 <!-- Add integrations here using /customize skills -->
+<!-- gcal: if mcp__gcal__* tools are available, you can manage Google Calendar events directly -->
 
 ## Communication
 

--- a/packages/mcp-gcal/package.json
+++ b/packages/mcp-gcal/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@deus-ai/gcal-mcp",
+  "version": "1.0.0",
+  "description": "Google Calendar MCP server — exposes calendar tools for any MCP client",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "deus-ai-gcal-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "google-auth-library": "^9.15.1",
+    "googleapis": "^146.0.0",
+    "pino": "^10.3.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/packages/mcp-gcal/src/gcal.test.ts
+++ b/packages/mcp-gcal/src/gcal.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('googleapis', () => {
+  const mockCalendar = {
+    calendarList: {
+      get: vi.fn().mockResolvedValue({ data: { summary: 'test@example.com' } }),
+    },
+    events: {
+      list: vi.fn(),
+      get: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+  return {
+    google: {
+      auth: {
+        OAuth2: class MockOAuth2 {
+          setCredentials = vi.fn();
+          on = vi.fn();
+        },
+      },
+      calendar: () => mockCalendar,
+    },
+    calendar_v3: {},
+  };
+});
+
+vi.mock('google-auth-library', () => ({
+  OAuth2Client: class MockOAuth2Client {
+    setCredentials = vi.fn();
+    on = vi.fn();
+  },
+}));
+
+vi.mock('pino', () => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+  };
+  const pinoFn: any = () => mockLogger;
+  pinoFn.destination = () => ({});
+  return { default: pinoFn };
+});
+
+import fs from 'fs';
+import { GCalProvider } from './gcal.js';
+
+describe('GCalProvider', () => {
+  let provider: GCalProvider;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    provider = new GCalProvider();
+  });
+
+  describe('isConnected', () => {
+    it('returns false before connect', () => {
+      expect(provider.isConnected()).toBe(false);
+    });
+  });
+
+  describe('hasCredentials', () => {
+    it('returns false when files do not exist', () => {
+      expect(provider.hasCredentials()).toBe(false);
+    });
+
+    it('returns true when both credential files exist', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      const p = new GCalProvider();
+      expect(p.hasCredentials()).toBe(true);
+    });
+  });
+
+  describe('connect', () => {
+    it('throws when credentials are missing', async () => {
+      await expect(provider.connect()).rejects.toThrow('credentials not found');
+    });
+
+    it('connects when credential files exist', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'readFileSync').mockImplementation((filePath: any) => {
+        if (filePath.includes('credentials')) {
+          return JSON.stringify({
+            installed: {
+              client_id: 'test-id',
+              client_secret: 'test-secret',
+              redirect_uris: ['http://localhost'],
+            },
+          });
+        }
+        return JSON.stringify({
+          access_token: 'test-token',
+          refresh_token: 'test-refresh',
+        });
+      });
+
+      const p = new GCalProvider();
+      await p.connect();
+      expect(p.isConnected()).toBe(true);
+    });
+  });
+
+  describe('operations throw when not connected', () => {
+    it('listEvents throws', async () => {
+      await expect(provider.listEvents()).rejects.toThrow('Not connected');
+    });
+
+    it('getEvent throws', async () => {
+      await expect(provider.getEvent('test-id')).rejects.toThrow(
+        'Not connected',
+      );
+    });
+
+    it('createEvent throws', async () => {
+      await expect(
+        provider.createEvent({ title: 'Test', start: '2026-04-07T14:00:00' }),
+      ).rejects.toThrow('Not connected');
+    });
+
+    it('updateEvent throws', async () => {
+      await expect(
+        provider.updateEvent('id', { title: 'New' }),
+      ).rejects.toThrow('Not connected');
+    });
+
+    it('deleteEvent throws', async () => {
+      await expect(provider.deleteEvent('id')).rejects.toThrow('Not connected');
+    });
+
+    it('searchEvents throws', async () => {
+      await expect(provider.searchEvents('query')).rejects.toThrow(
+        'Not connected',
+      );
+    });
+  });
+
+  describe('operations after connect', () => {
+    let calendarMock: any;
+
+    beforeEach(async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'readFileSync').mockImplementation((filePath: any) => {
+        if (filePath.includes('credentials')) {
+          return JSON.stringify({
+            installed: {
+              client_id: 'id',
+              client_secret: 'secret',
+              redirect_uris: ['http://localhost'],
+            },
+          });
+        }
+        return JSON.stringify({ access_token: 'tok' });
+      });
+
+      provider = new GCalProvider();
+      await provider.connect();
+
+      // Get the mock calendar instance
+      const { google } = await import('googleapis');
+      calendarMock = (google.calendar as any)();
+    });
+
+    it('listEvents returns mapped events', async () => {
+      calendarMock.events.list.mockResolvedValue({
+        data: {
+          items: [
+            {
+              id: 'e1',
+              summary: 'Meeting',
+              start: { dateTime: '2026-04-07T14:00:00Z' },
+              end: { dateTime: '2026-04-07T15:00:00Z' },
+              htmlLink: 'https://calendar.google.com/e1',
+            },
+          ],
+        },
+      });
+
+      const events = await provider.listEvents(7);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        id: 'e1',
+        summary: 'Meeting',
+        start: '2026-04-07T14:00:00Z',
+        end: '2026-04-07T15:00:00Z',
+        location: undefined,
+        description: undefined,
+        htmlLink: 'https://calendar.google.com/e1',
+      });
+    });
+
+    it('listEvents handles empty list', async () => {
+      calendarMock.events.list.mockResolvedValue({ data: { items: [] } });
+      const events = await provider.listEvents();
+      expect(events).toEqual([]);
+    });
+
+    it('getEvent returns a mapped event', async () => {
+      calendarMock.events.get.mockResolvedValue({
+        data: {
+          id: 'e1',
+          summary: 'Test',
+          start: { dateTime: '2026-04-07T10:00:00Z' },
+          end: { dateTime: '2026-04-07T11:00:00Z' },
+        },
+      });
+
+      const event = await provider.getEvent('e1');
+      expect(event.id).toBe('e1');
+      expect(event.summary).toBe('Test');
+    });
+
+    it('createEvent sends correct data', async () => {
+      calendarMock.events.insert.mockResolvedValue({
+        data: {
+          id: 'new-1',
+          summary: 'New Event',
+          start: { dateTime: '2026-04-07T14:00:00.000Z' },
+          end: { dateTime: '2026-04-07T15:00:00.000Z' },
+        },
+      });
+
+      const event = await provider.createEvent({
+        title: 'New Event',
+        start: '2026-04-07T14:00:00',
+        description: 'A test event',
+      });
+
+      expect(event.id).toBe('new-1');
+      expect(calendarMock.events.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calendarId: 'primary',
+          requestBody: expect.objectContaining({
+            summary: 'New Event',
+            description: 'A test event',
+          }),
+        }),
+      );
+    });
+
+    it('createEvent defaults end to start + 1 hour', async () => {
+      calendarMock.events.insert.mockResolvedValue({
+        data: {
+          id: 'new-2',
+          summary: 'Quick',
+          start: { dateTime: '2026-04-07T14:00:00.000Z' },
+          end: { dateTime: '2026-04-07T15:00:00.000Z' },
+        },
+      });
+
+      await provider.createEvent({
+        title: 'Quick',
+        start: '2026-04-07T14:00:00Z',
+      });
+
+      const call = calendarMock.events.insert.mock.calls[0][0];
+      const startMs = new Date(call.requestBody.start.dateTime).getTime();
+      const endMs = new Date(call.requestBody.end.dateTime).getTime();
+      expect(endMs - startMs).toBe(60 * 60 * 1000);
+    });
+
+    it('updateEvent patches only provided fields', async () => {
+      calendarMock.events.get.mockResolvedValue({
+        data: {
+          id: 'e1',
+          summary: 'Original',
+          start: { dateTime: '2026-04-07T10:00:00Z' },
+          end: { dateTime: '2026-04-07T11:00:00Z' },
+        },
+      });
+      calendarMock.events.update.mockResolvedValue({
+        data: {
+          id: 'e1',
+          summary: 'Updated',
+          start: { dateTime: '2026-04-07T10:00:00Z' },
+          end: { dateTime: '2026-04-07T11:00:00Z' },
+        },
+      });
+
+      const event = await provider.updateEvent('e1', { title: 'Updated' });
+      expect(event.summary).toBe('Updated');
+
+      const call = calendarMock.events.update.mock.calls[0][0];
+      expect(call.requestBody.summary).toBe('Updated');
+      // Start/end should remain from original
+      expect(call.requestBody.start.dateTime).toBe('2026-04-07T10:00:00Z');
+    });
+
+    it('deleteEvent calls API', async () => {
+      calendarMock.events.delete.mockResolvedValue({});
+      await provider.deleteEvent('e1');
+      expect(calendarMock.events.delete).toHaveBeenCalledWith({
+        calendarId: 'primary',
+        eventId: 'e1',
+      });
+    });
+
+    it('searchEvents passes query parameter', async () => {
+      calendarMock.events.list.mockResolvedValue({ data: { items: [] } });
+      await provider.searchEvents('standup', 14);
+      expect(calendarMock.events.list).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'standup' }),
+      );
+    });
+
+    it('mapEvent handles all-day events (date instead of dateTime)', async () => {
+      calendarMock.events.list.mockResolvedValue({
+        data: {
+          items: [
+            {
+              id: 'allday',
+              summary: 'Holiday',
+              start: { date: '2026-04-07' },
+              end: { date: '2026-04-08' },
+            },
+          ],
+        },
+      });
+
+      const events = await provider.listEvents();
+      expect(events[0].start).toBe('2026-04-07');
+      expect(events[0].end).toBe('2026-04-08');
+    });
+  });
+});

--- a/packages/mcp-gcal/src/gcal.ts
+++ b/packages/mcp-gcal/src/gcal.ts
@@ -1,0 +1,234 @@
+/**
+ * Google Calendar provider — handles OAuth2 auth and Calendar API operations.
+ *
+ * Config (env vars):
+ *   GCAL_CREDENTIALS_PATH — OAuth client credentials file (default: integrations/gcal/credentials.json)
+ *   GCAL_TOKENS_PATH      — OAuth tokens file (default: integrations/gcal/tokens.json)
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { OAuth2Client } from 'google-auth-library';
+import { calendar_v3, google } from 'googleapis';
+import pino from 'pino';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
+
+export interface CalendarEvent {
+  id: string;
+  summary: string;
+  start: string;
+  end: string;
+  location?: string;
+  description?: string;
+  htmlLink?: string;
+}
+
+export class GCalProvider {
+  private auth: OAuth2Client | null = null;
+  private calendar: calendar_v3.Calendar | null = null;
+  private credentialsPath: string;
+  private tokensPath: string;
+
+  constructor() {
+    const projectRoot = process.env.DEUS_PROJECT_ROOT || process.cwd();
+    this.credentialsPath =
+      process.env.GCAL_CREDENTIALS_PATH ||
+      path.join(projectRoot, 'integrations', 'gcal', 'credentials.json');
+    this.tokensPath =
+      process.env.GCAL_TOKENS_PATH ||
+      path.join(projectRoot, 'integrations', 'gcal', 'tokens.json');
+  }
+
+  hasCredentials(): boolean {
+    return (
+      fs.existsSync(this.credentialsPath) && fs.existsSync(this.tokensPath)
+    );
+  }
+
+  async connect(): Promise<void> {
+    if (!this.hasCredentials()) {
+      throw new Error(
+        `Google Calendar credentials not found. Expected:\n` +
+          `  OAuth client: ${this.credentialsPath}\n` +
+          `  Tokens: ${this.tokensPath}\n` +
+          `Run: node scripts/setup-gcal-auth.mjs`,
+      );
+    }
+
+    const creds = JSON.parse(fs.readFileSync(this.credentialsPath, 'utf8'));
+    const { client_id, client_secret, redirect_uris } =
+      creds.installed || creds.web;
+    this.auth = new google.auth.OAuth2(
+      client_id,
+      client_secret,
+      redirect_uris[0],
+    );
+
+    const tokens = JSON.parse(fs.readFileSync(this.tokensPath, 'utf8'));
+    this.auth.setCredentials(tokens);
+
+    // Auto-persist refreshed tokens
+    this.auth.on('tokens', (newTokens) => {
+      const merged = { ...tokens, ...newTokens };
+      try {
+        fs.writeFileSync(this.tokensPath, JSON.stringify(merged, null, 2));
+        logger.info('Refreshed OAuth tokens saved');
+      } catch {
+        // Tokens path may be read-only (e.g., inside container)
+      }
+    });
+
+    this.calendar = google.calendar({ version: 'v3', auth: this.auth });
+
+    // Verify connection
+    const profile = await this.calendar.calendarList.get({
+      calendarId: 'primary',
+    });
+    logger.info(
+      { calendar: profile.data.summary },
+      'Google Calendar connected',
+    );
+  }
+
+  isConnected(): boolean {
+    return this.calendar !== null;
+  }
+
+  private ensureConnected(): calendar_v3.Calendar {
+    if (!this.calendar) throw new Error('Not connected to Google Calendar');
+    return this.calendar;
+  }
+
+  async listEvents(days: number = 7): Promise<CalendarEvent[]> {
+    const cal = this.ensureConnected();
+    const now = new Date();
+    const end = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+
+    const res = await cal.events.list({
+      calendarId: 'primary',
+      timeMin: now.toISOString(),
+      timeMax: end.toISOString(),
+      singleEvents: true,
+      orderBy: 'startTime',
+      maxResults: 50,
+    });
+
+    return (res.data.items || []).map(this.mapEvent);
+  }
+
+  async getEvent(eventId: string): Promise<CalendarEvent> {
+    const cal = this.ensureConnected();
+    const res = await cal.events.get({ calendarId: 'primary', eventId });
+    return this.mapEvent(res.data);
+  }
+
+  async createEvent(opts: {
+    title: string;
+    start: string;
+    end?: string;
+    description?: string;
+    location?: string;
+  }): Promise<CalendarEvent> {
+    const cal = this.ensureConnected();
+    const startDt = new Date(opts.start);
+    const endDt = opts.end
+      ? new Date(opts.end)
+      : new Date(startDt.getTime() + 60 * 60 * 1000); // default 1h
+
+    const event: calendar_v3.Schema$Event = {
+      summary: opts.title,
+      start: { dateTime: startDt.toISOString() },
+      end: { dateTime: endDt.toISOString() },
+    };
+    if (opts.description) event.description = opts.description;
+    if (opts.location) event.location = opts.location;
+
+    const res = await cal.events.insert({
+      calendarId: 'primary',
+      requestBody: event,
+    });
+    logger.info(
+      { id: res.data.id, summary: res.data.summary },
+      'Event created',
+    );
+    return this.mapEvent(res.data);
+  }
+
+  async updateEvent(
+    eventId: string,
+    patches: {
+      title?: string;
+      start?: string;
+      end?: string;
+      description?: string;
+      location?: string;
+    },
+  ): Promise<CalendarEvent> {
+    const cal = this.ensureConnected();
+    const existing = (await cal.events.get({ calendarId: 'primary', eventId }))
+      .data;
+
+    if (patches.title) existing.summary = patches.title;
+    if (patches.description) existing.description = patches.description;
+    if (patches.location) existing.location = patches.location;
+    if (patches.start)
+      existing.start = { dateTime: new Date(patches.start).toISOString() };
+    if (patches.end)
+      existing.end = { dateTime: new Date(patches.end).toISOString() };
+
+    const res = await cal.events.update({
+      calendarId: 'primary',
+      eventId,
+      requestBody: existing,
+    });
+    logger.info(
+      { id: res.data.id, summary: res.data.summary },
+      'Event updated',
+    );
+    return this.mapEvent(res.data);
+  }
+
+  async deleteEvent(eventId: string): Promise<void> {
+    const cal = this.ensureConnected();
+    await cal.events.delete({ calendarId: 'primary', eventId });
+    logger.info({ id: eventId }, 'Event deleted');
+  }
+
+  async searchEvents(
+    query: string,
+    days: number = 30,
+  ): Promise<CalendarEvent[]> {
+    const cal = this.ensureConnected();
+    const now = new Date();
+    const end = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+
+    const res = await cal.events.list({
+      calendarId: 'primary',
+      q: query,
+      timeMin: now.toISOString(),
+      timeMax: end.toISOString(),
+      singleEvents: true,
+      orderBy: 'startTime',
+      maxResults: 20,
+    });
+
+    return (res.data.items || []).map(this.mapEvent);
+  }
+
+  private mapEvent(e: calendar_v3.Schema$Event): CalendarEvent {
+    return {
+      id: e.id || '',
+      summary: e.summary || '(no title)',
+      start: e.start?.dateTime || e.start?.date || '',
+      end: e.end?.dateTime || e.end?.date || '',
+      location: e.location || undefined,
+      description: e.description || undefined,
+      htmlLink: e.htmlLink || undefined,
+    };
+  }
+}

--- a/packages/mcp-gcal/src/index.ts
+++ b/packages/mcp-gcal/src/index.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+/**
+ * Google Calendar MCP Server
+ *
+ * Standalone MCP server exposing Google Calendar tools.
+ * Communicates via stdio (JSON-RPC). Can be used by any MCP client.
+ *
+ * Config (env vars):
+ *   GCAL_CREDENTIALS_PATH — OAuth client file (default: integrations/gcal/credentials.json)
+ *   GCAL_TOKENS_PATH      — OAuth tokens file (default: integrations/gcal/tokens.json)
+ *   DEUS_PROJECT_ROOT     — project root for resolving default paths
+ *   LOG_LEVEL             — pino log level (default: info)
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+import { GCalProvider } from './gcal.js';
+
+const server = new McpServer(
+  { name: '@deus-ai/gcal-mcp', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
+
+const provider = new GCalProvider();
+
+// ── Calendar tools ──────────────────────────────────────────────────
+
+server.tool(
+  'list_events',
+  'List upcoming calendar events',
+  {
+    days: z
+      .number()
+      .optional()
+      .describe('Number of days to look ahead (default: 7)'),
+  },
+  async (args) => {
+    const events = await provider.listEvents(args.days ?? 7);
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(events, null, 2) },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'get_event',
+  'Get a single calendar event by ID',
+  { event_id: z.string().describe('The event ID') },
+  async (args) => {
+    const event = await provider.getEvent(args.event_id);
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(event, null, 2) },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'create_event',
+  'Create a new calendar event',
+  {
+    title: z.string().describe('Event title'),
+    start: z
+      .string()
+      .describe('Start time (ISO 8601, e.g. "2026-04-07T14:00:00")'),
+    end: z.string().optional().describe('End time (default: start + 1 hour)'),
+    description: z.string().optional().describe('Event description'),
+    location: z.string().optional().describe('Event location'),
+  },
+  async (args) => {
+    const event = await provider.createEvent({
+      title: args.title,
+      start: args.start,
+      end: args.end,
+      description: args.description,
+      location: args.location,
+    });
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(event, null, 2) },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'update_event',
+  'Update an existing calendar event',
+  {
+    event_id: z.string().describe('The event ID to update'),
+    title: z.string().optional().describe('New title'),
+    start: z.string().optional().describe('New start time (ISO 8601)'),
+    end: z.string().optional().describe('New end time (ISO 8601)'),
+    description: z.string().optional().describe('New description'),
+    location: z.string().optional().describe('New location'),
+  },
+  async (args) => {
+    const event = await provider.updateEvent(args.event_id, {
+      title: args.title,
+      start: args.start,
+      end: args.end,
+      description: args.description,
+      location: args.location,
+    });
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(event, null, 2) },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'delete_event',
+  'Delete a calendar event',
+  { event_id: z.string().describe('The event ID to delete') },
+  async (args) => {
+    await provider.deleteEvent(args.event_id);
+    return {
+      content: [
+        { type: 'text' as const, text: `Deleted event ${args.event_id}` },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'search_events',
+  'Search calendar events by text',
+  {
+    query: z.string().describe('Search text'),
+    days: z
+      .number()
+      .optional()
+      .describe('Number of days to search (default: 30)'),
+  },
+  async (args) => {
+    const events = await provider.searchEvents(args.query, args.days ?? 30);
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(events, null, 2) },
+      ],
+    };
+  },
+);
+
+// ── Auto-connect if credentials exist ───────────────────────────────
+
+if (provider.hasCredentials()) {
+  provider.connect().catch((err: Error) => {
+    console.error('[@deus-ai/gcal-mcp] Auto-connect failed:', err.message);
+  });
+}
+
+// ── Start MCP transport ─────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp-gcal/tsconfig.json
+++ b/packages/mcp-gcal/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Adds `packages/mcp-gcal/` — standalone MCP server exposing 6 Google Calendar tools (list, get, create, update, delete, search)
- Container-runner conditionally enables `mcp__gcal__*` tools when gcal credentials + built package exist on the host
- Fixes `googleapis not installed` error in containers — the MCP server runs from the host's built package via the read-only `/workspace/project` mount, so `googleapis` never needs to be in container deps

## Changes
- `packages/mcp-gcal/` — new MCP package with `GCalProvider` class and MCP tool registration
- `container/agent-runner/src/index.ts` — auto-detect gcal credentials/dist, add conditional `gcal` MCP server entry and `mcp__gcal__*` to allowed tools
- `groups/main/CLAUDE.md.template` — hint comment for gcal tools
- `README.md` — add `mcp-gcal/` to project structure
- 20 unit tests for GCalProvider

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 533 tests pass (including 20 new gcal tests)
- [ ] Manual: verify container agent can use `mcp__gcal__list_events` when gcal credentials are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)