### PR TITLE
feat(bench): reflexion-retrieval-quality suite

### DIFF
--- a/scripts/bench/fixtures/reflexion_retrieval.json
+++ b/scripts/bench/fixtures/reflexion_retrieval.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "case-1",
+    "query": "how to debug container agent logs",
+    "group_folder": "whatsapp_main",
+    "tools_planned": ["bash", "read"],
+    "expected_reflection_contains": ["container", "log"],
+    "top_k": 5
+  },
+  {
+    "id": "case-2",
+    "query": "multi-step instruction completion and task sequencing",
+    "group_folder": "whatsapp_main",
+    "tools_planned": [],
+    "expected_reflection_contains": ["multi-step", "instruction"],
+    "top_k": 5
+  },
+  {
+    "id": "case-3",
+    "query": "structured status report from skill execution logs",
+    "group_folder": "whatsapp_main",
+    "tools_planned": ["bash"],
+    "expected_reflection_contains": ["skill", "log"],
+    "top_k": 5
+  },
+  {
+    "id": "case-4",
+    "query": "image compression and file size optimization",
+    "group_folder": "whatsapp_main",
+    "tools_planned": [],
+    "expected_reflection_contains": ["compression", "dimension"],
+    "top_k": 5
+  },
+  {
+    "id": "case-5",
+    "query": "evidence-based data validation for repository analysis",
+    "group_folder": "whatsapp_main",
+    "tools_planned": ["bash", "grep"],
+    "expected_reflection_contains": ["evidence", "data"],
+    "top_k": 5
+  }
+]

--- a/scripts/bench/suites/__init__.py
+++ b/scripts/bench/suites/__init__.py
@@ -1,10 +1,11 @@
-from . import hygiene, memory, memory_tree, paraphrased_query, token, token_multiturn
+from . import hygiene, memory, memory_tree, paraphrased_query, reflexion_retrieval, token, token_multiturn
 
 __all__ = [
     "hygiene",
     "memory",
     "memory_tree",
     "paraphrased_query",
+    "reflexion_retrieval",
     "token",
     "token_multiturn",
 ]

