### PR TITLE
fix(channels): fix Windows path handling across all channel adapters and startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           cache: npm
       - run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Typecheck
         run: npx tsc --noEmit
 

--- a/docs/CONTRIBUTING-AI.md
+++ b/docs/CONTRIBUTING-AI.md
@@ -75,7 +75,10 @@ Before modifying `eval/`, `src/startup-gate.ts`, `src/checks.ts`, `setup/`, or `
 
 All source code must work on macOS, Linux, and Windows. See `docs/CROSS_PLATFORM.md` for rules. Key points:
 - Use `path.join()` or `path.resolve()`, never string concatenation for paths
-- Use `os.tmpdir()`, never hardcoded `/tmp`
+- Use `fileURLToPath()` / `pathToFileURL()`, never `.replace('file://', '')` or `new URL('file://' + path)`
+- Use `os.tmpdir()`, never hardcoded `/tmp`; use `os.devNull`, never `/dev/null`
+- Use platform-aware process kill (see `killProcess()` in `remote-control.ts`), never bare `.kill('SIGKILL')`
+- Automated pattern detection runs in `src/cross-platform.test.ts` on all CI platforms
 - Test with `npx vitest run` on the target platform
 
 ## MCP Channel Servers

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -223,8 +223,8 @@ Before opening a PR, run through this checklist for every file you changed:
 ```
 [ ] No shell redirect syntax in execSync strings (2>/dev/null, >/dev/null)
 [ ] No single-quoted strings in shell commands run via execSync
-[ ] No hardcoded /dev/null — use os.devNull
-[ ] No SIGTERM/process.kill without platform check — use killProcess() helper
+[ ] No hardcoded /dev/null — use os.devNull (CI-enforced)
+[ ] No SIGTERM/process.kill without platform check — use killProcess() helper (CI-enforced)
 [ ] No hardcoded Unix paths (/Users/, /home/, /proc/, /dev/, /etc/)
 [ ] No process.getuid() without optional chaining (?.)
 [ ] No process.env.HOME without os.homedir() fallback
@@ -232,18 +232,68 @@ Before opening a PR, run through this checklist for every file you changed:
 [ ] No PATH strings using ':' separator — use path.delimiter
 [ ] No .sh scripts invoked from Node.js without a Windows alternative
 [ ] New exec calls use execFileSync(binary, args) not execSync(shellString)
+[ ] No .replace('file://', '') — use fileURLToPath() (CI-enforced)
+[ ] No new URL(`file://${path}`) — use pathToFileURL() (CI-enforced)
+[ ] No sqlite3 CLI or other Unix-only binaries — use Node.js alternatives
 ```
+
+---
+
+### 11. `file://` URL to filesystem path conversion
+
+```ts
+// BAD — strips file:// prefix but leaves /C:/... on Windows
+const filePath = import.meta.resolve('pkg').replace('file://', '');
+const filePath = new URL(`file://${process.argv[1]}`).pathname;
+
+// GOOD — handles drive letters, encoding, and all platforms
+import { fileURLToPath, pathToFileURL } from 'url';
+const filePath = fileURLToPath(import.meta.resolve('pkg'));
+const isMatch = new URL(import.meta.url).href === pathToFileURL(process.argv[1]).href;
+```
+
+**Rule:** Never manually strip `file://` from URLs or manually construct `file://` URLs. Always use `fileURLToPath()` and `pathToFileURL()` from the `url` module.
+
+---
+
+### 12. `sqlite3` CLI and other Unix-only binaries
+
+```ts
+// BAD — sqlite3 CLI is not installed on Windows
+execSync(`sqlite3 "${dbPath}" "SELECT COUNT(*) FROM ..."`)
+
+// GOOD — use the Node.js binding (better-sqlite3) which is already a dependency
+execSync(`node -e "const D=require('better-sqlite3');..."`)
+// Or: use better-sqlite3 directly if async is acceptable
+```
+
+**Rule:** Never depend on CLI tools that aren't installed by default on all platforms. If you need SQLite, use `better-sqlite3` (an npm dependency). If you need other tools, check availability or provide a Node.js alternative.
 
 ---
 
 ## Testing on Multiple Platforms
 
