### PR TITLE
feat: add Gemini OCR script and shadow check

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -16,6 +16,7 @@ Usage:
   python3 scripts/drift_check.py --coverage        # report uncovered docs/
   python3 scripts/drift_check.py --paths           # verify all pattern path refs exist
   python3 scripts/drift_check.py --adr             # flag patterns stale vs ADRs
+  python3 scripts/drift_check.py --shadow          # check private/public symlink integrity
   python3 scripts/drift_check.py --all             # run every fast check above
   python3 scripts/drift_check.py --validate        # LLM pattern content check (slow)
   python3 scripts/drift_check.py --validate-router # LLM router selection check (slow)
@@ -1063,16 +1064,68 @@ def check_all(project_root: Path, base_ref: str | None = None) -> int:
     adr_rc = check_adr(project_root)
     print("\n=== test_tasks frontmatter ===")
     tt_rc = check_test_tasks(project_root)
+    print("\n=== shadow (private overrides) ===")
+    shadow_rc = check_shadow(project_root)
     print("\n=== coverage (informational) ===")
     cov_rc = check_coverage(project_root)
 
-    worst = max(drift_rc, paths_rc, adr_rc, tt_rc, cov_rc)
+    worst = max(drift_rc, paths_rc, adr_rc, tt_rc, shadow_rc, cov_rc)
     print()
     if worst == 0:
         print("ALL CHECKS PASSED")
     else:
         print(f"FAILED (worst exit code: {worst})")
     return worst
+
+
+def check_shadow(project_root: Path) -> int:
+    """Check that src/private/ mirrors are properly symlinked.
+
+    Scans src/private/ for files that shadow public equivalents (e.g.,
+    src/private/scripts/foo.py shadows scripts/foo.py). Warns if:
+    - A shadow exists but /tmp/ symlink points to the public version
+    - A shadow exists but no /tmp/ symlink exists at all
+    Returns 0 if all shadows are properly linked, 1 if issues found.
+    """
+    private_root = project_root / "src" / "private"
+    if not private_root.exists():
+        print("No src/private/ directory — nothing to check.")
+        return 0
+
+    issues = 0
+    for private_file in sorted(private_root.rglob("*")):
+        if private_file.is_dir() or private_file.name.startswith("."):
+            continue
+        # Compute the public equivalent path
+        # src/private/scripts/foo.py → scripts/foo.py
+        rel = private_file.relative_to(private_root)
+        public_file = project_root / rel
+        if not public_file.exists():
+            continue  # No shadow — private-only file, fine
+
+        # Check /tmp/ symlink
+        tmp_link = Path("/tmp") / private_file.name
+        if tmp_link.is_symlink():
+            target = tmp_link.resolve()
+            if target != private_file.resolve():
+                print(f"  WARN: /tmp/{private_file.name} → {target}")
+                print(f"        should point to {private_file}")
+                issues += 1
+            else:
+                print(f"  OK: /tmp/{private_file.name} → private (correct)")
+        elif tmp_link.exists():
+            print(f"  WARN: /tmp/{private_file.name} exists but is not a symlink")
+            issues += 1
+        else:
+            print(f"  WARN: {rel} shadows public version but no /tmp/ symlink")
+            print(f"        run: ln -sf {private_file} /tmp/{private_file.name}")
+            issues += 1
+
+    if issues == 0:
+        print("All private shadows properly linked.")
+    else:
+        print(f"\n{issues} shadow issue(s) found.")
+    return 1 if issues else 0
 
 
 def check_coverage(project_root: Path) -> int:
