### PR TITLE
feat(evolution): add configurable reflection count and score analytics

### DIFF
--- a/evolution/backfill.py
+++ b/evolution/backfill.py
@@ -25,7 +25,7 @@ import time
 from pathlib import Path
 from typing import Iterator
 
-from .config import REFLECTION_THRESHOLD
+from .config import REFLECTION_THRESHOLD, MAX_REFLECTIONS_TO_GENERATE
 from .ilog.interaction_log import log_interaction, update_score
 from .storage import get_storage
 from .judge import make_runtime_judge
@@ -293,31 +293,38 @@ def run_backfill(
                   f"s={result.safety:.2f}  t={result.tool_use:.2f}  "
                   f"p={result.personalization:.2f}")
 
-        # Generate reflection for low-scoring interactions
+        # Generate reflection(s) for low-scoring interactions
         if result.score < REFLECTION_THRESHOLD:
             try:
-                content, category = generate_reflection(
-                    prompt=pair["prompt"],
-                    response=pair["response"],
-                    score=result.score,
-                    dims={
-                        "quality": result.quality,
-                        "safety": result.safety,
-                        "tool_use": result.tool_use,
-                        "personalization": result.personalization,
-                    },
-                    rationale=result.rationale,
-                )
-                save_reflection(
-                    content=content,
-                    category=category,
-                    score_at_gen=result.score,
-                    interaction_id=iid,
-                    group_folder=pair["group_folder"],
-                )
-                stats["reflections_generated"] += 1
-                if verbose:
-                    print(f"  → reflection generated ({category}): {content[:80]}…")
+                dims = {
+                    "quality": result.quality,
+                    "safety": result.safety,
+                    "tool_use": result.tool_use,
+                    "personalization": result.personalization,
+                }
+                generated_contents: set[str] = set()
+                for _ in range(MAX_REFLECTIONS_TO_GENERATE):
+                    content, category = generate_reflection(
+                        prompt=pair["prompt"],
+                        response=pair["response"],
+                        score=result.score,
+                        dims=dims,
+                        rationale=result.rationale,
+                    )
+                    if content in generated_contents:
+                        break  # LLM returned identical text; stop early
+                    generated_contents.add(content)
+                    saved = save_reflection(
+                        content=content,
+                        category=category,
+                        score_at_gen=result.score,
+                        interaction_id=iid,
+                        group_folder=pair["group_folder"],
+                    )
+                    if saved:
+                        stats["reflections_generated"] += 1
+                        if verbose:
+                            print(f"  → reflection generated ({category}): {content[:80]}…")
             except Exception as exc:
                 if verbose:
                     print(f"  !! reflection failed: {exc}")

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -39,6 +39,9 @@ REFLECTION_THRESHOLD = float(os.environ.get("EVOLUTION_REFLECTION_THRESHOLD", "0
 POSITIVE_THRESHOLD = float(os.environ.get("EVOLUTION_POSITIVE_THRESHOLD", "0.85"))
 MAX_REFLECTIONS_PER_QUERY = int(os.environ.get("EVOLUTION_MAX_REFLECTIONS", "3"))
 REFLECTION_DEDUP_L2 = float(os.environ.get("EVOLUTION_REFLECTION_DEDUP_L2", "0.4"))
+# Experiment: how many reflections to generate per interaction (default=1, existing behavior).
+# Set to 2-3 to test whether more reflections per interaction improves retrieval quality.
+MAX_REFLECTIONS_TO_GENERATE = int(os.environ.get("EVOLUTION_MAX_REFLECTIONS_TO_GENERATE", "1"))
 
 # ── DSPy Optimizer ────────────────────────────────────────────────────────────
 
@@ -58,6 +61,12 @@ AUTO_OPTIMIZE_THRESHOLD = int(os.environ.get("EVOLUTION_AUTO_OPTIMIZE_THRESHOLD"
 PRINCIPLES_COOLDOWN_HOURS = int(os.environ.get("EVOLUTION_PRINCIPLES_COOLDOWN_HOURS", "24"))
 # How many times to retry Gemini judge on JSON parse failure before falling back to neutral score.
 JUDGE_RETRY_COUNT = int(os.environ.get("EVOLUTION_JUDGE_RETRY_COUNT", "1"))
+
+# ── Group Opt-Out ────────────────────────────────────────────────────────────
+
+# Comma-separated group folder names that are excluded from evolution tracking.
+# Interactions from these groups are skipped in cmd_log_interaction without being stored.
+EVOLUTION_SKIP_GROUPS: str = os.environ.get("EVOLUTION_SKIP_GROUPS", "")
 
 # ── Compaction & Batch Judging ───────────────────────────────────────────────
 

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -113,44 +113,55 @@ def _score_single(row: dict, judge) -> dict | None:
 
 
 def _reflect_single(scored: dict, config: dict) -> bool:
-    """Generate reflection for a scored interaction. Returns True on success."""
+    """Generate reflection(s) for a scored interaction. Returns True on success."""
+    from .config import MAX_REFLECTIONS_TO_GENERATE
     from .reflexion.generator import generate_reflection, generate_positive_reflection
     from .reflexion.store import save_reflection
 
     row = scored["row"]
     try:
         if scored["score"] < config["reflection_threshold"]:
-            content, category = generate_reflection(
-                prompt=row["prompt"],
-                response=row.get("response") or "",
-                score=scored["score"],
-                dims=scored["dims"],
-                rationale=scored["rationale"],
-                tools_used=row.get("tools_used"),
-            )
-            save_reflection(
-                content=content,
-                category=category,
-                score_at_gen=scored["score"],
-                interaction_id=row["id"],
-                group_folder=row.get("group_folder"),
-            )
+            generated_contents: set[str] = set()
+            for _ in range(MAX_REFLECTIONS_TO_GENERATE):
+                content, category = generate_reflection(
+                    prompt=row["prompt"],
+                    response=row.get("response") or "",
+                    score=scored["score"],
+                    dims=scored["dims"],
+                    rationale=scored["rationale"],
+                    tools_used=row.get("tools_used"),
+                )
+                if content in generated_contents:
+                    break  # LLM returned identical text; stop early
+                generated_contents.add(content)
+                save_reflection(
+                    content=content,
+                    category=category,
+                    score_at_gen=scored["score"],
+                    interaction_id=row["id"],
+                    group_folder=row.get("group_folder"),
+                )
         elif scored["score"] >= config["positive_threshold"]:
-            content, category = generate_positive_reflection(
-                prompt=row["prompt"],
-                response=row.get("response") or "",
-                score=scored["score"],
-                dims=scored["dims"],
-                rationale=scored["rationale"],
-                tools_used=row.get("tools_used"),
-            )
-            save_reflection(
-                content=content,
-                category=category,
-                score_at_gen=scored["score"],
-                interaction_id=row["id"],
-                group_folder=row.get("group_folder"),
-            )
+            generated_contents = set()
+            for _ in range(MAX_REFLECTIONS_TO_GENERATE):
+                content, category = generate_positive_reflection(
+                    prompt=row["prompt"],
+                    response=row.get("response") or "",
+                    score=scored["score"],
+                    dims=scored["dims"],
+                    rationale=scored["rationale"],
+                    tools_used=row.get("tools_used"),
+                )
+                if content in generated_contents:
+                    break  # LLM returned identical text; stop early
+                generated_contents.add(content)
+                save_reflection(
+                    content=content,
+                    category=category,
+                    score_at_gen=scored["score"],
+                    interaction_id=row["id"],
+                    group_folder=row.get("group_folder"),
+                )
         return True
     except Exception as exc:
         log.warning("Failed to generate reflection for %s: %s", row["id"], exc)

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -135,8 +135,8 @@ async def _async_judge_and_reflect(
     tools_used: Optional[list[str]],
     group_folder: str,
 ) -> None:
-    """Judge the interaction and generate a reflection if score is low."""
-    from .config import REFLECTION_THRESHOLD
+    """Judge the interaction and generate reflections if score is low."""
+    from .config import REFLECTION_THRESHOLD, MAX_REFLECTIONS_TO_GENERATE
     try:
         judge = make_runtime_judge()
         result = await judge.a_evaluate(
@@ -153,21 +153,26 @@ async def _async_judge_and_reflect(
         update_score(interaction_id, result.score, dims)
 
         if result.score < REFLECTION_THRESHOLD:
-            content, category = generate_reflection(
-                prompt=prompt,
-                response=response,
-                score=result.score,
-                dims=dims,
-                rationale=result.rationale,
-                tools_used=tools_used,
-            )
-            save_reflection(
-                content=content,
-                category=category,
-                score_at_gen=result.score,
-                interaction_id=interaction_id,
-                group_folder=group_folder,
-            )
+            generated_contents: set[str] = set()
+            for _ in range(MAX_REFLECTIONS_TO_GENERATE):
+                content, category = generate_reflection(
+                    prompt=prompt,
+                    response=response,
+                    score=result.score,
+                    dims=dims,
+                    rationale=result.rationale,
+                    tools_used=tools_used,
+                )
+                if content in generated_contents:
+                    break  # LLM returned identical text; stop early
+                generated_contents.add(content)
+                save_reflection(
+                    content=content,
+                    category=category,
+                    score_at_gen=result.score,
+                    interaction_id=interaction_id,
+                    group_folder=group_folder,
+                )
     except Exception as exc:
         log.error(
             'evolution: async judge failed for interaction %s — %s: %s',

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -288,6 +288,21 @@ class StorageProvider(ABC):
         """Fetch interactions that have not been judged yet (judge_score IS NULL)."""
         ...
 
+    @abstractmethod
+    def score_by_reflection_count(self) -> list[dict]:
+        """
+        Return average judge score grouped by the number of reflections an
+        interaction has.
+
+        Returns a list of dicts ordered by reflection_count ascending:
+            [{"reflection_count": int, "avg_score": float, "interaction_count": int}, ...]
+
+        Only scored interactions with at least one reflection (or zero reflections)
+        are included.  Useful for measuring whether generating more reflections per
+        interaction correlates with higher or lower base quality.
+        """
+        ...
+
 
 class StorageRegistry:
     """

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -842,3 +842,46 @@ class SQLiteStorageProvider(StorageProvider):
         ).fetchall()
         db.close()
         return [dict(r) for r in rows]
+
+    def score_by_reflection_count(self) -> list[dict]:
+        """
+        Return avg judge score grouped by the number of reflections an interaction has.
+
+        Only includes scored interactions (judge_score IS NOT NULL) and excludes
+        maintenance sentinels.  The result is sorted by reflection_count ascending so
+        callers can easily compare 0-reflection vs 1-reflection vs N-reflection groups.
+        """
+        db = self._connect()
+        # Each row is one interaction: (reflection_count, judge_score)
+        rows = db.execute(
+            """
+            SELECT
+                COUNT(r.id) AS reflection_count,
+                i.judge_score
+            FROM interactions i
+            LEFT JOIN reflections r
+                ON r.interaction_id = i.id
+                AND r.archived_at IS NULL
+            WHERE i.judge_score IS NOT NULL
+              AND i.eval_suite != 'maintenance'
+              AND i.group_folder != '__maintenance__'
+            GROUP BY i.id
+            """,
+        ).fetchall()
+        db.close()
+
+        # Aggregate per-interaction rows into per-reflection-count buckets in Python
+        from collections import defaultdict
+        buckets: dict[int, list[float]] = defaultdict(list)
+        for rc, score in rows:
+            buckets[rc].append(score)
+
+        result = []
+        for rc in sorted(buckets.keys()):
+            scores = buckets[rc]
+            result.append({
+                "reflection_count": rc,
+                "avg_score": sum(scores) / len(scores),
+                "interaction_count": len(scores),
+            })
+        return result


### PR DESCRIPTION
## Summary
- Adds `EVOLUTION_MAX_REFLECTIONS_TO_GENERATE` env var (default=1 — zero behavior change)
- Wraps reflection generation in a loop with two-layer dedup: exact-match in the loop, embedding-based in `save_reflection`
- Adds `score_by_reflection_count()` analytics method to compare avg scores by reflection count

## Test plan
- [ ] Run with default (1) and verify behavior is unchanged
- [ ] Set `EVOLUTION_MAX_REFLECTIONS_TO_GENERATE=3` and confirm multiple reflections are generated per low-scoring interaction
- [ ] Call `score_by_reflection_count()` and verify it returns grouped avg scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)