### PR TITLE
feat(bench): MRR in recall, growth alerts in diff, hygiene suite

### DIFF
--- a/scripts/bench/cli.py
+++ b/scripts/bench/cli.py
@@ -103,6 +103,7 @@ def cmd_report(args: argparse.Namespace) -> int:
 def cmd_diff(args: argparse.Namespace) -> int:
     suite_filter: str | None = args.suite
     tolerance: float = args.tolerance
+    growth_threshold: float = args.growth_threshold
 
     run_a = resolve_run(args.a, suite=suite_filter)
     run_b = resolve_run(args.b, suite=suite_filter)
@@ -189,7 +190,48 @@ def cmd_diff(args: argparse.Namespace) -> int:
         f" added={n_added} dropped={n_dropped}"
     )
 
-    return 1 if has_regression else 0
+    has_growth_alert = False
+
+    # Per-case growth alerts
+    for cid in common_ids:
+        ca = cases_a[cid]
+        cb = cases_b[cid]
+        tok_a = ca.get("tokens_in") or 0
+        tok_b = cb.get("tokens_in") or 0
+        sa = ca["score"] if ca["score"] is not None else 0.0
+        sb = cb["score"] if cb["score"] is not None else 0.0
+        score_unchanged = abs(sb - sa) <= tolerance
+        if tok_a > 0 and score_unchanged:
+            baseline = min(tok_a, tok_b)
+            growth = (tok_b - tok_a) / baseline if baseline > 0 else 0.0
+            if growth > growth_threshold:
+                pct = growth * 100
+                print(
+                    f"growth alert: {cid} tokens_in grew +{pct:.1f}%"
+                    f" (A: {tok_a} → B: {tok_b}) with unchanged score"
+                )
+                has_growth_alert = True
+
+    # Suite-level growth alert
+    suite_tok_a = run_a.get("tokens_in") or 0
+    suite_tok_b = run_b.get("tokens_in") or 0
+    suite_score_unchanged = (
+        score_a is not None
+        and score_b is not None
+        and abs(score_b - score_a) <= tolerance
+    )
+    if suite_tok_a > 0 and suite_score_unchanged:
+        baseline = min(suite_tok_a, suite_tok_b)
+        suite_growth = (suite_tok_b - suite_tok_a) / baseline if baseline > 0 else 0.0
+        if suite_growth > growth_threshold:
+            pct = suite_growth * 100
+            print(
+                f"growth alert: <suite> tokens_in grew +{pct:.1f}%"
+                f" (A: {suite_tok_a} → B: {suite_tok_b}) with unchanged score"
+            )
+            has_growth_alert = True
+
+    return 1 if (has_regression or has_growth_alert) else 0
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -215,6 +257,8 @@ def _build_parser() -> argparse.ArgumentParser:
     diff_p.add_argument("--suite", default=None, help="restrict resolution to this suite")
     diff_p.add_argument("--tolerance", type=float, default=0.01,
                         help="min |delta| to count as improved/regressed (default 0.01)")
+    diff_p.add_argument("--growth-threshold", type=float, default=0.05,
+                        help="tokens_in growth fraction that triggers an alert (default 0.05 = 5%%)")
 
     return p
 

--- a/scripts/bench/suites/__init__.py
+++ b/scripts/bench/suites/__init__.py
@@ -1,3 +1,3 @@
-from . import memory, memory_tree, token, token_multiturn
+from . import hygiene, memory, memory_tree, token, token_multiturn
 
-__all__ = ["memory", "memory_tree", "token", "token_multiturn"]
+__all__ = ["hygiene", "memory", "memory_tree", "token", "token_multiturn"]

