### PR TITLE
fix(embeddings): retry Ollama embed on transient timeout

### DIFF
--- a/evolution/providers/embeddings.py
+++ b/evolution/providers/embeddings.py
@@ -6,11 +6,17 @@ Override via EMBEDDING_PROVIDER env var: 'gemini', 'ollama', or 'auto'.
 'auto' (default) tries Ollama first, falls back to Gemini if unavailable.
 """
 import json
+import logging
 import os
+import socket
+import time
+import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
 
 from ..config import EMBED_DIM, EMBED_MODELS, load_api_key
+
+logger = logging.getLogger(__name__)
 
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 OLLAMA_EMBED_MODEL = os.environ.get("OLLAMA_EMBED_MODEL", "embeddinggemma")
@@ -52,6 +58,18 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
         self._model = model
         self._url = f"{host.rstrip('/')}/api/embed"
 
+    _MAX_ATTEMPTS = 3
+    _BACKOFF_BASE = 1.0  # seconds; doubles each retry
+
+    @staticmethod
+    def _is_timeout(exc: BaseException) -> bool:
+        """Return True if exc represents a transient socket timeout."""
+        if isinstance(exc, (TimeoutError, socket.timeout)):
+            return True
+        if isinstance(exc, urllib.error.URLError) and isinstance(exc.reason, (TimeoutError, socket.timeout)):
+            return True
+        return False
+
     def embed(self, text: str) -> list[float]:
         payload = json.dumps({"model": self._model, "input": text}).encode()
         req = urllib.request.Request(
@@ -59,8 +77,28 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
             data=payload,
             headers={"Content-Type": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read())
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._MAX_ATTEMPTS + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    data = json.loads(resp.read())
+                break
+            except BaseException as exc:
+                if not self._is_timeout(exc):
+                    raise
+                last_exc = exc
+                if attempt < self._MAX_ATTEMPTS:
+                    delay = self._BACKOFF_BASE * (2 ** (attempt - 1))
+                    logger.warning(
+                        "Ollama embed timeout (attempt %d/%d), retrying in %.0fs: %s",
+                        attempt,
+                        self._MAX_ATTEMPTS,
+                        delay,
+                        exc,
+                    )
+                    time.sleep(delay)
+        else:
+            raise last_exc  # type: ignore[misc]
         vec = data["embeddings"][0]
         # Truncate or pad to EMBED_DIM for compatibility with existing vec0 tables
         if len(vec) > EMBED_DIM:

--- a/evolution/providers/embeddings.py
+++ b/evolution/providers/embeddings.py
@@ -80,7 +80,7 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
         last_exc: BaseException | None = None
         for attempt in range(1, self._MAX_ATTEMPTS + 1):
             try:
-                with urllib.request.urlopen(req, timeout=30) as resp:
+                with urllib.request.urlopen(req, timeout=60) as resp:
                     data = json.loads(resp.read())
                 break
             except BaseException as exc:
@@ -106,6 +106,16 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
         elif len(vec) < EMBED_DIM:
             vec = vec + [0.0] * (EMBED_DIM - len(vec))
         return vec
+
+    def warmup(self) -> None:
+        """Send a throwaway embed to warm up the Ollama model.
+
+        If Ollama is cold-starting or loading the model, the first real embed
+        call can hit the per-attempt timeout.  Calling warmup() before the main
+        workload absorbs that startup latency.  If the warmup itself fails after
+        all retries, the exception propagates — caller decides how to handle it.
+        """
+        self.embed("warmup")
 
 
 def _is_ollama_available() -> bool:
@@ -152,3 +162,18 @@ def get_embedding_provider() -> EmbeddingProvider:
 def embed(text: str) -> list[float]:
     """Convenience: embed a single text using the configured provider."""
     return get_embedding_provider().embed(text)
+
+
+def warmup_embedding_provider() -> None:
+    """Warm up the embedding provider if it supports warmup.
+
+    Uses duck-typing so that Gemini and other providers that don't implement
+    warmup() are silently skipped.  Only OllamaEmbeddingProvider defines
+    warmup() today.
+
+    Call this once before a batch embedding workload to absorb Ollama cold-start
+    latency.  Any exception from warmup() propagates to the caller.
+    """
+    provider = get_embedding_provider()
+    if hasattr(provider, "warmup"):
+        provider.warmup()

--- a/evolution/tests/test_embeddings.py
+++ b/evolution/tests/test_embeddings.py
@@ -1,0 +1,148 @@
+"""Tests for OllamaEmbeddingProvider retry-with-backoff logic."""
+import json
+import socket
+import urllib.error
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from evolution.providers.embeddings import OllamaEmbeddingProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMBED_DIM = 768  # must match config.EMBED_DIM
+_FAKE_VEC = [0.1] * _EMBED_DIM
+
+
+def _ok_response(vec: list[float] = _FAKE_VEC) -> MagicMock:
+    """Build a context-manager mock that returns a valid embed response."""
+    body = json.dumps({"embeddings": [vec]}).encode()
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: no retry needed
+# ---------------------------------------------------------------------------
+
+
+def test_embed_success_no_retry():
+    """Single successful call returns the vector without any retry."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    with patch("urllib.request.urlopen", return_value=_ok_response()) as mock_open:
+        result = provider.embed("hello")
+    mock_open.assert_called_once()
+    assert result == _FAKE_VEC
+
+
+# ---------------------------------------------------------------------------
+# Retry: TimeoutError twice then success
+# ---------------------------------------------------------------------------
+
+
+def test_embed_retries_on_timeout_error():
+    """urlopen raises TimeoutError twice, then succeeds; embed returns the vector."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    side_effects = [TimeoutError("timed out"), TimeoutError("timed out"), _ok_response()]
+
+    with patch("urllib.request.urlopen", side_effect=side_effects) as mock_open, \
+         patch("time.sleep") as mock_sleep:
+        result = provider.embed("hello")
+
+    assert mock_open.call_count == 3
+    # Two sleeps: 1s after attempt 1, 2s after attempt 2
+    assert mock_sleep.call_count == 2
+    assert mock_sleep.call_args_list == [call(1.0), call(2.0)]
+    assert result == _FAKE_VEC
+
+
+def test_embed_retries_on_socket_timeout():
+    """socket.timeout is also treated as a transient timeout."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    side_effects = [socket.timeout("timed out"), _ok_response()]
+
+    with patch("urllib.request.urlopen", side_effect=side_effects) as mock_open, \
+         patch("time.sleep"):
+        result = provider.embed("hello")
+
+    assert mock_open.call_count == 2
+    assert result == _FAKE_VEC
+
+
+def test_embed_retries_on_urlerror_wrapping_timeout():
+    """urllib.error.URLError wrapping a socket.timeout is treated as transient."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    wrapped = urllib.error.URLError(reason=socket.timeout("timed out"))
+    side_effects = [wrapped, _ok_response()]
+
+    with patch("urllib.request.urlopen", side_effect=side_effects) as mock_open, \
+         patch("time.sleep"):
+        result = provider.embed("hello")
+
+    assert mock_open.call_count == 2
+    assert result == _FAKE_VEC
+
+
+# ---------------------------------------------------------------------------
+# Exhaust retries: final error is re-raised (fail-loud rule)
+# ---------------------------------------------------------------------------
+
+
+def test_embed_raises_after_all_retries_exhausted():
+    """After MAX_ATTEMPTS timeouts the original exception propagates (fail-loud)."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    exc = TimeoutError("timed out")
+    side_effects = [exc, TimeoutError("timed out again"), TimeoutError("still timing out")]
+
+    with patch("urllib.request.urlopen", side_effect=side_effects) as mock_open, \
+         patch("time.sleep"):
+        with pytest.raises(TimeoutError):
+            provider.embed("hello")
+
+    # All 3 attempts were made
+    assert mock_open.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Non-timeout errors are NOT retried
+# ---------------------------------------------------------------------------
+
+
+def test_embed_does_not_retry_on_http_error():
+    """HTTP 500 is a hard failure — no retry, exception propagates immediately."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    http_err = urllib.error.HTTPError(
+        url="http://localhost:11434/api/embed",
+        code=500,
+        msg="Internal Server Error",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=None,
+    )
+
+    with patch("urllib.request.urlopen", side_effect=http_err) as mock_open, \
+         patch("time.sleep") as mock_sleep:
+        with pytest.raises(urllib.error.HTTPError):
+            provider.embed("hello")
+
+    mock_open.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+def test_embed_does_not_retry_on_connection_refused():
+    """A URLError whose reason is not a timeout is not retried."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    conn_err = urllib.error.URLError(reason=ConnectionRefusedError("Connection refused"))
+
+    with patch("urllib.request.urlopen", side_effect=conn_err) as mock_open, \
+         patch("time.sleep") as mock_sleep:
+        with pytest.raises(urllib.error.URLError):
+            provider.embed("hello")
+
+    mock_open.assert_called_once()
+    mock_sleep.assert_not_called()

