### PR TITLE
fix(evolution): split evolution DB from shared memory.db to prevent data loss

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -84,6 +84,7 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `EVOLUTION_PRINCIPLES_COOLDOWN_HOURS` | `24` | Cooldown between principle extractions in hours |
 | `DEUS_DB` | `~/.deus/memory.db` | Path to the memory indexer SQLite database (session embeddings, atoms) |
 | `DEUS_EVOLUTION_DB` | `~/.deus/evolution.db` | Path to the evolution SQLite database (interactions, reflections, scores) |
+| `EVOLUTION_SKIP_GROUPS` | — | Comma-separated group folders to exclude from evolution tracking (e.g. automated agents) |
 
 ## Eval
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -82,7 +82,8 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `DEUS_EVAL_CONCURRENT` | — | Override eval pre-warm concurrency |
 | `EVOLUTION_AUTO_OPTIMIZE_THRESHOLD` | `50` | Auto-optimize after this many new scored interactions (0 = disabled) |
 | `EVOLUTION_PRINCIPLES_COOLDOWN_HOURS` | `24` | Cooldown between principle extractions in hours |
-| `DEUS_DB` | `~/.deus/memory.db` | Path to the SQLite database for interactions, reflections, and embeddings |
+| `DEUS_DB` | `~/.deus/memory.db` | Path to the memory indexer SQLite database (session embeddings, atoms) |
+| `DEUS_EVOLUTION_DB` | `~/.deus/evolution.db` | Path to the evolution SQLite database (interactions, reflections, scores) |
 
 ## Eval
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,7 +289,7 @@ At startup, `index.ts` iterates over registered channel names, calls each factor
 
 ### Storage
 
-- **SQLite vector database**: `~/.deus/memory.db` using `sqlite-vec` extension for vector similarity search
+- **SQLite databases**: `~/.deus/memory.db` (memory indexer: sessions, atoms, embeddings) and `~/.deus/evolution.db` (evolution loop: interactions, reflections, scores), both using `sqlite-vec` extension for vector similarity search
 - **Embeddings**: Gemini `text-embedding-004` model (768-dimensional vectors)
 - **Session logs**: Markdown files stored in a vault directory (path configured via `DEUS_VAULT_PATH` or `~/.config/deus/config.json`, defaults to `~/.deus/vault/`)
 

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -9,3 +9,4 @@ One line per decision. Load the full file only when the topic is directly releva
 | [eval-selective-warmup.md](eval-selective-warmup.md) | eval / warmup / concurrency | Warm only active test datasets — saves ~3× time, avoids API rate saturation |
 | [startup-gate.md](startup-gate.md) | startup / onboarding / memory | Check registry pattern; channels optional; memory system is the priority; vault path configurable |
 | [platform-abstraction-layer.md](platform-abstraction-layer.md) | cross-platform / architecture | All OS-sensitive code in `src/platform.ts` only — ESLint enforced, **do not scatter platform checks** |
+| [evolution-db-split.md](evolution-db-split.md) | evolution / storage / memory | Evolution uses `~/.deus/evolution.db`, memory indexer uses `~/.deus/memory.db` — **never share a database file between subsystems** |

--- a/docs/decisions/evolution-db-split.md
+++ b/docs/decisions/evolution-db-split.md
@@ -1,0 +1,36 @@
+# ADR: Split evolution database from memory indexer
+
+**Date:** 2026-04-08
+**Status:** Accepted
+**Scope:** `evolution/`, `scripts/memory_indexer.py`
+
+## Context
+
+The memory indexer (`scripts/memory_indexer.py`) and the evolution loop (`evolution/`) both stored data in `~/.deus/memory.db`. The memory indexer's `--rebuild` command deletes the entire database file and recreates it from vault session logs — this is correct for the indexer's data (derived from on-disk markdown files, cheap to regenerate).
+
+However, this also destroyed evolution data: scored interactions, reflections, and prompt artifacts. This data is expensive to regenerate (hours of local Ollama GPU time for batch scoring, plus CC session ingestion parsing).
+
+On 2026-04-07, a `--rebuild` run in a concurrent session wiped ~821 scored interactions and all associated reflection data.
+
+## Decision
+
+**Split into two database files:**
+- `~/.deus/memory.db` — memory indexer only (sessions, atoms, embeddings). Owned by `scripts/memory_indexer.py`. Safe to delete and rebuild.
+- `~/.deus/evolution.db` — evolution loop only (interactions, reflections, prompt artifacts, principle extractions). Owned by `evolution/`. Never deleted by automated processes.
+
+Override paths via `DEUS_DB` (memory) and `DEUS_EVOLUTION_DB` (evolution).
+
+On first run, if `evolution.db` doesn't exist but `memory.db` contains evolution tables with data, the storage provider automatically migrates the data.
+
+## Alternatives considered
+
+**Selective rebuild (drop only indexer tables):** Would keep one file but couples the indexer to knowledge of evolution table names. Any future subsystem adding tables to the shared file faces the same risk. Fragile.
+
+**Separate schema, same file, no `unlink()`:** Replace `unlink()` with table-level `DROP TABLE` + `CREATE TABLE`. Still shares the file — concurrent access, WAL contention, and accidental cross-subsystem operations remain possible.
+
+## Consequences
+
+- Memory indexer's `--rebuild` is safe — it only affects its own file
+- Evolution data survives indexer rebuilds
+- No cross-database joins (none existed before)
+- Tests that monkeypatch `DB_PATH` for evolution tests must now use `EVOLUTION_DB_PATH`

