### PR TITLE
fix(ops): surface silent failures + add daily Ollama log review + log rotation

### DIFF
--- a/.claude/skills/review-logs/SKILL.md
+++ b/.claude/skills/review-logs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: review-logs
+description: Review Deus system health logs, show daily reports, surface pinned issues, and rotate old log files. Uses a local Ollama model to analyze errors and warnings.
+---
+
+# /review-logs
+
+Runs the Deus log review and rotation system at `scripts/log_review.py`.
+
+## Subcommands
+
+Run the appropriate command based on what the user asks for:
+
+| User intent | Command |
+|-------------|---------|
+| Full run / daily review / "what's wrong" | `python3 scripts/log_review.py` |
+| See last report / summary | `python3 scripts/log_review.py --summary` |
+| See pinned / flagged issues | `python3 scripts/log_review.py --pinned` |
+| Clean up old logs / rotate | `python3 scripts/log_review.py --rotate-only` |
+| Re-analyze without rotating | `python3 scripts/log_review.py --review-only` |
+
+If invoked with no further context, run the full review (`python3 scripts/log_review.py`).
+
+## What each mode does
+
+**Full run (default):**
+1. Deletes container logs older than `LOG_CONTAINER_RETENTION_DAYS` (default: 14 days)
+2. Archives `logs/deus.log` / `logs/deus.error.log` to `logs/archives/` if they exceed `LOG_MAIN_MAX_MB` (default: 20 MB) and truncates them
+3. Reads new log entries since the last review (byte-offset tracked — never re-reads old entries)
+4. Scans new container session logs for errors
+5. Sends collected warnings/errors to a local Ollama model (`LOG_REVIEW_MODEL`, default: `gemma4:e4b`) for structured health analysis
+6. Saves daily report to `~/.deus/reviews/YYYY-MM-DD.md`
+7. Pins DEGRADED/CRITICAL reports to `~/.deus/reviews/pinned.md` and fires a macOS notification
+
+**Health levels returned by Ollama:**
+- `OK` — no actionable issues
+- `DEGRADED` — issues present, not urgent
+- `CRITICAL` — needs immediate attention, gets pinned
+
+## Output interpretation
+
+After running, explain the health report to the user:
+- Summarize the **Issues Found** section in plain language
+- For each **Action Required** item, explain what it means and how to fix it
+- If health is OK, confirm the system is running cleanly
+- If issues are pinned, tell the user they can run `deus logs pinned` anytime to review them
+
+## Environment overrides
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `LOG_REVIEW_MODEL` | `gemma4:e4b` | Ollama model for analysis |
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
+| `LOG_CONTAINER_RETENTION_DAYS` | `14` | Days before container logs are deleted |
+| `LOG_MAIN_MAX_MB` | `20` | Main log size threshold for archiving |
+| `LOG_ARCHIVE_RETENTION_DAYS` | `30` | Days before archived logs are deleted |
+
+## Scheduling
+
+The review runs automatically every day at 08:00 via a launchd job (`com.deus.log-review`).
+To check if it's registered: `launchctl list | grep log-review`
+To install it manually (macOS): `launchctl load ~/Library/LaunchAgents/com.deus.log-review.plist`

--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -9,7 +9,7 @@
       deus home         Launch Claude Code in home mode (~\deus)
       deus auth         Rebuild dist/ and restart the background service
       deus status       Show service status
-      deus logs         Tail the Deus service log
+      deus logs         Review system health logs (rotate|review|summary|pinned)
 
     The Deus background service runs under NSSM or Servy.
     Credential proxy reads ~/.claude/.credentials.json directly - do NOT
