### PR TITLE
feat(bench): --label, diff subcommand, token budget-based scoring

### DIFF
--- a/scripts/bench/cli.py
+++ b/scripts/bench/cli.py
@@ -12,7 +12,7 @@ if __name__ == "__main__" and __package__ in (None, ""):
 
 from . import suites as _suites_pkg  # noqa: F401 — triggers suite registration
 from .registry import get as get_suite, list_names
-from .store import recent_runs, save_run
+from .store import get_cases, recent_runs, resolve_run, save_run
 from .types import RunResult
 
 
@@ -24,8 +24,9 @@ def _fmt_row(r: dict) -> str:
     tok_in = r.get("tokens_in", 0)
     lat = r.get("latency_ms", 0)
     git = r.get("git_sha") or "—"
+    label = r.get("label") or "—"
     suite = r.get("suite", "")
-    return f"| {suite} | {ts} | {score_s} | {n} | {tok_in} | {lat} | {git} |"
+    return f"| {suite} | {ts} | {score_s} | {n} | {tok_in} | {lat} | {git} | {label} |"
 
 
 def cmd_list(_args: argparse.Namespace) -> int:
@@ -67,7 +68,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         )
 
         if args.save:
-            run_id = save_run(result)
+            run_id = save_run(result, label=args.label)
             print(f"saved run_id={run_id}")
 
     return 0
@@ -90,13 +91,105 @@ def cmd_report(args: argparse.Namespace) -> int:
         print("no runs found")
         return 0
 
-    header = "| suite | ts | score | n | tokens_in | latency_ms | git_sha |"
-    sep    = "|-------|-----|-------|---|-----------|------------|---------|"
+    header = "| suite | ts | score | n | tokens_in | latency_ms | git_sha | label |"
+    sep    = "|-------|-----|-------|---|-----------|------------|---------|-------|"
     print(header)
     print(sep)
     for r in rows:
         print(_fmt_row(r))
     return 0
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    suite_filter: str | None = args.suite
+    tolerance: float = args.tolerance
+
+    run_a = resolve_run(args.a, suite=suite_filter)
+    run_b = resolve_run(args.b, suite=suite_filter)
+
+    missing: list[str] = []
+    if run_a is None:
+        missing.append(args.a)
+    if run_b is None:
+        missing.append(args.b)
+
+    if missing:
+        for m in missing:
+            print(f"error: no run found for {m!r}", file=sys.stderr)
+        # Print candidates to help user
+        candidates = recent_runs(suite=suite_filter, limit=20)
+        if candidates:
+            print("available runs (run_id | label | git_sha | suite | ts):", file=sys.stderr)
+            for c in candidates:
+                rid = c.get("run_id", "")
+                lbl = c.get("label") or "—"
+                sha = c.get("git_sha") or "—"
+                sname = c.get("suite", "")
+                ts = c.get("ts", 0)
+                print(f"  {rid}  {lbl}  {sha}  {sname}  {ts}", file=sys.stderr)
+        return 2
+
+    cases_a = {c["case_id"]: c for c in get_cases(run_a["run_id"])}
+    cases_b = {c["case_id"]: c for c in get_cases(run_b["run_id"])}
+
+    all_ids = sorted(set(cases_a) | set(cases_b))
+    common_ids = sorted(set(cases_a) & set(cases_b))
+    only_a = sorted(set(cases_a) - set(cases_b))
+    only_b = sorted(set(cases_b) - set(cases_a))
+
+    rows: list[tuple[str, str, str, str, str]] = []  # case_id, score_a, score_b, delta, status
+
+    has_regression = False
+
+    for cid in common_ids:
+        sa = cases_a[cid]["score"] if cases_a[cid]["score"] is not None else 0.0
+        sb = cases_b[cid]["score"] if cases_b[cid]["score"] is not None else 0.0
+        delta = sb - sa
+        if delta < -tolerance:
+            status = "-regressed"
+            has_regression = True
+        elif delta > tolerance:
+            status = "+improved"
+        else:
+            status = "unchanged"
+        rows.append((cid, f"{sa:.3f}", f"{sb:.3f}", f"{delta:+.3f}", status))
+
+    for cid in only_a:
+        sa = cases_a[cid]["score"] if cases_a[cid]["score"] is not None else 0.0
+        rows.append((cid, f"{sa:.3f}", "—", "—", "dropped"))
+
+    for cid in only_b:
+        sb = cases_b[cid]["score"] if cases_b[cid]["score"] is not None else 0.0
+        rows.append((cid, "—", f"{sb:.3f}", "—", "added"))
+
+    print("| case_id | score_a | score_b | delta | status |")
+    print("|---------|---------|---------|-------|--------|")
+    for case_id, sa, sb, delta, status in rows:
+        print(f"| {case_id} | {sa} | {sb} | {delta} | {status} |")
+
+    score_a = run_a.get("score")
+    score_b = run_b.get("score")
+    score_a_s = f"{score_a:.3f}" if score_a is not None else "—"
+    score_b_s = f"{score_b:.3f}" if score_b is not None else "—"
+    if score_a is not None and score_b is not None:
+        suite_delta_s = f"{score_b - score_a:+.3f}"
+    else:
+        suite_delta_s = "—"
+
+    n_improved = sum(1 for *_, s in rows if s == "+improved")
+    n_regressed = sum(1 for *_, s in rows if s == "-regressed")
+    n_unchanged = sum(1 for *_, s in rows if s == "unchanged")
+    n_added = sum(1 for *_, s in rows if s == "added")
+    n_dropped = sum(1 for *_, s in rows if s == "dropped")
+
+    suite_name = run_a.get("suite", "")
+    print(
+        f"\nsuite={suite_name} score_a={score_a_s} score_b={score_b_s} delta={suite_delta_s}"
+        f" improved={n_improved} regressed={n_regressed} unchanged={n_unchanged}"
+        f" added={n_added} dropped={n_dropped}"
+    )
+
+    return 1 if has_regression else 0
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -108,13 +201,20 @@ def _build_parser() -> argparse.ArgumentParser:
     run_p = sub.add_parser("run", help="run a suite")
     run_p.add_argument("suite", help="suite name or 'all'")
     run_p.add_argument("suite_args", nargs=argparse.REMAINDER)
