### PR TITLE
chore(patterns): update drifted patterns

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-09"
+last_verified: "2026-04-12"
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"
@@ -57,7 +57,7 @@ docker builder prune -f && ./container/build.sh
 
 ## Credentials rule
 
-Never write rotating credentials (OAuth tokens, short-lived session keys) to `.env`. Read them dynamically at request time from their source file (e.g., `~/.claude/.credentials.json`). `.env` is for **static, long-lived secrets only** (API keys, bot tokens like `TELEGRAM_BOT_TOKEN`, model names).
+Never write rotating credentials (OAuth tokens, short-lived session keys) to `.env`. Read them dynamically at request time from the OS credential store (macOS Keychain, Linux libsecret, Windows Credential Manager) with `~/.claude/.credentials.json` as fallback. `.env` is for **static, long-lived secrets only** (API keys, bot tokens like `TELEGRAM_BOT_TOKEN`, model names).
 
 ## Config file locations
 
@@ -68,7 +68,7 @@ Different components read config from different locations. Getting this wrong ca
 | Main process (`src/`) + evolution layer | Project root `.env` |
 | Setup / startup gate | `~/.config/deus/.env` |
 | Memory indexer | `~/.config/deus/.env` |
-| Credential proxy | `~/.claude/.credentials.json` (dynamic read — never `.env`) |
+| Credential proxy | OS credential store → `~/.claude/.credentials.json` fallback (dynamic — never `.env`) |
 
 **Common mistake:** Putting a key in `~/.config/deus/.env` but expecting the main process or evolution layer to find it — both read from the project root `.env`.
 

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-09"
+last_verified: "2026-04-12"
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-04-09"
+last_verified: "2026-04-12"
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Bump `last_verified` to 2026-04-12 on `skill-add.md`, `deployment.md`, `general-code.md`
- Update `deployment.md` credentials rule and config table to reflect OS credential store as primary source

Fixes the pattern drift CI check failure (3 patterns flagged as drifted since 2026-04-09).

## Test plan
- [ ] CI pattern drift check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)