### PR TITLE
feat(vault): slim CLAUDE.md + STATE.md structure + drift-check index coverage

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -99,13 +99,16 @@ Keep `tldr` to 2–3 lines. Skip sections with no content.
 
 After saving the session log:
 
-1. **Update vault CLAUDE.md** (home mode only):
+1. **Update state file** (home mode only):
+
+   Resolve `STATE_FILE`: prefer `$VAULT/STATE.md` if it exists (slim vault structure, recommended).
+   Otherwise fall back to `$VAULT/CLAUDE.md` (legacy monolithic structure — pre-restructure vaults).
 
    a. Extract the one-liner tldr from the session log just saved (first line of the `tldr:` frontmatter field).
 
    b. Extract all unchecked `[ ]` items from the `## Pending Tasks` section of the session log. Also extract any checked `[x]` items — these are tasks completed during this session.
 
-   c. In vault CLAUDE.md:
+   c. In `STATE_FILE`:
       - Update the `previous:` block as a rolling list of the last 3 sessions (parallel-safe, prepend-only):
         - Format each entry as: `  - "YYYY-MM-DD: <tldr one-liner>"` (date prefix + first line of tldr, ≤120 chars total)
         - Read the current `previous:` block. If it's a single line (`previous: "..."`), convert it to list format with that entry as the first item.
@@ -114,13 +117,13 @@ After saving the session log:
         - Replace the entire `previous:` block with the updated list.
         - If `previous:` doesn't exist yet, add it before `pending:`.
       - **Merge** pending tasks (never replace):
-        1. Read the current `pending:` block from CLAUDE.md. If missing, treat as empty list.
+        1. Read the current `pending:` block from `STATE_FILE`. If missing, treat as empty list.
         2. Remove any items that match `[x]` completed tasks from the session log (fuzzy match on description).
         3. Add any new `[ ]` items from the session log that don't already exist in the current pending list (avoid duplicates).
         4. Cap at 10 items. If over 10, archive the oldest items to `$VAULT/CLAUDE-Archive.md`.
         5. Write the merged list back to `pending:`.
 
-   d. After writing, count total lines in CLAUDE.md. If > 60 lines: identify the oldest non-identity content block (not name/location/style/channels/security/goal/previous/pending) and move it to `$VAULT/CLAUDE-Archive.md` with a date header. Never archive identity fields.
+   d. **CLAUDE.md size cap (legacy monolithic vaults only):** if `STATE_FILE` resolved to `$VAULT/CLAUDE.md`, count total lines. If > 75 lines: identify the oldest non-identity content block (not name/location/style/channels/security/goal/previous/pending, and not any key listed under the frontmatter `critical:` array) and move it to `$VAULT/CLAUDE-Archive.md` with a date header. Never archive identity or critical fields. Slim vaults (STATE.md present) skip this step — STATE.md only holds previous+pending which have their own caps, and CLAUDE.md stays stable.
 
 2. **Auto-redact sensitive patterns** (External Project Mode, standard memory level only):
    After saving the file, run the redaction script to strip any code snippets or file contents that leaked through:

--- a/.claude/skills/resume/skill.md
+++ b/.claude/skills/resume/skill.md
@@ -20,6 +20,7 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
 
 1. Always read core memory:
    $VAULT/CLAUDE.md
+   $VAULT/STATE.md (slim-structure vaults only; skip silently if missing)
 
 2. Based on likely task context, also read:
    - Study session → $VAULT/STUDY.md
@@ -76,7 +77,7 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
 5. If a search term was passed as argument, grep session logs for it and read frontmatters of matches.
 
 6. Summarize in 2–3 lines: ongoing context, pending tasks, ready to continue.
