### PR TITLE
chore(deus-cmd): verify snapshot freshness before catch-up

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1026,7 +1026,15 @@ $STARTUP_INSTRUCTION"
         cd "$HOME/deus" && launch_claude
       fi
     else
-      STARTUP_INSTRUCTION="STARTUP INSTRUCTION: Context from the memory vault has been pre-loaded above. Catch the user up using exactly this format:
+      STARTUP_INSTRUCTION="STARTUP INSTRUCTION: Context from the memory vault has been pre-loaded above, BUT it is a snapshot taken at deus launch and does not refresh across /clear or same-session work. Before drafting the catch-up, verify freshness:
+
+  1. ls -t \"$VAULT/Checkpoints\" | head -3
+  2. ls -t \"$VAULT/Session-Logs/$(date +%Y-%m-%d)\" 2>/dev/null
+  3. If anything on disk is newer than the newest date in the === RECENT SESSIONS === block, re-run: python3 \$HOME/deus/scripts/memory_indexer.py --recent 3
+     and lead the catch-up from that output plus the newest same-day checkpoint's next_action / in_progress fields. Ignore the stale pre-loaded block.
+  4. If disk matches the block, the snapshot is fresh — use it.
+
+Then catch the user up using exactly this format:
 
 • Previous session: [1-2 lines of ongoing context and last session topic]
 • Pending: [bullet list of pending tasks, max 3 items]


### PR DESCRIPTION
## Summary
- Pre-loaded vault + `=== RECENT SESSIONS ===` block is captured once at `deus` launch and does not refresh on `/clear` or same-session work.
- Adds explicit freshness-check steps to the `STARTUP_INSTRUCTION` so the model verifies `Checkpoints/` and `Session-Logs/<today>/` against the snapshot, and re-queries `memory_indexer.py --recent 3` if disk is newer.

## Why
On 2026-04-17 the catch-up led with 2026-04-16 sessions even though five 2026-04-17 session-logs and a 20:10 checkpoint existed on disk. The `deus` session had launched before those sessions were written, so the snapshot was stale and `/clear` didn't refresh it.

## Test plan
- [ ] Run `bash -n deus-cmd.sh` (done — syntax OK)
- [ ] Launch a fresh `deus` session, confirm the new instruction text appears in the system prompt block
- [ ] Verify `$VAULT` and `$(date +%Y-%m-%d)` expand at launch time (not escaped into the prompt as literals)
- [ ] Next catch-up: confirm the freshness check is executed before answering

🤖 Generated with [Claude Code](https://claude.com/claude-code)