### PR TITLE
feat(agent-runner): token-efficiency tier 1 — prefix unpoisoning + tool-size logging

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -34,6 +34,7 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
+  projectHint?: string;
 }
 
 interface ImageContentBlock {
@@ -566,9 +567,9 @@ async function runQuery(
   const effort =
     effortEnv === 'default'
       ? undefined
-      : (['low', 'medium', 'high', 'max'].includes(effortEnv)
-          ? (effortEnv as 'low' | 'medium' | 'high' | 'max')
-          : 'low');
+      : ['low', 'medium', 'high', 'max'].includes(effortEnv)
+        ? (effortEnv as 'low' | 'medium' | 'high' | 'max')
+        : 'low';
   log(`Effort level: ${effort ?? 'SDK default'}`);
 
   // Load global CLAUDE.md as additional system context (shared across all groups)
@@ -577,6 +578,13 @@ async function runQuery(
   if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
+
+  // Session-stable system append: global CLAUDE.md (non-main groups) plus the
+  // project hint (when the group has a project). Placing the hint here instead
+  // of prepending to every user prompt avoids re-billing it per turn.
+  const systemAppend = [globalClaudeMd, containerInput.projectHint]
+    .filter((s): s is string => !!s && s.length > 0)
+    .join('\n\n');
 
   // Detect external project mount: if /workspace/project exists and has content,
   // use it as the primary cwd. The agent works in the user's project directory
@@ -671,11 +679,11 @@ async function runQuery(
       resume: sessionId,
       resumeSessionAt: resumeAt,
       effort,
-      systemPrompt: globalClaudeMd
+      systemPrompt: systemAppend
         ? {
             type: 'preset' as const,
             preset: 'claude_code' as const,
-            append: globalClaudeMd,
+            append: systemAppend,
           }
         : undefined,
       allowedTools: [

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-04-16"
+last_verified: "2026-04-18"  # re-reviewed for token-efficiency tier 1 project-hint move (PR #199) — debugging rules unchanged
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-18"  # re-reviewed for slim vault seed in setup/memory.ts (PR #202) — deploy rules unchanged
+last_verified: "2026-04-18"  # re-reviewed for token-efficiency tier 1 project-hint move (PR #199) — deploy rules unchanged
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-18"  # re-reviewed for slim vault seed in setup/memory.ts (PR #202) — general patterns unchanged
+last_verified: "2026-04-18"  # re-reviewed for token-efficiency tier 1 project-hint move (PR #199) — general patterns unchanged
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -48,6 +48,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
+  projectHint?: string;
 }
 
 export interface ContainerOutput {
@@ -141,9 +142,9 @@ export async function runContainerAgent(
   const userSignal = detectUserSignal(input.prompt);
   const domains = await detectDomainsWithFallback(input.prompt);
 
-  // Pre-dispatch: inject project type hint if group has an associated project.
-  // This gives the agent immediate context about the project without waiting
-  // for it to inspect files. The hint is kept brief to minimize token overhead.
+  // Pre-dispatch: build project type hint if group has an associated project.
+  // Placed on systemPrompt (session-stable) instead of per-turn user prompt so
+  // it's sent once and doesn't repeat across turns in a resumed session.
   if (group.projectId) {
     const project = getProjectById(group.projectId);
     if (project?.type) {
@@ -154,10 +155,10 @@ export async function runContainerAgent(
       if (project.type.testRunner)
         parts.push(`test:${project.type.testRunner}`);
       const hint = `[Project: ${project.name} (${parts.join(', ')}) at /workspace/project${project.readonly ? ' — READ-ONLY' : ''}]`;
-      input = { ...input, prompt: `${hint}\n\n${input.prompt}` };
+      input = { ...input, projectHint: hint };
     } else if (project) {
       const hint = `[Project: ${project.name} at /workspace/project${project.readonly ? ' — READ-ONLY' : ''}]`;
-      input = { ...input, prompt: `${hint}\n\n${input.prompt}` };
+      input = { ...input, projectHint: hint };
     }
   }
 


### PR DESCRIPTION
## Summary

**This PR is scoped to the behavior change only. Merge after the instrumentation PR has accrued ~3-5 days of baseline data.**

**Commit — `feat(agent-runner): move project hint to systemPrompt.append`**
The per-group project hint was prepended to every user prompt, re-billing its tokens on each turn of a resumed session. It is session-stable (same project across turns), so it belongs in `systemPrompt.append` where it is sent once. Also fixes the case where a main group with a project had no way to set a system append (which was gated on `globalClaudeMd`, only loaded for non-main groups).

## Expected impact

Savings ≈ `hint_tokens × (turns_per_session − 1)` for groups with a `projectId`. Personal-agent volume is low, so the raw dollar win is modest — the architectural value is prefix stability (prep for `cache_control` when the SDK exposes it).

## Merge ordering

This PR was originally opened with two more commits (tool-size hook + usage logging); those have been moved to #200 so we can establish a clean token baseline before this behavior change lands. Flow:

1. Merge #200 first
2. Let `usage.jsonl` accrue for ~3-5 days of real traffic
3. Merge this PR
4. Compare before/after on the same user's workload

## Test plan

- [ ] Host `tsc` clean
- [ ] Agent-runner `tsc` clean
- [ ] Host `eslint` — no new errors
- [ ] Host `vitest` — no new failures (one pre-existing `credential-proxy` OAuth test fails on main, tracked separately)
- [ ] Post-merge: verify `input_tokens` per turn ≥ 2 drops by roughly `hint_tokens` vs pre-merge baseline
- [ ] Quality check: `OllamaJudge` reflexion score distribution pre-merge vs post-merge should be statistically indistinguishable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