--- a/scripts/bench/suites/hygiene.py
+++ b/scripts/bench/suites/hygiene.py
@@ -1,0 +1,92 @@
+import importlib.util
+import re
+import sys
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import CaseResult, RunResult
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
+_MB_PATH = _SCRIPTS_DIR / "memory_benchmark.py"
+
+
+def _load_mb():
+    if "memory_benchmark" in sys.modules:
+        return sys.modules["memory_benchmark"]
+    spec = importlib.util.spec_from_file_location("memory_benchmark", _MB_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["memory_benchmark"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def run_claude_md_hygiene() -> dict:
+    mb = _load_mb()
+    vault_root = mb._load_vault_root()
+    claude_md = (
+        (vault_root / "CLAUDE.md")
+        if vault_root
+        else Path(__file__).resolve().parent.parent.parent.parent / "CLAUDE.md"
+    )
+
+    pending_items = 0
+    all_checkbox_format = True
+    pending_issues: list[str] = []
+
+    if claude_md.exists():
+        content = claude_md.read_text(encoding="utf-8")
+        pending_section = re.search(
+            r"(?i)#+\s*(pending|todo|backlog).*?\n(.*?)(?=\n#+|\Z)",
+            content,
+            re.DOTALL,
+        )
+        if pending_section:
+            section_body = pending_section.group(2)
+            items = re.findall(r"^\s*-\s+(.+)$", section_body, re.MULTILINE)
+            pending_items = len(items)
+            for item in items:
+                if not re.match(r"\[[ x]\]", item):
+                    all_checkbox_format = False
+                    pending_issues.append(item[:60])
+
+    return {
+        "items": pending_items,
+        "within_limit": pending_items <= 10,
+        "all_checkbox_format": all_checkbox_format,
+        "issues": pending_issues[:3],
+    }
+
+
+@register("hygiene")
+def run_hygiene(argv: list[str]) -> RunResult:
+    t_start = time.monotonic()
+    pa = run_claude_md_hygiene()
+    elapsed_ms = int((time.monotonic() - t_start) * 1000)
+
+    within_limit = pa["within_limit"]
+    all_checkbox = pa["all_checkbox_format"]
+    both_passed = within_limit and all_checkbox
+
+    cases = [
+        CaseResult(
+            case_id="pending_items_within_limit",
+            score=1.0 if within_limit else 0.0,
+            passed=within_limit,
+            meta={"items": pa["items"]},
+        ),
+        CaseResult(
+            case_id="pending_all_checkbox_format",
+            score=1.0 if all_checkbox else 0.0,
+            passed=all_checkbox,
+            meta={"issues": pa["issues"]},
+        ),
+    ]
+
+    return RunResult(
+        suite="hygiene",
+        score=1.0 if both_passed else 0.0,
+        cases=cases,
+        latency_ms=elapsed_ms,
+        meta={"items": pa["items"], "issues": pa["issues"]},
+    )

--- a/scripts/bench/suites/memory.py
+++ b/scripts/bench/suites/memory.py
@@ -69,7 +69,6 @@ def run_memory(argv: list[str]) -> RunResult:
 
         lr = result["local_recall"]
         te = result["token_efficiency"]
-        pa = result["pending_accuracy"]
 
         score = lr["rate"]
 
@@ -81,22 +80,18 @@ def run_memory(argv: list[str]) -> RunResult:
                 meta={"hits": lr["hits"], "total": lr["total"]},
             ),
             CaseResult(
+                case_id="local_recall_mrr",
+                score=lr["mrr"],
+                passed=lr["mrr"] > 0.0,
+                meta={"mrr": lr["mrr"], "ranks": lr["ranks"]},
+            ),
+            CaseResult(
                 case_id="token_efficiency",
                 score=1.0,
                 meta={
                     "full_chars": te["full_chars"],
                     "compact_chars": te["compact_chars"],
                     "reduction_pct": te["reduction_pct"],
-                },
-            ),
-            CaseResult(
-                case_id="pending_accuracy",
-                score=1.0 if pa["within_limit"] and pa["all_checkbox_format"] else 0.0,
-                passed=pa["within_limit"] and pa["all_checkbox_format"],
-                meta={
-                    "items": pa["items"],
-                    "within_limit": pa["within_limit"],
-                    "all_checkbox_format": pa["all_checkbox_format"],
                 },
             ),
         ]
