### PR TITLE
feat(memory-tree): Phase 8 verifier-augmented retrieval

### DIFF
--- a/docs/research/memory-tree-reranker-plan.md
+++ b/docs/research/memory-tree-reranker-plan.md
@@ -1,0 +1,130 @@
+# Memory-tree Tier 3: Cross-encoder reranker
+
+**Status:** Plan, not yet implemented.
+**Gated on:** ≥1 week of real query logs showing Phase 8 LLM verifier either insufficient or unsuitable. If real-world dogfood reveals the baseline is adequate, skip Tier 3 entirely.
+**Parent context:** [`memory-tree-verifier-plan.md`](./memory-tree-verifier-plan.md) — Phase 8 LLM verifier. Benchmark showed it was too slow (45× p95) and over-rejects legitimate "partial" matches. [`memory-tree-benchmark-robustness.md`](./memory-tree-benchmark-robustness.md) — baseline characterization. [Tier 1 grid-sweep, 2026-04-15 session] — threshold/margin calibration doesn't help; abstain-near FPs share score-space with legit queries.
+
+## Problem
+
+Phase 8 (LLM verifier) proved two things:
+1. **Latency wall.** Any autoregressive LLM takes seconds per query — 36–45× slower than baseline 102ms p95. Unusable as default-on.
+2. **Wrong accuracy shape.** gemma4:e4b over-rejects ambiguous/multi legit hits because a general instruction-tuned LLM treats "partial answer" as not-answer. Drop-by-label is too aggressive.
+
+The core intuition from Phase 8 is still correct: retrieval-layer cosine is a weak proxy for relevance, so a second-stage signal would help. But we need the right *shape* of second-stage — fast, relevance-native, not score-vs-score-LLM-judge.
+
+## Proposal
+
+Replace the Phase 8 LLM verifier with a **cross-encoder reranker**: a lightweight model purpose-built for (query, document) relevance scoring. Cross-encoders:
+
+- take (query, doc) jointly as one input, attend over both
+- output a single scalar relevance score (0–1), not a categorical label
+- are ~100× smaller than instruction-tuned LLMs
+- run at ~5–40ms per pair on CPU (vs ~1s for gemma4:e2b)
+- are the standard IR re-ranking primitive (MS-MARCO, BEIR leaderboards)
+
+## Model selection
+
+| Model | Size | Latency/pair (CPU) | Notes |
+|---|---|---|---|
+| MS-MARCO MiniLM L-6-v2 | ~80 MB | ~5 ms | English only, ubiquitous baseline |
+| MS-MARCO MiniLM L-12-v2 | ~130 MB | ~10 ms | Slightly better accuracy |
+| **BGE-reranker-v2-m3** | **~560 MB** | **~20–40 ms** | **Multilingual (Hebrew), strong** |
+| jina-reranker-v2-base-multilingual | ~300 MB | ~15 ms | Multilingual alt |
+| BGE-reranker-base-v2-gemma-2b | ~1.4 GB | ~80 ms | Upper bound, overkill |
+
+**Default pick: BGE-reranker-v2-m3.** The vault is multilingual-adjacent (Hebrew content in study notes, English frontmatter). MiniLM L-6 is English-only and would silently degrade on Hebrew queries. 560MB one-time download via `/setup` alongside the existing embedder (matches the Ollama-required precedent in PR #175).
+
+For k=5 candidates: 100–200ms total cross-encoder latency → **well under the 500ms p95 target.**
+
+## Runtime
+
+Three viable paths, ranked:
+
+1. **onnxruntime + quantized ONNX model.** `pip install onnxruntime` (~30MB). Download a pre-quantized int8 ONNX of BGE-reranker-v2-m3 (~150MB post-quantize) during setup. No torch dependency. Single forward pass per pair.
+2. **fastembed** (`pip install fastembed`). Wraps onnxruntime + curates model list. Handles download automatically. ~10MB on top of onnxruntime. Cleaner API.
+3. **sentence-transformers.** `pip install sentence-transformers` pulls torch (~800MB). Way too heavy for the payoff. **Rejected.**
+
+**Default pick: fastembed.** Curation + auto-download cuts integration to ~30 lines of Python.
+
+## Integration points
+
+The reranker drop-in replaces the Phase 8 block in `retrieve()`:
+
+```python
+# Existing Phase 8 (LLM verifier — to be removed)
+if use_verifier and top:
+    labeled = verify_candidates(query, candidates, ...)
+    top, dropped = rerank_by_verifier(top, labeled)
+
+# Replacement Phase 8' (cross-encoder reranker)
+if use_reranker and top:
+    pairs = [(query, cand_text(id)) for (id, _, _, _, _) in top]
+    rerank_scores = reranker.score(pairs)  # list[float]
+    top = merge_scores(top, rerank_scores, weight=RERANKER_WEIGHT)
+    top.sort(key=lambda r: r[3], reverse=True)
+```
+
+Key design choice: **combine, don't replace.** Phase 8 dropped candidates labelled 'no' — too binary. The reranker returns a continuous score, which we combine with the retriever score:
+
+```python
+final_score = (1 - w) * cosine_score + w * reranker_score
+```
+
+with `w ∈ [0, 1]` tunable. This preserves the retriever's signal (abstain-threshold still works) while letting the reranker demote "topically close but not answering" without hard-dropping them. Both signals agree → high final; disagree → moderate → may abstain via existing threshold logic.
+
+**Default `w = 0.5`.** Gridable.
+
+## Evaluation plan
+
+Phase 3.1 — offline benchmark on 90q fixture:
+- Compute `recall@k`, `MRR@k`, per-tag breakdown (reuse existing `benchmark` CLI)
+- Compare to baseline (no reranker) and to PR #176 (LLM verifier)
+- Target: `recall@k ≥ 0.822` (baseline — no regression) AND `abstain-near ≥ 0.75` (meaningful gain) AND `p95 ≤ 500ms`
+
+Phase 3.2 — real-log calibration:
+- After ≥1 week of dogfood, extract real queries from `~/.deus/memory_tree_queries.jsonl`
+- Dedupe against benchmark fixture (to avoid contamination)
+- Run `calibrate` on real queries labeled by query-log analysis heuristics (rephrasing cluster detection)
+- Compare reranker-on vs reranker-off on this real subset
+
+Phase 3.3 — ablation:
+- Sweep `RERANKER_WEIGHT ∈ {0.0, 0.3, 0.5, 0.7, 1.0}`
+- Find Pareto-optimal on (recall, abstain-near, p95)
+
+## Rollback / opt-in gate
+
+Match PR #176's pattern:
+- Off by default behind `--rerank` CLI flag + `DEUS_TREE_RERANK=1` env
+- `RERANKER_UNREACHABLE` exception class → fail-open to cosine-only ranking
+- Feature flag in `retrieve()` kwarg: `use_reranker: bool = False`
+
+Default-on gate only if Phase 3.1 benchmark + Phase 3.2 real-log analysis both meet targets.
+
+## Risks and unknowns
+
+1. **Download size.** BGE-reranker-v2-m3 is 560MB (150MB quantized). Adds ~2 min to `/setup` on broadband. Justified only if accuracy gain is real.
+2. **Cold-start latency.** First reranker call loads the ONNX session (~1s). Subsequent calls are fast. Must pre-warm at startup (add to the existing setup/ollama.ts pattern).
+3. **Hebrew content.** The vault has Hebrew study notes. BGE-reranker-v2-m3 is multilingual but not Hebrew-specialized. Worth spot-checking on a few Hebrew queries before committing.
+4. **The same over-rejection risk as LLM verifier.** A trained reranker is less pathological than a general LLM, but may still downrank "topically close" above "partial answer." The combine-don't-replace design mitigates but doesn't eliminate this.
+5. **May still not help abstain-near.** Tier 1 grid sweep revealed the fundamental issue: abstain-near false positives share score-space with legit queries. A reranker re-weights within the shortlist but doesn't synthesize new information. If the retriever puts a wrong file in top-5, the reranker can demote it, but abstain-near queries often don't have any right answer — so every rerank result is still wrong.
+
+## Estimated effort
+
+- Plan (this doc): **done** (~1 hr).
+- Spike: `fastembed` install, download model, single-query smoke test against vault — 1 hr.
+- Integration: `MemoryTreeReranker` wrapper + Phase 8' block + CLI flag + env gate — 3 hr.
+- Tests: unit tests for reranker wrapper (transport stub, fail-open, score merge) — 2 hr.
+- Phase 3.1 benchmark on 90q: 1 hr (mostly waiting).
+- Phase 3.2 real-log calibration: 2 hr after ≥1 week of real data.
+- Default-on decision + PR follow-up: 1 hr.
+
+**Total: ~10 hr engineering + 1 week wall-clock for Phase 3.2.**
+
+## Decision gate before starting
+
+Do NOT start implementation until one of the following is true:
+1. Real query logs (after ≥1 week of dogfood) show abstain-near false positives are actually user-visible problems (rephrased queries, user complaints, confidently-wrong answers that mislead).
+2. We decide to ship PR #176's LLM verifier and need a lower-latency replacement.
+3. A specific user-facing bug is traced back to retrieval quality that a reranker would fix.
+
+If none of the above are true after ≥1 week, the baseline is good enough. Close Phase 8 + Tier 3, move on.

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -588,13 +588,21 @@ def retrieve(
     query_vec: list[float] | None = None,
     use_see_also: bool = True,
     use_abstain: bool = True,
+    use_verifier: bool = False,
+    verifier_model: str | None = None,
+    verifier_transport: Any = None,
 ) -> dict[str, Any]:
-    """3-phase retrieval: collapsed flat → graph expansion → abstain.
+    """3-phase retrieval + optional verifier: collapsed flat → graph expansion
+    → verifier filter (Phase 8) → abstain.
 
     `use_see_also=False` skips Phase 2 (flat-only mode). `use_abstain=False`
     skips Phase 3 (surface results regardless of confidence). Together they
     support V0/V1/V2/V3 ablation for benchmarking. Defaults keep current
     production behavior unchanged.
+
+    `use_verifier=True` enables Phase 8: a local Ollama model labels each
+    candidate yes/partial/no and candidates labelled 'no' are dropped.
+    Fails open — if the verifier is unreachable the original ranking stands.
 
     Returns {results: [{id, path, score, route}], confidence, fell_back, trace}.
     """
@@ -669,6 +677,48 @@ def retrieve(
         merged = sorted(expanded.values(), key=lambda r: r[3], reverse=True)[:k]
         top = merged
         trace.append(f"expanded→{len(expanded)}")
+
+    # Phase 8: verifier-augmented re-ranking. Drops candidates the local
+    # judge labels 'no' (topically adjacent but doesn't answer). Fails open:
+    # if the verifier is unreachable, keep the unverified ranking.
+    if use_verifier and top:
+        _here = str(Path(__file__).parent)
+        if _here not in sys.path:
+            sys.path.insert(0, _here)
+        try:
+            from memory_tree_verifier import (
+                verify_candidates,
+                rerank_by_verifier,
+                VerifierUnreachable,
+                DEFAULT_VERIFIER_MODEL,
+            )
+        except ImportError:
+            trace.append("verifier_import_failed")
+        else:
+            candidates = []
+            for (nid, npath, _ntitle, _score, _route) in top:
+                drow = db.execute(
+                    "SELECT description FROM nodes WHERE id = ?", (nid,)
+                ).fetchone()
+                candidates.append({
+                    "path": npath,
+                    "text": (drow[0] if drow else "") or "",
+                })
+            try:
+                labeled = verify_candidates(
+                    query,
+                    candidates,
+                    model=verifier_model or DEFAULT_VERIFIER_MODEL,
+                    transport=verifier_transport,
+                )
+            except VerifierUnreachable as exc:
+                trace.append(f"verifier_unreachable:{type(exc).__name__}")
+            else:
+                trace.append(f"verifier_labelled→{len(labeled)}")
+                top, dropped = rerank_by_verifier(top, labeled)
+                if dropped:
+                    trace.append(f"verifier_dropped→{len(dropped)}")
+                best = top[0][3] if top else 0.0
 
     # Phase 3: abstain when the best score is below the floor.
     if use_abstain and best < abstain_threshold:
@@ -1006,6 +1056,8 @@ def benchmark(
     abstain_threshold: float = DEFAULT_ABSTAIN_THRESHOLD,
     use_see_also: bool = True,
     use_abstain: bool = True,
+    use_verifier: bool = False,
+    verifier_model: str | None = None,
     wrong_confident_score: float = 0.65,
 ) -> dict[str, Any]:
     """Run dataset queries, compute recall@k, MRR@k, per-tag breakdown, latency.
@@ -1047,6 +1099,8 @@ def benchmark(
             abstain_threshold=abstain_threshold,
             use_see_also=use_see_also,
             use_abstain=use_abstain,
+            use_verifier=use_verifier,
+            verifier_model=verifier_model,
         )
         latencies.append(_time.monotonic() - t0)
 
@@ -1100,6 +1154,8 @@ def benchmark(
             "abstain_threshold": abstain_threshold,
             "use_see_also": use_see_also,
             "use_abstain": use_abstain,
+            "use_verifier": use_verifier,
+            "verifier_model": verifier_model,
         },
     }
 
