### PR TITLE
feat(agent-runner): token-efficiency instrumentation (logging only, no behavior change)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -20,6 +20,7 @@ import {
   query,
   HookCallback,
   PreCompactHookInput,
+  PostToolUseHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
@@ -258,6 +259,42 @@ function createPreCompactHook(assistantName?: string): HookCallback {
       );
     }
 
+    return {};
+  };
+}
+
+/**
+ * Log per-tool-call response size to JSONL. Measurement only; does not modify
+ * the tool output the model sees. Feeds the Headroom POC Phase A decision
+ * (docs/HEADROOM_POC.md). Opt-out via DEUS_TOOL_SIZE_LOG=0.
+ */
+function createToolSizeLogHook(): HookCallback {
+  const logPath = '/workspace/group/logs/tool-sizes.jsonl';
+  return async (input, _toolUseId, _context) => {
+    try {
+      const hookInput = input as PostToolUseHookInput;
+      const serialized =
+        typeof hookInput.tool_response === 'string'
+          ? hookInput.tool_response
+          : JSON.stringify(hookInput.tool_response ?? '');
+      const bytes = Buffer.byteLength(serialized, 'utf8');
+      // Rough heuristic: ~3.7 bytes per token for mixed English+code. Phase A
+      // uses this for relative comparison, not absolute budgeting.
+      const approxTokens = Math.round(bytes / 3.7);
+      const entry = {
+        ts: new Date().toISOString(),
+        tool: hookInput.tool_name,
+        tool_use_id: hookInput.tool_use_id,
+        bytes,
+        approx_tokens: approxTokens,
+      };
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.appendFileSync(logPath, JSON.stringify(entry) + '\n');
+    } catch (err) {
+      log(
+        `tool-size-log failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     return {};
   };
 }
@@ -662,6 +699,9 @@ async function runQuery(
         PreCompact: [
           { hooks: [createPreCompactHook(containerInput.assistantName)] },
         ],
+        ...(process.env.DEUS_TOOL_SIZE_LOG !== '0'
+          ? { PostToolUse: [{ hooks: [createToolSizeLogHook()] }] }
+          : {}),
       },
     },
   })) {

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -21,6 +21,7 @@ import {
   HookCallback,
   PreCompactHookInput,
   PostToolUseHookInput,
+  SDKResultMessage,
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
@@ -261,6 +262,38 @@ function createPreCompactHook(assistantName?: string): HookCallback {
 
     return {};
   };
+}
+
+/**
+ * Append SDK-reported per-turn usage metadata to JSONL. This is the direct
+ * billing signal (inputTokens, outputTokens, cache read/create, cost) and the
+ * basis for before/after token-efficiency comparisons. Opt-out: DEUS_USAGE_LOG=0.
+ */
+function logUsage(msg: SDKResultMessage): void {
+  if (process.env.DEUS_USAGE_LOG === '0') return;
+  try {
+    const logPath = '/workspace/group/logs/usage.jsonl';
+    const entry = {
+      ts: new Date().toISOString(),
+      session_id: msg.session_id,
+      subtype: msg.subtype,
+      num_turns: msg.num_turns,
+      duration_ms: msg.duration_ms,
+      duration_api_ms: msg.duration_api_ms,
+      total_cost_usd: msg.total_cost_usd,
+      input_tokens: msg.usage.inputTokens,
+      output_tokens: msg.usage.outputTokens,
+      cache_read_input_tokens: msg.usage.cacheReadInputTokens,
+      cache_creation_input_tokens: msg.usage.cacheCreationInputTokens,
+      model_usage: msg.modelUsage,
+    };
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(logPath, JSON.stringify(entry) + '\n');
+  } catch (err) {
+    log(
+      `usage-log failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /**
@@ -742,6 +775,7 @@ async function runQuery(
       log(
         `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
       );
+      logUsage(message as SDKResultMessage);
       writeOutput({
         status: 'success',
         result: textResult || null,


### PR DESCRIPTION
## Summary

Pure instrumentation — adds two JSONL logs that produce the data needed to evaluate token-efficiency changes. **No LLM-facing behavior changes.** Merge this first; use the data to measure the effect of #199 (projectHint → systemPrompt.append) after that PR merges.

**Commit 1 — `feat(agent-runner): log tool-result sizes for Headroom Phase A`**
PostToolUse hook appends `{tool, bytes, approx_tokens}` per tool call to `/workspace/group/logs/tool-sizes.jsonl`. Feeds the Headroom POC Phase A decision (`docs/HEADROOM_POC.md`) — we need real data on whether tool outputs dominate the input-token budget before investing in a compression proxy. Opt-out: `DEUS_TOOL_SIZE_LOG=0`.

**Commit 2 — `feat(agent-runner): log SDK usage metadata per turn`**
Appends per-turn token usage from the SDK result message to `/workspace/group/logs/usage.jsonl`. Captures `inputTokens`, `outputTokens`, `cacheReadInputTokens`, `cacheCreationInputTokens`, `total_cost_usd`, `num_turns`, `duration_ms`. This is the direct billing signal — `evolution.db` only stores a host-side estimate of the user prompt, not what Anthropic actually charges. Opt-out: `DEUS_USAGE_LOG=0`.

## Why this PR exists separately

#199 moves the project hint from the per-turn user prompt to `systemPrompt.append`. To measure its real token impact, we need ground-truth billing data from before and after. Merging this PR first, waiting ~3-5 days of real traffic to establish a baseline, and only then merging #199 gives us a clean before/after delta on the same user's workload.

## Test plan

- [ ] Host `tsc` clean
- [ ] Agent-runner `tsc` clean
- [ ] Host `vitest` — no new failures
- [ ] After deploy: send 1-2 messages through a channel; verify `usage.jsonl` and `tool-sizes.jsonl` appear in the group's `logs/` dir with sensible entries
- [ ] Let logs accrue for ~3-5 days → analyze → merge #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
