### PR TITLE
feat(memory-tree): port evo exp_0006 retrieval policy

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -76,6 +76,83 @@ _AUDIT_PATH = Path(os.environ.get(
 REBUILD_MIN_RETENTION = 0.5
 
 
+# ── Retrieval policy (ported from ~/deus-memory-evo exp_0006) ─────────────────
+# Evo round (2026-04-16) lifted end-to-end retrieval from 0.7172 → 0.9931 by
+# adding persona-keyword gating on below-threshold hits, focused retries on
+# abstain, supplementary hints for ambiguous triggers, and adaptive top-K.
+# Tune these sets carefully: adding a noisy trigger re-introduces false
+# Persona leaves for abstain-near queries (salary, car, etc.).
+
+PERSONA_TRIGGERS = {
+    # life / household
+    "roommate", "roommates", "flatmate", "flatmates", "housemate", "housemates",
+    "apartment", "flat", "household", "live", "lives", "living", "moving",
+    "shani", "omer", "eden", "rent", "home",
+    # taste
+    "movie", "movies", "film", "films", "cinema", "director", "directors",
+    "music", "genre", "genres", "instrument", "song", "songs", "album",
+    "taste", "media", "watch", "watching", "shows",
+    # work style / communication
+    "communicat", "communicates", "communication", "learn", "learning", "learns",
+    "explanation", "explanations", "tone", "style", "prefer", "preference", "preferences",
+    "phrase", "address", "pick",
+    # identity / background
+    "persona", "background", "engineering", "education", "history", "employment",
+    "enroll", "university", "college", "program", "prior", "came",
+    # study vault files (non-Persona but tree-indexed)
+    "lecture", "tutor", "study",
+    # broad personal descriptors
+    "enjoy", "enjoys", "enjoyed", "describe", "described", "culture", "cultural",
+    "world", "person", "identity", "interest", "interests", "care",
+}
+
+# On fell_back, retry with a focused alias when the query contains these words.
+TRIGGER_RETRY_TERMS = {
+    "director": "directors", "directors": "directors",
+    "film": "films", "films": "films", "cinema": "cinema",
+    "movie": "movies", "movies": "movies",
+    "music": "music", "genre": "music genres", "genres": "music genres",
+    "song": "music", "songs": "music", "album": "music",
+    "roommate": "roommates", "roommates": "roommates",
+    "flatmate": "roommates", "housemate": "roommates", "housemates": "roommates",
+    "household": "household",
+    "lecture": "lecture strategies", "tutor": "study tutor",
+}
+
+# Parallel focused hints merged into the primary results when the trigger is
+# too ambiguous to route alone. Only below-threshold Persona queries use these.
+SUPPLEMENTARY_HINTS = {
+    "home": "roommates",  # "home stuff" → household.md via "roommates"
+}
+
+# Adaptive K: shrink supplementary results when the top hit is high-confidence
+# (query strongly matched one file → noisy extras hurt). Low-confidence Persona
+# queries keep top-K for multi-path coverage.
+POLICY_K_HIGH_CONF = 2
+POLICY_K_LOW_CONF = 4
+
+_POLICY_TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9_-]{2,}")
+
+
+def _query_persona_triggers(query: str) -> tuple[bool, list[str]]:
+    """Return (has_trigger, matched_trigger_stems)."""
+    matched: list[str] = []
+    for raw in _POLICY_TOKEN_RE.findall(query.lower()):
+        if raw in PERSONA_TRIGGERS:
+            matched.append(raw)
+            continue
+        for suf in ("ies", "es", "ed", "ing", "s"):
+            if len(raw) > len(suf) + 2 and raw.endswith(suf):
+                stem = raw[: -len(suf)]
+                if stem in PERSONA_TRIGGERS:
+                    matched.append(stem)
+                    break
+                if raw[:-1] in PERSONA_TRIGGERS:
+                    matched.append(raw[:-1])
+                    break
+    return bool(matched), matched
+
+
 # ── ID + hashing ──────────────────────────────────────────────────────────────
 
 def make_id() -> str:
@@ -758,6 +835,122 @@ def retrieve(
     return result
 
 
+def retrieve_with_policy(
+    db: sqlite3.Connection,
+    query: str,
+    *,
+    k: int = DEFAULT_TOP_K,
+    low_threshold: float = DEFAULT_LOW_THRESHOLD,
+    abstain_threshold: float = DEFAULT_ABSTAIN_THRESHOLD,
+) -> dict[str, Any]:
+    """Retrieval with persona-trigger gating, focused retries, supplementary
+    hints, and adaptive K. Ported from ~/deus-memory-evo exp_0006 (round 1
+    winner, 0.7172 → 0.9931 on 145-query retrieval benchmark).
+
+    Gating rules:
+    - fell_back=True: abstain unless the query contains a PERSONA_TRIGGER;
+      then retry once with the TRIGGER_RETRY_TERMS alias and accept that.
+    - fell_back=False, confidence >= low_threshold: accept unconditionally.
+    - fell_back=False, confidence <  low_threshold: accept only if the query
+      contains a PERSONA_TRIGGER (otherwise abstain to protect abstain-near
+      gates like "what car do I drive").
+
+    Post-acceptance:
+    - Adaptive K: top_score >= low_threshold → cap at POLICY_K_HIGH_CONF;
+      else POLICY_K_LOW_CONF.
+    - Supplementary hints: for below-threshold Persona queries whose primary
+      result might miss a key path, merge the top-1 of a focused hint query.
+    """
+    has_trigger, trigger_words = _query_persona_triggers(query)
+    policy_trace: list[str] = []
+
+    primary = retrieve(
+        db, query, k=max(k, POLICY_K_LOW_CONF),
+        low_threshold=low_threshold, abstain_threshold=abstain_threshold,
+    )
+
+    fell_back = primary["fell_back"]
+    confidence = primary["confidence"]
+    results = list(primary["results"])
+
+    if fell_back:
+        # Try a focused retry when we have a trigger word.
+        retry_alias = None
+        for tw in trigger_words:
+            alias = TRIGGER_RETRY_TERMS.get(tw)
+            if alias:
+                retry_alias = alias
+                break
+        if retry_alias:
+            policy_trace.append(f"retry:{retry_alias}")
+            retry = retrieve(
+                db, retry_alias, k=max(k, POLICY_K_LOW_CONF),
+                low_threshold=low_threshold, abstain_threshold=abstain_threshold,
+            )
+            if not retry["fell_back"] and retry["results"]:
+                fell_back = False
+                confidence = retry["confidence"]
+                results = list(retry["results"])
+                primary = retry
+        if fell_back:
+            return {
+                "results": [],
+                "confidence": confidence,
+                "fell_back": True,
+                "trace": primary["trace"],
+                "policy_trace": policy_trace + ["abstain:fell_back"],
+            }
+
+    low_confidence = confidence < low_threshold
+    if low_confidence and not has_trigger:
+        # Below-threshold and nothing in the query signals Persona coverage →
+        # abstain rather than surface a noisy leaf.
+        policy_trace.append("abstain:low_conf_no_trigger")
+        return {
+            "results": [],
+            "confidence": confidence,
+            "fell_back": True,
+            "trace": primary["trace"],
+            "policy_trace": policy_trace,
+        }
+
+    # Adaptive K cap.
+    effective_k = POLICY_K_HIGH_CONF if not low_confidence else POLICY_K_LOW_CONF
+    effective_k = min(effective_k, k) if k < POLICY_K_LOW_CONF else effective_k
+    results = results[:effective_k]
+    policy_trace.append(f"k={effective_k}")
+
+    # Supplementary hints for ambiguous triggers on below-threshold queries.
+    if has_trigger and low_confidence:
+        seen_paths = {r.get("path") for r in results}
+        seen_hints: set[str] = set()
+        for tw in trigger_words:
+            hint = SUPPLEMENTARY_HINTS.get(tw)
+            if not hint or hint in seen_hints:
+                continue
+            seen_hints.add(hint)
+            hint_res = retrieve(
+                db, hint, k=1,
+                low_threshold=low_threshold, abstain_threshold=abstain_threshold,
+            )
+            if hint_res["fell_back"] or not hint_res["results"]:
+                continue
+            top = hint_res["results"][0]
+            if top.get("path") in seen_paths:
+                continue
+            results.append(top)
+            seen_paths.add(top.get("path"))
+            policy_trace.append(f"hint:{hint}")
+
+    return {
+        "results": results,
+        "confidence": confidence,
+        "fell_back": False,
+        "trace": primary["trace"],
+        "policy_trace": policy_trace,
+    }
+
+
 def _log_query(db: sqlite3.Connection, query: str, result: dict[str, Any]) -> None:
     try:
         db.execute(
@@ -1418,6 +1611,11 @@ def main(argv: list[str] | None = None) -> int:
     p_query.add_argument("--json", action="store_true")
     p_query.add_argument("--low", type=float, default=DEFAULT_LOW_THRESHOLD)
     p_query.add_argument("--abstain", type=float, default=DEFAULT_ABSTAIN_THRESHOLD)
+    p_query.add_argument(
+        "--raw", action="store_true",
+        help="Bypass retrieve_with_policy (persona gating / retry / hints / adaptive-K). "
+             "Used by benchmarks that need the raw embedding similarity path.",
+    )
 
     p_reembed = sub.add_parser("reembed", help="Re-embed a single file")
     p_reembed.add_argument("path", help="Relative path from vault root")
@@ -1472,17 +1670,28 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.cmd == "query":
-        result = retrieve(
-            db, args.text, k=args.k,
-            low_threshold=args.low, abstain_threshold=args.abstain,
-        )
+        if args.raw:
+            result = retrieve(
+                db, args.text, k=args.k,
+                low_threshold=args.low, abstain_threshold=args.abstain,
+            )
+        else:
+            result = retrieve_with_policy(
+                db, args.text, k=args.k,
+                low_threshold=args.low, abstain_threshold=args.abstain,
+            )
         if args.json:
             print(json.dumps(result, indent=2))
         else:
             for r in result["results"]:
-                print(f"{r['score']:.3f}  {r['route']:<20}  {r['path']}")
-            print(f"— confidence={result['confidence']:.3f} fell_back={result['fell_back']}")
-        return 0 if result["confidence"] >= args.low else 1
+                route = r.get("route") or "policy"
+                print(f"{r['score']:.3f}  {route:<20}  {r['path']}")
+            extra = ""
+            if "policy_trace" in result and result["policy_trace"]:
+                extra = f" policy={','.join(result['policy_trace'])}"
+            print(f"— confidence={result['confidence']:.3f} fell_back={result['fell_back']}{extra}")
+        # Exit code: 0 when a usable result was surfaced, 1 on abstain.
+        return 0 if not result["fell_back"] else 1
 
     if args.cmd == "reembed":
         status = reembed_file(vault, args.path, db)

--- a/scripts/tests/test_memory_tree_phase3.py
+++ b/scripts/tests/test_memory_tree_phase3.py
@@ -1013,3 +1013,124 @@ class TestAutofixTree:
         )
         counts = mt.autofix_tree(tmp_db, vault)
         assert counts["discovered"] == 0
+
+
+# ── TestRetrieveWithPolicy — ported evo exp_0006 gating ───────────────────────
+
+class TestRetrieveWithPolicy:
+    """Guards the persona-trigger gating, focused retry, supplementary hint,
+    and adaptive-K behavior ported from ~/deus-memory-evo exp_0006.
+
+    Monkeypatches retrieve() so we drive (query → confidence/path/fell_back)
+    deterministically. Tests the policy layer in isolation.
+    """
+
+    @staticmethod
+    def _stub(outcomes: dict[str, dict]):
+        """Build a fake retrieve() returning dicts from `outcomes` by query.
+
+        outcomes value keys: confidence, paths (list), fell_back.
+        """
+        def _fake(db, query, **kw):
+            o = outcomes.get(query)
+            if o is None:
+                return {"results": [], "confidence": 0.0, "fell_back": True, "trace": ["miss"]}
+            results = [
+                {"id": f"id{i}", "path": p, "title": p, "score": o["confidence"], "route": "flat"}
+                for i, p in enumerate(o.get("paths", []))
+            ]
+            return {
+                "results": results,
+                "confidence": o["confidence"],
+                "fell_back": o.get("fell_back", False),
+                "trace": ["stub"],
+            }
+        return _fake
+
+    def test_high_confidence_accept_adaptive_k_high(self, tmp_db, monkeypatch):
+        """conf >= low_threshold → cap at POLICY_K_HIGH_CONF."""
+        monkeypatch.setattr(mt, "retrieve", self._stub({
+            "q": {"confidence": 0.70, "paths": ["a.md", "b.md", "c.md", "d.md"], "fell_back": False},
+        }))
+        out = mt.retrieve_with_policy(tmp_db, "q", low_threshold=0.55)
+        assert out["fell_back"] is False
+        assert len(out["results"]) == mt.POLICY_K_HIGH_CONF
+        assert f"k={mt.POLICY_K_HIGH_CONF}" in out["policy_trace"]
+
+    def test_low_conf_with_trigger_accepts_adaptive_k_low(self, tmp_db, monkeypatch):
+        """Below threshold but query has PERSONA_TRIGGER → accept with K_LOW."""
+        monkeypatch.setattr(mt, "retrieve", self._stub({
+            "what about my roommates": {
+                "confidence": 0.40, "paths": ["a.md", "b.md", "c.md", "d.md", "e.md"], "fell_back": False,
+            },
+        }))
+        out = mt.retrieve_with_policy(tmp_db, "what about my roommates", low_threshold=0.55)
+        assert out["fell_back"] is False
+        assert len(out["results"]) == mt.POLICY_K_LOW_CONF
+        assert any(p.startswith("k=") for p in out["policy_trace"])
+
+    def test_low_conf_no_trigger_abstains(self, tmp_db, monkeypatch):
+        """Below threshold and no persona trigger → abstain."""
+        monkeypatch.setattr(mt, "retrieve", self._stub({
+            "what was my salary": {"confidence": 0.40, "paths": ["noise.md"], "fell_back": False},
+        }))
+        out = mt.retrieve_with_policy(tmp_db, "what was my salary", low_threshold=0.55)
+        assert out["fell_back"] is True
+        assert out["results"] == []
+        assert "abstain:low_conf_no_trigger" in out["policy_trace"]
+
+    def test_fell_back_with_trigger_retries(self, tmp_db, monkeypatch):
+        """fell_back=True + trigger → retry with alias → accept retry result."""
+        calls = []
+        def _fake(db, query, **kw):
+            calls.append(query)
+            if query == "directors whose work I rate highly":
+                return {"results": [], "confidence": 0.0, "fell_back": True, "trace": ["no_match"]}
+            if query == "directors":
+                return {
+                    "results": [{"id": "m", "path": "Persona/taste/movies.md", "title": "Movies",
+                                 "score": 0.62, "route": "flat"}],
+                    "confidence": 0.62, "fell_back": False, "trace": ["retry_hit"],
+                }
+            return {"results": [], "confidence": 0.0, "fell_back": True, "trace": []}
+        monkeypatch.setattr(mt, "retrieve", _fake)
+        out = mt.retrieve_with_policy(tmp_db, "directors whose work I rate highly")
+        assert out["fell_back"] is False
+        assert out["results"][0]["path"] == "Persona/taste/movies.md"
+        assert "retry:directors" in out["policy_trace"]
+        assert "directors whose work I rate highly" in calls and "directors" in calls
+
+    def test_fell_back_no_trigger_abstains_without_retry(self, tmp_db, monkeypatch):
+        """fell_back=True with no trigger → no retry, abstain."""
+        calls = []
+        def _fake(db, query, **kw):
+            calls.append(query)
+            return {"results": [], "confidence": 0.1, "fell_back": True, "trace": []}
+        monkeypatch.setattr(mt, "retrieve", _fake)
+        out = mt.retrieve_with_policy(tmp_db, "random unrelated question")
+        assert out["fell_back"] is True
+        assert "abstain:fell_back" in out["policy_trace"]
+        assert calls == ["random unrelated question"]  # no retry
+
+    def test_supplementary_hint_merges_household(self, tmp_db, monkeypatch):
+        """Low-conf 'home' query → primary result + hint result merged."""
+        def _fake(db, query, **kw):
+            if query == "home stuff":
+                return {
+                    "results": [{"id": "c", "path": "Persona/work-style/communication.md",
+                                 "title": "Comm", "score": 0.44, "route": "flat"}],
+                    "confidence": 0.44, "fell_back": False, "trace": [],
+                }
+            if query == "roommates":
+                return {
+                    "results": [{"id": "h", "path": "Persona/life/household.md",
+                                 "title": "Household", "score": 0.70, "route": "flat"}],
+                    "confidence": 0.70, "fell_back": False, "trace": [],
+                }
+            return {"results": [], "confidence": 0.0, "fell_back": True, "trace": []}
+        monkeypatch.setattr(mt, "retrieve", _fake)
+        out = mt.retrieve_with_policy(tmp_db, "home stuff", low_threshold=0.55)
+        paths = [r["path"] for r in out["results"]]
+        assert "Persona/life/household.md" in paths
+        assert "Persona/work-style/communication.md" in paths
+        assert "hint:roommates" in out["policy_trace"]


### PR DESCRIPTION
## Summary
- Port round-1 evo winner from `~/deus-memory-evo` (0.7172 → 0.9931 on a 145-query retrieval benchmark) into `scripts/memory_tree.py` as a new `retrieve_with_policy()` wrapping `retrieve()`.
- Policy adds persona-keyword gating on below-threshold hits, focused retries on `fell_back`, supplementary hints for ambiguous triggers, and adaptive top-K.
- Wired as the default path for `query`; `--raw` bypasses the policy for benchmarks that need raw embedding similarity.

### Policy details
- `PERSONA_TRIGGERS` — keyword set (roommates, movies, music, learning, etc.) that signals the query has Persona-vault coverage.
- `TRIGGER_RETRY_TERMS` — on `fell_back=True`, retry once with a focused alias (e.g. `"directors whose work I rate highly"` → retry as `"directors"`).
- `SUPPLEMENTARY_HINTS` — on below-threshold Persona queries, merge the top-1 of a parallel hint query (e.g. `"home stuff"` → merge `"roommates"` result → surfaces `household.md`).
- Adaptive K: `POLICY_K_HIGH_CONF=2` when `confidence ≥ low_threshold`, `POLICY_K_LOW_CONF=4` otherwise.

### Acceptance matrix
| case | trigger? | behavior |
|---|---|---|
| `confidence ≥ low_threshold` | any | accept, cap at K_HIGH_CONF |
| `confidence < low_threshold`, has trigger | yes | accept + hints, cap at K_LOW_CONF |
| `confidence < low_threshold`, no trigger | no | abstain (`abstain:low_conf_no_trigger`) |
| `fell_back=True`, has trigger | yes | retry with alias; accept retry if it succeeds |
| `fell_back=True`, no trigger | no | abstain (`abstain:fell_back`) |

## Test plan
- [x] `TestRetrieveWithPolicy` covering all five rows of the acceptance matrix (6 new tests)
- [x] Full memory_tree suite: 119/119 pass
- [ ] Run evo round 2 against the new policy path to confirm no regression on the benchmark
- [ ] Smoke-test a handful of real vault queries via the container agent before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)