@@ -1286,6 +1342,8 @@ def main(argv: list[str] | None = None) -> int:
     p_query.add_argument("--json", action="store_true")
     p_query.add_argument("--low", type=float, default=DEFAULT_LOW_THRESHOLD)
     p_query.add_argument("--abstain", type=float, default=DEFAULT_ABSTAIN_THRESHOLD)
+    p_query.add_argument("--verify", action="store_true", help="Phase 8: local-LLM verifier filter (drops candidates labelled 'no'). Overrides DEUS_TREE_VERIFY.")
+    p_query.add_argument("--verifier-model", help="Ollama model for verifier (default: gemma4:e2b, or DEUS_TREE_VERIFIER_MODEL)")
 
     p_reembed = sub.add_parser("reembed", help="Re-embed a single file")
     p_reembed.add_argument("path", help="Relative path from vault root")
@@ -1309,6 +1367,8 @@ def main(argv: list[str] | None = None) -> int:
     p_bench.add_argument("--abstain", type=float, default=DEFAULT_ABSTAIN_THRESHOLD)
     p_bench.add_argument("--ablation", action="store_true", help="Run V0/V1/V2/V3 variants side by side")
     p_bench.add_argument("--loo", action="store_true", help="Leave-one-out CV (honest generalization estimate)")