-    # --save is consumed before argparse in main() so it can appear anywhere
-    # around the suite name without being eaten by REMAINDER.
+    # --save and --label are consumed before argparse in main() so they can
+    # appear anywhere around the suite name without being eaten by REMAINDER.
 
     report_p = sub.add_parser("report", help="show recent runs")
     report_p.add_argument("--suite", default=None)
     report_p.add_argument("--since", default="30d", help="7d, 30d, or all")
     report_p.add_argument("--limit", type=int, default=20)
+
+    diff_p = sub.add_parser("diff", help="compare two runs case-by-case")
+    diff_p.add_argument("a", help="run_id, label, or git_sha of run A")
+    diff_p.add_argument("b", help="run_id, label, or git_sha of run B")
+    diff_p.add_argument("--suite", default=None, help="restrict resolution to this suite")
+    diff_p.add_argument("--tolerance", type=float, default=0.01,
+                        help="min |delta| to count as improved/regressed (default 0.01)")
 
     return p
 
@@ -124,13 +224,27 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv[1:]
 
     save = False
+    label: str | None = None
+
     if argv and argv[0] == "run":
         filtered = ["run"]
-        for token in argv[1:]:
+        i = 1
+        while i < len(argv):
+            token = argv[i]
             if token == "--save":
                 save = True
+                i += 1
+            elif token == "--label":
+                i += 1
+                if i < len(argv):
+                    label = argv[i]
+                i += 1
+            elif token.startswith("--label="):
+                label = token[len("--label="):]
+                i += 1
             else:
                 filtered.append(token)
+                i += 1
         argv = filtered
 
     p = _build_parser()
@@ -140,11 +254,14 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_list(args)
     if args.command == "run":
         args.save = save
+        args.label = label
         if args.suite_args and args.suite_args[0] == "--":
             args.suite_args = args.suite_args[1:]
         return cmd_run(args)
     if args.command == "report":
         return cmd_report(args)
+    if args.command == "diff":
+        return cmd_diff(args)
 
     p.print_help()
     return 0

