### PR TITLE
test(token-bench): salvage real_claude_probe.sh + Ollama-judge unreliability details

### DIFF
--- a/docs/TOKEN_OPTIMIZATION.md
+++ b/docs/TOKEN_OPTIMIZATION.md
@@ -58,6 +58,10 @@ cycles. Runtime-only filter.
 - `preservation_bench.py` — alternative LLM-based fact check (Ollama gemma4).
   Kept for reference; proved unreliable on small template files, documented
   below.
+- `real_claude_probe.sh` — end-to-end behavior probe. Drops a CLAUDE.md into
+  an isolated temp cwd and runs `claude -p` with 5 fixed prompts (formatting,
+  bullets, internal-tag, voice-reminder, persona), emitting JSONL. Usable as
+  a before/after check when compressing any CLAUDE.md.
 - `aggregate_compression.py`, `fixtures.json` — supporting aggregator and
   fixtures.
 
@@ -99,6 +103,26 @@ returned non-deterministic empty responses even with `num_predict: 256` and
 `gemma4 quirk — or response is empty` pattern documented elsewhere in the
 codebase. Kept in the repo so future work can revisit with a different
 judge, but not used as a gate here.
+
+For a concrete read on how unreliable, the numbers per file (Ollama bench
+vs the deterministic keyword bench vs a manual audit of every keyword-bench
+MISS):
+
+| File              | Ollama bench | Keyword bench | Manual audit |
+|-------------------|-------------:|--------------:|-------------:|
+| root `CLAUDE.md`  |        42.9% |         92.9% |         100% |
+| global template   |        54.5% |         90.9% |         100% |
+| main template     |        84.2% |         89.5% |         100% |
+
+Typical failure mode: the bench flags a fact as missing (e.g. "agent
+must skip INDEX read on session start") when the compressed file contains
+the same directive in a paraphrased form one line down. Spot-checking a
+sample of "missing" facts against the compressed source confirmed every
+one was actually present. Conclusion: **gemma4:e4b is not a viable
+single-question fact-verification judge at this doc scale.** Use
+`keyword_bench.py` (deterministic — can false-negative on paraphrase but
+never false-positive) and manually verify the flagged misses, or use
+`real_claude_probe.sh` for a real-behavior read.
 
 ## What's on the table but blocked
 

--- a/scripts/token_bench/real_claude_probe.sh
+++ b/scripts/token_bench/real_claude_probe.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Real-Claude behavior probe for CLAUDE.md variants.
+#
+# Drops a target CLAUDE.md into an isolated temp cwd and runs `claude -p`
+# with 5 fixed probes covering formatting, bullets, internal-tag usage,
+# voice-reminder handling, and persona recall. Emits one JSON line per
+# probe to stdout so you can diff two runs.
+#
+# Uses `claude -p` which reuses the user's OAuth — no API key needed.
+#
+# Usage:
+#   real_claude_probe.sh <path/to/CLAUDE.md> [label]
+#
+# Example — compare baseline vs compressed:
+#   real_claude_probe.sh /tmp/CLAUDE.md.orig baseline > baseline.jsonl
+#   real_claude_probe.sh ./CLAUDE.md           after    > after.jsonl
+#   diff <(jq -S . baseline.jsonl) <(jq -S . after.jsonl)
+#
+# Requires: claude, jq.
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <path/to/CLAUDE.md> [label]" >&2
+  exit 64
+fi
+
+SRC="$1"
+LABEL="${2:-run}"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "error: $SRC not found" >&2
+  exit 66
+fi
+
+for dep in claude jq; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "error: $dep not on PATH" >&2
+    exit 69
+  fi
+done
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+cp "$SRC" "$TMPDIR/CLAUDE.md"
+
+run_probe() {
+  local id="$1"
+  local prompt="$2"
+  local resp
+  resp=$(cd "$TMPDIR" && claude -p "$prompt" --dangerously-skip-permissions 2>/dev/null || echo "ERROR")
+  jq -cn --arg probe "$id" --arg label "$LABEL" --arg resp "$resp" \
+    '{probe: $probe, label: $label, response: $resp}'
+}
+
+run_probe "fmt_bold"       "Say hello to me. Include the word important in bold. Just the hello line, nothing more."
+run_probe "fmt_no_heading" "Give me three bullet points about using a vault for long-term memory. No preamble."
+run_probe "internal_tag"   "Plan your response privately, then answer: what is 2+2? Keep everything minimal."
+run_probe "voice_reminder" "[Voice: remind me to call the doctor tomorrow at 2pm]"
+run_probe "persona_recall" "In one sentence, what do you know about me?"


### PR DESCRIPTION
## Summary

Salvages the two unmerged pieces from \`feat/token-optimization\` — the
core value of that branch already shipped via #179 + #180, but these two
items were left behind. Zero functional change; pure tooling + docs.

- **\`scripts/token_bench/real_claude_probe.sh\`** — generic real-Claude
  behavior probe. Takes a CLAUDE.md path as arg (no hardcoded user paths),
  drops it into an isolated temp cwd, runs \`claude -p\` with 5 fixed
  probes (formatting, bullets, internal-tag, voice-reminder, persona),
  emits JSONL. Usable as a before/after check when compressing any
  CLAUDE.md. Complements the deterministic \`keyword_bench.py\` with a
  real-behavior read.

- **\`docs/TOKEN_OPTIMIZATION.md\`** — extends the existing Ollama
  \`preservation_bench.py\` warning with concrete numbers (42.9 / 54.5 /
  84.2 % vs keyword bench 89.5–92.9 % vs manual 100 %) and the typical
  failure mode, so the next person doesn't retrace the dead end. Also
  documents \`real_claude_probe.sh\` in the harness list.

The original branch (\`feat/token-optimization\`) had these in a form
tangled with personal configs (hardcoded \`/Users/liam10play/...\` paths,
personal-config facts). This PR ships only the generic, user-agnostic
bits.

## Test plan

- [x] \`bash -n real_claude_probe.sh\` — syntax OK
- [x] No-arg + nonexistent-path error paths return usage/error with non-zero exit
- [x] Grep for personal paths/names in both files — clean
- [ ] Reviewer: skim the doc delta for tone/accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)