### PR TITLE
feat(token-bench): ci gate for CLAUDE.md keyword coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Pattern tests (Python)
         run: python3 -m pytest scripts/tests/test_drift_check.py -v
 
+      - name: CLAUDE.md keyword coverage
+        run: scripts/token_bench/ci_coverage_gate.sh origin/${{ github.base_ref }}
+
       - name: Install evolution test dependencies
         run: python3 -m pip install sqlite-vec==0.1.6
 

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -6,6 +6,7 @@
 |-----------|--------------|------------------------------------------------|
 | channel-add | `patterns/channel-add.md` | `docs/CONTRIBUTING-AI.md` §MCP Channel Servers, `docs/ENVIRONMENT.md` |
 | skill-add | `patterns/skill-add.md` | — |
+| claude-md-edit | `patterns/claude-md-edit.md` | `docs/TOKEN_OPTIMIZATION.md` (only if reshaping fact list) |
 | eval-change | `patterns/eval-change.md` | `docs/decisions/INDEX.md`, `docs/ENVIRONMENT.md` |
 | deployment | `patterns/deployment.md` | — |
 | debugging | `patterns/debugging.md` | `docs/DEBUG_CHECKLIST.md` |

--- a/patterns/INDEX.md
+++ b/patterns/INDEX.md
@@ -4,7 +4,7 @@
 |---|---|---|
 | `patterns/channel-add.md` | Adding or modifying MCP channel servers | `docs/CONTRIBUTING-AI.md` §MCP Channel Servers |
 | `patterns/skill-add.md` | Adding or modifying skills in `.claude/skills/` | `docs/CONTRIBUTING-AI.md` §Skill Contributions + §Source Code Changes |
-| `patterns/claude-md-edit.md` | Editing root `CLAUDE.md` or any `groups/*/CLAUDE.md.template` | `docs/TOKEN_OPTIMIZATION.md` |
+| `patterns/claude-md-edit.md` | Editing the root CLAUDE.md or any group CLAUDE.md.template | `docs/TOKEN_OPTIMIZATION.md` |
 | `patterns/eval-change.md` | Changes to `evolution/` or `eval/` | ADRs: eval-ipc-file-output, eval-no-disk-cache, eval-selective-warmup, evolution-db-split |
 | `patterns/deployment.md` | Service restart, dist/ rebuild, credentials | `docs/CONTRIBUTING-AI.md` §Deploy and Service Restart |
 | `patterns/debugging.md` | Diagnosing silent failures in the message pipeline | `docs/CONTRIBUTING-AI.md` §Debugging + §Message Pipeline Stages |

--- a/patterns/INDEX.md
+++ b/patterns/INDEX.md
@@ -4,6 +4,7 @@
 |---|---|---|
 | `patterns/channel-add.md` | Adding or modifying MCP channel servers | `docs/CONTRIBUTING-AI.md` §MCP Channel Servers |
 | `patterns/skill-add.md` | Adding or modifying skills in `.claude/skills/` | `docs/CONTRIBUTING-AI.md` §Skill Contributions + §Source Code Changes |
+| `patterns/claude-md-edit.md` | Editing root `CLAUDE.md` or any `groups/*/CLAUDE.md.template` | `docs/TOKEN_OPTIMIZATION.md` |
 | `patterns/eval-change.md` | Changes to `evolution/` or `eval/` | ADRs: eval-ipc-file-output, eval-no-disk-cache, eval-selective-warmup, evolution-db-split |
 | `patterns/deployment.md` | Service restart, dist/ rebuild, credentials | `docs/CONTRIBUTING-AI.md` §Deploy and Service Restart |
 | `patterns/debugging.md` | Diagnosing silent failures in the message pipeline | `docs/CONTRIBUTING-AI.md` §Debugging + §Message Pipeline Stages |