--- a/scripts/bench/store.py
+++ b/scripts/bench/store.py
@@ -60,7 +60,8 @@ CREATE TABLE IF NOT EXISTS runs (
   tokens_out INTEGER NOT NULL DEFAULT 0,
   latency_ms INTEGER NOT NULL DEFAULT 0,
   cost_usd REAL NOT NULL DEFAULT 0.0,
-  meta TEXT
+  meta TEXT,
+  label TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_runs_suite_ts ON runs (suite, ts);
@@ -79,22 +80,45 @@ CREATE TABLE IF NOT EXISTS cases (
 );
 """
 
+_CURRENT_VERSION = 2
+
+
+def _migrate(con: sqlite3.Connection) -> None:
+    row = con.execute("SELECT version FROM schema_version").fetchone()
+    ver = row[0] if row else 0
+    if ver < 2:
+        con.execute("ALTER TABLE runs ADD COLUMN label TEXT")
+        con.execute("UPDATE schema_version SET version = 2")
+        con.commit()
+
 
 def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.exists()
     con = sqlite3.connect(str(path))
     con.row_factory = sqlite3.Row
     con.execute("PRAGMA foreign_keys = ON")
     con.executescript(_SCHEMA)
-    con.execute(
-        "INSERT OR IGNORE INTO schema_version (version) VALUES (1)"
-    )
-    con.commit()
+    if not existing:
+        # Fresh DB — set directly to current version
+        con.execute(
+            "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
+            (_CURRENT_VERSION,),
+        )
+        con.commit()
+    else:
+        row = con.execute("SELECT version FROM schema_version").fetchone()
+        if row is None:
+            con.execute(
+                "INSERT INTO schema_version (version) VALUES (1)"
+            )
+            con.commit()
+        _migrate(con)
     return con
 
 
-def save_run(result: RunResult) -> str:
+def save_run(result: RunResult, label: str | None = None) -> str:
     run_id = _make_run_id()
     ts = int(time.time())
     git_sha = _git_sha()
@@ -106,8 +130,8 @@ def save_run(result: RunResult) -> str:
             """
             INSERT INTO runs
               (run_id, ts, suite, git_sha, host, n_cases, score,
-               tokens_in, tokens_out, latency_ms, cost_usd, meta)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               tokens_in, tokens_out, latency_ms, cost_usd, meta, label)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 run_id,
@@ -122,6 +146,7 @@ def save_run(result: RunResult) -> str:
                 result.latency_ms,
                 result.cost_usd,
                 json.dumps(result.meta) if result.meta else None,
+                label,
             ),
         )
         for case in result.cases:
@@ -183,6 +208,63 @@ def recent_runs(
             params,
         ).fetchall()
         return [dict(row) for row in rows]
