### PR TITLE
fix(config): fall back to ~/.config/deus/.env for GEMINI_API_KEY

### DIFF
--- a/evolution/config.py
+++ b/evolution/config.py
@@ -12,6 +12,8 @@ ARTIFACTS_DIR = EVOLUTION_DIR / "artifacts"
 DB_PATH = Path(os.environ.get("DEUS_DB", "~/.deus/memory.db")).expanduser()
 EVOLUTION_DB_PATH = Path(os.environ.get("DEUS_EVOLUTION_DB", "~/.deus/evolution.db")).expanduser()
 CONFIG_ENV = Path(__file__).resolve().parent.parent / ".env"
+USER_CONFIG_ENV = Path("~/.config/deus/.env").expanduser()
+_ENV_SEARCH_PATHS: list[Path] = [CONFIG_ENV, USER_CONFIG_ENV]
 
 # ── Ollama ────────────────────────────────────────────────────────────────────
 
@@ -77,14 +79,16 @@ JUDGE_BATCH_SIZE = int(os.environ.get("EVOLUTION_JUDGE_BATCH_SIZE", "5"))
 
 
 def load_api_key() -> str:
-    """Load GEMINI_API_KEY from project .env or environment."""
-    if CONFIG_ENV.exists():
-        for line in CONFIG_ENV.read_text().splitlines():
-            if line.startswith("GEMINI_API_KEY="):
-                return line.split("=", 1)[1].strip()
+    """Load GEMINI_API_KEY from .env files (in priority order) or environment."""
+    for path in _ENV_SEARCH_PATHS:
+        if path.exists():
+            for line in path.read_text().splitlines():
+                if line.startswith("GEMINI_API_KEY="):
+                    return line.split("=", 1)[1].strip()
     key = os.environ.get("GEMINI_API_KEY", "")
     if not key:
+        checked = ", ".join(str(p) for p in _ENV_SEARCH_PATHS)
         raise RuntimeError(
-            "GEMINI_API_KEY not found in .env or environment"
+            f"GEMINI_API_KEY not found. Checked: {checked}, and env var."
         )
     return key

--- a/evolution/tests/test_config.py
+++ b/evolution/tests/test_config.py
@@ -1,0 +1,87 @@
+"""Tests for evolution/config.py — load_api_key fallback chain."""
+import os
+from pathlib import Path
+
+import pytest
+
+import evolution.config as config_mod
+from evolution.config import load_api_key
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    """Ensure GEMINI_API_KEY is unset before each test."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+
+def _write_env(path: Path, key: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"GEMINI_API_KEY={key}\n")
+
+
+def test_repo_env_returned(tmp_path, monkeypatch):
+    """Case 1: GEMINI_API_KEY in repo .env → returned (current behavior preserved)."""
+    repo_env = tmp_path / ".env"
+    _write_env(repo_env, "repo-key-123")
+    user_env = tmp_path / "user" / ".env"
+
+    monkeypatch.setattr(config_mod, "CONFIG_ENV", repo_env)
+    monkeypatch.setattr(config_mod, "USER_CONFIG_ENV", user_env)
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    assert load_api_key() == "repo-key-123"
+
+
+def test_user_level_env_fallback(tmp_path, monkeypatch):
+    """Case 2: Repo .env missing, user-level .env has key → returned."""
+    repo_env = tmp_path / "missing" / ".env"
+    user_env = tmp_path / "user" / ".env"
+    _write_env(user_env, "user-key-456")
+
+    monkeypatch.setattr(config_mod, "CONFIG_ENV", repo_env)
+    monkeypatch.setattr(config_mod, "USER_CONFIG_ENV", user_env)
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    assert load_api_key() == "user-key-456"
+
+
+def test_env_var_fallback(tmp_path, monkeypatch):
+    """Case 3: Both .env files missing, env var set → env-var value returned."""
+    repo_env = tmp_path / "missing1" / ".env"
+    user_env = tmp_path / "missing2" / ".env"
+
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+    monkeypatch.setenv("GEMINI_API_KEY", "envvar-key-789")
+
+    assert load_api_key() == "envvar-key-789"
+
+
+def test_all_sources_missing_raises(tmp_path, monkeypatch):
+    """Case 4: All sources empty → RuntimeError mentioning both paths + env var."""
+    repo_env = tmp_path / "missing1" / ".env"
+    user_env = tmp_path / "missing2" / ".env"
+
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        load_api_key()
+
+    msg = str(exc_info.value)
+    assert str(repo_env) in msg
+    assert str(user_env) in msg
+    assert "env var" in msg
+
+
+def test_repo_env_no_key_falls_through_to_user(tmp_path, monkeypatch):
+    """Case 5: Repo .env exists but has no GEMINI_API_KEY, user-level .env has it → user-level wins."""
+    repo_env = tmp_path / ".env"
+    repo_env.write_text("OTHER_KEY=something\nFOO=bar\n")
+
+    user_env = tmp_path / "user" / ".env"
+    _write_env(user_env, "user-fallback-key")
+
+    monkeypatch.setattr(config_mod, "CONFIG_ENV", repo_env)
+    monkeypatch.setattr(config_mod, "USER_CONFIG_ENV", user_env)
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    assert load_api_key() == "user-fallback-key"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-15"
+last_verified: "2026-04-18"
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-15"
+last_verified: "2026-04-18"
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary
- `CONFIG_ENV` resolves relative to `evolution/config.py`, so tools run from a git worktree can't find the main repo's `.env` and fail with `GEMINI_API_KEY not found`.
- `load_api_key` now scans `<repo-root>/.env`, then `~/.config/deus/.env` (canonical user-level fallback, alongside `config.json`), then `GEMINI_API_KEY` env var.
- Error message now enumerates every path checked so users know where to drop the key.

## Test plan
- [x] 5 new tests in `evolution/tests/test_config.py` covering all fallback orderings
- [x] `scripts/tests/test_memory_benchmark.py` + `test_memory_indexer.py` unchanged, 277 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)