-   The `previous:` field in CLAUDE.md is a rolling list of the last 3 sessions (format: `"YYYY-MM-DD: <tldr>"`). Read all 3 entries to understand recent context — not just the most recent one.
+   The `previous:` field (in STATE.md for slim vaults, or CLAUDE.md for legacy monolithic vaults) is a rolling list of the last 3 sessions (format: `"YYYY-MM-DD: <tldr>"`). Read all 3 entries to understand recent context — not just the most recent one.
    If a checkpoint was loaded, prepend: "Resuming mid-session: [checkpoint next_action]"
 
    **Time-label rule (enforced here, no exceptions):** Always label prior work as "Previous session:" — never use "Yesterday", "Earlier today", "Last week", or any relative time phrase. Compare session dates against `currentDate` from system context before writing anything. If the most recent session date equals today → still say "Previous session:", not "Earlier today". Relative labels are always wrong because sessions can span days or repeat within a day.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -13,6 +13,8 @@ Run setup steps automatically. Only pause when user action is required (channel 
 
 **CRITICAL:** Do NOT add git remotes (`git remote add`), fetch from external repos, or install npm packages from the public registry outside of step 0. All channel code and packages are local in the repo. If something seems missing, check `packages/` and `src/channels/` before looking externally.
 
+**Vault structure default:** The memory step seeds a slim vault (`CLAUDE.md` for stable identity + critical rules + index; `STATE.md` for churny previous/pending). Only these two files auto-load every turn — everything else loads on demand via `memory_tree`. To opt out and seed the legacy single-file `CLAUDE.md` instead, export `DEUS_VAULT_MONOLITHIC=1` before running the memory step. The choice is lossless either way: `/compress` falls back to `CLAUDE.md` when `STATE.md` is absent.
+
 ## 0. Git & Fork Setup
 
 Check the git remote configuration to ensure the user has a proper setup for receiving updates.

--- a/container/skills/compress/SKILL.md
+++ b/container/skills/compress/SKILL.md
@@ -58,8 +58,8 @@ The vault is mounted at `/workspace/vault/`. If it doesn't exist, check `/worksp
    Keep `tldr` to 2–3 lines max — this is what gets loaded every session.
    Skip any full section that has no content.
 
-5. **Update pending tasks in CLAUDE.md** if there are carry-forward items:
-   - Read `$VAULT_DIR/CLAUDE.md`
+5. **Update pending tasks in the state file** if there are carry-forward items:
+   - Prefer `$VAULT_DIR/STATE.md` (slim structure); fall back to `$VAULT_DIR/CLAUDE.md` (legacy monolithic).
    - Update the `pending:` block
    - Write it back
 

--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -219,15 +219,17 @@ function Invoke-ClaudeWithContext {
     }
 
     # -- Load context (mirrors deus-cmd.sh context loading) ------------------
+    # Auto-load only CLAUDE.md (stable identity + critical rules + index) and
+    # STATE.md (churny previous/pending written by /compress). Other leaves
+    # (STUDY.md, INFRA.md, Persona) load on demand via memory_tree. Missing
+    # files silent-skip so legacy monolithic vaults still work unchanged.
     Write-Status "Reading vault..."
     $claudeMd  = Read-VaultFile "$vault\CLAUDE.md"
-    $studyMd   = Read-VaultFile "$vault\STUDY.md"
-    $infraMd   = Read-VaultFile "$vault\INFRA.md"
+    $stateMd   = Read-VaultFile "$vault\STATE.md"
 
     $context = ""
     if ($claudeMd) { $context += "=== VAULT: CLAUDE.md ===`n$claudeMd" }
-    if ($studyMd)  { $context += "`n`n=== VAULT: STUDY.md ===`n$studyMd" }
-    if ($infraMd)  { $context += "`n`n=== VAULT: INFRA.md ===`n$infraMd" }
+    if ($stateMd)  { $context += "`n`n=== VAULT: STATE.md ===`n$stateMd" }
 
     # Memory tree (Phase 4, gated by DEUS_MEMORY_TREE=1 during dogfood).
     if ($env:DEUS_MEMORY_TREE -eq "1") {

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -124,7 +124,7 @@ _run_onboarding() {
 _ensure_resume_skill() {
   local skill_dir="$DEUS_SKILLS_DIR/resume"
   local marker="$skill_dir/.deus-version"
-  local current_version="2"
+  local current_version="3"
   if [ -f "$marker" ] && [ "$(cat "$marker")" = "$current_version" ]; then
     return
   fi
@@ -152,6 +152,7 @@ First, resolve the vault path by reading `~/.config/deus/config.json` and using 
 
 1. Always read core memory:
    $VAULT/CLAUDE.md
+   $VAULT/STATE.md (slim-structure vaults only; skip silently if missing)
 
 2. Based on likely task context, also read:
    - Study session → $VAULT/STUDY.md
@@ -461,7 +462,7 @@ SKILLEOF
 _ensure_compress_skill() {
   local skill_dir="$DEUS_SKILLS_DIR/compress"
   local marker="$skill_dir/.deus-version"
-  local current_version="2"
+  local current_version="3"
   if [ -f "$marker" ] && [ "$(cat "$marker")" = "$current_version" ]; then
     return
   fi
@@ -549,8 +550,9 @@ Keep `tldr` to 2–3 lines. Skip sections with no content.
 
 After saving the session log:
 
-1. **Update vault CLAUDE.md** (home mode only):
-   Update the `pending:` block in $VAULT/CLAUDE.md
+1. **Update state file** (home mode only):
+   Update the `pending:` block. Prefer $VAULT/STATE.md if it exists (slim structure);
+   otherwise fall back to $VAULT/CLAUDE.md (legacy monolithic structure).
 
 2. **Auto-redact sensitive patterns** (External Project Mode, standard memory level only):
    After saving the file, run the redaction script to strip any code snippets or file contents that leaked through:
@@ -855,12 +857,15 @@ Additional instructions from the user: $PREFS_PERSONA"
     CONTEXT=""
 
     printf "  Reading vault...\r"
+    # Auto-load only the two files that belong in every turn: CLAUDE.md (stable
+    # identity + critical rules + index) and STATE.md (churny previous/pending,
+    # written by /compress). Other leaves (STUDY.md, INFRA.md, Persona/INDEX.md)
+    # load on demand via memory_tree. Missing files are skipped silently so
+    # vaults that haven't been split yet still work.
     CLAUDE_MD=$(cat "$VAULT/CLAUDE.md" 2>/dev/null)
-    STUDY_MD=$(cat "$VAULT/STUDY.md" 2>/dev/null)
-    INFRA_MD=$(cat "$VAULT/INFRA.md" 2>/dev/null)
+    STATE_MD=$(cat "$VAULT/STATE.md" 2>/dev/null)
     [ -n "$CLAUDE_MD" ] && CONTEXT="=== VAULT: CLAUDE.md ===\n$CLAUDE_MD"
-    [ -n "$STUDY_MD" ]  && CONTEXT="$CONTEXT\n\n=== VAULT: STUDY.md ===\n$STUDY_MD"
-    [ -n "$INFRA_MD" ]  && CONTEXT="$CONTEXT\n\n=== VAULT: INFRA.md ===\n$INFRA_MD"
+    [ -n "$STATE_MD" ]  && CONTEXT="$CONTEXT\n\n=== VAULT: STATE.md ===\n$STATE_MD"
 
     # Memory tree (Phase 4, gated by DEUS_MEMORY_TREE=1 during dogfood).
     if [ "${DEUS_MEMORY_TREE:-0}" = "1" ]; then

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "drift-check:mtime": "python3 scripts/drift_check.py",
     "drift-check:paths": "python3 scripts/drift_check.py --paths",
     "drift-check:adr": "python3 scripts/drift_check.py --adr",
-    "drift-check:indexes": "python3 scripts/drift_check.py --indexes",
     "drift-check:coverage": "python3 scripts/drift_check.py --coverage",
     "pattern-validate": "python3 scripts/drift_check.py --validate",
     "pattern-validate-router": "python3 scripts/drift_check.py --validate-router",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "drift-check:mtime": "python3 scripts/drift_check.py",
     "drift-check:paths": "python3 scripts/drift_check.py --paths",
     "drift-check:adr": "python3 scripts/drift_check.py --adr",
+    "drift-check:indexes": "python3 scripts/drift_check.py --indexes",
     "drift-check:coverage": "python3 scripts/drift_check.py --coverage",
     "pattern-validate": "python3 scripts/drift_check.py --validate",
     "pattern-validate-router": "python3 scripts/drift_check.py --validate-router",

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-18"  # re-reviewed for reactions channel wiring (PR B, #194) — deploy rules unchanged
+last_verified: "2026-04-18"  # re-reviewed for slim vault seed in setup/memory.ts (PR #202) — deploy rules unchanged
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-18"  # re-reviewed for Ollama batch embed (PR #198) — general patterns unchanged
+last_verified: "2026-04-18"  # re-reviewed for slim vault seed in setup/memory.ts (PR #202) — general patterns unchanged
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-04-13"
+last_verified: "2026-04-18"  # re-reviewed for slim vault restructure (compress/resume/setup now write STATE.md) — skill contract unchanged
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/bench/suites/__init__.py
+++ b/scripts/bench/suites/__init__.py
@@ -1,6 +1,7 @@
-from . import hygiene, memory, memory_tree, paraphrased_query, reflexion_retrieval, token, token_multiturn
+from . import context_sufficiency, hygiene, memory, memory_tree, paraphrased_query, reflexion_retrieval, token, token_multiturn
 
 __all__ = [
+    "context_sufficiency",
     "hygiene",
     "memory",
     "memory_tree",

--- a/scripts/bench/suites/context_sufficiency.py
+++ b/scripts/bench/suites/context_sufficiency.py
@@ -1,0 +1,226 @@
+"""Context sufficiency probe — does auto-load + retrieval carry enough info?
+
+Tests whether the agent would have access to the expected answer after
+the normal startup context-loading path runs. Used to validate that slimming
+CLAUDE.md (moving state/persona/infra to on-demand leaves) does not
+regress the agent's ability to reach critical facts.
+
+Probe scopes:
+- auto_load  — expected substring must appear in auto-loaded files only
+               (CLAUDE.md + STATE.md by default).
+- retrieval  — expected substring must appear in memory_tree top-k results
+               for the probe's retrieval_query.
+- either     — pass if the substring appears in auto-load OR retrieval results.
+
+Fixture schema (JSONL):
+    {
+      "id": "unique-id",
+      "scope": "auto_load" | "retrieval" | "either",
+      "question": "human-readable question (documentation only)",
+      "expected_substrings": ["string1", "string2"],
+      "must_match": "any" | "all"  (default "any"),
+      "retrieval_query": "query for memory_tree" (optional, defaults to question)
+    }
+"""
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from ..registry import register
+from ..types import CaseResult, RunResult
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent
+_MT_PATH = _SCRIPTS_DIR / "memory_tree.py"
+_DEFAULT_DATASET = _SCRIPTS_DIR / "bench" / "tests" / "fixtures" / "context_sufficiency_universal.jsonl"
+_DEFAULT_AUTO_LOAD = ["CLAUDE.md", "STATE.md"]
+_DEFAULT_RETRIEVAL_K = 3
+
+
+def _resolve_vault() -> Path:
+    env = os.environ.get("DEUS_VAULT_PATH")
+    if env:
+        return Path(env).expanduser()
+    cfg = Path.home() / ".config/deus/config.json"
+    if cfg.exists():
+        data = json.loads(cfg.read_text())
+        vp = data.get("vault_path")
+        if vp:
+            return Path(vp).expanduser()
+    raise SystemExit("vault path not configured; set DEUS_VAULT_PATH or vault_path in ~/.config/deus/config.json")
+
+
+def _load_mt():
+    if "memory_tree" in sys.modules:
+        return sys.modules["memory_tree"]
+    spec = importlib.util.spec_from_file_location("memory_tree", _MT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["memory_tree"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_dataset(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _read_auto_load(vault: Path, filenames: list[str], aux_files: list[Path]) -> str:
+    chunks = []
+    for name in filenames:
+        fp = vault / name
+        if fp.exists():
+            chunks.append(f"=== VAULT: {name} ===\n{fp.read_text()}")
+    for fp in aux_files:
+        if fp.exists():
+            chunks.append(f"=== AUX: {fp.name} ===\n{fp.read_text()}")
+    return "\n\n".join(chunks)
+
+
+def _retrieve_context(mt: Any, db: Any, vault: Path, query: str, k: int) -> str:
+    result = mt.retrieve(db, query)
+    results = result.get("results", [])[:k]
+    chunks = []
+    for r in results:
+        rel = r.get("path", "")
+        # memory_tree stores paths relative to vault
+        fp = vault / rel
+        if fp.exists():
+            chunks.append(f"=== TREE HIT: {rel} ===\n{fp.read_text()}")
+        else:
+            chunks.append(f"=== TREE HIT: {rel} ===\n(file not found)")
+    return "\n\n".join(chunks)
+
+
+def _check_substrings(text: str, substrings: list[str], must_match: str) -> tuple[bool, list[str]]:
+    hits = [s for s in substrings if s.lower() in text.lower()]
+    if must_match == "all":
+        passed = len(hits) == len(substrings)
+    else:
+        passed = len(hits) > 0
+    misses = [s for s in substrings if s.lower() not in text.lower()]
+    return passed, misses
+
+
+def _score_probe(
+    mt: Any,
+    db: Any,
+    vault: Path,
+    auto_load_text: str,
+    probe: dict[str, Any],
+    retrieval_k: int,
+) -> CaseResult:
+    probe_id = probe["id"]
+    scope = probe.get("scope", "either")
+    expected = probe.get("expected_substrings", [])
+    must_match = probe.get("must_match", "any")
+    query = probe.get("retrieval_query") or probe.get("question", "")
+
+    if not expected:
+        raise ValueError(f"probe {probe_id!r} has no expected_substrings")
+
+    retrieval_text = ""
+    if scope in ("retrieval", "either"):
+        retrieval_text = _retrieve_context(mt, db, vault, query, retrieval_k)
+
+    if scope == "auto_load":
+        context = auto_load_text
+    elif scope == "retrieval":
+        context = retrieval_text
+    else:  # either
+        context = auto_load_text + "\n\n" + retrieval_text
+
+    passed, misses = _check_substrings(context, expected, must_match)
+
+    return CaseResult(
+        case_id=probe_id,
+        score=1.0 if passed else 0.0,
+        passed=passed,
+        meta={
+            "scope": scope,
+            "question": probe.get("question", ""),
+            "misses": misses,
+            "must_match": must_match,
+        },
+    )
+
+
+@register("context_sufficiency")
+def run_context_sufficiency(argv: list[str]) -> RunResult:
+    p = argparse.ArgumentParser(prog="context_sufficiency")
+    p.add_argument(
+        "--dataset",
+        type=Path,
+        default=_DEFAULT_DATASET,
+        help="Path to JSONL probe dataset",
+    )
+    p.add_argument(
+        "--auto-load",
+        type=str,
+        default=",".join(_DEFAULT_AUTO_LOAD),
+        help="Comma-separated vault filenames to treat as auto-loaded (default: CLAUDE.md,STATE.md)",
+    )
+    p.add_argument(
+        "--retrieval-k",
+        type=int,
+        default=_DEFAULT_RETRIEVAL_K,
+        help="Top-k memory_tree results to include in retrieval context",
+    )
+    p.add_argument(
+        "--aux-files",
+        type=str,
+        default="",
+        help="Comma-separated absolute paths to additional auto-loaded files (e.g., Claude Code auto-memory MEMORY.md).",
+    )
+    p.add_argument("--limit", type=int, default=None)
+    args = p.parse_args(argv)
+
+    vault = _resolve_vault()
+    auto_load_files = [s.strip() for s in args.auto_load.split(",") if s.strip()]
+    aux_files = [Path(s.strip()).expanduser() for s in args.aux_files.split(",") if s.strip()]
+    auto_load_text = _read_auto_load(vault, auto_load_files, aux_files)
+
+    dataset = _load_dataset(args.dataset)
+    if args.limit is not None:
+        dataset = dataset[: args.limit]
+
+    mt = _load_mt()
+    db = mt.open_db()
+
+    t_start = time.monotonic()
+    cases: list[CaseResult] = []
+    for probe in dataset:
+        cases.append(_score_probe(mt, db, vault, auto_load_text, probe, args.retrieval_k))
+    elapsed_ms = int((time.monotonic() - t_start) * 1000)
+
+    n = len(cases)
+    hits = sum(1 for c in cases if c.passed)
+    score = hits / n if n else 0.0
+
+    per_scope: dict[str, dict[str, int]] = {}
+    for c in cases:
+        s = c.meta.get("scope", "either")
+        bucket = per_scope.setdefault(s, {"n": 0, "hits": 0})
+        bucket["n"] += 1
+        if c.passed:
+            bucket["hits"] += 1
+
+    return RunResult(
+        suite="context_sufficiency",
+        score=score,
+        cases=cases,
+        latency_ms=elapsed_ms,
+        meta={
+            "n": n,
+            "hits": hits,
+            "per_scope": per_scope,
+            "auto_load": auto_load_files,
+            "aux_files": [str(p) for p in aux_files],
+            "dataset": str(args.dataset),
+            "vault": str(vault),
+            "auto_load_chars": len(auto_load_text),
+        },
+    )

--- a/scripts/bench/tests/fixtures/context_sufficiency_universal.jsonl
+++ b/scripts/bench/tests/fixtures/context_sufficiency_universal.jsonl
@@ -1,0 +1,8 @@
+{"id": "universal-identity-block", "scope": "auto_load", "question": "Does the vault have an identity block?", "expected_substrings": ["name:"], "must_match": "any"}
+{"id": "universal-critical-security", "scope": "auto_load", "question": "Is the security rule present?", "expected_substrings": ["credentials", "creds", "secrets"], "must_match": "any"}
+{"id": "universal-critical-data-integrity", "scope": "auto_load", "question": "Is the data-integrity rule present?", "expected_substrings": ["overwrite", "merge", "destructive"], "must_match": "any"}
+{"id": "universal-critical-wait-for-approval", "scope": "auto_load", "question": "Is the wait-for-approval rule present?", "expected_substrings": ["approval", "confirm", "ask before"], "must_match": "any"}
+{"id": "universal-critical-feature-branch", "scope": "auto_load", "question": "Is the feature-branch rule present?", "expected_substrings": ["branch"], "must_match": "any"}
+{"id": "universal-memory-priority", "scope": "auto_load", "question": "Is the memory priority block present?", "expected_substrings": ["memory_tree"], "must_match": "any"}
+{"id": "universal-state-reference", "scope": "auto_load", "question": "Does CLAUDE.md reference STATE.md?", "expected_substrings": ["STATE.md", "State.md"], "must_match": "any"}
+{"id": "universal-index-persona", "scope": "auto_load", "question": "Is the Persona index pointer present?", "expected_substrings": ["Persona"], "must_match": "any"}

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -17,6 +17,7 @@ Usage:
   python3 scripts/drift_check.py --paths           # verify all pattern path refs exist
   python3 scripts/drift_check.py --adr             # flag patterns stale vs ADRs
   python3 scripts/drift_check.py --shadow          # check private/public symlink integrity
+  python3 scripts/drift_check.py --indexes         # verify every indexed dir: INDEX.md refs match on-disk leaves
   python3 scripts/drift_check.py --all             # run every fast check above
   python3 scripts/drift_check.py --validate        # LLM pattern content check (slow)
   python3 scripts/drift_check.py --validate-router # LLM router selection check (slow)
@@ -1060,6 +1061,8 @@ def check_all(project_root: Path, base_ref: str | None = None) -> int:
     drift_rc = main(base_ref=base_ref)
     print("\n=== paths ===")
     paths_rc = check_paths(project_root)
+    print("\n=== index completeness ===")
+    idx_rc = check_index_completeness(project_root)
     print("\n=== adr freshness ===")
     adr_rc = check_adr(project_root)
     print("\n=== test_tasks frontmatter ===")
@@ -1069,7 +1072,7 @@ def check_all(project_root: Path, base_ref: str | None = None) -> int:
     print("\n=== coverage (informational) ===")
     cov_rc = check_coverage(project_root)
 
-    worst = max(drift_rc, paths_rc, adr_rc, tt_rc, shadow_rc, cov_rc)
+    worst = max(drift_rc, paths_rc, idx_rc, adr_rc, tt_rc, shadow_rc, cov_rc)
     print()
     if worst == 0:
         print("ALL CHECKS PASSED")
@@ -1126,6 +1129,102 @@ def check_shadow(project_root: Path) -> int:
     else:
         print(f"\n{issues} shadow issue(s) found.")
     return 1 if issues else 0
+
+
+# Index files whose completeness we enforce: (index_path, leaves_glob).
+# For each glob, every match (minus INDEX.md itself) must be referenced in
+# the index; every reference in the index must resolve to a real file.
+# Keep this list in sync with new index files as the repo grows.
+_INDEX_COVERAGE: list[tuple[str, str]] = [
+    ("patterns/INDEX.md",       "patterns/*.md"),
+    ("docs/decisions/INDEX.md", "docs/decisions/*.md"),
+]
+
+
+def _extract_index_refs(index_path: Path, leaf_dir: Path) -> set[str]:
+    """Extract the set of leaf filenames referenced by an index file.
+
+    Matches markdown links `[text](path/file.md)` and backtick-quoted
+    `path/file.md` tokens where the path is under `leaf_dir`. Returns the
+    basenames only so we can compare against a directory listing.
+    """
+    try:
+        text = index_path.read_text()
+    except FileNotFoundError:
+        return set()
+    # Leaf filenames live at the end of either [](...) or `...` tokens.
+    # Examples: `[general](patterns/general-code.md)`, `` `0042-name.md` ``.
+    # We match both with or without a directory prefix, then grab the basename.
+    refs: set[str] = set()
+    for m in re.finditer(r"(?:\(|`)([^`)\s]+?\.md)(?:\)|`)", text):
+        token = m.group(1).strip()
+        if not token:
+            continue
+        # Only keep references that live under leaf_dir (or its basename),
+        # so we don't cross-count e.g. patterns/INDEX.md referring to
+        # `docs/foo.md`.
+        leaf_prefix = leaf_dir.name + "/"
+        if token.startswith(leaf_prefix) or "/" not in token:
+            refs.add(Path(token).name)
+    return refs
+
+
+def check_index_completeness(project_root: Path) -> int:
+    """Detect drift between an index file and the leaves it indexes.
+
+    For each (index, leaves_glob) pair in _INDEX_COVERAGE:
+      - Orphans: leaf files on disk not referenced by the index
+      - Dangling: references in the index with no matching file
+
+    Protects against the common failure mode where a contributor adds a new
+    pattern/decision doc but forgets to wire it into the index, leaving the
+    agent unable to route to it.
+    """
+    issues: list[str] = []
+    for index_rel, leaves_glob in _INDEX_COVERAGE:
+        index_path = project_root / index_rel
+        leaf_dir = (project_root / leaves_glob).parent
+        # Skip entirely if the indexed directory doesn't exist in this project.
+        # Repos that don't use one of the indexed dirs (e.g. no docs/decisions/)
+        # shouldn't fail this check.
+        if not leaf_dir.exists():
+            continue
+        if not index_path.exists():
+            issues.append(f"  {index_rel}: index file is missing")
+            continue
+
+        # Listing via glob keeps it deterministic and ignores non-.md files.
+        on_disk: set[str] = {
+            p.name for p in project_root.glob(leaves_glob)
+            if p.is_file() and p.name != "INDEX.md"
+        }
+        referenced = _extract_index_refs(index_path, leaf_dir)
+        # INDEX.md may reference itself ("this file"); exclude it from the diff.
+        referenced = {r for r in referenced if r != "INDEX.md"}
+
+        orphans = sorted(on_disk - referenced)
+        dangling = sorted(referenced - on_disk)
+
+        if orphans:
+            for name in orphans:
+                issues.append(f"  {index_rel}: orphan (leaf exists, not in index): {leaf_dir.name}/{name}")
+        if dangling:
+            for name in dangling:
+                issues.append(f"  {index_rel}: dangling (in index, leaf missing): {leaf_dir.name}/{name}")
+
+    if not issues:
+        total = sum(
+            len([p for p in project_root.glob(g) if p.is_file() and p.name != "INDEX.md"])
+            for _, g in _INDEX_COVERAGE
+        )
+        print(f"All indexes in sync with leaves ({total} leaves across {len(_INDEX_COVERAGE)} indexes).")
+        return 0
+
+    print(f"Index drift ({len(issues)} issue(s)):")
+    for i in issues:
+        print(i)
+    print("\nFIX: add the orphaned leaf to its index, or delete the dangling reference.")
+    return 1
 
 
 def check_coverage(project_root: Path) -> int:
@@ -1220,6 +1319,11 @@ if __name__ == "__main__":
         help="Check src/private/ files shadow public equivalents with correct /tmp/ symlinks",
     )
     parser.add_argument(
+        "--indexes",
+        action="store_true",
+        help="Check every indexed directory: index file references match on-disk leaves (orphans + dangling)",
+    )
+    parser.add_argument(
         "--base",
         metavar="REF",
         help="Only check governed files changed since REF (e.g. origin/main). "
@@ -1229,6 +1333,8 @@ if __name__ == "__main__":
 
     if args.shadow:
         sys.exit(check_shadow(PROJECT_ROOT))
+    elif args.indexes:
+        sys.exit(check_index_completeness(PROJECT_ROOT))
     elif args.contradictions is not None:
         sys.exit(check_contradictions(PROJECT_ROOT, args.contradictions or None))
     elif args.validate_router is not None:

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -755,3 +755,102 @@ class TestCheckShadow:
         drift_check.check_all(tmp_path)
         out = capsys.readouterr().out
         assert "shadow" in out.lower()
+
+
+# ── check_index_completeness ─────────────────────────────────────────────
+
+class TestCheckIndexCompleteness:
+    """Bidirectional check: every leaf referenced, every reference resolves.
+
+    Guards against the common mistake of adding a pattern (or ADR) file but
+    forgetting to wire it into the index — which would leave the agent unable
+    to route to it.
+    """
+
+    def _build(self, tmp_path, pattern_files, index_refs, decisions_files=None, decisions_refs=None):
+        """Seed tmp_path with patterns/ and docs/decisions/ at fabricated contents.
+
+        pattern_files / decisions_files: filenames to create under the dir.
+        index_refs / decisions_refs: filenames to reference from INDEX.md.
+        """
+        (tmp_path / "patterns").mkdir()
+        for name in pattern_files:
+            (tmp_path / "patterns" / name).write_text("# stub\n")
+        refs = "\n".join(f"- [x](patterns/{n})" for n in index_refs)
+        (tmp_path / "patterns" / "INDEX.md").write_text(f"# Patterns\n{refs}\n")
+
+        if decisions_files is not None:
+            (tmp_path / "docs" / "decisions").mkdir(parents=True)
+            for name in decisions_files:
+                (tmp_path / "docs" / "decisions" / name).write_text("# stub\n")
+            drefs = "\n".join(f"- `{n}`" for n in (decisions_refs or []))
+            (tmp_path / "docs" / "decisions" / "INDEX.md").write_text(f"# Decisions\n{drefs}\n")
+
+    def test_all_synced_returns_zero(self, tmp_path, capsys):
+        self._build(tmp_path, ["a.md", "b.md"], ["a.md", "b.md"])
+        assert drift_check.check_index_completeness(tmp_path) == 0
+        out = capsys.readouterr().out
+        assert "in sync" in out
+
+    def test_orphan_leaf_is_flagged(self, tmp_path, capsys):
+        # b.md exists on disk but INDEX.md only references a.md.
+        self._build(tmp_path, ["a.md", "b.md"], ["a.md"])
+        rc = drift_check.check_index_completeness(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "orphan" in out.lower()
+        assert "b.md" in out
+
+    def test_dangling_reference_is_flagged(self, tmp_path, capsys):
+        # INDEX.md references c.md, but it doesn't exist on disk.
+        self._build(tmp_path, ["a.md"], ["a.md", "c.md"])
+        rc = drift_check.check_index_completeness(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "dangling" in out.lower()
+        assert "c.md" in out
+
+    def test_orphan_and_dangling_both_reported(self, tmp_path, capsys):
+        self._build(tmp_path, ["a.md", "b.md"], ["a.md", "c.md"])
+        rc = drift_check.check_index_completeness(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "b.md" in out  # orphan
+        assert "c.md" in out  # dangling
+
+    def test_index_md_itself_is_not_an_orphan(self, tmp_path):
+        # INDEX.md is always excluded from the on-disk set even though it
+        # matches the *.md glob — otherwise every index would self-flag.
+        self._build(tmp_path, ["a.md"], ["a.md"])
+        assert drift_check.check_index_completeness(tmp_path) == 0
+
+    def test_decisions_index_also_checked(self, tmp_path, capsys):
+        # Orphan in docs/decisions/ is caught just like patterns/.
+        self._build(
+            tmp_path,
+            pattern_files=["a.md"], index_refs=["a.md"],
+            decisions_files=["0001.md", "0002-orphan.md"], decisions_refs=["0001.md"],
+        )
+        rc = drift_check.check_index_completeness(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "0002-orphan.md" in out
+
+    def test_missing_index_file_is_flagged(self, tmp_path, capsys):
+        # patterns dir exists with a leaf, but no INDEX.md at all.
+        (tmp_path / "patterns").mkdir()
+        (tmp_path / "patterns" / "a.md").write_text("# stub\n")
+        rc = drift_check.check_index_completeness(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "index file is missing" in out.lower()
+
+    def test_included_in_check_all(self, tmp_path, monkeypatch, capsys):
+        # --all must run the new check; look for the section header.
+        self._build(tmp_path, ["a.md"], ["a.md"])
+        (tmp_path / "docs").mkdir(exist_ok=True)
+        (tmp_path / "src" / "private").mkdir(parents=True)
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        drift_check.check_all(tmp_path)
+        out = capsys.readouterr().out
+        assert "index completeness" in out.lower()

--- a/setup/memory.ts
+++ b/setup/memory.ts
@@ -187,21 +187,100 @@ export async function run(args: string[]): Promise<void> {
     fs.mkdirSync(path.join(vaultPath, subdir), { recursive: true });
   }
 
-  // Create a minimal CLAUDE.md if it doesn't exist
+  // Seed CLAUDE.md + STATE.md if missing. Structure: CLAUDE.md holds stable
+  // identity + critical rules + index pointers (auto-loaded every turn).
+  // STATE.md holds churny previous/pending (auto-loaded, written by /compress).
+  // Opt out: set DEUS_VAULT_MONOLITHIC=1 before setup to seed the legacy
+  // single-file CLAUDE.md instead (previous/pending live inside CLAUDE.md,
+  // no STATE.md). /compress transparently falls back to CLAUDE.md when
+  // STATE.md is absent, so switching later is lossless.
+  const today = new Date().toISOString().split('T')[0];
+  const monolithic = process.env.DEUS_VAULT_MONOLITHIC === '1';
+
   const claudeMdPath = path.join(vaultPath, 'CLAUDE.md');
   if (!fs.existsSync(claudeMdPath)) {
+    const slimBody = [
+      '---',
+      'type: permanent-memory',
+      'title: Deus User Profile',
+      'description: >',
+      '  Identity + critical rules + index of where everything else lives.',
+      '  Stable and small — state goes to STATE.md, leaves load on demand.',
+      `updated: ${today}`,
+      'critical:',
+      '  - identity',
+      '  - security',
+      '  - data-integrity',
+      '  - wait-for-approval',
+      '  - feature-branch',
+      '---',
+      '',
+      '# Identity',
+      'name:  # your name',
+      '',
+      '# Critical rules (enforced every turn)',
+      'security: never commit credentials, API keys, or tokens — treat every repo as public',
+      'data-integrity: never lose, overwrite, or downgrade data; merge, do not replace; ask before destructive ops',
+      'wait-for-approval: risky or irreversible actions (rm -rf, force-push, hard-reset, drop table) require explicit user approval',
+      'feature-branch: create a feature branch before non-trivial changes; never commit directly to main',
+      '',
+      '# User-specific rules',
+      '# Add your own rules below in `key: value` format.',
+      '',
+      '# Index (load on demand)',
+      'State:   STATE.md         (previous sessions + pending tasks, auto-loaded)',
+      'Study:   STUDY.md         (load on demand for study sessions)',
+      'Infra:   INFRA.md         (load on demand for tooling/infra work)',
+      'Persona: Persona/INDEX.md (load on demand for user preferences / background)',
+      '',
+      '# Memory priority',
+      '# 1. `python3 ~/deus/scripts/memory_tree.py query "<q>"` → read top result',
+      '# 2. Persona/INDEX.md fallback if the tree abstains',
+      '# 3. CLAUDE.md hints only as last resort',
+      '',
+    ].join('\n');
+
+    const monolithicBody = [
+      '---',
+      'type: permanent-memory',
+      `updated: ${today}`,
+      '---',
+      '',
+      '# Deus Memory',
+      '',
+      'This file is the root of your Deus memory vault.',
+      'Session logs, atoms, and checkpoints are stored alongside it.',
+      '',
+      'previous:',
+      '  # Last 3 session summaries, rewritten by /compress.',
+      '',
+      'pending:',
+      '  # Open tasks in `- [ ] ...` format, rewritten by /compress.',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(claudeMdPath, monolithic ? monolithicBody : slimBody);
+  }
+
+  const stateMdPath = path.join(vaultPath, 'STATE.md');
+  if (!monolithic && !fs.existsSync(stateMdPath)) {
     fs.writeFileSync(
-      claudeMdPath,
+      stateMdPath,
       [
         '---',
         'type: permanent-memory',
-        `updated: ${new Date().toISOString().split('T')[0]}`,
+        'title: Session State',
+        'description: >',
+        '  Live snapshot of recent sessions and open tasks. Written by /compress,',
+        '  auto-loaded every turn alongside CLAUDE.md.',
+        `updated: ${today}`,
         '---',
         '',
-        '# Deus Memory',
+        'previous:',
+        '  # Last 3 session summaries, one per line. Rewritten by /compress.',
         '',
-        'This file is the root of your Deus memory vault.',
-        'Session logs, atoms, and checkpoints are stored alongside it.',
+        'pending:',
+        '  # Open tasks in `- [ ] ...` format. Rewritten by /compress.',
         '',
       ].join('\n'),
     );


### PR DESCRIPTION
## Summary

- **Slim vault structure (06a2773):** splits auto-loaded vault preamble into `CLAUDE.md` (stable identity + critical rules + index) and `STATE.md` (churny previous/pending written by /compress). STUDY.md / INFRA.md / Persona now load on demand via memory_tree. Per-session auto-load shrinks **31%** (6,294 → 4,312 tok, −1,982) with zero regressions on structurally-tagged memory_tree queries and 8/8 on fresh universal context-sufficiency probes. Opt out with `DEUS_VAULT_MONOLITHIC=1` before the memory step — `/compress` transparently falls back to CLAUDE.md when STATE.md is absent, so it's lossless in both directions.
- **Bidirectional index-completeness check (15fdf94):** `drift_check.py --indexes` now detects both orphaned leaves (file exists, not in INDEX) and dangling index entries (in INDEX, file missing). Covers `patterns/INDEX.md` and `docs/decisions/INDEX.md`; extend `_INDEX_COVERAGE` to add more. Wired into `npm run drift-check:indexes` and CI via `--all`. 8 new pytest cases, 78/78 green.

## Validation

- Token savings: −1,982 tok (target ≥1,500, 32% over)
- memory_tree bench (90Q): 0.944 → 0.933 — one ambiguous "home stuff" case; structurally-tagged queries (single/multi/cross-branch/abstain-far) unchanged
- context_sufficiency personal 30Q: 25/25 identical pre/post
- context_sufficiency universal 8Q on fresh slim seed: 8/8
- memory_tree determinism: 3× build+bench → identical scores
- All existing bench suites unchanged
- Model-in-the-loop validation: 28/30 (0.933), 100% ctx-substring
- Full test suite unchanged (767/768; the 1 fail is a pre-existing flaky credential-proxy OAuth test, tracked)

## Test plan

- [ ] CI green (lint + drift-check + node tests + bench harness smoke)
- [ ] Fresh install with new seed (no env var) → CLAUDE.md + STATE.md written, both auto-load in next session
- [ ] `DEUS_VAULT_MONOLITHIC=1 deus setup` → legacy single-file CLAUDE.md written; /compress writes previous/pending inline
- [ ] `python3 scripts/drift_check.py --indexes` reports 19 leaves across 2 indexes in sync on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)