### PR TITLE
feat(memory): per-channel privacy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Every production interaction is scored by a local judge (Ollama or Gemini). Low 
 - **Container isolation** — Every agent runs in a Linux container (Docker). Agents cannot access your host filesystem beyond explicitly mounted directories.
 - **No credentials in code** — All secrets live in `.env` files that are gitignored. The codebase is designed as if the repo is always public.
 - **Mount allowlist** — Only directories you explicitly configure are visible to the agent. Everything else is inaccessible.
+- **Per-channel privacy** — Each channel (WhatsApp, Telegram, etc.) can be configured with its own memory privacy allowlist. Sensitive data is excluded by default; configure via `/settings memory_privacy=public,internal,private` per group.
 - **Local-first** — Memory lives in a local SQLite database. Voice transcription runs on-device. No data is sent to external services unless you configure it.
 
 ---

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-04-09"
+last_verified: "2026-04-16"
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-12"
+last_verified: "2026-04-17"
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-15"
+last_verified: "2026-04-17"
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-12"
+last_verified: "2026-04-17"
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -873,7 +873,8 @@ def _rrf_fuse(
 def cmd_query(query: str, top: int = 3, recency_boost: bool = False,
               show_source: bool = False, domain: str | None = None,
               intent: str | None = None, as_of: str | None = None,
-              privacy: str | None = None):
+              privacy: str | None = None,
+              allowed_privacy: list[str] | None = None):
     db = open_db()
 
     # Check if anything is indexed