@@ -106,5 +101,5 @@ def run_memory(argv: list[str]) -> RunResult:
             score=score,
             cases=cases,
             latency_ms=elapsed_ms,
-            meta={"mode": "internal"},
+            meta={"mode": "internal", "mrr": lr["mrr"]},
         )

--- a/scripts/bench/tests/test_cli.py
+++ b/scripts/bench/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_list_shows_memory_and_token(isolate_bench_db):
     names = r.stdout.strip().splitlines()
     assert "memory" in names
     assert "token" in names
+    assert "hygiene" in names
 
 
 def test_report_empty_db(isolate_bench_db):
@@ -153,3 +154,66 @@ def test_diff_added_dropped_cases(isolate_bench_db):
     assert r.returncode == 0, r.stderr + r.stdout
     assert "dropped" in r.stdout
     assert "added" in r.stdout
+
+
+# ── growth alert ──────────────────────────────────────────────────────────────
+
+def _seed_run_with_tokens(
+    suite: str,
+    score: float,
+    cases: list[tuple[str, float, int]],
+    suite_tokens_in: int = 0,
+    label: str | None = None,
+) -> str:
+    """Seed a run with per-case tokens_in and suite-level tokens_in."""
+    result = RunResult(
+        suite=suite,
+        score=score,
+        cases=[
+            CaseResult(case_id=cid, score=s, tokens_in=tok)
+            for cid, s, tok in cases
+        ],
+        tokens_in=suite_tokens_in,
+    )
+    return save_run(result, label=label)
+
+
+def test_diff_growth_alert_fires_on_token_growth_unchanged_score(isolate_bench_db):
+    """tokens_in grew >5% with unchanged score → growth alert + exit 1."""
+    db = str(isolate_bench_db)
+    # c1: score unchanged 0.8→0.8, tokens 1000→1100 (10% growth > 5% threshold)
+    id_a = _seed_run_with_tokens("token", 0.8, [("c1", 0.8, 1000)])
+    id_b = _seed_run_with_tokens("token", 0.8, [("c1", 0.8, 1100)])
+    r = _run_cli("diff", id_a, id_b, env={"DEUS_BENCH_DB": db})
+    assert r.returncode == 1, f"expected exit 1, got {r.returncode}\n{r.stdout}"
+    assert "growth alert" in r.stdout
+    assert "c1" in r.stdout
+    assert "+10.0%" in r.stdout
+
+
+def test_diff_growth_alert_does_not_fire_when_score_changed(isolate_bench_db):
+    """Score improved → no growth alert even if tokens grew."""
+    db = str(isolate_bench_db)
+    # c1: score changed 0.5→0.9, tokens 1000→1200 (20% growth but score changed)
+    id_a = _seed_run_with_tokens("token", 0.5, [("c1", 0.5, 1000)])
+    id_b = _seed_run_with_tokens("token", 0.9, [("c1", 0.9, 1200)])
+    r = _run_cli("diff", id_a, id_b, env={"DEUS_BENCH_DB": db})
+    assert "growth alert" not in r.stdout
+
+
+def test_diff_growth_alert_does_not_fire_below_threshold(isolate_bench_db):
+    """tokens grew 3% (below 5% default threshold) → no alert."""
+    db = str(isolate_bench_db)
+    id_a = _seed_run_with_tokens("token", 0.8, [("c1", 0.8, 1000)])
+    id_b = _seed_run_with_tokens("token", 0.8, [("c1", 0.8, 1030)])
+    r = _run_cli("diff", id_a, id_b, env={"DEUS_BENCH_DB": db})
+    assert "growth alert" not in r.stdout
+
+
+def test_diff_growth_alert_respects_custom_threshold(isolate_bench_db):
+    """--growth-threshold 0.20 → 10% growth does not fire."""
+    db = str(isolate_bench_db)
+    id_a = _seed_run_with_tokens("token", 0.8, [("c1", 0.8, 1000)])
+    id_b = _seed_run_with_tokens("token", 0.8, [("c1", 0.8, 1100)])
+    r = _run_cli("diff", id_a, id_b, "--growth-threshold", "0.20", env={"DEUS_BENCH_DB": db})
+    assert "growth alert" not in r.stdout

