### PR TITLE
chore: gitignore .coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ scripts/rename-repo.sh
 # Python virtual env
 .venv/
 __pycache__/
+.coverage
 
 # Temp files
 .tmp-*


### PR DESCRIPTION
One-line hygiene fix. `coverage.py` drops `.coverage` into the working tree after bench runs; gitignore it alongside the other Python artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)