@@ -341,10 +341,23 @@ switch ($Command.ToLower()) {
     }
 
     "logs" {
-        if (Test-Path $LogFile) {
-            Get-Content $LogFile -Wait -Tail 50
-        } else {
-            Write-Host "Log file not found: $LogFile" -ForegroundColor Yellow
+        $sub = if ($args.Count -gt 0) { $args[0] } else { "" }
+        $reviewScript = Join-Path $DeusHome "scripts\log_review.py"
+        switch ($sub.ToLower()) {
+            "summary" { & python3 $reviewScript --summary }
+            "pinned"  { & python3 $reviewScript --pinned }
+            "rotate"  { & python3 $reviewScript --rotate-only }
+            "review"  { & python3 $reviewScript --review-only }
+            ""        { & python3 $reviewScript }
+            default {
+                Write-Host "Usage: deus logs [summary|pinned|rotate|review]"
+                Write-Host ""
+                Write-Host "  deus logs           Rotate old logs + run Ollama health review"
+                Write-Host "  deus logs summary   Print last saved daily report"
+                Write-Host "  deus logs pinned    Print pinned issues needing attention"
+                Write-Host "  deus logs rotate    Rotation only"
+                Write-Host "  deus logs review    Health review only"
+            }
         }
     }
 
@@ -434,7 +447,7 @@ switch ($Command.ToLower()) {
         Write-Host "  deus home   Launch in home mode (~\deus) regardless of current directory"
         Write-Host "  deus auth   Rebuild dist/ and restart background service"
         Write-Host "  deus status Show service status (NSSM or Servy)"
-        Write-Host "  deus logs   Tail the Deus service log"
+        Write-Host "  deus logs   Review system health logs (rotate|review|summary|pinned)"
         Write-Host "  deus listen Record from mic, transcribe, and copy to clipboard"
     }
 }

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1027,12 +1027,33 @@ $STARTUP_INSTRUCTION" "Catch me up."
     shift
     exec "$HOME/deus/scripts/deus-listen.sh" "$@"
     ;;
+  logs)
+    # Log review, rotation, and health reporting.
+    shift
+    case "$1" in
+      summary)  exec python3 "$HOME/deus/scripts/log_review.py" --summary ;;
+      pinned)   exec python3 "$HOME/deus/scripts/log_review.py" --pinned ;;
+      rotate)   exec python3 "$HOME/deus/scripts/log_review.py" --rotate-only ;;
+      review)   exec python3 "$HOME/deus/scripts/log_review.py" --review-only ;;
+      "")       exec python3 "$HOME/deus/scripts/log_review.py" ;;
+      *)
+        echo "Usage: deus logs [summary|pinned|rotate|review]"
+        echo ""
+        echo "  deus logs           Rotate old logs + run Ollama health review"
+        echo "  deus logs summary   Print last saved daily report"
+        echo "  deus logs pinned    Print pinned issues needing attention"
+        echo "  deus logs rotate    Rotate old logs only (no review)"
+        echo "  deus logs review    Run health review only (no rotation)"
+        ;;
+    esac
+    ;;
   *)
-    echo "Usage: deus [home|auth|listen]"
+    echo "Usage: deus [home|auth|listen|logs]"
     echo ""
     echo "  deus        Launch in current directory (external project mode if not ~/deus)"
     echo "  deus home   Launch in home mode (~/deus) regardless of current directory"
     echo "  deus auth   Restart background services (credential proxy auto-reads ~/.claude/.credentials.json)"
     echo "  deus listen Record from mic, transcribe, and copy to clipboard"
+    echo "  deus logs   Review system health logs (rotate|review|summary|pinned)"
     ;;
 esac

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -12,9 +12,12 @@ Usage:
 """
 import argparse
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Optional
+
+log = logging.getLogger(__name__)
 
 # Allow running as a script (python evolution/cli.py) or module (-m evolution.cli)
 if __name__ == "__main__" and __package__ is None:
@@ -123,8 +126,9 @@ def _maybe_auto_extract_principles(domain_presets: Optional[list] = None) -> Non
         # Data-count check + extraction (extract_principles handles its own min_new gate)
         try:
             extract_principles(domain=domain)
-        except Exception:
-            pass  # Non-fatal — principles are supplementary
+        except Exception as exc:
+            log.warning('evolution: principles extraction failed for domain=%s — %s: %s',
+                        domain, type(exc).__name__, exc)
 
 
 def _maybe_auto_optimize(domain_presets: Optional[list] = None) -> None:
@@ -199,15 +203,15 @@ def cmd_log_interaction(json_str: str) -> None:
     # Batch judge: check if we've accumulated enough unjudged interactions
     try:
         _maybe_batch_judge(domain_presets)
-    except Exception:
-        pass  # Non-fatal — judging will catch up during maintenance
+    except Exception as exc:
+        log.warning('evolution: batch judge failed — %s: %s', type(exc).__name__, exc)
 
     # Post-interaction maintenance check (non-blocking, best-effort).
     try:
         from .maintenance import run_maintenance
         run_maintenance()
-    except Exception:
-        pass  # Non-fatal — maintenance is supplementary
+    except Exception as exc:
+        log.warning('evolution: maintenance failed — %s: %s', type(exc).__name__, exc)
 
     print(json.dumps({"id": iid, "status": "ok"}))
 

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -22,8 +22,11 @@ Register in ~/.claude/settings.json:
 """
 import asyncio
 import json