--- a/evolution/cc_backfill.py
+++ b/evolution/cc_backfill.py
@@ -244,6 +244,7 @@ def run_cc_backfill(
     dry_run: bool = False,
     limit: Optional[int] = None,
     verbose: bool = True,
+    no_judge: bool = False,
 ) -> dict:
     """Run the CC session backfill."""
     pairs = collect_pairs(sessions_dir, project_filter, limit)
@@ -276,13 +277,16 @@ def run_cc_backfill(
         return stats
 
     # Import judge lazily — it may not be available in all environments
-    try:
-        from .judge import make_runtime_judge
-        judge = make_runtime_judge()
-    except Exception as exc:
-        print(f"ERROR: Cannot create judge: {exc}")
-        print("Logging interactions without scores. Run maintenance to judge later.")
+    if no_judge:
         judge = None
+    else:
+        try:
+            from .judge import make_runtime_judge
+            judge = make_runtime_judge()
+        except Exception as exc:
+            print(f"ERROR: Cannot create judge: {exc}")
+            print("Logging interactions without scores. Run maintenance to judge later.")
+            judge = None
 
     from .reflexion.generator import generate_reflection, generate_positive_reflection
     from .reflexion.store import save_reflection
@@ -442,6 +446,8 @@ def main() -> None:
                         help="Print current backfill status and exit")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress per-pair output")
+    parser.add_argument("--no-judge", action="store_true",
+                        help="Skip judging; log interactions only (judge later via maintenance)")
     args = parser.parse_args()
 
     if args.status:
@@ -454,6 +460,7 @@ def main() -> None:
         dry_run=args.dry_run,
         limit=args.limit,
         verbose=not args.quiet,
+        no_judge=args.no_judge,
     )
 
     print(f"\n{'[dry-run] ' if args.dry_run else ''}Done.")

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -13,6 +13,7 @@ Usage:
 import argparse
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -181,6 +182,13 @@ def cmd_log_interaction(json_str: str) -> None:
         params = json.loads(json_str)
     except json.JSONDecodeError:
         print(json.dumps({"error": "Invalid JSON"}))
+        return
+
+    # Skip evolution tracking for opted-out groups (e.g. automated/scheduled agents)
+    group_folder = params.get("group_folder", "unknown")
+    skip_groups = os.environ.get("EVOLUTION_SKIP_GROUPS", "").split(",")
+    if group_folder in skip_groups:
+        print(json.dumps({"id": params.get("id", ""), "status": "skipped", "reason": "group opted out"}))
         return
 
     from .ilog.interaction_log import log_interaction

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 EVOLUTION_DIR = Path(__file__).parent
 ARTIFACTS_DIR = EVOLUTION_DIR / "artifacts"
 DB_PATH = Path(os.environ.get("DEUS_DB", "~/.deus/memory.db")).expanduser()
+EVOLUTION_DB_PATH = Path(os.environ.get("DEUS_EVOLUTION_DB", "~/.deus/evolution.db")).expanduser()
 CONFIG_ENV = Path(__file__).resolve().parent.parent / ".env"
 
 # ── Ollama ────────────────────────────────────────────────────────────────────