@@ -1162,6 +1215,11 @@ if __name__ == "__main__":
              "GEMINI_API_KEY). Optional PATTERN arg filters to matching files.",
     )
     parser.add_argument(
+        "--shadow",
+        action="store_true",
+        help="Check src/private/ files shadow public equivalents with correct /tmp/ symlinks",
+    )
+    parser.add_argument(
         "--base",
         metavar="REF",
         help="Only check governed files changed since REF (e.g. origin/main). "
@@ -1169,7 +1227,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.contradictions is not None:
+    if args.shadow:
+        sys.exit(check_shadow(PROJECT_ROOT))
+    elif args.contradictions is not None:
         sys.exit(check_contradictions(PROJECT_ROOT, args.contradictions or None))
     elif args.validate_router is not None:
         sys.exit(check_validate_router(PROJECT_ROOT, args.validate_router or None))

--- a/scripts/gemini_ocr.py
+++ b/scripts/gemini_ocr.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Gemini OCR — extract text from images using Google's Gemini API.
+
+Usage:
+    python3 scripts/gemini_ocr.py <image_path> [--prompt "custom prompt"]
+    python3 scripts/gemini_ocr.py photo.jpg
+    python3 scripts/gemini_ocr.py scan.pdf --prompt "Extract all handwritten notes"
+
+Requires:
+    pip install google-genai
+
+Environment:
+    GEMINI_API_KEY — your Gemini API key (from https://aistudio.google.com/apikey)
+    Also checks ~/.config/deus/.env if the env var is not set.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from google import genai
+from google.genai import types
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+MODELS = ["gemini-3-flash-preview", "gemini-2.5-flash"]
+
+DEFAULT_PROMPT = """\
+You are an OCR engine. Extract ALL text from this image exactly as written.
+For mathematical formulas, use LaTeX notation (inline $...$ and display $$...$$).
+Preserve the original layout, language, and line breaks.
+Output ONLY the extracted content, no commentary or explanation."""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_api_key():
+    key = os.environ.get("GEMINI_API_KEY")
+    if key:
+        return key
+    env_path = Path.home() / ".config" / "deus" / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith("GEMINI_API_KEY="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    print(
+        "Error: GEMINI_API_KEY not set. "
+        "Export it or add to ~/.config/deus/.env",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _read_image_bytes(path: str) -> tuple[bytes, str]:
+    p = Path(path)
+    if not p.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    suffix = p.suffix.lower()
+    mime_map = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".heic": "image/heic",
+        ".gif": "image/gif",
+        ".pdf": "application/pdf",
+    }
+    mime = mime_map.get(suffix, "image/png")
+    return p.read_bytes(), mime
+
+
+def _ocr(client, model: str, img_bytes: bytes, mime: str, prompt: str) -> str:
+    response = client.models.generate_content(
+        model=model,
+        contents=[
+            types.Part.from_bytes(data=img_bytes, mime_type=mime),
+            prompt,
+        ],
+        config=types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(thinking_budget=0),
+            max_output_tokens=65536,
+        ),
+    )
+    return response.text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract text from images using Gemini OCR"
+    )
+    parser.add_argument("image", help="Path to image or PDF file")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Custom OCR prompt")
+    args = parser.parse_args()
+
+    api_key = _load_api_key()
+    client = genai.Client(api_key=api_key)
+    img_bytes, mime = _read_image_bytes(args.image)
+
+    for i, model in enumerate(MODELS):
+        try:
+            result = _ocr(client, model, img_bytes, mime, args.prompt)
+            print(result)
+            return
+        except Exception as e:
+            if "429" in str(e) and i < len(MODELS) - 1:
+                print(f"Rate limited on {model}, trying {MODELS[i+1]}...", file=sys.stderr)
+                continue
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -644,3 +644,114 @@ class TestFileInChangedSet:
 
     def test_empty_changed_set(self, tmp_path):
         assert not drift_check._file_in_changed_set("src/", set(), tmp_path)
+
+
+# ── check_shadow ─────────────────────────────────────────────────────────────
+
+
+def _build_shadow_project(
+    tmp_path: Path,
+    public_files: list[str],
+    private_files: list[str],
+) -> Path:
+    """Create a project tree with public and private script files."""
+    for f in public_files:
+        p = tmp_path / f
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f"# public {f}")
+    for f in private_files:
+        p = tmp_path / "src" / "private" / f
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f"# private {f}")
+    return tmp_path
+
+
+class TestCheckShadow:
+    def test_no_private_dir(self, tmp_path, monkeypatch):
+        """No src/private/ at all — should pass cleanly."""
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        assert drift_check.check_shadow(tmp_path) == 0
+
+    def test_private_only_file_no_warning(self, tmp_path, monkeypatch):
+        """Private file with no public equivalent — no shadow, no warning."""
+        _build_shadow_project(tmp_path, [], ["scripts/secret.py"])
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        assert drift_check.check_shadow(tmp_path) == 0
+
+    def test_shadow_with_correct_symlink(self, tmp_path, monkeypatch):
+        """Private shadows public and /tmp/ symlink points to private — OK."""
+        _build_shadow_project(
+            tmp_path,
+            ["scripts/tool.py"],
+            ["scripts/tool.py"],
+        )
+        private_path = tmp_path / "src" / "private" / "scripts" / "tool.py"
+        tmp_link = Path("/tmp") / "tool.py"
+        # Clean up any pre-existing symlink
+        if tmp_link.exists() or tmp_link.is_symlink():
+            tmp_link.unlink()
+        tmp_link.symlink_to(private_path)
+        try:
+            monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+            assert drift_check.check_shadow(tmp_path) == 0
+        finally:
+            tmp_link.unlink()
+
+    def test_shadow_with_missing_symlink(self, tmp_path, monkeypatch, capsys):
+        """Private shadows public but no /tmp/ symlink — should warn."""
+        # Use a unique filename to avoid collisions with real /tmp/ files
+        fname = "_drift_test_shadow_missing.py"
+        _build_shadow_project(
+            tmp_path,
+            [f"scripts/{fname}"],
+            [f"scripts/{fname}"],
+        )
+        tmp_link = Path("/tmp") / fname
+        if tmp_link.exists() or tmp_link.is_symlink():
+            tmp_link.unlink()
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        assert drift_check.check_shadow(tmp_path) == 1
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert fname in out
+
+    def test_shadow_with_wrong_symlink(self, tmp_path, monkeypatch, capsys):
+        """Private shadows public but /tmp/ symlink points to public — should warn."""
+        fname = "_drift_test_shadow_wrong.py"
+        _build_shadow_project(
+            tmp_path,
+            [f"scripts/{fname}"],
+            [f"scripts/{fname}"],
+        )
+        public_path = tmp_path / "scripts" / fname
+        tmp_link = Path("/tmp") / fname
+        if tmp_link.exists() or tmp_link.is_symlink():
+            tmp_link.unlink()
+        tmp_link.symlink_to(public_path)
+        try:
+            monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+            assert drift_check.check_shadow(tmp_path) == 1
+            out = capsys.readouterr().out
+            assert "WARN" in out
+            assert "should point to" in out
+        finally:
+            tmp_link.unlink()
+
+    def test_skips_dotfiles(self, tmp_path, monkeypatch):
+        """Hidden files in src/private/ should be ignored."""
+        _build_shadow_project(tmp_path, ["scripts/.hidden"], ["scripts/.hidden"])
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        assert drift_check.check_shadow(tmp_path) == 0
+
+    def test_included_in_check_all(self, tmp_path, monkeypatch, capsys):
+        """check_all should include the shadow check."""
+        (tmp_path / "patterns").mkdir()
+        (tmp_path / "patterns" / "INDEX.md").write_text(
+            "| task | pattern | source |\n|---|---|---|\n"
+        )
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "src" / "private").mkdir(parents=True)
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        drift_check.check_all(tmp_path)
+        out = capsys.readouterr().out
+        assert "shadow" in out.lower()


### PR DESCRIPTION
## Summary
- Adds general-purpose Gemini OCR script (`scripts/gemini_ocr.py`) — supports images/PDFs with model fallback (gemini-3-flash-preview → gemini-2.5-flash)
- Adds `--shadow` mode to `drift_check.py` — verifies `src/private/` overrides have correct `/tmp/` symlinks, included in `--all`
- 7 new tests for the shadow checker (70 total passing)

## Test plan
- [x] `python3 -m pytest scripts/tests/test_drift_check.py` — 70 passed
- [x] `python3 scripts/drift_check.py --shadow` — detects correct/missing/wrong symlinks

Supersedes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)