--- a/scripts/bench/tests/test_suites.py
+++ b/scripts/bench/tests/test_suites.py
@@ -1,4 +1,4 @@
-"""Tests for the memory and token suite adapters (no real benchmarks)."""
+"""Tests for the memory, token, and hygiene suite adapters (no real benchmarks)."""
 import sys
 import types
 from pathlib import Path
@@ -30,12 +30,12 @@ def _make_mb_mock() -> MagicMock:
             "reduction_pct": 30.0,
             "sessions": 5,
         },
-        "local_recall": {"hits": 8, "total": 10, "rate": 0.8},
-        "pending_accuracy": {
-            "items": 3,
-            "within_limit": True,
-            "all_checkbox_format": True,
-            "issues": [],
+        "local_recall": {
+            "hits": 8,
+            "total": 10,
+            "rate": 0.8,
+            "mrr": 0.65,
+            "ranks": [1, 2, None, 1, 3, 1, 2, 1, None, 1],
         },
     }
     return mb
@@ -78,8 +78,24 @@ def test_memory_internal_cases(patched_mb):
     result = run_memory(["--mode", "internal"])
     case_ids = {c.case_id for c in result.cases}
     assert "local_recall" in case_ids
+    assert "local_recall_mrr" in case_ids
     assert "token_efficiency" in case_ids
-    assert "pending_accuracy" in case_ids
+    assert "pending_accuracy" not in case_ids
+
+
+def test_memory_internal_mrr_case(patched_mb):
+    from scripts.bench.suites.memory import run_memory
+    result = run_memory(["--mode", "internal"])
+    mrr_case = next(c for c in result.cases if c.case_id == "local_recall_mrr")
+    assert abs(mrr_case.score - 0.65) < 1e-6
+    assert "ranks" in mrr_case.meta
+
+
+def test_memory_internal_meta_has_mrr(patched_mb):
+    from scripts.bench.suites.memory import run_memory
+    result = run_memory(["--mode", "internal"])
+    assert "mrr" in result.meta
+    assert abs(result.meta["mrr"] - 0.65) < 1e-6
 
 
 # ── Token adapter ─────────────────────────────────────────────────────────────
@@ -206,3 +222,135 @@ def test_token_case_over_budget_score_fractional(monkeypatch):
     # budget=700, tokens_in=1400 → score=0.5
     assert abs(c.score - 0.5) < 1e-6
     assert c.meta["over_by"] == 700