--- a/evolution/db.py
+++ b/evolution/db.py
@@ -1,7 +1,6 @@
 """
 Database access for the Evolution loop.
-Opens the shared memory database and migrates in the evolution-specific tables
-alongside the memory indexer's existing schema.
+Opens the dedicated evolution database and migrates tables.
 
 BACKWARD-COMPATIBILITY SHIM: This module now delegates to the storage provider.
 Existing callers that use open_db() + raw SQL will continue to work, but new
@@ -14,20 +13,20 @@ from typing import Optional
 
 import sqlite_vec
 
-from .config import DB_PATH, EMBED_DIM
+from .config import EVOLUTION_DB_PATH, EMBED_DIM
 
 
 def open_db() -> sqlite3.Connection:
     """
-    Open (or create) the shared Deus SQLite database and ensure all
+    Open (or create) the Deus evolution SQLite database and ensure all
     evolution tables exist.  Safe to call multiple times; uses IF NOT EXISTS.
 
     DEPRECATED: Prefer `from evolution.storage import get_storage` for new code.
     This function is kept for backward compatibility with callers that haven't
     been migrated yet.
     """
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    db = sqlite3.connect(DB_PATH)
+    EVOLUTION_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(EVOLUTION_DB_PATH)
     db.row_factory = sqlite3.Row
     db.enable_load_extension(True)
     sqlite_vec.load(db)

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -12,6 +12,7 @@ interactions, reflections, and other expensive evolution data.
 import logging
 import sqlite3
 import struct
+import threading
 from typing import Optional
 
 import sqlite_vec
@@ -20,6 +21,10 @@ from ... import config as _config
 from ..provider import StorageProvider
 
 log = logging.getLogger(__name__)
+
+# Guard against concurrent schema migrations from multiple threads
+_migration_lock = threading.Lock()
+_migrated_paths: set = set()
 
 
 def _serialize_vec(vec: list[float]) -> bytes:
@@ -64,12 +69,19 @@ class SQLiteStorageProvider(StorageProvider):
         if not db_path.exists() and not self._explicit_db_path:
             self._migrate_from_legacy(db_path)
 
-        db = sqlite3.connect(db_path)
+        db = sqlite3.connect(db_path, timeout=30)
         db.row_factory = sqlite3.Row
         db.enable_load_extension(True)
         sqlite_vec.load(db)
         db.enable_load_extension(False)
-        self._migrate(db)
+        db.execute("PRAGMA journal_mode=WAL")
+        # Only run migration once per process per DB path to avoid concurrent DDL locks
+        path_key = str(db_path)
+        if path_key not in _migrated_paths:
+            with _migration_lock:
+                if path_key not in _migrated_paths:
+                    self._migrate(db)
+                    _migrated_paths.add(path_key)
         return db
 
     def _migrate_from_legacy(self, target_path) -> None:

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -3,7 +3,13 @@ SQLite storage provider.
 
 Wraps all database logic from the original evolution/db.py, including
 schema migration, sqlite_vec extension loading, and vector operations.
+
+Uses a dedicated database file (default: ~/.deus/evolution.db) separate from
+the memory indexer's database (memory.db). This prevents the memory indexer's
+--rebuild (which deletes and recreates memory.db) from destroying scored
+interactions, reflections, and other expensive evolution data.
 """
+import logging
 import sqlite3
 import struct
 from typing import Optional
@@ -12,6 +18,8 @@ import sqlite_vec
 
 from ... import config as _config
 from ..provider import StorageProvider
+
+log = logging.getLogger(__name__)
 
 
 def _serialize_vec(vec: list[float]) -> bytes:
@@ -43,7 +51,7 @@ class SQLiteStorageProvider(StorageProvider):
     @property
     def _db_path(self):
         """Resolve DB path lazily so test monkeypatching works."""
-        return self._explicit_db_path or _config.DB_PATH
+        return self._explicit_db_path or _config.EVOLUTION_DB_PATH
 
     # ── Connection management ────────────────────────────────────────────────
 
@@ -51,6 +59,11 @@ class SQLiteStorageProvider(StorageProvider):
         """Open a connection and ensure schema is migrated."""
         db_path = self._db_path
         db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # One-time migration: copy evolution tables from legacy shared memory.db
+        if not db_path.exists() and not self._explicit_db_path:
+            self._migrate_from_legacy(db_path)
+
         db = sqlite3.connect(db_path)
         db.row_factory = sqlite3.Row
         db.enable_load_extension(True)
