### PR TITLE
feat(async): boundary helpers for fire-and-forget, timeout, fanout (PR #4/10)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-19"  # re-reviewed for bootstrap entry-point harness (PR #215) — deploy rules unchanged, bootstrap() is a pure addition
+last_verified: "2026-04-19"  # re-reviewed for async-boundary helpers (PR #216) — deploy rules unchanged, async primitives are pure additions
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-19"  # re-reviewed for bootstrap entry-point harness (PR #215) — pattern rules unchanged, bootstrap() integration lands in PR #3/10
+last_verified: "2026-04-19"  # re-reviewed for async-boundary helpers (PR #216) — pattern rules unchanged, fireAndForget/withTimeout/allSettledOrThrow add non-breaking utilities
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/async/index.test.ts
+++ b/src/async/index.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DeusError, RetryableError } from '../errors/index.js';
+
+const logCalls: Array<{ level: string; ctx: unknown; msg: string }> = [];
+vi.mock('../logger.js', () => ({
+  logger: {
+    fatal: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'fatal', ctx, msg }),
+    error: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'error', ctx, msg }),
+    warn: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'warn', ctx, msg }),
+    info: (ctx: unknown, msg: string) =>
+      logCalls.push({ level: 'info', ctx, msg }),
+  },
+}));
+
+const { fireAndForget, withTimeout, allSettledOrThrow } =
+  await import('./index.js');
+
+beforeEach(() => {
+  logCalls.length = 0;
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('fireAndForget', () => {
+  it('swallows success silently', async () => {
+    fireAndForget(Promise.resolve(42), { name: 'ok' });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(logCalls).toEqual([]);
+  });
+
+  it('routes promise rejection to default logger', async () => {
+    fireAndForget(Promise.reject(new Error('boom')), { name: 'work' });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0].level).toBe('error');
+    expect(logCalls[0].msg).toBe('fireAndForget(work) failed');
+    expect(logCalls[0].ctx).toMatchObject({ task: 'work' });
+  });
+
+  it('routes rejection to custom onError', async () => {
+    const onError = vi.fn();
+    fireAndForget(Promise.reject(new Error('boom')), { name: 'work', onError });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(onError).toHaveBeenCalledOnce();
+    expect(logCalls).toEqual([]);
+  });
+
+  it('catches synchronous throws from a thunk', async () => {
+    const onError = vi.fn();
+    fireAndForget(
+      () => {
+        throw new Error('sync');
+      },
+      { name: 'work', onError },
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    expect(onError).toHaveBeenCalledOnce();
+    expect((onError.mock.calls[0][0] as Error).message).toBe('sync');
+  });
+
+  it('handles thunk returning a non-promise', async () => {
+    fireAndForget(() => 42, { name: 'ok' });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(logCalls).toEqual([]);
+  });
+
+  it('does not throw if onError itself throws', async () => {
+    const bad = () => {
+      throw new Error('handler broke');
+    };
+    expect(() =>
+      fireAndForget(Promise.reject(new Error('x')), {
+        name: 'w',
+        onError: bad,
+      }),
+    ).not.toThrow();
+    await new Promise((r) => setTimeout(r, 5));
+  });
+});
+
+describe('withTimeout', () => {
+  it('resolves when inner completes in time', async () => {
+    const value = await withTimeout(Promise.resolve('ok'), 100, {
+      name: 'fast',
+    });
+    expect(value).toBe('ok');
+  });
+
+  it('rejects with RetryableError after timeout', async () => {
+    const slow = new Promise((resolve) =>
+      setTimeout(() => resolve('late'), 100),
+    );
+    await expect(withTimeout(slow, 10, { name: 'slow' })).rejects.toThrow(
+      RetryableError,
+    );
+  });
+
+  it('timeout error carries name and timeoutMs in context', async () => {
+    const slow = new Promise((resolve) => setTimeout(() => resolve('x'), 100));
+    try {
+      await withTimeout(slow, 5, { name: 'auth.refresh' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RetryableError);
+      expect((err as RetryableError).context).toMatchObject({
+        task: 'auth.refresh',
+        timeoutMs: 5,
+      });
+    }
+  });
+
+  it('propagates inner rejection before timeout fires', async () => {
+    const fails = Promise.reject(new Error('inner'));
+    await expect(withTimeout(fails, 1000, { name: 't' })).rejects.toThrow(
+      'inner',
+    );
+  });
+
+  it('honors custom message', async () => {
+    const slow = new Promise((resolve) => setTimeout(() => resolve('x'), 100));
+    await expect(
+      withTimeout(slow, 5, { name: 't', message: 'custom!' }),
+    ).rejects.toThrow('custom!');
+  });
+});
+
+describe('allSettledOrThrow', () => {
+  it('returns values when all succeed', async () => {
+    const result = await allSettledOrThrow(
+      [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)],
+      { name: 'fanout' },
+    );
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("default 'any' policy throws DeusError on first failure", async () => {
+    await expect(
+      allSettledOrThrow(
+        [
+          Promise.resolve(1),
+          Promise.reject(new Error('x')),
+          Promise.resolve(3),
+        ],
+        { name: 'fanout' },
+      ),
+    ).rejects.toThrow(DeusError);
+  });
+
+  it("'all' policy tolerates partial failure", async () => {
+    const result = await allSettledOrThrow(
+      [Promise.resolve(1), Promise.reject(new Error('x')), Promise.resolve(3)],
+      { name: 'fanout', throwIf: 'all' },
+    );
+    expect(result).toEqual([1, undefined, 3]);
+  });
+
+  it("'all' policy throws when every promise rejects", async () => {
+    await expect(
+      allSettledOrThrow(
+        [Promise.reject(new Error('a')), Promise.reject(new Error('b'))],
+        { name: 'fanout', throwIf: 'all' },
+      ),
+    ).rejects.toThrow(DeusError);
+  });
+
+  it('custom predicate gates the throw', async () => {
+    // Throw only if majority rejected.
+    const majority = (failures: number, total: number) => failures * 2 > total;
+    const result = await allSettledOrThrow(
+      [Promise.resolve(1), Promise.reject(new Error('x')), Promise.resolve(3)],
+      { name: 'fanout', throwIf: majority },
+    );
+    expect(result).toEqual([1, undefined, 3]);
+  });
+
+  it('aggregate error carries per-slot causes', async () => {
+    try {
+      await allSettledOrThrow(
+        [
+          Promise.resolve(1),
+          Promise.reject(new Error('boom')),
+          Promise.resolve(3),
+        ],
+        { name: 'fanout' },
+      );
+      expect.fail('should throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeusError);
+      const ctx = (err as DeusError).context as {
+        failures: number;
+        total: number;
+        causes: Array<{ index: number; reason: { message: string } } | null>;
+      };
+      expect(ctx.failures).toBe(1);
+      expect(ctx.total).toBe(3);
+      expect(ctx.causes[0]).toBeNull();
+      expect(ctx.causes[1]).toMatchObject({
+        index: 1,
+        reason: { message: 'boom' },
+      });
+      expect(ctx.causes[2]).toBeNull();
+    }
+  });
+
+  it('handles empty input', async () => {
+    const result = await allSettledOrThrow([], { name: 'empty' });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/async/index.ts
+++ b/src/async/index.ts
@@ -1,0 +1,212 @@
+/**
+ * Async-boundary helpers — see docs/decisions/error-discipline.md (PR #4 of 10)
+ *
+ * Three primitives for the three async patterns that keep tripping up Deus:
+ *
+ *   fireAndForget  — "I intend to ignore this, but log failures with owner"
+ *   withTimeout    — "I intend to wait, but not forever"
+ *   allSettledOrThrow — "I intend to run these in parallel, fail-policy is X"
+ *
+ * Why these three: TrueCourse's 16 HIGH floating-promise findings decompose
+ * into exactly these patterns. Having named primitives makes the correct
+ * pattern the default — the linter (PR #5) can then flag raw floating
+ * promises as "use fireAndForget or .then().catch() explicitly".
+ */
+
+import { DeusError, RetryableError, isDeusError } from '../errors/index.js';
+import { logger } from '../logger.js';
+
+// ── fireAndForget ─────────────────────────────────────────────────────────
+
+export interface FireAndForgetOptions {
+  /**
+   * Owner of this background task — included in every failure log.
+   * Example: `'telegram.reconnect'`, `'gcal.sync'`.
+   */
+  readonly name: string;
+
+  /**
+   * Custom failure handler. Default: logs at `error` level with the owner.
+   * Return nothing; errors from the handler itself are swallowed (they
+   * can't safely propagate from a fire-and-forget boundary).
+   */
+  readonly onError?: (err: unknown) => void;
+}
+
+/**
+ * Mark a promise as intentionally unawaited. Failures are routed to
+ * `onError` (default: `logger.error`) so they never vanish.
+ *
+ * Accepts either a promise or a thunk — the thunk form catches *synchronous*
+ * throws inside the factory as well, which a bare promise can't.
+ *
+ *   fireAndForget(doWork(), { name: 'work' });
+ *   fireAndForget(() => doWork(), { name: 'work' }); // safer: catches sync throws
+ */
+export function fireAndForget(
+  work: Promise<unknown> | (() => Promise<unknown> | unknown),
+  options: FireAndForgetOptions,
+): void {
+  const { name, onError = defaultFireAndForgetHandler(name) } = options;
+
+  let promise: Promise<unknown>;
+  try {
+    promise = typeof work === 'function' ? Promise.resolve(work()) : work;
+  } catch (err) {
+    // Synchronous throw from the thunk.
+    safeCallOnError(onError, err);
+    return;
+  }
+
+  promise.catch((err: unknown) => {
+    safeCallOnError(onError, err);
+  });
+}
+
+function defaultFireAndForgetHandler(name: string): (err: unknown) => void {
+  return (err) =>
+    logger.error(
+      { err: serializeForLog(err), task: name },
+      `fireAndForget(${name}) failed`,
+    );
+}
+
+function safeCallOnError(handler: (err: unknown) => void, err: unknown): void {
+  try {
+    handler(err);
+  } catch {
+    // Onerror itself threw. Nothing safe to do at this boundary — the caller
+    // opted into fire-and-forget. Log via pino if possible, else drop.
+    try {
+      logger.error(
+        { err: serializeForLog(err) },
+        'fireAndForget onError handler threw',
+      );
+    } catch {
+      /* last-ditch: drop */
+    }
+  }
+}
+
+// ── withTimeout ───────────────────────────────────────────────────────────
+
+export interface WithTimeoutOptions {
+  /** Label for the timeout error — e.g. `'oauth.refresh'`. */
+  readonly name: string;
+  /** Optional message override. Default: `<name> timed out after <ms>ms`. */
+  readonly message?: string;
+}
+
+/**
+ * Race a promise against a deadline. Throws `RetryableError` on timeout
+ * (timeouts are almost always transient — retry is the sane default).
+ *
+ * The underlying promise keeps running after timeout (there's no way to
+ * abort a generic Promise). Pass an AbortSignal at the source if you need
+ * to cancel the real work.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  options: WithTimeoutOptions,
+): Promise<T> {
+  const { name, message = `${name} timed out after ${ms}ms` } = options;
+
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new RetryableError(message, { context: { task: name, timeoutMs: ms } }),
+      );
+    }, ms);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+// ── allSettledOrThrow ─────────────────────────────────────────────────────
+
+export type AllSettledThrowPolicy =
+  | 'any'
+  | 'all'
+  | ((failures: number, total: number) => boolean);
+
+export interface AllSettledOrThrowOptions {
+  /** Label for aggregate failure — e.g. `'channel.fanout'`. */
+  readonly name: string;
+  /**
+   * When to throw:
+   *   `'any'` — if any promise rejects (like Promise.all but waits for all to settle).
+   *   `'all'` — only if every promise rejects (strictest partial-success).
+   *   `(failures, total) => boolean` — custom quorum.
+   * Default: `'any'`.
+   */
+  readonly throwIf?: AllSettledThrowPolicy;
+}
+
+/**
+ * Run promises in parallel; decide failure by policy rather than
+ * short-circuit-on-first-reject (Promise.all) or silent-swallow
+ * (Promise.allSettled).
+ *
+ * Returns a dense array of values in input order; failed slots are
+ * replaced with `undefined` when the policy allows partial success.
+ * The aggregate error carries a `context.causes` list with per-slot
+ * reasons for debuggability.
+ */
+export async function allSettledOrThrow<T>(
+  promises: ReadonlyArray<Promise<T>>,
+  options: AllSettledOrThrowOptions,
+): Promise<Array<T | undefined>> {
+  const { name, throwIf = 'any' } = options;
+
+  const settled = await Promise.allSettled(promises);
+  const failures = settled.filter((s) => s.status === 'rejected').length;
+
+  if (shouldThrow(throwIf, failures, settled.length)) {
+    const causes = settled.map((s, i) =>
+      s.status === 'rejected'
+        ? { index: i, reason: summarizeCause(s.reason) }
+        : null,
+    );
+    throw new DeusError(`${name}: ${failures}/${settled.length} rejected`, {
+      context: { task: name, failures, total: settled.length, causes },
+    });
+  }
+
+  return settled.map((s) => (s.status === 'fulfilled' ? s.value : undefined));
+}
+
+function shouldThrow(
+  policy: AllSettledThrowPolicy,
+  failures: number,
+  total: number,
+): boolean {
+  if (failures === 0) return false;
+  if (policy === 'any') return true;
+  if (policy === 'all') return failures === total;
+  return policy(failures, total);
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function serializeForLog(err: unknown): unknown {
+  if (isDeusError(err)) return err.toJSON();
+  if (err instanceof Error)
+    return { name: err.name, message: err.message, stack: err.stack };
+  return err;
+}
+
+function summarizeCause(err: unknown): unknown {
+  if (isDeusError(err)) return { name: err.name, message: err.message };
+  if (err instanceof Error) return { name: err.name, message: err.message };
+  return err;
+}


### PR DESCRIPTION
## Summary

Fourth of 10 PRs from the Error & Async Discipline plan.

**Stacked on #214** (targets `feat/error-discipline`). Independent of #215. Can merge in any order relative to #215 once #214 lands.

## What it adds — three primitives

| Helper | Signature | Caller semantic |
|--------|-----------|-----------------|
| `fireAndForget(work, { name, onError? })` | `void` | "Intend to ignore, log failures with owner" |
| `withTimeout(promise, ms, { name, message? })` | `Promise<T>` | "Intend to wait, but not forever" — throws `RetryableError` on timeout |
| `allSettledOrThrow(promises, { name, throwIf? })` | `Promise<(T\|undefined)[]>` | "Intend to run parallel, fail-policy is 'any' / 'all' / custom" |

## Design highlights

- **Every call requires a `name`.** A fire-and-forget without an owner is indistinguishable from a forgotten await; the name appears in every failure log so crashes get attribution.
- **`fireAndForget` accepts a thunk** as well as a promise — the thunk form catches *synchronous* throws from the factory that a bare promise can't.
- **`withTimeout` throws `RetryableError`** — timeouts are transient by default; caller narrows to something stricter if appropriate. Context includes `{ task, timeoutMs }`.
- **`allSettledOrThrow` carries per-slot causes** in `context.causes`, so debugging doesn't require re-running with added logs.
- **`onError` handlers that themselves throw are swallowed** with a last-ditch log — you can't safely propagate from a fire-and-forget boundary without defeating its purpose.

## ESLint rule — deferred

The plan pairs these helpers with `@typescript-eslint/no-floating-promises`. That rule requires type-aware linting (`parserOptions.project`), which is a repo-wide change and better landed in its own PR. This PR ships the helpers so PR #5 can migrate the 16 HIGH floating-promise call sites mechanically; the ESLint activation follows after.

## Test plan

- [x] 18 unit tests covering all three helpers including edge cases (sync throws, empty input, handler-throws-too, custom predicates, context shape)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `npx prettier --check` clean
- [ ] CI green before merge

## Revertability

Pure addition; no imports from the rest of the codebase. Clean `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)