--- a/patterns/claude-md-edit.md
+++ b/patterns/claude-md-edit.md
@@ -1,0 +1,52 @@
+---
+governs:
+  - CLAUDE.md
+  - groups/global/CLAUDE.md.template
+  - groups/main/CLAUDE.md.template
+last_verified: "2026-04-19"
+test_tasks:
+  - "Compress the root CLAUDE.md to remove a redundant section"
+  - "Add a new rule to groups/main/CLAUDE.md.template"
+  - "Update the global container template to mention a new shared command"
+---
+# Pattern: claude-md-edit
+
+CLAUDE.md files (the project root + the two `groups/*/CLAUDE.md.template` container templates) auto-load on every session. Bytes here are the most expensive bytes in the repo — they cost tokens on every turn for every user. They are also the most fragile: removing or paraphrasing a rule can silently change agent behavior.
+
+This pattern protects against drift in both directions: bloat that wastes tokens, and slimming that drops a load-bearing rule.
+
+## Before editing
+
+- Each gated file has a curated facts file under `scripts/token_bench/facts/` listing the rules it must convey.
+  - `CLAUDE.md` ↔ `scripts/token_bench/facts/root_claudemd.txt`
+  - `groups/global/CLAUDE.md.template` ↔ `scripts/token_bench/facts/global_template.txt`
+  - `groups/main/CLAUDE.md.template` ↔ `scripts/token_bench/facts/main_template.txt`
+- Read the facts file first. If your edit *changes* what the file should convey (adds a new permanent rule, removes an obsolete one), update the facts file in the same PR.
+
+## When adding content
+
+- Prefer placing the rule in a more specific home — a pattern file, a skill's `SKILL.md`, or `docs/CONTRIBUTING-AI.md` — and link from CLAUDE.md only if it must apply to every session.
+- Three similar rules can stay as three lines; resist abstracting them into a meta-rule that's easier to misread.
+
+## When removing or paraphrasing content
+
+- Keep the **signal words** of each fact: proper nouns, paths, slash commands, MCP tool names, file extensions. The keyword bench matches on these.
+- After your edit, run the gate locally:
+
+  ```bash
+  scripts/token_bench/ci_coverage_gate.sh
+  ```
+
+  This runs `keyword_bench.py` on each gated file changed in your branch and fails if critical-fact coverage drops below 90%.
+- Audit every `MISS`. If the fact survives in paraphrase, add a `# kw=token1,token2` override to the facts file pointing at the new wording. If the fact was dropped intentionally, remove it from the facts file with a note in the PR description.
+
+## CI enforcement
+
+The `CLAUDE.md keyword coverage` step in `.github/workflows/ci.yml` runs the same gate on every PR that touches any gated file or its facts file. PRs below the 90% floor will fail.
+
+The gate is conservative — keyword matches can false-negative on heavy paraphrase. That's intentional: a `MISS` is a prompt to look at the diff, not an automatic verdict.
+
+## What this pattern does **not** cover
+
+- The live `groups/<channel>_main/CLAUDE.md` files (e.g. `groups/whatsapp_main/CLAUDE.md`). These contain user-specific persona/tool wiring and are not gated.
+- The semantic correctness of remaining rules. The keyword gate checks fact preservation; behavioral verification still requires `scripts/token_bench/real_claude_probe.sh` (manual, not CI).

