### PR TITLE
fix(bench): fail loud on indexer subprocess error

### DIFF
--- a/scripts/memory_benchmark.py
+++ b/scripts/memory_benchmark.py
@@ -72,11 +72,14 @@ def _run_indexer(
 
 def _run_indexer_real(args: list[str]) -> subprocess.CompletedProcess:
     """Run memory_indexer.py against the REAL production vault/DB."""
-    return subprocess.run(
-        [sys.executable, str(_INDEXER)] + args,
-        capture_output=True,
-        text=True,
-    )
+    cmd = [sys.executable, str(_INDEXER)] + args
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"memory_indexer.py failed (rc={proc.returncode}): {proc.stderr.strip()}\n"
+            f"command: {cmd}"
+        )
+    return proc
 
 
 def _run_indexer_with_home(
@@ -85,13 +88,15 @@ def _run_indexer_with_home(
     vault_path: str,
 ) -> subprocess.CompletedProcess:
     """Run indexer with HOME overridden so DB_PATH resolves to fake_home/.deus/memory.db."""
+    cmd = [sys.executable, str(_INDEXER)] + args
     env = {**os.environ, "HOME": fake_home, "DEUS_VAULT_PATH": vault_path}
-    return subprocess.run(
-        [sys.executable, str(_INDEXER)] + args,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"memory_indexer.py failed (rc={proc.returncode}): {proc.stderr.strip()}\n"
+            f"command: {cmd}"
+        )
+    return proc
 
 
 # ── Dataset download ──────────────────────────────────────────────────────────

--- a/scripts/tests/test_memory_benchmark.py
+++ b/scripts/tests/test_memory_benchmark.py
@@ -452,3 +452,55 @@ def test_sample_real_sessions_inline_tldr(tmp_path):
     assert len(sessions) == 1
     # topics takes priority but either way the query must be non-empty
     assert len(sessions[0]["query"]) > 10
+
+
+# ── _run_indexer_real fail-loud ───────────────────────────────────────────────
+
+
+def test_run_indexer_real_raises_on_nonzero_rc():
+    proc = MagicMock()
+    proc.returncode = 1
+    proc.stderr = "boom"
+    proc.stdout = ""
+    with patch("subprocess.run", return_value=proc):
+        with pytest.raises(RuntimeError) as exc_info:
+            mb._run_indexer_real(["--query", "test"])
+    msg = str(exc_info.value)
+    assert "boom" in msg
+    assert "memory_indexer.py" in msg
+
+
+def test_run_indexer_real_ok_on_zero_rc():
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = "ok"
+    proc.stderr = ""
+    with patch("subprocess.run", return_value=proc):
+        result = mb._run_indexer_real(["--query", "test"])
+    assert result.stdout == "ok"
+
+
+# ── _run_indexer_with_home fail-loud ─────────────────────────────────────────
+
+
+def test_run_indexer_with_home_raises_on_nonzero_rc():
+    proc = MagicMock()
+    proc.returncode = 1
+    proc.stderr = "boom"
+    proc.stdout = ""
+    with patch("subprocess.run", return_value=proc):
+        with pytest.raises(RuntimeError) as exc_info:
+            mb._run_indexer_with_home(["--query", "test"], fake_home="/tmp/fake", vault_path="/tmp/vault")
+    msg = str(exc_info.value)
+    assert "boom" in msg
+    assert "memory_indexer.py" in msg
+
+
+def test_run_indexer_with_home_ok_on_zero_rc():
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = "ok"
+    proc.stderr = ""
+    with patch("subprocess.run", return_value=proc):
+        result = mb._run_indexer_with_home(["--query", "test"], fake_home="/tmp/fake", vault_path="/tmp/vault")
+    assert result.stdout == "ok"


### PR DESCRIPTION
## Summary
- `_run_indexer_real` and `_run_indexer_with_home` in `scripts/memory_benchmark.py` silently returned empty `CompletedProcess` on indexer crash, which `run_internal`'s recall loop then counted as a miss.
- Result: a misconfigured env (e.g. missing `GEMINI_API_KEY`) showed up as a false `local_recall: 0/N` regression instead of a loud error. Caught during the unified-bench PR wet run.
- Both helpers now `raise RuntimeError` with stderr + the invoked command when returncode is nonzero. No callers wrap these in `except`, so the error propagates.

## Test plan
- [x] 4 new tests in `scripts/tests/test_memory_benchmark.py` (38 pass, up from 34)
- [x] `scripts/bench/tests/` suite unchanged, 28 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)