### PR TITLE
feat(trading): add trading analysis engine

### DIFF
--- a/src/trading/config.test.ts
+++ b/src/trading/config.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadTradingConfig, getSafetyConfig } from './config.js';
+
+describe('loadTradingConfig', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clear trading-related env vars
+    for (const key of Object.keys(process.env)) {
+      if (
+        key.startsWith('TRADING_') ||
+        key.startsWith('IBKR_')
+      ) {
+        delete process.env[key];
+      }
+    }
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns safe defaults when no env vars set', () => {
+    const config = loadTradingConfig();
+
+    expect(config.safety.allowOrders).toBe(false);
+    expect(config.safety.mode).toBe('paper');
+    expect(config.safety.maxRiskPerTrade).toBe(0.02);
+    expect(config.safety.maxDailyDrawdown).toBe(0.03);
+    expect(config.safety.maxOpenPositions).toBe(5);
+    expect(config.safety.maxCorrelation).toBe(0.7);
+    expect(config.safety.earningsBlackoutHours).toBe(48);
+    expect(config.safety.stalenessThreshold).toBe(0.005);
+    expect(config.safety.approvalTtlMs).toBe(600000);
+    expect(config.safety.minConfluenceFactors).toBe(3);
+    expect(config.safety.minConfidence).toBe(0.6);
+    expect(config.safety.minRiskReward).toBe(2.0);
+    expect(config.safety.vixCircuitBreaker).toBe(35);
+    expect(config.ibkrPort).toBe(4002);
+    expect(config.analysisTimeframes).toEqual(['15m', '1h', '4h', '1D']);
+  });
+
+  it('reads IBKR_ALLOW_ORDERS from env', () => {
+    process.env.IBKR_ALLOW_ORDERS = 'true';
+    const config = loadTradingConfig();
+    expect(config.safety.allowOrders).toBe(true);
+  });
+
+  it('sets live port when IBKR_MODE is live', () => {
+    process.env.IBKR_MODE = 'live';
+    const config = loadTradingConfig();
+    expect(config.safety.mode).toBe('live');
+    expect(config.ibkrPort).toBe(5000);
+  });
+
+  it('respects explicit IBKR_PORT override', () => {
+    process.env.IBKR_PORT = '4003';
+    const config = loadTradingConfig();
+    expect(config.ibkrPort).toBe(4003);
+  });
+
+  it('parses comma-separated instrument lists', () => {
+    process.env.TRADING_INSTRUMENT_WHITELIST = 'AAPL,MSFT,GOOGL';
+    const config = loadTradingConfig();
+    expect(config.safety.instrumentWhitelist).toEqual([
+      'AAPL',
+      'MSFT',
+      'GOOGL',
+    ]);
+  });
+
+  it('parses custom timeframes', () => {
+    process.env.TRADING_TIMEFRAMES = '5m,15m,1h';
+    const config = loadTradingConfig();
+    expect(config.analysisTimeframes).toEqual(['5m', '15m', '1h']);
+  });
+
+  it('parses numeric config values', () => {
+    process.env.TRADING_MAX_RISK_PER_TRADE = '0.01';
+    process.env.TRADING_MAX_DAILY_DRAWDOWN = '0.05';
+    process.env.TRADING_MAX_OPEN_POSITIONS = '3';
+    const config = loadTradingConfig();
+    expect(config.safety.maxRiskPerTrade).toBe(0.01);
+    expect(config.safety.maxDailyDrawdown).toBe(0.05);
+    expect(config.safety.maxOpenPositions).toBe(3);
+  });
+});
+
+describe('getSafetyConfig', () => {
+  it('returns the safety subset of config', () => {
+    const config = loadTradingConfig();
+    const safety = getSafetyConfig(config);
+    expect(safety).toBe(config.safety);
+    expect(safety.allowOrders).toBe(false);
+  });
+});

