### PR TITLE
feat(bootstrap): process-level entry-point harness (PR #2/10)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-19"  # re-verified for OAuth auto-refresh launchd + service wiring (PR #211) + error-discipline ADR (PR #214) — rules unchanged, error taxonomy does not affect deploy rules
+last_verified: "2026-04-19"  # re-reviewed for bootstrap entry-point harness (PR #215) — deploy rules unchanged, bootstrap() is a pure addition
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-19"  # re-verified for OAuth auto-refresh CLI (PR #211) + error-discipline ADR (PR #214) — added Error handling section
+last_verified: "2026-04-19"  # re-reviewed for bootstrap entry-point harness (PR #215) — pattern rules unchanged, bootstrap() integration lands in PR #3/10
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FatalError, RetryableError } from './errors/index.js';
+
+// Mock logger before importing bootstrap so it captures calls.
+const logCalls: Array<{ level: string; ctx: unknown; msg: string }> = [];
+vi.mock('./logger.js', () => ({
+  logger: {
+    fatal: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'fatal', ctx, msg }),
+    error: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'error', ctx, msg }),
+    warn: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'warn', ctx, msg }),
+    info: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'info', ctx, msg }),
+  },
+}));
+
+const { bootstrap, __resetBootstrapForTesting } =
+  await import('./bootstrap.js');
+
+// Silence actual process.exit during tests — jsdom/node would kill the runner.
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logCalls.length = 0;
+  __resetBootstrapForTesting();
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  __resetBootstrapForTesting();
+});
+
+async function waitForLog(
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`timeout waiting for log; saw: ${JSON.stringify(logCalls)}`);
+}
+
+describe('bootstrap', () => {
+  it('runs mainFn to completion without exiting on success', async () => {
+    const main = vi.fn(async () => {});
+    bootstrap(main, { name: 'test' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(main).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs at error level and exits when mainFn rejects with plain Error', async () => {
+    const main = async () => {
+      throw new Error('boom');
+    };
+    bootstrap(main, { name: 'entry-a' });
+    await waitForLog(() => logCalls.length > 0);
+    expect(logCalls[0].level).toBe('error');
+    expect(logCalls[0].msg).toBe('entry-a main() failed');
+    expect(logCalls[0].ctx).toMatchObject({ entry: 'entry-a' });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('logs at fatal level when mainFn rejects with FatalError', async () => {
+    const main = async () => {
+      throw new FatalError('corrupt db');
+    };
+    bootstrap(main, { name: 'entry-b' });
+    await waitForLog(() => logCalls.length > 0);
+    expect(logCalls[0].level).toBe('fatal');
+    expect(logCalls[0].msg).toBe('entry-b main() failed');
+  });
+
+  it('respects custom exitCode', async () => {
+    const main = async () => {
+      throw new Error('x');
+    };
+    bootstrap(main, { name: 'entry-c', exitCode: 42 });
+    await waitForLog(() => logCalls.length > 0);
+    expect(exitSpy).toHaveBeenCalledWith(42);
+  });
+
+  it('treats non-FatalError Deus errors (e.g. RetryableError) at error level', async () => {
+    const main = async () => {
+      throw new RetryableError('rate limited');
+    };
+    bootstrap(main, { name: 'entry-d' });
+    await waitForLog(() => logCalls.length > 0);
+    expect(logCalls[0].level).toBe('error');
+  });
+
+  it('installs global uncaughtException handler that logs + exits', async () => {
+    bootstrap(async () => {}, { name: 'entry-e' });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const listeners = process.listeners('uncaughtException');
+    expect(listeners.length).toBeGreaterThanOrEqual(1);
+
+    const err = new FatalError('synthetic');
+    expect(() =>
+      (listeners[listeners.length - 1] as (e: Error) => void)(err),
+    ).toThrow(/process\.exit/);
+    expect(
+      logCalls.some(
+        (c) => c.level === 'fatal' && c.msg === 'uncaughtException',
+      ),
+    ).toBe(true);
+  });
+
+  it('installs unhandledRejection handler that logs; no exit by default', async () => {
+    bootstrap(async () => {}, { name: 'entry-f' });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const listeners = process.listeners('unhandledRejection');
+    expect(listeners.length).toBeGreaterThanOrEqual(1);
+
+    (listeners[listeners.length - 1] as (r: unknown) => void)(new Error('rej'));
+    expect(
+      logCalls.some(
+        (c) => c.level === 'error' && c.msg === 'unhandledRejection',
+      ),
+    ).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exitOnUnhandledRejection=true terminates the process', async () => {
+    bootstrap(async () => {}, {
+      name: 'entry-g',
+      exitOnUnhandledRejection: true,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const listeners = process.listeners('unhandledRejection');
+    expect(() =>
+      (listeners[listeners.length - 1] as (r: unknown) => void)('oops'),
+    ).toThrow(/process\.exit/);
+  });
+
+  it('installs global handlers only once even across multiple bootstrap() calls', async () => {
+    const before = process.listeners('uncaughtException').length;
+    bootstrap(async () => {}, { name: 'e1' });
+    bootstrap(async () => {}, { name: 'e2' });
+    bootstrap(async () => {}, { name: 'e3' });
+    await new Promise((r) => setTimeout(r, 20));
+    const after = process.listeners('uncaughtException').length;
+    expect(after - before).toBe(1);
+  });
+});

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,116 @@
+/**
+ * Process-level entry-point harness — see docs/decisions/error-discipline.md
+ *
+ * Every Node entry point (agent-runner, setup, channels, skills, etc.) calls
+ * `bootstrap(main, { name })` instead of `main()`. This guarantees:
+ *
+ *   1. A `.catch()` on the top-level main() — no silently-swallowed async throws.
+ *   2. Global `uncaughtException` / `unhandledRejection` handlers installed
+ *      before main() runs, so a crash anywhere in the process lands in logs
+ *      with entry-point attribution instead of vanishing.
+ *   3. `FatalError` is logged at `fatal` level; everything else at `error`.
+ *
+ * The global handlers are installed exactly once per process. Safe to call
+ * `bootstrap()` even if another module (e.g. `src/logger.ts`) also wires
+ * `process.on('uncaughtException')` — multiple listeners coexist on Node;
+ * whichever calls `process.exit` first terminates. We install our own
+ * so attribution is correct regardless of import order.
+ */
+
+import { FatalError, isDeusError } from './errors/index.js';
+import { logger } from './logger.js';
+
+export interface BootstrapOptions {
+  /**
+   * Identifier for the entry point (e.g. `'agent-runner'`, `'setup'`).
+   * Included in every error log for attribution across a multi-process daemon.
+   */
+  readonly name: string;
+
+  /** Exit code when `main()` rejects. Default: `1`. */
+  readonly exitCode?: number;
+
+  /**
+   * Terminate the process on `unhandledRejection`? Default: `false`.
+   * Node's default since v15 is to crash; we keep the current Deus behavior
+   * (log + continue) until every entry point has migrated. Flip to `true`
+   * per-entry-point once its call sites have been audited.
+   */
+  readonly exitOnUnhandledRejection?: boolean;
+}
+
+let globalHandlersInstalled = false;
+
+/**
+ * Wrap `mainFn` with attribution + guaranteed catch, and install global
+ * process-level error handlers (once per process).
+ *
+ * Usage at an entry point:
+ *
+ *   import { bootstrap } from './bootstrap.js';
+ *   async function main() { ... }
+ *   bootstrap(main, { name: 'agent-runner' });
+ */
+export function bootstrap(
+  mainFn: () => Promise<void> | void,
+  options: BootstrapOptions,
+): void {
+  const { name, exitCode = 1, exitOnUnhandledRejection = false } = options;
+
+  installGlobalHandlers(name, exitOnUnhandledRejection);
+
+  Promise.resolve()
+    .then(() => mainFn())
+    .catch((err: unknown) => {
+      const severity = err instanceof FatalError ? 'fatal' : 'error';
+      logger[severity](
+        { err: serializeError(err), entry: name },
+        `${name} main() failed`,
+      );
+      process.exit(exitCode);
+    });
+}
+
+function installGlobalHandlers(
+  name: string,
+  exitOnUnhandledRejection: boolean,
+): void {
+  if (globalHandlersInstalled) return;
+  globalHandlersInstalled = true;
+
+  process.on('uncaughtException', (err: Error) => {
+    logger.fatal(
+      { err: serializeError(err), entry: name },
+      'uncaughtException',
+    );
+    process.exit(1);
+  });
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    logger.error(
+      { err: serializeError(reason), entry: name },
+      'unhandledRejection',
+    );
+    if (exitOnUnhandledRejection) process.exit(1);
+  });
+}
+
+function serializeError(err: unknown): unknown {
+  if (isDeusError(err)) return err.toJSON();
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message, stack: err.stack };
+  }
+  return err;
+}
+
+/**
+ * Test-only: reset the install-once guard so `bootstrap()` can be exercised
+ * fresh in each unit test. Do NOT call in production code.
+ *
+ * @internal
+ */
+export function __resetBootstrapForTesting(): void {
+  globalHandlersInstalled = false;
+  process.removeAllListeners('uncaughtException');
+  process.removeAllListeners('unhandledRejection');
+}


### PR DESCRIPTION
## Summary

Second of 10 PRs from the Error & Async Discipline plan (see #214).

**Stacked on #214** (targets `feat/error-discipline`). Merge #214 first, then this can retarget `main`.

Adds `src/bootstrap.ts` — a single wrapper every Node entry point will call instead of raw `main()`. Pure addition; no existing call sites touched in this PR (PR #3 does the wire-up).

## What it does

- `.catch()` on top-level `main()` — no more silent async throws.
- Installs `process.on('uncaughtException' | 'unhandledRejection')` exactly once per process.
- Attribution: every log carries `entry: '<name>'` so crashes are traceable across the multi-process daemon.
- `FatalError` → `logger.fatal`; everything else → `logger.error`.

## Usage

```ts
import { bootstrap } from './bootstrap.js';

async function main() { /* ... */ }

bootstrap(main, { name: 'agent-runner' });
```

Optional knobs:
- `exitCode` — default `1`
- `exitOnUnhandledRejection` — default `false` (preserves current Deus behavior; flip per-entry-point once audited)

## Coexistence with `src/logger.ts`

`src/logger.ts` today installs its own `process.on` handlers as an import side-effect. Bootstrap is idempotent via a module-level guard, and duplicate handlers coexist harmlessly on Node (all fire before exit). **PR #3 will remove the logger.ts side-effect handlers** so bootstrap becomes the single owner. Called out here so reviewers know this isn't an oversight.

## Test plan

- [x] 9 unit tests covering success, error, fatal, custom exit code, handler install-once, both rejection modes
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `npx prettier --check` clean
- [ ] CI green before merge

## Revertability

Pure addition with no imports from the rest of the codebase. `git revert` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)