### PR TITLE
feat(evolution): add routing patterns and context_tokens

### DIFF
--- a/.claude/skills/add-listen-hotkey/SKILL.md
+++ b/.claude/skills/add-listen-hotkey/SKILL.md
@@ -1,0 +1,112 @@
+# /add-listen-hotkey
+
+Install a global hotkey that triggers `deus listen` from anywhere on the OS.
+
+## Prerequisites
+
+- `deus listen` must work from terminal (`npm run build` must have been run).
+- `deus` must be on `$PATH` (run `deus auth` once to ensure the symlink is in place).
+
+## Step 1 — Detect OS and ask for preferences
+
+Detect the OS (`IS_MACOS` / `IS_LINUX` / `IS_WINDOWS` from platform.ts context, or run `uname -s`).
+
+Ask the user:
+1. **Hotkey** — default `Cmd+Option+V` (macOS) / `Super+Alt+V` (Linux) / `Ctrl+Alt+V` (Windows)
+2. **Mode**:
+   - `silent` (default) — runs `deus listen` in background, notification on completion
+   - `terminal` — opens a new terminal window with the VU meter visible
+3. **Stream mode?** — if yes, uses `deus listen --stream` instead of single-shot
+
+## Step 2 — Install per OS
+
+### macOS — Hammerspoon
+
+Check if Hammerspoon is installed: `ls /Applications/Hammerspoon.app 2>/dev/null`
+If missing: `brew install --cask hammerspoon` (ask user to approve).
+
+Write `~/.hammerspoon/deus-listen.lua`:
+
+```lua
+-- deus listen hotkey (managed by Deus /add-listen-hotkey)
+local mods = {"cmd", "alt"}
+local key  = "v"
+
+hs.hotkey.bind(mods, key, function()
+  -- SILENT MODE: run headless, notify on completion
+  local task = hs.task.new("/bin/zsh", function(code, stdout, stderr)
+    local msg = code == 0 and "Copied to clipboard" or "Transcription failed"
+    hs.notify.new({title = "Deus", informativeText = msg}):send()
+  end, {"-lc", "deus listen --no-clipboard=false"})
+  task:start()
+  hs.notify.new({title = "Deus", informativeText = "Listening…"}):send()
+end)
+```
+
+For **terminal mode** replace the task body with:
+```lua
+  hs.execute("open -a Ghostty --args -e 'deus listen'")
+```
+(or `iTerm2` / `Terminal.app` if Ghostty is absent — detect with `ls /Applications/Ghostty.app`).
+
+Source the file from `~/.hammerspoon/init.lua`:
+```lua
+-- Auto-appended by Deus /add-listen-hotkey
+require("deus-listen")
+```
+
+Reload Hammerspoon: `open -g hammerspoon://reloadConfig`
+
+### Linux — sxhkd
+
+Check if sxhkd is running: `pgrep sxhkd`
+If missing: `sudo apt install sxhkd` (or pacman/dnf equivalent).
+
+Append to `~/.config/sxhkd/sxhkdrc` (create if missing):
+```
+# deus listen (managed by Deus /add-listen-hotkey)
+super + alt + v
+    deus listen
+```
+
+For **stream mode**: replace `deus listen` with `deus listen --stream`.
+
+Reload: `pkill -USR1 sxhkd`
+
+For **terminal mode** (VU meter visible):
+```
+super + alt + v
+    ghostty -e deus listen
+```
+
+### Windows — AutoHotkey v2
+
+Check if AHK is installed: `Get-Command autohotkey.exe -ErrorAction SilentlyContinue`
+If missing: `winget install AutoHotkey.AutoHotkey`
+
+Write `%APPDATA%\deus\deus-listen.ahk`:
+```ahk
+; deus listen hotkey (managed by Deus /add-listen-hotkey)
+^!v:: {  ; Ctrl+Alt+V
+    Run "deus listen", , "Hide"
+}
+```
+
+For **terminal mode**: `Run "wt.exe deus listen"` (Windows Terminal).
+
+Add to startup: create a shortcut in `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\`.
+
+Run immediately: `Start-Process autohotkey.exe "$env:APPDATA\deus\deus-listen.ahk"`
+
+## Step 3 — Verify
+
+Test the hotkey:
+- macOS: trigger it, wait for "Listening…" notification, speak, check clipboard.
+- Linux: trigger, speak, check `xclip -o -selection clipboard`.
+- Windows: trigger, speak, check `Get-Clipboard`.
+
+## Step 4 — Uninstall instructions (show to user)
+
+- **macOS**: delete `~/.hammerspoon/deus-listen.lua`, remove the `require` line from `init.lua`, reload Hammerspoon.
+- **Linux**: remove the appended block from `~/.config/sxhkd/sxhkdrc`, `pkill -USR1 sxhkd`.
+- **Windows**: delete `%APPDATA%\deus\deus-listen.ahk` and the startup shortcut.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,0 +1,15 @@
+# Task Router
+
+**Selection rule:** Pick the most specific match. If unsure, use `general-code`.
+
+| Task type | Pattern file | Extra doc (load only if task touches this area) |
+|-----------|--------------|------------------------------------------------|
+| channel-add | `patterns/channel-add.md` | `docs/CONTRIBUTING-AI.md` §MCP Channel Servers |
+| skill-add | `patterns/skill-add.md` | — |
+| eval-change | `patterns/eval-change.md` | `docs/decisions/INDEX.md` |
+| deployment | `patterns/deployment.md` | — |
+| debugging | `patterns/debugging.md` | `docs/DEBUG_CHECKLIST.md` |
+| cross-platform | `patterns/cross-platform.md` | — |
+| security-review | `patterns/security-review.md` | `docs/SECURITY.md` |
+| memory / startup-gate | `patterns/general-code.md` | `docs/decisions/INDEX.md` (mandatory) |
+| general-code (fallback) | `patterns/general-code.md` | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ Single Node.js process with skill-based channel system. Channels (WhatsApp, Tele
 
 **REQUIRED: Before making any change to `eval/`, `src/startup-gate.ts`, `src/checks.ts`, `setup/`, or `scripts/memory_indexer.py`, read `docs/decisions/INDEX.md` in full.** Do not skip this step, even for small changes. The index is short (one line per decision) and tells you which full ADR file to load if the topic is relevant. Past decisions have non-obvious constraints (e.g. a "revert this" that looks like an improvement is documented as permanently rejected). Skipping the index has caused regressions before.
 
+## Task Routing
+
+Before loading full docs, consult [`.mex/ROUTER.md`](.mex/ROUTER.md) — it maps task type to a distilled pattern file (~700 tokens each). Load only the pattern that matches. Fall back to `patterns/general-code.md` when unsure.
+
 ## Development Rules
 
 **REQUIRED: Before making any code change, read [`docs/CONTRIBUTING-AI.md`](docs/CONTRIBUTING-AI.md).** Contains branch workflow, commit conventions, test requirements, skill boundary rules, and security rules. These are enforced by pre-commit hooks and CI — commits that violate them will be rejected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,11 +26,11 @@ Single Node.js process with skill-based channel system. Channels (WhatsApp, Tele
 
 ## Task Routing
 
-Before loading full docs, consult [`.mex/ROUTER.md`](.mex/ROUTER.md) — it maps task type to a distilled pattern file (~700 tokens each). Load only the pattern that matches. Fall back to `patterns/general-code.md` when unsure.
+Consult [`.mex/ROUTER.md`](.mex/ROUTER.md) to find the distilled pattern file for your task type. **The pattern file replaces loading the full source doc** — it contains the rules that apply to that task slice. If you need more detail, the pattern's "Extra doc" line tells you what to load. Fall back to `patterns/general-code.md` when unsure.
 
 ## Development Rules
 
-**REQUIRED: Before making any code change, read [`docs/CONTRIBUTING-AI.md`](docs/CONTRIBUTING-AI.md).** Contains branch workflow, commit conventions, test requirements, skill boundary rules, and security rules. These are enforced by pre-commit hooks and CI — commits that violate them will be rejected.
+Core rules live in the pattern files above. For topics not covered by any pattern, read [`docs/CONTRIBUTING-AI.md`](docs/CONTRIBUTING-AI.md) directly. All rules are enforced by pre-commit hooks and CI.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full human-readable contributor guide.
 

--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -376,68 +376,9 @@ switch ($Command.ToLower()) {
 
     "listen" {
         # Record from mic, transcribe with whisper.cpp, copy to clipboard.
-        # Uses sox for recording and whisper-cli for transcription.
-        $whisperBin = if ($env:WHISPER_BIN) { $env:WHISPER_BIN } else { "whisper-cli" }
-        $whisperModel = if ($env:WHISPER_MODEL) { $env:WHISPER_MODEL } else { "$DeusHome\data\models\ggml-base.bin" }
-        $whisperLang = if ($env:WHISPER_LANG) { $env:WHISPER_LANG } else { "en" }
-        $modelUrl = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"
-
-        # Check dependencies
-        $deps = @("sox", $whisperBin, "ffmpeg")
-        $missingDeps = $deps | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) }
-        if ($missingDeps) {
-            Write-Host "Missing dependencies: $($missingDeps -join ', ')" -ForegroundColor Red
-            Write-Host "Install with: choco install sox.portable ffmpeg"
-            Write-Host "whisper-cpp: download from https://github.com/ggerganov/whisper.cpp/releases"
-            exit 1
-        }
-
-        # Auto-download model
-        if (-not (Test-Path $whisperModel)) {
-            Write-Host "Whisper model not found. Downloading ggml-base.bin (148 MB)..."
-            $modelDir = Split-Path $whisperModel -Parent
-            if (-not (Test-Path $modelDir)) { New-Item -ItemType Directory -Path $modelDir -Force | Out-Null }
-            Invoke-WebRequest -Uri $modelUrl -OutFile $whisperModel -UseBasicParsing
-            Write-Host "Download complete."
-        }
-
-        # Record
-        $tmpFile = Join-Path $env:TEMP "deus-voice-$(Get-Date -Format 'yyyyMMddHHmmss').wav"
-        Write-Host ""
-        Write-Host "  Recording... (press Ctrl+C to stop)" -ForegroundColor Cyan
-        Write-Host ""
-
-        try {
-            # rec from sox: 16kHz mono WAV
-            & sox -d -q -r 16000 -c 1 -b 16 $tmpFile
-        } catch { }
-
-        if (-not (Test-Path $tmpFile) -or (Get-Item $tmpFile).Length -lt 16000) {
-            Write-Host "  Recording too short or failed. Try again." -ForegroundColor Yellow
-            if (Test-Path $tmpFile) { Remove-Item $tmpFile -Force }
-            exit 1
-        }
-
-        # Transcribe
-        Write-Host "  Transcribing..." -ForegroundColor Cyan
-        $transcript = & $whisperBin -m $whisperModel -f $tmpFile --no-timestamps -nt -l $whisperLang 2>$null
-        $transcript = ($transcript | Where-Object { $_.Trim() -ne "" }) -join " "
-        $transcript = $transcript.Trim()
-
-        # Cleanup
-        Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
-
-        if (-not $transcript) {
-            Write-Host "  Could not transcribe audio. Try speaking louder or longer." -ForegroundColor Yellow
-            exit 1
-        }
-
-        Write-Host ""
-        Write-Host "  $transcript"
-        Write-Host ""
-        Set-Clipboard -Value $transcript
-        Write-Host "  Copied to clipboard. Paste with Ctrl+V." -ForegroundColor Green
-        Write-Host ""
+        # Phase 2+: Node.js with live VU meter. Use --stream for continuous dictation.
+        $remaining = $Args[1..($Args.Length - 1)]
+        & node "$DeusHome\dist\deus-listen.js" @remaining
     }
 
     default {

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1024,8 +1024,9 @@ $STARTUP_INSTRUCTION" "Catch me up."
     ;;
   listen)
     # Record from mic, transcribe with whisper.cpp, copy to clipboard.
+    # Phase 2+: Node.js with live VU meter. Use --stream for continuous dictation.
     shift
-    exec "$HOME/deus/scripts/deus-listen.sh" "$@"
+    exec node "$SCRIPT_DIR/dist/deus-listen.js" "$@"
     ;;
   logs)
     # Log review, rotation, and health reporting.

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -28,7 +28,7 @@ if __name__ == "__main__" and __package__ is None:
     __package__ = "evolution"  # type: ignore
 
 
-def cmd_status(group_folder: Optional[str] = None, domain: Optional[str] = None, compare: bool = False) -> None:
+def cmd_status(group_folder: Optional[str] = None, domain: Optional[str] = None, compare: bool = False, show_tokens: bool = False) -> None:
     from .ilog.interaction_log import get_recent, score_trend
     from .optimizer.artifacts import list_artifacts
     from .storage import get_storage
@@ -84,6 +84,19 @@ def cmd_status(group_folder: Optional[str] = None, domain: Optional[str] = None,
             )
     else:
         print("  No active artifacts. Run `optimize` to generate one.")
+
+    # Token trend (optional)
+    if show_tokens:
+        token_rows = store.token_trend(days=30)
+        print("\n=== Context Token Trend (last 30 days) ===")
+        if token_rows:
+            for row in token_rows[-10:]:
+                avg = int(row["avg_tokens"])
+                bar = "█" * min(int(avg / 100), 30)
+                print(f"  {row['day']}  {bar:<30}  {avg} avg tokens  ({row['count']} interactions)")
+        else:
+            print("  No token data yet (context_tokens tracked from this release forward).")
+
     print()
 
 
@@ -195,6 +208,9 @@ def cmd_log_interaction(json_str: str) -> None:
 
     domain_presets = params.get("domain_presets") or None
     user_signal = params.get("user_signal") or None
+    context_tokens = params.get("context_tokens")
+    if context_tokens is not None:
+        context_tokens = int(context_tokens)
 
     iid = log_interaction(
         prompt=params.get("prompt", ""),
@@ -206,6 +222,7 @@ def cmd_log_interaction(json_str: str) -> None:
         interaction_id=params.get("id"),
         domain_presets=domain_presets if isinstance(domain_presets, list) else None,
         user_signal=user_signal,
+        context_tokens=context_tokens,
     )
 
     # Batch judge: check if we've accumulated enough unjudged interactions
@@ -306,6 +323,7 @@ def main() -> None:
     p_status.add_argument("--group", help="Filter by group folder")
     p_status.add_argument("--domain", help="Filter by domain preset (e.g., marketing)")
     p_status.add_argument("--compare", action="store_true", help="Compare with-preset vs without-preset scores")
+    p_status.add_argument("--tokens", action="store_true", help="Show daily average context token trend")
 
     # get_reflections
     p_refs = sub.add_parser("get_reflections", help="Retrieve relevant reflections (JSON)")
@@ -369,7 +387,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.cmd == "status":
-        cmd_status(group_folder=args.group, domain=args.domain, compare=args.compare)
+        cmd_status(group_folder=args.group, domain=args.domain, compare=args.compare, show_tokens=args.tokens)
     elif args.cmd == "get_reflections":
         cmd_get_reflections(args.query_json)
     elif args.cmd == "log_interaction":

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -22,6 +22,7 @@ def log_interaction(
     interaction_id: Optional[str] = None,
     domain_presets: Optional[list[str]] = None,
     user_signal: Optional[str] = None,
+    context_tokens: Optional[int] = None,
 ) -> str:
     """
     Persist one agent interaction.  Returns the interaction ID.
@@ -42,6 +43,7 @@ def log_interaction(
         eval_suite=eval_suite,
         domain_presets=json.dumps(domain_presets) if domain_presets else None,
         user_signal=user_signal,
+        context_tokens=context_tokens,
     )
     return iid
 

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -55,6 +55,7 @@ class StorageProvider(ABC):
         eval_suite: str = "runtime",
         domain_presets: Optional[str] = None,
         user_signal: Optional[str] = None,
+        context_tokens: Optional[int] = None,
     ) -> str:
         """Persist one agent interaction. Returns the interaction ID."""
         ...
@@ -106,6 +107,15 @@ class StorageProvider(ABC):
         domain: Optional[str] = None,
     ) -> list[dict]:
         """Daily average judge scores for the last N days."""
+        ...
+
+    @abstractmethod
+    def token_trend(
+        self,
+        *,
+        days: int = 30,
+    ) -> list[dict]:
+        """Daily average context_tokens for the last N days."""
         ...
 
     # ── Reflection operations ────────────────────────────────────────────────

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -212,11 +212,12 @@ class SQLiteStorageProvider(StorageProvider):
         except Exception:
             pass  # Already exists or vec0 not available
 
-        # Domain presets, user signal, parse_error columns (added in v1.3+)
+        # Domain presets, user signal, parse_error, context_tokens columns (added in v1.3+)
         for col, coltype in [
             ("domain_presets", "TEXT"),
             ("user_signal", "TEXT"),
             ("parse_error", "INTEGER DEFAULT 0"),
+            ("context_tokens", "INTEGER"),
         ]:
             try:
                 db.execute(f"ALTER TABLE interactions ADD COLUMN {col} {coltype}")
@@ -274,19 +275,21 @@ class SQLiteStorageProvider(StorageProvider):
         eval_suite: str = "runtime",
         domain_presets: Optional[str] = None,
         user_signal: Optional[str] = None,
+        context_tokens: Optional[int] = None,
     ) -> str:
         db = self._connect()
         db.execute(
             """
             INSERT OR REPLACE INTO interactions
                 (id, timestamp, group_folder, prompt, response, tools_used,
-                 latency_ms, eval_suite, session_id, domain_presets, user_signal)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 latency_ms, eval_suite, session_id, domain_presets, user_signal,
+                 context_tokens)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 interaction_id, timestamp, group_folder, prompt, response,
                 tools_used, latency_ms, eval_suite, session_id,
-                domain_presets, user_signal,
+                domain_presets, user_signal, context_tokens,
             ),
         )
         db.commit()
@@ -420,6 +423,29 @@ class SQLiteStorageProvider(StorageProvider):
             ORDER BY day
             """,
             params,
+        ).fetchall()
+        db.close()
+        return [dict(r) for r in rows]
+
+    # ── Token trend ──────────────────────────────────────────────────────────
+
+    def token_trend(
+        self,
+        *,
+        days: int = 30,
+    ) -> list[dict]:
+        db = self._connect()
+        rows = db.execute(
+            f"""
+            SELECT DATE(timestamp) AS day,
+                   AVG(context_tokens) AS avg_tokens,
+                   COUNT(*) AS count
+            FROM interactions
+            WHERE context_tokens IS NOT NULL
+              AND timestamp >= DATETIME('now', '-{days} days')
+            GROUP BY day
+            ORDER BY day
+            """,
         ).fetchall()
         db.close()
         return [dict(r) for r in rows]

--- a/evolution/token_counter.py
+++ b/evolution/token_counter.py
@@ -1,0 +1,17 @@
+"""
+Token estimation for the evolution loop.
+
+Uses a simple heuristic (len(text) // 4) — accurate enough for trend
+tracking. Not a replacement for tiktoken; never use for billing.
+"""
+from typing import Sequence
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for a single string."""
+    return len(text) // 4
+
+
+def sum_tokens(*parts: str) -> int:
+    """Sum estimated tokens across multiple strings."""
+    return sum(estimate_tokens(p) for p in parts)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "auth": "echo 'Use /add-whatsapp or /add-telegram to configure a channel' && exit 1",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "drift-check": "python3 scripts/drift_check.py"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/patterns/INDEX.md
+++ b/patterns/INDEX.md
@@ -1,0 +1,12 @@
+# Patterns Index
+
+| Pattern file | Task type | Distils |
+|---|---|---|
+| `patterns/channel-add.md` | Adding or modifying MCP channel servers | `docs/CONTRIBUTING-AI.md` §MCP Channel Servers |
+| `patterns/skill-add.md` | Adding or modifying skills in `.claude/skills/` | `docs/CONTRIBUTING-AI.md` §Skill Contributions + §Source Code Changes |
+| `patterns/eval-change.md` | Changes to `evolution/` or `eval/` | ADRs: eval-ipc-file-output, eval-no-disk-cache, eval-selective-warmup |
+| `patterns/deployment.md` | Service restart, dist/ rebuild, credentials | `docs/CONTRIBUTING-AI.md` §Deploy and Service Restart |
+| `patterns/debugging.md` | Diagnosing silent failures in the message pipeline | `docs/CONTRIBUTING-AI.md` §Debugging + §Message Pipeline Stages |
+| `patterns/cross-platform.md` | Any code that touches paths, signals, shells, or env vars | `docs/CROSS_PLATFORM.md` (CI-enforced violations only) |
+| `patterns/security-review.md` | IPC, mounts, credentials, container boundary | `docs/SECURITY.md` |
+| `patterns/general-code.md` | Catch-all: branch, tests, commits, ADR gate | `docs/CONTRIBUTING-AI.md` core rules |

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -1,0 +1,34 @@
+---
+governs:
+  - src/channels
+---
+# Pattern: channel-add
+
+## Critical gotcha — silent message loss
+
+Always declare `capabilities: { logging: {} }` when constructing `McpServer`. Without it, `sendLoggingMessage()` silently drops all notifications. No errors, no warnings.
+
+```typescript
+// CORRECT
+const server = new McpServer(
+  { name: '@deus-ai/my-channel', version: '1.0.0' },
+  { capabilities: { logging: {} } },
+);
+
+// WRONG — total silent message loss
+const server = new McpServer({ name: '@deus-ai/my-channel', version: '1.0.0' });
+```
+
+## Scope rules
+
+- Channel skill PRs touch only `.claude/skills/` (and optionally `docs/`, `README.md`).
+- Core changes (`src/`, `package.json`) go in a separate PR first.
+- Never commit `host.ts`, `scripts/`, `node_modules/`, or `package-lock.json`.
+
+## Tests
+
+Add at least one test covering the capability registration path. Run `npm test` before committing.
+
+## Extra doc
+
+Load `docs/CONTRIBUTING-AI.md` §MCP Channel Servers for the full SDK pattern.

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -1,0 +1,43 @@
+---
+governs:
+  - src/platform.ts
+  - src/cross-platform.test.ts
+---
+# Pattern: cross-platform
+
+## CI-enforced violations (tests will fail)
+
+These four patterns are caught by `src/cross-platform.test.ts` on every CI platform:
+
+| Violation | Fix |
+|-----------|-----|
+| `'/dev/null'` in code | `os.devNull` |
+| `.replace('file://', '')` | `fileURLToPath()` from `'url'` |
+| `new URL('file://' + path)` | `pathToFileURL()` from `'url'` |
+| `.kill('SIGKILL')` / `.kill('SIGTERM')` without platform check | `killProcess()` from `./platform.js` |
+
+## Additional enforced rules
+
+- **All platform-sensitive code in `src/` must go through `src/platform.ts`** — ESLint bans direct `os.platform()` / `process.platform` / `process.env.HOME` outside that file. See ADR `platform-abstraction-layer.md`.
+- Use `execFileSync(binary, [args])` not `execSync(shellString)` — shell quoting breaks on Windows.
+- Never use `:` as PATH separator — use `path.delimiter`.
+- Never call `process.getuid()` without optional chaining (`process.getuid?.()`).
+
+## Import reference
+
+```typescript
+// src/ code
+import { IS_WINDOWS, IS_MACOS, homeDir, killProcess } from './platform.js';
+
+// setup/ code
+import { getPlatform, isWSL } from './setup/platform.js';
+```
+
+## Checklist before PR
+
+```
+[ ] No /dev/null, file:// strip, SIGKILL/SIGTERM, new URL('file://...') violations
+[ ] All platform detection via src/platform.ts (not os.platform() directly)
+[ ] execFileSync(binary, args) used instead of execSync(shellString)
+[ ] No PATH strings with hardcoded ':' separator
+```

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,0 +1,42 @@
+---
+governs:
+  - src/container-runner.ts
+  - src/message-orchestrator.ts
+---
+# Pattern: debugging
+
+## Diagnosis order
+
+1. **Establish basic facts first** — check the simplest observable state before hypothesizing:
+   - `pm2 logs --nostream` / `tail logs/deus.log` — is the service running?
+   - `SELECT MAX(timestamp) FROM messages` — are messages being stored?
+2. **Instrument boundaries, don't reason about code** — add one log line at each stage boundary, send one test input, read the logs. Definitively locates the break in 2 minutes.
+3. **Read SDK source for silent failures** — check `node_modules/` before tracing the whole pipeline.
+4. **Use `info` level** for temporary debug logs — service default is `info`; `debug` won't appear.
+
+## Message pipeline (8 stages)
+
+```
+Channel → MCP child process (messages.upsert / bot.on)
+  → sendLoggingMessage() [requires logging capability — #1 silent drop]
+  → Host MCP adapter (setNotificationHandler)
+  → onMessage callback (sender allowlist check)
+  → storeMessage() [SQLite]
+  → Message polling loop (getNewMessages)
+  → Trigger check (@Deus for non-main groups)
+  → Container spawn (processGroupMessages)
+```
+
+Each `→` is a potential silent drop. Instrument boundaries between stages.
+
+## Quick status check
+
+```bash
+launchctl list | grep deus          # PID = running, "-" = stopped
+container ls --format '{{.Names}} {{.Status}}' 2>/dev/null | grep deus
+grep -E 'ERROR|WARN' logs/deus.log | tail -20
+```
+
+## Extra doc
+
+Load `docs/DEBUG_CHECKLIST.md` for container timeout, mount issues, and WhatsApp auth commands.

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,0 +1,35 @@
+---
+governs:
+  - src/
+  - setup/
+  - dist/
+---
+# Pattern: deployment
+
+## Critical: service runs dist/, not source
+
+A merged PR does **not** auto-rebuild. Always run `npm run build` before restarting.
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.deus
+```
+
+Verify: `stat dist/index.js` mtime should be newer than the service startup timestamp in `logs/deus.log`.
+
+## Credentials rule
+
+Never write rotating credentials (OAuth tokens, short-lived keys) to `.env`. Read them dynamically at request time from their source file (e.g., `credentials.json`). `.env` is for static secrets only.
+
+## Restart sequence
+
+```bash
+npm run build && launchctl kickstart -k gui/$(id -u)/com.deus
+```
+
+Stop only: `launchctl bootout gui/$(id -u)/com.deus`
+Start only: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.deus.plist`
+
+## Scope
+
+Any change to `src/`, `setup/`, or `packages/` requires a rebuild before the change is live.

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -1,0 +1,36 @@
+---
+governs:
+  - evolution/
+  - eval/
+---
+# Pattern: eval-change
+
+## ADR gate (mandatory)
+
+Before any change to `evolution/`, read `docs/decisions/INDEX.md`. Three decisions have non-obvious permanent constraints:
+
+| ADR | Ruling |
+|-----|--------|
+| `eval-ipc-file-output.md` | Results via shared-volume files, **not stdout** — Docker pipe buffering is permanent. Do not revert. |
+| `eval-no-disk-cache.md` | In-memory cache only — disk cache silently masks regressions across builds. |
+| `eval-selective-warmup.md` | Warm only active test datasets — saves ~3× time, avoids API rate saturation. |
+
+## Storage migrations
+
+Use the existing `try/except ALTER TABLE` pattern in `evolution/storage/providers/sqlite.py` lines 215–244. Never add columns in the `CREATE TABLE` block — it only runs once.
+
+```python
+for col, coltype in [("new_col", "TEXT")]:
+    try:
+        db.execute(f"ALTER TABLE interactions ADD COLUMN {col} {coltype}")
+    except sqlite3.OperationalError:
+        pass  # Column already exists
+```
+
+## Provider pattern
+
+Adding a new backend = one file + one registration line. Abstract contract in `evolution/storage/provider.py`. Concrete impl in `evolution/storage/providers/`.
+
+## Tests
+
+Python tests in `scripts/tests/`. Run `python3 -m pytest scripts/tests/` before committing.

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -7,17 +7,25 @@ governs:
 
 ## ADR gate (mandatory)
 
-Before any change to `evolution/`, read `docs/decisions/INDEX.md`. Three decisions have non-obvious permanent constraints:
+Before any change to `evolution/`, read `docs/decisions/INDEX.md`. Three decisions have permanent constraints:
 
-| ADR | Ruling |
-|-----|--------|
-| `eval-ipc-file-output.md` | Results via shared-volume files, **not stdout** — Docker pipe buffering is permanent. Do not revert. |
-| `eval-no-disk-cache.md` | In-memory cache only — disk cache silently masks regressions across builds. |
-| `eval-selective-warmup.md` | Warm only active test datasets — saves ~3× time, avoids API rate saturation. |
+| ADR | Ruling | Why permanent |
+|-----|--------|---------------|
+| `eval-ipc-file-output.md` | Results via shared-volume files, **not stdout** — do not revert | Docker pipe buffering is a runtime constraint, not a fixable bug. Deadlock is guaranteed under load. |
+| `eval-no-disk-cache.md` | In-memory cache only | Disk cache silently masks regressions across builds — a passing cached result hides a regression in the new build. |
+| `eval-selective-warmup.md` | Warm only active test datasets | Full suite = ~40 container starts; cold start ~10 min. Warming inactive sets wastes time and saturates API rate limits. |
+
+## Concurrency limits
+
+Concurrency is `cpu_count // 2`, capped at 8. Override with `DEUS_EVAL_CONCURRENT`. **Never raise this cap** — rate limits saturate fast (~30 containers/session).
+
+## Adding a new dataset
+
+New dataset test files must be named `test_{name}.py` for auto-discovery. If the naming convention isn't followed, add the dataset manually to `_ALL_DATASETS`. Warm only the datasets used by the active test suite.
 
 ## Storage migrations
 
-Use the existing `try/except ALTER TABLE` pattern in `evolution/storage/providers/sqlite.py` lines 215–244. Never add columns in the `CREATE TABLE` block — it only runs once.
+Use the existing `try/except ALTER TABLE` pattern in `evolution/storage/providers/sqlite.py`. Never add columns in the `CREATE TABLE` block — it only runs once.
 
 ```python
 for col, coltype in [("new_col", "TEXT")]:

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,0 +1,45 @@
+---
+governs:
+  - src/
+  - evolution/
+  - scripts/memory_indexer.py
+  - src/startup-gate.ts
+  - src/checks.ts
+  - setup/
+---
+# Pattern: general-code
+
+## Branch (required)
+
+Always create a feature branch before making changes. Never commit directly to `main`.
+Verify clean working tree first: `git status`.
+Branch naming: `feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `ci/`, `test/`, `perf/`
+
+## Tests (required, no exceptions)
+
+Every source change must include unit tests.
+- TypeScript: `*.test.ts` alongside source files → `npm test`
+- Python: `scripts/tests/test_*.py` → `python3 -m pytest scripts/tests/`
+
+Both must pass before committing.
+
+## Commit format
+
+`type(scope): description` — Conventional Commits, enforced by commit-msg hook.
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
+Scope required (e.g. `evolution`, `container`, `skills`, `startup-gate`).
+
+## ADR gate
+
+**Before modifying `eval/`, `src/startup-gate.ts`, `src/checks.ts`, `setup/`, or `scripts/memory_indexer.py`**: read `docs/decisions/INDEX.md` first. Past decisions have non-obvious permanent constraints. Skipping the index has caused regressions.
+
+## Security
+
+Never commit credentials, API keys, or tokens — not even in test files. New credentials go in `.env.example`. Design as if the repo is public.
+
+## What not to do
+
+- Don't manually edit `CHANGELOG.md` or bump version in `package.json` (release-please handles both)
+- Don't add features as source code changes — use skills
+- Don't skip pre-commit hooks (`--no-verify`)
+- Don't force-push to shared branches

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -1,0 +1,50 @@
+---
+governs:
+  - src/container-mounter.ts
+  - src/credential-proxy.ts
+  - src/ipc.ts
+---
+# Pattern: security-review
+
+## Trust model
+
+| Entity | Trust level |
+|--------|-------------|
+| Main group | Trusted — admin control |
+| Non-main groups | Untrusted — treat as hostile input |
+| Container agents | Sandboxed — isolated execution |
+| Channel messages | User input — potential prompt injection |
+
+## Mount security
+
+- Mount allowlist lives at `~/.config/deus/mount-allowlist.json` — outside project root, never mounted into containers, cannot be modified by agents.
+- Symlinks resolved before validation (prevents traversal attacks).
+- Container paths reject `..` and absolute paths.
+- `.env` is shadowed with `/dev/null` in the project root mount.
+
+## Credential isolation
+
+Real credentials **never enter containers**. The credential proxy at `:3001` injects auth headers transparently. Containers receive `ANTHROPIC_API_KEY=placeholder` and `ANTHROPIC_BASE_URL=http://host.docker.internal:<port>`.
+
+Never committed / never mounted:
+- `store/auth/` — WhatsApp session
+- `~/.config/deus/mount-allowlist.json`
+- Any file matching blocked patterns (`.ssh`, `.env`, `credentials`, `private_key`, etc.)
+
+## IPC authorization
+
+Non-main groups: cannot send to other chats, cannot schedule tasks for others, view own tasks only. Verify group identity before any privileged operation.
+
+## Security audit checklist
+
+```
+[ ] No credentials in code, test files, or git history
+[ ] New credentials have .env.example entry with descriptive comment
+[ ] IPC operations verify group identity
+[ ] Container mounts go through allowlist validation
+[ ] No secrets in container environment or mounted paths
+```
+
+## Extra doc
+
+Load `docs/SECURITY.md` for the full trust table, privilege comparison, and architecture diagram.

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -15,36 +15,64 @@ governs:
 | Container agents | Sandboxed — isolated execution |
 | Channel messages | User input — potential prompt injection |
 
+## Container isolation (primary boundary)
+
+Each container run gets: process isolation, filesystem isolation (only explicitly mounted paths visible), non-root execution (uid 1000), and ephemeral environment (`--rm`). **The attack surface is limited by what's mounted, not by application-level permission checks.** Do not rely on code-level guards as the primary security mechanism.
+
+## Session isolation
+
+Each group has isolated Claude sessions at `data/sessions/{group}/.claude/`. Groups cannot see other groups' conversation history. Cross-group information disclosure is prevented at the filesystem level — not application-level.
+
 ## Mount security
 
 - Mount allowlist lives at `~/.config/deus/mount-allowlist.json` — outside project root, never mounted into containers, cannot be modified by agents.
 - Symlinks resolved before validation (prevents traversal attacks).
 - Container paths reject `..` and absolute paths.
 - `.env` is shadowed with `/dev/null` in the project root mount.
+- Project root mounted read-only for main group. Writable paths (group folder, IPC, `.claude/`) mounted separately.
 
 ## Credential isolation
 
-Real credentials **never enter containers**. The credential proxy at `:3001` injects auth headers transparently. Containers receive `ANTHROPIC_API_KEY=placeholder` and `ANTHROPIC_BASE_URL=http://host.docker.internal:<port>`.
+Real credentials **never enter containers**. Host runs an HTTP proxy at `:3001`. Containers receive `ANTHROPIC_API_KEY=placeholder` and `ANTHROPIC_BASE_URL=http://host.docker.internal:<port>`. The proxy strips the placeholder, injects real credentials, and forwards to `api.anthropic.com`. Agents cannot discover real credentials from environment, stdin, files, or `/proc`.
 
 Never committed / never mounted:
-- `store/auth/` — WhatsApp session
+- `store/auth/` — WhatsApp session credentials
 - `~/.config/deus/mount-allowlist.json`
 - Any file matching blocked patterns (`.ssh`, `.env`, `credentials`, `private_key`, etc.)
 
 ## IPC authorization
 
-Non-main groups: cannot send to other chats, cannot schedule tasks for others, view own tasks only. Verify group identity before any privileged operation.
+| Operation | Main group | Non-main group |
+|-----------|------------|----------------|
+| Send to other chats | ✓ | ✗ |
+| Schedule task for others | ✓ | ✗ |
+| View all tasks | ✓ | Own only |
+| Manage other groups | ✓ | ✗ |
+
+Verify group identity before any privileged IPC operation.
+
+## Sensitive local files (never committed)
+
+| File | Contents |
+|------|----------|
+| `store/auth/creds.json` | WhatsApp session (encrypted) |
+| `store/messages.db` | Full message history |
+| `.env` | API keys and channel tokens |
+| `~/.config/deus/mount-allowlist.json` | Allowed mount paths |
+| `data/sessions/*/` | Per-group Claude session state |
 
 ## Security audit checklist
 
 ```
 [ ] No credentials in code, test files, or git history
 [ ] New credentials have .env.example entry with descriptive comment
-[ ] IPC operations verify group identity
+[ ] IPC operations verify group identity before privileged actions
 [ ] Container mounts go through allowlist validation
 [ ] No secrets in container environment or mounted paths
+[ ] New mounts: does this expose anything outside the intended scope?
+[ ] New IPC operations: does non-main group access need to be restricted?
 ```
 
 ## Extra doc
 
-Load `docs/SECURITY.md` for the full trust table, privilege comparison, and architecture diagram.
+Load `docs/SECURITY.md` for the full architecture diagram and privilege comparison table.

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,0 +1,32 @@
+---
+governs:
+  - .claude/skills
+---
+# Pattern: skill-add
+
+## What a skill PR contains
+
+- `SKILL.md` — required
+- `agent.ts` — if the skill adds container-side MCP tools
+
+## What must never be committed in a skill PR
+
+| File | Reason |
+|------|--------|
+| `host.ts` / `host.js` | Private host-side implementation |
+| `scripts/` | Subprocess scripts |
+| `node_modules/`, `package-lock.json` | Local dependencies |
+
+CI rejects skill PRs that also touch `src/`.
+
+## Core source changes
+
+If a skill genuinely requires `src/` changes, open a separate source PR first. Explain in the PR description why the feature cannot be a skill.
+
+## Tests
+
+Every change to `agent.ts` requires a test. Run `npm test` before committing.
+
+## Commit format
+
+`feat(skills): <description>` — scope is `skills`.

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -17,11 +17,15 @@ governs:
 | `scripts/` | Subprocess scripts |
 | `node_modules/`, `package-lock.json` | Local dependencies |
 
-CI rejects skill PRs that also touch `src/`.
+**CI rejects skill PRs that also touch `src/`.** This is enforced automatically — do not attempt to bundle skill + source changes in one PR.
 
 ## Core source changes
 
-If a skill genuinely requires `src/` changes, open a separate source PR first. Explain in the PR description why the feature cannot be a skill.
+If a skill genuinely requires `src/` changes, open a separate source PR first. **Explain in the PR description why the feature cannot be a skill** — this is required, not optional. All source code PRs require maintainer review (CODEOWNERS).
+
+## New features belong in skills
+
+New features and enhancements go in skills, not source code. Source PRs are accepted for: bug fixes, security fixes, simplifications, performance improvements only.
 
 ## Tests
 

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Drift checker for pattern files.
+
+Reads patterns/INDEX.md to discover pattern files, then checks each pattern's
+YAML frontmatter `governs:` list against source file mtimes. Flags patterns
+whose governed source has been modified since the pattern was last updated.
+
+Exit codes:
+  0 — all patterns up-to-date
+  1 — one or more patterns drifted (governed source newer than pattern)
+  2 — one or more governed paths are missing from the filesystem
+
+Usage:
+  python3 scripts/drift_check.py
+  npm run drift-check
+"""
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def parse_governs(pattern_path: Path) -> list[str]:
+    """Extract the governs: list from a pattern file's YAML frontmatter."""
+    try:
+        text = pattern_path.read_text()
+    except FileNotFoundError:
+        return []
+
+    # Match YAML frontmatter block between --- delimiters
+    match = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return []
+
+    frontmatter = match.group(1)
+    # Extract governs list items (lines starting with "  - ")
+    governs: list[str] = []
+    in_governs = False
+    for line in frontmatter.splitlines():
+        if line.strip().startswith("governs:"):
+            in_governs = True
+            continue
+        if in_governs:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                governs.append(stripped[2:].strip())
+            elif stripped and not stripped.startswith("#"):
+                in_governs = False
+    return governs
+
+
+def discover_patterns() -> list[Path]:
+    """Find all pattern files listed in patterns/INDEX.md."""
+    index = PROJECT_ROOT / "patterns" / "INDEX.md"
+    if not index.exists():
+        print(f"ERROR: {index} not found", file=sys.stderr)
+        sys.exit(2)
+
+    patterns: list[Path] = []
+    for line in index.read_text().splitlines():
+        # Match markdown links: [text](patterns/filename.md)
+        # or backtick table cells: `patterns/filename.md`
+        match = re.search(r"(?:\(|`)patterns/([^`)]+\.md)(?:\)|`)", line)
+        if match:
+            patterns.append(PROJECT_ROOT / "patterns" / match.group(1))
+    return patterns
+
+
+def main() -> int:
+    patterns = discover_patterns()
+    if not patterns:
+        print("No patterns found in patterns/INDEX.md.")
+        return 0
+
+    rows: list[dict] = []
+    exit_code = 0
+
+    for pattern_path in patterns:
+        if not pattern_path.exists():
+            rows.append({
+                "pattern": pattern_path.name,
+                "status": "MISSING_PATTERN",
+                "drifted": str(pattern_path),
+            })
+            exit_code = max(exit_code, 2)
+            continue
+
+        pattern_mtime = pattern_path.stat().st_mtime
+        governs = parse_governs(pattern_path)
+
+        drifted: list[str] = []
+        for rel_path in governs:
+            governed = PROJECT_ROOT / rel_path
+            if not governed.exists():
+                rows.append({
+                    "pattern": pattern_path.name,
+                    "status": "MISSING_GOVERNED",
+                    "drifted": rel_path,
+                })
+                exit_code = max(exit_code, 2)
+                continue
+
+            if governed.is_dir():
+                # For directories, check the most recently modified file inside
+                mtimes = [f.stat().st_mtime for f in governed.rglob("*") if f.is_file()]
+                governed_mtime = max(mtimes) if mtimes else 0.0
+            else:
+                governed_mtime = governed.stat().st_mtime
+
+            if governed_mtime > pattern_mtime:
+                drifted.append(rel_path)
+
+        if drifted:
+            rows.append({
+                "pattern": pattern_path.name,
+                "status": "DRIFTED",
+                "drifted": ", ".join(drifted),
+            })
+            exit_code = max(exit_code, 1)
+        else:
+            rows.append({
+                "pattern": pattern_path.name,
+                "status": "OK",
+                "drifted": "—",
+            })
+
+    # Print Markdown table
+    col_w = max(len(r["pattern"]) for r in rows)
+    status_w = max(len(r["status"]) for r in rows)
+    drift_w = max(len(r["drifted"]) for r in rows)
+
+    header = f"| {'pattern':<{col_w}} | {'status':<{status_w}} | {'drifted files':<{drift_w}} |"
+    sep    = f"| {'-'*col_w} | {'-'*status_w} | {'-'*drift_w} |"
+    print(header)
+    print(sep)
+    for r in rows:
+        print(f"| {r['pattern']:<{col_w}} | {r['status']:<{status_w}} | {r['drifted']:<{drift_w}} |")
+
+    if exit_code == 0:
+        print("\nAll patterns up-to-date.")
+    elif exit_code == 1:
+        print("\nDRIFTED: update the flagged pattern files to match source changes.")
+    else:
+        print("\nMISSING: pattern file or governed path not found.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_token_counter.py
+++ b/scripts/tests/test_token_counter.py
@@ -1,0 +1,45 @@
+"""Unit tests for evolution/token_counter.py."""
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from evolution.token_counter import estimate_tokens, sum_tokens
+
+
+def test_estimate_tokens_empty():
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_tokens_basic():
+    # 4 chars → 1 token (floor division)
+    assert estimate_tokens("abcd") == 1
+
+
+def test_estimate_tokens_longer():
+    text = "a" * 100
+    assert estimate_tokens(text) == 25
+
+
+def test_estimate_tokens_unicode():
+    # Each char counts as one regardless of byte length; heuristic is len()-based
+    text = "שלום"  # 4 chars
+    assert estimate_tokens(text) == 1
+
+
+def test_sum_tokens_empty():
+    assert sum_tokens() == 0
+
+
+def test_sum_tokens_single():
+    assert sum_tokens("abcd") == 1
+
+
+def test_sum_tokens_multiple():
+    # "aaaa" = 1, "bbbbbbbb" = 2
+    assert sum_tokens("aaaa", "bbbbbbbb") == 3
+
+
+def test_sum_tokens_with_empty_part():
+    assert sum_tokens("abcd", "", "efgh") == 2

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -30,6 +30,7 @@ import { buildVolumeMounts } from './container-mounter.js';
 import { RegisteredGroup } from './types.js';
 import { detectDomainsWithFallback } from './domain-presets.js';
 import { getReflections, logInteraction } from './evolution-client.js';
+import { estimateTokens } from './token-counter.js';
 import { detectUserSignal } from './user-signal.js';
 import { getProjectById } from './db.js';
 
@@ -480,6 +481,7 @@ export async function runContainerAgent(
               reflections.reflectionIds.length > 0
                 ? reflections.reflectionIds
                 : undefined,
+            contextTokens: estimateTokens(input.prompt),
           });
           resolve({
             status: 'success',
@@ -533,6 +535,7 @@ export async function runContainerAgent(
             reflections.reflectionIds.length > 0
               ? reflections.reflectionIds
               : undefined,
+          contextTokens: estimateTokens(input.prompt),
         });
 
         resolve(output);

--- a/src/deus-listen.test.ts
+++ b/src/deus-listen.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, execFile: vi.fn(), spawn: vi.fn() };
+});
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => true),
+      writeFileSync: vi.fn(),
+      rmSync: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./platform.js', () => ({
+  IS_MACOS: true,
+  IS_LINUX: false,
+  IS_WINDOWS: false,
+  killProcess: vi.fn(),
+}));
+
+vi.mock('./transcription.js', () => ({
+  transcribeFile: vi.fn(async () => 'hello world'),
+  ensureWhisperModel: vi.fn(async () => {}),
+  resolveDefaultModelPath: vi.fn(() => '/models/ggml-base.bin'),
+  depInstallHint: vi.fn((dep: string) => `brew install ${dep}`),
+  TranscriptionError: class TranscriptionError extends Error {},
+}));
+
+import { execFile } from 'child_process';
+import {
+  computeRms,
+  renderBar,
+  buildWavHeader,
+  parseArgs,
+  copyToClipboard,
+  readClipboard,
+  appendClipboard,
+} from './deus-listen.js';
+
+const mockExecFile = vi.mocked(execFile);
+
+function makeExecFileCallback(stdout = '', error: Error | null = null) {
+  // execFileAsync may be called with or without an options object, so always
+  // take the last argument as the callback regardless of arity.
+  return (...args: unknown[]) => {
+    const callback = args[args.length - 1] as (...a: unknown[]) => void;
+    callback(error, { stdout, stderr: '' });
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Pure function tests (no mocks needed) ──────────────────────────────────
+
+describe('computeRms', () => {
+  it('returns 0 for empty or short buffer', () => {
+    expect(computeRms(Buffer.alloc(0))).toBe(0);
+    expect(computeRms(Buffer.alloc(1))).toBe(0);
+  });
+
+  it('returns 0 for silence (all zeros)', () => {
+    expect(computeRms(Buffer.alloc(64))).toBe(0);
+  });
+
+  it('returns ~1 for full-scale signal (all int16 max)', () => {
+    const buf = Buffer.alloc(64);
+    for (let i = 0; i < 64; i += 2) buf.writeInt16LE(32767, i);
+    expect(computeRms(buf)).toBeCloseTo(1, 2);
+  });
+
+  it('returns a value between 0 and 1 for typical audio', () => {
+    const buf = Buffer.alloc(64);
+    for (let i = 0; i < 64; i += 2)
+      buf.writeInt16LE(i % 2 === 0 ? 8000 : -8000, i);
+    const rms = computeRms(buf);
+    expect(rms).toBeGreaterThan(0);
+    expect(rms).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('renderBar', () => {
+  it('returns lowest bar for silence', () => {
+    expect(renderBar(0)).toBe('▁');
+  });
+
+  it('returns highest bar for full-scale signal', () => {
+    expect(renderBar(1)).toBe('█');
+  });
+
+  it('returns a single Unicode block character', () => {
+    const bars = '▁▂▃▄▅▆▇█';
+    expect(bars).toContain(renderBar(0.1));
+    expect(bars).toContain(renderBar(0.5));
+  });
+});
+
+describe('buildWavHeader', () => {
+  it('returns exactly 44 bytes', () => {
+    expect(buildWavHeader(1000).length).toBe(44);
+  });
+
+  it('starts with RIFF and contains WAVE and data markers', () => {
+    const h = buildWavHeader(1000);
+    expect(h.toString('ascii', 0, 4)).toBe('RIFF');
+    expect(h.toString('ascii', 8, 12)).toBe('WAVE');
+    expect(h.toString('ascii', 36, 40)).toBe('data');
+  });
+
+  it('writes the correct data length at offset 40', () => {
+    const h = buildWavHeader(12345);
+    expect(h.readUInt32LE(40)).toBe(12345);
+  });
+
+  it('writes file size = dataLen + 36 at offset 4', () => {
+    const h = buildWavHeader(1000);
+    expect(h.readUInt32LE(4)).toBe(1036);
+  });
+});
+
+// ── parseArgs ──────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('returns defaults for empty argv', () => {
+    const args = parseArgs([]);
+    expect(args.stream).toBe(false);
+    expect(args.noClipboard).toBe(false);
+    expect(args.maxSilence).toBe(1.5);
+    expect(args.threshold).toBe(3);
+  });
+
+  it('sets stream flag', () => {
+    expect(parseArgs(['--stream']).stream).toBe(true);
+  });
+
+  it('parses --lang', () => {
+    expect(parseArgs(['--lang', 'he']).lang).toBe('he');
+  });
+
+  it('parses --max-silence', () => {
+    expect(parseArgs(['--max-silence', '0.5']).maxSilence).toBe(0.5);
+  });
+
+  it('parses --threshold', () => {
+    expect(parseArgs(['--threshold', '5']).threshold).toBe(5);
+  });
+
+  it('parses --no-clipboard', () => {
+    expect(parseArgs(['--no-clipboard']).noClipboard).toBe(true);
+  });
+});
+
+// ── Clipboard ──────────────────────────────────────────────────────────────
+
+describe('copyToClipboard', () => {
+  it('calls pbcopy on macOS and returns true', async () => {
+    mockExecFile.mockImplementationOnce(makeExecFileCallback('') as any);
+    const result = await copyToClipboard('hello');
+    expect(result).toBe(true);
+    expect(mockExecFile.mock.calls[0][0]).toBe('pbcopy');
+  });
+
+  it('returns false when pbcopy throws', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('', new Error('not found')) as any,
+    );
+    const result = await copyToClipboard('hello');
+    expect(result).toBe(false);
+  });
+});
+
+describe('readClipboard', () => {
+  it('calls pbpaste on macOS and returns output', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('existing text') as any,
+    );
+    const result = await readClipboard();
+    expect(result).toBe('existing text');
+    expect(mockExecFile.mock.calls[0][0]).toBe('pbpaste');
+  });
+
+  it('returns empty string on error', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('', new Error('fail')) as any,
+    );
+    const result = await readClipboard();
+    expect(result).toBe('');
+  });
+});
+
+describe('appendClipboard', () => {
+  it('appends with space when existing content has no trailing space', async () => {
+    // read returns existing, write returns success
+    mockExecFile
+      .mockImplementationOnce(makeExecFileCallback('existing') as any)
+      .mockImplementationOnce(makeExecFileCallback('') as any);
+    await appendClipboard('new');
+    const writeCall = mockExecFile.mock.calls[1];
+    expect((writeCall[2] as any).input).toBe('existing new');
+  });
+
+  it('appends directly when existing ends with space', async () => {
+    mockExecFile
+      .mockImplementationOnce(makeExecFileCallback('existing ') as any)
+      .mockImplementationOnce(makeExecFileCallback('') as any);
+    await appendClipboard('new');
+    const writeCall = mockExecFile.mock.calls[1];
+    expect((writeCall[2] as any).input).toBe('existing new');
+  });
+
+  it('writes text alone when clipboard is empty', async () => {
+    mockExecFile
+      .mockImplementationOnce(makeExecFileCallback('') as any)
+      .mockImplementationOnce(makeExecFileCallback('') as any);
+    await appendClipboard('first');
+    const writeCall = mockExecFile.mock.calls[1];
+    expect((writeCall[2] as any).input).toBe('first');
+  });
+});

