### PR TITLE
feat(evolution): document exchange-pair chunking + add --chunk-stats and context_window

### DIFF
--- a/evolution/backfill.py
+++ b/evolution/backfill.py
@@ -68,10 +68,24 @@ def _extract_text(content) -> str:
     return ""
 
 
-def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
+def _extract_pairs(jsonl_path: Path, context_window: int = 0) -> Iterator[dict]:
     """
-    Yield (prompt, response, pair_index) dicts from a session .jsonl file.
-    Only yields pairs where neither side is junk.
+    Yield exchange-pair dicts from a session .jsonl file.
+
+    Strategy: exchange-pair chunking — each yielded dict represents exactly one
+    (user turn, immediately following assistant turn) pair. This preserves the
+    Q&A relationship as an atomic unit, which improves retrieval coherence compared
+    to paragraph-based chunking. The assistant entry is found within a 5-message
+    lookahead to handle tool calls between user and assistant turns.
+
+    Args:
+        jsonl_path: Path to the .jsonl session file.
+        context_window: When > 0, include the N preceding messages (regardless of
+            role) as a "context" field in the yielded dict. Useful for future
+            retrieval experiments that benefit from conversational context.
+
+    Only yields pairs where neither side is junk (length filters + prefix blocklist).
+    Idempotent: pair_index is deterministic from position in the file.
     """
     try:
         lines = [json.loads(l) for l in jsonl_path.read_text().splitlines() if l.strip()]
@@ -89,7 +103,7 @@ def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
         if any(prompt.startswith(p) for p in _SKIP_PROMPT_PREFIXES):
             continue
 
-        # Find the immediately following assistant entry
+        # Find the immediately following assistant entry (exchange-pair chunking)
         for j in range(i + 1, min(i + 6, len(lines))):
             if lines[j].get("type") == "assistant":
                 response = _extract_text(lines[j].get("message", {}).get("content", ""))
@@ -97,7 +111,16 @@ def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
                     break
                 if any(response.startswith(p) for p in _SKIP_RESPONSE_PREFIXES):
                     break
-                yield {"prompt": prompt, "response": response, "pair_index": pair_index}
+                pair: dict = {"prompt": prompt, "response": response, "pair_index": pair_index}
+                if context_window > 0:
+                    ctx_start = max(0, i - context_window)
+                    pair["context"] = [
+                        {"role": lines[k].get("type", ""), "text": _extract_text(
+                            lines[k].get("message", {}).get("content", "")
+                        )}
+                        for k in range(ctx_start, i)
+                    ]
+                yield pair
                 pair_index += 1
                 break
 
@@ -111,10 +134,19 @@ def _infer_group_folder(jsonl_path: Path) -> str:
     return "unknown"
 
 
-def collect_pairs(sessions_dir: Path, limit: int | None = None) -> list[dict]:
+def collect_pairs(
+    sessions_dir: Path,
+    limit: int | None = None,
+    chunk_stats: bool = False,
+) -> list[dict]:
     """
     Walk sessions_dir, extract all valid pairs from non-subagent .jsonl files.
-    Returns list of dicts with: prompt, response, session_id, group_folder, interaction_id
+    Returns list of dicts with: prompt, response, session_id, group_folder, interaction_id.
+
+    When chunk_stats=True, prints a summary of extraction quality to stdout:
+    total files scanned, total pairs extracted, average prompt/response lengths,
+    and per-file pair counts. Useful for validating the exchange-pair chunking
+    strategy before ingesting a new batch of sessions.
     """
     pattern = str(sessions_dir / "**" / ".claude" / "projects" / "*" / "*.jsonl")
     all_files = [
@@ -123,9 +155,12 @@ def collect_pairs(sessions_dir: Path, limit: int | None = None) -> list[dict]:
     ]
 
     pairs = []
+    file_pair_counts: dict[str, int] = {}
+
     for fpath in all_files:
         session_id = fpath.stem
         group_folder = _infer_group_folder(fpath)
+        file_count = 0
         for pair in _extract_pairs(fpath):
             iid = _deterministic_id(session_id, pair["pair_index"])
             pairs.append({
@@ -135,9 +170,46 @@ def collect_pairs(sessions_dir: Path, limit: int | None = None) -> list[dict]:
                 "prompt": pair["prompt"],
                 "response": pair["response"],
             })
+            file_count += 1
             if limit and len(pairs) >= limit:
+                if chunk_stats:
+                    file_pair_counts[fpath.name] = file_count
+                    _print_chunk_stats(all_files, pairs, file_pair_counts)
                 return pairs
+        if file_count > 0:
+            file_pair_counts[fpath.name] = file_count
+
+    if chunk_stats:
+        _print_chunk_stats(all_files, pairs, file_pair_counts)
+
     return pairs
+
+
+def _print_chunk_stats(
+    all_files: list[Path],
+    pairs: list[dict],
+    file_pair_counts: dict[str, int],
+) -> None:
+    """Print exchange-pair chunking quality stats to stdout."""
+    total_pairs = len(pairs)
+    files_with_pairs = len(file_pair_counts)
+
+    print("=== Exchange-pair chunk stats ===")
+    print(f"  files scanned         : {len(all_files)}")
+    print(f"  files with pairs      : {files_with_pairs}")
+    print(f"  total pairs extracted : {total_pairs}")
+
+    if total_pairs > 0:
+        avg_prompt = sum(len(p["prompt"]) for p in pairs) / total_pairs
+        avg_response = sum(len(p["response"]) for p in pairs) / total_pairs
+        print(f"  avg prompt length     : {avg_prompt:.0f} chars")
+        print(f"  avg response length   : {avg_response:.0f} chars")
+
+        # Top 5 most productive files
+        top_files = sorted(file_pair_counts.items(), key=lambda x: -x[1])[:5]
+        print("  top files by pairs:")
+        for fname, count in top_files:
+            print(f"    {fname}: {count} pairs")
 
 
 def run_backfill(
@@ -279,10 +351,18 @@ def main() -> None:
                         help="Print current backfill status and exit")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress per-pair output")
+    parser.add_argument("--chunk-stats", action="store_true",
+                        help="Print exchange-pair chunking quality stats (files, pair counts, avg lengths) "
+                             "without running judge or writing to DB. Useful for validating a new batch "
+                             "of sessions before full ingestion.")
     args = parser.parse_args()
 
     if args.status:
         print_status()