--- a/scripts/bench/suites/reflexion_retrieval.py
+++ b/scripts/bench/suites/reflexion_retrieval.py
@@ -1,0 +1,167 @@
+"""
+reflexion-retrieval-quality bench
+==================================
+Measures whether the reflexion retrieval pipeline surfaces relevant past
+reflections for a given (query, group_folder, tools_planned) triple.
+
+For each fixture case, ``get_reflections`` is called with top_k results.
+A case is a hit if ANY returned reflection's ``content`` field contains ALL
+strings listed in ``expected_reflection_contains`` (case-insensitive).
+
+Score = mean hit rate across all cases.
+
+Fixture format: scripts/bench/fixtures/reflexion_retrieval.json
+  [
+    {
+      "id": "case-1",
+      "query": "how to debug container agent logs",
+      "group_folder": "whatsapp_main",
+      "tools_planned": ["bash", "read"],
+      "expected_reflection_contains": ["container", "log"],
+      "top_k": 5
+    },
+    ...
+  ]
+
+# TODO: expand to 20 cases — sample additional reflections with:
+#   python3 -c "import sqlite3; c=sqlite3.connect('/Users/liam10play/.deus/evolution.db').cursor(); \\
+#     c.execute('SELECT content FROM reflections WHERE archived_at IS NULL LIMIT 20'); \\
+#     [print(r[0][:120]) for r in c.fetchall()]"
+
+Missing vault / import errors are handled gracefully: the suite returns score
+0.0 with an ``error`` key in meta rather than crashing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import CaseResult, RunResult
+
+_FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "reflexion_retrieval.json"
+
+_SUITE_NAME = "reflexion-retrieval"
+
+
+def _load_retriever():
+    """Import get_reflections from the reflexion retriever module."""
+    try:
+        from evolution.reflexion.retriever import get_reflections  # noqa: PLC0415
+        return get_reflections
+    except Exception as exc:  # noqa: BLE001
+        return exc
+
+
+def _case_hit(reflections: list[dict], expected_contains: list[str]) -> bool:
+    """Return True if any reflection's content contains ALL expected strings (case-insensitive)."""
+    needles = [s.lower() for s in expected_contains]
+    for r in reflections:
+        content = (r.get("content") or "").lower()
+        if all(needle in content for needle in needles):
+            return True
+    return False
+
+
+@register(_SUITE_NAME)
+def run_reflexion_retrieval(argv: list[str]) -> RunResult:
+    p = argparse.ArgumentParser(prog=_SUITE_NAME)
+    p.add_argument(
+        "--fixture",
+        default=str(_FIXTURE_PATH),
+        help="Path to fixture JSON (default: scripts/bench/fixtures/reflexion_retrieval.json)",
+    )
+    args = p.parse_args(argv)
+
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        return RunResult(
+            suite=_SUITE_NAME,
+            score=0.0,
+            cases=[],
+            meta={"error": f"fixture not found: {fixture_path}"},
+        )
+
+    with fixture_path.open("r", encoding="utf-8") as f:
+        fixtures = json.load(f)
+
+    get_reflections = _load_retriever()
+    if isinstance(get_reflections, Exception):
+        # Fail gracefully — document the import error but don't crash
+        return RunResult(
+            suite=_SUITE_NAME,
+            score=0.0,
+            cases=[
+                CaseResult(
+                    case_id=fx["id"],
+                    score=0.0,
+                    passed=False,
+                    meta={"error": f"import failed: {get_reflections}"},
+                )
+                for fx in fixtures
+            ],
+            meta={"error": f"retriever import failed: {get_reflections}"},
+        )
+
+    t_start = time.monotonic()
+    cases: list[CaseResult] = []
+    hits = 0
+
+    for fx in fixtures:
+        case_id = fx["id"]
+        query = fx["query"]
+        group_folder = fx.get("group_folder")
+        tools_planned = fx.get("tools_planned") or []
+        expected_contains = fx.get("expected_reflection_contains", [])
+        top_k = fx.get("top_k", 5)
+
+        try:
+            reflections = get_reflections(
+                query=query,
+                group_folder=group_folder,
+                tools_planned=tools_planned or None,
+                top_k=top_k,
+            )
+        except Exception as exc:  # noqa: BLE001
+            cases.append(
+                CaseResult(
+                    case_id=case_id,
+                    score=0.0,
+                    passed=False,
+                    meta={"error": str(exc), "query": query},
+                )
+            )
+            continue
+
+        hit = _case_hit(reflections, expected_contains)
+        if hit:
+            hits += 1
+
+        cases.append(
+            CaseResult(
+                case_id=case_id,
+                score=1.0 if hit else 0.0,
+                passed=hit,
+                meta={
+                    "query": query,
+                    "group_folder": group_folder,
+                    "top_k": top_k,
+                    "retrieved_count": len(reflections),
+                    "expected_reflection_contains": expected_contains,
+                },
+            )
+        )
+
+    total = len(fixtures)
+    score = hits / total if total else 0.0
+    elapsed_ms = int((time.monotonic() - t_start) * 1000)
+
+    return RunResult(
+        suite=_SUITE_NAME,
+        score=score,
+        cases=cases,
+        latency_ms=elapsed_ms,
+        meta={"hits": hits, "total": total},
+    )


### PR DESCRIPTION
## Summary

- Adds `reflexion-retrieval` bench suite (Batch 2, suite 2 of 3) measuring whether `evolution/reflexion/retriever.py`'s `get_reflections` surfaces relevant past reflections for a `(query, group_folder, tools_planned)` triple
- Score = mean hit rate: a case hits when any top-k reflection's `content` contains all strings in `expected_reflection_contains` (case-insensitive)
- Ships 5 placeholder fixture cases drawn from real vault reflection content; marked `TODO: expand to 20 cases`
- Graceful degradation: import failures produce score 0.0 with error detail rather than crashing the bench runner

**Files added/modified:**
- `scripts/bench/suites/reflexion_retrieval.py` — registered as `reflexion-retrieval`
- `scripts/bench/fixtures/reflexion_retrieval.json` — 5 placeholder cases
- `scripts/bench/suites/__init__.py` — import + `__all__` entry

## Test plan

- [ ] `python3 -c "import sys; sys.path.insert(0, 'scripts'); from bench.suites import reflexion_retrieval; from bench.registry import list_names; print(list_names())"` — confirms `reflexion-retrieval` appears in registry
- [ ] Run `python3 scripts/bench/runner.py reflexion-retrieval` with a live `.deus/evolution.db` to verify retriever integration end-to-end
- [ ] Fixture expansion: sample 15+ more reflections from the DB and add cases before merging to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)