### PR TITLE
feat(agent): add Ollama MCP integration for local model offloading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ WHISPER_LANG=en
 WHISPER_BIN=whisper-cli
 WHISPER_MODEL=
 
+# === Ollama (optional) ===
+# Custom Ollama API host (default: http://host.docker.internal:11434)
+OLLAMA_HOST=
+
 # === Container Runtime ===
 CONTAINER_RUNTIME=docker
 CONTAINER_IMAGE=deus-agent:latest

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -430,6 +430,7 @@ async function runQuery(
   prompt: string,
   sessionId: string | undefined,
   mcpServerPath: string,
+  ollamaMcpPath: string,
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
@@ -611,6 +612,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__deus__*',
+        'mcp__ollama__*',
         ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
       ],
       env: sdkEnv,
@@ -625,6 +627,14 @@ async function runQuery(
             DEUS_CHAT_JID: containerInput.chatJid,
             DEUS_GROUP_FOLDER: containerInput.groupFolder,
             DEUS_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+        // Ollama MCP — always available; provides access to locally installed models
+        ollama: {
+          command: 'node',
+          args: [ollamaMcpPath],
+          env: {
+            OLLAMA_HOST: process.env.OLLAMA_HOST || '',
           },
         },
         // Google Calendar MCP — only available when credentials exist on the host
@@ -729,6 +739,7 @@ async function main(): Promise<void> {
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+  const ollamaMcpPath = path.join(__dirname, 'ollama-mcp-stdio.js');
 
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
@@ -880,6 +891,7 @@ async function main(): Promise<void> {
         prompt,
         sessionId,
         mcpServerPath,
+        ollamaMcpPath,
         containerInput,
         sdkEnv,
         resumeAt,

--- a/container/agent-runner/src/ollama-mcp-stdio.ts
+++ b/container/agent-runner/src/ollama-mcp-stdio.ts
@@ -1,0 +1,202 @@
+/**
+ * Ollama stdio MCP Server for Deus
+ * Exposes local Ollama models as tools for the container agent.
+ * Claude remains the orchestrator; Ollama handles offloaded inference.
+ *
+ * Environment:
+ *   OLLAMA_HOST — Ollama API base URL (default: http://host.docker.internal:11434)
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const OLLAMA_FALLBACKS = [
+  'http://host.docker.internal:11434',
+  'http://localhost:11434',
+];
+
+function getOllamaHost(): string {
+  return process.env.OLLAMA_HOST || OLLAMA_FALLBACKS[0];
+}
+
+function log(message: string): void {
+  process.stderr.write(`[OLLAMA] ${message}\n`);
+}
+
+async function ollamaFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const host = getOllamaHost();
+  const url = `${host}${path}`;
+  try {
+    return await fetch(url, init);
+  } catch {
+    // Try fallback hosts if the primary fails
+    for (const fallback of OLLAMA_FALLBACKS.slice(1)) {
+      if (fallback === host) continue;
+      try {
+        return await fetch(`${fallback}${path}`, init);
+      } catch {
+        continue;
+      }
+    }
+    throw new Error(
+      `Failed to connect to Ollama at ${host}. Is Ollama running?`,
+    );
+  }
+}
+
+const server = new McpServer({
+  name: 'ollama',
+  version: '1.0.0',
+});
+
+server.tool(
+  'ollama_list_models',
+  'List all locally installed Ollama models. Call this first to know which models are available before generating.',
+  {},
+  async () => {
+    try {
+      const res = await ollamaFetch('/api/tags');
+      if (!res.ok) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Ollama API error: ${res.status} ${res.statusText}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      const data = (await res.json()) as {
+        models?: Array<{ name: string; size: number; modified_at: string }>;
+      };
+      const models = data.models || [];
+      if (models.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'No models installed. Pull one with: ollama pull llama3.2',
+            },
+          ],
+        };
+      }
+      const lines = models.map((m) => {
+        const gb = (m.size / 1e9).toFixed(1);
+        return `- ${m.name} (${gb} GB)`;
+      });
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Installed models:\n${lines.join('\n')}`,
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.tool(
+  'ollama_generate',
+  `Send a prompt to a local Ollama model and return its response.
+Use ollama_list_models first to see what's available.
+Good uses: summarization, classification, translation, code generation, analysis tasks you want to offload from the main Claude context.
+Tip: smaller models (e.g., gemma3:1b, llama3.2) are fast; larger models (gemma4:e4b, llama3.3) are higher quality.`,
+  {
+    model: z
+      .string()
+      .describe('Model name (e.g., "llama3.2", "gemma4:e4b", "qwen3.5:4b")'),
+    prompt: z.string().describe('The prompt to send to the model'),
+    system: z
+      .string()
+      .optional()
+      .describe('Optional system prompt to set context or behavior'),
+    temperature: z
+      .number()
+      .min(0)
+      .max(2)
+      .optional()
+      .describe(
+        'Sampling temperature 0–2 (default: 0.7). Lower = more deterministic.',
+      ),
+  },
+  async (args) => {
+    log(
+      `>>> Generating with ${args.model} (prompt: ${args.prompt.length} chars)`,
+    );
+    try {
+      const body: Record<string, unknown> = {
+        model: args.model,
+        prompt: args.prompt,
+        stream: false,
+        options: {} as Record<string, unknown>,
+      };
+      if (args.system) body.system = args.system;
+      if (args.temperature !== undefined) {
+        (body.options as Record<string, unknown>).temperature =
+          args.temperature;
+      }
+
+      const res = await ollamaFetch('/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Ollama error (${res.status}): ${errText}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const data = (await res.json()) as { response?: string; error?: string };
+      if (data.error) {
+        return {
+          content: [
+            { type: 'text' as const, text: `Model error: ${data.error}` },
+          ],
+          isError: true,
+        };
+      }
+
+      const response = data.response || '';
+      log(`<<< Done (${response.length} chars)`);
+      return { content: [{ type: 'text' as const, text: response }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/scripts/ollama-watch.sh
+++ b/scripts/ollama-watch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Watches Deus logs for Ollama activity and surfaces macOS notifications.
+# Usage: ./scripts/ollama-watch.sh
+set -euo pipefail
+
+LOG_FILE="${DEUS_LOG:-logs/deus.log}"
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "Log file not found: $LOG_FILE"
+  echo "Start Deus first, then run this watcher."
+  exit 1
+fi
+
+echo "Watching $LOG_FILE for Ollama activity... (Ctrl+C to stop)"
+
+tail -F "$LOG_FILE" | grep --line-buffered '\[OLLAMA\]' | while IFS= read -r line; do
+  # Strip ANSI codes and JSON wrappers for readable notification text
+  clean=$(echo "$line" | sed 's/\x1b\[[0-9;]*m//g' | grep -oP '(?<=\[OLLAMA\] ).*' || echo "$line")
+  osascript -e "display notification \"$clean\" with title \"Deus · Ollama\"" 2>/dev/null || true
+  echo "[$(date '+%H:%M:%S')] $clean"
+done

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -261,7 +261,12 @@ export async function runContainerAgent(
       const chunk = data.toString();
       const lines = chunk.trim().split('\n');
       for (const line of lines) {
-        if (line) logger.debug({ container: group.folder }, line);
+        if (!line) continue;
+        if (line.includes('[OLLAMA]')) {
+          logger.info({ container: group.folder }, line);
+        } else {
+          logger.debug({ container: group.folder }, line);
+        }
       }
       // Don't reset timeout on stderr — SDK writes debug logs continuously.
       // Timeout only resets on actual output (OUTPUT_MARKER in stdout).


### PR DESCRIPTION
## Summary

- Adds `ollama-mcp-stdio.ts` — a stdio MCP server that exposes two tools to the container agent: `ollama_list_models` and `ollama_generate`
- Registers the `ollama` MCP server in `index.ts` alongside the existing `deus` and `gcal` servers; adds `mcp__ollama__*` to `allowedTools`
- Surfaces `[OLLAMA]` log lines at `info` level in `container-runner.ts` (all other stderr stays at `debug`)
- Adds `OLLAMA_HOST` to `.env.example` for custom host override
- Adds `scripts/ollama-watch.sh` — macOS notification watcher that alerts when Ollama is used

Claude stays the orchestrator. Ollama handles offloaded inference (summarization, classification, translation, code generation) without burning Anthropic API quota. Connects to `host.docker.internal:11434` by default with `localhost` fallback.

## Test plan

- [ ] Send a message: "use ollama to tell me the capital of France" — agent should call `ollama_list_models` then `ollama_generate`
- [ ] Check that `[OLLAMA] >>> Generating` appears in `logs/deus.log` at info level
- [ ] Verify `scripts/ollama-watch.sh` surfaces macOS notifications during a generation
- [ ] Set `OLLAMA_HOST=http://custom:11434` in `.env` and confirm it routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)