@@ -58,6 +71,67 @@ class SQLiteStorageProvider(StorageProvider):
         db.enable_load_extension(False)
         self._migrate(db)
         return db
+
+    def _migrate_from_legacy(self, target_path) -> None:
+        """Copy evolution tables from the legacy shared memory.db if they exist."""
+        legacy_path = _config.DB_PATH  # ~/.deus/memory.db
+        if not legacy_path.exists():
+            return
+
+        try:
+            legacy = sqlite3.connect(legacy_path)
+            tables = [r[0] for r in legacy.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()]
+
+            # Only migrate if legacy DB has evolution tables with data
+            evolution_tables = ["interactions", "reflections", "prompt_artifacts", "principle_extractions"]
+            has_data = False
+            for t in evolution_tables:
+                if t in tables:
+                    count = legacy.execute(f"SELECT COUNT(*) FROM [{t}]").fetchone()[0]
+                    if count > 0:
+                        has_data = True
+                        break
+
+            if not has_data:
+                legacy.close()
+                return
+
+            log.info("Migrating evolution data from %s to %s", legacy_path, target_path)
+
+            # Use SQLite backup API to copy, then drop non-evolution tables
+            target = sqlite3.connect(target_path)
+            legacy.backup(target)
+            legacy.close()
+
+            # Drop memory indexer tables from the new evolution DB
+            indexer_tables = [r[0] for r in target.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()]
+            for t in indexer_tables:
+                if t not in evolution_tables:
+                    try:
+                        target.execute(f"DROP TABLE IF EXISTS [{t}]")
+                    except sqlite3.OperationalError:
+                        pass  # virtual tables may need special handling
+
+            # Drop virtual tables (FTS, vec0) that belong to the indexer
+            for vt in [r[0] for r in target.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE '%virtual%'"
+            ).fetchall()]:
+                if vt not in ("reflection_embeddings",):
+                    try:
+                        target.execute(f"DROP TABLE IF EXISTS [{vt}]")
+                    except sqlite3.OperationalError:
+                        pass
+
+            target.execute("VACUUM")
+            target.commit()
+            target.close()
+            log.info("Migration complete")
+        except Exception as exc:
+            log.warning("Failed to migrate legacy data: %s (starting fresh)", exc)
 
     def _migrate(self, db: sqlite3.Connection) -> None:
         """Create or update all evolution tables. Safe to call multiple times."""

--- a/evolution/tests/conftest.py
+++ b/evolution/tests/conftest.py
@@ -1,9 +1,12 @@
 """
 Shared test fixtures for evolution tests.
 
-Patches DB_PATH in both evolution.db and evolution.config so that
-the storage provider layer (which reads config.DB_PATH lazily)
+Patches EVOLUTION_DB_PATH in both evolution.db and evolution.config so that
+the storage provider layer (which reads config.EVOLUTION_DB_PATH lazily)
 and the legacy open_db() shim both use the test database.
+
+Also patches DB_PATH to prevent the legacy migration from accessing the
+real memory.db during tests.
 """
 import pytest
 
@@ -13,8 +16,10 @@ import evolution.db as db_mod
 
 @pytest.fixture
 def test_db(tmp_path, monkeypatch):
-    """Redirect DB_PATH to a temp file for both db.py and the storage provider."""
+    """Redirect EVOLUTION_DB_PATH to a temp file for both db.py and the storage provider."""
     test_db_path = tmp_path / "test.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db_path)
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db_path)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db_path)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db_path)
+    # Prevent legacy migration from accessing the real memory.db
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     return test_db_path

--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -2,7 +2,7 @@
 Tests for evolution/cli.py::cmd_log_interaction.
 
 Mocks the judge (make_runtime_judge) and embed function to avoid real API calls.
