### PR TITLE
fix(tests): repair test_maintenance.py autouse fixture

### DIFF
--- a/scripts/tests/test_maintenance.py
+++ b/scripts/tests/test_maintenance.py
@@ -29,10 +29,11 @@ import evolution.db as db_mod
 
 @pytest.fixture(autouse=True)
 def patch_db_path(tmp_path, monkeypatch):
-    """Redirect evolution DB_PATH to a temp file and ensure providers are registered."""
+    """Redirect evolution EVOLUTION_DB_PATH to a temp file and ensure providers are registered."""
     test_db_path = tmp_path / "test_maint.db"
-    monkeypatch.setattr(db_mod, "DB_PATH", test_db_path)
-    monkeypatch.setattr(config_mod, "DB_PATH", test_db_path)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db_path)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db_path)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
 
     # Re-register built-in storage providers unconditionally.
     # test_storage_provider.py has an autouse fixture that calls StorageRegistry.reset()


### PR DESCRIPTION
## Summary
- The `patch_db_path` autouse fixture in `scripts/tests/test_maintenance.py` tried to patch `db_mod.DB_PATH`, which was renamed to `EVOLUTION_DB_PATH` (imported from `evolution.config`) when the storage-provider layer was introduced.
- Every test in the file raised `AttributeError` at fixture setup, blocking all 25 tests before they could execute.

## Fix
- Patch `EVOLUTION_DB_PATH` on both `db_mod` and `config_mod` (matches `evolution/tests/conftest.py`).
- Shadow the legacy `DB_PATH` with a throwaway tmp path so any residual reference doesn't hit `~/.deus/`.

## Before / after
- Before: 25 errors, 0 passed
- After: 25 passed, 0 errors

## Test plan
- [x] `python3 -m pytest scripts/tests/test_maintenance.py -v` — 25 pass
- [x] `python3 -m pytest scripts/tests/ -q` — no new failures elsewhere
- [x] `scripts/drift_check.py --all` — ALL PASSED
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)