--- a/evolution/tests/test_embeddings.py
+++ b/evolution/tests/test_embeddings.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from evolution.providers.embeddings import OllamaEmbeddingProvider
+from evolution.providers.embeddings import OllamaEmbeddingProvider, warmup_embedding_provider
 
 
 # ---------------------------------------------------------------------------
@@ -146,3 +146,78 @@ def test_embed_does_not_retry_on_connection_refused():
 
     mock_open.assert_called_once()
     mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Timeout bumped to 60 s
+# ---------------------------------------------------------------------------
+
+
+def test_urlopen_called_with_timeout_60():
+    """urlopen must be called with timeout=60 (bumped from 30 s per 2026-04-18 bench incident)."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    with patch("urllib.request.urlopen", return_value=_ok_response()) as mock_open:
+        provider.embed("hello")
+
+    call_positional = mock_open.call_args.args
+    call_keyword = mock_open.call_args.kwargs
+    # urlopen(req, timeout=60) — timeout may be positional or keyword
+    all_args = list(call_positional) + list(call_keyword.values())
+    assert 60 in all_args, f"Expected timeout=60 in urlopen call args, got: {mock_open.call_args}"
+
+
+# ---------------------------------------------------------------------------
+# warmup() on OllamaEmbeddingProvider
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_calls_embed_with_warmup_string():
+    """warmup() must call embed() exactly once with the string 'warmup'."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    with patch("urllib.request.urlopen", return_value=_ok_response()) as mock_open, \
+         patch("time.sleep"):
+        provider.warmup()
+
+    mock_open.assert_called_once()
+    # The request body should contain 'warmup' as the input
+    req_obj = mock_open.call_args.args[0]
+    body = req_obj.data.decode()
+    assert '"warmup"' in body
+
+
+def test_warmup_raises_on_failure_after_retries():
+    """warmup() must propagate the exception if embed() exhausts all retries."""
+    provider = OllamaEmbeddingProvider(model="test-model", host="http://localhost:11434")
+    side_effects = [TimeoutError("timed out")] * 3
+
+    with patch("urllib.request.urlopen", side_effect=side_effects), \
+         patch("time.sleep"):
+        with pytest.raises(TimeoutError):
+            provider.warmup()
+
+
+# ---------------------------------------------------------------------------
+# warmup_embedding_provider() facade
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_embedding_provider_calls_warmup_on_ollama():
+    """warmup_embedding_provider() calls warmup() when provider has that method."""
+    mock_provider = MagicMock(spec=OllamaEmbeddingProvider)
+
+    with patch("evolution.providers.embeddings.get_embedding_provider", return_value=mock_provider):
+        warmup_embedding_provider()
+
+    mock_provider.warmup.assert_called_once_with()
+
+
+def test_warmup_embedding_provider_skips_providers_without_warmup():
+    """warmup_embedding_provider() is a no-op for providers that don't define warmup()."""
+    from evolution.providers.embeddings import GeminiEmbeddingProvider
+
+    mock_provider = MagicMock(spec=GeminiEmbeddingProvider)
+    # GeminiEmbeddingProvider has no warmup — spec ensures hasattr returns False
+    assert not hasattr(mock_provider, "warmup")
+
+    with patch("evolution.providers.embeddings.get_embedding_provider", return_value=mock_provider):
+        warmup_embedding_provider()  # should not raise

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-18"  # re-reviewed for user_signal feedback loop (PR #186)
+last_verified: "2026-04-18"  # re-reviewed for Ollama embed retry + warmup (PR #193)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-18"  # re-reviewed for evolution/ test revival (PR #186)
+last_verified: "2026-04-18"  # re-reviewed for Ollama embed retry + warmup (PR #193)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/scripts/bench/suites/memory.py
+++ b/scripts/bench/suites/memory.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..registry import register
 from ..types import CaseResult, RunResult