@@ -918,7 +919,10 @@ def cmd_query(query: str, top: int = 3, recency_boost: bool = False,
     # Partition into atoms and sessions; deduplicate sessions by path
     atom_results: list[dict] = []
     seen: dict[str, dict] = {}
-    sensitive_filtered = 0  # track how many sensitive atoms were blocked
+    privacy_filtered = 0  # track how many sensitive atoms were blocked
+
+    # Resolve effective privacy allowlist once (not per-atom)
+    effective_allowlist = _resolve_privacy_allowlist(allowed_privacy)
 
     for path, date, tldr, topics, decisions, chunk_type, confidence, corroborations, dist, source_chunk in rows:
         if chunk_type == "atom":
@@ -929,18 +933,22 @@ def cmd_query(query: str, top: int = 3, recency_boost: bool = False,
                 ).fetchone()
                 if entry_domain and entry_domain[0] != domain:
                     continue
-            # Apply privacy filter: exclude sensitive by default
+            # Apply privacy filter
             entry_privacy = db.execute(
                 "SELECT privacy FROM entries WHERE path = ? LIMIT 1", [path]
             ).fetchone()
             atom_privacy = entry_privacy[0] if entry_privacy else "internal"
-            if privacy:
-                # Explicit filter: show only this level
+            if effective_allowlist:
+                if atom_privacy not in effective_allowlist:
+                    privacy_filtered += 1
+                    continue
+            elif privacy:
+                # Legacy single-level filter: show only this level
                 if atom_privacy != privacy:
                     continue
             elif atom_privacy == "sensitive":
                 # Default: exclude sensitive
-                sensitive_filtered += 1
+                privacy_filtered += 1
                 continue
             # Temperature: used for ranking, not exclusion.
             # Cold atoms rank lower but are never fully hidden.
@@ -1068,14 +1076,21 @@ def cmd_query(query: str, top: int = 3, recency_boost: bool = False,
         except sqlite3.OperationalError:
             pass
 
-    # Notify when sensitive atoms were filtered
-    if sensitive_filtered > 0:
+    # Notify when atoms were filtered by privacy
+    if privacy_filtered > 0:
         lines.append("")
-        lines.append(
-            f"({sensitive_filtered} result(s) blocked by privacy filter — "
-            f"sensitive atoms are excluded by default. "
-            f"Use --privacy sensitive to query them explicitly.)"
-        )
+        if effective_allowlist:
+            lines.append(
+                f"({privacy_filtered} result(s) blocked by channel privacy policy — "
+                f"this channel can only access: {', '.join(effective_allowlist)}. "
+                f"Change channel privacy via /settings memory_privacy=level1,level2)"
+            )
+        else:
+            lines.append(
+                f"({privacy_filtered} result(s) blocked by privacy filter — "
+                f"sensitive atoms are excluded by default. "
+                f"Use --privacy sensitive to query them explicitly.)"
+            )
 
     print("\n".join(lines))
 
@@ -1992,6 +2007,35 @@ def cmd_decay(dry_run: bool = False):
     db.close()
 
 
+VALID_PRIVACY_LEVELS = {"public", "internal", "private", "sensitive"}
+
+
+def _resolve_privacy_allowlist(explicit: list[str] | None = None) -> list[str] | None:
+    """Resolve the effective privacy allowlist from explicit arg or env var.
+
+    Priority: explicit arg > DEUS_MEMORY_PRIVACY env var > None (caller uses default).
+    Invalid levels are silently stripped. Empty result returns None.
+
+    Note: DEUS_MEMORY_PRIVACY is injected by container-runner from validated
+    /settings config. A container agent with shell access could unset it,
+    falling back to the default (exclude sensitive only). This is acceptable
+    given the semi-trusted agent threat model.
+    """
+    if explicit:
+        return [p for p in explicit if p in VALID_PRIVACY_LEVELS] or None
+    raw = os.environ.get("DEUS_MEMORY_PRIVACY", "")
+    levels = [p.strip() for p in raw.split(",") if p.strip()]
+    validated = [p for p in levels if p in VALID_PRIVACY_LEVELS]
+    return validated or None
+
+
+def _parse_allowed_privacy_arg(raw: str | None) -> list[str] | None:
+    """Parse --allowed-privacy CLI value into a validated list."""
+    if not raw:
+        return None
+    return [p.strip() for p in raw.split(",") if p.strip()] or None
+
+
 PRIVACY_KEYWORDS: dict[str, list[str]] = {
     "sensitive": ["password", "token", "secret", "api_key", "credential", "ssn",
                   "credit card", "bank account", "social security", "trade", "stock",
@@ -2209,7 +2253,7 @@ def cmd_blind_spots(top: int = 10):
 def cmd_export(output_path: str, privacy_levels: list[str] | None = None):
     """Export atoms filtered by privacy to standalone markdown."""
     db = open_db()
-    levels = privacy_levels or ["public", "internal"]
+    levels = _resolve_privacy_allowlist(privacy_levels) or ["public", "internal"]
 
     placeholders = ",".join("?" * len(levels))
     atoms = db.execute(
@@ -2962,9 +3006,13 @@ def main():
                         help="Override auto-detected query intent for --query")
     parser.add_argument("--privacy",
                         choices=["public", "internal", "private", "sensitive"],
-                        help="Filter --query/--export by privacy level. "
+                        help="Filter --query/--export by single privacy level. "
                              "Sensitive atoms are excluded from --query by default; "
                              "pass --privacy sensitive to see only sensitive atoms.")
+    parser.add_argument("--allowed-privacy",
+                        help="Comma-separated allowlist of privacy levels for --query "
+                             "(e.g. public,internal,private). Overrides --privacy. "
+                             "Also reads from DEUS_MEMORY_PRIVACY env var.")
     args = parser.parse_args()
 
     global _client
@@ -3000,7 +3048,8 @@ def main():
         cmd_blind_spots(top=args.top)
         return
     if args.export:
-        cmd_export(args.export, privacy_levels=[args.privacy] if args.privacy else None)
+        ap = _parse_allowed_privacy_arg(args.allowed_privacy)
+        cmd_export(args.export, privacy_levels=ap or ([args.privacy] if args.privacy else None))
         return
 
     _client = genai.Client(api_key=load_api_key())
@@ -3018,9 +3067,11 @@ def main():
     if args.add:
         cmd_add(args.add, extract=not args.no_extract)
     elif args.query:
+        ap = _parse_allowed_privacy_arg(args.allowed_privacy)
         cmd_query(args.query, top=args.top, recency_boost=args.recency_boost,
                   show_source=args.source, domain=args.domain,
-                  intent=args.intent, as_of=args.as_of, privacy=args.privacy)
+                  intent=args.intent, as_of=args.as_of, privacy=args.privacy,
+                  allowed_privacy=ap)
     elif args.rebuild:
         cmd_rebuild()
     elif args.extract:

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -3266,3 +3266,217 @@ def test_export_default_excludes_sensitive_and_private(mi, tmp_path):
     assert "public study fact" in content
     assert "sensitive trading secret" not in content
     assert "private family fact" not in content
+
+
+# ── Channel privacy: --allowed-privacy and DEUS_MEMORY_PRIVACY ───────────────
+
+
+def test_allowed_privacy_filters_to_allowlist(mi, capsys):
+    """--allowed-privacy should only show atoms in the allowlist."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    mi.cmd_query("fact secret", top=10, allowed_privacy=["public", "internal"])
+    out = capsys.readouterr().out
+    assert "public study fact" in out or "internal dev fact" in out
+    assert "private family fact" not in out
+    assert "sensitive trading secret" not in out
+
+
+def test_allowed_privacy_includes_sensitive_when_listed(mi, capsys):
+    """If sensitive is in the allowlist, it should appear."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    mi.cmd_query("sensitive trading secret", top=10, allowed_privacy=["sensitive"])
+    out = capsys.readouterr().out
+    assert "sensitive trading secret" in out
+    assert "public study fact" not in out
+
+
+def test_allowed_privacy_env_fallback(mi, capsys, monkeypatch):
+    """DEUS_MEMORY_PRIVACY env var should act as fallback for --allowed-privacy."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", "public,internal")
+    mi.cmd_query("fact secret", top=10)
+    out = capsys.readouterr().out
+    assert "private family fact" not in out
+    assert "sensitive trading secret" not in out
+
+
+def test_allowed_privacy_overrides_env(mi, capsys, monkeypatch):
+    """Explicit --allowed-privacy should override DEUS_MEMORY_PRIVACY env."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", "public")
+    # Explicit allowlist includes private, env says only public
+    mi.cmd_query("private family fact", top=10, allowed_privacy=["public", "internal", "private"])
+    out = capsys.readouterr().out
+    assert "private family fact" in out
+
+
+def test_allowed_privacy_blocked_notice_shows_channel_message(mi, capsys):
+    """When atoms are blocked by allowlist, notice should mention channel policy."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    mi.cmd_query("sensitive trading secret", top=10, allowed_privacy=["public", "internal"])
+    out = capsys.readouterr().out
+    assert "blocked by channel privacy policy" in out
+    assert "/settings memory_privacy" in out
+
+
+def test_allowed_privacy_no_blocked_notice_when_all_allowed(mi, capsys):
+    """No blocked notice when all privacy levels are in the allowlist."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    mi.cmd_query("fact", top=10, allowed_privacy=["public", "internal", "private", "sensitive"])
+    out = capsys.readouterr().out
+    assert "blocked" not in out
+
+
+def test_export_uses_env_var_privacy(mi, tmp_path, monkeypatch):
+    """cmd_export should respect DEUS_MEMORY_PRIVACY env var."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", "public,internal,private")
+    out_path = tmp_path / "export.md"
+    mi.cmd_export(str(out_path))
+    content = out_path.read_text()
+    assert "private family fact" in content
+    assert "sensitive trading secret" not in content
+
+
+def test_export_explicit_overrides_env(mi, tmp_path, monkeypatch):
+    """Explicit privacy_levels should override DEUS_MEMORY_PRIVACY env."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", "public,internal,private,sensitive")
+    out_path = tmp_path / "export.md"
+    mi.cmd_export(str(out_path), privacy_levels=["public"])
+    content = out_path.read_text()
+    assert "public study fact" in content
+    assert "internal dev fact" not in content
+    assert "sensitive trading secret" not in content
+
+
+def test_allowed_privacy_takes_precedence_over_legacy_privacy(mi, capsys):
+    """When both --allowed-privacy and --privacy are given, allowlist wins."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    # --privacy=sensitive would normally show ONLY sensitive
+    # --allowed-privacy=public,internal should override that
+    mi.cmd_query("fact", top=10, privacy="sensitive", allowed_privacy=["public", "internal"])
+    out = capsys.readouterr().out
+    assert "sensitive trading secret" not in out
+    # Allowlist should filter, not the legacy flag
+    assert "private family fact" not in out
+
+
+def test_empty_env_var_falls_through_to_default(mi, capsys, monkeypatch):
+    """DEUS_MEMORY_PRIVACY='' should behave like no env var (default filtering)."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", "")
+    mi.cmd_query("sensitive trading secret", top=10)
+    out = capsys.readouterr().out
+    # Default behavior: sensitive excluded, blocked notice shown
+    assert "sensitive trading secret" not in out
+    assert "blocked by privacy filter" in out
+
+
+def test_allowed_privacy_with_no_matching_atoms(mi, capsys):
+    """Allowlist with levels that have no atoms should return empty gracefully."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    # Only seed has public/internal/private/sensitive — query with allowlist
+    # that excludes everything the query matches
+    mi.cmd_query("sensitive trading secret", top=10, allowed_privacy=["public"])
+    out = capsys.readouterr().out
+    assert "sensitive trading secret" not in out
+    assert "blocked by channel privacy policy" in out
+
+
+def test_new_channel_gets_safe_default(mi, capsys):
+    """Without any privacy config (new channel), sensitive is excluded by default."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    # No allowed_privacy, no env var, no --privacy → default excludes sensitive
+    mi.cmd_query("fact secret", top=10)
+    out = capsys.readouterr().out
+    assert "sensitive trading secret" not in out
+    assert "public study fact" in out or "internal dev fact" in out or "private family fact" in out
+
+
+def test_commas_only_env_var_falls_through_to_default(mi, capsys, monkeypatch):
+    """DEUS_MEMORY_PRIVACY=',,,' should behave like no env var."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", ",,,")
+    mi.cmd_query("sensitive trading secret", top=10)
+    out = capsys.readouterr().out
+    assert "sensitive trading secret" not in out
+    assert "blocked by privacy filter" in out
+
+
+def test_invalid_levels_in_env_var_stripped(mi, capsys, monkeypatch):
+    """Invalid privacy levels in DEUS_MEMORY_PRIVACY should be silently stripped."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    monkeypatch.setenv("DEUS_MEMORY_PRIVACY", "public,bogus,internal")
+    mi.cmd_query("fact", top=10)
+    out = capsys.readouterr().out
+    # 'bogus' is stripped; only public and internal are allowed
+    assert "private family fact" not in out
+    assert "sensitive trading secret" not in out
+
+
+def test_export_respects_allowed_privacy_arg(mi, tmp_path):
+    """cmd_export should respect explicit privacy_levels allowlist."""
+    db = mi.open_db()
+    _seed_privacy_atoms(db, mi)
+    db.close()
+
+    out_path = tmp_path / "export.md"
+    mi.cmd_export(str(out_path), privacy_levels=["public", "internal", "private"])
+    content = out_path.read_text()
+    assert "private family fact" in content
+    assert "sensitive trading secret" not in content
+
+
+def test_resolve_privacy_allowlist_validates(mi):
+    """_resolve_privacy_allowlist should strip invalid levels."""
+    result = mi._resolve_privacy_allowlist(["public", "bogus", "internal"])
+    assert result == ["public", "internal"]
+
+
+def test_resolve_privacy_allowlist_all_invalid_returns_none(mi):
+    """_resolve_privacy_allowlist with all-invalid input returns None."""
+    result = mi._resolve_privacy_allowlist(["bogus", "fake"])
+    assert result is None

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -60,11 +60,17 @@ export interface ContainerOutput {
 function buildContainerArgs(
   mounts: ReturnType<typeof buildVolumeMounts>,
   containerName: string,
+  group?: RegisteredGroup,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Inject per-channel memory privacy allowlist if configured
+  if (group?.containerConfig?.memoryPrivacy?.length) {
+    args.push('-e', `DEUS_MEMORY_PRIVACY=${group.containerConfig.memoryPrivacy.join(',')}`);
+  }
 
   // Route API traffic through the credential proxy (containers never see real secrets)
   args.push(
@@ -158,7 +164,7 @@ export async function runContainerAgent(
   const mounts = buildVolumeMounts(group, input.isControlGroup);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `deus-${safeName}-${Date.now()}`;
-  const containerArgs = buildContainerArgs(mounts, containerName);
+  const containerArgs = buildContainerArgs(mounts, containerName, group);
 
   logger.debug(
     {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -69,7 +69,10 @@ function buildContainerArgs(
 
   // Inject per-channel memory privacy allowlist if configured
   if (group?.containerConfig?.memoryPrivacy?.length) {
-    args.push('-e', `DEUS_MEMORY_PRIVACY=${group.containerConfig.memoryPrivacy.join(',')}`);
+    args.push(
+      '-e',
+      `DEUS_MEMORY_PRIVACY=${group.containerConfig.memoryPrivacy.join(',')}`,
+    );
   }
 
   // Route API traffic through the credential proxy (containers never see real secrets)

--- a/src/session-commands.test.ts
+++ b/src/session-commands.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   extractSessionCommand,
   handleSessionCommand,
+  handleSettingsCommand,
   isSessionCommandAllowed,
 } from './session-commands.js';
-import type { NewMessage } from './types.js';
+import type { NewMessage, RegisteredGroup } from './types.js';
 import type { SessionCommandDeps } from './session-commands.js';
 
 describe('extractSessionCommand', () => {
@@ -243,5 +244,114 @@ describe('handleSessionCommand', () => {
     expect(deps.sendMessage).toHaveBeenCalledWith(
       expect.stringContaining('Failed to process'),
     );
+  });
+});
+
+// ── /settings memory_privacy ────────────────────────────────────────────────
+
+function makeGroup(
+  overrides: Partial<RegisteredGroup> = {},
+): RegisteredGroup {
+  return {
+    name: 'test-group',
+    folder: 'test-group',
+    trigger: '@Test',
+    added_at: '2024-01-01',
+    ...overrides,
+  };
+}
+
+describe('handleSettingsCommand — memory_privacy', () => {
+  it('sets valid privacy levels', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand(
+      '/settings memory_privacy=public,internal,private',
+      group,
+      24,
+    );
+    expect(result.response).toBe(
+      'memory_privacy set to public,internal,private',
+    );
+    expect(result.updatedGroup?.containerConfig?.memoryPrivacy).toEqual([
+      'public',
+      'internal',
+      'private',
+    ]);
+  });
+
+  it('rejects invalid privacy levels', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand(
+      '/settings memory_privacy=public,bogus',
+      group,
+      24,
+    );
+    expect(result.response).toContain('Invalid privacy level(s): bogus');
+    expect(result.updatedGroup).toBeUndefined();
+  });
+
+  it('rejects empty value', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand(
+      '/settings memory_privacy=',
+      group,
+      24,
+    );
+    expect(result.response).toContain('Missing value');
+    expect(result.updatedGroup).toBeUndefined();
+  });
+
+  it('includes sensitive when explicitly listed', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand(
+      '/settings memory_privacy=sensitive',
+      group,
+      24,
+    );
+    expect(result.updatedGroup?.containerConfig?.memoryPrivacy).toEqual([
+      'sensitive',
+    ]);
+  });
+
+  it('displays current memory_privacy in settings output', () => {
+    const group = makeGroup({
+      containerConfig: { memoryPrivacy: ['public', 'internal'] },
+    });
+    const result = handleSettingsCommand('/settings', group, 24);
+    expect(result.response).toContain('memory_privacy: public,internal');
+  });
+
+  it('displays default when no memory_privacy configured', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand('/settings', group, 24);
+    expect(result.response).toContain(
+      'memory_privacy: public,internal,private (default)',
+    );
+  });
+
+  it('normalizes to lowercase', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand(
+      '/settings memory_privacy=Public,INTERNAL',
+      group,
+      24,
+    );
+    expect(result.updatedGroup?.containerConfig?.memoryPrivacy).toEqual([
+      'public',
+      'internal',
+    ]);
+  });
+
+  it('deduplicates levels', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand(
+      '/settings memory_privacy=public,public,internal',
+      group,
+      24,
+    );
+    expect(result.updatedGroup?.containerConfig?.memoryPrivacy).toEqual([
+      'public',
+      'internal',
+    ]);
   });
 });