-The CI runs on `ubuntu-latest`, `macos-latest`, and `windows-latest`. If your change touches anything in the checklist above, you should:
+The CI runs on `ubuntu-latest`, `macos-latest`, and `windows-latest`. The `test-windows` job runs lint, typecheck, and all tests — including automated cross-platform pattern detection tests in `src/cross-platform.test.ts`.
+
+If your change touches anything in the checklist above, you should:
 
 1. Look at the CI output for the `windows-latest` job in your PR
 2. If you don't have a Windows machine, annotate your PR with `needs-windows-test` and describe what you expect might fail
 
 For the Windows service path (NSSM/Servy integration), a real Windows machine smoke test is required — see `docs/windows-setup.md`.
+
+### Automated Enforcement
+
+The following patterns are caught automatically by `src/cross-platform.test.ts`, which runs on every CI platform:
+
+| Pattern | Detection |
+|---------|-----------|
+| `.replace('file://', '')` | Caught — use `fileURLToPath()` |
+| `new URL('file://' + path)` | Caught — use `pathToFileURL()` |
+| `'/dev/null'` in code (not comments) | Caught — use `os.devNull` |
+| `.kill('SIGKILL')` / `.kill('SIGTERM')` without platform check | Caught — use `killProcess()` helper |
+
+These tests scan all `.ts` files in `src/` and fail the build if violations are found. To add new patterns, edit `src/cross-platform.test.ts`.
 
 ---
 

--- a/packages/mcp-whatsapp/src/whatsapp.ts
+++ b/packages/mcp-whatsapp/src/whatsapp.ts
@@ -113,7 +113,10 @@ export class WhatsAppProvider implements ChannelProvider {
       },
       printQRInTerminal: false,
       logger: baileysLogger,
-      browser: Browsers.macOS('Chrome'),
+      browser:
+        process.platform === 'win32'
+          ? Browsers.windows('Chrome')
+          : Browsers.macOS('Chrome'),
       cachedGroupMetadata: async (jid: string) =>
         this.getNormalizedGroupMetadata(jid),
       getMessage: async (key: WAMessageKey) => {

--- a/scripts/whatsapp-auth.ts
+++ b/scripts/whatsapp-auth.ts
@@ -55,7 +55,10 @@ async function main() {
     auth: { creds: state.creds, keys: state.keys },
     printQRInTerminal: false,
     logger,
-    browser: Browsers.macOS('Chrome'),
+    browser:
+      process.platform === 'win32'
+        ? Browsers.windows('Chrome')
+        : Browsers.macOS('Chrome'),
   });
 
   let pairingCodeRequested = false;