+    p_bench.add_argument("--verify", action="store_true", help="Phase 8: enable verifier filter for this benchmark run")
+    p_bench.add_argument("--verifier-model", help="Ollama model for verifier (default: gemma4:e2b)")
 
     args = parser.parse_args(argv)
     db = open_db()
@@ -1329,9 +1389,13 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.cmd == "query":
+        use_verifier = args.verify or os.environ.get("DEUS_TREE_VERIFY") == "1"
+        verifier_model = args.verifier_model or os.environ.get("DEUS_TREE_VERIFIER_MODEL")
         result = retrieve(
             db, args.text, k=args.k,
             low_threshold=args.low, abstain_threshold=args.abstain,
+            use_verifier=use_verifier,
+            verifier_model=verifier_model,
         )
         if args.json:
             print(json.dumps(result, indent=2))
@@ -1371,12 +1435,19 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "benchmark":
         data = [json.loads(l) for l in Path(args.dataset_jsonl).read_text().splitlines() if l.strip()]
+        use_verifier = args.verify or os.environ.get("DEUS_TREE_VERIFY") == "1"
+        verifier_model = args.verifier_model or os.environ.get("DEUS_TREE_VERIFIER_MODEL")
         if args.ablation:
             report = benchmark_ablation(db, data, k=args.k, low_threshold=args.low, abstain_threshold=args.abstain)
         elif args.loo:
             report = benchmark_loo(db, data, k=args.k)
         else:
-            report = benchmark(db, data, k=args.k, low_threshold=args.low, abstain_threshold=args.abstain)
+            report = benchmark(
+                db, data, k=args.k,
+                low_threshold=args.low, abstain_threshold=args.abstain,
+                use_verifier=use_verifier,
+                verifier_model=verifier_model,
+            )
         print(json.dumps(report, indent=2))
         return 0
 

--- a/scripts/memory_tree_verifier.py
+++ b/scripts/memory_tree_verifier.py
@@ -1,0 +1,195 @@
+"""Second-stage verifier for memory-tree retrieval (Phase 8).
+
+Takes stage-1 candidates (cosine top-k) and asks a local Ollama model
+whether each candidate document actually answers the query. Returns
+per-candidate labels: yes / partial / no / unknown.
+
+Design goals:
+  - O(k) per query, independent of corpus size N
+  - Zero API cost (runs against local Ollama)
+  - Fails open — if Ollama is unreachable or malformed, return every
+    candidate as 'unknown' so the caller's original ranking stands
+  - Single batched prompt per query, not k separate calls
+  - Pure: no DB coupling. Caller supplies the candidate text.
+
+See docs/research/memory-tree-verifier-plan.md for motivation and
+predicted metric impact.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Iterable
+
+
+DEFAULT_VERIFIER_MODEL = "gemma4:e2b"
+DEFAULT_VERIFIER_URL = "http://localhost:11434/api/generate"
+VERIFIER_TIMEOUT_S = 15.0
+MAX_TEXT_CHARS_PER_CANDIDATE = 500
+
+# Keep the prompt compact — the verifier only needs the question and a
+# title+description excerpt per candidate. Longer context hurts e2b latency
+# without improving accuracy on this task.
+_PROMPT_TEMPLATE = """\
+You are a relevance judge. For each CANDIDATE below, decide whether it \
+answers the QUESTION. Respond with exactly one line per candidate in the \
+format:
+
+  PATH|LABEL|REASON
+
+LABEL is one of:
+  - yes     : directly answers the question
+  - partial : relevant topic but does not fully answer
+  - no      : off-topic or does not contain the answer
+
+QUESTION:
+{query}
+
+CANDIDATES:
+{candidates_block}
+
+Output ONLY the PATH|LABEL|REASON lines. No preamble, no markdown."""
+
+
+class VerifierUnreachable(Exception):
+    """Raised when the Ollama endpoint cannot be reached or times out."""
+
+
+def verify_candidates(
+    query: str,
+    candidates: list[dict[str, Any]],
+    *,
+    model: str = DEFAULT_VERIFIER_MODEL,
+    ollama_url: str = DEFAULT_VERIFIER_URL,
+    timeout: float = VERIFIER_TIMEOUT_S,
+    transport: Callable[[str, dict[str, Any], float], str] | None = None,
+) -> list[dict[str, Any]]:
+    """Ask the verifier which candidates answer the query.
+
+    Each candidate must be a dict with at least {"path": str, "text": str}.
+    Additional keys (id, score, etc.) are preserved on output.
+
+    Returns a list parallel to input with added keys:
+      - label: "yes" | "partial" | "no" | "unknown"
+      - reason: str
+
+    `transport` is an injection point for tests: given
+    (ollama_url, payload, timeout) → response_text. The default uses
+    urllib to hit Ollama's /api/generate endpoint.
+
+    Raises VerifierUnreachable if the endpoint is unreachable. Callers
+    in production should catch and fall through to the unverified ranking.
+    """
+    if not candidates:
+        return []
+
+    prompt = _PROMPT_TEMPLATE.format(
+        query=query.strip(),
+        candidates_block=_format_candidates(candidates),
+    )
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        # gemma4 family has "thinking" capability; without think=false the model
+        # spends its budget on hidden reasoning and returns an empty response.
+        "think": False,
+        "options": {"temperature": 0.0, "num_predict": 256},
+    }
+    try:
+        raw = (transport or _http_transport)(ollama_url, payload, timeout)
+    except VerifierUnreachable:
+        raise
+    except Exception as exc:
+        raise VerifierUnreachable(f"verifier transport failed: {exc}") from exc
+
+    labels = _parse_response(raw, [c["path"] for c in candidates])
+    out: list[dict[str, Any]] = []
+    for cand in candidates:
+        entry = dict(cand)
+        parsed = labels.get(cand["path"], {"label": "unknown", "reason": "no response"})
+        entry["label"] = parsed["label"]
+        entry["reason"] = parsed["reason"]
+        out.append(entry)
+    return out
+
+
+def _format_candidates(candidates: Iterable[dict[str, Any]]) -> str:
+    blocks = []
+    for cand in candidates:
+        text = (cand.get("text") or "").strip().replace("\n", " ")
+        if len(text) > MAX_TEXT_CHARS_PER_CANDIDATE:
+            text = text[:MAX_TEXT_CHARS_PER_CANDIDATE].rstrip() + "…"
+        blocks.append(f"- PATH: {cand['path']}\n  TEXT: {text}")
+    return "\n".join(blocks)
+
+
+_LINE_RE = re.compile(r"^\s*([^\s|][^|]*?)\s*\|\s*(\w+)\s*\|\s*(.*?)\s*$")
+_VALID_LABELS = {"yes", "partial", "no"}
+
+
+def _parse_response(text: str, known_paths: list[str]) -> dict[str, dict[str, str]]:
+    """Parse `PATH|LABEL|REASON` lines. Unknown labels → 'unknown'.
+
+    Only records paths that appeared in the input — the verifier occasionally
+    hallucinates extra lines with invented paths. Those are ignored.
+    """
+    known = set(known_paths)
+    out: dict[str, dict[str, str]] = {}
+    for line in text.splitlines():
+        m = _LINE_RE.match(line)
+        if not m:
+            continue
+        path, label, reason = m.group(1), m.group(2).lower(), m.group(3)
+        if path not in known:
+            continue
+        if label not in _VALID_LABELS:
+            label = "unknown"
+        out[path] = {"label": label, "reason": reason[:200]}
+    return out
+
+
+def _http_transport(url: str, payload: dict[str, Any], timeout: float) -> str:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise VerifierUnreachable(str(exc)) from exc
+    try:
+        obj = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise VerifierUnreachable(f"malformed JSON from Ollama: {exc}") from exc
+    return obj.get("response", "")
+
+
+def rerank_by_verifier(
+    ranked: list[tuple[Any, ...]],
+    labeled: list[dict[str, Any]],
+) -> tuple[list[tuple[Any, ...]], list[str]]:
+    """Filter ranked candidates by verifier labels.
+
+    `ranked` is the tuple-of-tuples shape retrieve() uses internally:
+      (id, path, title, score, route)
+    `labeled` is the output of verify_candidates.
+
+    Drops tuples whose path was labelled 'no'. Keeps 'yes', 'partial',
+    'unknown'. Returns (filtered_ranked, dropped_paths).
+    """
+    by_path = {e["path"]: e["label"] for e in labeled}
+    kept = []
+    dropped: list[str] = []
+    for row in ranked:
+        path = row[1]
+        label = by_path.get(path, "unknown")
+        if label == "no":
+            dropped.append(path)
+            continue
+        kept.append(row)
+    return kept, dropped

--- a/scripts/memory_tree_verifier.py
+++ b/scripts/memory_tree_verifier.py
@@ -34,24 +34,26 @@ MAX_TEXT_CHARS_PER_CANDIDATE = 500
 # title+description excerpt per candidate. Longer context hurts e2b latency
 # without improving accuracy on this task.
 _PROMPT_TEMPLATE = """\