+
+
+# ── MRR calculation ───────────────────────────────────────────────────────────
+
+def test_mrr_known_ranks():
+    """MRR for [1, 2, None] = (1/1 + 1/2 + 0) / 3."""
+    from scripts.bench.suites.hygiene import run_claude_md_hygiene  # noqa: F401 (import check)
+    # Verify formula directly against known values
+    ranks = [1, 2, None]
+    total = len(ranks)
+    mrr = sum(1.0 / r for r in ranks if r is not None) / max(1, total)
+    assert abs(mrr - (1.0 + 0.5) / 3) < 1e-9
+
+
+def test_mrr_all_hits_rank_one():
+    ranks = [1, 1, 1]
+    mrr = sum(1.0 / r for r in ranks if r is not None) / max(1, len(ranks))
+    assert abs(mrr - 1.0) < 1e-9
+
+
+def test_mrr_all_none():
+    ranks = [None, None]
+    mrr = sum(1.0 / r for r in ranks if r is not None) / max(1, len(ranks))
+    assert abs(mrr - 0.0) < 1e-9
+
+
+# ── Hygiene suite ─────────────────────────────────────────────────────────────
+
+def _make_hygiene_mock(within_limit: bool = True, all_checkbox: bool = True) -> MagicMock:
+    mb = MagicMock()
+    mb._load_vault_root.return_value = None
+    return mb
+
+
+@pytest.fixture()
+def patched_hygiene_mb(monkeypatch, tmp_path):
+    mb = MagicMock()
+    mb._load_vault_root.return_value = None
+    monkeypatch.setitem(sys.modules, "memory_benchmark", mb)
+    import scripts.bench.suites.hygiene as hygiene_suite
+    monkeypatch.setattr(hygiene_suite, "_load_mb", lambda: mb)
+
+    claude_md = tmp_path / "CLAUDE.md"
+    # Valid CLAUDE.md: pending section with checkbox items within limit
+    claude_md.write_text(
+        "# Main\n\n"
+        "## Pending\n"
+        "- [x] item one\n"
+        "- [ ] item two\n"
+    )
+    monkeypatch.setattr(
+        "scripts.bench.suites.hygiene.run_claude_md_hygiene",
+        lambda: {
+            "items": 2,
+            "within_limit": True,
+            "all_checkbox_format": True,
+            "issues": [],
+        },
+    )
+    return mb
+
+
+def test_hygiene_suite_returns_expected_cases(patched_hygiene_mb):
+    from scripts.bench.suites.hygiene import run_hygiene
+    result = run_hygiene([])
+    assert isinstance(result, RunResult)
+    assert result.suite == "hygiene"
+    case_ids = {c.case_id for c in result.cases}
+    assert "pending_items_within_limit" in case_ids
+    assert "pending_all_checkbox_format" in case_ids
+
+
+def test_hygiene_suite_score_both_passed(patched_hygiene_mb):
+    from scripts.bench.suites.hygiene import run_hygiene
+    result = run_hygiene([])
+    assert result.score == 1.0
+    for c in result.cases:
+        assert c.passed is True
+
+
+def test_hygiene_suite_score_fails_when_over_limit(monkeypatch):
+    import scripts.bench.suites.hygiene as hygiene_suite
+    monkeypatch.setattr(
+        hygiene_suite,
+        "run_claude_md_hygiene",
+        lambda: {
+            "items": 15,
+            "within_limit": False,
+            "all_checkbox_format": True,
+            "issues": [],
+        },
+    )
+    result = hygiene_suite.run_hygiene([])
+    assert result.score == 0.0
+    limit_case = next(c for c in result.cases if c.case_id == "pending_items_within_limit")
+    assert limit_case.passed is False
+    assert limit_case.score == 0.0
+
+
+def test_hygiene_suite_score_fails_when_bad_format(monkeypatch):
+    import scripts.bench.suites.hygiene as hygiene_suite
+    monkeypatch.setattr(
+        hygiene_suite,
+        "run_claude_md_hygiene",
+        lambda: {
+            "items": 3,
+            "within_limit": True,
+            "all_checkbox_format": False,
+            "issues": ["bad item here"],
+        },
+    )
+    result = hygiene_suite.run_hygiene([])
+    assert result.score == 0.0
+    fmt_case = next(c for c in result.cases if c.case_id == "pending_all_checkbox_format")
+    assert fmt_case.passed is False
+
+
+def test_hygiene_meta_includes_item_count_and_issues(monkeypatch):
+    import scripts.bench.suites.hygiene as hygiene_suite
+    monkeypatch.setattr(
+        hygiene_suite,
+        "run_claude_md_hygiene",
+        lambda: {
+            "items": 4,
+            "within_limit": True,
+            "all_checkbox_format": True,
+            "issues": [],
+        },
+    )
+    result = hygiene_suite.run_hygiene([])
+    assert result.meta["items"] == 4
+    assert "issues" in result.meta

--- a/scripts/memory_benchmark.py
+++ b/scripts/memory_benchmark.py
@@ -462,40 +462,24 @@ def run_internal(limit: int = 20) -> dict:
 
     recall3_hits = 0
     recall3_total = 0
+    ranks: list[Optional[int]] = []
     for sess in sessions:
         proc = _run_indexer_real(["--query", sess["query"], "--top", "3"])
         result_paths = _parse_query_output(proc.stdout)
         sess_stem = Path(sess["path"]).stem
