### PR TITLE
fix(cli): remove frozen OAuth token export that causes 401 after /login

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -754,11 +754,11 @@ case "$1" in
       echo "Error: could not read token from ~/.claude/.credentials.json"
       exit 1
     fi
-    # Do NOT write token to .env — the credential proxy reads credentials.json
-    # directly via getDynamicOAuthToken() with a 5-min cache. Writing to .env
-    # would permanently freeze the token and cause a login loop on next refresh.
+    # Do NOT export CLAUDE_CODE_OAUTH_TOKEN — the Claude CLI reads
+    # ~/.claude/.credentials.json directly and auto-refreshes on /login.
+    # Exporting a frozen token causes 401s after token rotation because
+    # the CLI prioritizes the env var over the credentials file.
     launchctl kickstart -k "gui/$(id -u)/com.deus" 2>/dev/null
-    export CLAUDE_CODE_OAUTH_TOKEN="$TOKEN"
     # Launch claude with bypass mode; fall back to normal mode if user declines
     launch_claude() {
       claude --dangerously-skip-permissions "$@"


### PR DESCRIPTION
## Summary
- **Root cause:** `deus` exports `CLAUDE_CODE_OAUTH_TOKEN` at launch, freezing the current token into the env var. The Claude CLI prioritizes this env var over `~/.claude/.credentials.json`. After token rotation (via `/login` or auto-refresh), the CLI keeps using the stale token → persistent 401s.
- **Fix:** Remove the `export CLAUDE_CODE_OAUTH_TOKEN="$TOKEN"` line so the CLI reads directly from `.credentials.json` — matching how the credential proxy already works. The startup validation check (ensure credentials exist) is preserved.

## Test plan
- [ ] Run `deus` — verify it launches without errors
- [ ] Wait for token to expire (or manually invalidate), run `/login`, verify subsequent API calls succeed without restarting
- [ ] Verify `env | grep CLAUDE_CODE_OAUTH` shows no stale token in the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)