--- a/scripts/token_bench/ci_coverage_gate.sh
+++ b/scripts/token_bench/ci_coverage_gate.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# CLAUDE.md keyword-coverage gate for CI.
+#
+# Runs keyword_bench.py against any user-agnostic CLAUDE.md whose facts file
+# also lives in this repo. Fails if critical-fact coverage drops below
+# THRESHOLD on any changed file.
+#
+# Skips files that aren't touched by the diff — fast no-op on unrelated PRs.
+#
+# Usage:
+#   scripts/token_bench/ci_coverage_gate.sh                      # diff vs origin/main
+#   scripts/token_bench/ci_coverage_gate.sh origin/feature-x     # custom base ref
+#   THRESHOLD=92 scripts/token_bench/ci_coverage_gate.sh         # custom floor
+#   FORCE_ALL=1  scripts/token_bench/ci_coverage_gate.sh         # gate every pair regardless of diff
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+THRESHOLD="${THRESHOLD:-90}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# File ↔ facts mapping. Add a row when a new user-agnostic CLAUDE.md grows
+# a curated facts file under scripts/token_bench/facts/.
+PAIRS=(
+  "CLAUDE.md|scripts/token_bench/facts/root_claudemd.txt"
+  "groups/global/CLAUDE.md.template|scripts/token_bench/facts/global_template.txt"
+  "groups/main/CLAUDE.md.template|scripts/token_bench/facts/main_template.txt"
+)
+
+if [[ "${FORCE_ALL:-0}" = "1" ]]; then
+  CHANGED=""  # treat every pair as changed
+else
+  if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    echo "Base ref '$BASE_REF' not found; fetching." >&2
+    git fetch origin "${BASE_REF#origin/}" --depth=1 >/dev/null 2>&1 || true
+  fi
+  CHANGED="$(git diff --name-only "$BASE_REF"...HEAD || true)"
+fi
+
+failed=0
+ran=0
+for pair in "${PAIRS[@]}"; do
+  doc="${pair%%|*}"
+  facts="${pair##*|}"
+
+  if [[ "${FORCE_ALL:-0}" != "1" ]]; then
+    if ! grep -qx -e "$doc" -e "$facts" <<<"$CHANGED"; then
+      continue
+    fi
+  fi
+
+  ran=$((ran + 1))
+  echo "::group::keyword_bench: $doc (threshold ${THRESHOLD}%)"
+  if ! python3 scripts/token_bench/keyword_bench.py \
+      --label "$(basename "$doc")" \
+      --compressed "$doc" \
+      --facts "$facts" \
+      --threshold "$THRESHOLD"; then
+    failed=$((failed + 1))
+  fi
+  echo "::endgroup::"
+done
+
+if [[ "$ran" -eq 0 ]]; then
+  echo "No gated CLAUDE.md or facts file in this diff — skipping."
+  exit 0
+fi
+
+if [[ "$failed" -gt 0 ]]; then
+  echo
+  echo "$failed file(s) below ${THRESHOLD}% critical coverage. Audit each MISS as paraphrase before merging."
+  echo "If the MISS is a real omission, restore the missing rule. If it's preserved in paraphrase, add a 'kw=' override to the facts file."
+  exit 1
+fi
+
+echo "All gated CLAUDE.md files preserve critical facts (≥ ${THRESHOLD}%)."

--- a/scripts/token_bench/facts/global_template.txt
+++ b/scripts/token_bench/facts/global_template.txt
@@ -4,12 +4,12 @@
 CRITICAL: Output is sent to the user or group
 CRITICAL: mcp__deus__send_message is used to acknowledge mid-task before longer work
 CRITICAL: Internal reasoning should be wrapped in <internal>...</internal> tags
-CRITICAL: Text inside <internal> tags is logged but not sent to the user
+CRITICAL: Text inside <internal> tags is logged but not sent to the user   # kw=internal,logged,sent
 CRITICAL: Sub-agents and teammates only use send_message if the main agent told them to
 CRITICAL: Files at /workspace/group/ persist and are used for notes and research
 CRITICAL: Past-session conversation history lives in conversations/
 CRITICAL: When learning important info, create structured files and keep an index
-CRITICAL: Large files should be split into folders (>500 lines)
+CRITICAL: Large files should be split into folders (>500 lines)   # kw=split,500,folders
 CRITICAL: Never use markdown formatting for messages
 CRITICAL: Use single-asterisk *bold* for bold (never double-asterisk)
 CRITICAL: Use _underscores_ for italic

--- a/scripts/token_bench/facts/main_template.txt
+++ b/scripts/token_bench/facts/main_template.txt
@@ -2,7 +2,7 @@
 # Context: this template is used for main-group channel containers.
 
 CRITICAL: The assistant is a personal AI assistant
-CRITICAL: It collaborates on tasks, questions, research, recommendations, brainstorming
+CRITICAL: It collaborates on tasks, questions, research, recommendations, brainstorming   # kw=collaborate,brainstorming
 CRITICAL: The assistant can answer questions and have conversations
 CRITICAL: The assistant can search the web and fetch URLs
 CRITICAL: The assistant can browse the web with agent-browser
@@ -13,7 +13,7 @@ CRITICAL: The assistant can send messages back to the chat
 CRITICAL: Output goes directly to the user
 CRITICAL: mcp__deus__send_message is used to acknowledge mid-task before longer work
 CRITICAL: Internal reasoning is wrapped in <internal>...</internal> tags
-CRITICAL: Text inside <internal> tags is logged but not sent to the user
+CRITICAL: Text inside <internal> tags is logged but not sent to the user   # kw=internal,logged,sent
 CRITICAL: Never use markdown formatting
 CRITICAL: Use single-asterisk *bold* for bold (never double-asterisk)
 CRITICAL: Use _underscores_ for italic

