### PR TITLE
fix(memory_tree): flip default to raw retrieve

### DIFF
--- a/scripts/bench/suites/memory_tree.py
+++ b/scripts/bench/suites/memory_tree.py
@@ -122,10 +122,10 @@ def run_memory_tree(argv: list[str]) -> RunResult:
     p.add_argument("--dataset", type=Path, default=_DEFAULT_DATASET,
                    help="Path to JSONL benchmark dataset")
     policy_grp = p.add_mutually_exclusive_group()
-    policy_grp.add_argument("--policy", dest="policy", action="store_true", default=True,
-                            help="Use retrieve_with_policy (default)")
+    policy_grp.add_argument("--policy", dest="policy", action="store_true", default=False,
+                            help="Use retrieve_with_policy (opt-in as of 2026-04-18; raw retrieve is default)")
     policy_grp.add_argument("--no-policy", dest="policy", action="store_false",
-                            help="Use raw retrieve instead of retrieve_with_policy")
+                            help="Use raw retrieve instead of retrieve_with_policy (default)")
     args = p.parse_args(argv)
 
     mt = _load_mt()

--- a/scripts/bench/tests/test_suite_memory_tree.py
+++ b/scripts/bench/tests/test_suite_memory_tree.py
@@ -224,6 +224,25 @@ class TestPolicyDispatch:
         assert r_policy.meta["policy"] is True
         assert r_raw.meta["policy"] is False
 
+    def test_default_is_no_policy(self, tmp_path, monkeypatch):
+        mt = _make_mt_mock(
+            policy_outcomes={},
+            raw_outcomes={
+                "who do I live with": {"results": [], "fell_back": True, "confidence": 0.1},
+                "my favorite directors and movies": {"results": [], "fell_back": True, "confidence": 0.1},
+                "how to cook a chocolate souffle": {"results": [], "fell_back": True, "confidence": 0.1},
+            },
+        )
+        _inject_mt(monkeypatch, mt)
+        dataset_path = _write_dataset(tmp_path, _FIXTURE_ITEMS)
+
+        from scripts.bench.suites.memory_tree import run_memory_tree
+        result = run_memory_tree(["--dataset", str(dataset_path)])
+
+        assert mt.retrieve.called
+        assert not mt.retrieve_with_policy.called
+        assert result.meta["policy"] is False
+
 
 # ── Tests — abstentions ───────────────────────────────────────────────────────
 

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -1612,9 +1612,14 @@ def main(argv: list[str] | None = None) -> int:
     p_query.add_argument("--low", type=float, default=DEFAULT_LOW_THRESHOLD)
     p_query.add_argument("--abstain", type=float, default=DEFAULT_ABSTAIN_THRESHOLD)
     p_query.add_argument(
+        "--policy", action="store_true",
+        help="Opt into retrieve_with_policy (persona gating / retry / hints / adaptive-K). "
+             "Raw retrieve is the default as of 2026-04-18 after bench showed --no-policy "
+             "at 0.944 vs --policy at 0.844 on the 90-item fixture.",
+    )
+    p_query.add_argument(
         "--raw", action="store_true",
-        help="Bypass retrieve_with_policy (persona gating / retry / hints / adaptive-K). "
-             "Used by benchmarks that need the raw embedding similarity path.",
+        help="[deprecated] No-op kept for backward compatibility — raw retrieve is now the default.",
     )
 
     p_reembed = sub.add_parser("reembed", help="Re-embed a single file")
@@ -1670,13 +1675,13 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.cmd == "query":
-        if args.raw:
-            result = retrieve(
+        if args.policy:
+            result = retrieve_with_policy(
                 db, args.text, k=args.k,
                 low_threshold=args.low, abstain_threshold=args.abstain,
             )
         else:
-            result = retrieve_with_policy(
+            result = retrieve(
                 db, args.text, k=args.k,
                 low_threshold=args.low, abstain_threshold=args.abstain,
             )


### PR DESCRIPTION
## Summary

- 2026-04-18 90-item bench: `--no-policy` 0.944 vs `--policy` 0.844 (Δ +0.100)
- Policy wins 5 persona queries but loses 14 system/models/infra/cross-branch queries — representative of real Deus usage
- Flip the production default (both CLI `query` subcommand and bench suite) to raw retrieve
- Keep `retrieve_with_policy()` reachable via explicit `--policy` flag

## Behavior change

- `python3 scripts/memory_tree.py query "<text>"` now uses raw retrieve by default. Pass `--policy` to opt in.
- `--raw` flag kept as a deprecated no-op so existing callers don't break.
- `bench run memory_tree` now benchmarks raw retrieve by default; pass `--policy` to benchmark the policy path.

## Saved baselines

| label                      | run_id                             | score  |
|----------------------------|------------------------------------|--------|
| memtree-policy-on-apr18    | 1776464355472dd7c9514a4f6fbe9      | 0.844  |
| memtree-policy-off-apr18   | 1776464362441bb9332eca5fa76fd      | 0.944  |

Per-case diff via `bench diff memtree-policy-on-apr18 memtree-policy-off-apr18` — 14 improved, 5 regressed.

## Follow-up (not in this PR)

Investigate whether the 5 persona regressions under raw retrieve can be addressed with a narrower PERSONA_TRIGGERS gate (opt-in to policy only for a specific query shape) without reintroducing the 14 non-persona regressions.

## Test plan

- [x] `pytest scripts/bench/tests/test_suite_memory_tree.py` — 15 passed
- [x] Added `test_default_is_no_policy` regression guard
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)