### PR TITLE
chore(container): drop fonts-noto-cjk for ~100MB savings

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,7 +8,6 @@ FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091c
 RUN apt-get update && apt-get install -y \
     chromium \
     fonts-liberation \
-    fonts-noto-cjk \
     fonts-noto-color-emoji \
     libgbm1 \
     libnss3 \


### PR DESCRIPTION
## Summary

- Removes `fonts-noto-cjk` from the Dockerfile apt-get install list
- CJK fonts are ~100MB compressed and unused — the agent only renders Latin + emoji in headless Chromium
- Projected image size: ~732MB → ~630MB compressed

## Test plan

- [ ] Rebuild image: `./container/build.sh`
- [ ] Verify size: `docker images deus-agent` — confirm compressed size dropped by ~100MB
- [ ] Smoke test: run a container session and confirm headless Chromium still renders pages correctly