+        return
+
+    if args.chunk_stats:
+        collect_pairs(args.sessions_dir, limit=args.limit, chunk_stats=True)
         return
 
     stats = run_backfill(

--- a/evolution/backfill.py
+++ b/evolution/backfill.py
@@ -138,6 +138,7 @@ def collect_pairs(
     sessions_dir: Path,
     limit: int | None = None,
     chunk_stats: bool = False,
+    context_window: int = 0,
 ) -> list[dict]:
     """
     Walk sessions_dir, extract all valid pairs from non-subagent .jsonl files.
@@ -147,6 +148,9 @@ def collect_pairs(
     total files scanned, total pairs extracted, average prompt/response lengths,
     and per-file pair counts. Useful for validating the exchange-pair chunking
     strategy before ingesting a new batch of sessions.
+
+    context_window: passed through to _extract_pairs(). When > 0, each pair dict
+    includes a "context" field with the N preceding messages (for retrieval experiments).
     """
     pattern = str(sessions_dir / "**" / ".claude" / "projects" / "*" / "*.jsonl")
     all_files = [
@@ -161,15 +165,18 @@ def collect_pairs(
         session_id = fpath.stem
         group_folder = _infer_group_folder(fpath)
         file_count = 0
-        for pair in _extract_pairs(fpath):
+        for pair in _extract_pairs(fpath, context_window=context_window):
             iid = _deterministic_id(session_id, pair["pair_index"])
-            pairs.append({
+            entry: dict = {
                 "interaction_id": iid,
                 "session_id": session_id,
                 "group_folder": group_folder,
                 "prompt": pair["prompt"],
                 "response": pair["response"],
-            })
+            }
+            if "context" in pair:
+                entry["context"] = pair["context"]
+            pairs.append(entry)
             file_count += 1
             if limit and len(pairs) >= limit:
                 if chunk_stats:

--- a/scripts/tests/test_backfill.py
+++ b/scripts/tests/test_backfill.py
@@ -183,3 +183,31 @@ def test_chunk_stats_shows_zero_for_empty_dir(tmp_path, capsys):
     output = capsys.readouterr().out
 
     assert "0" in output
+
+
+def test_collect_pairs_threads_context_window(tmp_path):
+    """context_window parameter is forwarded from collect_pairs to _extract_pairs."""
+    from evolution.backfill import collect_pairs
+
+    session_dir = _make_session_dir(tmp_path)
+    fpath = session_dir / "ctx_test.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "Tell me about Python programming language"),
+        _make_entry("assistant", "Python is a high-level programming language."),
+        _make_entry("user", "What about its type system in detail?"),
+        _make_entry("assistant", "Python uses dynamic typing by default."),
+    ])
+
+    # Without context_window: no context field
+    pairs_no_ctx = collect_pairs(tmp_path / "sessions", context_window=0)
+    assert all("context" not in p for p in pairs_no_ctx)
+
+    # With context_window=2: second pair should have context from prior exchange
+    pairs_with_ctx = collect_pairs(tmp_path / "sessions", context_window=2)
+    assert len(pairs_with_ctx) == 2
+    # First pair may have empty context (nothing before it)
+    # Second pair should have context
+    second = pairs_with_ctx[1]
+    assert "context" in second
+    ctx_texts = [c["text"] for c in second["context"]]
+    assert any("Python" in t for t in ctx_texts)

--- a/scripts/tests/test_backfill.py
+++ b/scripts/tests/test_backfill.py
@@ -1,0 +1,185 @@
+"""
+Tests for evolution/backfill.py — exchange-pair chunking, chunk_stats, context_window.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+def _make_entry(role: str, text: str) -> dict:
+    return {"type": role, "message": {"content": text}}
+
+
+# ── _extract_pairs ────────────────────────────────────────────────────────
+
+
+def test_extract_pairs_yields_exchange_pairs(tmp_path):
+    """Each yielded pair contains exactly one user turn and its following assistant turn."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "What is the capital of France?"),
+        _make_entry("assistant", "The capital of France is Paris."),
+        _make_entry("user", "What is the capital of Germany?"),
+        _make_entry("assistant", "The capital of Germany is Berlin."),
+    ])
+
+    pairs = list(_extract_pairs(fpath))
+    assert len(pairs) == 2
+    assert pairs[0]["prompt"] == "What is the capital of France?"
+    assert "Paris" in pairs[0]["response"]
+    assert pairs[1]["prompt"] == "What is the capital of Germany?"
+    assert "Berlin" in pairs[1]["response"]
+
+
+def test_extract_pairs_pair_index_is_sequential(tmp_path):
+    """pair_index increments from 0 for each yielded pair."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "First question here please"),
+        _make_entry("assistant", "First answer to the question."),
+        _make_entry("user", "Second question here please"),
+        _make_entry("assistant", "Second answer to the question."),
+    ])
+
+    pairs = list(_extract_pairs(fpath))
+    assert [p["pair_index"] for p in pairs] == [0, 1]
+
+
+def test_extract_pairs_skips_short_prompts(tmp_path):
+    """Prompts shorter than _MIN_PROMPT_LEN are skipped."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "hi"),                          # too short
+        _make_entry("assistant", "Hello! How can I help?"),
+        _make_entry("user", "What is the weather today?"),  # valid
+        _make_entry("assistant", "I don't have real-time weather data."),
+    ])
+
+    pairs = list(_extract_pairs(fpath))
+    assert len(pairs) == 1
+    assert "weather" in pairs[0]["prompt"]
+
+
+def test_extract_pairs_skips_error_responses(tmp_path):
+    """Responses starting with error prefixes are skipped."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "Please do something for me today"),
+        _make_entry("assistant", "API Error: rate limit exceeded"),  # skip
+        _make_entry("user", "What is two plus two exactly?"),
+        _make_entry("assistant", "Two plus two equals four."),
+    ])
+
+    pairs = list(_extract_pairs(fpath))
+    assert len(pairs) == 1
+    assert "two plus two" in pairs[0]["prompt"].lower()
+
+
+def test_extract_pairs_with_context_window(tmp_path):
+    """context_window > 0 includes preceding messages as 'context' field."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "Tell me about Python programming language"),
+        _make_entry("assistant", "Python is a high-level programming language."),
+        _make_entry("user", "What about its type system?"),
+        _make_entry("assistant", "Python uses dynamic typing by default."),
+    ])
+
+    pairs = list(_extract_pairs(fpath, context_window=2))
+    assert len(pairs) == 2
+
+    # First pair has no prior context
+    assert pairs[0].get("context") == [] or "context" not in pairs[0] or pairs[0]["context"] == []
+
+    # Second pair should include the first exchange as context
+    assert "context" in pairs[1]
+    ctx_texts = [c["text"] for c in pairs[1]["context"]]
+    assert any("Python" in t for t in ctx_texts)
+
+
+def test_extract_pairs_no_context_window_by_default(tmp_path):
+    """Without context_window, no 'context' key in yielded pairs."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "Tell me about Python programming language"),
+        _make_entry("assistant", "Python is a high-level programming language."),
+    ])
+
+    pairs = list(_extract_pairs(fpath))
+    assert len(pairs) == 1
+    assert "context" not in pairs[0]
+
+
+def test_extract_pairs_handles_corrupt_jsonl(tmp_path):
+    """Corrupt .jsonl files return zero pairs (no exception)."""
+    from evolution.backfill import _extract_pairs
+
+    fpath = tmp_path / "session.jsonl"
+    fpath.write_text("not valid json\n{broken")
+
+    pairs = list(_extract_pairs(fpath))
+    assert pairs == []
+
+
+# ── collect_pairs + chunk_stats ───────────────────────────────────────────
+
+
+def _make_session_dir(base: Path, project: str = "proj") -> Path:
+    """Create the expected .claude/projects/<proj>/ directory structure."""
+    d = base / "sessions" / "group" / ".claude" / "projects" / project
+    d.mkdir(parents=True)
+    return d
+
+
+def test_chunk_stats_prints_summary(tmp_path, capsys):
+    """--chunk-stats prints file count, pair count, and avg lengths."""
+    from evolution.backfill import collect_pairs
+
+    session_dir = _make_session_dir(tmp_path)
+    fpath = session_dir / "abc123.jsonl"
+    _write_jsonl(fpath, [
+        _make_entry("user", "What is the capital of France?"),
+        _make_entry("assistant", "The capital of France is Paris."),
+    ])
+
+    collect_pairs(tmp_path / "sessions", chunk_stats=True)
+    output = capsys.readouterr().out
+
+    assert "Exchange-pair chunk stats" in output
+    assert "files scanned" in output
+    assert "total pairs extracted" in output
+    assert "avg prompt length" in output
+
+
+def test_chunk_stats_shows_zero_for_empty_dir(tmp_path, capsys):
+    """--chunk-stats with no sessions prints zero counts."""
+    from evolution.backfill import collect_pairs
+
+    (tmp_path / "sessions").mkdir()
+    collect_pairs(tmp_path / "sessions", chunk_stats=True)
+    output = capsys.readouterr().out
+
+    assert "0" in output


### PR DESCRIPTION
## Summary

The ultraplan identified a gap: backfill's chunking strategy was undocumented, with no observability into extraction quality. This PR closes that gap and unblocks the 485 pending pairs.

- `_extract_pairs()`: added full docstring explaining the exchange-pair strategy (one user + immediately following assistant = one atomic unit; 5-message lookahead for tool calls)
- `_extract_pairs(context_window=N)`: when > 0, includes N preceding messages as `"context"` field for future retrieval quality experiments
- `collect_pairs(chunk_stats=True)` + `_print_chunk_stats()`: prints files scanned, pair counts, avg prompt/response lengths, top productive files
- `--chunk-stats` CLI flag: runs stats without calling the judge or writing to DB

**Key finding:** Exchange-pair chunking was already implemented correctly in the existing code. This PR adds documentation and observability, not a fix.

## Benchmark

Run `--chunk-stats` before ingesting the 485 pending pairs to validate extraction quality:

```
python3 -m evolution.backfill --chunk-stats --sessions-dir data/sessions
=== Exchange-pair chunk stats ===
  files scanned         : N
  files with pairs      : N
  total pairs extracted : 485+
  avg prompt length     : XX chars
  avg response length   : XX chars
  top files by pairs:
    ...
```

## Test plan

- [x] `test_extract_pairs_yields_exchange_pairs` — 2-exchange session → 2 pairs
- [x] `test_extract_pairs_pair_index_is_sequential` — indexes 0, 1, 2...
- [x] `test_extract_pairs_skips_short_prompts` — < MIN_PROMPT_LEN filtered
- [x] `test_extract_pairs_skips_error_responses` — error prefix filtered
- [x] `test_extract_pairs_with_context_window` — prior messages included
- [x] `test_extract_pairs_no_context_window_by_default` — no context field by default
- [x] `test_extract_pairs_handles_corrupt_jsonl` — no crash on bad input
- [x] `test_chunk_stats_prints_summary` — stats output contains key fields
- [x] `test_chunk_stats_shows_zero_for_empty_dir` — handles empty sessions dir

All 9 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)