--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -149,7 +149,7 @@ async function connect() {
     auth: { creds: state.creds, keys: state.keys },
     printQRInTerminal: false,
     logger,
-    browser: Browsers.macOS('Chrome'),
+    browser: process.platform === 'win32' ? Browsers.windows('Chrome') : Browsers.macOS('Chrome'),
   });
 
   const timeout = setTimeout(() => {

--- a/src/channels/mcp-discord.ts
+++ b/src/channels/mcp-discord.ts
@@ -4,6 +4,7 @@
  */
 
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { ASSISTANT_NAME, PROJECT_ROOT } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -18,9 +19,7 @@ registerChannel('discord', (opts) => {
 
   let serverPath: string;
   try {
-    serverPath = import.meta
-      .resolve('@deus-ai/discord-mcp')
-      .replace('file://', '');
+    serverPath = fileURLToPath(import.meta.resolve('@deus-ai/discord-mcp'));
   } catch {
     serverPath = path.join(
       PROJECT_ROOT,

--- a/src/channels/mcp-gmail.ts
+++ b/src/channels/mcp-gmail.ts
@@ -6,6 +6,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { PROJECT_ROOT } from '../config.js';
 import { McpChannelAdapter } from './mcp-adapter.js';
@@ -23,9 +24,7 @@ registerChannel('gmail', (opts) => {
 
   let serverPath: string;
   try {
-    serverPath = import.meta
-      .resolve('@deus-ai/gmail-mcp')
-      .replace('file://', '');
+    serverPath = fileURLToPath(import.meta.resolve('@deus-ai/gmail-mcp'));
   } catch {
     serverPath = path.join(
       PROJECT_ROOT,

--- a/src/channels/mcp-slack.ts
+++ b/src/channels/mcp-slack.ts
@@ -4,6 +4,7 @@
  */
 
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { ASSISTANT_NAME, PROJECT_ROOT } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -18,9 +19,7 @@ registerChannel('slack', (opts) => {
 
   let serverPath: string;
   try {
-    serverPath = import.meta
-      .resolve('@deus-ai/slack-mcp')
-      .replace('file://', '');
+    serverPath = fileURLToPath(import.meta.resolve('@deus-ai/slack-mcp'));
   } catch {
     serverPath = path.join(
       PROJECT_ROOT,

--- a/src/channels/mcp-telegram.ts
+++ b/src/channels/mcp-telegram.ts
@@ -4,6 +4,7 @@
  */
 
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { ASSISTANT_NAME, PROJECT_ROOT } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -18,9 +19,7 @@ registerChannel('telegram', (opts) => {
 
   let serverPath: string;
   try {
-    serverPath = import.meta
-      .resolve('@deus-ai/telegram-mcp')
-      .replace('file://', '');
+    serverPath = fileURLToPath(import.meta.resolve('@deus-ai/telegram-mcp'));
   } catch {
     serverPath = path.join(
       PROJECT_ROOT,

--- a/src/channels/mcp-whatsapp.ts
+++ b/src/channels/mcp-whatsapp.ts
@@ -5,6 +5,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import {
   ASSISTANT_HAS_OWN_NUMBER,
@@ -23,9 +24,7 @@ registerChannel('whatsapp', (opts) => {
   let serverPath: string;
   try {
     // When @deus-ai/whatsapp-mcp is installed as a dependency
-    serverPath = import.meta
-      .resolve('@deus-ai/whatsapp-mcp')
-      .replace('file://', '');
+    serverPath = fileURLToPath(import.meta.resolve('@deus-ai/whatsapp-mcp'));
   } catch {
     // Fallback: local packages directory (monorepo dev)
     serverPath = path.join(

--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -268,17 +268,17 @@ describe('countRegisteredGroups', () => {
     expect(countRegisteredGroups()).toBe(0);
   });
 
-  it('returns 0 when execSync fails', () => {
+  it('returns 0 when node subprocess fails', () => {
     mockExistsSync.mockReturnValue(true);
     mockExecSync.mockImplementation(() => {
-      throw new Error('sqlite3 not found');
+      throw new Error('better-sqlite3 not found');
     });
     expect(countRegisteredGroups()).toBe(0);
   });
 
-  it('parses count from sqlite3 output', () => {
+  it('parses count from node subprocess output', () => {
     mockExistsSync.mockReturnValue(true);
-    // The source uses { encoding: 'utf-8' } so execSync returns a string
+    // The source spawns node -e with better-sqlite3 and prints the count
     mockExecSync.mockReturnValue('3\n' as unknown as string);
     expect(countRegisteredGroups()).toBe(3);
   });

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -188,12 +188,15 @@ export function countRegisteredGroups(): number {
   if (!fs.existsSync(dbPath)) return 0;
 
   try {
-    // Dynamic import avoidance: use execSync to query without loading better-sqlite3
-    // into the main process before initDatabase() runs.
-    const result = execSync(
-      `sqlite3 "${dbPath}" "SELECT COUNT(*) FROM registered_groups;"`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 },
-    );
+    // Use node -e with better-sqlite3 instead of sqlite3 CLI — sqlite3 is not
+    // available on Windows. This spawns a short-lived node process that loads
+    // better-sqlite3 (already an npm dependency) and prints the count.
+    const script = `const D=require('better-sqlite3');const db=new D(${JSON.stringify(dbPath)},{readonly:true});try{const r=db.prepare('SELECT COUNT(*) as cnt FROM registered_groups').get();console.log(r?r.cnt:0)}finally{db.close()}`;
+    const result = execSync(`node -e "${script.replace(/"/g, '\\"')}"`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
     return parseInt(result.trim(), 10) || 0;
   } catch {
     return 0;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,8 +4,9 @@
  *
  * Mount assembly lives in container-mounter.ts.
  */
-import { ChildProcess, execFile, spawn } from 'child_process';
+import { ChildProcess, execFile, execFileSync, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -299,7 +300,19 @@ export async function runContainerAgent(
               { group: group.name, containerName, err },
               'Graceful stop failed, force killing',
             );
-            container.kill('SIGKILL');
+            if (os.platform() === 'win32') {
+              try {
+                execFileSync(
+                  'taskkill',
+                  ['/F', '/T', '/PID', String(container.pid)],
+                  { stdio: 'pipe' },
+                );
+              } catch {
+                /* already dead */
+              }
+            } else {
+              container.kill('SIGKILL');
+            }
           }
         },
       );

--- a/src/cross-platform.test.ts
+++ b/src/cross-platform.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Cross-platform compatibility tests.
+ *
+ * These tests verify that the codebase doesn't contain patterns that break on
+ * Windows. They scan source files for known anti-patterns (hardcoded Unix paths,
+ * unsafe file:// stripping, missing platform branches, etc.).
+ *
+ * Run on every CI platform to catch regressions early.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const SRC_DIR = path.resolve(__dirname);
+
+/** Recursively collect .ts files (excluding tests, node_modules, dist). */
+function collectTsFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', 'dist', '.claude'].includes(entry.name)) continue;
+      files.push(...collectTsFiles(full));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const sourceFiles = collectTsFiles(SRC_DIR);
+
+describe('cross-platform: no unsafe file:// stripping', () => {
+  it('should use fileURLToPath instead of .replace("file://", "")', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (
+          lines[i].includes(".replace('file://'") ||
+          lines[i].includes('.replace("file://"')
+        ) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Found unsafe file:// stripping (breaks Windows paths). Use fileURLToPath() instead:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('cross-platform: no new URL("file://"+path) pattern', () => {
+  it('should use pathToFileURL instead of manual file:// URL construction', () => {
+    const violations: string[] = [];
+    // Pattern: new URL(`file://${...}`) or new URL('file://' + ...)
+    const pattern = /new URL\([`'"]file:\/\//;
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (pattern.test(lines[i])) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Found manual file:// URL construction (breaks Windows drive letters). Use pathToFileURL() instead:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('cross-platform: no hardcoded /dev/null', () => {
+  it('should use os.devNull instead of literal /dev/null in source code', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Skip comments and string literals that are documentation
+        if (
+          line.trimStart().startsWith('//') ||
+          line.trimStart().startsWith('*')
+        )
+          continue;
+        // Match /dev/null in string literals (quotes or backticks)
+        if (/['"`]\/dev\/null['"`]/.test(line)) {
+          violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Found hardcoded /dev/null (doesn't exist on Windows). Use os.devNull instead:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('cross-platform: no bare SIGKILL/SIGTERM without platform check', () => {
+  it('should use platform-aware kill instead of direct signal sends', () => {
+    const violations: string[] = [];
+    const pattern = /\.kill\(['"]SIG(KILL|TERM)['"]\)/;
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (!pattern.test(lines[i])) continue;
+        // Check if there's a platform check nearby (within 5 lines before)
+        const context = lines.slice(Math.max(0, i - 5), i + 1).join('\n');
+        if (context.includes('win32') || context.includes('platform')) continue;
+        violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
+      }
+    }
+    expect(
+      violations,
+      `Found signal sends without platform check (SIGKILL/SIGTERM are unsupported on Windows). Use killProcess() helper or add platform branch:\n${violations.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/src/cross-platform.test.ts
+++ b/src/cross-platform.test.ts
@@ -110,8 +110,8 @@ describe('cross-platform: no bare SIGKILL/SIGTERM without platform check', () =>
       const lines = content.split('\n');
       for (let i = 0; i < lines.length; i++) {
         if (!pattern.test(lines[i])) continue;
-        // Check if there's a platform check nearby (within 5 lines before)
-        const context = lines.slice(Math.max(0, i - 5), i + 1).join('\n');
+        // Check if there's a platform check nearby (within 15 lines before)
+        const context = lines.slice(Math.max(0, i - 15), i + 1).join('\n');
         if (context.includes('win32') || context.includes('platform')) continue;
         violations.push(`${path.relative(SRC_DIR, file)}:${i + 1}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'url';
+
 import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
@@ -292,11 +294,11 @@ async function main(): Promise<void> {
   });
 }
 
-// Guard: only run when executed directly, not when imported by tests
+// Guard: only run when executed directly, not when imported by tests.
+// pathToFileURL handles Windows drive letters correctly (file:///C:/...)
 const isDirectRun =
   process.argv[1] &&
-  new URL(import.meta.url).pathname ===
-    new URL(`file://${process.argv[1]}`).pathname;
+  new URL(import.meta.url).href === pathToFileURL(process.argv[1]).href;
 
 if (isDirectRun) {
   main().catch((err) => {


### PR DESCRIPTION
## Summary

- Replace unsafe `.replace('file://', '')` with `fileURLToPath()` in all 5 channel MCP adapters — fixes subprocess spawn failure on Windows (`/C:/...` is not a valid path)
- Fix `isDirectRun` guard in `src/index.ts` using `pathToFileURL()` — `main()` was silently never executing on Windows
- Use platform-appropriate Baileys browser fingerprint (`Browsers.windows('Chrome')` on win32)
- Replace `sqlite3` CLI with `node -e` + `better-sqlite3` in startup gate group count — `sqlite3` isn't available on Windows
- Add platform-aware process kill in `container-runner.ts` (`SIGKILL` → `taskkill` on win32)
- Add `src/cross-platform.test.ts` — automated pattern detection for 4 common Windows-breaking anti-patterns
- Add lint step to Windows CI job (`test-windows`)
- Update `CROSS_PLATFORM.md` and `CONTRIBUTING-AI.md` with new rules and enforcement docs

## Files changed (16)

| Area | Files | What |
|------|-------|------|
| Channel adapters | `src/channels/mcp-{whatsapp,discord,slack,telegram,gmail}.ts` | `fileURLToPath()` fix |
| Startup | `src/index.ts` | `pathToFileURL()` fix for `isDirectRun` |
| Container | `src/container-runner.ts` | Platform-aware SIGKILL |
| Startup gate | `src/checks.ts`, `src/checks.test.ts` | sqlite3 CLI → better-sqlite3 |
| WhatsApp | `packages/mcp-whatsapp/src/whatsapp.ts`, `scripts/whatsapp-auth.ts`, `setup/groups.ts` | Platform-aware browser fingerprint |
| CI | `.github/workflows/ci.yml` | Lint on Windows job |
| Tests | `src/cross-platform.test.ts` | New: 4 automated pattern checks |
| Docs | `docs/CROSS_PLATFORM.md`, `docs/CONTRIBUTING-AI.md` | Updated rules + enforcement |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, warnings only)
- [x] `npm test` passes (613 tests including 4 new cross-platform tests)
- [ ] CI `test-windows` job passes with new lint step
- [ ] Verify Yonatan's WhatsApp connection works after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)