### PR TITLE
fix(scripts): two NameError bugs in memory_indexer + review_benchmark

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-19"  # re-verified for Gemini cascade fix in memory_indexer (PR #213) — eval rules unchanged
+last_verified: "2026-04-19"  # re-verified for Gemini cascade fix (PR #213) + NameError side-fix in cmd_add_dir (PR #217) — eval rules unchanged
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -621,14 +621,6 @@ def cmd_add_dir(dir_str: str, extract: bool = True):
             except Exception as exc:
                 print(f"  WARN: atom extraction failed for {f.name}: {exc}", file=sys.stderr)
 
-    if extract:
-        try:
-            cmd_extract(str(path))
-        except SystemExit:
-            pass  # cmd_extract uses sys.exit(1) for missing files — already resolved above
-        except Exception as exc:
-            print(f"  WARN: atom extraction failed for {path.name}: {exc}", file=sys.stderr)
-
     # Phase 3: check for stale entity articles
     try:
         stale_count = 0

--- a/scripts/review_benchmark.py
+++ b/scripts/review_benchmark.py
@@ -156,6 +156,7 @@ class HardcodedSecret(BugPattern):
         ])
 
         name, value = secret_type
+        filepath = context["filepath"]
         is_py = filepath.endswith(".py")
 
         if is_py:

--- a/scripts/tests/test_review_benchmark.py
+++ b/scripts/tests/test_review_benchmark.py
@@ -546,3 +546,31 @@ class TestFullCycle:
         rb.cmd_revert()
 
         assert files1 != files2, "Different seeds produced identical results"
+
+
+class TestHardcodedSecretInject:
+    """HardcodedSecret.inject previously referenced an undefined `filepath`
+    (only defined in the sibling `find_targets`). Regression: ensure it now
+    reads `filepath` from the `context` dict the caller passes."""
+
+    def test_inject_does_not_raise_nameerror_on_py(self):
+        pattern = rb.HardcodedSecret()
+        content = "API_TIMEOUT = 30\n"
+        line_no, match = 1, "API_TIMEOUT = 30"
+        context = {"filepath": "src/example.py", "rng": __import__("random").Random(0)}
+
+        modified, desc, disguise = pattern.inject(content, line_no, match, context)
+        assert "API_TIMEOUT" in modified
+        assert "fallback for CI environments" in modified
+        # Python path → should emit `NAME = "..."`, not `const NAME = "..."`
+        assert "const " not in modified
+
+    def test_inject_does_not_raise_nameerror_on_ts(self):
+        pattern = rb.HardcodedSecret()
+        content = "const API_TIMEOUT = 30;\n"
+        line_no, match = 1, "const API_TIMEOUT = 30;"
+        context = {"filepath": "src/example.ts", "rng": __import__("random").Random(0)}
+
+        modified, _, _ = pattern.inject(content, line_no, match, context)
+        assert "const " in modified
+        assert "fallback for CI environments" in modified


### PR DESCRIPTION
## Summary

Two independent NameError bugs surfaced during the TrueCourse static-analysis pass (2026-04-19). Both would raise at runtime if the relevant code path executed. Shipped separately from the Error & Async Discipline series (#214/#215/#216) because they're small, unrelated to the taxonomy, and ship-today valuable.

## Fixes

### `scripts/memory_indexer.py` — `cmd_add_dir`

Duplicate `if extract:` block at lines 623–629 referenced `path`, which was never bound in this function's scope (the caller passes `dir_str`, looped over as `f in path_to_chunks`). The block is dead code — the preceding loop already handles extraction correctly — so this is removal rather than a behavior change.

### `scripts/review_benchmark.py` — `HardcodedSecret.inject`

Line 159 referenced `filepath`, but it was only bound inside the sibling `find_targets` method. The dispatcher (line 613) already passes `context={"filepath": ..., "rng": ...}`, so the fix is one line: read `filepath = context["filepath"]`.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_review_benchmark.py` — 21/21 pass, including new `TestHardcodedSecretInject` regressions for .py and .ts file paths
- [x] `python3 -m pytest scripts/tests/test_memory_indexer.py` — 241 pass, same 2 pre-existing failures as main (unrelated: `test_cmd_add_calls_extract_by_default`, `test_cmd_add_stale_entity_articles_notification`)
- [x] Both files compile (`py_compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)