### PR TITLE
feat(bootstrap): wire process harness into entry points (PR #3/10)

### DIFF
--- a/container/agent-runner/src/bootstrap.ts
+++ b/container/agent-runner/src/bootstrap.ts
@@ -1,0 +1,84 @@
+/**
+ * Process-level entry-point harness — container/agent-runner copy.
+ *
+ * Mirrors src/bootstrap.ts (PR #2/10), minus the pino logger and FatalError
+ * dependency, since container/agent-runner has its own tsconfig + node_modules
+ * and cannot import from src/. Logging goes through the same stderr convention
+ * the file's `log()` helper uses elsewhere: `[<entry-name>] <message>`.
+ *
+ * Drift risk: two copies of the harness must stay behaviorally aligned.
+ * Extracting both into a shared packages/ workspace is tracked in issue #218;
+ * until then, any change here MUST be mirrored in src/bootstrap.ts (and vice
+ * versa).
+ */
+
+export interface BootstrapOptions {
+  /**
+   * Identifier for the entry point (e.g. `'agent-runner'`).
+   * Included in every error log for attribution.
+   */
+  readonly name: string;
+
+  /** Exit code when `main()` rejects. Default: `1`. */
+  readonly exitCode?: number;
+
+  /** Terminate the process on `unhandledRejection`? Default: `false`. */
+  readonly exitOnUnhandledRejection?: boolean;
+}
+
+let globalHandlersInstalled = false;
+
+export function bootstrap(
+  mainFn: () => Promise<void> | void,
+  options: BootstrapOptions,
+): void {
+  const { name, exitCode = 1, exitOnUnhandledRejection = false } = options;
+
+  installGlobalHandlers(name, exitOnUnhandledRejection);
+
+  Promise.resolve()
+    .then(() => mainFn())
+    .catch((err: unknown) => {
+      logError(name, `${name} main() failed`, err);
+      process.exit(exitCode);
+    });
+}
+
+function installGlobalHandlers(
+  name: string,
+  exitOnUnhandledRejection: boolean,
+): void {
+  if (globalHandlersInstalled) return;
+  globalHandlersInstalled = true;
+
+  process.on('uncaughtException', (err: Error) => {
+    logError(name, 'uncaughtException', err);
+    process.exit(1);
+  });
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    logError(name, 'unhandledRejection', reason);
+    if (exitOnUnhandledRejection) process.exit(1);
+  });
+}
+
+function logError(name: string, msg: string, err: unknown): void {
+  const serialized = serializeError(err);
+  console.error(
+    `[${name}] ${msg}: ${typeof serialized === 'string' ? serialized : JSON.stringify(serialized)}`,
+  );
+}
+
+function serializeError(err: unknown): unknown {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message, stack: err.stack };
+  }
+  return err;
+}
+
+/** Test-only: reset the install-once guard. Do NOT call in production code. */
+export function __resetBootstrapForTesting(): void {
+  globalHandlersInstalled = false;
+  process.removeAllListeners('uncaughtException');
+  process.removeAllListeners('unhandledRejection');
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -25,6 +25,8 @@ import {
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
+import { bootstrap } from './bootstrap.js';
+
 interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -1024,4 +1026,4 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+bootstrap(main, { name: 'agent-runner' });

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-19"  # re-reviewed for async-boundary helpers (PR #216) — deploy rules unchanged, async primitives are pure additions
+last_verified: "2026-04-19"  # re-reviewed for entry-point bootstrap wiring (PR #3/10) — deploy rules unchanged, harness adds attribution + crash logging without changing dist/ shape
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-19"  # re-reviewed for async-boundary helpers (PR #216) — pattern rules unchanged, fireAndForget/withTimeout/allSettledOrThrow add non-breaking utilities
+last_verified: "2026-04-19"  # re-reviewed for entry-point bootstrap wiring (PR #3/10) — pattern rules unchanged, drop-in main()→bootstrap() replacements at three call sites
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -5,6 +5,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { bootstrap } from '../src/bootstrap.js';
 import { logger } from '../src/logger.js';
 import { emitStatus } from './status.js';
 
@@ -73,4 +74,4 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+bootstrap(main, { name: 'setup' });

--- a/src/deus-listen.ts
+++ b/src/deus-listen.ts
@@ -14,6 +14,7 @@ import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
 
+import { bootstrap } from './bootstrap.js';
 import { IS_MACOS, IS_LINUX, IS_WINDOWS, killProcess } from './platform.js';
 import {
   transcribeFile,
@@ -533,7 +534,4 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err: unknown) => {
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
+bootstrap(main, { name: 'deus-listen' });


### PR DESCRIPTION
## Summary
PR #3/10 of the Error & Async Discipline initiative — wires the `bootstrap()` harness (added in #215) into all three first-party `main()` entry points so no entry point silently swallows a top-level async throw.

- `setup/index.ts` — bare `main()` → `bootstrap(main, { name: 'setup' })`
- `container/agent-runner/src/index.ts` — same wiring; uses a local copy of the harness (see below)
- `src/deus-listen.ts` — replaces the existing 4-line `.catch()` block for consistency

## Why a duplicate `bootstrap.ts` in container/agent-runner

`container/agent-runner/` is a separate npm package with its own `tsconfig` and `node_modules` — it cannot `import` from `src/`. Three options were considered:

1. **Duplicate the harness** (chosen) — ~85 lines, no `pino`/`FatalError` deps, uses `console.error('[<name>] ...')` for crash logs. Ships PR #3 today; drift risk noted in the file's docblock.
2. **`packages/` workspace extraction** — proper, but requires npm workspaces wiring + container Dockerfile updates. Out of scope; tracked as #218.
3. **Symlink / tsconfig path alias** — fragile across container build boundary; rejected.

## Container reload

`./container/build.sh` + container restart required for the agent-runner change to take effect (existing dist/ inside the image is unchanged).

## Out of scope (separate PRs)
- `exitOnUnhandledRejection: true` audit per entry point
- PR #5 floating-promise migration

## Test plan
- [x] `npx vitest run src/bootstrap.test.ts` — 9/9 green (unchanged)
- [x] `npx tsc --noEmit` (main + container tsconfig) — clean
- [x] `python3 scripts/drift_check.py --all` — ALL CHECKS PASSED
- [x] ESLint — 0 errors (only pre-existing warnings)
- [ ] After merge: `./container/build.sh` + restart deus, confirm agent-runner emits attributed crash logs on synthetic throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)