### PR TITLE
fix(memory): rebuild preserves runtime tables instead of deleting entire DB

### DIFF
--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -2526,29 +2526,23 @@ def cmd_extract(session_path: str, no_contradict: bool = False):
             print(f"  WARN: contradiction detection failed: {e}", file=sys.stderr)
 
 
-def cmd_rebuild(force: bool = False):
+def cmd_rebuild():
     if not VAULT_SESSION_LOGS.exists():
         print(f"ERROR: session logs not found at {VAULT_SESSION_LOGS}", file=sys.stderr)
         sys.exit(1)
 
-    # Wipe and recreate DB — safety check: never delete a file with evolution data
+    # Tables that CAN be rebuilt from disk (session logs + atom .md files):
+    rebuildable_tables = ["entries", "embeddings", "entries_fts", "entities",
+                          "relationships", "atom_entities"]
+    # Tables with NO disk source — runtime data that must be preserved:
+    # access_log, query_log, entity_articles, digests, synthesis_suggestions, pending_conflicts
+
     if DB_PATH.exists():
         import sqlite3 as _sql
         _check = _sql.connect(DB_PATH)
         _tables = {r[0] for r in _check.execute(
             "SELECT name FROM sqlite_master WHERE type='table'"
         ).fetchall()}
-        # Report what will be lost
-        runtime_tables = {"access_log", "query_log", "entity_articles", "digests",
-                          "synthesis_suggestions", "pending_conflicts"}
-        populated = {}
-        for t in runtime_tables & _tables:
-            try:
-                count = _check.execute(f"SELECT COUNT(*) FROM [{t}]").fetchone()[0]
-                if count > 0:
-                    populated[t] = count
-            except _sql.OperationalError:
-                pass
         _check.close()
 
         _evolution_tables = {"interactions", "reflections", "principles"}
@@ -2558,23 +2552,23 @@ def cmd_rebuild(force: bool = False):
                   file=sys.stderr)
             sys.exit(1)
 
-        if populated and not force:
-            print("WARNING: --rebuild will permanently delete the following runtime data:",
-                  file=sys.stderr)
-            for table, count in populated.items():
-                print(f"  {table}: {count} row(s)", file=sys.stderr)
-            print("\nPass --force to confirm, or back up ~/.deus/memory.db first.",
-                  file=sys.stderr)
-            sys.exit(1)
+        # Always back up before rebuild
+        import shutil
+        backup_path = DB_PATH.with_suffix(f".bak-{datetime.now().strftime('%Y%m%d-%H%M%S')}")
+        shutil.copy2(DB_PATH, backup_path)
+        print(f"Backed up to {backup_path}")
 
-        if populated:
-            # Backup before destructive operation
-            backup_path = DB_PATH.with_suffix(f".bak-{datetime.now().strftime('%Y%m%d-%H%M%S')}")
-            import shutil
-            shutil.copy2(DB_PATH, backup_path)
-            print(f"Backed up to {backup_path}")
+        # Selective clear: only drop rebuildable tables, preserve runtime data
+        db = open_db()
+        for table in rebuildable_tables:
+            try:
+                db.execute(f"DROP TABLE IF EXISTS [{table}]")
+            except sqlite3.OperationalError:
+                pass
+        db.commit()
+        db.close()
 
-        DB_PATH.unlink()
+    # Recreate schema (open_db creates missing tables with IF NOT EXISTS)
     db = open_db()
     db.close()
 
@@ -3127,8 +3121,6 @@ def main():
                         help="Skip saving snapshot for --health (useful for CI/dry-run)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview --prune changes without applying them")
-    parser.add_argument("--force", action="store_true",
-                        help="Confirm destructive operations (e.g. --rebuild when runtime data exists)")
     parser.add_argument("--reason", default="manual",
                         help="Reason for --invalidate (default: manual)")
     parser.add_argument("--domain", metavar="DOMAIN",
@@ -3220,7 +3212,7 @@ def main():
                   intent=args.intent, as_of=args.as_of, privacy=args.privacy,
                   allowed_privacy=ap)
     elif args.rebuild:
-        cmd_rebuild(force=args.force)
+        cmd_rebuild()
     elif args.extract:
         cmd_extract(args.extract, no_contradict=args.no_contradict)
 

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -2558,17 +2558,16 @@ def cmd_rebuild():
         shutil.copy2(DB_PATH, backup_path)
         print(f"Backed up to {backup_path}")
 
-        # Selective clear: only drop rebuildable tables, preserve runtime data
+        # Clear rebuildable tables (rows only, keep schema intact)
         db = open_db()
         for table in rebuildable_tables:
             try:
-                db.execute(f"DROP TABLE IF EXISTS [{table}]")
+                db.execute(f"DELETE FROM [{table}]")
             except sqlite3.OperationalError:
                 pass
         db.commit()
         db.close()
 
-    # Recreate schema (open_db creates missing tables with IF NOT EXISTS)
     db = open_db()
     db.close()
 

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -3647,3 +3647,121 @@ def test_dismiss_conflict_marks_resolved(mi):
     assert conflict[0] == 1
     assert conflict[1] == "dismissed"
     db.close()