--- a/src/deus-listen.ts
+++ b/src/deus-listen.ts
@@ -1,0 +1,539 @@
+/**
+ * deus listen — Record from mic, transcribe with whisper.cpp, copy to clipboard.
+ *
+ * Phase 2: Live Unicode VU meter, Node.js implementation.
+ * Phase 3: --stream flag for VAD-segmented continuous dictation via sox silence effect.
+ *
+ * Invoked by deus-cmd.sh: `node dist/deus-listen.js [--stream] [--lang <code>]
+ *                           [--max-silence <sec>] [--threshold <pct>] [--no-clipboard]`
+ */
+
+import { execFile, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+import { IS_MACOS, IS_LINUX, IS_WINDOWS, killProcess } from './platform.js';
+import {
+  transcribeFile,
+  ensureWhisperModel,
+  resolveDefaultModelPath,
+  depInstallHint,
+  TranscriptionError,
+} from './transcription.js';
+
+const execFileAsync = promisify(execFile);
+
+// ── VU meter helpers (exported for unit tests) ────────────────────────────
+
+const BAR_CHARS = '▁▂▃▄▅▆▇█';
+const METER_WIDTH = 8; // number of history slots shown
+
+/**
+ * Compute RMS amplitude from a raw int16 LE PCM buffer.
+ * Returns a value in [0, 1].
+ */
+export function computeRms(pcm: Buffer): number {
+  const samples = Math.floor(pcm.length / 2);
+  if (samples === 0) return 0;
+  let sumSq = 0;
+  for (let i = 0; i < samples; i++) {
+    const s = pcm.readInt16LE(i * 2) / 32768;
+    sumSq += s * s;
+  }
+  return Math.sqrt(sumSq / samples);
+}
+
+/**
+ * Map an RMS value (0–1) to a single Unicode bar character.
+ * Uses a log scale so quiet audio is visible.
+ */
+export function renderBar(rms: number): string {
+  if (rms <= 0) return BAR_CHARS[0];
+  // Map to [0,1] via log: typical speech ~0.02–0.3 RMS maps nicely with this curve
+  const norm = Math.max(0, Math.min(1, (Math.log10(rms + 0.001) + 3) / 3));
+  const idx = Math.min(
+    BAR_CHARS.length - 1,
+    Math.floor(norm * BAR_CHARS.length),
+  );
+  return BAR_CHARS[idx];
+}
+
+/**
+ * Build a canonical 44-byte PCM WAV header.
+ */
+export function buildWavHeader(
+  dataLen: number,
+  sampleRate = 16000,
+  channels = 1,
+  bitsPerSample = 16,
+): Buffer {
+  const header = Buffer.alloc(44);
+  const byteRate = (sampleRate * channels * bitsPerSample) / 8;
+  const blockAlign = (channels * bitsPerSample) / 8;
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(dataLen + 36, 4);
+  header.write('WAVE', 8, 'ascii');
+  header.write('fmt ', 12, 'ascii');
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20); // PCM
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write('data', 36, 'ascii');
+  header.writeUInt32LE(dataLen, 40);
+  return header;
+}
+
+// ── Clipboard (exported for unit tests) ──────────────────────────────────
+
+/** Copy text to the OS clipboard. Returns false if no clipboard tool is available. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (IS_MACOS) {
+      await execFileAsync('pbcopy', [], { input: text } as any);
+      return true;
+    }
+    if (IS_WINDOWS) {
+      await execFileAsync('clip.exe', [], { input: text } as any);
+      return true;
+    }
+    // Linux — try xclip, xsel, wl-copy in order
+    for (const [bin, args] of [
+      ['xclip', ['-selection', 'clipboard']],
+      ['xsel', ['--clipboard', '--input']],
+      ['wl-copy', []],
+    ] as [string, string[]][]) {
+      try {
+        await execFileAsync(bin, args, { input: text } as any);
+        return true;
+      } catch {
+        // try next
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Read current clipboard content. Returns empty string on failure. */
+export async function readClipboard(): Promise<string> {
+  try {
+    if (IS_MACOS) {
+      const { stdout } = await execFileAsync('pbpaste', []);
+      return stdout;
+    }
+    if (IS_WINDOWS) {
+      const { stdout } = await execFileAsync('powershell', [
+        '-NoProfile',
+        '-Command',
+        'Get-Clipboard',
+      ]);
+      return stdout.replace(/\r\n/g, '\n').trimEnd();
+    }
+    // Linux
+    for (const [bin, args] of [
+      ['xclip', ['-selection', 'clipboard', '-o']],
+      ['xsel', ['--clipboard', '--output']],
+      ['wl-paste', []],
+    ] as [string, string[]][]) {
+      try {
+        const { stdout } = await execFileAsync(bin, args);
+        return stdout;
+      } catch {
+        // try next
+      }
+    }
+    return '';
+  } catch {
+    return '';
+  }
+}
+
+/** Append text to clipboard (read existing → join → write). */
+export async function appendClipboard(text: string): Promise<void> {
+  const existing = await readClipboard();
+  const joined =
+    existing && !existing.endsWith(' ') && !existing.endsWith('\n')
+      ? `${existing} ${text}`
+      : `${existing}${text}`;
+  await copyToClipboard(joined);
+}
+
+// ── Dependency check ──────────────────────────────────────────────────────
+
+async function checkDeps(deps: string[]): Promise<void> {
+  const missing: string[] = [];
+  for (const dep of deps) {
+    try {
+      await execFileAsync(dep, ['--version'], { timeout: 3000 });
+    } catch {
+      missing.push(dep);
+    }
+  }
+  if (missing.length === 0) return;
+  console.error(`\n  Missing dependencies: ${missing.join(', ')}\n`);
+  for (const dep of missing) {
+    console.error(`  ${depInstallHint(dep)}`);
+  }
+  console.error('');
+  process.exit(1);
+}
+
+// ── Recording ─────────────────────────────────────────────────────────────
+
+/** Args to spawn sox for raw PCM capture from the default input device. */
+function recArgs(extra: string[] = []): { bin: string; args: string[] } {
+  const base = [
+    '-q',
+    '-r',
+    '16000',
+    '-c',
+    '1',
+    '-b',
+    '16',
+    '-t',
+    'raw',
+    '-e',
+    'signed-integer',
+    '-L',
+    '-',
+  ];
+  if (IS_WINDOWS) {
+    return { bin: 'sox', args: ['-d', ...base, ...extra] };
+  }
+  return { bin: 'rec', args: [...base, ...extra] };
+}
+
+/** Format elapsed seconds as m:ss. */
+function mmss(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Record from the microphone, streaming raw PCM through the VU meter.
+ * Stops on SIGINT or Enter keypress (TTY only).
+ * Writes a valid WAV file to `wavPath` on completion.
+ *
+ * In `--stream` mode, sox silence args cause sox to exit automatically —
+ * no Enter/SIGINT needed per segment.
+ */
+export function recordWithMeter(
+  wavPath: string,
+  opts: {
+    silenceArgs?: string[]; // if set, appended to rec args for VAD
+    label?: string; // e.g. "Recording..." or "Listening..."
+    noClipboard?: boolean;
+  } = {},
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const { bin, args } = recArgs(opts.silenceArgs ?? []);
+    const rec = spawn(bin, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+
+    const chunks: Buffer[] = [];
+    const history: string[] = Array(METER_WIDTH).fill(BAR_CHARS[0]);
+    const isTTY = process.stdout.isTTY;
+    const startTime = Date.now();
+    let stopped = false;
+    let meterInterval: ReturnType<typeof setInterval> | null = null;
+
+    const label = opts.label ?? 'Recording… (Enter to stop)';
+
+    const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      if (meterInterval) clearInterval(meterInterval);
+      if (isTTY) {
+        process.stdout.write('\r' + ' '.repeat(60) + '\r');
+        try {
+          process.stdin.setRawMode(false);
+          process.stdin.pause();
+        } catch {
+          /* non-TTY or already paused */
+        }
+      }
+      if (rec.pid) killProcess(rec.pid);
+    };
+
+    // Stdin keypress (TTY only)
+    if (isTTY && !opts.silenceArgs) {
+      try {
+        process.stdin.setRawMode(true);
+        process.stdin.resume();
+        process.stdin.setEncoding('utf8');
+        process.stdin.once('data', (key: string) => {
+          // Ctrl+C (0x03) or Enter (\r / \n)
+          if (key === '\u0003') {
+            stop();
+            process.exit(0);
+          }
+          stop();
+        });
+      } catch {
+        /* stdin not controllable */
+      }
+    }
+
+    // SIGINT handler for this recording session
+    const onSigint = () => {
+      stop();
+      // In stream mode, reject so the outer loop can exit
+      reject(new Error('SIGINT'));
+    };
+    process.once('SIGINT', onSigint);
+
+    rec.stdout.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+      const rms = computeRms(chunk);
+      history.shift();
+      history.push(renderBar(rms));
+
+      if (isTTY) {
+        const elapsed = Math.floor((Date.now() - startTime) / 1000);
+        process.stdout.write(
+          `\r  ${history.join('')}  ${mmss(elapsed)}  ${label}  `,
+        );
+      }
+    });
+
+    // Periodic elapsed update even when silent
+    if (isTTY && !opts.silenceArgs) {
+      meterInterval = setInterval(() => {
+        const elapsed = Math.floor((Date.now() - startTime) / 1000);
+        process.stdout.write(
+          `\r  ${history.join('')}  ${mmss(elapsed)}  ${label}  `,
+        );
+      }, 200);
+    }
+
+    rec.once('close', () => {
+      process.removeListener('SIGINT', onSigint);
+      if (!stopped) stop();
+
+      const pcm = Buffer.concat(chunks);
+      const minBytes = 16000; // ~0.5 s at 16kHz s16 mono
+
+      if (pcm.length < minBytes) {
+        reject(new Error('Recording too short (< 0.5 s). Try again.'));
+        return;
+      }
+
+      const header = buildWavHeader(pcm.length);
+      fs.writeFileSync(wavPath, Buffer.concat([header, pcm]));
+      resolve();
+    });
+
+    rec.once('error', (err) => {
+      process.removeListener('SIGINT', onSigint);
+      reject(new Error(`sox failed to start: ${err.message}`));
+    });
+  });
+}
+
+// ── Single-shot mode (Phase 2) ────────────────────────────────────────────
+
+async function runSingleShot(opts: {
+  lang: string;
+  noClipboard: boolean;
+  modelPath: string;
+}): Promise<void> {
+  const wavPath = path.join(os.tmpdir(), `deus-voice-${Date.now()}.wav`);
+  console.log('\n  Recording… (press Enter or Ctrl+C to stop)\n');
+
+  try {
+    await recordWithMeter(wavPath);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`\n  ${msg}`);
+    process.exit(1);
+  }
+
+  console.log('\n  Transcribing…\n');
+
+  let text: string;
+  try {
+    text = await transcribeFile(wavPath, {
+      language: opts.lang,
+      model: opts.modelPath,
+    });
+  } catch (err: unknown) {
+    if (err instanceof TranscriptionError) {
+      console.error(`  ${err.message}`);
+    } else {
+      console.error('  Transcription failed unexpectedly.');
+    }
+    process.exit(1);
+  } finally {
+    fs.rmSync(wavPath, { force: true });
+  }
+
+  if (!text) {
+    console.error(
+      '  Could not transcribe audio. Try speaking louder or longer.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`  ${text}\n`);
+
+  if (!opts.noClipboard) {
+    const ok = await copyToClipboard(text);
+    console.log(
+      ok
+        ? '  Copied to clipboard. Paste with Cmd+V / Ctrl+V.\n'
+        : '  (clipboard not available)\n',
+    );
+  }
+}
+
+// ── Stream mode (Phase 3) ─────────────────────────────────────────────────
+
+async function runStream(opts: {
+  lang: string;
+  noClipboard: boolean;
+  modelPath: string;
+  maxSilence: number;
+  threshold: number;
+}): Promise<void> {
+  const { maxSilence, threshold } = opts;
+
+  // sox silence effect args: start on first speech, stop after maxSilence of quiet
+  const silenceArgs = [
+    'silence',
+    '1',
+    '0.1',
+    `${threshold}%`, // leading: start after 0.1s above threshold%
+    '1',
+    String(maxSilence),
+    `${threshold}%`, // trailing: stop after maxSilence below threshold%
+  ];
+
+  console.log('\n  Streaming… (speak naturally, Ctrl+C to exit)\n');
+
+  let segmentIndex = 0;
+
+  while (true) {
+    const wavPath = path.join(
+      os.tmpdir(),
+      `deus-voice-${Date.now()}-${segmentIndex}.wav`,
+    );
+
+    process.stdout.write(
+      `  ${Array(METER_WIDTH).fill(BAR_CHARS[0]).join('')}  Listening…  `,
+    );
+
+    try {
+      await recordWithMeter(wavPath, {
+        silenceArgs,
+        label: 'Recording…',
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg === 'SIGINT') break;
+      // Too short / no speech — loop
+      fs.rmSync(wavPath, { force: true });
+      continue;
+    }
+
+    process.stdout.write('\r  Transcribing…' + ' '.repeat(40) + '\r');
+
+    let text = '';
+    try {
+      text = await transcribeFile(wavPath, {
+        language: opts.lang,
+        model: opts.modelPath,
+      });
+    } catch {
+      process.stdout.write('\r  (transcription failed, continuing…)\n');
+    } finally {
+      fs.rmSync(wavPath, { force: true });
+    }
+
+    if (text) {
+      process.stdout.write(`\r  ${text}\n`);
+      if (!opts.noClipboard) {
+        await appendClipboard(text).catch(() => {});
+      }
+    }
+
+    segmentIndex++;
+  }
+
+  console.log('\n  Stopped.\n');
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────
+
+interface CliArgs {
+  stream: boolean;
+  lang: string;
+  noClipboard: boolean;
+  maxSilence: number;
+  threshold: number;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    stream: false,
+    lang: process.env.WHISPER_LANG ?? 'en',
+    noClipboard: process.env.DEUS_LISTEN_NO_CLIPBOARD === '1',
+    maxSilence: 1.5,
+    threshold: 3,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--stream':
+        args.stream = true;
+        break;
+      case '--no-clipboard':
+        args.noClipboard = true;
+        break;
+      case '--lang':
+        args.lang = argv[++i] ?? args.lang;
+        break;
+      case '--max-silence':
+        args.maxSilence = parseFloat(argv[++i] ?? '1.5');
+        break;
+      case '--threshold':
+        args.threshold = parseFloat(argv[++i] ?? '3');
+        break;
+    }
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const deps = IS_WINDOWS ? ['sox'] : ['sox', 'rec'];
+  await checkDeps(deps);
+
+  const modelPath = resolveDefaultModelPath();
+  await ensureWhisperModel(modelPath);
+
+  if (args.stream) {
+    await runStream({
+      lang: args.lang,
+      noClipboard: args.noClipboard,
+      modelPath,
+      maxSilence: args.maxSilence,
+      threshold: args.threshold,
+    });
+  } else {
+    await runSingleShot({
+      lang: args.lang,
+      noClipboard: args.noClipboard,
+      modelPath,
+    });
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/evolution-client.ts
+++ b/src/evolution-client.ts
@@ -29,6 +29,7 @@ export interface LogInteractionParams {
   domainPresets?: string[];
   userSignal?: string;
   retrievedReflectionIds?: string[];
+  contextTokens?: number;
 }
 
 export interface ReflectionsResult {
@@ -84,6 +85,7 @@ export function logInteraction(params: LogInteractionParams): void {
     domain_presets: params.domainPresets ?? [],
     user_signal: params.userSignal ?? null,
     retrieved_reflection_ids: params.retrievedReflectionIds ?? [],
+    context_tokens: params.contextTokens ?? null,
   });
 
   // Spawn detached so it survives even if the host process exits quickly

--- a/src/token-counter.test.ts
+++ b/src/token-counter.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTokens, sumTokens } from './token-counter.js';
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('returns floor(length / 4)', () => {
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abc')).toBe(0); // floor(3/4) = 0
+    expect(estimateTokens('abcde')).toBe(1); // floor(5/4) = 1
+  });
+
+  it('handles longer strings', () => {
+    expect(estimateTokens('a'.repeat(100))).toBe(25);
+  });
+
+  it('handles unicode characters', () => {
+    // len('שלום') = 4 chars → 1 token
+    expect(estimateTokens('שלום')).toBe(1);
+  });
+});
+
+describe('sumTokens', () => {
+  it('returns 0 with no arguments', () => {
+    expect(sumTokens()).toBe(0);
+  });
+
+  it('sums a single part', () => {
+    expect(sumTokens('abcd')).toBe(1);
+  });
+
+  it('sums multiple parts', () => {
+    // 'aaaa' = 1, 'bbbbbbbb' = 2
+    expect(sumTokens('aaaa', 'bbbbbbbb')).toBe(3);
+  });
+
+  it('handles empty parts', () => {
+    expect(sumTokens('abcd', '', 'efgh')).toBe(2);
+  });
+});

--- a/src/token-counter.ts
+++ b/src/token-counter.ts
@@ -1,0 +1,14 @@
+/**
+ * Token estimation for the evolution loop.
+ *
+ * Uses a simple heuristic (Math.floor(text.length / 4)) — symmetric with
+ * evolution/token_counter.py. Not tiktoken-accurate; for trend tracking only.
+ */
+
+export function estimateTokens(text: string): number {
+  return Math.floor(text.length / 4);
+}
+
+export function sumTokens(...parts: string[]): number {
+  return parts.reduce((acc, p) => acc + estimateTokens(p), 0);
+}

--- a/src/transcription.test.ts
+++ b/src/transcription.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, execFile: vi.fn() };
+});
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./platform.js', () => ({
+  IS_MACOS: true,
+  IS_LINUX: false,
+  IS_WINDOWS: false,
+}));
+
+import { execFile } from 'child_process';
+import fs from 'fs';
+import {
+  transcribeFile,
+  resolveDefaultModelPath,
+  depInstallHint,
+  TranscriptionError,
+} from './transcription.js';
+
+const mockExecFile = vi.mocked(execFile);
+
+function makeExecFileCallback(
+  stdout: string,
+  stderr = '',
+  error: Error | null = null,
+) {
+  return (
+    _bin: string,
+    _args: string[],
+    callback: (...args: unknown[]) => void,
+  ) => {
+    callback(error, { stdout, stderr });
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveDefaultModelPath', () => {
+  it('returns WHISPER_MODEL env var when set', () => {
+    const orig = process.env.WHISPER_MODEL;
+    process.env.WHISPER_MODEL = '/custom/model.bin';
+    expect(resolveDefaultModelPath()).toBe('/custom/model.bin');
+    process.env.WHISPER_MODEL = orig;
+  });
+
+  it('returns a path ending with ggml-base.bin by default', () => {
+    const orig = process.env.WHISPER_MODEL;
+    delete process.env.WHISPER_MODEL;
+    expect(resolveDefaultModelPath()).toMatch(/ggml-base\.bin$/);
+    process.env.WHISPER_MODEL = orig;
+  });
+});
+
+describe('transcribeFile', () => {
+  it('returns trimmed transcript from whisper stdout', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('  Hello, world.\n\n') as any,
+    );
+    const result = await transcribeFile('/tmp/test.wav');
+    expect(result).toBe('Hello, world.');
+  });
+
+  it('joins multiple non-empty lines with a space', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('  line one\n  line two\n') as any,
+    );
+    const result = await transcribeFile('/tmp/test.wav');
+    expect(result).toBe('line one line two');
+  });
+
+  it('returns empty string when stdout is blank', async () => {
+    mockExecFile.mockImplementationOnce(makeExecFileCallback('   \n\n') as any);
+    const result = await transcribeFile('/tmp/test.wav');
+    expect(result).toBe('');
+  });
+
+  it('throws TranscriptionError on whisper failure', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('', '', new Error('spawn error')) as any,
+    );
+    await expect(transcribeFile('/tmp/test.wav')).rejects.toBeInstanceOf(
+      TranscriptionError,
+    );
+  });
+
+  it('uses opts.language and opts.bin when provided', async () => {
+    mockExecFile.mockImplementationOnce(
+      makeExecFileCallback('שלום עולם') as any,
+    );
+    await transcribeFile('/tmp/test.wav', {
+      language: 'he',
+      bin: 'my-whisper',
+      model: '/m.bin',
+    });
+    const call = mockExecFile.mock.calls[0];
+    expect(call[0]).toBe('my-whisper');
+    expect(call[1]).toContain('-l');
+    expect(call[1]).toContain('he');
+    expect(call[1]).toContain('/m.bin');
+  });
+});
+
+describe('depInstallHint', () => {
+  it('returns brew command on macOS', () => {
+    expect(depInstallHint('sox')).toContain('brew');
+    expect(depInstallHint('whisper-cli')).toContain('brew');
+  });
+});

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared transcription module — whisper.cpp wrapper.
+ *
+ * Used by `deus listen` and available to voice-note skills
+ * (add-voice-transcription, use-local-whisper).
+ *
+ * All config comes from env vars; callers can override via TranscribeOptions.
+ */
+
+import { execFile } from 'child_process';
+import { createWriteStream } from 'fs';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+
+import { IS_MACOS, IS_LINUX } from './platform.js';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+const MODEL_URL =
+  'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface TranscribeOptions {
+  /** BCP-47 language code, e.g. 'en', 'he'. Default: WHISPER_LANG env || 'en'. */
+  language?: string;
+  /** Absolute path to ggml model file. Default: WHISPER_MODEL env || project default. */
+  model?: string;
+  /** whisper-cli binary name. Default: WHISPER_BIN env || 'whisper-cli'. */
+  bin?: string;
+}
+
+export class TranscriptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TranscriptionError';
+  }
+}
+
+// ── Path resolution ────────────────────────────────────────────────────────
+
+export function resolveDefaultModelPath(): string {
+  return (
+    process.env.WHISPER_MODEL ||
+    path.join(PROJECT_ROOT, 'data', 'models', 'ggml-base.bin')
+  );
+}
+
+// ── Model bootstrap ────────────────────────────────────────────────────────
+
+/** Download ggml-base.bin on first use. No-op if the file already exists. */
+export async function ensureWhisperModel(modelPath: string): Promise<void> {
+  if (fs.existsSync(modelPath)) return;
+  const dir = path.dirname(modelPath);
+  fs.mkdirSync(dir, { recursive: true });
+  console.log(
+    '  Whisper model not found. Downloading ggml-base.bin (148 MB)...',
+  );
+  const res = await fetch(MODEL_URL);
+  if (!res.ok || !res.body) {
+    throw new TranscriptionError(
+      `Failed to download model: HTTP ${res.status}`,
+    );
+  }
+  await pipeline(
+    res.body as unknown as NodeJS.ReadableStream,
+    createWriteStream(modelPath),
+  );
+  console.log('  Download complete.\n');
+}
+
+// ── Transcription ──────────────────────────────────────────────────────────
+
+/**
+ * Transcribe a WAV file using whisper-cli.
+ * Returns trimmed transcript text, or empty string if nothing was heard.
+ */
+export async function transcribeFile(
+  wavPath: string,
+  opts?: TranscribeOptions,
+): Promise<string> {
+  const bin = opts?.bin ?? process.env.WHISPER_BIN ?? 'whisper-cli';
+  const model = opts?.model ?? resolveDefaultModelPath();
+  const lang = opts?.language ?? process.env.WHISPER_LANG ?? 'en';
+
+  const { stdout } = await execFileAsync(bin, [
+    '-m',
+    model,
+    '-f',
+    wavPath,
+    '--no-timestamps',
+    '-nt',
+    '-l',
+    lang,
+  ]).catch((err: Error & { stderr?: string }) => {
+    throw new TranscriptionError(
+      `Transcription failed: ${err.message}${err.stderr ? '\n' + err.stderr : ''}`,
+    );
+  });
+
+  return stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+// ── Dep hints ─────────────────────────────────────────────────────────────
+
+/** Returns a user-facing install hint for a missing dependency. */
+export function depInstallHint(dep: string): string {
+  const isSox = dep === 'sox';
+  const isWhisper = dep === 'whisper-cli';
+  if (IS_MACOS) {
+    if (isWhisper) return 'brew install whisper-cpp';
+    if (isSox) return 'brew install sox';
+    return `brew install ${dep}`;
+  }
+  if (IS_LINUX) {
+    if (isWhisper)
+      return '# Build whisper-cpp from source: https://github.com/ggerganov/whisper.cpp';
+    return `sudo apt install ${isSox ? 'sox libsox-fmt-all' : dep}`;
+  }
+  // Windows
+  if (isWhisper)
+    return '# Download whisper-cpp: https://github.com/ggerganov/whisper.cpp/releases';
+  return `choco install ${isSox ? 'sox.portable' : dep}`;
+}


### PR DESCRIPTION
## Summary

- **Routing system** (`.mex/ROUTER.md` + `patterns/`): 8 distilled pattern files map task types to only the rules that apply — 27–72% fewer context tokens per task vs loading full docs up-front
- **`context_tokens` column**: additive SQLite migration tracks estimated prompt tokens per interaction; `evolution status --tokens` shows a daily avg trend
- **`drift_check.py`** (`npm run drift-check`): compares pattern file mtimes against governed source files — exits 0 (clean), 1 (drifted), 2 (missing)

## Token savings (estimated from Phase 0 baseline)

| Task type | Before | After | Reduction |
|---|---|---|---|
| cross-platform | ~2,740 | ~770 | 72% |
| deployment | ~2,250 | ~800 | 64% |
| channel-add | ~1,040 | ~720 | 31% |
| eval-change | ~1,110 | ~810 | 27% |

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 667 tests pass (8 new: `src/token-counter.test.ts`)
- [x] `python3 -m pytest scripts/tests/test_token_counter.py -v` — 8 tests pass
- [x] `python3 -m evolution.cli status` — existing output unchanged
- [x] `python3 -m evolution.cli status --tokens` — new section renders (empty until runtime data, no crash)
- [x] `npm run drift-check` — exit 0 on clean tree
- [x] `wc -l CLAUDE.md` — 47 lines (≤ 50 constraint met)
- [ ] Phase 4: benchmark 5 targeted eval interactions after merge (token column will be populated from first real container run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)