+    finally:
+        con.close()
+
+
+def get_cases(run_id: str) -> list[dict[str, Any]]:
+    con = _connect()
+    try:
+        rows = con.execute(
+            "SELECT * FROM cases WHERE run_id = ? ORDER BY case_id",
+            (run_id,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        con.close()
+
+
+def resolve_run(arg: str, suite: str | None = None) -> dict[str, Any] | None:
+    """Return the most-recent run matching arg by run_id, label, or git_sha.
+
+    Resolution order: exact run_id → label → git_sha (prefix or full).
+    If suite is given, restrict candidates to that suite.
+    Returns None when no match is found.
+    """
+    con = _connect()
+    try:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if suite is not None:
+            conditions.append("suite = ?")
+            params.append(suite)
+        where_suite = ("WHERE " + " AND ".join(conditions) + " AND ") if conditions else "WHERE "
+
+        # 1. exact run_id
+        row = con.execute(
+            f"SELECT * FROM runs {where_suite}run_id = ? ORDER BY ts DESC LIMIT 1",
+            [*params, arg],
+        ).fetchone()
+        if row:
+            return dict(row)
+
+        # 2. label
+        row = con.execute(
+            f"SELECT * FROM runs {where_suite}label = ? ORDER BY ts DESC LIMIT 1",
+            [*params, arg],
+        ).fetchone()
+        if row:
+            return dict(row)
+
+        # 3. git_sha (prefix match)
+        row = con.execute(
+            f"SELECT * FROM runs {where_suite}git_sha LIKE ? ORDER BY ts DESC LIMIT 1",
+            [*params, arg + "%"],
+        ).fetchone()
+        if row:
+            return dict(row)
+
+        return None
     finally:
         con.close()
 

--- a/scripts/bench/suites/token.py
+++ b/scripts/bench/suites/token.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib.util
+import os
 import sys
 import time
 from pathlib import Path
@@ -9,6 +10,23 @@ from ..types import CaseResult, RunResult
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
 _HARNESS_PATH = _SCRIPTS_DIR / "token_bench" / "harness.py"
+
+# Default budget: current measured values rounded up to nearest 100, +10% headroom.
+# Measured 2026-04-17: host_cc_session=631, container_whatsapp_main_turn1=1203,
+# container_telegram_main_turn1=1018  →  totals 2852 across 3 scenarios.
+TOKEN_BUDGETS_PER_SCENARIO: dict[str, int] = {
+    "host_cc_session": 700,                  # 631 → ceil100=700 (+10%)
+    "container_whatsapp_main_turn1": 1400,   # 1203 → ceil100=1300 +10% ≈ 1400
+    "container_telegram_main_turn1": 1200,   # 1018 → ceil100=1100 +10% ≈ 1200
+}
+# Overall suite budget (sum of per-scenario defaults + 10% headroom, round to 100)
+TOKEN_BUDGET: int = int(os.environ.get("DEUS_BENCH_TOKEN_BUDGET", "3500"))
+
+
+def _score(tokens_in: int, budget: int) -> float:
+    if tokens_in <= budget:
+        return 1.0
+    return min(1.0, budget / max(tokens_in, 1))
 
 
 def _load_harness():
@@ -51,18 +69,34 @@ def run_token(argv: list[str]) -> RunResult:
     for name, s in scenarios.items():
         est = s["est_tokens"]
         total_tokens_in += est
+        budget = TOKEN_BUDGETS_PER_SCENARIO.get(name, TOKEN_BUDGET)
+        case_score = _score(est, budget)
+        over_by = max(0, est - budget)
         cases.append(CaseResult(
             case_id=name,
-            score=1.0,
+            score=case_score,
             tokens_in=est,
-            meta={"chars": s["total_chars"], "components": s["components"]},
+            meta={
+                "chars": s["total_chars"],
+                "components": s["components"],
+                "budget": budget,
+                "over_by": over_by,
+            },
         ))
+
+    suite_score = _score(total_tokens_in, TOKEN_BUDGET)
+    suite_over_by = max(0, total_tokens_in - TOKEN_BUDGET)
 
     return RunResult(
         suite="token",
-        score=1.0,
+        score=suite_score,
         cases=cases,
         tokens_in=total_tokens_in,
         latency_ms=elapsed_ms,
-        meta={"label": args.label, "chars_per_token": h.CHARS_PER_TOKEN},
+        meta={
+            "label": args.label,
+            "chars_per_token": h.CHARS_PER_TOKEN,
+            "budget": TOKEN_BUDGET,
+            "over_by": suite_over_by,
+        },
     )

--- a/scripts/bench/tests/test_cli.py
+++ b/scripts/bench/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Smoke tests for the CLI (list, run --dry, report)."""
+"""Smoke tests for the CLI (list, run --dry, report, diff)."""
 import os
 import subprocess
 import sys
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.bench.store import save_run
+from scripts.bench.store import recent_runs, resolve_run, save_run
 from scripts.bench.types import CaseResult, RunResult
 
 _WORKTREE = Path(__file__).resolve().parent.parent.parent.parent
@@ -22,6 +22,17 @@ def _run_cli(*args: str, env: dict | None = None) -> subprocess.CompletedProcess
         cwd=str(_WORKTREE),
         env=e,
     )
+
+
+def _seed_run(suite: str, score: float, cases: list[tuple[str, float]], label: str | None = None) -> str:
+    """Helper: seed a run with given cases directly via store."""
+    result = RunResult(
+        suite=suite,
+        score=score,
+        cases=[CaseResult(case_id=cid, score=s) for cid, s in cases],
+        tokens_in=0,
+    )
+    return save_run(result, label=label)
 
 
 def test_list_shows_memory_and_token(isolate_bench_db):
@@ -61,3 +72,84 @@ def test_run_unknown_suite_exits_1(isolate_bench_db):
 def test_list_exit_code(isolate_bench_db):
     r = _run_cli("list", env={"DEUS_BENCH_DB": str(isolate_bench_db)})
     assert r.returncode == 0
+
+
+# ── --label flag ──────────────────────────────────────────────────────────────
+
+def test_report_shows_label_column(isolate_bench_db):
+    save_run(RunResult(
+        suite="memory",
+        score=0.9,
+        cases=[CaseResult(case_id="c1", score=0.9)],
+        tokens_in=10,
+    ), label="my-label")
+    r = _run_cli("report", env={"DEUS_BENCH_DB": str(isolate_bench_db)})
+    assert r.returncode == 0, r.stderr
+    assert "label" in r.stdout
+    assert "my-label" in r.stdout
+
+
+# ── diff subcommand ───────────────────────────────────────────────────────────
+
+def test_diff_basic_table(isolate_bench_db):
+    """Two runs with 3 cases: assert all case_ids and correct deltas appear."""
+    db = str(isolate_bench_db)
+    id_a = _seed_run("token", 0.8, [("c1", 0.8), ("c2", 1.0), ("c3", 0.5)], label="pre")
+    id_b = _seed_run("token", 0.9, [("c1", 0.9), ("c2", 1.0), ("c3", 0.6)], label="post")
+    r = _run_cli("diff", id_a, id_b, env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "c1" in r.stdout
+    assert "c2" in r.stdout
+    assert "c3" in r.stdout
+    # c1 improved by 0.1
+    assert "+0.100" in r.stdout or "+0.10" in r.stdout
+
+
+def test_diff_by_label(isolate_bench_db):
+    """Diff can be invoked using labels."""
+    db = str(isolate_bench_db)
+    _seed_run("token", 0.8, [("c1", 0.8)], label="before")
+    _seed_run("token", 0.9, [("c1", 0.9)], label="after")
+    r = _run_cli("diff", "before", "after", env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "c1" in r.stdout
+
+
+def test_diff_regression_exit_1(isolate_bench_db):
+    """At least one regression → exit code 1."""
+    db = str(isolate_bench_db)
+    id_a = _seed_run("token", 1.0, [("c1", 1.0)])
+    id_b = _seed_run("token", 0.5, [("c1", 0.5)])
+    r = _run_cli("diff", id_a, id_b, env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 1, f"expected exit 1, got {r.returncode}\n{r.stdout}"
+    assert "-regressed" in r.stdout
+
+
+def test_diff_same_run_unchanged_exit_0(isolate_bench_db):
+    """Diffing a run against itself → all unchanged, exit 0."""
+    db = str(isolate_bench_db)
+    run_id = _seed_run("token", 0.8, [("c1", 0.8), ("c2", 0.6)])
+    r = _run_cli("diff", run_id, run_id, env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "unchanged" in r.stdout
+    assert "-regressed" not in r.stdout
+
+
+def test_diff_unknown_arg_exit_2(isolate_bench_db):
+    """Unknown argument → exit 2, stderr lists candidates."""
+    db = str(isolate_bench_db)
+    _seed_run("token", 0.8, [("c1", 0.8)], label="existing")
+    r = _run_cli("diff", "ghost-run-xyz", "also-ghost", env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 2
+    assert "ghost-run-xyz" in r.stderr
+
+
+def test_diff_added_dropped_cases(isolate_bench_db):
+    """Cases only in A are 'dropped'; cases only in B are 'added'."""
+    db = str(isolate_bench_db)
+    id_a = _seed_run("token", 0.8, [("c1", 0.8), ("old_case", 1.0)])
+    id_b = _seed_run("token", 0.9, [("c1", 0.9), ("new_case", 1.0)])
+    r = _run_cli("diff", id_a, id_b, env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "dropped" in r.stdout
+    assert "added" in r.stdout

--- a/scripts/bench/tests/test_store.py
+++ b/scripts/bench/tests/test_store.py
@@ -1,10 +1,11 @@
 """Tests for scripts/bench/store.py"""
 import sqlite3
 import time
+from pathlib import Path
 
 import pytest
 
-from scripts.bench.store import _connect, _db_path, list_suites, recent_runs, save_run, trend
+from scripts.bench.store import _connect, _db_path, get_cases, list_suites, recent_runs, resolve_run, save_run, trend
 from scripts.bench.types import CaseResult, RunResult
 
 
@@ -40,7 +41,105 @@ def test_schema_version(isolate_bench_db):
     con = _connect()
     ver = con.execute("SELECT version FROM schema_version").fetchone()[0]
     con.close()
-    assert ver == 1
+    assert ver == 2
+
+
+def test_migration_v1_to_v2(tmp_path, monkeypatch):
+    """A version-1 DB (no label column) is migrated to version 2 with the column added."""
+    db_path = tmp_path / "v1_test.db"
+    monkeypatch.setenv("DEUS_BENCH_DB", str(db_path))
+
+    # Build a v1 schema manually (no label column)
+    con = sqlite3.connect(str(db_path))
+    con.executescript("""
+        CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        CREATE TABLE runs (
+          run_id TEXT PRIMARY KEY,
+          ts INTEGER NOT NULL,
+          suite TEXT NOT NULL,
+          model TEXT,
+          git_sha TEXT,
+          host TEXT,
+          n_cases INTEGER NOT NULL DEFAULT 0,
+          score REAL,
+          tokens_in INTEGER NOT NULL DEFAULT 0,
+          tokens_out INTEGER NOT NULL DEFAULT 0,
+          latency_ms INTEGER NOT NULL DEFAULT 0,
+          cost_usd REAL NOT NULL DEFAULT 0.0,
+          meta TEXT
+        );
+        CREATE TABLE cases (
+          run_id TEXT NOT NULL,
+          case_id TEXT NOT NULL,
+          score REAL,
+          tokens_in INTEGER NOT NULL DEFAULT 0,
+          tokens_out INTEGER NOT NULL DEFAULT 0,
+          latency_ms INTEGER NOT NULL DEFAULT 0,
+          passed INTEGER NOT NULL DEFAULT 1,
+          meta TEXT,
+          PRIMARY KEY (run_id, case_id)
+        );
+        INSERT INTO schema_version (version) VALUES (1);
+    """)
+    con.commit()
+    con.close()
+
+    # Now call _connect() — should run migration
+    con = _connect()
+    ver = con.execute("SELECT version FROM schema_version").fetchone()[0]
+    cols = {row[1] for row in con.execute("PRAGMA table_info(runs)").fetchall()}
+    con.close()
+
+    assert ver == 2
+    assert "label" in cols
+
+
+def test_save_run_with_label(isolate_bench_db):
+    run_id = save_run(_make_result(suite="labeled"), label="pre-fix")
+    rows = recent_runs(suite="labeled")
+    assert len(rows) == 1
+    assert rows[0]["label"] == "pre-fix"
+
+
+def test_save_run_without_label(isolate_bench_db):
+    run_id = save_run(_make_result(suite="nolabel"))
+    rows = recent_runs(suite="nolabel")
+    assert rows[0]["label"] is None
+
+
+def test_resolve_run_by_run_id(isolate_bench_db):
+    run_id = save_run(_make_result(suite="res"))
+    row = resolve_run(run_id)
+    assert row is not None
+    assert row["run_id"] == run_id
+
+
+def test_resolve_run_by_label(isolate_bench_db):
+    run_id = save_run(_make_result(suite="res2"), label="my-label")
+    row = resolve_run("my-label")
+    assert row is not None
+    assert row["run_id"] == run_id
+
+
+def test_resolve_run_by_git_sha(isolate_bench_db, monkeypatch):
+    import scripts.bench.store as store_mod
+    monkeypatch.setattr(store_mod, "_git_sha", lambda: "abc1234")
+    run_id = save_run(_make_result(suite="res3"))
+    row = resolve_run("abc1234")
+    assert row is not None
+    assert row["run_id"] == run_id
+
+
+def test_resolve_run_not_found(isolate_bench_db):
+    row = resolve_run("definitely-not-there")
+    assert row is None
+
+
+def test_get_cases_returns_all(isolate_bench_db):
+    run_id = save_run(_make_result())
+    cases = get_cases(run_id)
+    assert len(cases) == 2
+    assert {c["case_id"] for c in cases} == {"c1", "c2"}
 
 
 def test_save_run_returns_id(isolate_bench_db):

--- a/scripts/bench/tests/test_suites.py
+++ b/scripts/bench/tests/test_suites.py
@@ -148,3 +148,61 @@ def test_token_suite_case_meta(patched_harness):
     for c in result.cases:
         assert "chars" in c.meta
         assert "components" in c.meta
+
+
+def test_token_score_under_budget(patched_harness):
+    """tokens_in < budget → score 1.0."""
+    from scripts.bench.suites.token import _score
+    assert _score(100, 500) == 1.0
+
+
+def test_token_score_at_budget(patched_harness):
+    """tokens_in == budget → score 1.0."""
+    from scripts.bench.suites.token import _score
+    assert _score(500, 500) == 1.0
+
+
+def test_token_score_double_budget(patched_harness):
+    """tokens_in == 2× budget → score 0.5."""
+    from scripts.bench.suites.token import _score
+    assert abs(_score(1000, 500) - 0.5) < 1e-9
+
+
+def test_token_case_meta_includes_budget_and_over_by(patched_harness):
+    """Each case meta has 'budget' and 'over_by' keys."""
+    from scripts.bench.suites.token import run_token
+    result = run_token([])
+    for c in result.cases:
+        assert "budget" in c.meta, f"case {c.case_id!r} missing 'budget'"
+        assert "over_by" in c.meta, f"case {c.case_id!r} missing 'over_by'"
+        assert c.meta["over_by"] >= 0
+
+
+def test_token_case_over_budget_score_fractional(monkeypatch):
+    """A scenario over its per-scenario budget scores < 1.0."""
+    import scripts.bench.suites.token as tok_suite
+
+    h = _make_harness_mock()
+    # Make est_tokens return a value larger than the per-scenario budget.
+    # host_cc_session budget = 700; return 1400 → score should be 0.5
+    h.SCENARIOS = {"host_cc_session": ["host_claude_md"]}
+    h.STATIC_CONTEXT_TARGETS = [("host_claude_md", "CLAUDE.md")]
+    h.file_info.side_effect = lambda p: {
+        "path": str(p),
+        "exists": True,
+        "chars": 1400 * 3,  # chars don't matter; est_tokens mocked below
+        "lines": 50,
+        "est_tokens": 1400,
+        "sha256_8": "abcd1234",
+    }
+    h.est_tokens.side_effect = lambda chars: 1400
+
+    monkeypatch.setitem(sys.modules, "token_bench_harness", h)
+    monkeypatch.setattr(tok_suite, "_load_harness", lambda: h)
+
+    result = tok_suite.run_token([])
+    assert len(result.cases) == 1
+    c = result.cases[0]
+    # budget=700, tokens_in=1400 → score=0.5
+    assert abs(c.score - 0.5) < 1e-6
+    assert c.meta["over_by"] == 700


### PR DESCRIPTION
## Summary
Three related improvements that make before/after comparison of benchmark runs actually work.

1. **`--label` on `run`** — store a human-readable tag alongside `git_sha`. Schema migration (v1→v2, `ALTER TABLE` for existing DBs). `report` gains a label column.
2. **`bench diff <a> <b>`** — resolve each arg as run_id, then label, then git_sha (most recent wins on ties). `--suite` restricts. Per-case markdown table with score_a, score_b, delta, status (improved/regressed/unchanged), + added/dropped cases at the bottom. Exit 0 / 1 / 2 for clean / regression / unresolved.
3. **Token suite real scoring** — was hardcoded `1.0` so token growth was invisible. Now `score = min(1.0, budget / max(tokens_in, 1))` per scenario, with per-scenario budgets (~10% headroom above current measured baseline). Env-overridable via `DEUS_BENCH_TOKEN_BUDGET`.

## Wet run
`diff 2fcd181 62cbcd2` correctly surfaces the +0.950 `local_recall` jump produced by the config-env-fallback fix (#184).

## Test plan
- [x] 20 new tests across `test_store.py`, `test_cli.py`, `test_suites.py` (48 total in `scripts/bench/tests/`, all pass)
- [x] `run token` scores 1.0 on current codebase (no regression)
- [x] Drift check clean locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)