-        hit = any(Path(rp).stem == sess_stem for rp in result_paths)
+        first_rank: Optional[int] = None
+        for pos, rp in enumerate(result_paths[:3], start=1):
+            if Path(rp).stem == sess_stem:
+                first_rank = pos
+                break
+        hit = first_rank is not None
         if hit:
             recall3_hits += 1
+        ranks.append(first_rank)
         recall3_total += 1
 
     recall3_rate = recall3_hits / recall3_total if recall3_total else 0.0
-
-    # ── Pending accuracy (CLAUDE.md) ─────────────────────────────────────────
-    print("  Pending accuracy (CLAUDE.md)...", flush=True)
-    vault_root = _load_vault_root()
-    claude_md = (vault_root / "CLAUDE.md") if vault_root else Path(__file__).resolve().parent.parent / "CLAUDE.md"
-    pending_items = 0
-    all_checkbox_format = True
-    pending_issues: list[str] = []
-
-    if claude_md.exists():
-        content = claude_md.read_text(encoding="utf-8")
-        pending_section = re.search(
-            r"(?i)#+\s*(pending|todo|backlog).*?\n(.*?)(?=\n#+|\Z)",
-            content,
-            re.DOTALL,
-        )
-        if pending_section:
-            section_body = pending_section.group(2)
-            items = re.findall(r"^\s*-\s+(.+)$", section_body, re.MULTILINE)
-            pending_items = len(items)
-            for item in items:
-                if not re.match(r"\[[ x]\]", item):
-                    all_checkbox_format = False
-                    pending_issues.append(item[:60])
+    mrr = sum(1.0 / r for r in ranks if r is not None) / max(1, recall3_total)
 
     return {
         "mode": "internal",
@@ -509,12 +493,8 @@ def run_internal(limit: int = 20) -> dict:
             "hits": recall3_hits,
             "total": recall3_total,
             "rate": recall3_rate,
-        },
-        "pending_accuracy": {
-            "items": pending_items,
-            "within_limit": pending_items <= 10,
-            "all_checkbox_format": all_checkbox_format,
-            "issues": pending_issues[:3],
+            "mrr": mrr,
+            "ranks": ranks,
         },
     }
 
@@ -522,7 +502,6 @@ def run_internal(limit: int = 20) -> dict:
 def print_internal_results(result: dict) -> None:
     te = result["token_efficiency"]
     lr = result["local_recall"]
-    pa = result["pending_accuracy"]
 
     print("\n=== Internal Benchmarks ===")
 
@@ -541,21 +520,9 @@ def print_internal_results(result: dict) -> None:
     print(f"\nLocal recall@3 (sample={lr['total']}):")
     if lr["total"] > 0:
         print(f"  Hit rate: {lr['rate'] * 100:.1f}% ({lr['hits']}/{lr['total']})")
+        print(f"  MRR:      {lr['mrr']:.3f}")
     else:
         print("  Hit rate: N/A (no indexed sessions found in real DB)")
-
-    print("\nPending accuracy:")
-    items = pa["items"]
-    if items == 0:
-        print("  Items: none found in CLAUDE.md pending section")
-    else:
-        limit_mark = "within 10-item limit" if pa["within_limit"] else "EXCEEDS 10-item limit"
-        limit_ok = "ok" if pa["within_limit"] else "FAIL"
-        fmt_ok = "all [ ] ok" if pa["all_checkbox_format"] else "some missing [ ] format FAIL"
-        print(f"  Items: {items} ({limit_mark}) [{limit_ok}]")
-        print(f"  Format: {fmt_ok}")
-        for issue in pa["issues"]:
-            print(f"    - bad format: {issue}")
 
 
 # ── Save results ──────────────────────────────────────────────────────────────

--- a/scripts/tests/test_memory_benchmark.py
+++ b/scripts/tests/test_memory_benchmark.py
@@ -237,10 +237,11 @@ def test_run_internal_token_efficiency():
     assert te["full_chars"] == 2000
     assert te["compact_chars"] == 600
     assert te["reduction_pct"] == pytest.approx(70.0)
+    assert "pending_accuracy" not in result
 
 
 def test_run_internal_local_recall_hit():
