### PR TITLE
fix: post.ts tweet URL, resume time-label rule, finetune gitignore

### DIFF
--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -41,3 +41,11 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
 
 6. Summarize in 2–3 lines: ongoing context, pending tasks, ready to continue.
    If a checkpoint was loaded, prepend: "Resuming mid-session: [checkpoint next_action]"
+
+7. Register daily reminders cron (always, every /resume):
+   Use CronCreate with:
+     cron: "3 9 * * *"
+     recurring: true
+     durable: true
+     prompt: "Read ~/.deus/daily-tasks.md and ~/.deus/posting-schedule.md. Show a morning checklist: first, any posts due today from the posting schedule (platform + ready-to-copy text); then any pending one-time tasks that are approaching or overdue. If absolutely nothing is due today, say nothing at all."
+   Do not mention this step in the summary — just register it silently.

--- a/.claude/skills/resume/skill.md
+++ b/.claude/skills/resume/skill.md
@@ -79,6 +79,8 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
    The `previous:` field in CLAUDE.md is a rolling list of the last 3 sessions (format: `"YYYY-MM-DD: <tldr>"`). Read all 3 entries to understand recent context — not just the most recent one.
    If a checkpoint was loaded, prepend: "Resuming mid-session: [checkpoint next_action]"
 
+   **Time-label rule (enforced here, no exceptions):** Always label prior work as "Previous session:" — never use "Yesterday", "Earlier today", "Last week", or any relative time phrase. Compare session dates against `currentDate` from system context before writing anything. If the most recent session date equals today → still say "Previous session:", not "Earlier today". Relative labels are always wrong because sessions can span days or repeat within a day.
+
 ## External Project Mode
 
 Resume work on the current external project by gathering project-specific context.

--- a/.claude/skills/x-integration/scripts/post.ts
+++ b/.claude/skills/x-integration/scripts/post.ts
@@ -50,12 +50,38 @@ async function postTweet(input: PostInput): Promise<ScriptResult> {
       return { success: false, message: 'Post button disabled. Content may be empty or exceed character limit.' };
     }
 
+    // Intercept CreateTweet API response to capture tweet ID
+    const responsePromise = page.waitForResponse(
+      (response) => response.url().includes('CreateTweet'),
+      { timeout: 15000 }
+    ).catch(() => null);
+
     await postButton.click();
     await page.waitForTimeout(config.timeouts.afterSubmit);
 
+    let tweetUrl: string | undefined;
+    try {
+      const response = await responsePromise;
+      if (response) {
+        const data = await response.json().catch(() => null);
+        const tweetId = data?.data?.create_tweet?.tweet_results?.result?.rest_id;
+        if (tweetId) {
+          const handleEl = page.locator('[data-testid="SideNav_AccountSwitcher_Button"] [dir="ltr"] span').first();
+          const handleText = await handleEl.textContent().catch(() => null);
+          const handle = handleText?.replace('@', '').trim() || 'me';
+          tweetUrl = `https://x.com/${handle}/status/${tweetId}`;
+        }
+      }
+    } catch {
+      // URL capture failed silently — post still succeeded
+    }
+
     return {
       success: true,
-      message: `Tweet posted: ${content.slice(0, 50)}${content.length > 50 ? '...' : ''}`
+      message: tweetUrl
+        ? `Tweet posted: ${tweetUrl}`
+        : `Tweet posted: ${content.slice(0, 50)}${content.length > 50 ? '...' : ''}`,
+      data: tweetUrl ? { url: tweetUrl } : undefined
     };
 
   } finally {

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ packages/*/package-lock.json
 
 agents-sdk-docs
 deus.db
+
+# Fine-tune artifacts
+finetune/data/
+finetune/adapters/
+finetune/gemma4-tool-fused/


### PR DESCRIPTION
## Summary
- `fix(x-integration)`: Intercept CreateTweet GraphQL response to capture tweet ID + handle and return full tweet URL in result
- `fix(resume)`: Enforce "Previous session:" time-label rule in skill.md; add daily reminders cron step (step 7)
- `chore`: Ignore finetune artifacts (data/, adapters/, gemma4-tool-fused/)

## Test plan
- [ ] Post a tweet via X integration and verify URL is returned in response
- [ ] Run /resume and verify time labels say "Previous session:" not relative terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)