--- a/src/session-commands.test.ts
+++ b/src/session-commands.test.ts
@@ -249,9 +249,7 @@ describe('handleSessionCommand', () => {
 
 // ── /settings memory_privacy ────────────────────────────────────────────────
 
-function makeGroup(
-  overrides: Partial<RegisteredGroup> = {},
-): RegisteredGroup {
+function makeGroup(overrides: Partial<RegisteredGroup> = {}): RegisteredGroup {
   return {
     name: 'test-group',
     folder: 'test-group',

--- a/src/session-commands.ts
+++ b/src/session-commands.ts
@@ -23,11 +23,15 @@ export interface SettingsCommandResult {
   updatedGroup?: RegisteredGroup; // Present when a setting was changed
 }
 
+const VALID_PRIVACY_LEVELS = ['public', 'internal', 'private', 'sensitive'];
+
 const SETTINGS_HELP =
   'Available settings:\n' +
   '  session_idle_hours=N  — reset session after N idle hours (0 = never)\n' +
   '  timeout=N             — container timeout in seconds (min 30)\n' +
-  '  requires_trigger=true/false  — whether @Name prefix is required';
+  '  requires_trigger=true/false  — whether @Name prefix is required\n' +
+  '  memory_privacy=level1,level2  — privacy levels this channel can access\n' +
+  '    levels: public, internal, private, sensitive (default: public,internal,private)';
 
 /**
  * Parse and apply a /settings command.
@@ -55,6 +59,7 @@ export function handleSettingsCommand(
       }`,
       `  timeout: ${timeoutMs !== undefined ? `${Math.round(timeoutMs / 1000)}s` : '300s (default)'}`,
       `  requires_trigger: ${group.requiresTrigger !== false}`,
+      `  memory_privacy: ${group.containerConfig?.memoryPrivacy?.join(',') || 'public,internal,private (default)'}`,
       '',
       SETTINGS_HELP,
     ];
@@ -115,6 +120,26 @@ export function handleSettingsCommand(
       }
       updatedGroup.requiresTrigger = value === 'true';
       return { response: `requires_trigger set to ${value}`, updatedGroup };
+    }
+    case 'memory_privacy': {
+      const levels = [...new Set(value.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean))];
+      const invalid = levels.filter((l) => !VALID_PRIVACY_LEVELS.includes(l));
+      if (invalid.length > 0) {
+        return {
+          response: `Invalid privacy level(s): ${invalid.join(', ')}. Valid: ${VALID_PRIVACY_LEVELS.join(', ')}`,
+        };
+      }
+      if (levels.length === 0) {
+        return { response: 'memory_privacy requires at least one level.' };
+      }
+      updatedGroup.containerConfig = {
+        ...updatedGroup.containerConfig,
+        memoryPrivacy: levels,
+      };
+      return {
+        response: `memory_privacy set to ${levels.join(',')}`,
+        updatedGroup,
+      };
     }
     default:
       return { response: `Unknown setting: ${key}\n\n${SETTINGS_HELP}` };

--- a/src/session-commands.ts
+++ b/src/session-commands.ts
@@ -122,7 +122,14 @@ export function handleSettingsCommand(
       return { response: `requires_trigger set to ${value}`, updatedGroup };
     }
     case 'memory_privacy': {
-      const levels = [...new Set(value.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean))];
+      const levels = [
+        ...new Set(
+          value
+            .split(',')
+            .map((s) => s.trim().toLowerCase())
+            .filter(Boolean),
+        ),
+      ];
       const invalid = levels.filter((l) => !VALID_PRIVACY_LEVELS.includes(l));
       if (invalid.length > 0) {
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000ms (5 minutes). Configurable via /settings timeout=N (seconds).
   sessionIdleResetHours?: number; // Override global SESSION_IDLE_RESET_HOURS. 0 = never reset.
+  memoryPrivacy?: string[]; // Privacy levels the container can access (e.g. ["public","internal","private"]).
+                            // Injected as DEUS_MEMORY_PRIVACY env var. Default: all except sensitive.
 }
 
 export interface ProjectType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface ContainerConfig {
   timeout?: number; // Default: 300000ms (5 minutes). Configurable via /settings timeout=N (seconds).
   sessionIdleResetHours?: number; // Override global SESSION_IDLE_RESET_HOURS. 0 = never reset.
   memoryPrivacy?: string[]; // Privacy levels the container can access (e.g. ["public","internal","private"]).
-                            // Injected as DEUS_MEMORY_PRIVACY env var. Default: all except sensitive.
+  // Injected as DEUS_MEMORY_PRIVACY env var. Default: all except sensitive.
 }
 
 export interface ProjectType {


### PR DESCRIPTION
## Summary
- Add `--allowed-privacy` CLI flag and `DEUS_MEMORY_PRIVACY` env var for per-channel memory privacy allowlists
- Each channel can control which privacy levels its container agent can access via `/settings memory_privacy=level1,level2`
- Shared `_resolve_privacy_allowlist()` helper with level validation (strips invalid levels)
- Container-runner injects `DEUS_MEMORY_PRIVACY` from group config into container env
- Channel-aware blocked notice distinguishes channel policy vs default filter
- 226 Python tests, 27 TypeScript tests (17 new)

## Test plan
- [x] `--allowed-privacy` filters atoms to allowlist only
- [x] `DEUS_MEMORY_PRIVACY` env var acts as fallback
- [x] Explicit `--allowed-privacy` overrides env var
- [x] `--allowed-privacy` takes precedence over legacy `--privacy`
- [x] Empty/commas-only env var falls through to default
- [x] Invalid levels in env var are silently stripped
- [x] Channel-aware vs default blocked notice
- [x] New channels get safe default (sensitive excluded)
- [x] `/settings memory_privacy` validates, deduplicates, normalizes
- [x] `--export` respects `--allowed-privacy`
- [x] TypeScript compiles, drift check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)