--- a/src/trading/config.ts
+++ b/src/trading/config.ts
@@ -1,0 +1,180 @@
+/**
+ * Trading analysis engine configuration.
+ *
+ * All risk parameters are environment-configurable with safe defaults.
+ * Paper trading mode is the default — live mode requires explicit opt-in.
+ */
+
+import { z } from 'zod/v4';
+
+import { readEnvFile } from '../env.js';
+
+import type { SafetyConfig, Timeframe, TradingMode } from './types.js';
+
+// --- Zod Schemas ---
+
+const TradingModeSchema = z.enum(['paper', 'live']);
+
+const SafetyConfigSchema = z.object({
+  allowOrders: z.boolean().default(false),
+  mode: TradingModeSchema.default('paper'),
+  maxRiskPerTrade: z.number().min(0).max(1).default(0.02),
+  maxDailyDrawdown: z.number().min(0).max(1).default(0.03),
+  maxOpenPositions: z.number().int().min(1).default(5),
+  maxCorrelation: z.number().min(0).max(1).default(0.7),
+  earningsBlackoutHours: z.number().int().min(0).default(48),
+  stalenessThreshold: z.number().min(0).max(1).default(0.005),
+  approvalTtlMs: z.number().int().min(60000).default(600000),
+  minConfluenceFactors: z.number().int().min(1).default(3),
+  minConfidence: z.number().min(0).max(1).default(0.6),
+  minRiskReward: z.number().min(0).default(2.0),
+  marketOpenBufferMinutes: z.number().int().min(0).default(15),
+  marketCloseBufferMinutes: z.number().int().min(0).default(15),
+  vixCircuitBreaker: z.number().min(0).default(35),
+  instrumentWhitelist: z.array(z.string()).default([]),
+  instrumentBlacklist: z.array(z.string()).default([]),
+});
+
+const TradingConfigSchema = z.object({
+  safety: SafetyConfigSchema,
+  ibkrPort: z.number().int().default(4002),
+  analysisTimeframes: z
+    .array(z.enum(['1m', '5m', '15m', '1h', '4h', '1D', '1W']))
+    .default(['15m', '1h', '4h', '1D']),
+  portfolioValue: z.number().min(0).default(0),
+  analysisModel: z.string().default('claude-sonnet-4-20250514'),
+  decisionModel: z.string().default('claude-opus-4-20250514'),
+});
+
+export type TradingConfig = z.infer<typeof TradingConfigSchema>;
+
+// --- Environment Parsing ---
+
+const TRADING_ENV_KEYS = [
+  'IBKR_ALLOW_ORDERS',
+  'IBKR_MODE',
+  'IBKR_PORT',
+  'TRADING_MAX_RISK_PER_TRADE',
+  'TRADING_MAX_DAILY_DRAWDOWN',
+  'TRADING_MAX_OPEN_POSITIONS',
+  'TRADING_MAX_CORRELATION',
+  'TRADING_EARNINGS_BLACKOUT_HOURS',
+  'TRADING_STALENESS_THRESHOLD',
+  'TRADING_APPROVAL_TTL_MS',
+  'TRADING_MIN_CONFLUENCE',
+  'TRADING_MIN_CONFIDENCE',
+  'TRADING_MIN_RISK_REWARD',
+  'TRADING_MARKET_OPEN_BUFFER',
+  'TRADING_MARKET_CLOSE_BUFFER',
+  'TRADING_VIX_CIRCUIT_BREAKER',
+  'TRADING_INSTRUMENT_WHITELIST',
+  'TRADING_INSTRUMENT_BLACKLIST',
+  'TRADING_TIMEFRAMES',
+  'TRADING_PORTFOLIO_VALUE',
+  'TRADING_ANALYSIS_MODEL',
+  'TRADING_DECISION_MODEL',
+];
+
+function parseCommaSeparated(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseFloat_(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const n = parseFloat(value);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+function parseInt_(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const n = parseInt(value, 10);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+/** Load trading config from environment + .env file with Zod validation. */
+export function loadTradingConfig(): TradingConfig {
+  const env = readEnvFile(TRADING_ENV_KEYS);
+  const get = (key: string) => process.env[key] || env[key];
+
+  const mode: TradingMode =
+    get('IBKR_MODE') === 'live' ? 'live' : 'paper';
+
+  const raw = {
+    safety: {
+      allowOrders: get('IBKR_ALLOW_ORDERS') === 'true',
+      mode,
+      maxRiskPerTrade: parseFloat_(get('TRADING_MAX_RISK_PER_TRADE'), 0.02),
+      maxDailyDrawdown: parseFloat_(
+        get('TRADING_MAX_DAILY_DRAWDOWN'),
+        0.03,
+      ),
+      maxOpenPositions: parseInt_(get('TRADING_MAX_OPEN_POSITIONS'), 5),
+      maxCorrelation: parseFloat_(get('TRADING_MAX_CORRELATION'), 0.7),
+      earningsBlackoutHours: parseInt_(
+        get('TRADING_EARNINGS_BLACKOUT_HOURS'),
+        48,
+      ),
+      stalenessThreshold: parseFloat_(
+        get('TRADING_STALENESS_THRESHOLD'),
+        0.005,
+      ),
+      approvalTtlMs: parseInt_(get('TRADING_APPROVAL_TTL_MS'), 600000),
+      minConfluenceFactors: parseInt_(get('TRADING_MIN_CONFLUENCE'), 3),
+      minConfidence: parseFloat_(get('TRADING_MIN_CONFIDENCE'), 0.6),
+      minRiskReward: parseFloat_(get('TRADING_MIN_RISK_REWARD'), 2.0),
+      marketOpenBufferMinutes: parseInt_(
+        get('TRADING_MARKET_OPEN_BUFFER'),
+        15,
+      ),
+      marketCloseBufferMinutes: parseInt_(
+        get('TRADING_MARKET_CLOSE_BUFFER'),
+        15,
+      ),
+      vixCircuitBreaker: parseFloat_(
+        get('TRADING_VIX_CIRCUIT_BREAKER'),
+        35,
+      ),
+      instrumentWhitelist: parseCommaSeparated(
+        get('TRADING_INSTRUMENT_WHITELIST'),
+      ),
+      instrumentBlacklist: parseCommaSeparated(
+        get('TRADING_INSTRUMENT_BLACKLIST'),
+      ),
+    },
+    ibkrPort: mode === 'live' ? 5000 : 4002,
+    analysisTimeframes: parseCommaSeparated(
+      get('TRADING_TIMEFRAMES'),
+    ) as Timeframe[],
+    portfolioValue: parseFloat_(get('TRADING_PORTFOLIO_VALUE'), 0),
+    analysisModel: get('TRADING_ANALYSIS_MODEL') || 'claude-sonnet-4-20250514',
+    decisionModel: get('TRADING_DECISION_MODEL') || 'claude-opus-4-20250514',
+  };
+
+  // Override port if explicitly set
+  const explicitPort = parseInt_(get('IBKR_PORT'), 0);
+  if (explicitPort > 0) {
+    raw.ibkrPort = explicitPort;
+  }
+
+  // Default timeframes if none specified
+  if (raw.analysisTimeframes.length === 0) {
+    raw.analysisTimeframes = ['15m', '1h', '4h', '1D'];
+  }
+
+  return TradingConfigSchema.parse(raw);
+}
+
+/** Get safety config subset for quick access. */
+export function getSafetyConfig(config: TradingConfig): SafetyConfig {
+  return config.safety;
+}

--- a/src/trading/index.ts
+++ b/src/trading/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Trading analysis engine — public API.
+ *
+ * Re-exports the pipeline, configuration, safety, and types
+ * needed by consumers (channel handlers, CLI commands).
+ */
+
+export { loadTradingConfig, getSafetyConfig } from './config.js';
+export type { TradingConfig } from './config.js';
+
+export {
+  TradingPipeline,
+  type ChartAdapter,
+  type AnalysisAdapter,
+  type BrokerAdapter,
+  type ApprovalAdapter,
+  type PipelineResult,
+} from './pipeline.js';
+
+export {
+  runSafetyChecks,
+  validateBracketOrder,
+  checkStaleness,
+  isApprovalExpired,
+  createExpirationTime,
+  type SafetyCheckResult,
+  type DailyState,
+} from './safety.js';
+
+export {
+  regimeDetectionPrompt,
+  multiTimeframeBiasPrompt,
+  setupIdentificationPrompt,
+  riskAssessmentPrompt,
+  decisionPrompt,
+  formatApprovalMessage,
+  type PromptPair,
+} from './prompts.js';
+
+export type {
+  MarketRegime,
+  Direction,
+  TradeAction,
+  OrderType,
+  TradingMode,
+  Timeframe,
+  ApprovalStatus,
+  RegimeState,
+  TimeframeBias,
+  MultiTimeframeAnalysis,
+  ConfluenceFactor,
+  TradeSetup,
+  PositionSizing,
+  RiskAssessment,
+  BracketOrder,
+  TradeDecision,
+  ApprovalRequest,
+  StalenessCheck,
+  SafetyConfig,
+  PipelineContext,
+  OhlcvBar,
+  ChartData,
+  IndicatorValues,
+} from './types.js';

--- a/src/trading/pipeline.test.ts
+++ b/src/trading/pipeline.test.ts
@@ -1,0 +1,424 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  AnalysisAdapter,
+  ApprovalAdapter,
+  BrokerAdapter,
+  ChartAdapter,
+} from './pipeline.js';
+import { TradingPipeline } from './pipeline.js';
+import type { TradingConfig } from './config.js';
+import type {
+  ApprovalStatus,
+  BracketOrder,
+  ChartData,
+  IndicatorValues,
+  MultiTimeframeAnalysis,
+  RegimeState,
+  RiskAssessment,
+  Timeframe,
+  TradeSetup,
+} from './types.js';
+
+// --- Mock Adapters ---
+
+function makeChartData(tf: Timeframe): ChartData {
+  return {
+    symbol: 'AAPL',
+    timeframe: tf,
+    bars: Array.from({ length: 50 }, (_, i) => ({
+      time: Date.now() - (50 - i) * 86400000,
+      open: 148 + i * 0.1,
+      high: 149 + i * 0.1,
+      low: 147 + i * 0.1,
+      close: 148.5 + i * 0.1,
+      volume: 50000000,
+    })),
+    indicators: {},
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function makeIndicators(): IndicatorValues {
+  return {
+    rsi: 55,
+    adx: 28,
+    atr: 2.5,
+    ema20: 150,
+    ema50: 148,
+    ema200: 145,
+    volume: 55000000,
+    avgVolume: 50000000,
+  };
+}
+
+function mockChartAdapter(): ChartAdapter {
+  return {
+    getChartData: vi.fn((_symbol: string, tf: Timeframe) =>
+      Promise.resolve(makeChartData(tf)),
+    ),
+    getIndicators: vi.fn(() => Promise.resolve(makeIndicators())),
+    getVix: vi.fn(() => Promise.resolve(18)),
+    getCurrentPrice: vi.fn(() => Promise.resolve(150.2)),
+  };
+}
+
+function mockAnalysisAdapter(responses: Record<string, unknown>): AnalysisAdapter {
+  let callIndex = 0;
+  const responseOrder = [
+    'regime',
+    'mtf',
+    'setup',
+    'risk',
+    'decision',
+  ];
+
+  return {
+    analyze: vi.fn(() => {
+      const key = responseOrder[callIndex] || 'decision';
+      callIndex++;
+      return Promise.resolve(responses[key] as never);
+    }),
+  };
+}
+
+function mockBrokerAdapter(): BrokerAdapter {
+  return {
+    getOpenPositions: vi.fn(() =>
+      Promise.resolve([
+        { symbol: 'MSFT', value: 15000, direction: 'bullish' },
+      ]),
+    ),
+    getDailyPnl: vi.fn(() => Promise.resolve(-0.005)),
+    submitBracketOrder: vi.fn((_order: BracketOrder) =>
+      Promise.resolve('ORDER-123'),
+    ),
+  };
+}
+
+function mockApprovalAdapter(status: ApprovalStatus = 'approved'): ApprovalAdapter {
+  return {
+    requestApproval: vi.fn(() => Promise.resolve(status)),
+  };
+}
+
+function makeConfig(overrides: Partial<TradingConfig> = {}): TradingConfig {
+  return {
+    safety: {
+      allowOrders: true,
+      mode: 'paper',
+      maxRiskPerTrade: 0.02,
+      maxDailyDrawdown: 0.03,
+      maxOpenPositions: 5,
+      maxCorrelation: 0.7,
+      earningsBlackoutHours: 48,
+      stalenessThreshold: 0.005,
+      approvalTtlMs: 600000,
+      minConfluenceFactors: 3,
+      minConfidence: 0.6,
+      minRiskReward: 2.0,
+      marketOpenBufferMinutes: 15,
+      marketCloseBufferMinutes: 15,
+      vixCircuitBreaker: 35,
+      instrumentWhitelist: [],
+      instrumentBlacklist: [],
+    },
+    ibkrPort: 4002,
+    analysisTimeframes: ['15m', '1h', '4h', '1D'],
+    portfolioValue: 100000,
+    analysisModel: 'claude-sonnet-4-20250514',
+    decisionModel: 'claude-opus-4-20250514',
+    ...overrides,
+  };
+}
+
+// --- Analysis Responses ---
+
+const analysisResponses = {
+  regime: {
+    regime: 'trending',
+    confidence: 0.85,
+    adx: 30,
+    vix: 18,
+    vixPercentile: 40,
+    hmmState: 0,
+    transitionProb: 0.1,
+    timestamp: new Date().toISOString(),
+    reasoning: 'Strong uptrend with ADX above 25',
+  } satisfies RegimeState & { reasoning: string },
+
+  mtf: {
+    biases: [
+      {
+        timeframe: '1D' as Timeframe,
+        direction: 'bullish' as const,
+        strength: 0.8,
+        keyLevels: { support: [145, 148], resistance: [155, 160] },
+        trendStructure: 'higher-highs' as const,
+      },
+    ],
+    alignment: 0.85,
+    dominantBias: 'bullish' as const,
+    conflictingTimeframes: [] as Timeframe[],
+    timestamp: new Date().toISOString(),
+    reasoning: 'All timeframes aligned bullish',
+  } satisfies MultiTimeframeAnalysis & { reasoning: string },
+
+  setup: {
+    setup: {
+      symbol: 'AAPL',
+      direction: 'bullish' as const,
+      entry: 150,
+      stop: 147,
+      targets: [156, 162],
+      riskRewardRatio: 2.5,
+      confluenceFactors: [
+        { name: 'EMA alignment', weight: 0.3, description: 'Price above EMAs' },
+        { name: 'Volume spike', weight: 0.25, description: 'Above average' },
+        { name: 'Support bounce', weight: 0.3, description: 'Key level' },
+      ],
+      confluenceScore: 0.85,
+      pattern: 'bull flag',
+      timeframe: '1h' as Timeframe,
+      validUntil: new Date(Date.now() + 14400000).toISOString(),
+      timestamp: new Date().toISOString(),
+      reasoning: 'Bull flag at support with volume',
+    } satisfies TradeSetup & { reasoning: string },
+    reasoning: 'Valid setup found',
+  },
+
+  risk: {
+    sizing: {
+      shares: 100,
+      dollarRisk: 300,
+      portfolioRiskPercent: 1.5,
+      kellyFraction: 0.12,
+      adjustedKelly: 0.06,
+      positionValue: 15000,
+    },
+    maxCorrelation: 0.3,
+    correlatedPositions: [],
+    dailyDrawdownUsed: 0.5,
+    dailyDrawdownRemaining: 2.5,
+    openPositionCount: 1,
+    earningsWithin48h: false,
+    riskScore: 0.3,
+    warnings: [],
+    timestamp: new Date().toISOString(),
+    reasoning: 'Acceptable risk profile',
+  } satisfies RiskAssessment & { reasoning: string },
+
+  decision: {
+    action: 'BUY' as const,
+    confidence: 0.78,
+    order: {
+      symbol: 'AAPL',
+      action: 'BUY' as const,
+      orderType: 'LIMIT' as const,
+      quantity: 100,
+      entryPrice: 150,
+      stopPrice: 147,
+      targetPrices: [156, 162],
+      timeInForce: 'DAY' as const,
+    },
+    reasoning: 'Strong setup with favorable risk',
+    holdReasons: [],
+  },
+};
+
+// --- Tests ---
+
+describe('TradingPipeline', () => {
+  it('runs full pipeline to approval', async () => {
+    const chart = mockChartAdapter();
+    const analysis = mockAnalysisAdapter(analysisResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter('approved');
+    const config = makeConfig();
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      config,
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(true);
+    expect(result.context.decision?.action).toBe('BUY');
+    expect(result.context.approval?.status).toBe('approved');
+    expect(approval.requestApproval).toHaveBeenCalled();
+  });
+
+  it('aborts when regime confidence is low', async () => {
+    const lowConfidenceResponses = {
+      ...analysisResponses,
+      regime: { ...analysisResponses.regime, confidence: 0.3 },
+    };
+    const chart = mockChartAdapter();
+    const analysis = mockAnalysisAdapter(lowConfidenceResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter();
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      makeConfig(),
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(true);
+    expect(result.context.decision?.action).toBe('HOLD');
+    expect(result.context.abortReason).toContain('indeterminate');
+    expect(approval.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('aborts when MTF alignment is low', async () => {
+    const lowAlignmentResponses = {
+      ...analysisResponses,
+      mtf: { ...analysisResponses.mtf, alignment: 0.3 },
+    };
+    const chart = mockChartAdapter();
+    const analysis = mockAnalysisAdapter(lowAlignmentResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter();
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      makeConfig(),
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(true);
+    expect(result.context.decision?.action).toBe('HOLD');
+    expect(result.context.abortReason).toContain('alignment');
+  });
+
+  it('aborts when no setup is found', async () => {
+    const noSetupResponses = {
+      ...analysisResponses,
+      setup: { setup: null, reasoning: 'No confluence' },
+    };
+    const chart = mockChartAdapter();
+    const analysis = mockAnalysisAdapter(noSetupResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter();
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      makeConfig(),
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(true);
+    expect(result.context.decision?.action).toBe('HOLD');
+    expect(result.context.abortReason).toContain('No valid setup');
+  });
+
+  it('respects approval rejection', async () => {
+    const chart = mockChartAdapter();
+    const analysis = mockAnalysisAdapter(analysisResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter('rejected');
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      makeConfig(),
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(true);
+    expect(result.context.approval?.status).toBe('rejected');
+    expect(broker.submitBracketOrder).not.toHaveBeenCalled();
+  });
+
+  it('aborts on stale price after approval', async () => {
+    const chart = mockChartAdapter();
+    // Return a price that drifted significantly
+    (chart.getCurrentPrice as ReturnType<typeof vi.fn>).mockResolvedValue(160);
+
+    const analysis = mockAnalysisAdapter(analysisResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter('approved');
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      makeConfig(),
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(true);
+    expect(result.context.approval?.status).toBe('aborted');
+    expect(result.context.approval?.stalenesCheck?.isStale).toBe(true);
+    expect(broker.submitBracketOrder).not.toHaveBeenCalled();
+  });
+
+  it('handles pipeline errors gracefully', async () => {
+    const chart = mockChartAdapter();
+    (chart.getChartData as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('TradingView disconnected'),
+    );
+
+    const analysis = mockAnalysisAdapter(analysisResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter();
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      makeConfig(),
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('TradingView disconnected');
+  });
+
+  it('skips order submission when allowOrders is false', async () => {
+    const chart = mockChartAdapter();
+    const analysis = mockAnalysisAdapter(analysisResponses);
+    const broker = mockBrokerAdapter();
+    const approval = mockApprovalAdapter('approved');
+    const config = makeConfig({
+      safety: { ...makeConfig().safety, allowOrders: false },
+    });
+
+    const pipeline = new TradingPipeline(
+      chart,
+      analysis,
+      broker,
+      approval,
+      config,
+    );
+
+    const result = await pipeline.run('AAPL');
+
+    // Safety check blocks because allowOrders is false
+    expect(result.context.abortReason).toContain('IBKR_ALLOW_ORDERS');
+    expect(broker.submitBracketOrder).not.toHaveBeenCalled();
+  });
+});

--- a/src/trading/pipeline.ts
+++ b/src/trading/pipeline.ts
@@ -1,0 +1,555 @@
+/**
+ * Trading analysis pipeline orchestrator.
+ *
+ * Connects the 5-step analysis chain:
+ * 1. Regime Detection
+ * 2. Multi-Timeframe Bias
+ * 3. Setup Identification
+ * 4. Risk Assessment
+ * 5. Decision
+ *
+ * Then validates against safety rails, prepares bracket order,
+ * and manages the approval flow.
+ *
+ * This module is the skeleton — actual MCP calls to TradingView and IBKR
+ * are injected via the adapter interfaces so the pipeline can be tested
+ * independently.
+ */
+
+import { logger } from '../logger.js';
+
+import { loadTradingConfig, type TradingConfig } from './config.js';
+import {
+  decisionPrompt,
+  formatApprovalMessage,
+  multiTimeframeBiasPrompt,
+  regimeDetectionPrompt,
+  riskAssessmentPrompt,
+  setupIdentificationPrompt,
+  type PromptPair,
+} from './prompts.js';
+import {
+  checkStaleness,
+  createExpirationTime,
+  isApprovalExpired,
+  runSafetyChecks,
+  validateBracketOrder,
+  type DailyState,
+} from './safety.js';
+import type {
+  ApprovalRequest,
+  ApprovalStatus,
+  BracketOrder,
+  ChartData,
+  IndicatorValues,
+  MultiTimeframeAnalysis,
+  PipelineContext,
+  RegimeState,
+  RiskAssessment,
+  Timeframe,
+  TradeDecision,
+  TradeSetup,
+} from './types.js';
+
+// --- Adapter Interfaces ---
+// These abstract over MCP tool calls so the pipeline is testable.
+
+export interface ChartAdapter {
+  /** Fetch OHLCV + indicator data for a symbol/timeframe from TradingView MCP. */
+  getChartData(symbol: string, timeframe: Timeframe): Promise<ChartData>;
+  /** Fetch current indicator values for a symbol/timeframe. */
+  getIndicators(symbol: string, timeframe: Timeframe): Promise<IndicatorValues>;
+  /** Fetch current VIX value. */
+  getVix(): Promise<number>;
+  /** Fetch current price for staleness check. */
+  getCurrentPrice(symbol: string): Promise<number>;
+}
+
+export interface AnalysisAdapter {
+  /** Send a prompt pair to Claude and get structured JSON response. */
+  analyze<T>(prompt: PromptPair, model: string): Promise<T>;
+}
+
+export interface BrokerAdapter {
+  /** Get current open positions. */
+  getOpenPositions(): Promise<
+    { symbol: string; value: number; direction: string }[]
+  >;
+  /** Get today's realized P&L as fraction of portfolio. */
+  getDailyPnl(): Promise<number>;
+  /** Submit a bracket order. Returns order ID. */
+  submitBracketOrder(order: BracketOrder): Promise<string>;
+}
+
+export interface ApprovalAdapter {
+  /** Send approval request via WhatsApp and wait for response. */
+  requestApproval(message: string, ttlMs: number): Promise<ApprovalStatus>;
+}
+
+// --- Pipeline Result ---
+
+export interface PipelineResult {
+  context: PipelineContext;
+  success: boolean;
+  error?: string;
+}
+
+// --- Pipeline ---
+
+export class TradingPipeline {
+  private config: TradingConfig;
+  private chart: ChartAdapter;
+  private analysis: AnalysisAdapter;
+  private broker: BrokerAdapter;
+  private approval: ApprovalAdapter;
+
+  constructor(
+    chart: ChartAdapter,
+    analysis: AnalysisAdapter,
+    broker: BrokerAdapter,
+    approval: ApprovalAdapter,
+    config?: TradingConfig,
+  ) {
+    this.chart = chart;
+    this.analysis = analysis;
+    this.broker = broker;
+    this.approval = approval;
+    this.config = config ?? loadTradingConfig();
+  }
+
+  /** Run the full analysis pipeline for a symbol. */
+  async run(symbol: string): Promise<PipelineResult> {
+    const ctx: PipelineContext = {
+      symbol,
+      requestedAt: new Date().toISOString(),
+      timeframes: this.config.analysisTimeframes as Timeframe[],
+    };
+
+    try {
+      // Step 1: Regime Detection
+      logger.info({ symbol }, 'Step 1: Regime detection');
+      ctx.regime = await this.detectRegime(symbol);
+      logger.info(
+        { regime: ctx.regime.regime, confidence: ctx.regime.confidence },
+        'Regime detected',
+      );
+
+      // Early exit: regime indeterminate
+      if (ctx.regime.confidence < 0.5) {
+        ctx.abortReason = `Regime indeterminate (confidence ${(ctx.regime.confidence * 100).toFixed(0)}%)`;
+        logger.warn({ reason: ctx.abortReason }, 'Pipeline aborted');
+        return this.buildHoldResult(ctx);
+      }
+
+      // Step 2: Multi-Timeframe Bias
+      logger.info({ symbol }, 'Step 2: Multi-timeframe bias');
+      ctx.timeframeAnalysis = await this.analyzeTimeframes(
+        symbol,
+        ctx.regime,
+      );
+      logger.info(
+        {
+          bias: ctx.timeframeAnalysis.dominantBias,
+          alignment: ctx.timeframeAnalysis.alignment,
+        },
+        'MTF analysis complete',
+      );
+
+      // Early exit: no alignment
+      if (ctx.timeframeAnalysis.alignment < 0.5) {
+        ctx.abortReason = `MTF alignment too low (${(ctx.timeframeAnalysis.alignment * 100).toFixed(0)}%)`;
+        logger.warn({ reason: ctx.abortReason }, 'Pipeline aborted');
+        return this.buildHoldResult(ctx);
+      }
+
+      // Step 3: Setup Identification
+      logger.info({ symbol }, 'Step 3: Setup identification');
+      const executionTf = this.selectExecutionTimeframe();
+      const maybeSetup = await this.identifySetup(
+        symbol,
+        executionTf,
+        ctx.regime,
+        ctx.timeframeAnalysis,
+      );
+
+      if (!maybeSetup) {
+        ctx.abortReason = 'No valid setup identified';
+        logger.info({ reason: ctx.abortReason }, 'No setup found');
+        return this.buildHoldResult(ctx);
+      }
+
+      ctx.setup = maybeSetup;
+
+      logger.info(
+        {
+          direction: ctx.setup.direction,
+          entry: ctx.setup.entry,
+          rr: ctx.setup.riskRewardRatio,
+        },
+        'Setup identified',
+      );
+
+      // Step 4: Risk Assessment
+      logger.info({ symbol }, 'Step 4: Risk assessment');
+      ctx.risk = await this.assessRisk(ctx.setup);
+      logger.info(
+        {
+          riskScore: ctx.risk.riskScore,
+          shares: ctx.risk.sizing.shares,
+        },
+        'Risk assessed',
+      );
+
+      // Step 5: Decision
+      logger.info({ symbol }, 'Step 5: Final decision');
+      ctx.decision = await this.makeDecision(
+        ctx.regime,
+        ctx.timeframeAnalysis,
+        ctx.setup,
+        ctx.risk,
+      );
+      logger.info(
+        {
+          action: ctx.decision.action,
+          confidence: ctx.decision.confidence,
+        },
+        'Decision made',
+      );
+
+      if (ctx.decision.action === 'HOLD') {
+        return this.buildHoldResult(ctx);
+      }
+
+      // Safety validation
+      logger.info({ symbol }, 'Running safety checks');
+      const daily = await this.getDailyState();
+      const safetyResult = runSafetyChecks(
+        ctx.decision,
+        this.config.safety,
+        daily,
+      );
+
+      if (!safetyResult.passed) {
+        ctx.abortReason = `Safety violation: ${safetyResult.violations.join('; ')}`;
+        logger.warn(
+          { violations: safetyResult.violations },
+          'Safety check failed',
+        );
+        return this.buildHoldResult(ctx);
+      }
+
+      if (safetyResult.warnings.length > 0) {
+        logger.warn({ warnings: safetyResult.warnings }, 'Safety warnings');
+      }
+
+      // Validate bracket order
+      if (ctx.decision.order) {
+        const orderErrors = validateBracketOrder(ctx.decision.order);
+        if (orderErrors.length > 0) {
+          ctx.abortReason = `Invalid order: ${orderErrors.join('; ')}`;
+          logger.error({ errors: orderErrors }, 'Order validation failed');
+          return this.buildHoldResult(ctx);
+        }
+      }
+
+      // Approval flow
+      logger.info({ symbol }, 'Requesting approval');
+      const expiresAt = createExpirationTime(this.config.safety.approvalTtlMs);
+      const message = formatApprovalMessage(ctx.decision, expiresAt);
+
+      ctx.approval = {
+        id: crypto.randomUUID(),
+        decision: ctx.decision,
+        summary: message,
+        expiresAt,
+        status: 'pending',
+        sentAt: new Date().toISOString(),
+      };
+
+      const approvalStatus = await this.approval.requestApproval(
+        message,
+        this.config.safety.approvalTtlMs,
+      );
+      ctx.approval.status = approvalStatus;
+      ctx.approval.respondedAt = new Date().toISOString();
+
+      if (approvalStatus !== 'approved') {
+        ctx.abortReason = `Approval ${approvalStatus}`;
+        logger.info({ status: approvalStatus }, 'Trade not approved');
+        ctx.completedAt = new Date().toISOString();
+        return { context: ctx, success: true };
+      }
+
+      // Staleness check before execution
+      logger.info({ symbol }, 'Staleness check');
+      const currentPrice = await this.chart.getCurrentPrice(symbol);
+      const staleness = checkStaleness(
+        ctx.decision.order!.entryPrice,
+        currentPrice,
+        this.config.safety.stalenessThreshold,
+      );
+      ctx.approval.stalenesCheck = staleness;
+
+      if (staleness.isStale) {
+        ctx.abortReason = `Price stale: drifted ${(staleness.priceDrift * 100).toFixed(2)}% since proposal`;
+        ctx.approval.status = 'aborted';
+        logger.warn(
+          { drift: staleness.priceDrift, threshold: this.config.safety.stalenessThreshold },
+          'Trade aborted due to staleness',
+        );
+        ctx.completedAt = new Date().toISOString();
+        return { context: ctx, success: true };
+      }
+
+      // Execute
+      if (this.config.safety.allowOrders && ctx.decision.order) {
+        logger.info({ symbol, order: ctx.decision.order }, 'Submitting order');
+        const orderId = await this.broker.submitBracketOrder(
+          ctx.decision.order,
+        );
+        logger.info({ orderId }, 'Order submitted');
+      } else {
+        logger.info('Orders disabled — skipping execution');
+      }
+
+      ctx.completedAt = new Date().toISOString();
+      return { context: ctx, success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error({ err, symbol }, 'Pipeline error');
+      ctx.abortReason = `Pipeline error: ${msg}`;
+      ctx.completedAt = new Date().toISOString();
+      return { context: ctx, success: false, error: msg };
+    }
+  }
+
+  // --- Step Implementations ---
+
+  private async detectRegime(symbol: string): Promise<RegimeState> {
+    const dailyTf: Timeframe = '1D';
+    const [chartData, indicators, vix] = await Promise.all([
+      this.chart.getChartData(symbol, dailyTf),
+      this.chart.getIndicators(symbol, dailyTf),
+      this.chart.getVix(),
+    ]);
+
+    const prompt = regimeDetectionPrompt(chartData, indicators, vix);
+    const result = await this.analysis.analyze<
+      RegimeState & { reasoning: string }
+    >(prompt, this.config.analysisModel);
+
+    return {
+      regime: result.regime,
+      confidence: result.confidence,
+      adx: result.adx,
+      vix: result.vix,
+      vixPercentile: result.vixPercentile,
+      hmmState: result.hmmState,
+      transitionProb: result.transitionProb,
+      timestamp: result.timestamp,
+    };
+  }
+
+  private async analyzeTimeframes(
+    symbol: string,
+    regime: RegimeState,
+  ): Promise<MultiTimeframeAnalysis> {
+    const timeframes = this.config.analysisTimeframes as Timeframe[];
+
+    // Fetch all timeframes in parallel
+    const chartDataMap = new Map<Timeframe, ChartData>();
+    const indicatorsMap = new Map<Timeframe, IndicatorValues>();
+
+    const fetches = timeframes.map(async (tf) => {
+      const [data, ind] = await Promise.all([
+        this.chart.getChartData(symbol, tf),
+        this.chart.getIndicators(symbol, tf),
+      ]);
+      chartDataMap.set(tf, data);
+      indicatorsMap.set(tf, ind);
+    });
+    await Promise.all(fetches);
+
+    const prompt = multiTimeframeBiasPrompt(
+      chartDataMap,
+      indicatorsMap,
+      regime,
+    );
+    const result = await this.analysis.analyze<
+      MultiTimeframeAnalysis & { reasoning: string }
+    >(prompt, this.config.analysisModel);
+
+    return {
+      biases: result.biases,
+      alignment: result.alignment,
+      dominantBias: result.dominantBias,
+      conflictingTimeframes: result.conflictingTimeframes,
+      timestamp: result.timestamp,
+    };
+  }
+
+  private async identifySetup(
+    symbol: string,
+    timeframe: Timeframe,
+    regime: RegimeState,
+    mtfAnalysis: MultiTimeframeAnalysis,
+  ): Promise<TradeSetup | null> {
+    const [chartData, indicators] = await Promise.all([
+      this.chart.getChartData(symbol, timeframe),
+      this.chart.getIndicators(symbol, timeframe),
+    ]);
+
+    const prompt = setupIdentificationPrompt(
+      chartData,
+      indicators,
+      regime,
+      mtfAnalysis,
+    );
+    const result = await this.analysis.analyze<{
+      setup: (TradeSetup & { reasoning: string }) | null;
+      reasoning: string;
+    }>(prompt, this.config.analysisModel);
+
+    if (!result.setup) {
+      logger.info({ reasoning: result.reasoning }, 'No setup found');
+      return null;
+    }
+
+    return {
+      symbol: result.setup.symbol,
+      direction: result.setup.direction,
+      entry: result.setup.entry,
+      stop: result.setup.stop,
+      targets: result.setup.targets,
+      riskRewardRatio: result.setup.riskRewardRatio,
+      confluenceFactors: result.setup.confluenceFactors,
+      confluenceScore: result.setup.confluenceScore,
+      pattern: result.setup.pattern,
+      timeframe: result.setup.timeframe as Timeframe,
+      validUntil: result.setup.validUntil,
+      timestamp: result.setup.timestamp,
+    };
+  }
+
+  private async assessRisk(setup: TradeSetup): Promise<RiskAssessment> {
+    const openPositions = await this.broker.getOpenPositions();
+
+    const prompt = riskAssessmentPrompt(
+      setup,
+      this.config.portfolioValue,
+      openPositions,
+      this.config.safety,
+    );
+    const result = await this.analysis.analyze<
+      RiskAssessment & { reasoning: string }
+    >(prompt, this.config.analysisModel);
+
+    return {
+      sizing: result.sizing,
+      maxCorrelation: result.maxCorrelation,
+      correlatedPositions: result.correlatedPositions,
+      dailyDrawdownUsed: result.dailyDrawdownUsed,
+      dailyDrawdownRemaining: result.dailyDrawdownRemaining,
+      openPositionCount: result.openPositionCount,
+      earningsWithin48h: result.earningsWithin48h,
+      earningsDate: result.earningsDate,
+      riskScore: result.riskScore,
+      warnings: result.warnings,
+      timestamp: result.timestamp,
+    };
+  }
+
+  private async makeDecision(
+    regime: RegimeState,
+    mtfAnalysis: MultiTimeframeAnalysis,
+    setup: TradeSetup | null,
+    risk: RiskAssessment | null,
+  ): Promise<TradeDecision> {
+    const prompt = decisionPrompt(
+      regime,
+      mtfAnalysis,
+      setup,
+      risk,
+      this.config.safety,
+    );
+    const result = await this.analysis.analyze<{
+      action: 'BUY' | 'SELL' | 'HOLD';
+      confidence: number;
+      order: BracketOrder | null;
+      reasoning: string;
+      holdReasons: string[];
+    }>(prompt, this.config.decisionModel);
+
+    return {
+      action: result.action,
+      confidence: result.confidence,
+      regime,
+      timeframeAnalysis: mtfAnalysis,
+      setup,
+      risk,
+      order: result.order,
+      reasoning: result.reasoning,
+      holdReasons: result.holdReasons || [],
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  // --- Helpers ---
+
+  private async getDailyState(): Promise<DailyState> {
+    const [positions, dailyPnl] = await Promise.all([
+      this.broker.getOpenPositions(),
+      this.broker.getDailyPnl(),
+    ]);
+
+    return {
+      realizedPnl: dailyPnl,
+      openPositionCount: positions.length,
+      openSymbols: positions.map((p) => p.symbol),
+    };
+  }
+
+  private selectExecutionTimeframe(): Timeframe {
+    // Use the lowest available timeframe for entry precision
+    const priority: Timeframe[] = ['15m', '1h', '4h', '1D'];
+    const available = new Set(this.config.analysisTimeframes);
+    for (const tf of priority) {
+      if (available.has(tf)) return tf;
+    }
+    return '1h'; // fallback
+  }
+
+  private buildHoldResult(ctx: PipelineContext): PipelineResult {
+    if (!ctx.decision) {
+      ctx.decision = {
+        action: 'HOLD',
+        confidence: 0,
+        regime: ctx.regime ?? {
+          regime: 'ranging',
+          confidence: 0,
+          adx: 0,
+          vix: 0,
+          vixPercentile: 0,
+          hmmState: 1,
+          transitionProb: 0,
+          timestamp: new Date().toISOString(),
+        },
+        timeframeAnalysis: ctx.timeframeAnalysis ?? {
+          biases: [],
+          alignment: 0,
+          dominantBias: 'neutral',
+          conflictingTimeframes: [],
+          timestamp: new Date().toISOString(),
+        },
+        setup: null,
+        risk: null,
+        order: null,
+        reasoning: ctx.abortReason || 'No actionable setup',
+        holdReasons: [ctx.abortReason || 'No actionable setup'],
+        timestamp: new Date().toISOString(),
+      };
+    }
+    ctx.completedAt = new Date().toISOString();
+    return { context: ctx, success: true };
+  }
+}

--- a/src/trading/prompts.test.ts
+++ b/src/trading/prompts.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decisionPrompt,
+  formatApprovalMessage,
+  multiTimeframeBiasPrompt,
+  regimeDetectionPrompt,
+  riskAssessmentPrompt,
+  setupIdentificationPrompt,
+} from './prompts.js';
+import type {
+  ChartData,
+  IndicatorValues,
+  MultiTimeframeAnalysis,
+  RegimeState,
+  RiskAssessment,
+  SafetyConfig,
+  Timeframe,
+  TradeDecision,
+  TradeSetup,
+} from './types.js';
+
+// --- Fixtures ---
+
+function makeChartData(
+  overrides: Partial<ChartData> = {},
+): ChartData {
+  return {
+    symbol: 'AAPL',
+    timeframe: '1D',
+    bars: Array.from({ length: 50 }, (_, i) => ({
+      time: Date.now() - (50 - i) * 86400000,
+      open: 148 + i * 0.1,
+      high: 149 + i * 0.1,
+      low: 147 + i * 0.1,
+      close: 148.5 + i * 0.1,
+      volume: 50000000 + i * 100000,
+    })),
+    indicators: {},
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeIndicators(
+  overrides: Partial<IndicatorValues> = {},
+): IndicatorValues {
+  return {
+    rsi: 55,
+    adx: 28,
+    atr: 2.5,
+    ema20: 150,
+    ema50: 148,
+    ema200: 145,
+    vwap: 149.5,
+    volume: 55000000,
+    avgVolume: 50000000,
+    ...overrides,
+  };
+}
+
+function makeRegime(overrides: Partial<RegimeState> = {}): RegimeState {
+  return {
+    regime: 'trending',
+    confidence: 0.85,
+    adx: 30,
+    vix: 18,
+    vixPercentile: 40,
+    hmmState: 0,
+    transitionProb: 0.1,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeSafetyConfig(overrides: Partial<SafetyConfig> = {}): SafetyConfig {
+  return {
+    allowOrders: true,
+    mode: 'paper',
+    maxRiskPerTrade: 0.02,
+    maxDailyDrawdown: 0.03,
+    maxOpenPositions: 5,
+    maxCorrelation: 0.7,
+    earningsBlackoutHours: 48,
+    stalenessThreshold: 0.005,
+    approvalTtlMs: 600000,
+    minConfluenceFactors: 3,
+    minConfidence: 0.6,
+    minRiskReward: 2.0,
+    marketOpenBufferMinutes: 15,
+    marketCloseBufferMinutes: 15,
+    vixCircuitBreaker: 35,
+    instrumentWhitelist: [],
+    instrumentBlacklist: [],
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('regimeDetectionPrompt', () => {
+  it('produces system and user messages', () => {
+    const prompt = regimeDetectionPrompt(
+      makeChartData(),
+      makeIndicators(),
+      18,
+    );
+    expect(prompt.system).toContain('regime analyst');
+    expect(prompt.user).toContain('AAPL');
+    expect(prompt.user).toContain('ADX: 28');
+    expect(prompt.user).toContain('VIX: 18');
+  });
+
+  it('includes JSON schema in system prompt', () => {
+    const prompt = regimeDetectionPrompt(
+      makeChartData(),
+      makeIndicators(),
+      18,
+    );
+    expect(prompt.system).toContain('"regime"');
+    expect(prompt.system).toContain('"confidence"');
+  });
+});
+
+describe('multiTimeframeBiasPrompt', () => {
+  it('includes all timeframes in user message', () => {
+    const chartMap = new Map<Timeframe, ChartData>();
+    const indMap = new Map<Timeframe, IndicatorValues>();
+    for (const tf of ['15m', '1h', '4h', '1D'] as Timeframe[]) {
+      chartMap.set(tf, makeChartData({ timeframe: tf }));
+      indMap.set(tf, makeIndicators());
+    }
+
+    const prompt = multiTimeframeBiasPrompt(
+      chartMap,
+      indMap,
+      makeRegime(),
+    );
+    expect(prompt.user).toContain('### 15m');
+    expect(prompt.user).toContain('### 1h');
+    expect(prompt.user).toContain('### 4h');
+    expect(prompt.user).toContain('### 1D');
+  });
+
+  it('includes regime context in system prompt', () => {
+    const chartMap = new Map<Timeframe, ChartData>();
+    const indMap = new Map<Timeframe, IndicatorValues>();
+    chartMap.set('1D', makeChartData());
+    indMap.set('1D', makeIndicators());
+
+    const prompt = multiTimeframeBiasPrompt(
+      chartMap,
+      indMap,
+      makeRegime({ regime: 'volatile' }),
+    );
+    expect(prompt.system).toContain('volatile');
+  });
+});
+
+describe('setupIdentificationPrompt', () => {
+  it('includes regime and MTF analysis', () => {
+    const mtf: MultiTimeframeAnalysis = {
+      biases: [
+        {
+          timeframe: '1D',
+          direction: 'bullish',
+          strength: 0.8,
+          keyLevels: { support: [145, 148], resistance: [155, 160] },
+          trendStructure: 'higher-highs',
+        },
+      ],
+      alignment: 0.85,
+      dominantBias: 'bullish',
+      conflictingTimeframes: [],
+      timestamp: new Date().toISOString(),
+    };
+
+    const prompt = setupIdentificationPrompt(
+      makeChartData({ timeframe: '1h' }),
+      makeIndicators(),
+      makeRegime(),
+      mtf,
+    );
+    expect(prompt.user).toContain('trending');
+    expect(prompt.user).toContain('bullish');
+    expect(prompt.user).toContain('145');
+    expect(prompt.system).toContain('confluence');
+  });
+});
+
+describe('riskAssessmentPrompt', () => {
+  it('includes setup details and portfolio info', () => {
+    const setup: TradeSetup = {
+      symbol: 'AAPL',
+      direction: 'bullish',
+      entry: 150,
+      stop: 147,
+      targets: [156, 162],
+      riskRewardRatio: 2.5,
+      confluenceFactors: [
+        { name: 'EMA', weight: 0.3, description: 'test' },
+        { name: 'Volume', weight: 0.25, description: 'test' },
+        { name: 'Support', weight: 0.3, description: 'test' },
+      ],
+      confluenceScore: 0.85,
+      timeframe: '1h',
+      validUntil: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+    };
+
+    const prompt = riskAssessmentPrompt(
+      setup,
+      100000,
+      [{ symbol: 'MSFT', value: 15000, direction: 'bullish' }],
+      makeSafetyConfig(),
+    );
+    expect(prompt.user).toContain('AAPL');
+    expect(prompt.user).toContain('$100000');
+    expect(prompt.user).toContain('MSFT');
+    expect(prompt.system).toContain('Kelly');
+  });
+});
+
+describe('decisionPrompt', () => {
+  it('produces decision prompt with all inputs', () => {
+    const mtf: MultiTimeframeAnalysis = {
+      biases: [],
+      alignment: 0.8,
+      dominantBias: 'bullish',
+      conflictingTimeframes: [],
+      timestamp: new Date().toISOString(),
+    };
+
+    const setup: TradeSetup = {
+      symbol: 'AAPL',
+      direction: 'bullish',
+      entry: 150,
+      stop: 147,
+      targets: [156],
+      riskRewardRatio: 2.5,
+      confluenceFactors: [
+        { name: 'A', weight: 0.3, description: '' },
+        { name: 'B', weight: 0.3, description: '' },
+        { name: 'C', weight: 0.3, description: '' },
+      ],
+      confluenceScore: 0.9,
+      timeframe: '1h',
+      validUntil: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+    };
+
+    const risk: RiskAssessment = {
+      sizing: {
+        shares: 100,
+        dollarRisk: 300,
+        portfolioRiskPercent: 1.5,
+        kellyFraction: 0.12,
+        adjustedKelly: 0.06,
+        positionValue: 15000,
+      },
+      maxCorrelation: 0.2,
+      correlatedPositions: [],
+      dailyDrawdownUsed: 0.5,
+      dailyDrawdownRemaining: 2.5,
+      openPositionCount: 1,
+      earningsWithin48h: false,
+      riskScore: 0.3,
+      warnings: [],
+      timestamp: new Date().toISOString(),
+    };
+
+    const prompt = decisionPrompt(
+      makeRegime(),
+      mtf,
+      setup,
+      risk,
+      makeSafetyConfig(),
+    );
+    expect(prompt.system).toContain('portfolio manager');
+    expect(prompt.user).toContain('REGIME');
+    expect(prompt.user).toContain('SETUP');
+    expect(prompt.user).toContain('RISK');
+  });
+
+  it('handles null setup and risk', () => {
+    const mtf: MultiTimeframeAnalysis = {
+      biases: [],
+      alignment: 0.3,
+      dominantBias: 'neutral',
+      conflictingTimeframes: ['1h'],
+      timestamp: new Date().toISOString(),
+    };
+
+    const prompt = decisionPrompt(
+      makeRegime(),
+      mtf,
+      null,
+      null,
+      makeSafetyConfig(),
+    );
+    expect(prompt.user).toContain('No valid setup identified');
+    expect(prompt.user).toContain('Not assessed');
+  });
+});
+
+describe('formatApprovalMessage', () => {
+  it('formats BUY decision as WhatsApp message', () => {
+    const decision: TradeDecision = {
+      action: 'BUY',
+      confidence: 0.78,
+      regime: makeRegime(),
+      timeframeAnalysis: {
+        biases: [],
+        alignment: 0.8,
+        dominantBias: 'bullish',
+        conflictingTimeframes: [],
+        timestamp: new Date().toISOString(),
+      },
+      setup: {
+        symbol: 'AAPL',
+        direction: 'bullish',
+        entry: 150,
+        stop: 147,
+        targets: [156, 162],
+        riskRewardRatio: 2.5,
+        confluenceFactors: [
+          { name: 'EMA alignment', weight: 0.3, description: '' },
+          { name: 'Volume', weight: 0.25, description: '' },
+          { name: 'Support', weight: 0.3, description: '' },
+        ],
+        confluenceScore: 0.85,
+        pattern: 'bull flag',
+        timeframe: '1h',
+        validUntil: new Date().toISOString(),
+        timestamp: new Date().toISOString(),
+      },
+      risk: {
+        sizing: {
+          shares: 100,
+          dollarRisk: 300,
+          portfolioRiskPercent: 1.5,
+          kellyFraction: 0.12,
+          adjustedKelly: 0.06,
+          positionValue: 15000,
+        },
+        maxCorrelation: 0.2,
+        correlatedPositions: [],
+        dailyDrawdownUsed: 0.5,
+        dailyDrawdownRemaining: 2.5,
+        openPositionCount: 1,
+        earningsWithin48h: false,
+        riskScore: 0.3,
+        warnings: [],
+        timestamp: new Date().toISOString(),
+      },
+      order: {
+        symbol: 'AAPL',
+        action: 'BUY',
+        orderType: 'LIMIT',
+        quantity: 100,
+        entryPrice: 150,
+        stopPrice: 147,
+        targetPrices: [156, 162],
+        timeInForce: 'DAY',
+      },
+      reasoning: 'Strong trend with multi-timeframe alignment',
+      holdReasons: [],
+      timestamp: new Date().toISOString(),
+    };
+
+    const msg = formatApprovalMessage(
+      decision,
+      new Date(Date.now() + 600000).toISOString(),
+    );
+    expect(msg).toContain('*BUY AAPL*');
+    expect(msg).toContain('Entry: $150.00');
+    expect(msg).toContain('Stop: $147.00');
+    expect(msg).toContain('R:R: 2.5');
+    expect(msg).toContain('Qty: 100');
+    expect(msg).toContain('Reply YES');
+  });
+
+  it('formats HOLD decision as simple message', () => {
+    const decision: TradeDecision = {
+      action: 'HOLD',
+      confidence: 0,
+      regime: makeRegime(),
+      timeframeAnalysis: {
+        biases: [],
+        alignment: 0.3,
+        dominantBias: 'neutral',
+        conflictingTimeframes: [],
+        timestamp: new Date().toISOString(),
+      },
+      setup: null,
+      risk: null,
+      order: null,
+      reasoning: 'No valid setup found',
+      holdReasons: ['No confluence'],
+      timestamp: new Date().toISOString(),
+    };
+
+    const msg = formatApprovalMessage(decision, new Date().toISOString());
+    expect(msg).toContain('HOLD');
+    expect(msg).toContain('No valid setup found');
+  });
+});

--- a/src/trading/prompts.ts
+++ b/src/trading/prompts.ts
@@ -1,0 +1,423 @@
+/**
+ * Expert analysis prompts for the 5-step trading chain.
+ *
+ * Each prompt is a template function that accepts structured input from
+ * the previous step and returns a system+user message pair. Prompts are
+ * designed for token efficiency — no fluff, compact directives, structured
+ * JSON output schemas inline.
+ *
+ * Prompt diversity (per Lopez-Lira arXiv:2504.10789): each step uses a
+ * distinct analytical persona to avoid correlated failure modes.
+ */
+
+import type {
+  ChartData,
+  IndicatorValues,
+  MultiTimeframeAnalysis,
+  RegimeState,
+  RiskAssessment,
+  SafetyConfig,
+  Timeframe,
+  TradeDecision,
+  TradeSetup,
+} from './types.js';
+
+export interface PromptPair {
+  system: string;
+  user: string;
+}
+
+// --- Step 1: Regime Detection ---
+
+export function regimeDetectionPrompt(
+  chartData: ChartData,
+  indicators: IndicatorValues,
+  vix: number,
+): PromptPair {
+  return {
+    system: `You are a quantitative regime analyst. Your sole task: classify the current market regime from price data and volatility indicators. You think in statistical terms — HMM states, volatility clustering, trend persistence.
+
+Output ONLY valid JSON matching this schema:
+{
+  "regime": "trending" | "ranging" | "volatile",
+  "confidence": 0-1,
+  "adx": number,
+  "vix": number,
+  "vixPercentile": 0-100,
+  "hmmState": 0 | 1 | 2,
+  "transitionProb": 0-1,
+  "timestamp": "ISO8601",
+  "reasoning": "1-2 sentences"
+}
+
+Classification rules:
+- trending: ADX > 25 AND price making directional higher-highs or lower-lows over 20+ bars
+- ranging: ADX < 20 AND price oscillating between identifiable S/R levels
+- volatile: VIX > 75th percentile of 252-day range OR ATR expanding >1.5x 20-period average OR sudden regime transition detected
+- When indicators conflict, weight ADX 40%, price structure 35%, VIX context 25%
+- hmmState mapping: 0=low-vol trending, 1=mean-reverting range, 2=high-vol crisis
+- transitionProb: estimate probability the regime changes within 5 sessions based on ADX slope and VIX trajectory
+
+Confidence scoring:
+- 0.9+: all indicators agree, clear regime
+- 0.7-0.9: majority agree, minor conflicts
+- 0.5-0.7: mixed signals, regime possibly transitioning
+- <0.5: regime indeterminate, recommend HOLD`,
+
+    user: `Analyze regime for ${chartData.symbol} on ${chartData.timeframe}:
+
+Bars (last 50): ${JSON.stringify(chartData.bars.slice(-50).map((b) => ({ t: b.time, o: b.open, h: b.high, l: b.low, c: b.close, v: b.volume })))}
+
+Indicators:
+- ADX: ${indicators.adx ?? 'N/A'}
+- ATR: ${indicators.atr ?? 'N/A'}
+- RSI: ${indicators.rsi ?? 'N/A'}
+- EMA20: ${indicators.ema20 ?? 'N/A'}
+- EMA50: ${indicators.ema50 ?? 'N/A'}
+- EMA200: ${indicators.ema200 ?? 'N/A'}
+- Bollinger: ${indicators.bollingerBands ? JSON.stringify(indicators.bollingerBands) : 'N/A'}
+- Volume: ${indicators.volume ?? 'N/A'} (avg: ${indicators.avgVolume ?? 'N/A'})
+
+VIX: ${vix}
+Timestamp: ${chartData.timestamp}`,
+  };
+}
+
+// --- Step 2: Multi-Timeframe Bias ---
+
+export function multiTimeframeBiasPrompt(
+  chartDataByTimeframe: Map<Timeframe, ChartData>,
+  indicatorsByTimeframe: Map<Timeframe, IndicatorValues>,
+  regime: RegimeState,
+): PromptPair {
+  const timeframeEntries: string[] = [];
+  for (const [tf, data] of chartDataByTimeframe) {
+    const ind = indicatorsByTimeframe.get(tf);
+    timeframeEntries.push(
+      `### ${tf}
+Last 20 bars: ${JSON.stringify(data.bars.slice(-20).map((b) => ({ t: b.time, o: b.open, h: b.high, l: b.low, c: b.close })))}
+EMA20: ${ind?.ema20 ?? 'N/A'}, EMA50: ${ind?.ema50 ?? 'N/A'}, EMA200: ${ind?.ema200 ?? 'N/A'}
+RSI: ${ind?.rsi ?? 'N/A'}, VWAP: ${ind?.vwap ?? 'N/A'}`,
+    );
+  }
+
+  return {
+    system: `You are a multi-timeframe technical analyst. You read price structure across timeframes top-down (daily first, then intraday) to establish directional bias and identify alignment or conflict.
+
+Output ONLY valid JSON matching this schema:
+{
+  "biases": [
+    {
+      "timeframe": string,
+      "direction": "bullish" | "bearish" | "neutral",
+      "strength": 0-1,
+      "keyLevels": { "support": [numbers], "resistance": [numbers] },
+      "trendStructure": "higher-highs" | "lower-lows" | "consolidation"
+    }
+  ],
+  "alignment": 0-1,
+  "dominantBias": "bullish" | "bearish" | "neutral",
+  "conflictingTimeframes": [timeframes that disagree],
+  "timestamp": "ISO8601",
+  "reasoning": "2-3 sentences"
+}
+
+Rules:
+- Process timeframes top-down: daily sets the primary bias, 4H confirms, 1H/15m refine entry timing
+- direction: based on price vs EMAs, swing structure, and momentum (RSI)
+- strength: 0.8+ = strong trend, 0.5-0.8 = moderate, <0.5 = weak/transitioning
+- keyLevels: identify 2-3 most significant S/R per timeframe from swing points and EMAs
+- alignment: fraction of timeframes agreeing with dominantBias (1.0 = perfect alignment)
+- If alignment < 0.5, dominantBias should be "neutral" regardless of individual TF readings
+
+Current regime: ${regime.regime} (confidence: ${regime.confidence})
+Regime context matters: in volatile regime, weight higher timeframes more heavily.`,
+
+    user: `Multi-timeframe analysis:
+
+${timeframeEntries.join('\n\n')}`,
+  };
+}
+
+// --- Step 3: Setup Identification ---
+
+export function setupIdentificationPrompt(
+  chartData: ChartData,
+  indicators: IndicatorValues,
+  regime: RegimeState,
+  mtfAnalysis: MultiTimeframeAnalysis,
+): PromptPair {
+  return {
+    system: `You are a pattern recognition specialist and trade setup architect. You identify high-probability setups ONLY when sufficient confluence exists. You are conservative — no setup is better than a bad setup.
+
+Output ONLY valid JSON matching this schema (or null if no valid setup):
+{
+  "symbol": string,
+  "direction": "bullish" | "bearish",
+  "entry": number,
+  "stop": number,
+  "targets": [number, number],
+  "riskRewardRatio": number,
+  "confluenceFactors": [
+    { "name": string, "weight": 0-1, "description": string }
+  ],
+  "confluenceScore": number,
+  "pattern": string | null,
+  "timeframe": string,
+  "validUntil": "ISO8601",
+  "timestamp": "ISO8601",
+  "reasoning": "2-3 sentences"
+}
+
+Return {"setup": null, "reasoning": "..."} if no valid setup exists.
+
+Confluence factors (must identify at least 3):
+- Key level interaction (support/resistance bounce/break)
+- EMA alignment (price vs 20/50/200)
+- Volume confirmation (above average on setup bar)
+- RSI divergence or extreme
+- VWAP interaction
+- Pattern completion (flag, wedge, double top/bottom, etc.)
+- Multi-timeframe alignment (from prior step)
+- Momentum shift (MACD crossover, RSI inflection)
+
+Entry rules:
+- Entry at limit price, not market — calculate optimal entry from structure
+- Stop placement: beyond the invalidation level (swing point + ATR buffer)
+- Primary target: nearest significant resistance/support
+- Secondary target: 2x the risk distance or next major level
+- R:R must be >= 2.0 or setup is invalid
+- validUntil: setup expires in 4 hours for intraday, 2 days for daily TF
+
+Regime-specific behavior:
+- trending: favor pullback entries in trend direction, tighter stops
+- ranging: favor mean-reversion at range extremes, wider stops
+- volatile: ONLY take setups with R:R >= 3.0 and 4+ confluence factors`,
+
+    user: `Identify setup for ${chartData.symbol} on ${chartData.timeframe}:
+
+Regime: ${regime.regime} (confidence: ${regime.confidence})
+MTF dominant bias: ${mtfAnalysis.dominantBias} (alignment: ${mtfAnalysis.alignment})
+Conflicting TFs: ${mtfAnalysis.conflictingTimeframes.join(', ') || 'none'}
+
+Key levels from MTF analysis:
+${mtfAnalysis.biases
+  .map(
+    (b) =>
+      `${b.timeframe}: S=${b.keyLevels.support.join(', ')} R=${b.keyLevels.resistance.join(', ')}`,
+  )
+  .join('\n')}
+
+Recent bars (last 30): ${JSON.stringify(chartData.bars.slice(-30).map((b) => ({ t: b.time, o: b.open, h: b.high, l: b.low, c: b.close, v: b.volume })))}
+
+Indicators:
+- RSI: ${indicators.rsi ?? 'N/A'}
+- MACD: ${indicators.macd ? JSON.stringify(indicators.macd) : 'N/A'}
+- ADX: ${indicators.adx ?? 'N/A'}
+- ATR: ${indicators.atr ?? 'N/A'}
+- EMA20: ${indicators.ema20 ?? 'N/A'}, EMA50: ${indicators.ema50 ?? 'N/A'}, EMA200: ${indicators.ema200 ?? 'N/A'}
+- VWAP: ${indicators.vwap ?? 'N/A'}
+- Bollinger: ${indicators.bollingerBands ? JSON.stringify(indicators.bollingerBands) : 'N/A'}
+- Volume: ${indicators.volume ?? 'N/A'} (avg: ${indicators.avgVolume ?? 'N/A'})`,
+  };
+}
+
+// --- Step 4: Risk Assessment ---
+
+export function riskAssessmentPrompt(
+  setup: TradeSetup,
+  portfolioValue: number,
+  openPositions: { symbol: string; value: number; direction: string }[],
+  safetyConfig: SafetyConfig,
+): PromptPair {
+  const riskPerShare = Math.abs(setup.entry - setup.stop);
+  const riskPercent = riskPerShare / setup.entry;
+
+  return {
+    system: `You are a risk manager and position sizing specialist. Your job: calculate exact position size using hybrid Kelly-VIX and check portfolio-level risk. You are the last line of defense — conservative by nature.
+
+Output ONLY valid JSON matching this schema:
+{
+  "sizing": {
+    "shares": integer,
+    "dollarRisk": number,
+    "portfolioRiskPercent": number,
+    "kellyFraction": 0-1,
+    "adjustedKelly": 0-1,
+    "positionValue": number
+  },
+  "maxCorrelation": 0-1,
+  "correlatedPositions": [string],
+  "dailyDrawdownUsed": number,
+  "dailyDrawdownRemaining": number,
+  "openPositionCount": integer,
+  "earningsWithin48h": boolean,
+  "earningsDate": string | null,
+  "riskScore": 0-1,
+  "warnings": [string],
+  "timestamp": "ISO8601",
+  "reasoning": "2-3 sentences"
+}
+
+Position sizing algorithm (hybrid Kelly-VIX):
+1. Estimate win rate from confluence score: winRate = min(0.65, 0.4 + setup.confluenceScore * 0.05)
+2. Calculate Kelly fraction: f = (winRate * R:R - (1 - winRate)) / R:R
+3. Apply half-Kelly: adjustedKelly = f * 0.5
+4. VIX adjustment: if VIX > 20, scale down by (20 / VIX); if VIX < 15, allow up to 1.2x
+5. Cap at maxRiskPerTrade: final risk = min(adjustedKelly, ${safetyConfig.maxRiskPerTrade})
+6. Shares = floor(portfolioValue * finalRisk / riskPerShare)
+
+Correlation check:
+- Estimate sector correlation between new trade and each open position
+- Same sector = 0.7+, adjacent sectors = 0.4-0.7, uncorrelated < 0.4
+- Flag if max correlation > ${safetyConfig.maxCorrelation}
+
+Risk score (aggregate):
+- 0.0-0.3: low risk, high confidence setup
+- 0.3-0.6: moderate risk, acceptable
+- 0.6-0.8: elevated risk, proceed with caution
+- 0.8-1.0: high risk, recommend HOLD`,
+
+    user: `Assess risk for proposed trade:
+
+Setup: ${setup.direction} ${setup.symbol}
+Entry: ${setup.entry}, Stop: ${setup.stop}, Targets: ${setup.targets.join(', ')}
+R:R: ${setup.riskRewardRatio}
+Risk per share: $${riskPerShare.toFixed(2)} (${(riskPercent * 100).toFixed(2)}%)
+Confluence: ${setup.confluenceFactors.length} factors (score: ${setup.confluenceScore})
+
+Portfolio value: $${portfolioValue.toFixed(2)}
+Max risk per trade: ${(safetyConfig.maxRiskPerTrade * 100).toFixed(1)}%
+Max daily drawdown: ${(safetyConfig.maxDailyDrawdown * 100).toFixed(1)}%
+
+Open positions (${openPositions.length}):
+${openPositions.length > 0 ? openPositions.map((p) => `- ${p.symbol}: $${p.value.toFixed(2)} (${p.direction})`).join('\n') : 'None'}
+
+Max open positions: ${safetyConfig.maxOpenPositions}`,
+  };
+}
+
+// --- Step 5: Decision ---
+
+export function decisionPrompt(
+  regime: RegimeState,
+  mtfAnalysis: MultiTimeframeAnalysis,
+  setup: TradeSetup | null,
+  risk: RiskAssessment | null,
+  safetyConfig: SafetyConfig,
+): PromptPair {
+  return {
+    system: `You are the senior portfolio manager making the final trade decision. You synthesize all prior analysis — regime, multi-timeframe bias, setup quality, and risk assessment — into a single actionable decision. You are accountable for outcomes.
+
+Output ONLY valid JSON matching this schema:
+{
+  "action": "BUY" | "SELL" | "HOLD",
+  "confidence": 0-1,
+  "order": {
+    "symbol": string,
+    "action": "BUY" | "SELL",
+    "orderType": "LIMIT" | "STOP_LIMIT",
+    "quantity": integer,
+    "entryPrice": number,
+    "stopPrice": number,
+    "targetPrices": [number],
+    "timeInForce": "DAY" | "GTC" | "GTD",
+    "gtdDate": string | null
+  } | null,
+  "reasoning": "2-4 sentences",
+  "holdReasons": [string]
+}
+
+Decision framework:
+1. If no valid setup exists → HOLD
+2. If risk score > 0.8 → HOLD
+3. If regime confidence < 0.5 → HOLD (regime indeterminate)
+4. If MTF alignment < 0.5 → HOLD (conflicting timeframes)
+5. If setup direction conflicts with MTF dominant bias → HOLD
+6. Otherwise → BUY or SELL per setup direction
+
+Order construction (bracket order):
+- orderType: LIMIT for entries at support/resistance, STOP_LIMIT for breakout entries
+- quantity: from risk assessment sizing
+- stopPrice: from setup stop level
+- targetPrices: from setup targets
+- timeInForce: DAY for intraday setups, GTC for swing (2-5 day), GTD for position trades
+- gtdDate: setup.validUntil for GTD orders
+
+Confidence calibration:
+- Start at regime.confidence
+- Multiply by MTF alignment
+- Multiply by (confluenceScore / maxPossibleScore)
+- Adjust for risk score: multiply by (1 - riskScore * 0.3)
+- Final confidence must be explicit and honest — overconfidence causes trust collapse
+
+HOLD is always valid. When in doubt, HOLD. Document all hold reasons explicitly.`,
+
+    user: `Make final decision:
+
+REGIME: ${regime.regime} (confidence: ${regime.confidence}, VIX: ${regime.vix})
+MTF: dominant=${mtfAnalysis.dominantBias}, alignment=${mtfAnalysis.alignment}, conflicts=${mtfAnalysis.conflictingTimeframes.join(', ') || 'none'}
+
+${
+  setup
+    ? `SETUP: ${setup.direction} ${setup.symbol}
+Entry: ${setup.entry}, Stop: ${setup.stop}, Targets: ${setup.targets.join(', ')}
+R:R: ${setup.riskRewardRatio}, Confluence: ${setup.confluenceFactors.length} factors (score: ${setup.confluenceScore})
+Pattern: ${setup.pattern || 'none'}`
+    : 'SETUP: No valid setup identified'
+}
+
+${
+  risk
+    ? `RISK: Score ${risk.riskScore}, Shares: ${risk.sizing.shares}, Position: $${risk.sizing.positionValue.toFixed(2)}
+Portfolio risk: ${risk.sizing.portfolioRiskPercent.toFixed(2)}%, Daily DD remaining: ${risk.dailyDrawdownRemaining.toFixed(2)}%
+Correlation: ${risk.maxCorrelation.toFixed(2)} (${risk.correlatedPositions.join(', ') || 'none'})
+Earnings: ${risk.earningsWithin48h ? 'WITHIN BLACKOUT' : 'clear'}
+Warnings: ${risk.warnings.join('; ') || 'none'}`
+    : 'RISK: Not assessed (no setup)'
+}
+
+Safety limits: maxRisk=${(safetyConfig.maxRiskPerTrade * 100).toFixed(1)}%, maxDD=${(safetyConfig.maxDailyDrawdown * 100).toFixed(1)}%, minRR=${safetyConfig.minRiskReward}, minConfidence=${(safetyConfig.minConfidence * 100).toFixed(0)}%`,
+  };
+}
+
+// --- Approval Message Formatter ---
+
+/** Format a trade decision into a human-readable WhatsApp approval message. */
+export function formatApprovalMessage(
+  decision: TradeDecision,
+  expiresAt: string,
+): string {
+  if (decision.action === 'HOLD' || !decision.setup || !decision.order) {
+    return `HOLD: ${decision.reasoning}`;
+  }
+
+  const setup = decision.setup;
+  const order = decision.order;
+  const risk = decision.risk!;
+  const riskPerShare = Math.abs(order.entryPrice - order.stopPrice);
+  const totalRisk = riskPerShare * order.quantity;
+
+  const lines = [
+    `*${order.action} ${order.symbol}*`,
+    ``,
+    `Entry: $${order.entryPrice.toFixed(2)} (${order.orderType})`,
+    `Stop: $${order.stopPrice.toFixed(2)}`,
+    `Targets: ${order.targetPrices.map((t) => `$${t.toFixed(2)}`).join(' / ')}`,
+    `R:R: ${setup.riskRewardRatio.toFixed(1)}`,
+    ``,
+    `Qty: ${order.quantity} shares ($${(order.entryPrice * order.quantity).toFixed(0)})`,
+    `Risk: $${totalRisk.toFixed(0)} (${risk.sizing.portfolioRiskPercent.toFixed(1)}% of portfolio)`,
+    ``,
+    `Regime: ${decision.regime.regime} (${(decision.regime.confidence * 100).toFixed(0)}%)`,
+    `Confidence: ${(decision.confidence * 100).toFixed(0)}%`,
+    `Confluence: ${setup.confluenceFactors.map((f) => f.name).join(', ')}`,
+    ``,
+    `${decision.reasoning}`,
+    ``,
+    `Reply YES to execute, NO to cancel.`,
+    `Expires: ${new Date(expiresAt).toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour: '2-digit', minute: '2-digit' })} ET`,
+  ];
+
+  return lines.join('\n');
+}

--- a/src/trading/safety.test.ts
+++ b/src/trading/safety.test.ts
@@ -1,0 +1,490 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkStaleness,
+  createExpirationTime,
+  isApprovalExpired,
+  runSafetyChecks,
+  validateBracketOrder,
+  type DailyState,
+} from './safety.js';
+import type {
+  ApprovalRequest,
+  BracketOrder,
+  RegimeState,
+  SafetyConfig,
+  TradeDecision,
+} from './types.js';
+
+// --- Fixtures ---
+
+function makeSafetyConfig(overrides: Partial<SafetyConfig> = {}): SafetyConfig {
+  return {
+    allowOrders: true,
+    mode: 'paper',
+    maxRiskPerTrade: 0.02,
+    maxDailyDrawdown: 0.03,
+    maxOpenPositions: 5,
+    maxCorrelation: 0.7,
+    earningsBlackoutHours: 48,
+    stalenessThreshold: 0.005,
+    approvalTtlMs: 600000,
+    minConfluenceFactors: 3,
+    minConfidence: 0.6,
+    minRiskReward: 2.0,
+    marketOpenBufferMinutes: 15,
+    marketCloseBufferMinutes: 15,
+    vixCircuitBreaker: 35,
+    instrumentWhitelist: [],
+    instrumentBlacklist: [],
+    ...overrides,
+  };
+}
+
+function makeRegime(overrides: Partial<RegimeState> = {}): RegimeState {
+  return {
+    regime: 'trending',
+    confidence: 0.85,
+    adx: 30,
+    vix: 18,
+    vixPercentile: 40,
+    hmmState: 0,
+    transitionProb: 0.1,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeDecision(
+  overrides: Partial<TradeDecision> = {},
+): TradeDecision {
+  return {
+    action: 'BUY',
+    confidence: 0.75,
+    regime: makeRegime(),
+    timeframeAnalysis: {
+      biases: [],
+      alignment: 0.8,
+      dominantBias: 'bullish',
+      conflictingTimeframes: [],
+      timestamp: new Date().toISOString(),
+    },
+    setup: {
+      symbol: 'AAPL',
+      direction: 'bullish',
+      entry: 150,
+      stop: 147,
+      targets: [156, 162],
+      riskRewardRatio: 2.5,
+      confluenceFactors: [
+        { name: 'EMA alignment', weight: 0.3, description: 'Price above 20/50 EMA' },
+        { name: 'Volume spike', weight: 0.25, description: 'Volume 1.5x average' },
+        { name: 'Support bounce', weight: 0.3, description: 'Bounced off key level' },
+      ],
+      confluenceScore: 0.85,
+      pattern: 'bull flag',
+      timeframe: '1h',
+      validUntil: new Date(Date.now() + 14400000).toISOString(),
+      timestamp: new Date().toISOString(),
+    },
+    risk: {
+      sizing: {
+        shares: 100,
+        dollarRisk: 300,
+        portfolioRiskPercent: 1.5,
+        kellyFraction: 0.12,
+        adjustedKelly: 0.06,
+        positionValue: 15000,
+      },
+      maxCorrelation: 0.3,
+      correlatedPositions: [],
+      dailyDrawdownUsed: 0.5,
+      dailyDrawdownRemaining: 2.5,
+      openPositionCount: 2,
+      earningsWithin48h: false,
+      riskScore: 0.3,
+      warnings: [],
+      timestamp: new Date().toISOString(),
+    },
+    order: {
+      symbol: 'AAPL',
+      action: 'BUY',
+      orderType: 'LIMIT',
+      quantity: 100,
+      entryPrice: 150,
+      stopPrice: 147,
+      targetPrices: [156, 162],
+      timeInForce: 'DAY',
+    },
+    reasoning: 'Strong trend with multi-timeframe alignment',
+    holdReasons: [],
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeDailyState(overrides: Partial<DailyState> = {}): DailyState {
+  return {
+    realizedPnl: -0.005,
+    openPositionCount: 2,
+    openSymbols: ['MSFT', 'GOOGL'],
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+describe('runSafetyChecks', () => {
+  it('passes when all checks are met', () => {
+    const result = runSafetyChecks(
+      makeDecision(),
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('fails when orders are disabled', () => {
+    const config = makeSafetyConfig({ allowOrders: false });
+    const result = runSafetyChecks(makeDecision(), config, makeDailyState());
+    expect(result.passed).toBe(false);
+    expect(result.violations).toContain(
+      'IBKR_ALLOW_ORDERS is false — order submission disabled',
+    );
+  });
+
+  it('fails when risk per trade exceeds limit', () => {
+    const decision = makeDecision({
+      risk: {
+        ...makeDecision().risk!,
+        sizing: {
+          ...makeDecision().risk!.sizing,
+          portfolioRiskPercent: 3.5,
+        },
+      },
+    });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations.some((v) => v.includes('Risk per trade'))).toBe(
+      true,
+    );
+  });
+
+  it('fails when max open positions reached', () => {
+    const daily = makeDailyState({ openPositionCount: 5 });
+    const result = runSafetyChecks(
+      makeDecision(),
+      makeSafetyConfig(),
+      daily,
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('open positions')),
+    ).toBe(true);
+  });
+
+  it('fails when VIX exceeds circuit breaker', () => {
+    const decision = makeDecision({
+      regime: makeRegime({ vix: 40 }),
+    });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('VIX')),
+    ).toBe(true);
+  });
+
+  it('fails when confidence is too low', () => {
+    const decision = makeDecision({ confidence: 0.4 });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('Confidence')),
+    ).toBe(true);
+  });
+
+  it('fails when not enough confluence factors', () => {
+    const decision = makeDecision({
+      setup: {
+        ...makeDecision().setup!,
+        confluenceFactors: [
+          { name: 'EMA', weight: 0.3, description: 'test' },
+        ],
+      },
+    });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('confluence')),
+    ).toBe(true);
+  });
+
+  it('fails when R:R is too low', () => {
+    const decision = makeDecision({
+      setup: {
+        ...makeDecision().setup!,
+        riskRewardRatio: 1.2,
+      },
+    });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.violations.some((v) => v.includes('R:R'))).toBe(true);
+  });
+
+  it('fails when symbol is blacklisted', () => {
+    const config = makeSafetyConfig({ instrumentBlacklist: ['AAPL'] });
+    const result = runSafetyChecks(makeDecision(), config, makeDailyState());
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('blacklisted')),
+    ).toBe(true);
+  });
+
+  it('fails when symbol is not in whitelist', () => {
+    const config = makeSafetyConfig({ instrumentWhitelist: ['MSFT', 'GOOGL'] });
+    const result = runSafetyChecks(makeDecision(), config, makeDailyState());
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('whitelist')),
+    ).toBe(true);
+  });
+
+  it('fails when earnings within blackout', () => {
+    const decision = makeDecision({
+      risk: {
+        ...makeDecision().risk!,
+        earningsWithin48h: true,
+        earningsDate: '2026-04-16',
+      },
+    });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('Earnings')),
+    ).toBe(true);
+  });
+
+  it('fails when correlation is too high', () => {
+    const decision = makeDecision({
+      risk: {
+        ...makeDecision().risk!,
+        maxCorrelation: 0.85,
+        correlatedPositions: ['MSFT'],
+      },
+    });
+    const result = runSafetyChecks(
+      decision,
+      makeSafetyConfig(),
+      makeDailyState(),
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.includes('correlation')),
+    ).toBe(true);
+  });
+
+  it('passes HOLD decisions even with orders disabled', () => {
+    const config = makeSafetyConfig({ allowOrders: false });
+    const decision = makeDecision({ action: 'HOLD' });
+    const result = runSafetyChecks(decision, config, makeDailyState());
+    // HOLD still fails on allowOrders but that's correct —
+    // the orders-disabled check is always evaluated
+    expect(result.violations).toContain(
+      'IBKR_ALLOW_ORDERS is false — order submission disabled',
+    );
+  });
+});
+
+describe('validateBracketOrder', () => {
+  it('passes for valid BUY order', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'BUY',
+      orderType: 'LIMIT',
+      quantity: 100,
+      entryPrice: 150,
+      stopPrice: 147,
+      targetPrices: [156],
+      timeInForce: 'DAY',
+    };
+    expect(validateBracketOrder(order)).toHaveLength(0);
+  });
+
+  it('passes for valid SELL order', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'SELL',
+      orderType: 'LIMIT',
+      quantity: 50,
+      entryPrice: 150,
+      stopPrice: 153,
+      targetPrices: [144],
+      timeInForce: 'DAY',
+    };
+    expect(validateBracketOrder(order)).toHaveLength(0);
+  });
+
+  it('rejects BUY with stop above entry', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'BUY',
+      orderType: 'LIMIT',
+      quantity: 100,
+      entryPrice: 150,
+      stopPrice: 155,
+      targetPrices: [160],
+      timeInForce: 'DAY',
+    };
+    const errors = validateBracketOrder(order);
+    expect(errors.some((e) => e.includes('Stop must be below entry'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects SELL with stop below entry', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'SELL',
+      orderType: 'LIMIT',
+      quantity: 50,
+      entryPrice: 150,
+      stopPrice: 145,
+      targetPrices: [140],
+      timeInForce: 'DAY',
+    };
+    const errors = validateBracketOrder(order);
+    expect(errors.some((e) => e.includes('Stop must be above entry'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects zero quantity', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'BUY',
+      orderType: 'LIMIT',
+      quantity: 0,
+      entryPrice: 150,
+      stopPrice: 147,
+      targetPrices: [156],
+      timeInForce: 'DAY',
+    };
+    const errors = validateBracketOrder(order);
+    expect(errors.some((e) => e.includes('Quantity must be positive'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects no target prices', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'BUY',
+      orderType: 'LIMIT',
+      quantity: 100,
+      entryPrice: 150,
+      stopPrice: 147,
+      targetPrices: [],
+      timeInForce: 'DAY',
+    };
+    const errors = validateBracketOrder(order);
+    expect(
+      errors.some((e) => e.includes('At least one target price')),
+    ).toBe(true);
+  });
+
+  it('rejects BUY with target below entry', () => {
+    const order: BracketOrder = {
+      symbol: 'AAPL',
+      action: 'BUY',
+      orderType: 'LIMIT',
+      quantity: 100,
+      entryPrice: 150,
+      stopPrice: 147,
+      targetPrices: [148],
+      timeInForce: 'DAY',
+    };
+    const errors = validateBracketOrder(order);
+    expect(errors.some((e) => e.includes('must be above entry'))).toBe(true);
+  });
+});
+
+describe('checkStaleness', () => {
+  it('returns not stale when price within threshold', () => {
+    const result = checkStaleness(150, 150.5, 0.005);
+    expect(result.isStale).toBe(false);
+    expect(result.priceDrift).toBeCloseTo(0.0033, 3);
+  });
+
+  it('returns stale when price exceeds threshold', () => {
+    const result = checkStaleness(150, 152, 0.005);
+    expect(result.isStale).toBe(true);
+    expect(result.priceDrift).toBeCloseTo(0.0133, 3);
+  });
+
+  it('handles zero drift', () => {
+    const result = checkStaleness(150, 150, 0.005);
+    expect(result.isStale).toBe(false);
+    expect(result.priceDrift).toBe(0);
+  });
+});
+
+describe('createExpirationTime', () => {
+  it('creates future timestamp', () => {
+    const before = Date.now();
+    const expires = createExpirationTime(600000);
+    const expiresMs = new Date(expires).getTime();
+    expect(expiresMs).toBeGreaterThanOrEqual(before + 599000);
+    expect(expiresMs).toBeLessThanOrEqual(before + 601000);
+  });
+});
+
+describe('isApprovalExpired', () => {
+  it('returns false for future expiration', () => {
+    const approval: ApprovalRequest = {
+      id: 'test',
+      decision: makeDecision(),
+      summary: 'test',
+      expiresAt: new Date(Date.now() + 60000).toISOString(),
+      status: 'pending',
+      sentAt: new Date().toISOString(),
+    };
+    expect(isApprovalExpired(approval)).toBe(false);
+  });
+
+  it('returns true for past expiration', () => {
+    const approval: ApprovalRequest = {
+      id: 'test',
+      decision: makeDecision(),
+      summary: 'test',
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+      status: 'pending',
+      sentAt: new Date().toISOString(),
+    };
+    expect(isApprovalExpired(approval)).toBe(true);
+  });
+});

--- a/src/trading/safety.ts
+++ b/src/trading/safety.ts
@@ -1,0 +1,360 @@
+/**
+ * Safety rails for the trading analysis engine.
+ *
+ * Every trade proposal passes through these checks before reaching
+ * the approval stage. Any single failure blocks the trade.
+ *
+ * Design principles:
+ * - Fail closed: if data is missing, block the trade
+ * - No silent overrides: every block produces a human-readable reason
+ * - Stateless checks: daily drawdown state is passed in, not stored here
+ */
+
+import type {
+  ApprovalRequest,
+  BracketOrder,
+  RiskAssessment,
+  SafetyConfig,
+  StalenessCheck,
+  TradeDecision,
+  TradeSetup,
+} from './types.js';
+
+export interface SafetyCheckResult {
+  passed: boolean;
+  violations: string[];
+  warnings: string[];
+}
+
+export interface DailyState {
+  realizedPnl: number; // today's realized P&L as fraction of portfolio
+  openPositionCount: number;
+  openSymbols: string[]; // symbols currently held
+}
+
+// --- Individual Checks ---
+
+function checkOrdersEnabled(config: SafetyConfig): string | null {
+  if (!config.allowOrders) {
+    return 'IBKR_ALLOW_ORDERS is false — order submission disabled';
+  }
+  return null;
+}
+
+function checkRiskPerTrade(
+  risk: RiskAssessment,
+  config: SafetyConfig,
+): string | null {
+  if (risk.sizing.portfolioRiskPercent > config.maxRiskPerTrade * 100) {
+    return `Risk per trade ${risk.sizing.portfolioRiskPercent.toFixed(2)}% exceeds max ${(config.maxRiskPerTrade * 100).toFixed(1)}%`;
+  }
+  return null;
+}
+
+function checkDailyDrawdown(
+  daily: DailyState,
+  risk: RiskAssessment,
+  config: SafetyConfig,
+): string | null {
+  const totalExposure =
+    Math.abs(daily.realizedPnl) + risk.sizing.portfolioRiskPercent / 100;
+  if (totalExposure > config.maxDailyDrawdown) {
+    return `Daily drawdown would reach ${(totalExposure * 100).toFixed(2)}% — max is ${(config.maxDailyDrawdown * 100).toFixed(1)}%`;
+  }
+  return null;
+}
+
+function checkOpenPositions(
+  daily: DailyState,
+  config: SafetyConfig,
+): string | null {
+  if (daily.openPositionCount >= config.maxOpenPositions) {
+    return `Already at ${daily.openPositionCount} open positions — max is ${config.maxOpenPositions}`;
+  }
+  return null;
+}
+
+function checkCorrelation(
+  risk: RiskAssessment,
+  config: SafetyConfig,
+): string | null {
+  if (risk.maxCorrelation > config.maxCorrelation) {
+    const correlated = risk.correlatedPositions.join(', ');
+    return `High correlation (${risk.maxCorrelation.toFixed(2)}) with existing positions: ${correlated} — max is ${config.maxCorrelation}`;
+  }
+  return null;
+}
+
+function checkEarnings(
+  risk: RiskAssessment,
+  config: SafetyConfig,
+): string | null {
+  if (risk.earningsWithin48h && config.earningsBlackoutHours > 0) {
+    const date = risk.earningsDate || 'unknown date';
+    return `Earnings within ${config.earningsBlackoutHours}h blackout (${date})`;
+  }
+  return null;
+}
+
+function checkConfluence(
+  setup: TradeSetup,
+  config: SafetyConfig,
+): string | null {
+  if (setup.confluenceFactors.length < config.minConfluenceFactors) {
+    return `Only ${setup.confluenceFactors.length} confluence factors — minimum is ${config.minConfluenceFactors}`;
+  }
+  return null;
+}
+
+function checkConfidence(
+  decision: TradeDecision,
+  config: SafetyConfig,
+): string | null {
+  if (decision.confidence < config.minConfidence) {
+    return `Confidence ${(decision.confidence * 100).toFixed(0)}% below minimum ${(config.minConfidence * 100).toFixed(0)}%`;
+  }
+  return null;
+}
+
+function checkRiskReward(
+  setup: TradeSetup,
+  config: SafetyConfig,
+): string | null {
+  if (setup.riskRewardRatio < config.minRiskReward) {
+    return `R:R ${setup.riskRewardRatio.toFixed(2)} below minimum ${config.minRiskReward}`;
+  }
+  return null;
+}
+
+function checkVixCircuitBreaker(
+  vix: number,
+  config: SafetyConfig,
+): string | null {
+  if (vix >= config.vixCircuitBreaker) {
+    return `VIX at ${vix.toFixed(1)} — circuit breaker threshold is ${config.vixCircuitBreaker}`;
+  }
+  return null;
+}
+
+function checkInstrument(
+  symbol: string,
+  config: SafetyConfig,
+): string | null {
+  if (
+    config.instrumentBlacklist.length > 0 &&
+    config.instrumentBlacklist.includes(symbol)
+  ) {
+    return `${symbol} is blacklisted`;
+  }
+  if (
+    config.instrumentWhitelist.length > 0 &&
+    !config.instrumentWhitelist.includes(symbol)
+  ) {
+    return `${symbol} is not in the whitelist`;
+  }
+  return null;
+}
+
+function checkMarketHours(config: SafetyConfig): {
+  violation: string | null;
+  warning: string | null;
+} {
+  const now = new Date();
+  // US Eastern time market hours check
+  const eastern = new Date(
+    now.toLocaleString('en-US', { timeZone: 'America/New_York' }),
+  );
+  const hours = eastern.getHours();
+  const minutes = eastern.getMinutes();
+  const totalMinutes = hours * 60 + minutes;
+
+  const marketOpen = 9 * 60 + 30; // 9:30 AM ET
+  const marketClose = 16 * 60; // 4:00 PM ET
+  const day = eastern.getDay();
+
+  // Weekend check
+  if (day === 0 || day === 6) {
+    return { violation: null, warning: 'Market is closed (weekend)' };
+  }
+
+  // Outside market hours
+  if (totalMinutes < marketOpen || totalMinutes >= marketClose) {
+    return { violation: null, warning: 'Outside regular market hours' };
+  }
+
+  // Buffer zones
+  if (
+    config.marketOpenBufferMinutes > 0 &&
+    totalMinutes < marketOpen + config.marketOpenBufferMinutes
+  ) {
+    return {
+      violation: `Within ${config.marketOpenBufferMinutes}-minute market open buffer`,
+      warning: null,
+    };
+  }
+
+  if (
+    config.marketCloseBufferMinutes > 0 &&
+    totalMinutes >= marketClose - config.marketCloseBufferMinutes
+  ) {
+    return {
+      violation: `Within ${config.marketCloseBufferMinutes}-minute market close buffer`,
+      warning: null,
+    };
+  }
+
+  return { violation: null, warning: null };
+}
+
+// --- Staleness Gate ---
+
+/** Check if price has drifted beyond threshold since proposal was created. */
+export function checkStaleness(
+  originalPrice: number,
+  currentPrice: number,
+  threshold: number,
+): StalenessCheck {
+  const drift = Math.abs(currentPrice - originalPrice) / originalPrice;
+  return {
+    originalPrice,
+    currentPrice,
+    priceDrift: drift,
+    isStale: drift > threshold,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+// --- Approval TTL ---
+
+/** Check if an approval request has expired. */
+export function isApprovalExpired(approval: ApprovalRequest): boolean {
+  return new Date() > new Date(approval.expiresAt);
+}
+
+/** Create expiration timestamp from TTL. */
+export function createExpirationTime(ttlMs: number): string {
+  return new Date(Date.now() + ttlMs).toISOString();
+}
+
+// --- Composite Safety Check ---
+
+/** Run all safety checks against a trade decision. Returns pass/fail with reasons. */
+export function runSafetyChecks(
+  decision: TradeDecision,
+  config: SafetyConfig,
+  daily: DailyState,
+): SafetyCheckResult {
+  const violations: string[] = [];
+  const warnings: string[] = [];
+
+  // Always check: orders enabled
+  const ordersCheck = checkOrdersEnabled(config);
+  if (ordersCheck) violations.push(ordersCheck);
+
+  // HOLD decisions pass safety (nothing to block)
+  if (decision.action === 'HOLD') {
+    return { passed: violations.length === 0, violations, warnings };
+  }
+
+  // Instrument check
+  if (decision.setup) {
+    const instrumentCheck = checkInstrument(decision.setup.symbol, config);
+    if (instrumentCheck) violations.push(instrumentCheck);
+  }
+
+  // VIX circuit breaker
+  const vixCheck = checkVixCircuitBreaker(decision.regime.vix, config);
+  if (vixCheck) violations.push(vixCheck);
+
+  // Market hours
+  const marketCheck = checkMarketHours(config);
+  if (marketCheck.violation) violations.push(marketCheck.violation);
+  if (marketCheck.warning) warnings.push(marketCheck.warning);
+
+  // Confidence
+  const confidenceCheck = checkConfidence(decision, config);
+  if (confidenceCheck) violations.push(confidenceCheck);
+
+  // Setup-dependent checks
+  if (decision.setup) {
+    const confluenceCheck = checkConfluence(decision.setup, config);
+    if (confluenceCheck) violations.push(confluenceCheck);
+
+    const rrCheck = checkRiskReward(decision.setup, config);
+    if (rrCheck) violations.push(rrCheck);
+  }
+
+  // Risk-dependent checks
+  if (decision.risk) {
+    const riskCheck = checkRiskPerTrade(decision.risk, config);
+    if (riskCheck) violations.push(riskCheck);
+
+    const drawdownCheck = checkDailyDrawdown(daily, decision.risk, config);
+    if (drawdownCheck) violations.push(drawdownCheck);
+
+    const correlationCheck = checkCorrelation(decision.risk, config);
+    if (correlationCheck) violations.push(correlationCheck);
+
+    const earningsCheck = checkEarnings(decision.risk, config);
+    if (earningsCheck) violations.push(earningsCheck);
+  }
+
+  // Position count
+  const positionCheck = checkOpenPositions(daily, config);
+  if (positionCheck) violations.push(positionCheck);
+
+  return {
+    passed: violations.length === 0,
+    violations,
+    warnings,
+  };
+}
+
+// --- Order Validation ---
+
+/** Validate that a bracket order is internally consistent. */
+export function validateBracketOrder(order: BracketOrder): string[] {
+  const errors: string[] = [];
+
+  if (order.quantity <= 0) {
+    errors.push('Quantity must be positive');
+  }
+
+  if (order.entryPrice <= 0) {
+    errors.push('Entry price must be positive');
+  }
+
+  if (order.stopPrice <= 0) {
+    errors.push('Stop price must be positive');
+  }
+
+  if (order.action === 'BUY') {
+    if (order.stopPrice >= order.entryPrice) {
+      errors.push('Stop must be below entry for BUY orders');
+    }
+    for (const target of order.targetPrices) {
+      if (target <= order.entryPrice) {
+        errors.push(`Target ${target} must be above entry ${order.entryPrice}`);
+      }
+    }
+  }
+
+  if (order.action === 'SELL') {
+    if (order.stopPrice <= order.entryPrice) {
+      errors.push('Stop must be above entry for SELL orders');
+    }
+    for (const target of order.targetPrices) {
+      if (target >= order.entryPrice) {
+        errors.push(
+          `Target ${target} must be below entry ${order.entryPrice}`,
+        );
+      }
+    }
+  }
+
+  if (order.targetPrices.length === 0) {
+    errors.push('At least one target price required');
+  }
+
+  return errors;
+}

--- a/src/trading/types.ts
+++ b/src/trading/types.ts
@@ -1,0 +1,223 @@
+/**
+ * Trading analysis engine type definitions.
+ *
+ * All types follow the 5-step analysis chain:
+ * Regime Detection -> Multi-Timeframe Bias -> Setup Identification ->
+ * Risk Assessment -> Decision
+ */
+
+// --- Enums & Literals ---
+
+export type MarketRegime = 'trending' | 'ranging' | 'volatile';
+export type Direction = 'bullish' | 'bearish' | 'neutral';
+export type TradeAction = 'BUY' | 'SELL' | 'HOLD';
+export type OrderType = 'LIMIT' | 'MARKET' | 'STOP_LIMIT';
+export type TradingMode = 'paper' | 'live';
+export type Timeframe = '1m' | '5m' | '15m' | '1h' | '4h' | '1D' | '1W';
+export type ApprovalStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'expired'
+  | 'aborted';
+
+// --- Step 1: Regime Detection ---
+
+export interface RegimeState {
+  regime: MarketRegime;
+  confidence: number; // 0-1
+  adx: number;
+  vix: number;
+  vixPercentile: number; // 0-100, relative to 252-day lookback
+  hmmState: number; // raw HMM hidden state index
+  transitionProb: number; // probability of regime change in next period
+  timestamp: string; // ISO 8601
+}
+
+// --- Step 2: Multi-Timeframe Bias ---
+
+export interface TimeframeBias {
+  timeframe: Timeframe;
+  direction: Direction;
+  strength: number; // 0-1
+  keyLevels: {
+    support: number[];
+    resistance: number[];
+  };
+  trendStructure: 'higher-highs' | 'lower-lows' | 'consolidation';
+}
+
+export interface MultiTimeframeAnalysis {
+  biases: TimeframeBias[];
+  alignment: number; // 0-1, how well timeframes agree
+  dominantBias: Direction;
+  conflictingTimeframes: Timeframe[]; // which TFs disagree with dominant
+  timestamp: string;
+}
+
+// --- Step 3: Setup Identification ---
+
+export interface ConfluenceFactor {
+  name: string; // e.g. "EMA crossover", "volume spike", "support bounce"
+  weight: number; // 0-1
+  description: string;
+}
+
+export interface TradeSetup {
+  symbol: string;
+  direction: Direction;
+  entry: number;
+  stop: number;
+  targets: number[]; // multiple take-profit levels
+  riskRewardRatio: number;
+  confluenceFactors: ConfluenceFactor[];
+  confluenceScore: number; // sum of weights, minimum 3 factors required
+  pattern?: string; // e.g. "bull flag", "double bottom"
+  timeframe: Timeframe; // execution timeframe
+  validUntil: string; // ISO 8601, setup expiration
+  timestamp: string;
+}
+
+// --- Step 4: Risk Assessment ---
+
+export interface PositionSizing {
+  shares: number;
+  dollarRisk: number; // max $ at risk
+  portfolioRiskPercent: number; // % of portfolio at risk
+  kellyFraction: number; // raw Kelly
+  adjustedKelly: number; // VIX-adjusted (half-Kelly baseline)
+  positionValue: number; // total position $ value
+}
+
+export interface RiskAssessment {
+  sizing: PositionSizing;
+  maxCorrelation: number; // highest correlation with existing positions
+  correlatedPositions: string[]; // symbols of correlated positions
+  dailyDrawdownUsed: number; // % of daily drawdown budget consumed
+  dailyDrawdownRemaining: number; // % remaining
+  openPositionCount: number;
+  earningsWithin48h: boolean;
+  earningsDate?: string;
+  riskScore: number; // 0-1, aggregate risk (lower = safer)
+  warnings: string[]; // human-readable risk warnings
+  timestamp: string;
+}
+
+// --- Step 5: Decision ---
+
+export interface BracketOrder {
+  symbol: string;
+  action: TradeAction;
+  orderType: OrderType;
+  quantity: number;
+  entryPrice: number;
+  stopPrice: number;
+  targetPrices: number[];
+  timeInForce: 'DAY' | 'GTC' | 'GTD';
+  gtdDate?: string; // ISO 8601, for GTD orders
+}
+
+export interface TradeDecision {
+  action: TradeAction;
+  confidence: number; // 0-1
+  regime: RegimeState;
+  timeframeAnalysis: MultiTimeframeAnalysis;
+  setup: TradeSetup | null; // null when action is HOLD
+  risk: RiskAssessment | null;
+  order: BracketOrder | null;
+  reasoning: string; // concise explanation of the decision
+  holdReasons: string[]; // reasons for HOLD (empty if BUY/SELL)
+  timestamp: string;
+}
+
+// --- Approval Flow ---
+
+export interface ApprovalRequest {
+  id: string; // unique request ID
+  decision: TradeDecision;
+  summary: string; // human-readable WhatsApp message
+  expiresAt: string; // ISO 8601, 10min TTL
+  status: ApprovalStatus;
+  sentAt: string;
+  respondedAt?: string;
+  stalenesCheck?: StalenessCheck;
+}
+
+export interface StalenessCheck {
+  originalPrice: number;
+  currentPrice: number;
+  priceDrift: number; // absolute % change
+  isStale: boolean; // true if drift > threshold
+  checkedAt: string;
+}
+
+// --- Safety Configuration ---
+
+export interface SafetyConfig {
+  allowOrders: boolean; // IBKR_ALLOW_ORDERS, default false
+  mode: TradingMode; // paper (port 4002) or live (port 5000)
+  maxRiskPerTrade: number; // fraction, default 0.02 (2%)
+  maxDailyDrawdown: number; // fraction, default 0.03 (3%)
+  maxOpenPositions: number; // default 5
+  maxCorrelation: number; // default 0.7
+  earningsBlackoutHours: number; // default 48
+  stalenessThreshold: number; // fraction, default 0.005 (0.5%)
+  approvalTtlMs: number; // default 600000 (10 min)
+  minConfluenceFactors: number; // default 3
+  minConfidence: number; // fraction, default 0.6
+  minRiskReward: number; // default 2.0
+  marketOpenBufferMinutes: number; // no entries first N min, default 15
+  marketCloseBufferMinutes: number; // no entries last N min, default 15
+  vixCircuitBreaker: number; // VIX level above which all entries blocked, default 35
+  instrumentWhitelist: string[]; // empty = all allowed
+  instrumentBlacklist: string[];
+}
+
+// --- Pipeline State ---
+
+export interface PipelineContext {
+  symbol: string;
+  requestedAt: string;
+  timeframes: Timeframe[];
+  regime?: RegimeState;
+  timeframeAnalysis?: MultiTimeframeAnalysis;
+  setup?: TradeSetup;
+  risk?: RiskAssessment;
+  decision?: TradeDecision;
+  approval?: ApprovalRequest;
+  abortReason?: string;
+  completedAt?: string;
+}
+
+// --- Chart Data (from TradingView MCP) ---
+
+export interface OhlcvBar {
+  time: number; // unix timestamp
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface ChartData {
+  symbol: string;
+  timeframe: Timeframe;
+  bars: OhlcvBar[];
+  indicators: Record<string, number>; // name -> current value
+  timestamp: string;
+}
+
+export interface IndicatorValues {
+  rsi?: number;
+  macd?: { value: number; signal: number; histogram: number };
+  adx?: number;
+  atr?: number;
+  ema20?: number;
+  ema50?: number;
+  ema200?: number;
+  vwap?: number;
+  bollingerBands?: { upper: number; middle: number; lower: number };
+  volume?: number;
+  avgVolume?: number;
+}


### PR DESCRIPTION
## Summary

- Adds the 5-step trading analysis engine (`src/trading/`) — the private/internal component of the TV -> Claude -> IBKR pipeline
- Implements regime detection, multi-timeframe bias, setup identification, risk assessment, and decision prompts with structured JSON output
- Safety rails: 2% per-trade risk cap, 3% daily drawdown breaker, VIX circuit breaker, earnings blackout, staleness gate, correlation checks
- Pipeline orchestrator with injectable adapter interfaces (ChartAdapter, AnalysisAdapter, BrokerAdapter, ApprovalAdapter) for testability
- Zod-validated config with safe defaults: paper mode, orders disabled, all safety gates on
- 52 unit tests across 4 test files, TypeScript builds clean

## Architecture

```
src/trading/
  types.ts     — All type definitions (RegimeState, TradeSetup, BracketOrder, etc.)
  config.ts    — Zod-validated env config with safe defaults
  safety.ts    — Safety rails, staleness gate, order validation
  prompts.ts   — 5 expert prompts + approval message formatter
  pipeline.ts  — Orchestrator connecting all steps via adapter interfaces
  index.ts     — Public API re-exports
  *.test.ts    — 52 tests
```

## Key decisions

- **Adapter pattern**: MCP tool calls are injected via interfaces, not hardcoded. The pipeline is testable without TradingView or IBKR connected.
- **Prompt diversity**: Each analysis step uses a distinct expert persona (regime analyst, MTF analyst, pattern specialist, risk manager, portfolio manager) to avoid correlated LLM failure modes (per Lopez-Lira arXiv:2504.10789).
- **Fail closed**: Missing data blocks trades. No silent overrides. Every block produces a human-readable reason.
- **Bracket orders**: Entry + stop + target as atomic package, neutralizing the approval-delay timing problem.

## What this does NOT include (by design)

- No actual MCP adapter implementations (those depend on ibkr-mcp and TradingView MCP being connected)
- No WhatsApp channel integration (separate PR)
- No CLI command to trigger analysis (separate PR)
- No changes to existing code — this is a fully self-contained new module

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run src/trading/` — 52 tests pass
- [x] Full test suite: only pre-existing `credential-proxy.test.ts` failure (unrelated)
- [ ] Manual verification: adapter implementations wired up in future PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)