-You are a relevance judge. For each CANDIDATE below, decide whether it \
-answers the QUESTION. Respond with exactly one line per candidate in the \
-format:
+You are a relevance judge. Judge each candidate against the question.
 
-  PATH|LABEL|REASON
+LABEL must be one of:
+  yes     — directly answers the question
+  partial — relevant topic but does not fully answer
+  no      — off-topic or does not contain the answer
 
-LABEL is one of:
-  - yes     : directly answers the question
-  - partial : relevant topic but does not fully answer
-  - no      : off-topic or does not contain the answer
+QUESTION: {query}
 
-QUESTION:
-{query}
-
-CANDIDATES:
+CANDIDATES ({n} total):
 {candidates_block}
 
-Output ONLY the PATH|LABEL|REASON lines. No preamble, no markdown."""
+Output EXACTLY {n} lines, in the same order as the candidates above. \
+Each line must use this exact format (no `PATH:` prefix, no markdown, no preamble):
+
+  <path>|LABEL|REASON
+
+Replace `<path>` with the exact path shown above. Use a short reason (<80 chars).
+
+Output:"""
 
 
 class VerifierUnreachable(Exception):
@@ -89,6 +91,7 @@ def verify_candidates(
     prompt = _PROMPT_TEMPLATE.format(
         query=query.strip(),
         candidates_block=_format_candidates(candidates),
+        n=len(candidates),
     )
     payload = {
         "model": model,
@@ -97,7 +100,7 @@ def verify_candidates(
         # gemma4 family has "thinking" capability; without think=false the model
         # spends its budget on hidden reasoning and returns an empty response.
         "think": False,
-        "options": {"temperature": 0.0, "num_predict": 256},
+        "options": {"temperature": 0.0, "num_predict": 512},
     }
     try:
         raw = (transport or _http_transport)(ollama_url, payload, timeout)
@@ -119,15 +122,16 @@ def verify_candidates(
 
 def _format_candidates(candidates: Iterable[dict[str, Any]]) -> str:
     blocks = []
-    for cand in candidates:
+    for i, cand in enumerate(candidates, 1):
         text = (cand.get("text") or "").strip().replace("\n", " ")
         if len(text) > MAX_TEXT_CHARS_PER_CANDIDATE:
             text = text[:MAX_TEXT_CHARS_PER_CANDIDATE].rstrip() + "…"
-        blocks.append(f"- PATH: {cand['path']}\n  TEXT: {text}")
+        blocks.append(f"{i}. {cand['path']}\n   {text}")
     return "\n".join(blocks)
 
 
 _LINE_RE = re.compile(r"^\s*([^\s|][^|]*?)\s*\|\s*(\w+)\s*\|\s*(.*?)\s*$")
+_PATH_PREFIX_RE = re.compile(r"^(?:\d+[.)]\s*)?(?:-\s*)?(?:PATH:\s*)?", re.IGNORECASE)
 _VALID_LABELS = {"yes", "partial", "no"}
 
 
@@ -136,6 +140,10 @@ def _parse_response(text: str, known_paths: list[str]) -> dict[str, dict[str, st
 
     Only records paths that appeared in the input — the verifier occasionally
     hallucinates extra lines with invented paths. Those are ignored.
+
+    Defensively strips common prefixes the model may emit (`PATH:`, `- `,
+    numbered list markers like `1.`), since some models echo the format we
+    used in the prompt even when asked not to.
     """
     known = set(known_paths)
     out: dict[str, dict[str, str]] = {}
@@ -143,7 +151,9 @@ def _parse_response(text: str, known_paths: list[str]) -> dict[str, dict[str, st
         m = _LINE_RE.match(line)
         if not m:
             continue
-        path, label, reason = m.group(1), m.group(2).lower(), m.group(3)
+        path = _PATH_PREFIX_RE.sub("", m.group(1)).strip()
+        label = m.group(2).lower()
+        reason = m.group(3)
         if path not in known:
             continue
         if label not in _VALID_LABELS:

--- a/scripts/tests/test_memory_tree_verifier.py
+++ b/scripts/tests/test_memory_tree_verifier.py
@@ -1,0 +1,311 @@
+"""Unit tests for scripts/memory_tree_verifier.py (Phase 8).
+
+All tests use an injected transport stub — no Ollama needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+v = _load("memory_tree_verifier", _ROOT / "scripts" / "memory_tree_verifier.py")
+
+
+def _stub(response_text: str):
+    """Transport that returns a fixed response regardless of payload."""
+    def _t(url, payload, timeout):
+        return response_text
+    return _t
+
+
+class TestVerifyCandidates:
+    def test_empty_candidates_returns_empty(self):
+        out = v.verify_candidates("q", [], transport=_stub(""))
+        assert out == []
+
+    def test_parses_three_labels(self):
+        cands = [
+            {"path": "a.md", "text": "About A"},
+            {"path": "b.md", "text": "About B"},
+            {"path": "c.md", "text": "About C"},
+        ]
+        response = (
+            "a.md|yes|directly answers\n"
+            "b.md|partial|related topic\n"
+            "c.md|no|off-topic\n"
+        )
+        out = v.verify_candidates("q", cands, transport=_stub(response))
+        labels = {e["path"]: e["label"] for e in out}
+        assert labels == {"a.md": "yes", "b.md": "partial", "c.md": "no"}
+
+    def test_unknown_label_becomes_unknown(self):
+        cands = [{"path": "a.md", "text": "A"}]
+        out = v.verify_candidates("q", cands, transport=_stub("a.md|maybe|unsure"))
+        assert out[0]["label"] == "unknown"
+
+    def test_missing_candidate_becomes_unknown(self):
+        cands = [{"path": "a.md", "text": "A"}, {"path": "b.md", "text": "B"}]
+        # Only a.md labeled; b.md omitted.
+        out = v.verify_candidates("q", cands, transport=_stub("a.md|yes|x"))
+        by_path = {e["path"]: e["label"] for e in out}
+        assert by_path["a.md"] == "yes"
+        assert by_path["b.md"] == "unknown"
+
+    def test_hallucinated_path_ignored(self):
+        cands = [{"path": "a.md", "text": "A"}]
+        response = (
+            "a.md|yes|real\n"
+            "ghost.md|yes|verifier invented this\n"
+        )
+        out = v.verify_candidates("q", cands, transport=_stub(response))
+        assert len(out) == 1
+        assert out[0]["path"] == "a.md"
+
+    def test_label_case_insensitive(self):
+        cands = [{"path": "a.md", "text": "A"}]
+        out = v.verify_candidates("q", cands, transport=_stub("a.md|YES|x"))
+        assert out[0]["label"] == "yes"
+
+    def test_preserves_input_keys(self):
+        cands = [{"path": "a.md", "text": "A", "score": 0.7, "id": "xyz"}]
+        out = v.verify_candidates("q", cands, transport=_stub("a.md|yes|x"))
+        assert out[0]["score"] == 0.7
+        assert out[0]["id"] == "xyz"
+        assert out[0]["label"] == "yes"
+
+    def test_transport_raises_unreachable_propagates(self):
+        def raising(url, payload, timeout):
+            raise v.VerifierUnreachable("ollama offline")
+        with pytest.raises(v.VerifierUnreachable):
+            v.verify_candidates("q", [{"path": "a.md", "text": "A"}], transport=raising)
+
+    def test_transport_arbitrary_exception_wrapped(self):
+        def boom(url, payload, timeout):
+            raise RuntimeError("oops")
+        with pytest.raises(v.VerifierUnreachable):
+            v.verify_candidates("q", [{"path": "a.md", "text": "A"}], transport=boom)
+
+
+class TestFormatCandidates:
+    def test_truncates_long_text(self):
+        long = "x" * (v.MAX_TEXT_CHARS_PER_CANDIDATE + 100)
+        out = v._format_candidates([{"path": "a.md", "text": long}])
+        assert "…" in out
+        assert len(out) < len(long) + 100  # truncation happened
+
+    def test_flattens_newlines(self):
+        out = v._format_candidates([{"path": "a.md", "text": "line1\nline2"}])
+        assert "line1 line2" in out
+
+    def test_missing_text_renders_empty(self):
+        out = v._format_candidates([{"path": "a.md"}])
+        assert "a.md" in out
+
+
+class TestParseResponse:
+    def test_basic_three_lines(self):
+        text = (
+            "a.md|yes|reason1\n"
+            "b.md|no|reason2\n"
+        )
+        out = v._parse_response(text, ["a.md", "b.md"])
+        assert out["a.md"]["label"] == "yes"
+        assert out["b.md"]["label"] == "no"
+
+    def test_ignores_preamble(self):
+        text = (
+            "Sure, here are the labels:\n"
+            "\n"
+            "a.md|yes|relevant\n"
+            "Let me know if you need more.\n"
+        )
+        out = v._parse_response(text, ["a.md"])
+        assert out["a.md"]["label"] == "yes"
+
+    def test_ignores_malformed_lines(self):
+        text = "a.md|yes|ok\nrandom line without pipes\nb.md||missing label\n"
+        out = v._parse_response(text, ["a.md", "b.md"])
+        assert "a.md" in out
+        # b.md line has empty label → regex still matches but label isn't in valid set
+        # actually `b.md||missing label` has no word for label → regex won't match
+        assert "b.md" not in out
+
+    def test_reason_truncated_to_200(self):
+        long = "r" * 500
+        text = f"a.md|yes|{long}\n"
+        out = v._parse_response(text, ["a.md"])
+        assert len(out["a.md"]["reason"]) == 200
+
+
+class TestRerankByVerifier:
+    def test_drops_no_labels(self):
+        ranked = [
+            ("id1", "a.md", "A", 0.8, "flat"),
+            ("id2", "b.md", "B", 0.6, "flat"),
+            ("id3", "c.md", "C", 0.5, "flat"),
+        ]
+        labeled = [
+            {"path": "a.md", "label": "yes", "reason": ""},
+            {"path": "b.md", "label": "no", "reason": ""},
+            {"path": "c.md", "label": "partial", "reason": ""},
+        ]
+        kept, dropped = v.rerank_by_verifier(ranked, labeled)
+        kept_paths = [r[1] for r in kept]
+        assert kept_paths == ["a.md", "c.md"]
+        assert dropped == ["b.md"]
+
+    def test_unknown_labels_kept(self):
+        ranked = [("id1", "a.md", "A", 0.8, "flat")]
+        labeled = [{"path": "a.md", "label": "unknown", "reason": ""}]
+        kept, dropped = v.rerank_by_verifier(ranked, labeled)
+        assert len(kept) == 1
+        assert dropped == []
+
+    def test_missing_label_kept_as_unknown(self):
+        ranked = [("id1", "a.md", "A", 0.8, "flat")]
+        kept, dropped = v.rerank_by_verifier(ranked, [])
+        assert len(kept) == 1
+        assert dropped == []
+
+    def test_all_no_returns_empty(self):
+        ranked = [
+            ("id1", "a.md", "A", 0.8, "flat"),
+            ("id2", "b.md", "B", 0.6, "flat"),
+        ]
+        labeled = [
+            {"path": "a.md", "label": "no", "reason": ""},
+            {"path": "b.md", "label": "no", "reason": ""},
+        ]
+        kept, dropped = v.rerank_by_verifier(ranked, labeled)
+        assert kept == []
+        assert len(dropped) == 2
+
+
+# ── TestRetrieveWithVerifier — end-to-end wiring via stub transport ───────────
+
+mt = _load("memory_tree", _ROOT / "scripts" / "memory_tree.py")
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    db = mt.open_db(tmp_path / "tree.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def populated_db(tmp_db, tmp_path, monkeypatch):
+    """Vault with 2 distinguishable nodes so the verifier can label them."""
+    def stub_embed(text):
+        vec = [0.0] * mt.EMBED_DIM
+        for i, c in enumerate(text[:mt.EMBED_DIM]):
+            vec[i] = (ord(c) % 17) / 17.0
+        return vec
+    monkeypatch.setattr(mt, "embed_text", stub_embed)
+    vault = tmp_path / "vault"
+    (vault / "Persona" / "life").mkdir(parents=True)
+    (vault / "MEMORY_TREE.md").write_text(
+        "---\nid: root0000000000000000000000000001\ntitle: Root\n"
+        "description: Root.\nlevel: 0\nchildren:\n  - Persona/life/bg.md\n"
+        "  - Persona/life/household.md\n---\n"
+    )
+    (vault / "Persona" / "life" / "bg.md").write_text(
+        "---\nid: bg000000000000000000000000000002\ntitle: Background\n"
+        "description: AWS work history dates and roles.\nlevel: 2\n---\n"
+    )
+    (vault / "Persona" / "life" / "household.md").write_text(
+        "---\nid: hh000000000000000000000000000003\ntitle: Household\n"
+        "description: Lives with Shani; Eden moves in Aug 2026.\nlevel: 2\n---\n"
+    )
+    mt.build_tree(vault, tmp_db)
+    return tmp_db
+
+
+class TestRetrieveWithVerifier:
+    def test_off_by_default_keeps_ranking(self, populated_db):
+        # Use low thresholds so we always get results for comparison.
+        baseline = mt.retrieve(
+            populated_db, "AWS work", k=5,
+            low_threshold=0.0, abstain_threshold=0.0,
+        )
+        assert baseline["results"], "baseline should return something"
+        assert not any("verifier" in t for t in baseline["trace"])
+
+    def test_verifier_drops_no_labelled(self, populated_db):
+        def transport(url, payload, timeout):
+            # Label bg.md as 'no' so it should be dropped.
+            lines = []
+            for p in ["Persona/life/bg.md", "Persona/life/household.md", "MEMORY_TREE.md"]:
+                label = "no" if p == "Persona/life/bg.md" else "yes"
+                lines.append(f"{p}|{label}|stub")
+            return "\n".join(lines)
+
+        result = mt.retrieve(
+            populated_db, "AWS work", k=5,
+            low_threshold=0.0, abstain_threshold=0.0,
+            use_verifier=True,
+            verifier_transport=transport,
+        )
+        paths = [r["path"] for r in result["results"]]
+        assert "Persona/life/bg.md" not in paths
+        assert any("verifier_dropped" in t for t in result["trace"])
+
+    def test_verifier_unreachable_fails_open(self, populated_db):
+        def transport(url, payload, timeout):
+            raise v.VerifierUnreachable("offline")
+        result = mt.retrieve(
+            populated_db, "AWS work", k=5,
+            low_threshold=0.0, abstain_threshold=0.0,
+            use_verifier=True,
+            verifier_transport=transport,
+        )
+        # Fail-open: result still returned, trace records unreachable.
+        assert result["results"]
+        assert any("verifier_unreachable" in t for t in result["trace"])
+
+    def test_verifier_all_no_triggers_abstain(self, populated_db):
+        def transport(url, payload, timeout):
+            # Label every candidate 'no' → top empty → abstain fires.
+            lines = []
+            for p in ["MEMORY_TREE.md", "Persona/life/bg.md", "Persona/life/household.md"]:
+                lines.append(f"{p}|no|stub")
+            return "\n".join(lines)
+        result = mt.retrieve(
+            populated_db, "anything", k=5,
+            low_threshold=0.0, abstain_threshold=0.1,
+            use_verifier=True,
+            verifier_transport=transport,
+        )
+        assert result["fell_back"] is True
+        assert result["results"] == []
+
+    def test_verifier_partial_kept(self, populated_db):
+        def transport(url, payload, timeout):
+            lines = []
+            for p in ["MEMORY_TREE.md", "Persona/life/bg.md", "Persona/life/household.md"]:
+                lines.append(f"{p}|partial|stub")
+            return "\n".join(lines)
+        result = mt.retrieve(
+            populated_db, "household", k=5,
+            low_threshold=0.0, abstain_threshold=0.0,
+            use_verifier=True,
+            verifier_transport=transport,
+        )
+        assert len(result["results"]) >= 1


### PR DESCRIPTION
## Summary
- Optional second-stage Ollama judge filters candidates labelled 'no' after Phase 2 (graph expansion)
- Drop-only approach (no score adjustment), fail-open when verifier unreachable
- Gated by `--verify` flag or `DEUS_TREE_VERIFY=1` env; default off
- gemma4:e2b default (`"think": false` required — gemma4 family has thinking mode)
- Unconditional `verifier_labelled→N` trace entry so the run is visible even when nothing is dropped

## Files
- `scripts/memory_tree_verifier.py` (NEW, 195 LOC) — batched prompt, PATH|LABEL|REASON parser, urllib transport with VerifierUnreachable
- `scripts/memory_tree.py` (+73 lines) — retrieve() Phase 8 block, CLI flags on query + benchmark, env gate, benchmark passthrough
- `scripts/tests/test_memory_tree_verifier.py` (NEW, 311 LOC) — 25 tests

## Test plan
- [x] Unit tests green (25/25)
- [x] Smoke test: `query "what was my salary at AWS" --verify --json` → trace includes `verifier_labelled→5`
- [ ] Phase 8.4 — benchmark --verify on 90-query suite (follow-up)
- [ ] Phase 8.5 — default-on if abstain-near ≥0.85, adversarial ≥1.00, p95 ≤500ms (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)