--- a/scripts/token_bench/keyword_bench.py
+++ b/scripts/token_bench/keyword_bench.py
@@ -110,6 +110,8 @@ def main() -> int:
     ap.add_argument("--compressed", required=True)
     ap.add_argument("--facts", required=True)
     ap.add_argument("--out", default=None)
+    ap.add_argument("--threshold", type=float, default=95.0,
+                    help="Minimum critical-coverage %% for PASS verdict (default: 95)")
     args = ap.parse_args()
 
     compressed = Path(args.compressed).read_text()
@@ -141,7 +143,7 @@ def main() -> int:
     print()
     print(f"Critical coverage: {crit_preserved}/{crit_total} = {crit_pct:.1f}%")
     print(f"Overall coverage:  {crit_preserved + supp_preserved}/{total} = {overall_pct:.1f}%")
-    verdict = "PASS" if crit_pct >= 95.0 else "REVIEW"
+    verdict = "PASS" if crit_pct >= args.threshold else "REVIEW"
     print(f"Verdict: {verdict}  (MISS items deserve a manual eyeball — keyword-only test can false-negative on paraphrase)")
 
     report = {


### PR DESCRIPTION
## Summary

Token-slimming work on CLAUDE.md files (project root + `groups/*/CLAUDE.md.template`) currently has no automated defense. After a manual slim, nothing prevents the next PR from drifting back to bloat — or from quietly removing a load-bearing rule. This PR adds a CI gate that runs `keyword_bench.py` against changed CLAUDE.md (or facts) files and fails if critical-fact coverage drops below **90%**.

Per maintainer call, deliberately **no hard token budget** — that risk pressures real rules out, defeating the point. We measure preservation, not size.

## What's gated

| File | Facts | Baseline (this PR) |
|---|---|---|
| `CLAUDE.md` | `scripts/token_bench/facts/root_claudemd.txt` | 92.9% |
| `groups/global/CLAUDE.md.template` | `scripts/token_bench/facts/global_template.txt` | 100% |
| `groups/main/CLAUDE.md.template` | `scripts/token_bench/facts/main_template.txt` | 100% |

Personal `groups/<channel>_main/CLAUDE.md` files are out of scope (not user-agnostic).

## Pieces

- **`scripts/token_bench/ci_coverage_gate.sh`** — diff-aware runner. Skips no-op on PRs that don't touch a gated pair. Run locally before push: `scripts/token_bench/ci_coverage_gate.sh` (or `FORCE_ALL=1 …` to gate every pair).
- **`scripts/token_bench/keyword_bench.py`** — added `--threshold` flag. Default stays 95 (preserves existing behavior); CI uses 90.
- **`scripts/token_bench/facts/{global,main}_template.txt`** — three `kw=` overrides for facts that were paraphrase-preserved but keyword-missed (`collaborate/brainstorming`, `internal/logged/sent`, `split/500/folders`). All three gated files now ≥90%.
- **`.github/workflows/ci.yml`** — new "CLAUDE.md keyword coverage" step.
- **`patterns/claude-md-edit.md`** + **ROUTER** + **patterns/INDEX** — author guidance for editing any gated CLAUDE.md, including the local-bench command and the `kw=` override workflow when a true paraphrase MISS appears.

## Why 90% (not 95%)

`keyword_bench.py`'s built-in 95% verdict is the "needs a human eyeball" line — useful for the slim author, too strict for a CI gate that must not block legitimate paraphrase. 90% gives the bench room to paraphrase-fail without blocking, while still catching genuine fact loss. The script's own 95% default is unchanged.

## Why not relative-drop

Considered "fail if critical drops by more than X points from base" instead of an absolute floor. Absolute is simpler and the threshold is documented; relative-drop is straightforward to switch to later if absolute proves too lax/strict.

## Test plan

- [x] Local `FORCE_ALL=1 scripts/token_bench/ci_coverage_gate.sh` → all 3 gated files PASS at ≥90%
- [x] `keyword_bench.py --threshold 90` exits 0 on each gated file
- [ ] CI run on this PR confirms the new step is wired correctly and skips no-op when no gated file changed (the step itself touches a gated facts file, so it will run on this PR)

## Out of scope (noted, not fixed here)

- The committed `groups/whatsapp_main/CLAUDE.md` contains personal content (`feedback_public_repo_generic` violation) — separate concern, would require disentangling Liam's live setup from the public template.
- `real_claude_probe.sh` (real Anthropic API behavior probes) stays a manual local tool — not in CI to avoid API spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)