+import logging
 import sys
 from typing import Optional
+
+log = logging.getLogger(__name__)
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -166,8 +169,11 @@ async def _async_judge_and_reflect(
                 group_folder=group_folder,
             )
     except Exception as exc:
-        import traceback
-        traceback.print_exc(file=sys.stderr)
+        log.error(
+            'evolution: async judge failed for interaction %s — %s: %s',
+            interaction_id, type(exc).__name__, exc,
+            exc_info=True,
+        )
 
 
 if __name__ == "__main__":

--- a/launchd/com.deus.log-review.plist
+++ b/launchd/com.deus.log-review.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.deus.log-review</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{PYTHON_PATH}}</string>
+        <string>{{PROJECT_ROOT}}/scripts/log_review.py</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{{PROJECT_ROOT}}</string>
+    <!-- Run daily at 08:00 local time -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{{HOME}}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{PROJECT_ROOT}}/logs/log-review.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{PROJECT_ROOT}}/logs/log-review.log</string>
+    <!-- Run immediately if the last scheduled time was missed (e.g. laptop was asleep) -->
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/log_review.py
+++ b/scripts/log_review.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+Deus log review and rotation system.
+
+Reads pino-pretty main logs and container session logs, extracts warnings/errors,
+analyzes them with a local Ollama model, saves a daily report, and pins critical issues.
+Also rotates old logs to prevent disk bloat.
+
+Usage:
+    python3 scripts/log_review.py                  # full run (rotate + review)
+    python3 scripts/log_review.py --rotate-only    # rotation only
+    python3 scripts/log_review.py --review-only    # review without rotation
+    python3 scripts/log_review.py --summary        # print last saved report
+    python3 scripts/log_review.py --pinned         # print pinned issues
+
+Environment overrides:
+    LOG_REVIEW_MODEL              Ollama model (default: gemma4:e4b)
+    OLLAMA_HOST                   Ollama base URL (default: http://localhost:11434)
+    LOG_CONTAINER_RETENTION_DAYS  Days to keep container logs (default: 14)
+    LOG_MAIN_MAX_MB               Rotate main log when it exceeds this size (default: 20)
+    LOG_ARCHIVE_RETENTION_DAYS    Days to keep archived logs (default: 30)
+"""
+
+import argparse
+import gzip
+import json
+import os
+import re
+import shutil
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+
+PROJECT_ROOT = Path(__file__).parent.parent
+LOGS_DIR = PROJECT_ROOT / 'logs'
+GROUPS_DIR = PROJECT_ROOT / 'groups'
+DEUS_DIR = Path.home() / '.deus'
+STATE_FILE = DEUS_DIR / 'log_review_state.json'
+REPORTS_DIR = DEUS_DIR / 'reviews'
+PINNED_FILE = REPORTS_DIR / 'pinned.md'
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+OLLAMA_HOST = os.environ.get('OLLAMA_HOST', 'http://localhost:11434')
+OLLAMA_MODEL = os.environ.get('LOG_REVIEW_MODEL', 'gemma4:e4b')
+CONTAINER_LOG_RETENTION_DAYS = int(os.environ.get('LOG_CONTAINER_RETENTION_DAYS', '14'))
+MAIN_LOG_MAX_MB = int(os.environ.get('LOG_MAIN_MAX_MB', '20'))
+ARCHIVE_RETENTION_DAYS = int(os.environ.get('LOG_ARCHIVE_RETENTION_DAYS', '30'))
+MAX_ENTRIES_PER_REVIEW = 150   # cap to avoid huge Ollama prompts
+
+# ── Parsing ───────────────────────────────────────────────────────────────────
+
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07')
+_BOX_RE = re.compile(r'[\u2500-\u257f\u2580-\u259f\u2800-\u28ff]')
+# pino-pretty: [HH:MM:SS.mmm] LEVEL (pid): message
+_PINO_RE = re.compile(
+    r'^\[(\d{2}:\d{2}:\d{2}\.\d{3})\]\s+(WARN|ERROR|FATAL)\s+\(\d+\):\s+(.+)$'
+)
+# Container log header fields
+_CONTAINER_META_RE = re.compile(r'^(Timestamp|Exit Code|Duration|Group):\s+(.+)$')
+_CONTAINER_ERROR_RE = re.compile(
+    r'(error|warn|fail|exception|traceback|crash|killed|sigterm|sigsegv)',
+    re.IGNORECASE,
+)
+
+
+def _clean(text: str) -> str:
+    """Strip ANSI codes, box-drawing chars, and control characters."""
+    text = _ANSI_RE.sub('', text)
+    text = _BOX_RE.sub('', text)
+    return re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', text).strip()
+
+
+def parse_pino_log(path: Path, from_byte: int = 0) -> tuple[list[dict], int]:
+    """
+    Read pino-pretty log from byte offset.
+    Returns (warn/error entries, new byte offset).
+    """
+    entries: list[dict] = []
+    try:
+        size = path.stat().st_size
+        if from_byte > size:
+            from_byte = 0  # file was truncated/rotated
+        with open(path, 'rb') as f:
+            f.seek(from_byte)
+            raw = f.read()
+        new_offset = from_byte + len(raw)
+        for line in raw.decode('utf-8', errors='replace').splitlines():
+            clean = _clean(line)
+            if not clean:
+                continue
+            m = _PINO_RE.match(clean)
+            if m:
+                entries.append({
+                    'time': m.group(1),
+                    'level': m.group(2),
+                    'message': m.group(3).strip(),
+                    'source': path.name,
+                })
+    except OSError:
+        new_offset = from_byte
+    return entries, new_offset
+
+
+def parse_container_log(path: Path) -> dict:
+    """
+    Parse a container session log.
+    Returns metadata + any error lines found.
+    """
+    meta: dict = {'path': str(path), 'errors': []}
+    try:
+        content = path.read_text(errors='replace')
+        for line in content.splitlines():
+            m = _CONTAINER_META_RE.match(line.strip())
+            if m:
+                meta[m.group(1).lower().replace(' ', '_')] = m.group(2).strip()
+            elif _CONTAINER_ERROR_RE.search(line):
+                clean = _clean(line)
+                if clean and len(clean) > 10:
+                    meta['errors'].append(clean[:200])
+        # Deduplicate errors
+        seen: set = set()
+        unique = []
+        for e in meta['errors']:
+            k = e[:60]
+            if k not in seen:
+                seen.add(k)
+                unique.append(e)
+        meta['errors'] = unique[:10]
+    except OSError:
+        pass
+    return meta
+
+
+# ── Rotation ──────────────────────────────────────────────────────────────────
+
+def rotate_container_logs() -> int:
+    """Delete container logs older than retention period. Returns count deleted."""
+    cutoff = datetime.now() - timedelta(days=CONTAINER_LOG_RETENTION_DAYS)
+    deleted = 0
+    for log_file in GROUPS_DIR.glob('*/logs/container-*.log'):
+        try:
+            mtime = datetime.fromtimestamp(log_file.stat().st_mtime)
+            if mtime < cutoff:
+                log_file.unlink()
+                deleted += 1
+        except OSError:
+            pass
+    return deleted
+
+
+def rotate_main_logs() -> list[str]:
+    """
+    Archive main logs that exceed MAIN_LOG_MAX_MB by gzip-compressing them
+    to logs/archives/ and truncating the original.
+    Truncation is safe with launchd (O_APPEND): the running process will
+    continue writing at offset 0 of the now-empty file.
+    Also deletes archives older than ARCHIVE_RETENTION_DAYS.
+    Returns list of human-readable action strings.
+    """
+    actions: list[str] = []
+    archive_dir = LOGS_DIR / 'archives'
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove stale archives
+    cutoff = datetime.now() - timedelta(days=ARCHIVE_RETENTION_DAYS)
+    for f in archive_dir.glob('*.gz'):
+        try:
+            if datetime.fromtimestamp(f.stat().st_mtime) < cutoff:
+                f.unlink()
+                actions.append(f'deleted old archive: {f.name}')
+        except OSError:
+            pass
+
+    for log_file in [LOGS_DIR / 'deus.log', LOGS_DIR / 'deus.error.log']:
+        if not log_file.exists():
+            continue
+        size_mb = log_file.stat().st_size / (1024 * 1024)
+        if size_mb <= MAIN_LOG_MAX_MB:
+            continue
+        stamp = datetime.now().strftime('%Y-%m-%d-%H%M%S')
+        archive = archive_dir / f'{log_file.stem}.{stamp}.log.gz'
+        try:
+            with open(log_file, 'rb') as f_in, gzip.open(archive, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            # Truncate in place after successful archive
+            with open(log_file, 'w'):
+                pass
+            actions.append(f'archived {size_mb:.1f} MB → {archive.name}')
+        except OSError as exc:
+            actions.append(f'failed to archive {log_file.name}: {exc}')
+
+    return actions
+
+
+# ── Ollama ────────────────────────────────────────────────────────────────────
+
+def _ollama_available() -> bool:
+    try:
+        urllib.request.urlopen(
+            f'{OLLAMA_HOST.rstrip("/")}/api/tags', timeout=3
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _call_ollama(prompt: str) -> str:
+    url = f'{OLLAMA_HOST.rstrip("/")}/api/generate'
+    body = json.dumps({
+        'model': OLLAMA_MODEL,
+        'prompt': prompt,
+        'stream': False,
+        'options': {'temperature': 0.1},
+    }).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={'Content-Type': 'application/json'}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read())['response'].strip()
+    except urllib.error.HTTPError as exc:
+        return f'[Ollama error {exc.code}: {exc.reason}]'
+    except Exception as exc:
+        return f'[Ollama unavailable: {type(exc).__name__}: {exc}]'
+
+
+# ── Review ────────────────────────────────────────────────────────────────────
+
+def _load_state() -> dict:
+    DEUS_DIR.mkdir(exist_ok=True)
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _save_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def run_review() -> Optional[Path]:
+    """
+    Collect new warnings/errors from all log sources since last run,
+    analyze with Ollama, save daily report, pin critical issues.
+    Returns the report path, or None if nothing to review.
+    """
+    state = _load_state()
+    offsets: dict = state.get('offsets', {})
+    last_ts: float = state.get('last_review_ts', 0.0)
+
+    # ── Collect from main logs ─────────────────────────────────────────────
+    all_entries: list[dict] = []
+    new_offsets: dict = {}
+
+    for log_file in [LOGS_DIR / 'deus.log', LOGS_DIR / 'deus.error.log']:
+        key = str(log_file)
+        entries, new_off = parse_pino_log(log_file, offsets.get(key, 0))
+        all_entries.extend(entries)
+        new_offsets[key] = new_off
+
+    # ── Collect from new container logs ───────────────────────────────────
+    container_errors: list[dict] = []
+    for log_file in sorted(GROUPS_DIR.glob('*/logs/container-*.log')):
+        try:
+            if log_file.stat().st_mtime <= last_ts:
+                continue
+        except OSError:
+            continue
+        meta = parse_container_log(log_file)
+        exit_code = meta.get('exit_code', '0')
+        if meta['errors'] or (exit_code not in ('0', '1')):
+            container_errors.append(meta)
+
+    # ── Save state ────────────────────────────────────────────────────────
+    state['offsets'] = {**offsets, **new_offsets}
+    state['last_review_ts'] = datetime.now().timestamp()
+    _save_state(state)
+
+    total = len(all_entries) + sum(len(c['errors']) for c in container_errors)
+    if total == 0 and not container_errors:
+        print('No warnings or errors since last review — system healthy.')
+        return None
+
+    # ── Deduplicate and cap ───────────────────────────────────────────────
+    seen: set = set()
+    unique_entries: list[dict] = []
+    for e in all_entries:
+        k = e['message'][:80]
+        if k not in seen:
+            seen.add(k)
+            unique_entries.append(e)
+    unique_entries = unique_entries[:MAX_ENTRIES_PER_REVIEW]
+
+    # ── Build Ollama prompt ───────────────────────────────────────────────
+    sections: list[str] = []
+
+    if unique_entries:
+        lines = '\n'.join(
+            f"[{e['level']}] {e['message']}" for e in unique_entries
+        )
+        sections.append(f'## Main service logs\n{lines}')
+
+    if container_errors:
+        c_lines: list[str] = []
+        for c in container_errors[:20]:
+            meta_str = (
+                f"group={c.get('group', '?')} "
+                f"exit={c.get('exit_code', '?')} "
+                f"duration={c.get('duration', '?')}"
+            )
+            c_lines.append(f'  [{meta_str}]')
+            for err in c['errors'][:5]:
+                c_lines.append(f'    {err}')
+        sections.append(f'## Container session logs\n' + '\n'.join(c_lines))
+
+    log_block = '\n\n'.join(sections)
+
+    prompt = f"""You are a system health analyst for Deus — a personal AI assistant running locally.
+
+Analyze these log entries and write a concise health report. Deus runs on Node.js (pino logger) with a Python evolution pipeline. Container sessions are isolated Docker runs for each user message.
+
+{log_block}
+
+Respond in EXACTLY this format (no extra text before or after):
+
+## Health: [OK | DEGRADED | CRITICAL]
+
+### Issues Found
+- <each distinct issue, max 20 words, or "None">
+
+### Root Causes
+- <probable cause per issue, max 20 words, or "None">
+
+### Action Required
+- <concrete fix step per issue, or "None — system healthy">
+
+### Pinned
+<YES if health is DEGRADED or CRITICAL, NO otherwise>"""
+
+    if _ollama_available():
+        analysis = _call_ollama(prompt)
+    else:
+        # Fallback: plain summary without Ollama
+        issue_list = '\n'.join(f'- {e["message"][:100]}' for e in unique_entries[:10])
+        health = 'CRITICAL' if any(e['level'] == 'FATAL' for e in unique_entries) else 'DEGRADED'
+        analysis = (
+            f'## Health: {health}\n\n'
+            f'### Issues Found\n{issue_list or "- (see raw entries)"}\n\n'
+            f'### Root Causes\n- Ollama unavailable — automated analysis skipped\n\n'
+            f'### Action Required\n- Review log entries manually\n\n'
+            f'### Pinned\nYES'
+        )
+
+    # ── Save report ───────────────────────────────────────────────────────
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    today = datetime.now().strftime('%Y-%m-%d')
+    report_path = REPORTS_DIR / f'{today}.md'
+    report_content = (
+        f'---\ndate: {today}\n'
+        f'entries: {len(all_entries)}\n'
+        f'unique: {len(unique_entries)}\n'
+        f'container_sessions_with_errors: {len(container_errors)}\n'
+        f'model: {OLLAMA_MODEL}\n---\n\n'
+        f'{analysis}\n\n'
+        f'---\n*{len(all_entries)} log entries · '
+        f'{len(container_errors)} container sessions with errors*\n'
+    )
+    report_path.write_text(report_content)
+
+    # ── Pin if critical ───────────────────────────────────────────────────
+    if 'Pinned\nYES' in analysis or 'Pinned: YES' in analysis:
+        _pin_issue(today, analysis, report_path)
+
+    print(report_content)
+    print(f'[saved → {report_path}]')
+    return report_path
+
+
+def _pin_issue(date: str, analysis: str, report_path: Path) -> None:
+    """Append to pinned issues file."""
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    health_match = re.search(r'## Health: (\w+)', analysis)
+    health = health_match.group(1) if health_match else 'UNKNOWN'
+    issues_match = re.search(
+        r'### Issues Found\n(.*?)(?=###|\Z)', analysis, re.DOTALL
+    )
+    issues = issues_match.group(1).strip() if issues_match else '(see report)'
+
+    entry = (
+        f'\n## [{date}] {health}\n'
+        f'{issues}\n'
+        f'→ {report_path}\n'
+    )
+    mode = 'a' if PINNED_FILE.exists() else 'w'
+    with open(PINNED_FILE, mode) as f:
+        if mode == 'w':
+            f.write('# Pinned Issues\n\nReview these and mark as resolved by deleting the entry.\n')
+        f.write(entry)
+    print(f'[pinned → {PINNED_FILE}]')
+
+    # macOS notification
+    try:
+        import subprocess
+        subprocess.run([
+            'osascript', '-e',
+            f'display notification "Health: {health}" with title "Deus Log Review" '
+            f'subtitle "Issues pinned — check ~/.deus/reviews/pinned.md"'
+        ], timeout=5, capture_output=True)
+    except Exception:
+        pass
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Deus log review and rotation')
+    parser.add_argument('--rotate-only', action='store_true',
+                        help='Only rotate logs, skip review')
+    parser.add_argument('--review-only', action='store_true',
+                        help='Only review logs, skip rotation')
+    parser.add_argument('--summary', action='store_true',
+                        help='Print the last saved daily report')
+    parser.add_argument('--pinned', action='store_true',
+                        help='Print all pinned issues')
+    args = parser.parse_args()
+
+    if args.summary:
+        reports = sorted(REPORTS_DIR.glob('[0-9]*.md')) if REPORTS_DIR.exists() else []
+        print(reports[-1].read_text() if reports else 'No reports yet.')
+        return
+
+    if args.pinned:
+        print(PINNED_FILE.read_text() if PINNED_FILE.exists() else 'No pinned issues.')
+        return
+
+    if not args.review_only:
+        deleted = rotate_container_logs()
+        actions = rotate_main_logs()
+        if deleted:
+            print(f'Rotated {deleted} old container log(s).')
+        for action in actions:
+            print(f'Rotation: {action}')
+
+    if not args.rotate_only:
+        run_review()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -54,6 +54,7 @@ export async function run(_args: string[]): Promise<void> {
 
   if (platform === 'macos') {
     setupLaunchd(projectRoot, nodePath, homeDir);
+    setupLogReviewLaunchd(projectRoot, homeDir);
   } else if (platform === 'linux') {
     setupLinux(projectRoot, nodePath, homeDir);
   } else if (platform === 'windows') {
@@ -145,6 +146,72 @@ function setupLaunchd(
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
+}
+
+function setupLogReviewLaunchd(projectRoot: string, homeDir: string): void {
+  const pythonPath = (() => {
+    for (const bin of ['python3', 'python']) {
+      try {
+        return execSync(`which ${bin}`, { encoding: 'utf-8' }).trim();
+      } catch {
+        /* try next */
+      }
+    }
+    return 'python3';
+  })();
+
+  const plistPath = path.join(
+    homeDir,
+    'Library',
+    'LaunchAgents',
+    'com.deus.log-review.plist',
+  );
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.deus.log-review</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${pythonPath}</string>
+        <string>${projectRoot}/scripts/log_review.py</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>${projectRoot}</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>${homeDir}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${projectRoot}/logs/log-review.log</string>
+    <key>StandardErrorPath</key>
+    <string>${projectRoot}/logs/log-review.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>`;
+
+  fs.writeFileSync(plistPath, plist);
+  try {
+    execSync(`launchctl load ${JSON.stringify(plistPath)}`, {
+      stdio: 'ignore',
+    });
+    logger.info({ plistPath }, 'Log review job scheduled (daily 08:00)');
+  } catch {
+    logger.warn('launchctl load for log-review failed (may already be loaded)');
+  }
 }
 
 function setupLinux(

--- a/src/domain-presets.ts
+++ b/src/domain-presets.ts
@@ -16,6 +16,7 @@ import { execFile } from 'child_process';
 import path from 'path';
 
 import { IS_WINDOWS } from './platform.js';
+import { logger } from './logger.js';
 
 /** Minimum keyword hits to tag a domain. */
 const MIN_KEYWORD_HITS = 2;
@@ -277,6 +278,7 @@ except Exception:
       (err, stdout) => {
         clearTimeout(guard);
         if (err) {
+          logger.warn({ err }, 'domain: LLM classification subprocess failed');
           settle([]);
           return;
         }
@@ -290,9 +292,11 @@ except Exception:
           ) {
             settle(parsed as string[]);
           } else {
+            logger.warn({ lastLine }, 'domain: LLM output not a string array');
             settle([]);
           }
-        } catch {
+        } catch (parseErr) {
+          logger.warn({ err: parseErr }, 'domain: failed to parse LLM output');
           settle([]);
         }
       },
@@ -332,7 +336,8 @@ export async function detectDomainsWithFallback(
     // subprocess is bypassed.
     const validSet = new Set(allDomains);
     return llmResult.filter((d) => validSet.has(d));
-  } catch {
+  } catch (err) {
+    logger.warn({ err }, 'domain: LLM fallback failed, returning []');
     return [];
   }
 }

--- a/src/evolution-client.ts
+++ b/src/evolution-client.ts
@@ -92,13 +92,14 @@ export function logInteraction(params: LogInteractionParams): void {
     stdio: ['ignore', 'ignore', 'pipe'],
   });
   child.stderr?.on('data', (d: Buffer) => {
-    logger.debug(
-      { data: d.toString().trim() },
-      'evolution: log_interaction stderr',
-    );
+    const text = d.toString().trim();
+    if (text) logger.warn({ data: text }, 'evolution: log_interaction stderr');
   });
   child.on('error', (err) => {
-    logger.debug({ err }, 'evolution: log_interaction spawn error (non-fatal)');
+    logger.error(
+      { err },
+      'evolution: log_interaction spawn error — interaction not logged',
+    );
   });
   // Do not await — fire and forget
 }


### PR DESCRIPTION
## Summary

### Silent failure fixes (4 HIGH severity)
- **`src/evolution-client.ts`**: log_interaction spawn errors promoted from `debug` to `warn`/`error` — previously invisible without `LOG_LEVEL=debug`
- **`src/domain-presets.ts`**: LLM domain classification failures now log the error type and message before returning `[]`; subprocess exec errors and parse failures surfaced
- **`evolution/cli.py`**: batch judge, maintenance, and principles extraction failures now log `WARNING` with exception type/message instead of bare `except: pass`
- **`evolution/mcp_server.py`**: async judge task failures now use `log.error(..., exc_info=True)` instead of `traceback.print_exc(file=sys.stderr)`

### Daily log review system
- **`scripts/log_review.py`**: reads pino-pretty main logs (`logs/deus.log`, `logs/deus.error.log`) and container session logs incrementally (byte-offset tracking, no re-reads), deduplicates entries, analyzes with local Ollama model (`gemma4:e4b` default), saves daily report to `~/.deus/reviews/YYYY-MM-DD.md`, pins DEGRADED/CRITICAL issues to `~/.deus/reviews/pinned.md`, fires macOS notification on critical health
- **`launchd/com.deus.log-review.plist`**: daily 08:00 launchd schedule template
- **`setup/service.ts`**: `setupLogReviewLaunchd()` installs the job automatically on macOS during `/setup`

### Log rotation (prevents disk bloat)
- Container logs (`groups/*/logs/container-*.log`): deleted after 14 days (was: never)
- Main logs (`logs/deus.log`, `logs/deus.error.log`): archived to `logs/archives/*.log.gz` and truncated when exceeding 20 MB; archives deleted after 30 days

### CLI
```
python3 scripts/log_review.py               # full run
python3 scripts/log_review.py --summary     # print last report
python3 scripts/log_review.py --pinned      # print pinned issues
python3 scripts/log_review.py --rotate-only # rotation only
```

All thresholds configurable via env vars: `LOG_REVIEW_MODEL`, `OLLAMA_HOST`, `LOG_CONTAINER_RETENTION_DAYS`, `LOG_MAIN_MAX_MB`, `LOG_ARCHIVE_RETENTION_DAYS`

## Test plan
- [x] `python3 scripts/log_review.py --review-only` runs successfully against live logs (17,556 entries, 340 sessions with errors, Ollama analysis complete)
- [x] TypeScript builds clean with `setup/service.ts` changes
- [x] Evolution pipeline tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)