### PR TITLE
feat(reactions): emoji → userSignal foundation (PR A)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-15"
+last_verified: "2026-04-18"  # re-reviewed for reactions-signal foundation (PR #192)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-18"  # re-reviewed for evolution/ test revival (PR #186)
+last_verified: "2026-04-18"  # re-reviewed for reactions-signal foundation (PR #192)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/evolution-client.test.ts
+++ b/src/evolution-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock child_process BEFORE importing the module under test.
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+import { spawn } from 'child_process';
+import { logReactionSignal } from './evolution-client.js';
+
+const mockSpawn = vi.mocked(spawn);
+
+function _fakeChild() {
+  return {
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+  } as unknown as ReturnType<typeof spawn>;
+}
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+  mockSpawn.mockImplementation(() => _fakeChild());
+  delete process.env.EVOLUTION_ENABLED;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('logReactionSignal', () => {
+  it('spawns log_interaction with positive signal for 👍', () => {
+    logReactionSignal({ emoji: '👍', groupFolder: 'whatsapp_main' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    const payload = JSON.parse(args[args.length - 1]);
+    expect(payload.user_signal).toBe('positive');
+    expect(payload.group_folder).toBe('whatsapp_main');
+    expect(payload.prompt).toBe('[reaction]');
+    expect(payload.response).toBe('');
+  });
+
+  it('spawns log_interaction with negative signal for 👎', () => {
+    logReactionSignal({ emoji: '👎', groupFolder: 'telegram_main' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    const payload = JSON.parse(args[args.length - 1]);
+    expect(payload.user_signal).toBe('negative');
+  });
+
+  it('does NOT spawn for neutral emoji', () => {
+    logReactionSignal({ emoji: '😂', groupFolder: 'whatsapp_main' });
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT spawn for empty emoji (reaction-removed)', () => {
+    logReactionSignal({ emoji: '', groupFolder: 'whatsapp_main' });
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('forwards sessionId when provided', () => {
+    logReactionSignal({
+      emoji: '❤️',
+      groupFolder: 'whatsapp_main',
+      sessionId: 'sess_abc123',
+    });
+
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    const payload = JSON.parse(args[args.length - 1]);
+    expect(payload.session_id).toBe('sess_abc123');
+    expect(payload.user_signal).toBe('positive');
+  });
+
+  it('generates a fresh UUID id for each call', () => {
+    logReactionSignal({ emoji: '🔥', groupFolder: 'whatsapp_main' });
+    logReactionSignal({ emoji: '🔥', groupFolder: 'whatsapp_main' });
+
+    const id1 = JSON.parse(
+      (mockSpawn.mock.calls[0][1] as string[]).slice(-1)[0],
+    ).id;
+    const id2 = JSON.parse(
+      (mockSpawn.mock.calls[1][1] as string[]).slice(-1)[0],
+    ).id;
+    expect(id1).not.toBe(id2);
+    expect(id1).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+});

--- a/src/evolution-client.test.ts
+++ b/src/evolution-client.test.ts
@@ -86,5 +86,4 @@ describe('logReactionSignal', () => {
     expect(id1).not.toBe(id2);
     expect(id1).toMatch(/^[0-9a-f-]{36}$/);
   });
-
 });

--- a/src/evolution-client.ts
+++ b/src/evolution-client.ts
@@ -10,9 +10,11 @@
  * is missing — the agent continues to work normally without reflections.
  */
 import { execFile, spawn } from 'child_process';
+import { randomUUID } from 'crypto';
 import path from 'path';
 
 import { logger } from './logger.js';
+import { emojiToSignal } from './reaction-signal.js';
 
 const EVOLUTION_CLI = path.join(process.cwd(), 'evolution', 'cli.py');
 const PYTHON_BIN = process.env.EVOLUTION_PYTHON ?? 'python3';
@@ -104,6 +106,34 @@ export function logInteraction(params: LogInteractionParams): void {
     );
   });
   // Do not await — fire and forget
+}
+
+export interface ReactionSignalParams {
+  emoji: string;
+  groupFolder: string;
+  sessionId?: string;
+  reactedToMessageId?: string;
+}
+
+/**
+ * Convert a channel-received emoji reaction into a userSignal log entry.
+ *
+ * No-op when the emoji doesn't map to a positive/negative signal. Session
+ * lookup happens on the Python side via get_previous_in_session; this call
+ * only needs groupFolder + sessionId to attach the signal to the right
+ * previous interaction.
+ */
+export function logReactionSignal(params: ReactionSignalParams): void {
+  const signal = emojiToSignal(params.emoji);
+  if (signal === null) return;
+  logInteraction({
+    id: randomUUID(),
+    prompt: '[reaction]',
+    response: null,
+    groupFolder: params.groupFolder,
+    sessionId: params.sessionId,
+    userSignal: signal,
+  });
 }
 
 function _runPython(args: string[], timeoutMs: number): Promise<string> {

--- a/src/reaction-signal.test.ts
+++ b/src/reaction-signal.test.ts
@@ -2,12 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { emojiToSignal } from './reaction-signal.js';
 
 describe('emojiToSignal', () => {
-  it.each(['👍', '❤️', '🎉', '🔥', '👏', '🚀', '⭐', '✅', '😍', '🙏', '💯', '🤩'])(
-    'maps %s → positive',
-    (emoji) => {
-      expect(emojiToSignal(emoji)).toBe('positive');
-    },
-  );
+  it.each([
+    '👍',
+    '❤️',
+    '🎉',
+    '🔥',
+    '👏',
+    '🚀',
+    '⭐',
+    '✅',
+    '😍',
+    '🙏',
+    '💯',
+    '🤩',
+  ])('maps %s → positive', (emoji) => {
+    expect(emojiToSignal(emoji)).toBe('positive');
+  });
 
   it.each(['👎', '😞', '😢', '😡', '🤦', '💔', '❌', '🙁', '😕'])(
     'maps %s → negative',

--- a/src/reaction-signal.test.ts
+++ b/src/reaction-signal.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { emojiToSignal } from './reaction-signal.js';
+
+describe('emojiToSignal', () => {
+  it.each(['👍', '❤️', '🎉', '🔥', '👏', '🚀', '⭐', '✅', '😍', '🙏', '💯', '🤩'])(
+    'maps %s → positive',
+    (emoji) => {
+      expect(emojiToSignal(emoji)).toBe('positive');
+    },
+  );
+
+  it.each(['👎', '😞', '😢', '😡', '🤦', '💔', '❌', '🙁', '😕'])(
+    'maps %s → negative',
+    (emoji) => {
+      expect(emojiToSignal(emoji)).toBe('negative');
+    },
+  );
+
+  it.each(['😂', '🤔', '👀', '🧐', '🙃'])(
+    'returns null for neutral emoji %s',
+    (emoji) => {
+      expect(emojiToSignal(emoji)).toBeNull();
+    },
+  );
+
+  it('returns null for empty string', () => {
+    expect(emojiToSignal('')).toBeNull();
+  });
+
+  it('returns null for non-emoji text', () => {
+    expect(emojiToSignal('hello')).toBeNull();
+  });
+});

--- a/src/reaction-signal.ts
+++ b/src/reaction-signal.ts
@@ -1,0 +1,42 @@
+/**
+ * Maps an emoji reaction to a user feedback signal.
+ *
+ * Channel-agnostic — WhatsApp, Telegram, and future channels funnel their
+ * reaction events through this mapper before reaching the evolution loop.
+ * Mirrors the return shape of detectUserSignal() so both signal sources
+ * converge on the same user_signal column in the Python evolution store.
+ */
+
+const POSITIVE_EMOJIS: ReadonlySet<string> = new Set([
+  '👍',
+  '❤️',
+  '🎉',
+  '🔥',
+  '👏',
+  '🚀',
+  '⭐',
+  '✅',
+  '😍',
+  '🙏',
+  '💯',
+  '🤩',
+]);
+
+const NEGATIVE_EMOJIS: ReadonlySet<string> = new Set([
+  '👎',
+  '😞',
+  '😢',
+  '😡',
+  '🤦',
+  '💔',
+  '❌',
+  '🙁',
+  '😕',
+]);
+
+export function emojiToSignal(emoji: string): 'positive' | 'negative' | null {
+  if (!emoji) return null;
+  if (POSITIVE_EMOJIS.has(emoji)) return 'positive';
+  if (NEGATIVE_EMOJIS.has(emoji)) return 'negative';
+  return null;
+}


### PR DESCRIPTION
## Summary

- Introduces the channel-agnostic emoji-to-signal mapper and a thin wrapper over `logInteraction` so WhatsApp/Telegram reactions can funnel into the Python `user_signal` handler wired in #186
- **PR A / 2** — foundation only, zero runtime wiring. No channel listeners added here. PR B will add Baileys `messages.reaction` + grammY `message_reaction` handlers.
- Currently the evolution feedback loop is consuming zero real signal (Python side ready since #186, producer side missing). This PR is the smallest mergeable step toward closing that gap.

## Files

- `src/reaction-signal.ts` — `emojiToSignal(emoji): 'positive' | 'negative' | null`
  - Positive: 👍 ❤️ 🎉 🔥 👏 🚀 ⭐ ✅ 😍 🙏 💯 🤩
  - Negative: 👎 😞 😢 😡 🤦 💔 ❌ 🙁 😕
  - Everything else → null (skipped, no-op)
- `src/evolution-client.ts` — new `logReactionSignal({emoji, groupFolder, sessionId})` export. No-op when emoji maps to null. Session lookup happens Python-side via `get_previous_in_session`.
- `src/reaction-signal.test.ts` + `src/evolution-client.test.ts` — 34 unit tests, all passing.

## Test plan

- [x] `npx vitest run src/reaction-signal.test.ts src/evolution-client.test.ts` — 34 passed
- [x] `npx tsc --noEmit` — clean
- [ ] CI green before merge

## Follow-up (PR B)

- WhatsApp: `packages/mcp-whatsapp/src/whatsapp.ts` — add `this.sock.ev.on('messages.reaction', ...)` listener; populate `metadata.reaction_emoji`
- Telegram: `packages/mcp-telegram/src/telegram.ts` — add `allowed_updates: ['message', 'message_reaction']` to `bot.start()` + `bot.on('message_reaction', ...)` handler
- Host adapter: `src/channels/mcp-adapter.ts` — dispatch `reaction_emoji` metadata branch to `logReactionSignal` (not the main agent dispatch path)
- Decisions needed on: emoji set tuning, WhatsApp reaction-removal semantics (currently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)