### PR TITLE
feat(skills): add 6 core memory skills to repo and install via setup

### DIFF
--- a/.claude/commands/compress.md
+++ b/.claude/commands/compress.md
@@ -45,8 +45,15 @@ Keep `tldr` to 2–3 lines. Skip sections with no content.
 
 After saving the session log, do three things:
 
-1. Update the `pending:` block in:
-   $VAULT/CLAUDE.md
+1. Update vault CLAUDE.md (`$VAULT/CLAUDE.md`):
+
+   **`previous:` block** — rolling list of the last 3 sessions (parallel-safe, prepend-only):
+   - Format each entry as: `  - "YYYY-MM-DD: <tldr one-liner>"` (≤120 chars total)
+   - Read the current `previous:` block. If it's a single line (`previous: "..."`), convert it to list format first.
+   - Prepend the new entry at the top. Trim to 3 entries max (drop the oldest).
+   - If `previous:` doesn't exist, add it before `pending:`.
+
+   **`pending:` block** — replace entirely with unchecked `[ ]` items from `## Pending Tasks` (max 10). If section is missing or empty, keep current `pending:` unchanged.
 
 2. Index the new log into the semantic memory index by running:
    python3 scripts/memory_indexer.py --add "<full path to saved log>"

--- a/.claude/skills/checkpoint/skill.md
+++ b/.claude/skills/checkpoint/skill.md
@@ -1,0 +1,87 @@
+---
+name: checkpoint
+description: Save a mid-session checkpoint — for continuity between sessions of the same day
+user_invocable: true
+---
+
+# /checkpoint
+
+Context-aware mid-session checkpoint. Behavior adapts to home mode vs external project mode.
+
+## Detect mode
+
+Check if the current working directory is the Deus home directory (`~/deus`). If it is → **Home Mode**. Otherwise → **External Project Mode**.
+
+## Resolve vault path
+
+Read `~/.config/deus/config.json` and use the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+
+## Check memory level (External Project Mode only)
+
+Compute MD5 hash of the current working directory and read `~/.config/deus/projects/<hash>.json`.
+- If memory level is **restricted**: tell the user "Checkpoints are disabled for restricted projects (nothing persists between sessions)." and stop.
+- If memory level is **standard** or **full**: proceed normally.
+- Home mode: always proceed.
+
+## Step 1 — Write checkpoint
+
+Identify: what decisions or intermediate conclusions have been reached in this session that are NOT yet saved in a session log?
+
+Write to:
+$VAULT/Checkpoints/YYYY-MM-DD-HH.md
+(Use current date and 24h hour. Create the Checkpoints/ folder if it doesn't exist.)
+
+Use exactly this format:
+```markdown
+---
+type: checkpoint
+created: YYYY-MM-DDTHH:MM
+session_topic: short-slug
+project_path: "<working directory path, or '~/deus' for home mode>"
+decisions:
+  - "decision made so far (≤12 words)"
+in_progress:
+  - "what we are actively working on right now"
+next_action: "the exact next step to take after resuming"
+context_refs:
+  - "file path or resource name needed to continue"
+---
+
+## Mid-Session State
+3–5 sentences explaining where we are, what has been decided, and what comes next.
+Write as if explaining to yourself after a 30-minute break.
+```
+
+**External Project Mode additions:**
+- Always include `project_path` in frontmatter
+- In context_refs, include project-relative paths (not absolute)
+- If memory level is **standard**: do NOT include specific code snippets, file contents, or implementation details in the Mid-Session State — focus on decisions and what was tried
+
+Keep the checkpoint under 25 lines total. This is what /resume will load on the next session if it's the same day.
+
+## Step 2 — Confirm the checkpoint path was written.
+
+## Step 3 — Output context primer.
+
+Before running /compact, output the following block verbatim (filling in values from current session state). This is a "compaction seed" — structured content near the end of conversation that the compaction algorithm will preserve as high-signal.
+
+```
+---BEGIN CONTEXT PRIMER---
+## Active Task
+[1 sentence: what we are working on right now]
+
+## Session Decisions
+[Bulleted list: decisions made in THIS session, max 5]
+
+## Key Files
+[Bulleted list: file paths actively being modified or referenced]
+
+## Pending
+[Bulleted list: what still needs to be done, max 3 items]
+
+## Resume Hint
+[1 sentence: if resuming after compaction, start by doing X]
+---END CONTEXT PRIMER---
+```
+
+## Step 4 — Tell the user: "Checkpoint saved. Run /compact now to compact the context."

--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -1,0 +1,143 @@
+---
+name: compress
+description: Save this session to the vault and update the semantic memory index
+user_invocable: true
+---
+
+# /compress
+
+Context-aware session saving. Behavior adapts to home mode vs external project mode.
+
+## Detect mode
+
+Check if the current working directory is the Deus home directory (`~/deus`). If it is → **Home Mode**. Otherwise → **External Project Mode**.
+
+## Resolve vault path
+
+Read `~/.config/deus/config.json` and use the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+
+## Check memory level (External Project Mode only)
+
+Compute MD5 hash of the current working directory and read `~/.config/deus/projects/<hash>.json`.
+- If memory level is **restricted**: tell the user "Session saving is disabled for restricted projects. Your work is preserved in git commits and Claude Code's native session transcript. Use /project-settings to change this." and stop.
+- If `save_summaries` is **false**: tell the user the same message and stop.
+- If memory level is **standard** or **full** with summaries enabled: proceed.
+- Home mode: always proceed.
+
+## Step 0 — Preserve permanent memories
+
+Before saving the session log, scan the conversation for knowledge worth persisting beyond this session:
+
+- Preferences or habits the user revealed
+- Decisions made with lasting effect
+- Things the user corrected or clarified
+- Facts worth knowing in future sessions
+
+Do **not** preserve one-off requests or temporary context.
+
+**Where to save:** Update `$VAULT/CLAUDE.md` using the same compact `key: value` format as the file — no prose bullets. One line per insight. If nothing qualifies, skip silently.
+
+**External Project Mode — standard:** Only preserve USER preferences and behavioral corrections (things about the user, not the project). Skip project-specific architecture decisions or code patterns.
+
+**External Project Mode — full:** Preserve both user preferences AND project-relevant decisions.
+
+If `$VAULT/CLAUDE.md` exceeds 200 lines, archive old content to `$VAULT/CLAUDE-Archive.md`.
+
+## Save session log
+
+Review the conversation and create a session log at:
+$VAULT/Session-Logs/YYYY-MM-DD/{topic}.md
+
+Create the YYYY-MM-DD folder if it doesn't exist. The filename should be the topic only (no date prefix), since the date is already in the folder name.
+
+Use this format:
+```markdown
+---
+type: session
+date: YYYY-MM-DD
+topics: [topic1, topic2]
+project_path: "<working directory path, or '~/deus' for home mode>"
+tldr: |
+  What happened (1 sentence). Key decision or outcome. Pending: X, Y.
+decisions:
+  - "chose X over Y: brief reason"
+  - "rejected approach A: brief reason"
+---
+
+<!-- Full details — only loaded on demand -->
+
+## Decisions Made
+- ...
+
+## Key Learnings
+- ...
+
+## Files Modified
+- ...
+
+## Pending Tasks
+- [ ] ...
+```
+
+**External Project Mode — standard memory level redaction:**
+- Do NOT include specific file paths, function names, or code snippets in the session log
+- Focus on decisions, architecture, and what was tried/learned
+- Files Modified section should use descriptions ("updated the auth middleware") not paths
+- The goal: someone reading this log should understand WHAT was decided and WHY, without leaking code details
+
+**External Project Mode — full memory level:**
+- No redaction needed — include full details as in home mode
+
+Rules for `decisions:` array:
+- Maximum 3 items. Only include decisions that affect future sessions.
+- Each item: quoted string, verb-first, ≤12 words.
+- Omit the key entirely if no future-relevant decisions were made.
+
+Keep `tldr` to 2–3 lines. Skip sections with no content.
+
+## Post-save steps
+
+After saving the session log:
+
+1. **Update vault CLAUDE.md** (home mode only):
+
+   a. Extract the one-liner tldr from the session log just saved (first line of the `tldr:` frontmatter field).
+
+   b. Extract all unchecked `[ ]` items from the `## Pending Tasks` section of the session log. Max 10 items. If the section is missing or has 0 items, keep the current `pending:` unchanged and only update `previous:`.
+
+   c. In vault CLAUDE.md:
+      - Update the `previous:` block as a rolling list of the last 3 sessions (parallel-safe, prepend-only):
+        - Format each entry as: `  - "YYYY-MM-DD: <tldr one-liner>"` (date prefix + first line of tldr, ≤120 chars total)
+        - Read the current `previous:` block. If it's a single line (`previous: "..."`), convert it to list format with that entry as the first item.
+        - Prepend the new entry at the top of the list.
+        - Trim to the 3 most recent entries (drop the oldest).
+        - Replace the entire `previous:` block with the updated list.
+        - If `previous:` doesn't exist yet, add it before `pending:`.
+      - Replace the entire `pending:` block with the extracted `[ ]` items — one item per line, formatted as `  - [ ] ...`.
+      - Append the OLD pending block content to `$VAULT/CLAUDE-Archive.md` with header `## Archived YYYY-MM-DD` (create file if missing).
+
+   d. After writing, count total lines in CLAUDE.md. If > 60 lines: identify the oldest non-identity content block (not name/location/style/channels/security/goal/previous/pending) and move it to `$VAULT/CLAUDE-Archive.md` with a date header. Never archive identity fields.
+
+2. **Auto-redact sensitive patterns** (External Project Mode, standard memory level only):
+   After saving the file, run the redaction script to strip any code snippets or file contents that leaked through:
+   ```bash
+   python3 ~/deus/scripts/redact_session.py "<full path to saved log>"
+   ```
+   Only run this step when memory level is `standard` (not `full` or `restricted`).
+   If the script fails, skip silently — the log is still saved; instruct the user to review it manually.
+
+3. **Index the session log** (always, if scripts are available):
+   Run: `python3 ~/deus/scripts/memory_indexer.py --add "<full path to saved log>"`
+   If the script fails, skip silently — the log is still saved.
+
+4. **Extract atomic facts** (always, if scripts are available):
+   Run: `python3 ~/deus/scripts/memory_indexer.py --extract "<full path to saved log>"`
+   If the script fails, skip silently.
+
+5. **Delete today's checkpoint** (always):
+   Run: `find "$VAULT/Checkpoints" -name "$(date +%Y-%m-%d)-*.md" -delete 2>/dev/null`
+
+6. **Pre-warm semantic cache** (always, background):
+   Run: `python3 ~/deus/scripts/memory_indexer.py --query "recent work ongoing tasks" --top 2 --recency-boost > ~/.deus/resume_semantic_cache.txt 2>/dev/null &`
+
+Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, and atom extraction result.

--- a/.claude/skills/preferences/skill.md
+++ b/.claude/skills/preferences/skill.md
@@ -1,0 +1,77 @@
+---
+name: preferences
+description: View or modify Deus user preferences (name, catch-me-up behavior, bypass permissions, persona)
+user_invocable: true
+---
+
+# /preferences
+
+Manage Deus user preferences. These are stored in `~/.config/deus/config.json` alongside the vault path.
+
+## Config location
+
+```bash
+~/.config/deus/config.json
+```
+
+## Available preferences
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `name` | string | `""` | User's name - Deus uses it in greetings and context |
+| `catch_me_up` | boolean | `true` | Auto "Catch me up" greeting when launching in home mode |
+| `bypass_permissions` | boolean | `true` | Try `--dangerously-skip-permissions` on launch (falls back to normal if declined) |
+| `persona` | string | `""` | Free-text personality/behavior instructions appended to Deus identity |
+
+## When invoked with no arguments or `show`
+
+Read `~/.config/deus/config.json` and display current preferences:
+
+```
+Deus Preferences
+  name:               <value or "(not set)">
+  catch_me_up:        <on|off> (auto-greet with session summary on launch)
+  bypass_permissions:  <on|off> (skip permission prompts on launch)
+  persona:            <value or "(not set)">
+
+Set with: /preferences <key> <value>
+Examples:
+  /preferences name "Alex"
+  /preferences catch_me_up off
+  /preferences persona "Always respond in a casual tone"
+```
+
+## When invoked with arguments
+
+Parse the first argument as the key and the rest as the value.
+
+- For boolean keys (`catch_me_up`, `bypass_permissions`): accept `on/off`, `true/false`, `yes/no`
+- For string keys (`name`, `persona`): accept the remaining text as the value
+- To clear a string value: `/preferences name ""` or `/preferences persona clear`
+
+### Implementation
+
+Use Python to update the JSON file in-place (preserves other keys like `vault_path`):
+
+```bash
+python3 -c "
+import json, sys
+from pathlib import Path
+p = Path('~/.config/deus/config.json').expanduser()
+d = json.loads(p.read_text()) if p.exists() else {}
+key, val = sys.argv[1], sys.argv[2]
+if key in ('catch_me_up', 'bypass_permissions'):
+    d[key] = val.lower() in ('true', 'on', 'yes', '1')
+else:
+    d[key] = '' if val.lower() in ('clear', '\"\"', \"''\") else val
+p.write_text(json.dumps(d, indent=2))
+print(f'Set {key} = {d[key]}')
+" "<key>" "<value>"
+```
+
+Confirm the change and note that it takes effect on next `deus` launch (not mid-session).
+
+## Validation
+
+- Only allow the 4 documented keys. Reject unknown keys with a helpful message.
+- `persona` can be any text. Warn if it exceeds 500 characters (but still save it).

--- a/.claude/skills/preserve/skill.md
+++ b/.claude/skills/preserve/skill.md
@@ -1,0 +1,52 @@
+---
+name: preserve
+description: Scan this conversation and silently save anything worth permanent memory
+user_invocable: true
+---
+
+# /preserve
+
+Context-aware memory preservation. Behavior adapts to home mode vs external project mode.
+
+## Detect mode
+
+Check if the current working directory is the Deus home directory (`~/deus`). If it is → **Home Mode**. Otherwise → **External Project Mode**.
+
+## Resolve vault path
+
+Read `~/.config/deus/config.json` and use the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+
+## Check memory level (External Project Mode only)
+
+Compute MD5 hash of the current working directory and read `~/.config/deus/projects/<hash>.json`.
+- If memory level is **restricted**: tell the user "Memory preservation is disabled for restricted projects." and stop.
+- If memory level is **standard** or **full**: proceed, but with different scopes (see below).
+- Home mode: always proceed.
+
+## What to preserve
+
+Scan the conversation for:
+- Preferences or habits the user revealed
+- Decisions made with lasting effect
+- Things the user corrected or clarified
+- Facts worth knowing in future sessions
+
+Do not preserve one-off requests or temporary context.
+
+**External Project Mode — standard:**
+Only preserve USER preferences and behavioral corrections — things that are about the user, not the project. Skip project-specific architecture decisions, code patterns, or team info (those belong in Claude Code's auto-memory, not the vault).
+
+**External Project Mode — full:**
+Preserve both user preferences AND project-relevant decisions. Include project context where it helps future sessions.
+
+## Where to save
+
+Save findings to: $VAULT/CLAUDE.md
+
+Add findings using the same compact key:value format as the file — no prose bullets.
+One line per insight.
+
+If CLAUDE.md exceeds 200 lines, archive old content to:
+$VAULT/CLAUDE-Archive.md
+
+Confirm briefly what was added, or say nothing was worth preserving if nothing qualified.

--- a/.claude/skills/project-settings/skill.md
+++ b/.claude/skills/project-settings/skill.md
@@ -1,0 +1,89 @@
+---
+name: project-settings
+description: View or modify Deus external project settings (memory level, session summaries, description)
+user_invocable: true
+---
+
+# /project-settings
+
+Manage Deus data handling settings for the current external project.
+
+## Config location
+
+Project configs are stored at `~/.config/deus/projects/<hash>.json`. To find the config for the current directory, compute the MD5 hash of the absolute path of the current working directory and look for that file.
+
+```bash
+# macOS
+dir_hash=$(echo -n "$(pwd)" | md5 -q)
+# Linux
+dir_hash=$(echo -n "$(pwd)" | md5sum | cut -d' ' -f1)
+config_file="$HOME/.config/deus/projects/${dir_hash}.json"
+```
+
+## When invoked with no arguments or `show`
+
+Read the config file and display current settings. Also detect the project type by scanning for marker files (Cargo.toml → rust, go.mod → go, package.json → node/typescript, pyproject.toml/requirements.txt → python, Gemfile → ruby, pom.xml → java).
+
+Display in this format:
+
+```
+Project: <name> (<path>)
+Description: <description, or "(none — set with /project-settings description <text>)">
+Type: <detected type, e.g. "typescript / next.js" or "python / fastapi", or "unknown">
+Memory level: <full|standard|restricted>
+  full       — Remember everything. Sessions saved to vault with full details.
+  standard   — Remember decisions & architecture, redact code details.
+  restricted — Nothing persists. Each session starts fresh.
+Session summaries: <on|off>
+Created: <date>
+Last accessed: <date>
+```
+
+Then show available commands:
+- `/project-settings memory full|standard|restricted` — change memory level
+- `/project-settings summaries on|off` — toggle session summaries
+- `/project-settings description <text>` — set a short project description Deus uses as context
+- `/project-settings delete` — delete all Deus data for this project
+
+## When invoked with arguments
+
+Parse the argument and update the config JSON file accordingly using Python to read/write the JSON safely. Always preserve all existing fields when updating.
+
+### `memory full|standard|restricted`
+
+Update the `memory_level` field. If changing to `restricted`, also set `save_summaries` to false and inform the user.
+
+Memory level descriptions:
+- **full**: Remember everything. Claude auto-memory enabled. Session summaries saved to vault with full code details.
+- **standard**: Remember decisions and architecture, skip code details. Auto-memory enabled with guidance. Summaries saved but code-redacted.
+- **restricted**: Nothing persists. Auto-memory disabled. No summaries. Best for NDA/client work.
+
+### `summaries on|off`
+
+Update the `save_summaries` field. If memory level is `restricted` and user tries to enable summaries, warn that restricted mode doesn't support summaries and don't make the change.
+
+### `description <text>`
+
+Update the `description` field in the config JSON. This text is used by Deus as project context in future sessions. Keep it concise (1–2 sentences). Example: `/project-settings description "E-commerce backend for ACME Corp — Django REST API with PostgreSQL"`
+
+Use Python to update the field:
+```python
+import json, sys
+with open(sys.argv[1], 'r+') as f:
+    d = json.load(f)
+    d['description'] = sys.argv[2]
+    f.seek(0); json.dump(d, f, indent=2); f.truncate()
+```
+
+### `delete`
+
+First ask for explicit confirmation: "This will delete all Deus tracking data for this project (memory level, summary settings, description). Claude Code's own session data at ~/.claude/projects/ is NOT affected — that's managed by Claude Code itself. Type 'yes' to confirm."
+
+Only proceed if the user responds with 'yes' (case-insensitive). Then delete the config file.
+
+## Important
+
+- The config file uses the MD5 hash of the current working directory's absolute path as filename
+- Always use `umask 077` when writing config files (they may contain path information)
+- Use Python to update JSON fields — never rewrite the whole file from scratch (would reset created_at)
+- After modifying settings, confirm the change and remind the user the new settings take effect on the next session start

--- a/.claude/skills/resume/skill.md
+++ b/.claude/skills/resume/skill.md
@@ -1,0 +1,145 @@
+---
+name: resume
+description: Load context and catch up on recent work — adapts to home mode vs external project mode
+user_invocable: true
+---
+
+# /resume
+
+Context-aware session resume. Behavior depends on whether you're in the Deus home directory or an external project.
+
+## Detect mode
+
+Check if the current working directory is the Deus home directory (`~/deus`). If it is → **Home Mode**. Otherwise → **External Project Mode**.
+
+## Home Mode (~/deus)
+
+Load context from the vault before starting work.
+
+First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+
+1. Always read core memory:
+   $VAULT/CLAUDE.md
+
+2. Based on likely task context, also read:
+   - Study session → $VAULT/STUDY.md
+   - NanoClaw / tools / infra session → $VAULT/INFRA.md
+   - If unclear → read both (they're small, ~10 lines each)
+
+3. Check for a mid-session checkpoint from today:
+   Run: find "$VAULT/Checkpoints" -name "$(date +%Y-%m-%d)-*.md" 2>/dev/null | xargs ls -t 2>/dev/null | head -1
+   If a file is found → read it fully. Note "resuming mid-session checkpoint" in the summary.
+
+4a. Load warm tier — gap-aware (no API cost):
+
+    First, determine the gap since the last session:
+    Run: python3 scripts/memory_indexer.py --recent 1 2>/dev/null
+    Note the date of the most recent session.
+    
+    Compute gap = today's date minus that date (in days).
+    
+    ALWAYS load the most recent session in full (regardless of gap):
+    Run: python3 scripts/memory_indexer.py --recent 1
+    
+    Then load remaining recent sessions based on gap:
+    - If gap < 1 day (active session): load sessions from last 3 days in compact mode
+      Run: python3 scripts/memory_indexer.py --recent-days 3 --compact
+    - If gap >= 1 day (returning after time away): load sessions from last 7 days in compact mode
+      Run: python3 scripts/memory_indexer.py --recent-days 7 --compact
+      This ensures visibility after vacations/breaks without overloading context.
+    
+    Deduplicate: skip the most recent session if it appears in the --recent-days output (compare by filename).
+    
+    Include combined output as "Recent Sessions" context.
+    
+    FALLBACK — if the script fails, fall back to:
+    find "$VAULT/Session-Logs" -name "*.md" -not -path "*/.obsidian/*" | xargs ls -t 2>/dev/null | head -6
+    Then read frontmatter only (lines between the two --- markers) of those files.
+
+4b. Load learnings — what's new since last /resume (no API cost):
+    Run: python3 scripts/memory_indexer.py --learnings --since 7 --top 3
+    If output is non-empty, include it as a "What's Emerging" section after recent sessions.
+    If no output (nothing new), skip silently — silence signals stability.
+
+4c. Load cold tier — semantically relevant older sessions:
+    Extract the `topics:` array from the most recent session log's frontmatter (available in the --recent 1 output from step 4a). Join topics with spaces as the query.
+    Example: topics: [evolution, memory, indexer] → query: "evolution memory indexer"
+    If currently in a git repo, prepend the current branch: run `git branch --show-current 2>/dev/null` and prepend if non-empty.
+    Example: "fix/silent-failures evolution memory indexer"
+    Fallback: if topics are empty or unavailable, use "recent work ongoing tasks".
+    Run: python3 scripts/memory_indexer.py --query "<constructed query>" --top 2 --recency-boost
+    Deduplicate against warm tier: compare session filenames from the --recent-days output against cold tier results. Skip any cold tier session that already appeared in the warm tier.
+    Include the output as additional context.
+    If the script fails or returns nothing, skip silently — warm tier already provides continuity.
+    NOTE: Since warm tier now returns all sessions from 3 days, cold tier is purely for older context.
+
+5. If a search term was passed as argument, grep session logs for it and read frontmatters of matches.
+
+6. Summarize in 2–3 lines: ongoing context, pending tasks, ready to continue.
+   The `previous:` field in CLAUDE.md is a rolling list of the last 3 sessions (format: `"YYYY-MM-DD: <tldr>"`). Read all 3 entries to understand recent context — not just the most recent one.
+   If a checkpoint was loaded, prepend: "Resuming mid-session: [checkpoint next_action]"
+
+## External Project Mode
+
+Resume work on the current external project by gathering project-specific context.
+
+### Step 1 — Project config
+
+Compute MD5 hash of the current working directory and read `~/.config/deus/projects/<hash>.json`.
+Note the memory level. If restricted, skip steps that involve reading saved memory.
+
+### Step 2 — Git context (always, regardless of memory level)
+
+Run these commands and present the results:
+
+```bash
+# Current branch and status
+git branch --show-current
+git status --short
+
+# Recent commits on this branch (last 10)
+git log --oneline -10
+
+# Any stashed work
+git stash list 2>/dev/null | head -3
+
+# Open branches with recent activity
+git branch --sort=-committerdate --format='%(refname:short) (%(committerdate:relative))' | head -5
+```
+
+### Step 3 — Open PRs (if gh is available)
+
+```bash
+gh pr list --limit 5 2>/dev/null
+```
+
+If gh fails or isn't installed, skip silently.
+
+### Step 4 — Claude auto-memory (standard/full only)
+
+Check if Claude Code has auto-memory for this project:
+- Compute the project path encoding (replace / with - , prepend -)
+- Check `~/.claude/projects/<encoded-path>/memory/MEMORY.md`
+- If it exists, read it and note any saved context
+
+### Step 5 — Project CLAUDE.md
+
+Read the project's own CLAUDE.md if it exists (at the repo root). This contains project-specific instructions and context.
+
+### Step 6 — Summarize
+
+Present a concise project status:
+
+```
+Project: <name> (<branch>)
+Memory: <level> | Last session: <date from config>
+
+Recent activity:
+• <1-2 lines about recent commits>
+• <uncommitted changes if any>
+• <open PRs if any>
+
+<any auto-memory context, 2-3 lines max>
+```
+
+Then: "What would you like to work on?"

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -229,23 +229,45 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc  # or ~/.bashrc
 
 Install Deus's 6 core memory skills to `~/.claude/skills/` so they work in any directory (home mode AND external project mode).
 
-Run:
+Run using Python (cross-platform — macOS, Linux, Windows):
 ```bash
-REPO_DIR="$(pwd)"
-SKILLS_SRC="$REPO_DIR/.claude/skills"
-SKILLS_DEST="$HOME/.claude/skills"
-mkdir -p "$SKILLS_DEST"
+python3 -c "
+import os, shutil, sys
+from pathlib import Path
 
-for skill in compress resume checkpoint preserve preferences project-settings; do
-  mkdir -p "$SKILLS_DEST/$skill"
-  ln -sf "$SKILLS_SRC/$skill/skill.md" "$SKILLS_DEST/$skill/skill.md"
-  echo "  ✓ $skill"
-done
+repo = Path.cwd()
+src_base = repo / '.claude' / 'skills'
+dest_base = Path.home() / '.claude' / 'skills'
+skills = ['compress', 'resume', 'checkpoint', 'preserve', 'preferences', 'project-settings']
+failed = []
+
+for skill in skills:
+    src = src_base / skill / 'skill.md'
+    dest_dir = dest_base / skill
+    dest = dest_dir / 'skill.md'
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if dest.exists() or dest.is_symlink():
+        dest.unlink()
+    try:
+        dest.symlink_to(src.resolve())
+        print(f'  ✓ {skill} (symlink)')
+    except OSError:
+        # Windows without Developer Mode — fall back to copy
+        shutil.copy2(src, dest)
+        print(f'  ✓ {skill} (copied — re-run setup after repo updates)')
+
+if failed:
+    print(f'  ✗ failed: {failed}', file=sys.stderr)
+    sys.exit(1)
+"
 ```
 
-This creates symlinks so updates to the repo automatically reflect in `~/.claude/skills/`. Idempotent — safe to re-run.
+- **macOS/Linux:** creates symlinks — repo updates propagate automatically
+- **Windows (Developer Mode on):** creates symlinks
+- **Windows (Developer Mode off):** falls back to file copy — user must re-run setup after updating the repo
+- Idempotent — safe to re-run anytime
 
-**If any symlink fails** (permissions, existing non-symlink file): warn the user and continue — the other skills still install. The commands at `.claude/commands/` (home-mode-only) remain as fallback.
+**If any skill fails:** warn the user and continue — the other skills still install. The commands at `.claude/commands/` (home-mode-only) remain as fallback.
 
 **After installing:** Tell the user that `/compress`, `/resume`, `/checkpoint`, `/preserve`, `/preferences`, and `/project-settings` are now available in any project directory.
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -225,6 +225,30 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc  # or ~/.bashrc
 
 **After CLI registration:** Tell user they can type `deus` from any terminal after reopening their shell (or running `source ~/.zshrc` / `source ~/.bashrc` to apply immediately).
 
+## 6c. Install Core Skills
+
+Install Deus's 6 core memory skills to `~/.claude/skills/` so they work in any directory (home mode AND external project mode).
+
+Run:
+```bash
+REPO_DIR="$(pwd)"
+SKILLS_SRC="$REPO_DIR/.claude/skills"
+SKILLS_DEST="$HOME/.claude/skills"
+mkdir -p "$SKILLS_DEST"
+
+for skill in compress resume checkpoint preserve preferences project-settings; do
+  mkdir -p "$SKILLS_DEST/$skill"
+  ln -sf "$SKILLS_SRC/$skill/skill.md" "$SKILLS_DEST/$skill/skill.md"
+  echo "  ✓ $skill"
+done
+```
+
+This creates symlinks so updates to the repo automatically reflect in `~/.claude/skills/`. Idempotent — safe to re-run.
+
+**If any symlink fails** (permissions, existing non-symlink file): warn the user and continue — the other skills still install. The commands at `.claude/commands/` (home-mode-only) remain as fallback.
+
+**After installing:** Tell the user that `/compress`, `/resume`, `/checkpoint`, `/preserve`, `/preferences`, and `/project-settings` are now available in any project directory.
+
 ## 7. Verify
 
 Run `npx tsx setup/index.ts --step verify` and parse the status block.


### PR DESCRIPTION
## Summary

- **6 core skills missing from repo**: `compress`, `resume`, `checkpoint`, `preserve`, `preferences`, `project-settings` only existed locally at `~/.claude/skills/` — other users had no memory system or external project mode after cloning
- **Added all 6 skill files** to `.claude/skills/` in the repo
- **New setup step 6c** symlinks them to `~/.claude/skills/` at install time (idempotent, symlink-based so repo updates propagate automatically)
- **Synced rolling `previous:` logic** into `.claude/commands/compress.md` — `previous:` is now a rolling list of 3 sessions (prepend-only, parallel-safe)

## Test plan

- [ ] Run `/setup` on a fresh clone — verify 6 symlinks created at `~/.claude/skills/`
- [ ] Open an external project, run `/compress` — verify it detects external project mode
- [ ] Run `/resume` in an external project — verify project-focused context loads
- [ ] Run `/compress` twice in same session — verify `previous:` has 2 entries prepended correctly
- [ ] Re-run `/setup` — verify step 6c is idempotent (no errors, symlinks updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)