### PR TITLE
feat(evolution): document EVOLUTION_SKIP_GROUPS env var and add config constant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ CREDENTIAL_PROXY_HOST=
 # === Evolution / Eval ===
 EMBEDDING_PROVIDER=auto
 EVOLUTION_ENABLED=1
+# Comma-separated list of group folder names to opt out of evolution tracking.
+# Interactions from these groups are silently skipped and not logged to the DB.
+# Example: EVOLUTION_SKIP_GROUPS=scheduled-agent,internal-test
+EVOLUTION_SKIP_GROUPS=
 EVAL_JUDGE=
 EVOLUTION_REFLECTION_THRESHOLD=0.6
 EVOLUTION_AUTO_OPTIMIZE_THRESHOLD=50

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -59,6 +59,12 @@ PRINCIPLES_COOLDOWN_HOURS = int(os.environ.get("EVOLUTION_PRINCIPLES_COOLDOWN_HO
 # How many times to retry Gemini judge on JSON parse failure before falling back to neutral score.
 JUDGE_RETRY_COUNT = int(os.environ.get("EVOLUTION_JUDGE_RETRY_COUNT", "1"))
 
+# ── Group Opt-Out ────────────────────────────────────────────────────────────
+
+# Comma-separated group folder names that are excluded from evolution tracking.
+# Interactions from these groups are skipped in cmd_log_interaction without being stored.
+EVOLUTION_SKIP_GROUPS: str = os.environ.get("EVOLUTION_SKIP_GROUPS", "")
+
 # ── Compaction & Batch Judging ───────────────────────────────────────────────
 
 # Compact scored interactions older than N days (replace with summary, NULL response).


### PR DESCRIPTION
## Summary
- Adds `EVOLUTION_SKIP_GROUPS` to `.env.example` with a clear usage comment
- Adds a named constant in `evolution/config.py` for consistency with other config vars
- The skip logic in `evolution/cli.py` was already implemented — this just makes it discoverable and documented

## Test plan
- [ ] Set `EVOLUTION_SKIP_GROUPS=telegram_main` in `.env` and verify those interactions are skipped (status: skipped in response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)