+from evolution.providers.embeddings import warmup_embedding_provider
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
 _MB_PATH = _SCRIPTS_DIR / "memory_benchmark.py"
@@ -29,6 +30,7 @@ def run_memory(argv: list[str]) -> RunResult:
     p.add_argument("--k", default="1,3,5,10")
     args = p.parse_args(argv)
 
+    warmup_embedding_provider()
     mb = _load_mb()
     t_start = time.monotonic()
 

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -36,6 +36,7 @@ from evolution.config import (
     GEN_MODELS,
     load_api_key as _load_api_key,
 )
+from evolution.providers.embeddings import warmup_embedding_provider
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -3151,6 +3152,12 @@ def main():
                              "(e.g. public,internal,private). Overrides --privacy. "
                              "Also reads from DEUS_MEMORY_PRIVACY env var.")
     args = parser.parse_args()
+
+    # Warm up embedding provider before batch workloads when requested.
+    # Only fires when the caller sets DEUS_EMBED_WARMUP=1 to avoid adding
+    # latency to single-file indexer invocations.
+    if os.getenv("DEUS_EMBED_WARMUP") == "1":
+        warmup_embedding_provider()
 
     global _client
     # Commands that need no API key


### PR DESCRIPTION
## Summary

- Adds retry-with-backoff to `OllamaEmbeddingProvider.embed()` to survive transient socket timeouts during back-to-back indexing runs.
- Up to 3 total attempts (2 retries), exponential backoff 1 s → 2 s. Only `TimeoutError` / `socket.timeout` / `URLError` wrapping a timeout are retried — HTTP errors propagate immediately.
- **Bumps per-attempt socket timeout from 30 s → 60 s.** Ollama cold-start or under-load can legitimately exceed 30 s; combined with the retry layer the effective budget is ~3 min total per embedding.
- **Adds `OllamaEmbeddingProvider.warmup()`** — sends a throwaway embed before batch workloads to absorb model-load latency. Propagates on failure (fail-loud rule).
- **Adds `warmup_embedding_provider()` module-level facade** — duck-typed, skips Gemini and any provider without `warmup()`.
- **Wires warmup at two batch call sites:** `scripts/bench/suites/memory.py` (unconditional, before the per-case loop) and `scripts/memory_indexer.py` (gated by `DEUS_EMBED_WARMUP=1` to avoid overhead on single-file invocations).
- Per the fail-loud rule: the final exception is re-raised after retries are exhausted; nothing is swallowed.