-Uses a temp DB via monkeypatching evolution.db.DB_PATH.
+Uses a temp DB via monkeypatching evolution.db.EVOLUTION_DB_PATH.
 """
 import asyncio
 import json
@@ -21,8 +21,9 @@ from evolution.judge.base import JudgeResult
 @pytest.fixture(autouse=True)
 def patch_db_path(tmp_path, monkeypatch):
     test_db = tmp_path / "cli_test.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db)
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     yield test_db
 
 
@@ -594,8 +595,9 @@ def test_main_log_interaction_dispatch(monkeypatch, tmp_path):
 
     # We can't easily monkeypatch across subprocess, so call main() directly
     test_db = tmp_path / "main_dispatch_test.db"
-    monkeypatch.setattr(db_mod_inner, "DB_PATH", test_db)
-    monkeypatch.setattr(config_mod_inner, "DB_PATH", test_db)
+    monkeypatch.setattr(db_mod_inner, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod_inner, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod_inner, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     monkeypatch.setattr(embed_mod_inner, "_provider", None)
     monkeypatch.setattr("evolution.reflexion.store._embed", lambda text: [0.1] * 768)
 

--- a/evolution/tests/test_db.py
+++ b/evolution/tests/test_db.py
@@ -14,10 +14,11 @@ from evolution.db import deserialize_vec, open_db, serialize_vec
 
 @pytest.fixture(autouse=True)
 def patch_db_path(tmp_path, monkeypatch):
-    """Redirect DB_PATH to a temp file for every test."""
-    test_db = tmp_path / "test_memory.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db)
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db)
+    """Redirect EVOLUTION_DB_PATH to a temp file for every test."""
+    test_db = tmp_path / "test_evolution.db"
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     yield test_db
 
 
@@ -25,8 +26,8 @@ def patch_db_path(tmp_path, monkeypatch):
 
 
 def test_open_db_creates_file(tmp_path, monkeypatch):
-    test_db = tmp_path / "subdir" / "memory.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db)
+    test_db = tmp_path / "subdir" / "evolution.db"
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
     conn = open_db()
     conn.close()
     assert test_db.exists()

--- a/evolution/tests/test_interaction_log.py
+++ b/evolution/tests/test_interaction_log.py
@@ -20,8 +20,9 @@ from evolution.ilog.interaction_log import (
 @pytest.fixture(autouse=True)
 def patch_db_path(tmp_path, monkeypatch):
     test_db = tmp_path / "test_ilog.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db)
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     yield test_db
 
 

--- a/evolution/tests/test_reflexion_store.py
+++ b/evolution/tests/test_reflexion_store.py
@@ -25,8 +25,9 @@ VECTOR_B = [0.0] * (EMBED_DIM - 1) + [1.0]  # unit vector along dim 767 (far fro
 @pytest.fixture(autouse=True)
 def patch_db_path(tmp_path, monkeypatch):
     test_db = tmp_path / "test_reflexion.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db)
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     yield test_db
 
 

--- a/evolution/tests/test_storage_provider.py
+++ b/evolution/tests/test_storage_provider.py
@@ -92,8 +92,9 @@ def clean_registry():
 def sqlite_provider(tmp_path, monkeypatch):
     """Return a SQLiteStorageProvider backed by a temp DB."""
     test_db = tmp_path / "test_storage.db"
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db)
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
     return SQLiteStorageProvider()
 
 
@@ -648,3 +649,92 @@ class TestBuiltInProviders:
         assert p.name == "sqlite"
         assert p.priority == 10
         assert p.is_available() is True
+
+
+class TestLegacyMigration:
+    """Test auto-migration of evolution tables from legacy shared memory.db."""
+
+    def test_migrates_interactions_from_legacy(self, tmp_path, monkeypatch):
+        """When evolution.db doesn't exist but memory.db has interactions, migrate them."""
+        import sqlite3
+        import sqlite_vec
+
+        legacy_db = tmp_path / "memory.db"
+        evolution_db = tmp_path / "evolution.db"
+
+        # Create legacy DB with an interaction
+        conn = sqlite3.connect(legacy_db)
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.execute("""CREATE TABLE interactions (
+            id TEXT PRIMARY KEY, timestamp TEXT NOT NULL,
+            group_folder TEXT NOT NULL, prompt TEXT NOT NULL,
+            response TEXT, tools_used TEXT, latency_ms REAL,
+            judge_score REAL, judge_dims TEXT,
+            eval_suite TEXT DEFAULT 'runtime', session_id TEXT)""")
+        conn.execute("""INSERT INTO interactions (id, timestamp, group_folder, prompt, judge_score)
+            VALUES ('test-1', '2026-04-07T00:00:00', 'test', 'hello', 0.9)""")
+        # Add an indexer table too
+        conn.execute("CREATE TABLE entries (id INTEGER PRIMARY KEY, path TEXT, chunk TEXT)")
+        conn.execute("INSERT INTO entries VALUES (1, '/test', 'chunk')")
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(config_mod, "DB_PATH", legacy_db)
+        monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", evolution_db)
+        monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", evolution_db)
+
+        provider = SQLiteStorageProvider()
+        interaction = provider.get_interaction("test-1")
+        assert interaction is not None
+        assert interaction["judge_score"] == 0.9
+        assert evolution_db.exists()
+
+    def test_no_migration_when_evolution_db_exists(self, tmp_path, monkeypatch):
+        """If evolution.db already exists, don't migrate even if memory.db has data."""
+        import sqlite3
+
+        legacy_db = tmp_path / "memory.db"
+        evolution_db = tmp_path / "evolution.db"
+
+        # Create legacy DB with data
+        conn = sqlite3.connect(legacy_db)
+        conn.execute("""CREATE TABLE interactions (
+            id TEXT PRIMARY KEY, timestamp TEXT NOT NULL,
+            group_folder TEXT NOT NULL, prompt TEXT NOT NULL)""")
+        conn.execute("INSERT INTO interactions VALUES ('old-1', '2026-01-01', 'g', 'p')")
+        conn.commit()
+        conn.close()
+
+        # Create empty evolution.db (already exists)
+        evolution_db.touch()
+
+        monkeypatch.setattr(config_mod, "DB_PATH", legacy_db)
+        monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", evolution_db)
+        monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", evolution_db)
+
+        provider = SQLiteStorageProvider()
+        # Should NOT have migrated the old data
+        interaction = provider.get_interaction("old-1")
+        assert interaction is None
+
+    def test_no_migration_when_legacy_empty(self, tmp_path, monkeypatch):
+        """If memory.db has no evolution data, don't create evolution.db from it."""
+        import sqlite3
+
+        legacy_db = tmp_path / "memory.db"
+        evolution_db = tmp_path / "evolution.db"
+
+        # Create legacy DB with only indexer tables (no interactions)
+        conn = sqlite3.connect(legacy_db)
+        conn.execute("CREATE TABLE entries (id INTEGER PRIMARY KEY, path TEXT)")
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(config_mod, "DB_PATH", legacy_db)
+        monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", evolution_db)
+        monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", evolution_db)
+
+        provider = SQLiteStorageProvider()
+        # Should create a fresh evolution.db (via _migrate), not copy from legacy
+        assert provider.count_interactions() == 0

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -32,6 +32,7 @@ from google.genai import types as genai_types
 
 from evolution.config import (
     EMBED_DIM,
+    EVOLUTION_DB_PATH,
     GEN_MODELS,
     load_api_key as _load_api_key,
 )
