### PR TITLE
feat(reactions): wire WhatsApp + Telegram reactions to logReactionSignal (PR B)

### DIFF
--- a/packages/mcp-channel-core/src/server-base.ts
+++ b/packages/mcp-channel-core/src/server-base.ts
@@ -2,7 +2,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { MessageBuffer } from './message-buffer.js';
-import type { ChannelProvider, IncomingMessage } from './types.js';
+import type {
+  ChannelProvider,
+  IncomingMessage,
+  IncomingReaction,
+} from './types.js';
 
 /**
  * Register the common MCP tools that all channel servers share.
@@ -23,6 +27,15 @@ export function registerCommonTools(
       level: 'info',
       logger: 'incoming_message',
       data: msg,
+    });
+  };
+
+  // Reactions are ephemeral signals — push to client, don't buffer for polling.
+  provider.onReaction = (reaction: IncomingReaction) => {
+    server.server.sendLoggingMessage({
+      level: 'info',
+      logger: 'incoming_reaction',
+      data: reaction,
     });
   };
 

--- a/packages/mcp-channel-core/src/types.ts
+++ b/packages/mcp-channel-core/src/types.ts
@@ -13,6 +13,21 @@ export interface IncomingMessage {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Normalized incoming reaction from any channel.
+ * `emoji` is empty string when the user removed a reaction (no-op at sink).
+ */
+export interface IncomingReaction {
+  chat_id: string;
+  sender: string;
+  sender_name: string;
+  reacted_to_message_id: string;
+  emoji: string;
+  timestamp: string;
+  is_group?: boolean;
+  chat_name?: string;
+}
+
 /** Connection status returned by get_status. */
 export interface ChannelStatus {
   connected: boolean;
@@ -72,4 +87,10 @@ export interface ChannelProvider {
    * The channel calls this function whenever a new message arrives.
    */
   onMessage: (msg: IncomingMessage) => void;
+
+  /**
+   * Optional reaction handler. Channels that support reactions (WhatsApp, Telegram)
+   * call this when a user adds or removes a reaction. Empty-string emoji = removal.
+   */
+  onReaction?: (reaction: IncomingReaction) => void;
 }

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -14,6 +14,7 @@ import type {
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
+  IncomingReaction,
 } from '@deus-ai/channel-core';
 
 const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Deus';
@@ -58,6 +59,9 @@ export class TelegramProvider implements ChannelProvider {
 
   // Set by server-base.ts
   onMessage: (msg: IncomingMessage) => void = () => {};
+
+  // Set by server-base.ts — called on Telegram message_reaction updates.
+  onReaction?: (reaction: IncomingReaction) => void;
 
   async connect(): Promise<void> {
     if (!BOT_TOKEN) {
@@ -211,6 +215,70 @@ export class TelegramProvider implements ChannelProvider {
     this.bot.on('message:location', (ctx) => storeMedia(ctx, '[Location]'));
     this.bot.on('message:contact', (ctx) => storeMedia(ctx, '[Contact]'));
 
+    // Reactions: Telegram delivers an `old_reaction` + `new_reaction` diff.
+    // We emit one IncomingReaction per emoji added. Removal = empty emoji string.
+    this.bot.on('message_reaction', (ctx) => {
+      if (!this.onReaction) return;
+      try {
+        const upd = ctx.messageReaction;
+        if (!upd) return;
+        const chatId = `tg:${upd.chat.id}`;
+        const isGroup =
+          upd.chat.type === 'group' || upd.chat.type === 'supergroup';
+        const chatName = (upd.chat as any).title || undefined;
+        const senderId =
+          upd.user?.id != null
+            ? String(upd.user.id)
+            : `actor:${upd.actor_chat?.id ?? 'unknown'}`;
+        const senderName = upd.user
+          ? [upd.user.first_name, upd.user.last_name].filter(Boolean).join(' ')
+          : senderId;
+        const reactedTo = String(upd.message_id);
+        const timestamp = new Date(upd.date * 1000).toISOString();
+
+        const oldSet = new Set(
+          (upd.old_reaction || [])
+            .filter((r) => r.type === 'emoji')
+            .map((r) => (r as { type: 'emoji'; emoji: string }).emoji),
+        );
+        const newList = (upd.new_reaction || [])
+          .filter((r) => r.type === 'emoji')
+          .map((r) => (r as { type: 'emoji'; emoji: string }).emoji);
+
+        const added = newList.filter((e) => !oldSet.has(e));
+
+        if (added.length === 0) {
+          // Pure removal — emit one empty-emoji event (host treats as no-op).
+          this.onReaction({
+            chat_id: chatId,
+            sender: senderId,
+            sender_name: senderName,
+            reacted_to_message_id: reactedTo,
+            emoji: '',
+            timestamp,
+            is_group: isGroup,
+            chat_name: chatName,
+          });
+          return;
+        }
+
+        for (const emoji of added) {
+          this.onReaction({
+            chat_id: chatId,
+            sender: senderId,
+            sender_name: senderName,
+            reacted_to_message_id: reactedTo,
+            emoji,
+            timestamp,
+            is_group: isGroup,
+            chat_name: chatName,
+          });
+        }
+      } catch (err) {
+        logger.warn({ err }, 'Failed to handle Telegram reaction');
+      }
+    });
+
     this.bot.catch((err) => {
       this.consecutiveErrors++;
       logger.error(
@@ -225,6 +293,8 @@ export class TelegramProvider implements ChannelProvider {
 
     return new Promise<void>((resolve) => {
       this.bot!.start({
+        // message_reaction is not in the default allowed_updates set — opt in.
+        allowed_updates: ['message', 'edited_message', 'message_reaction'],
         onStart: (botInfo) => {
           this.botUsername = botInfo.username;
           this.connectTime = Date.now();

--- a/packages/mcp-whatsapp/src/whatsapp.ts
+++ b/packages/mcp-whatsapp/src/whatsapp.ts
@@ -33,6 +33,7 @@ import type {
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
+  IncomingReaction,
 } from '@deus-ai/channel-core';
 
 // ── Config from env vars ────────────────────────────────────────────────
@@ -75,6 +76,9 @@ export class WhatsAppProvider implements ChannelProvider {
 
   // Set by server-base.ts — called for every incoming message
   onMessage: (msg: IncomingMessage) => void = () => {};
+
+  // Set by server-base.ts — called for every incoming reaction (add or remove).
+  onReaction?: (reaction: IncomingReaction) => void;
 
   async connect(): Promise<void> {
     this.readyPromise = new Promise<void>((resolve) => {
@@ -265,6 +269,34 @@ export class WhatsAppProvider implements ChannelProvider {
         }
       },
     );
+
+    this.sock.ev.on('messages.reaction', async (reactions) => {
+      if (!this.onReaction) return;
+      for (const r of reactions) {
+        try {
+          const rawJid = r.key.remoteJid;
+          if (!rawJid || rawJid === 'status@broadcast') continue;
+          const chatJid = await this.translateJid(rawJid);
+          const isGroup = chatJid.endsWith('@g.us');
+          const senderJid = r.key.participant || r.key.remoteJid || '';
+          const emoji = r.reaction?.text || '';
+          const reactedTo = r.reaction?.key?.id || '';
+          if (!reactedTo) continue;
+          this.onReaction({
+            chat_id: chatJid,
+            sender: senderJid,
+            sender_name: senderJid.split('@')[0],
+            reacted_to_message_id: reactedTo,
+            emoji,
+            timestamp: new Date().toISOString(),
+            is_group: isGroup,
+            chat_name: this.knownChats.get(chatJid)?.name,
+          });
+        } catch (err) {
+          logger.warn({ err }, 'Failed to handle WhatsApp reaction');
+        }
+      }
+    });
 
     this.sock.ev.on('messages.upsert', async ({ messages }) => {
       for (const msg of messages) {

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,12 +2,13 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-04-09"
+last_verified: "2026-04-18"  # re-reviewed for reactions channel wiring (PR B, #194)
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"
   - "Register a new MCP tool on the Telegram channel with a Zod input schema"
   - "Create a new Slack channel package under packages/mcp-slack/"
+  - "Wire a new channel to emit incoming_reaction notifications via onReaction"
 ---
 # Pattern: channel-add
 
@@ -50,6 +51,10 @@ Then restart the service to pick up the change.
 - Channel skill PRs touch only `.claude/skills/` (and optionally `docs/`, `README.md`).
 - Core changes (`src/`, `packages/`, `package.json`) go in a separate PR first.
 - Never commit `host.ts`, `scripts/`, `node_modules/`, or `package-lock.json`.
+
+## Reactions (optional)
+
+If the channel supports message reactions (WhatsApp, Telegram), implement the optional `onReaction` callback on the `ChannelProvider`. `registerCommonTools` wires it to `sendLoggingMessage({ logger: 'incoming_reaction' })` — reactions are ephemeral signals, not buffered for polling. The host dispatches to `logReactionSignal` via the `incoming_reaction` branch in `src/channels/mcp-adapter.ts`. Empty-string emoji = reaction removed (no-op at the sink).
 
 ## Tool registration
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-18"  # re-reviewed for reactions-signal foundation (PR #192)
+last_verified: "2026-04-18"  # re-reviewed for reactions channel wiring (PR B, #194) — deploy rules unchanged
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-18"  # re-reviewed for Ollama embed retry + warmup (PR #193)
+last_verified: "2026-04-18"  # re-reviewed for reactions channel wiring (PR B, #194) — general patterns unchanged
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/channels/mcp-adapter.ts
+++ b/src/channels/mcp-adapter.ts
@@ -14,8 +14,10 @@ import { logger } from '../logger.js';
 import type {
   Channel,
   NewMessage,
+  NewReaction,
   OnChatMetadata,
   OnInboundMessage,
+  OnInboundReaction,
 } from '../types.js';
 
 export interface McpChannelAdapterOpts {
@@ -29,6 +31,8 @@ export interface McpChannelAdapterOpts {
   env?: Record<string, string>;
   /** Callback for incoming messages. */
   onMessage: OnInboundMessage;
+  /** Callback for incoming reactions. Channels without reaction support never call it. */
+  onReaction?: OnInboundReaction;
   /** Callback for chat metadata discovery. */
   onChatMetadata: OnChatMetadata;
   /** JID ownership check — return true if this channel owns the JID. */
@@ -64,10 +68,26 @@ export class McpChannelAdapter implements Channel {
       LoggingMessageNotificationSchema,
       (notification) => {
         const params = notification.params;
-        if (params.logger !== 'incoming_message') return;
-
         const data = params.data as Record<string, unknown> | undefined;
         if (!data) return;
+
+        if (params.logger === 'incoming_reaction') {
+          if (!opts.onReaction) return;
+          const chatJid = data.chat_id as string;
+          const reaction: NewReaction = {
+            chat_jid: chatJid,
+            sender: data.sender as string,
+            sender_name: data.sender_name as string,
+            reacted_to_message_id: data.reacted_to_message_id as string,
+            emoji: (data.emoji as string) ?? '',
+            timestamp: data.timestamp as string,
+            is_group: data.is_group as boolean | undefined,
+          };
+          opts.onReaction(chatJid, reaction);
+          return;
+        }
+
+        if (params.logger !== 'incoming_message') return;
 
         const chatJid = data.chat_id as string;
         const msg: NewMessage = {

--- a/src/channels/mcp-telegram.ts
+++ b/src/channels/mcp-telegram.ts
@@ -39,6 +39,7 @@ registerChannel('telegram', (opts) => {
       ASSISTANT_NAME: ASSISTANT_NAME,
     },
     onMessage: opts.onMessage,
+    onReaction: opts.onReaction,
     onChatMetadata: opts.onChatMetadata,
     ownsJid: (jid) => jid.startsWith('tg:'),
   });

--- a/src/channels/mcp-whatsapp.ts
+++ b/src/channels/mcp-whatsapp.ts
@@ -46,6 +46,7 @@ registerChannel('whatsapp', (opts) => {
       ASSISTANT_HAS_OWN_NUMBER: ASSISTANT_HAS_OWN_NUMBER ? 'true' : 'false',
     },
     onMessage: opts.onMessage,
+    onReaction: opts.onReaction,
     onChatMetadata: opts.onChatMetadata,
     ownsJid: (jid) => jid.endsWith('@g.us') || jid.endsWith('@s.whatsapp.net'),
   });

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,12 +1,14 @@
 import {
   Channel,
   OnInboundMessage,
+  OnInboundReaction,
   OnChatMetadata,
   RegisteredGroup,
 } from '../types.js';
 
 export interface ChannelOpts {
   onMessage: OnInboundMessage;
+  onReaction: OnInboundReaction;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,8 @@ import { runStartupChecks, printStartupReport } from './startup-gate.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { getAllTasks } from './db.js';
 import { writeGroupsSnapshot, writeTasksSnapshot } from './container-runner.js';
-import { Channel, NewMessage } from './types.js';
+import { Channel, NewMessage, NewReaction } from './types.js';
+import { logReactionSignal } from './evolution-client.js';
 import { logger } from './logger.js';
 
 export { getAvailableGroups } from './router-state.js';
@@ -190,6 +191,16 @@ async function main(): Promise<void> {
       }
 
       storeMessage(msg);
+    },
+    onReaction: (chatJid: string, reaction: NewReaction) => {
+      const group = state.registeredGroups[chatJid];
+      if (!group) return; // Reaction in an unregistered chat — ignore.
+      logReactionSignal({
+        emoji: reaction.emoji,
+        groupFolder: group.folder,
+        sessionId: state.getSession(group.folder),
+        reactedToMessageId: reaction.reacted_to_message_id,
+      });
     },
     onChatMetadata: (
       chatJid: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,17 @@ export interface NewMessage {
   is_bot_message?: boolean;
 }
 
+export interface NewReaction {
+  chat_jid: string;
+  sender: string;
+  sender_name: string;
+  reacted_to_message_id: string;
+  /** Empty string when the user removed a reaction. */
+  emoji: string;
+  timestamp: string;
+  is_group?: boolean;
+}
+
 export interface ScheduledTask {
   id: string;
   group_folder: string;
@@ -114,6 +125,12 @@ export interface Channel {
 
 // Callback type that channels use to deliver inbound messages
 export type OnInboundMessage = (chatJid: string, message: NewMessage) => void;
+
+// Callback for inbound reactions (add or remove) — optional per channel.
+export type OnInboundReaction = (
+  chatJid: string,
+  reaction: NewReaction,
+) => void;
 
 // Callback for chat metadata discovery.
 // name is optional — channels that deliver names inline (Telegram) pass it here;


### PR DESCRIPTION
## Summary
- Closes the emoji → userSignal loop opened in #192 (PR A). Channel MCP servers now emit `incoming_reaction` logging notifications when a user adds or removes a reaction; the host adapter dispatches to `logReactionSignal` with the group folder resolved from `state.registeredGroups[chatJid]`.
- `mcp-channel-core`: adds `IncomingReaction` type + optional `onReaction` on `ChannelProvider`; `registerCommonTools` wires reactions to `sendLoggingMessage({ logger: 'incoming_reaction' })` (no buffer — reactions are ephemeral signals, not polled content).
- `mcp-whatsapp`: new `messages.reaction` handler normalizes to `IncomingReaction`. Empty `reaction.text` surfaces as empty-string emoji (removal).
- `mcp-telegram`: opts into `message_reaction` via `allowed_updates: ['message', 'edited_message', 'message_reaction']`. Diffs `old_reaction`/`new_reaction` and emits one event per newly-added emoji, or one empty-emoji event for pure removals.
- Host: `src/channels/mcp-adapter.ts` branches on `params.logger === 'incoming_reaction'`. `src/index.ts` provides the top-level `onReaction` that resolves the group folder and calls `logReactionSignal`.

**Decisions (overridable in a follow-up):**
- Emoji set stays hardcoded (PR A's 12 positive / 9 negative). No env escape yet — tune after we see real reactions.
- Empty emoji (user removed a reaction) is a no-op at the sink, matching PR A's test expectations. Not treated as negative.

## Test plan
- [x] `tsc --noEmit` clean on the worktree
- [x] Existing `src/channels/*.test.ts` tests pass
- [ ] Manual: 👍 in a WhatsApp group → `logReactionSignal` logs with `userSignal: 'positive'` attached to the previous interaction via session lookup
- [ ] Manual: 👍 in Telegram supergroup → same
- [ ] Manual: remove a reaction → no `logReactionSignal` call observed (emoji-to-signal returns `null` for empty string)
- [ ] Manual: unsupported emoji (e.g., 🎨) → `logReactionSignal` is a no-op (filter is in `emojiToSignal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)