### PR TITLE
fix(evolution): make deepeval import lazy for host compatibility

### DIFF
--- a/evolution/judge/__init__.py
+++ b/evolution/judge/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
 from .base import BaseJudge, JudgeResult
 from .provider import JudgeProvider, JudgeRegistry, NoProviderAvailableError
 
@@ -8,8 +12,8 @@ from .ollama_judge import OllamaJudge, OllamaRuntimeJudge, is_ollama_available
 # Register built-in providers on import
 from . import providers as _providers  # noqa: F401
 
-from typing import Optional
-from deepeval.models import DeepEvalBaseLLM
+if TYPE_CHECKING:
+    from deepeval.models import DeepEvalBaseLLM
 
 
 def make_deepeval_judge(model: Optional[str] = None, provider: Optional[str] = None) -> DeepEvalBaseLLM:

--- a/evolution/judge/gemini_judge.py
+++ b/evolution/judge/gemini_judge.py
@@ -8,11 +8,17 @@ Two roles:
 
 Uses the same google-genai client and API key as memory_indexer.py.
 """
+from __future__ import annotations
+
 import json
 import os
+
 from typing import Any, Optional, Tuple
 
-from deepeval.models import DeepEvalBaseLLM
+try:
+    from deepeval.models import DeepEvalBaseLLM
+except ImportError:
+    DeepEvalBaseLLM = object  # type: ignore[misc,assignment]
 
 from ..config import GEN_MODELS, JUDGE_MODEL, JUDGE_RETRY_COUNT, load_api_key
 from .base import BaseJudge, JudgeResult

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -8,14 +8,20 @@ Two roles:
 
 Uses stdlib urllib for HTTP — no new dependencies required.
 """
+from __future__ import annotations
+
 import asyncio
 import json
 import os
 import urllib.request
 import urllib.error
+
 from typing import Any, Optional, Tuple
 
-from deepeval.models import DeepEvalBaseLLM
+try:
+    from deepeval.models import DeepEvalBaseLLM
+except ImportError:
+    DeepEvalBaseLLM = object  # type: ignore[misc,assignment]
 
 from .base import BaseJudge, JudgeResult
 from .criteria import RUBRIC, compose_score

--- a/evolution/judge/provider.py
+++ b/evolution/judge/provider.py
@@ -4,10 +4,13 @@ Provider/strategy pattern for judge backends.
 Each backend (Ollama, Gemini, Mock, ClaudeProxy) implements JudgeProvider.
 JudgeRegistry resolves the best available backend at runtime.
 """
-from abc import ABC, abstractmethod
-from typing import Optional
+from __future__ import annotations
 
-from deepeval.models import DeepEvalBaseLLM
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from deepeval.models import DeepEvalBaseLLM
 
 from .base import BaseJudge
 

--- a/evolution/judge/providers/claude_proxy.py
+++ b/evolution/judge/providers/claude_proxy.py
@@ -1,10 +1,15 @@
 """Claude proxy judge provider — last-resort fallback."""
+from __future__ import annotations
+
 import os
 import urllib.request
 import urllib.error
 from typing import Any, Optional, Tuple
 
-from deepeval.models import DeepEvalBaseLLM
+try:
+    from deepeval.models import DeepEvalBaseLLM
+except ImportError:
+    DeepEvalBaseLLM = object  # type: ignore[misc,assignment]
 
 from ..base import BaseJudge, JudgeResult
 from ..provider import JudgeProvider

--- a/evolution/judge/providers/gemini.py
+++ b/evolution/judge/providers/gemini.py
@@ -1,7 +1,10 @@
 """Gemini judge provider."""
-from typing import Optional
+from __future__ import annotations
 
-from deepeval.models import DeepEvalBaseLLM
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from deepeval.models import DeepEvalBaseLLM
 
 from ..base import BaseJudge
 from ..provider import JudgeProvider

--- a/evolution/judge/providers/mock.py
+++ b/evolution/judge/providers/mock.py
@@ -1,8 +1,13 @@
 """Mock judge provider — for CI smoke tests."""
+from __future__ import annotations
+
 import os
 from typing import Any, Optional, Tuple
 
-from deepeval.models import DeepEvalBaseLLM
+try:
+    from deepeval.models import DeepEvalBaseLLM
+except ImportError:
+    DeepEvalBaseLLM = object  # type: ignore[misc,assignment]
 
 from ..base import BaseJudge, JudgeResult
 from ..provider import JudgeProvider

--- a/evolution/judge/providers/ollama.py
+++ b/evolution/judge/providers/ollama.py
@@ -1,7 +1,10 @@
 """Ollama judge provider."""
-from typing import Optional
+from __future__ import annotations
 
-from deepeval.models import DeepEvalBaseLLM
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from deepeval.models import DeepEvalBaseLLM
 
 from ..base import BaseJudge
 from ..provider import JudgeProvider

--- a/evolution/tests/test_judge_registry.py
+++ b/evolution/tests/test_judge_registry.py
@@ -1,10 +1,16 @@
 """Tests for the JudgeProvider / JudgeRegistry pattern."""
+from __future__ import annotations
+
 import os
 from typing import Optional
 from unittest.mock import patch
 
 import pytest
-from deepeval.models import DeepEvalBaseLLM
+
+try:
+    from deepeval.models import DeepEvalBaseLLM
+except ImportError:
+    DeepEvalBaseLLM = object  # type: ignore[misc,assignment]
 
 from evolution.judge.base import BaseJudge, JudgeResult
 from evolution.judge.provider import (


### PR DESCRIPTION
## Summary
- The judge subsystem hard-imported `deepeval` at module level across 8 files, making the entire evolution loop crash on hosts without deepeval installed (like the host machine used for CC session ingestion and Ollama batch scoring)
- Uses `try/except` fallback to `object` for classes that subclass `DeepEvalBaseLLM`, and `TYPE_CHECKING` guards for type-only imports
- Runtime judges (Ollama, Gemini) now work without deepeval; DeepEval-specific judges gracefully degrade

## Test plan
- [x] `python3 -c "from evolution.judge import make_runtime_judge"` succeeds without deepeval
- [x] OllamaRuntimeJudge creates successfully and scores interactions
- [x] 73 existing tests pass (judge registry + maintenance + cc_backfill)
- [ ] CI passes (CodeQL, test suite, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)