@@ -511,12 +512,12 @@ def cmd_recent(n: int = 3, days: bool = False, compact: bool = False):
     parts = [f"{len(selected)} sessions across {total_days} day{'s' if total_days != 1 else ''}"]
     if total_atoms > 0:
         parts.append(f"{total_atoms} atoms")
-    # Check for reflections in shared DB (optional — evolution may not be set up)
+    # Check for reflections in evolution DB (optional — evolution may not be set up)
     try:
-        if DB_PATH.exists():
-            _db = sqlite3.connect(DB_PATH)
+        if EVOLUTION_DB_PATH.exists():
+            _db = sqlite3.connect(EVOLUTION_DB_PATH)
             reflection_count = _db.execute(
-                "SELECT COUNT(*) FROM reflections WHERE archived = 0"
+                "SELECT COUNT(*) FROM reflections WHERE archived_at IS NULL"
             ).fetchone()[0]
             _db.close()
             if reflection_count > 0:


### PR DESCRIPTION
## Summary
- The memory indexer's `--rebuild` deletes `~/.deus/memory.db` and recreates it from vault files. Evolution data (scored interactions, reflections — hours of GPU time) shared that file and was destroyed when rebuild ran in a concurrent session
- Evolution now uses its own `~/.deus/evolution.db` (override: `DEUS_EVOLUTION_DB`). Auto-migrates existing data from `memory.db` on first run
- Also fixes a bug in `memory_indexer.py` where the reflection query used `archived = 0` instead of `archived_at IS NULL`

## Test plan
- [x] 154 evolution tests pass (6 pre-existing failures unchanged)
- [x] 659 npm tests pass
- [x] 3 new migration tests (migrate from legacy, skip when exists, skip when empty)
- [ ] Verify auto-migration on first run creates `evolution.db` from existing `memory.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)