+
+
+# ── Data integrity: rebuild backup and runtime preservation ──────────────────
+
+
+def test_rebuild_creates_backup(mi, fresh_vault):
+    """--rebuild should create a timestamped .bak file before clearing tables."""
+    # Seed the DB so it exists
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO entries (path, date, chunk, type, tldr, topics) "
+        "VALUES ('/tmp/x.md', '2024-01-01', 'test', 'session', 'test', '')"
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_rebuild()
+
+    # Check backup was created
+    import glob
+    backups = glob.glob(str(mi.DB_PATH.with_suffix(".bak-*")))
+    assert len(backups) >= 1, "No backup file created by --rebuild"
+
+
+def test_rebuild_preserves_access_log(mi, fresh_vault):
+    """--rebuild should NOT destroy access_log (runtime data with no disk source)."""
+    db = mi.open_db()
+    # Seed an entry + access_log row
+    cur = db.execute(
+        "INSERT INTO entries (path, date, chunk, type, tldr, topics) "
+        "VALUES ('/tmp/x.md', '2024-01-01', 'test', 'atom', 'test', '')"
+    )
+    db.execute(
+        "INSERT INTO access_log (entry_id, accessed_at, access_type) VALUES (?, '2024-06-01', 'query')",
+        [cur.lastrowid],
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_rebuild()
+
+    db = mi.open_db()
+    count = db.execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+    assert count == 1, f"access_log was destroyed by rebuild (expected 1, got {count})"
+    db.close()
+
+
+def test_rebuild_preserves_query_log(mi, fresh_vault):
+    """--rebuild should NOT destroy query_log."""
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO query_log (query_text, intent, result_count, atom_hit, queried_at) "
+        "VALUES ('test query', 'factual', 3, 1, '2024-06-01')"
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_rebuild()
+
+    db = mi.open_db()
+    count = db.execute("SELECT COUNT(*) FROM query_log").fetchone()[0]
+    assert count == 1, f"query_log was destroyed by rebuild (expected 1, got {count})"
+    db.close()
+
+
+def test_rebuild_preserves_pending_conflicts(mi, fresh_vault):
+    """--rebuild should NOT destroy pending_conflicts."""
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO pending_conflicts (older_id, newer_id, older_text, newer_text, created_at) "
+        "VALUES (1, 2, 'old', 'new', '2024-06-01')"
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_rebuild()
+
+    db = mi.open_db()
+    count = db.execute("SELECT COUNT(*) FROM pending_conflicts").fetchone()[0]
+    assert count == 1, f"pending_conflicts was destroyed by rebuild (expected 1, got {count})"
+    db.close()
+
+
+def test_rebuild_preserves_digests(mi, fresh_vault):
+    """--rebuild should NOT destroy digests."""
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO digests (level, period_key, content, created_at) "
+        "VALUES ('weekly', '2024-W24', 'Weekly summary', '2024-06-15')"
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_rebuild()
+
+    db = mi.open_db()
+    count = db.execute("SELECT COUNT(*) FROM digests").fetchone()[0]
+    assert count == 1, f"digests was destroyed by rebuild (expected 1, got {count})"
+    db.close()
+
+
+def test_rebuild_clears_entries_and_embeddings(mi, fresh_vault):
+    """--rebuild should clear entries/embeddings (they're rebuilt from disk)."""
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO entries (path, date, chunk, type, tldr, topics) "
+        "VALUES ('/tmp/stale.md', '2024-01-01', 'stale', 'session', 'stale', '')"
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_rebuild()
+
+    db = mi.open_db()
+    # Old stale entry should be gone (it's not a real file on disk)
+    count = db.execute("SELECT COUNT(*) FROM entries WHERE path = '/tmp/stale.md'").fetchone()[0]
+    assert count == 0, "Stale entry survived rebuild"
+    db.close()


### PR DESCRIPTION
## Summary
- Replace `DB_PATH.unlink()` with selective table clearing — only drops tables rebuildable from disk
- Runtime tables (access_log, query_log, digests, entity_articles, synthesis_suggestions, pending_conflicts) are now **preserved** across rebuilds
- `--rebuild` always creates a timestamped `.bak` backup before clearing
- Removes `--force` flag (no longer needed since no runtime data is destroyed)

## Why
The previous `--rebuild` deleted the entire `memory.db` file, permanently destroying runtime data that has no disk source. Access log history, query analytics, generated digests, and pending conflict reviews were all lost. This was the root cause of forgetting curve data loss.

## Test plan
- [x] Backup file created on every rebuild (new test)
- [x] access_log preserved across rebuild (new test)
- [x] query_log preserved across rebuild (new test)
- [x] pending_conflicts preserved across rebuild (new test)
- [x] digests preserved across rebuild (new test)
- [x] entries/embeddings correctly cleared (new test)
- [x] Privacy + expired_at still preserved from atom files (existing tests)
- [x] 238 tests pass (6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)