### PR TITLE
feat(bench): memory_tree suite adapter

### DIFF
--- a/scripts/bench/suites/__init__.py
+++ b/scripts/bench/suites/__init__.py
@@ -1,3 +1,3 @@
-from . import memory, token, token_multiturn
+from . import memory, memory_tree, token, token_multiturn
 
-__all__ = ["memory", "token", "token_multiturn"]
+__all__ = ["memory", "memory_tree", "token", "token_multiturn"]

--- a/scripts/bench/suites/memory_tree.py
+++ b/scripts/bench/suites/memory_tree.py
@@ -1,0 +1,164 @@
+import argparse
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from ..registry import register
+from ..types import CaseResult, RunResult
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
+_MT_PATH = _SCRIPTS_DIR / "memory_tree.py"
+_DEFAULT_DATASET = _SCRIPTS_DIR / "tests" / "fixtures" / "memory_tree_queries.jsonl"
+
+
+def _load_mt():
+    if "memory_tree" in sys.modules:
+        return sys.modules["memory_tree"]
+    spec = importlib.util.spec_from_file_location("memory_tree", _MT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["memory_tree"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_dataset(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def _expected_paths(item: dict[str, Any]) -> list[str]:
+    if item.get("expected_paths"):
+        return item["expected_paths"]
+    if item.get("expected_path"):
+        return [item["expected_path"]]
+    return []
+
+
+def _score_item_policy(
+    mt: Any,
+    db: Any,
+    item: dict[str, Any],
+) -> CaseResult:
+    q = item["query"]
+    expected = _expected_paths(item)
+    expect_abstain = bool(item.get("abstain"))
+    case_id = item.get("id", q[:60])
+
+    result = mt.retrieve_with_policy(db, q)
+
+    returned = [r["path"] for r in result["results"]]
+    fell_back = result["fell_back"]
+    top_path = returned[0] if returned else None
+
+    if expect_abstain:
+        hit = fell_back
+    else:
+        hit = any(p in returned for p in expected) if expected else False
+
+    score = 1.0 if hit else 0.0
+    abstained = fell_back and not expect_abstain
+
+    return CaseResult(
+        case_id=case_id,
+        score=score,
+        passed=hit,
+        meta={
+            "abstained": abstained,
+            "top_path": top_path,
+            "expected_path": expected[0] if expected else None,
+            "tag": item.get("tag"),
+        },
+    )
+
+
+def _score_item_raw(
+    mt: Any,
+    db: Any,
+    item: dict[str, Any],
+) -> CaseResult:
+    q = item["query"]
+    expected = _expected_paths(item)
+    expect_abstain = bool(item.get("abstain"))
+    case_id = item.get("id", q[:60])
+
+    result = mt.retrieve(db, q)
+
+    returned = [r["path"] for r in result["results"]]
+    fell_back = result["fell_back"]
+    top_path = returned[0] if returned else None
+
+    if expect_abstain:
+        hit = fell_back
+    else:
+        hit = any(p in returned for p in expected) if expected else False
+
+    score = 1.0 if hit else 0.0
+    abstained = fell_back and not expect_abstain
+
+    return CaseResult(
+        case_id=case_id,
+        score=score,
+        passed=hit,
+        meta={
+            "abstained": abstained,
+            "top_path": top_path,
+            "expected_path": expected[0] if expected else None,
+            "tag": item.get("tag"),
+        },
+    )
+
+
+@register("memory_tree")
+def run_memory_tree(argv: list[str]) -> RunResult:
+    p = argparse.ArgumentParser(prog="memory_tree")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap the number of questions evaluated (default: all)")
+    p.add_argument("--dataset", type=Path, default=_DEFAULT_DATASET,
+                   help="Path to JSONL benchmark dataset")
+    policy_grp = p.add_mutually_exclusive_group()
+    policy_grp.add_argument("--policy", dest="policy", action="store_true", default=True,
+                            help="Use retrieve_with_policy (default)")
+    policy_grp.add_argument("--no-policy", dest="policy", action="store_false",
+                            help="Use raw retrieve instead of retrieve_with_policy")
+    args = p.parse_args(argv)
+
+    mt = _load_mt()
+    db = mt.open_db()
+
+    dataset = _load_dataset(args.dataset)
+    if args.limit is not None:
+        dataset = dataset[: args.limit]
+
+    t_start = time.monotonic()
+
+    cases: list[CaseResult] = []
+    score_fn = _score_item_policy if args.policy else _score_item_raw
+
+    for item in dataset:
+        cases.append(score_fn(mt, db, item))
+
+    elapsed_ms = int((time.monotonic() - t_start) * 1000)
+
+    n = len(cases)
+    hits = sum(1 for c in cases if c.passed)
+    abstain_count = sum(1 for c in cases if c.meta.get("abstained"))
+    recall = hits / n if n else 0.0
+
+    return RunResult(
+        suite="memory_tree",
+        score=recall,
+        cases=cases,
+        latency_ms=elapsed_ms,
+        meta={
+            "policy": args.policy,
+            "n": n,
+            "abstain_count": abstain_count,
+            "dataset": str(args.dataset),
+        },
+    )

--- a/scripts/bench/tests/test_suite_memory_tree.py
+++ b/scripts/bench/tests/test_suite_memory_tree.py
@@ -1,0 +1,322 @@
+"""Tests for scripts/bench/suites/memory_tree.py adapter."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.bench.types import RunResult
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_FIXTURE_ITEMS: list[dict] = [
+    {
+        "query": "who do I live with",
+        "expected_path": "Persona/life/household.md",
+        "expected_paths": ["Persona/life/household.md"],
+        "tag": "single",
+    },
+    {
+        "query": "my favorite directors and movies",
+        "expected_path": "Persona/taste/movies.md",
+        "expected_paths": ["Persona/taste/movies.md"],
+        "tag": "single",
+    },
+    {
+        "query": "how to cook a chocolate souffle",
+        "abstain": True,
+        "tag": "abstain-far",
+    },
+]
+
+
+def _make_mt_mock(
+    policy_outcomes: dict[str, dict],
+    raw_outcomes: dict[str, dict] | None = None,
+) -> MagicMock:
+    """Return a mock memory_tree module.
+
+    policy_outcomes and raw_outcomes map query → {results, fell_back, confidence}.
+    """
+    raw_outcomes = raw_outcomes or policy_outcomes
+
+    def _make_result(outcomes: dict, query: str) -> dict:
+        o = outcomes.get(query, {"results": [], "fell_back": True, "confidence": 0.0})
+        return {
+            "results": o.get("results", []),
+            "fell_back": o.get("fell_back", False),
+            "confidence": o.get("confidence", 0.0),
+            "trace": ["stub"],
+            "policy_trace": ["stub"],
+        }
+
+    mt = MagicMock()
+    mt.open_db.return_value = MagicMock()
+    mt.retrieve_with_policy.side_effect = lambda db, q, **kw: _make_result(policy_outcomes, q)
+    mt.retrieve.side_effect = lambda db, q, **kw: _make_result(raw_outcomes, q)
+    return mt
+
+
+def _inject_mt(monkeypatch, mt: MagicMock) -> None:
+    monkeypatch.setitem(sys.modules, "memory_tree", mt)
+    import scripts.bench.suites.memory_tree as suite_mod
+    monkeypatch.setattr(suite_mod, "_load_mt", lambda: mt)
+
+
+def _write_dataset(tmp_path: Path, items: list[dict]) -> Path:
+    p = tmp_path / "dataset.jsonl"
+    p.write_text("\n".join(json.dumps(i) for i in items))
+    return p
+
+
+# ── Tests — RunResult shape ───────────────────────────────────────────────────
+
+class TestRunResultShape:
+    def test_returns_run_result(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [{"path": "Persona/life/household.md"}], "fell_back": False, "confidence": 0.8},
+            "my favorite directors and movies": {"results": [{"path": "Persona/taste/movies.md"}], "fell_back": False, "confidence": 0.7},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert isinstance(result, RunResult)
+        assert result.suite == "memory_tree"
+        assert 0.0 <= result.score <= 1.0
+
+    def test_score_matches_hit_rate(self, tmp_path, monkeypatch):
+        """All three items hit → score 1.0."""
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [{"path": "Persona/life/household.md"}], "fell_back": False, "confidence": 0.8},
+            "my favorite directors and movies": {"results": [{"path": "Persona/taste/movies.md"}], "fell_back": False, "confidence": 0.7},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert abs(result.score - 1.0) < 1e-9
+
+    def test_score_partial_hits(self, tmp_path, monkeypatch):
+        """First item misses, second hits, abstain item hits → 2/3."""
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [{"path": "wrong.md"}], "fell_back": False, "confidence": 0.6},
+            "my favorite directors and movies": {"results": [{"path": "Persona/taste/movies.md"}], "fell_back": False, "confidence": 0.7},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert abs(result.score - 2 / 3) < 1e-9
+
+    def test_one_case_per_item(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+            "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert len(result.cases) == 3
+
+    def test_case_meta_fields(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {
+                "results": [{"path": "Persona/life/household.md"}],
+                "fell_back": False, "confidence": 0.8,
+            },
+            "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        for c in result.cases:
+            assert "abstained" in c.meta
+            assert "top_path" in c.meta
+            assert "expected_path" in c.meta
+
+    def test_suite_meta_fields(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+            "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert "policy" in result.meta
+        assert "n" in result.meta
+        assert "abstain_count" in result.meta
+        assert result.meta["n"] == 3
+
+
+# ── Tests — policy vs no-policy dispatch ─────────────────────────────────────
+
+class TestPolicyDispatch:
+    def test_policy_calls_retrieve_with_policy(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+            "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        run_memory_tree(["--policy", "--dataset", str(dataset_path)])
+
+        assert mt.retrieve_with_policy.called
+        assert not mt.retrieve.called
+
+    def test_no_policy_calls_retrieve(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock(
+            policy_outcomes={},
+            raw_outcomes={
+                "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+                "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+                "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+            },
+        )
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        run_memory_tree(["--no-policy", "--dataset", str(dataset_path)])
+
+        assert mt.retrieve.called
+        assert not mt.retrieve_with_policy.called
+
+    def test_policy_flag_stored_in_meta(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({"who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+                            "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+                            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1}})
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        r_policy = run_memory_tree(["--policy", "--dataset", str(dataset_path)])
+        r_raw = run_memory_tree(["--no-policy", "--dataset", str(dataset_path)])
+
+        assert r_policy.meta["policy"] is True
+        assert r_raw.meta["policy"] is False
+
+
+# ── Tests — abstentions ───────────────────────────────────────────────────────
+
+class TestAbstentions:
+    def test_abstain_item_scores_1_when_fell_back(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [{"path": "Persona/life/household.md"}], "fell_back": False, "confidence": 0.8},
+            "my favorite directors and movies": {"results": [{"path": "Persona/taste/movies.md"}], "fell_back": False, "confidence": 0.7},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        abstain_case = next(
+            c for c in result.cases
+            if c.meta.get("expected_path") is None
+        )
+        assert abstain_case.score == 1.0
+        assert abstain_case.passed is True
+
+    def test_abstain_item_scores_0_when_not_fell_back(self, tmp_path, monkeypatch):
+        """Abstain item where model returned results (leak) scores 0."""
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [{"path": "Persona/life/household.md"}], "fell_back": False, "confidence": 0.8},
+            "my favorite directors and movies": {"results": [{"path": "Persona/taste/movies.md"}], "fell_back": False, "confidence": 0.7},
+            "how to cook a chocolate souffle": {
+                "results": [{"path": "some.md"}], "fell_back": False, "confidence": 0.6
+            },
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        abstain_case = next(
+            c for c in result.cases
+            if c.meta.get("expected_path") is None
+        )
+        assert abstain_case.score == 0.0
+        assert abstain_case.passed is False
+
+    def test_non_abstain_miss_records_abstained_true(self, tmp_path, monkeypatch):
+        """Non-abstain item where retriever fell_back → abstained=True in meta."""
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+            "my favorite directors and movies": {"results": [{"path": "Persona/taste/movies.md"}], "fell_back": False, "confidence": 0.7},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        household_case = next(
+            c for c in result.cases
+            if c.meta.get("expected_path") == "Persona/life/household.md"
+        )
+        assert household_case.meta["abstained"] is True
+        assert result.meta["abstain_count"] == 1
+
+    def test_abstain_count_in_meta(self, tmp_path, monkeypatch):
+        """abstain_count counts unexpected abstentions (non-abstain items that fell_back)."""
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+            "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+            "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert result.meta["abstain_count"] == 2
+
+
+# ── Tests — limit arg ─────────────────────────────────────────────────────────
+
+class TestLimitArg:
+    def test_limit_truncates_dataset(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock({
+            "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+        })
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--limit", "1", "--dataset", str(dataset_path)])
+
+        assert len(result.cases) == 1
+        assert result.meta["n"] == 1


### PR DESCRIPTION
## Summary
Adds `memory_tree` as a third suite alongside `memory` (indexer) and `token`. Closes the biggest coverage gap in the unified bench harness: the memory tree (PR #177's retrieval policy) wasn't benchmarked.

## What it does
Mirrors `scripts/memory_tree.py::benchmark()` scoring semantics exactly:
- Non-abstain items: `hit = any(expected in returned)`
- Abstain items: `hit = result["fell_back"]`
- Suite score = hits / n

Flags:
- `--policy` / `--no-policy` — route to `retrieve_with_policy()` vs raw `retrieve()` for A/B. Default: policy.
- `--limit N` — truncate dataset (fast smoke runs)
- `--dataset PATH` — override default fixture

## Default dataset
`scripts/tests/fixtures/memory_tree_queries.jsonl` (90 items, `expected_path` format). The 145-question evo benchmark at `~/deus-memory-evo/benchmark/queries.jsonl` uses a different QA format and is out of scope here.

## Test plan
- [x] 14 new tests; 62 pass in `scripts/bench/tests/`
- [x] `run memory_tree -- --limit 5` smoke completes cleanly
- [x] Drift ALL PASSED
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)