## Why

During the 2026-04-18 LongMemEval outbound bench (50 cases), case #31 crashed mid-run:

```
File "evolution/providers/embeddings.py", line 62, in embed
    with urllib.request.urlopen(req, timeout=30) as resp:
  File ".../urllib/request.py", line 215, in urlopen
    return opener.open(url, data, timeout)
TimeoutError: timed out
```

30 prior embed calls succeeded. This is load-induced transient latency, not a hard failure. One retry would have recovered it. The 30 s ceiling was also too tight for Ollama under sustained load — bumped to 60 s as a follow-up.

## Test plan

- [x] `python3 -m pytest evolution/tests/test_embeddings.py -v` — all 12 tests pass
- [x] `test_embed_retries_on_timeout_error`: mocks `urlopen` to raise `TimeoutError` twice then succeed; asserts 3 calls and correct backoff sleeps (1 s, 2 s)
- [x] `test_embed_raises_after_all_retries_exhausted`: mocks 3 consecutive timeouts; asserts `TimeoutError` propagates (fail-loud)
- [x] `test_embed_does_not_retry_on_http_error`: HTTP 500 → single call, no sleep, error raised immediately
- [x] `test_embed_does_not_retry_on_connection_refused`: non-timeout `URLError` → single call, immediate raise
- [x] `test_urlopen_called_with_timeout_60`: asserts `urlopen` receives `timeout=60`
- [x] `test_warmup_calls_embed_with_warmup_string`: asserts `warmup()` sends exactly `"warmup"` as input
- [x] `test_warmup_raises_on_failure_after_retries`: asserts `warmup()` propagates `TimeoutError` after all attempts
- [x] `test_warmup_embedding_provider_calls_warmup_on_ollama`: facade calls `warmup()` on Ollama provider
- [x] `test_warmup_embedding_provider_skips_providers_without_warmup`: facade is no-op for Gemini path

🤖 Generated with [Claude Code](https://claude.com/claude-code)