### PR TITLE
fix(test): isolate credential-proxy OAuth tests from host keychain

### DIFF
--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -16,7 +16,13 @@ vi.mock('fs', async (importOriginal) => {
   return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
 });
 
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+  execSync: vi.fn(),
+}));
+
 import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import {
   startCredentialProxy,
   _resetCredentialsCacheForTest,
@@ -24,6 +30,7 @@ import {
 import { AuthProviderRegistry } from './auth-providers/types.js';
 
 const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
+const mockExecFileSync = vi.mocked(execFileSync);
 
 function makeRequest(
   port: number,
@@ -72,6 +79,11 @@ describe('credential-proxy', () => {
     mockReadFileSync.mockImplementation(() => {
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
+    // Default: keychain lookup fails — prevents real OS credentials leaking
+    // into tests on macOS/Linux/Windows dev machines.
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('no keychain (test isolation)');
+    });
 
     upstreamServer = http.createServer((req, res) => {
       lastUpstreamHeaders = { ...req.headers };
@@ -89,6 +101,7 @@ describe('credential-proxy', () => {
     await new Promise<void>((r) => upstreamServer?.close(() => r()));
     for (const key of Object.keys(mockEnv)) delete mockEnv[key];
     mockReadFileSync.mockReset();
+    mockExecFileSync.mockReset();
     _resetCredentialsCacheForTest();
     AuthProviderRegistry.reset();
   });


### PR DESCRIPTION
## Summary
Fixes the long-flaky `"OAuth mode: no crash when credentials file is missing"` test in `src/credential-proxy.test.ts`. The fs mock blocked `.credentials.json`, but `getDynamicOAuthToken` falls back to `readKeychainCredentials` which shells out via `execFileSync('security', ...)` — unmocked, so the host's real Bearer token leaked into assertions.

Mocks `child_process` alongside the existing fs mock; default `beforeEach` impl throws to simulate keychain miss.

## Why
Failing tests hide real regressions. This one has been red on main for weeks (tracked in `project_credential_proxy_test_isolation.md`).

## Test plan
- [x] Reproduce on main: `npm test -- --run src/credential-proxy.test.ts` → 1 fail, leaked `sk-ant-oat01-…`
- [x] After fix: 10/10 pass in the file
- [x] Full suite: 768/768
- [x] Sibling OAuth tests (reads-from-file, env-priority, cache-expiry) still pass — they short-circuit before keychain, new mock is a no-op for them

🤖 Generated with [Claude Code](https://claude.com/claude-code)