-    """Local recall: session stem found in query output -> hit."""
+    """Local recall: session stem found in query output -> hit, rank=1, mrr=1.0."""
     session = {"path": "/vault/Session-Logs/my-great-session.md", "query": "algebra exam"}
     query_output = (
         "## Relevant Past Sessions\n"
@@ -262,10 +263,12 @@ def test_run_internal_local_recall_hit():
     assert result["local_recall"]["hits"] == 1
     assert result["local_recall"]["total"] == 1
     assert result["local_recall"]["rate"] == pytest.approx(1.0)
+    assert result["local_recall"]["mrr"] == pytest.approx(1.0)
+    assert result["local_recall"]["ranks"] == [1]
 
 
 def test_run_internal_local_recall_miss():
-    """Local recall: unrelated path in query output -> miss."""
+    """Local recall: unrelated path in query output -> miss, rank=None, mrr=0.0."""
     session = {"path": "/vault/Session-Logs/my-session.md", "query": "algebra exam"}
     query_output = (
         "## Relevant Past Sessions\n"
@@ -286,10 +289,12 @@ def test_run_internal_local_recall_miss():
 
     assert result["local_recall"]["hits"] == 0
     assert result["local_recall"]["rate"] == pytest.approx(0.0)
+    assert result["local_recall"]["mrr"] == pytest.approx(0.0)
+    assert result["local_recall"]["ranks"] == [None]
 
 
 def test_run_internal_no_sessions():
-    """With no vault sessions, local recall reports 0/0 gracefully."""
+    """With no vault sessions, local recall reports 0/0 gracefully, mrr=0.0."""
     with (
         patch.object(mb, "_run_indexer_real", lambda args: _make_completed()),
         patch.object(mb, "_sample_real_sessions", return_value=[]),
@@ -298,6 +303,8 @@ def test_run_internal_no_sessions():
 
     assert result["local_recall"]["total"] == 0
     assert result["local_recall"]["rate"] == pytest.approx(0.0)
+    assert result["local_recall"]["mrr"] == pytest.approx(0.0)
+    assert result["local_recall"]["ranks"] == []
 
 
 # ── print helpers (smoke tests) ───────────────────────────────────────────────
@@ -329,19 +336,14 @@ def test_print_internal_results_runs(capsys):
             "reduction_pct": 64.3,
             "sessions": 5,
         },
-        "local_recall": {"hits": 17, "total": 20, "rate": 0.85},
-        "pending_accuracy": {
-            "items": 4,
-            "within_limit": True,
-            "all_checkbox_format": True,
-            "issues": [],
-        },
+        "local_recall": {"hits": 17, "total": 20, "rate": 0.85, "mrr": 0.72, "ranks": []},
     }
     mb.print_internal_results(result)
     out = capsys.readouterr().out
     assert "Internal Benchmarks" in out
     assert "Token efficiency" in out
     assert "recall@3" in out.lower()
+    assert "MRR" in out
 
 
 # ── save_results ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Three small, complementary improvements bundled (shared author file set):

1. **MRR in internal recall** — `run_internal` now tracks per-session ranks and computes MRR. Memory adapter surfaces as a separate `local_recall_mrr` CaseResult. Outbound already had MRR — this gives parity.
2. **Growth alerts in `bench diff`** — `--growth-threshold` (default 5%). Emits `growth alert: <case_id> tokens_in grew +X.X% …` when tokens grow beyond threshold with no score change. Applies per-case and suite-level. Exit 1 on any alert (parity with regression). Catches silent token bloat.
3. **Hygiene suite** — `pending_accuracy` was wedged into the memory suite; it's a CLAUDE.md check, not a memory metric. Extracted to `scripts/bench/suites/hygiene.py` (`@register("hygiene")`). Memory suite cleanup.

## Test plan
- [x] 100 pass across `scripts/bench/tests/` + `scripts/tests/test_memory_benchmark.py`
- [x] Drift ALL PASSED
- [x] `run hygiene` / `diff` with growth alert — outputs as specified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)