### PR TITLE
feat(wardens): add plan-reviewer + code-reviewer review agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,55 @@
+---
+name: code-reviewer
+description: Post-implementation, pre-commit review of actual code changes against Deus-specific rules stored in a versioned rules file. Runs on the working-tree + staged diff like a PR reviewer tuned to this repo's standards (CI gates, cross-platform, token efficiency, security basics, cleanup, type safety, comment discipline, etc.). Use AFTER finishing an implementation and BEFORE committing — catches what the plan couldn't predict and what generic tools won't flag. Sibling Warden to plan-reviewer. <example>Context: Just finished implementing the event-based plan-review gate. user: "I'm done with the wardens migration, review before I commit." assistant: "I'll use code-reviewer to run it against code-review-rules.md + the current diff." <commentary>Post-implementation, pre-commit, non-trivial diff = this agent's job.</commentary></example> <example>Context: User finished a refactor. user: "review my changes" assistant: "Running code-reviewer — reads the diff, applies all rules, returns structured PR-style feedback."</example>
+model: sonnet
+color: blue
+---
+
+You are the `code-reviewer` Warden — a Deus-specific reviewer of actual code changes POST-implementation, PRE-commit. Your job: match the diff against a versioned rules file, flag what doesn't belong, and surface what needs addressing before ship. You do NOT fix the code — you critique it like a PR reviewer.
+
+## At invocation, read these (be surgical)
+
+1. **Rules file (primary)** — `~/deus/.claude/wardens/code-review-rules.md`. Read every rule; apply every rule whose `Applies when` matches the diff. Source of truth.
+2. **The diff itself** — run both:
+   - `git -C ~/deus diff` → working-tree (unstaged) changes
+   - `git -C ~/deus diff --cached` → staged changes
+   - If BOTH are empty → "no changes to review" and stop.
+3. `~/deus/CLAUDE.md` — for context on vault-level rules the diff may interact with.
+4. **Memory index** — discover with: `ls $HOME/.claude/projects/*deus*/memory/MEMORY.md 2>/dev/null | head -1`. Check for active `project_*.md` that might be relevant (sequence context, active refactors). Skip silently if none.
+
+Do NOT read every source file the diff touches — the diff is usually enough context. Only read a file if a rule genuinely needs surrounding context (e.g., to check whether a function is used elsewhere for the `cleanup` rule).
+
+## Output format
+
+Return a single markdown report. No preamble.
+
+```
+## Verdict: SHIP | REVISE | BLOCK
+
+1-line reason.
+
+## Blocking Issues
+(severity=blocking violations. Format: `` `<rule-id>` at `path/to/file.ts:L42` — <one-line observation>``. Empty = "None.")
+
+## Warnings
+(severity=warning violations. Same format.)
+
+## Informational
+(severity=informational flags. Same format.)
+
+## Recommendations
+(optional concrete suggestions beyond the rules. Max 3. Terse.)
+
+## Questions for the author
+(ambiguities in the diff. Empty = "None.")
+```
+
+## Rules of engagement
+
+- **Cite rule ids + diff locations.** Every finding ties to a specific rule. Format: `` `<rule-id>` at `path:line` — <observation>``. No generic advice.
+- **Don't rewrite the code.** Point out the problem; leave the fix to the author.
+- **Skip rules with no match.** If `Applies when` doesn't match any hunk in the diff, don't mention the rule.
+- **Off-rule findings go to Recommendations.** If you spot something worth flagging that no rule covers, put it in Recommendations (not Blocking/Warnings). Keep it rare.
+- **Tight output.** Target ≤50 lines. A long review is a signal/noise red flag.
+- **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/code-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
+- **Diff is authoritative.** If memory or docs contradict what's in the diff, trust the diff — memory is a snapshot, code is live.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: plan-reviewer
+description: Independent second opinion on a development plan BEFORE implementation. Distinct from the built-in `Plan` agent (which CREATES plans) — this one CRITIQUES them against a versioned rules file plus active-project constraints and prior-decision alignment. Use when the user (or you) just drafted a plan for a non-trivial change — new feature, refactor, migration, infra change — and you want to catch gotchas before touching code. Sibling Warden to code-reviewer. <example>Context: Just drafted a plan to port the memory tree verifier to main. user: "Here's my plan to merge the verifier branch — review before I start." assistant: "I'll use the plan-reviewer agent to critique it against plan-review-rules.md and active project state." <commentary>Non-trivial change + plan exists + pre-implementation = exactly this agent's job.</commentary></example> <example>Context: User sketched a schema change. user: "Does this migration plan look sound?" assistant: "Running it through plan-reviewer — it reads the versioned rule set and current project memories so it catches Deus-specific issues a generic review misses."</example>
+model: sonnet
+color: yellow
+---
+
+You are the `plan-reviewer` Warden — a Deus-specific critic of development plans BEFORE implementation. Your job: find show-stoppers, missing considerations, and rule violations against a versioned rules file. You do NOT write the plan or alternatives — you critique.
+
+## At invocation, read these (in order, be surgical — stop early if plan is out of scope)
+
+1. **Rules file (primary)** — `~/deus/.claude/wardens/plan-review-rules.md`. Read every rule; apply every rule whose `Applies when` matches the plan. This is the source of truth — never cite a rule from memory if it's not in the current file.
+2. `~/deus/CLAUDE.md` — vault-level rules, critical gates, indexes.
+3. `~/deus/.mex/ROUTER.md` — find the pattern file for this plan's task type; read ONLY that pattern file, not all of them.
+4. `~/deus/docs/decisions/INDEX.md` — ADR index. If any ADR subject overlaps the plan, read that specific ADR. Also skim `~/deus/docs/KNOWN_LIMITATIONS.md` and `~/deus/docs/EFFORT_AB_RESULTS.md` if the plan's subject is a known constraint or previously A/B-tested approach.
+5. **Memory index** — discover with: `ls $HOME/.claude/projects/*deus*/memory/MEMORY.md 2>/dev/null | head -1`. Skip silently if none exists (non-Liam users of the repo). If found, scan for `project_*.md` whose title sounds relevant (active sequence context) and any `feedback_*.md` tagged **(CRITICAL)** that could plausibly apply.
+
+Do NOT read all memory files — be surgical. If you find yourself reading >8 files, you're over-researching.
+
+## Output format
+
+Return a single markdown report. No preamble, no "I'll review...".
+
+```
+## Verdict: SHIP | REVISE | BLOCK
+
+1-line reason.
+
+## Blocking Issues
+(rules with severity=blocking violated. Cite rule id + specific reason. Empty section = "None.")
+
+## Warnings
+(severity=warning violations. Empty = "None.")
+
+## Informational
+(severity=informational flags. Empty = "None.")
+
+## Questions for the author
+(ambiguities in the plan. If none, "None.")
+```
+
+## Rules of engagement
+
+- **Don't invent problems.** If the plan is fine, say "Verdict: SHIP" with empty sections. That's a valid output.
+- **Cite rule ids verbatim.** "Violates `public-repo-generic`" beats "has scoping issues." Reference the rule's `Cite:` field so findings are verifiable against memory/docs.
+- **Skip rules with no match.** Mechanical: if a rule's `Applies when` doesn't match this plan, don't mention it. Only list the ones that fired.
+- **Flag unknowns, don't guess.** If a memory file is stale (>14 days for project memories, >60 for reference) or repo state contradicts it, say so rather than asserting.
+- **Stay in critique mode.** If asked to fix, respond: "out of scope for this agent — invoke the `Plan` subagent or implement directly."
+- **Keep it tight.** A useful review is ≤40 lines. Padding is noise.
+- **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/plan-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.

--- a/.claude/wardens/README.md
+++ b/.claude/wardens/README.md
@@ -1,0 +1,77 @@
+# Wardens
+
+Two specialized review agents that guard the Deus codebase. Both run on **Sonnet 4.6** (structured rule-matching + multi-doc reads; ~15× cheaper than Opus with negligible quality hit).
+
+| Warden | Phase | Rules file | Invocation |
+|--------|-------|------------|------------|
+| **plan-reviewer** | BEFORE implementation | `plan-review-rules.md` | Gated by PreToolUse hook (auto-required for Edit/Write in `~/deus/`) |
+| **code-reviewer** | AFTER implementation, BEFORE commit | `code-review-rules.md` | Manual: `Agent(subagent_type="code-reviewer", prompt="review my changes")` |
+
+## Directory
+
+```
+~/deus/.claude/agents/
+  plan-reviewer.md       ← agent definition (read by Claude Code)
+  code-reviewer.md       ← agent definition
+~/deus/.claude/wardens/
+  README.md              ← this file
+  plan-review-rules.md   ← rules loaded by plan-reviewer at invocation
+  code-review-rules.md   ← rules loaded by code-reviewer at invocation
+```
+
+## How the plan-review gate works
+
+Before any Edit/Write/MultiEdit in `~/deus/`, the hook `~/.claude/hooks/plan-review-gate.sh` checks for the marker `~/deus/.claude/.plan-reviewed`. If missing, the edit is blocked with instructions to invoke `plan-reviewer`.
+
+**Marker lifecycle (event-based, no timer):**
+
+- **Invalidated** by:
+  - `SessionStart` hook (`~/.claude/hooks/plan-mode-session-init.sh`) — every new conversation starts clean.
+  - PreToolUse `ExitPlanMode` — submitting a new plan via `/plan` or Shift-Tab plan mode.
+  - PreToolUse `Agent`/`Task` with `subagent_type=Plan` — invoking the built-in `Plan` subagent.
+- **Refreshed** ONLY by:
+  - `plan-reviewer` returning `VERDICT: SHIP` → author runs `touch ~/deus/.claude/.plan-reviewed`.
+  - Trivial-change bypass (typos, comments, single-line renames): same `touch` command, with the judgment call stated aloud in the response so it's visible.
+
+## Invoking the Wardens
+
+**plan-reviewer (required via gate):**
+```
+Agent(subagent_type="plan-reviewer", prompt="<your plan: what, why, files>")
+```
+Then on `VERDICT: SHIP`:
+```
+touch ~/deus/.claude/.plan-reviewed
+```
+
+**code-reviewer (manual, post-implementation):**
+```
+Agent(subagent_type="code-reviewer", prompt="review my changes for <task>")
+```
+The agent runs `git diff` + `git diff --cached` and reviews both.
+
+## Adding or editing rules
+
+Rules files are the single source of truth — agents read them at invocation. Add a new rule by appending a section to the relevant file. Agents pick it up immediately on next invocation; no agent-file edit needed.
+
+**Format per rule:**
+```
+## <rule-id>
+**Severity:** blocking | warning | informational
+**Applies when:** <precondition — when this rule is relevant>
+**Check:** <what the agent looks for to decide violation>
+**Rule:** <the rule, one sentence>
+**Cite:** <source — memory file, doc path, or system-prompt reference>
+```
+
+Keep rules concise. Total file size matters — every rule adds context cost per invocation. If the file exceeds ~300 lines, split by category and index from the main file.
+
+> **Note on `Cite:` fields:** Rules may cite filenames like `feedback_public_repo_generic` or `project_error_discipline_plan.md` — these refer to the maintainer's auto-memory system (Claude Code's per-project memory). Rules themselves are self-contained; citations are for traceability only and safe to ignore if you don't have the same memory setup.
+
+## What's NOT a Warden
+
+- `.claude/skills/code-review/` — a DIFFERENT concept (multi-agent review skill with false-positive learning loop). Not part of this system.
+- Built-in `Plan` subagent — CREATES plans; doesn't review them. Wardens critique, Plan drafts.
+- `general-purpose`, `Explore` — no Deus-specific rule knowledge.
+
+Wardens are specifically the two rule-enforcing reviewers in this directory.

--- a/.claude/wardens/code-review-rules.md
+++ b/.claude/wardens/code-review-rules.md
@@ -1,0 +1,147 @@
+# Code Review Rules — Wardens/code-reviewer
+
+> Rules the `code-reviewer` agent checks against POST-implementation, PRE-commit.
+> The agent reads the working-tree diff (`git diff` or staged) and applies every rule whose "Applies when" matches.
+>
+> Format per rule: `Severity`, `Applies when`, `Check`, `Rule`, `Cite`.
+> Severity: `blocking` (must fix before SHIP) · `warning` (should address) · `informational` (author's awareness).
+
+## ci-preservation-95
+**Severity:** blocking
+**Applies when:** Diff modifies vault `CLAUDE.md`, `STATE.md`, `INFRA.md`, `STUDY.md`, or `MEMORY.md`.
+**Check:** Are any `critical:` keys dropped? Are any `**(CRITICAL)**` memory entries removed? Estimate critical-key retention — does it stay ≥95%?
+**Rule:** Never reduce CRITICAL preservation below 95%.
+**Cite:** `feedback_compression_rule`; vault CLAUDE.md `claude-md-gates` line
+
+## ci-coverage-90
+**Severity:** blocking
+**Applies when:** Diff modifies any root-loaded file (vault CLAUDE.md + the two CLAUDE.md.template files in `groups/`).
+**Check:** Do the canned keyword-coverage queries still hit at ≥90%? Paraphrase misses should be addressed via `kw=` overrides, not by lowering the floor.
+**Rule:** Maintain ≥90% behavioral coverage.
+**Cite:** `feedback_compression_rule`
+
+## ci-drift-check
+**Severity:** blocking
+**Applies when:** Diff modifies vault leaf files (STATE.md, INFRA.md, STUDY.md, Persona/*) or memory indexes.
+**Check:** Was `memory_tree.py check` / `drift_check.py --indexes` run after the edit?
+**Rule:** Vault leaf changes require drift-check validation before commit.
+**Cite:** `feedback_memory_tree_check`
+
+## cross-platform-actual
+**Severity:** blocking
+**Applies when:** Diff adds/modifies code under `~/deus/src/` or `~/deus/scripts/`.
+**Check:** Are paths constructed via `src/platform.ts` helpers? Are OS-specific commands (e.g., `pngpaste`, `launchctl`, `osascript`) gated by a platform check? Does the diff use `~`/`$HOME` instead of `/Users/...`?
+**Rule:** Default to cross-platform; guard OS-specific code.
+**Cite:** `feedback_cross_platform_default`
+
+## efficiency
+**Severity:** warning
+**Applies when:** Diff touches hot paths (request handlers, event loops, parsers, tight benchmarks).
+**Check:** N+1 queries? Sync-over-async? Blocking I/O in async contexts? String concat in loops? Any obvious sub-optimality that changes complexity class?
+**Rule:** Flag performance red flags. Don't micro-optimize — call out genuine issues only.
+**Cite:** vault CLAUDE.md `design: perf-aware` line
+
+## token-efficiency
+**Severity:** warning
+**Applies when:** Diff adds output to stdout/stderr that ends up in Claude context (hooks, CLI tools, `deus` subcommands, status lines, system prompts, CLAUDE.md).
+**Check:** Is the new output terse? Does it bloat CLAUDE.md-gated behavior? Was the token cost measured or at least estimated?
+**Rule:** Token cost matters. Noisy output in context pressure-drops real rules.
+**Cite:** vault CLAUDE.md `design: token-efficient` line; `reference_mcp_token_overhead`
+
+## modularity
+**Severity:** informational
+**Applies when:** Diff adds a new file or significantly extends an existing one (>100 lines added).
+**Check:** Is the new code coupled tightly to unrelated modules? Could it be extracted? Does it duplicate logic already elsewhere?
+**Rule:** Favor simple, decoupled units. Three similar lines beat a premature abstraction — but genuine duplication should be flagged.
+**Cite:** vault CLAUDE.md `design: modular` (implied)
+
+## benchmark-validation
+**Severity:** blocking
+**Applies when:** Diff claims a performance improvement (commit message mentions "faster", "optimize", "speedup") OR is a compress/eval/retrieval change.
+**Check:** Is there before/after data in the commit message, session log, or PR body? Was the bench run on a realistic workload (not a short-prompt probe for long-context code)?
+**Rule:** Never ship "improvements" without measurement. Predict the outcome before running the bench.
+**Cite:** `feedback_predict_before_testing`; `feedback_measure_on_real_workload`
+
+## pros-cons
+**Severity:** warning
+**Applies when:** Diff implements a non-trivial design choice (new architecture, new dependency, new pattern).
+**Check:** Does the PR body or session log enumerate alternatives considered and why this one was picked?
+**Rule:** Non-trivial decisions deserve documented trade-offs. Flag absent justification.
+**Cite:** `feedback_no_speculation`
+
+## pr-title-format
+**Severity:** blocking
+**Applies when:** Preparing a commit that will become a PR.
+**Check:** Conventional-commits format (`type(scope): description`)? Under 70 chars? Matches the CI title-gate expectations?
+**Rule:** Title must pass the CI title-gate on first push.
+**Cite:** `project_error_discipline_plan` (noted #214 was CI-blocked on title)
+
+## no-hardcoded-personal
+**Severity:** blocking
+**Applies when:** Diff touches public-repo files.
+**Check:** Grep the diff for hardcoded personal values — usernames (e.g. `liam10play`), emails, government IDs, Hebrew names, absolute paths under `/Users/...`, personal project IDs.
+**Rule:** Public-repo code must be user-agnostic in reality, not just in intent.
+**Cite:** `feedback_public_repo_generic`
+
+## container-reload-noted
+**Severity:** informational
+**Applies when:** Diff modifies `groups/*/CLAUDE.md` or `container/` files.
+**Check:** Does the commit message or PR body note that users must run `deus auth` / restart to pick up the change?
+**Rule:** Container reloads aren't automatic. Document them.
+**Cite:** vault INFRA.md `container:` line
+
+## backwards-compat-hacks
+**Severity:** warning
+**Applies when:** Diff touches code where something was removed, renamed, or changed.
+**Check:** Does the diff contain (a) unused variables renamed to `_var` to silence warnings instead of being deleted, (b) `// removed` / `// deprecated` tombstone comments, (c) re-exports of types or functions whose implementations were removed, or (d) feature-flag gates for behavior changes where rollback is trivial (one-commit revert)?
+**Rule:** Delete unused code completely. Change behavior in place when rollback is cheap. Git history preserves deletions — no shims, no tombstone comments, no flags that only exist "just in case".
+**Cite:** system-prompt "Avoid backwards-compatibility hacks" rule
+
+## comment-discipline
+**Severity:** warning
+**Applies when:** Diff adds or modifies code comments (inline, block, or docstrings).
+**Check:** Flag BOTH failure modes: (a) over-commenting — narrative commentary ("used by X", "added for feature Y", "fix for issue #123"), WHAT-comments where naming already explains the code, multi-line docstrings on trivial functions; AND (b) under-commenting — genuinely complex logic (non-obvious invariants, subtle workarounds, hidden constraints, performance-critical ordering) with zero explanation.
+**Rule:** Default to no comments. Only comment when the WHY is non-obvious. For genuinely complex sections, a 1–2 sentence comment that translates intent or simplifies the logic is appropriate — but keep it tight, never multi-paragraph. Not every function needs a docstring; most don't.
+**Cite:** system-prompt "Default to writing no comments" rule
+
+## cleanup
+**Severity:** warning
+**Applies when:** Diff touches code files.
+**Check:** Dead imports, unused variables/functions/exports, commented-out code blocks, unreachable branches, unused parameters, TODO/FIXME without owner or date, legacy files the diff deprecates but doesn't delete, stray debug helpers.
+**Rule:** Keep the codebase lean. Every line should have a reason to exist. Delete dead code — don't mark it. Git history preserves deletions.
+**Cite:** vault CLAUDE.md `design: modular` + `prefs: scalable > quick-fix`; system-prompt minimalism rules
+
+## error-handling-discipline
+**Severity:** warning
+**Applies when:** Diff adds try/catch blocks, validation code, defensive null checks, or `if (x === undefined)` guards — OR the diff adds a system-boundary entry point (HTTP handler, CLI entry, file parser, external API response handler).
+**Check:** Dual direction — (a) is error handling added for scenarios that can't happen (internal function calling internal function with framework-guaranteed non-null input)? (b) is validation MISSING at system boundaries where untrusted data enters?
+**Rule:** No defensive handling for impossible cases. Trust internal code and framework guarantees. But ALWAYS validate at system boundaries.
+**Cite:** system-prompt "Don't add error handling for scenarios that can't happen"
+
+## type-safety
+**Severity:** warning
+**Applies when:** Diff modifies TypeScript files.
+**Check:** Use of `any`, `@ts-ignore`, `@ts-expect-error` without an accompanying reason comment, type assertions `as X` that skip structural verification, generics defaulted to `any`, union types widened to `any`.
+**Rule:** Prefer typed unknowns + narrow with guards over `any`. `@ts-ignore` and non-obvious `as X` need a WHY comment pointing to the specific limitation they work around.
+**Cite:** vault CLAUDE.md `prefs: scalable > quick-fix`; generally accepted TS practice
+
+## log-discipline
+**Severity:** warning
+**Applies when:** Diff adds `console.log`, `console.debug`, `print()`, `logger.debug` or similar output.
+**Check:** Is the log transient debug (leftover from development) or production-intentional? Is it on a hot path that would flood stdout? Does it leak sensitive values (tokens, PII, absolute paths)? Is the level appropriate?
+**Rule:** Remove debug leftovers before ship. Production logs must have clear purpose, correct level, and no secrets.
+**Cite:** vault CLAUDE.md `design: token-efficient`; `reference_mcp_token_overhead`
+
+## test-presence
+**Severity:** informational
+**Applies when:** Diff adds or significantly modifies non-trivial logic (new function >~20 lines, new module, changed algorithm, new endpoint, new public export).
+**Check:** Is there at least one test (unit, integration, or E2E) covering the new behavior? For bug fixes, a regression test targeting the specific bug?
+**Rule:** Non-trivial changes deserve verification in code, not just "I tried it manually". Informational because coverage depth is judgment-dependent — we're flagging the zero-test case.
+**Cite:** general engineering practice; not strict TDD
+
+## security-basics
+**Severity:** blocking
+**Applies when:** Diff handles user input, external API responses, file paths, shell commands, SQL queries, HTML rendering, or network I/O with user-controllable URLs.
+**Check:** Shell injection (user input interpolated into `exec`/`child_process.spawn` without sanitization), SQL injection (string concat into queries vs parameterized), path traversal (user input concatenated into file paths without basename/normalize), XSS (user input rendered without escaping), SSRF (user-controllable URLs fetched server-side without host allowlist).
+**Rule:** No classic OWASP vectors. Parameterize queries, escape output, normalize paths, allowlist hosts for user-controlled URLs.
+**Cite:** system-prompt "Be careful not to introduce security vulnerabilities" rule; `feedback_security_first`

--- a/.claude/wardens/plan-review-rules.md
+++ b/.claude/wardens/plan-review-rules.md
@@ -1,0 +1,91 @@
+# Plan Review Rules — Wardens/plan-reviewer
+
+> Rules the `plan-reviewer` agent checks against BEFORE implementation.
+> Add a new rule by appending a section. No agent edit needed.
+>
+> Format per rule: `Severity`, `Applies when`, `Check`, `Rule`, `Cite`.
+> Severity: `blocking` (must fix before SHIP) · `warning` (should address) · `informational` (flag for author's awareness).
+
+## public-repo-generic
+**Severity:** blocking
+**Applies when:** Plan touches files under `~/deus/src/`, `~/deus/scripts/`, `~/deus/docs/`, or any other tracked public-repo path.
+**Check:** Does the plan hardcode personal values (usernames, emails, absolute personal paths, specific IDs, session tokens)?
+**Rule:** Public-repo code must be user-agnostic. Personal fixtures belong in `~/.claude/`, `~/.config/deus/`, or `src/private/`.
+**Cite:** `feedback_public_repo_generic`
+
+## commit-scoping
+**Severity:** blocking
+**Applies when:** Plan touches BOTH public-repo files AND personal tooling (`~/.claude/`, `~/.config/deus/`, user-local dotfiles).
+**Check:** Are the changes conceptually one concern, or multiple?
+**Rule:** Split into separate commits/PRs. Never bundle personal-tooling changes into public-repo PRs.
+**Cite:** `feedback_scope_commits_by_concern`
+
+## private-override
+**Severity:** warning
+**Applies when:** Plan edits a public file that has a counterpart under `src/private/`.
+**Check:** Does the plan modify the public file when a private override exists, or vice versa?
+**Rule:** Private overrides take precedence. If both exist, plan must specify which to edit and why.
+**Cite:** vault CLAUDE.md `private-override:` line; `feedback_private_override`
+
+## active-sequence-conflict
+**Severity:** blocking
+**Applies when:** An active `project_*.md` memory describes an in-progress sequence (e.g., `project_error_discipline_plan.md` → PRs #214–#216).
+**Check:** Does this plan skip ahead in the sequence, contradict a prior commitment, or touch files owned by an open PR in the sequence?
+**Rule:** Finish or explicitly re-plan the active sequence before branching into parallel work on the same surface.
+**Cite:** The relevant active `project_*.md`
+
+## no-db-deletion
+**Severity:** blocking
+**Applies when:** Plan involves deleting user data, removing records, or dropping tables.
+**Check:** Does the plan propose a hard delete?
+**Rule:** Soft-delete only — set a deleted-at field, archive, or tombstone. Never hard-delete user data.
+**Cite:** `docs/decisions/no-db-deletion.md`
+
+## cross-platform-intent
+**Severity:** warning
+**Applies when:** Plan adds new code under `~/deus/src/` or `~/deus/scripts/`.
+**Check:** Does the plan acknowledge OS-specific behavior (paths, commands, syscalls) and route through `src/platform.ts` where relevant?
+**Rule:** Default to cross-platform. Flag any OS-specific code loudly.
+**Cite:** `feedback_cross_platform_default`; `project_windows_sot_plan`
+
+## secrets-design
+**Severity:** blocking
+**Applies when:** Plan handles credentials, API keys, OAuth tokens, or webhook secrets.
+**Check:** Does the plan commit secrets to git (anywhere — `.env`, fixtures, tests)? Does it rely on env vars without `.env.example` documentation?
+**Rule:** No credentials in git ever. Use `.env` + `.env.example`; gitignore strictly. For rotation, use the credential-proxy pattern.
+**Cite:** vault CLAUDE.md `security:` line; `feedback_deploy_integrity`
+
+## commit-preview-rule
+**Severity:** informational
+**Applies when:** Plan ends with "and then commit" or otherwise implies auto-commit.
+**Check:** Does the plan note that the commit message will be shown for approval before execution?
+**Rule:** Always show the commit message preview; wait for explicit approval before committing.
+**Cite:** `feedback_commit_preview`
+
+## prior-decisions
+**Severity:** blocking
+**Applies when:** Plan proposes an architectural choice, design pattern, new abstraction, eval methodology change, memory system change, cross-platform approach, storage layout, or anything touching a surface with a known decision record.
+**Check:** Scan `docs/decisions/INDEX.md` for any ADR whose subject overlaps the plan. Also cross-check `docs/KNOWN_LIMITATIONS.md` (standing constraints) and `docs/EFFORT_AB_RESULTS.md` (A/B outcomes — "we already tried this"). If an overlapping ADR or result exists, does the plan align with it or contradict it?
+**Rule:** Don't re-litigate settled decisions. If the plan contradicts an existing ADR, either the plan needs revision, or the ADR needs an explicit superseding successor authored alongside the change — never silently diverge.
+**Cite:** `docs/decisions/INDEX.md` + the specific ADR(s); `docs/KNOWN_LIMITATIONS.md`; `docs/EFFORT_AB_RESULTS.md`
+
+## scope-creep
+**Severity:** warning
+**Applies when:** Plan bundles multiple concerns — bug fix plus refactor, config change plus adjacent cleanup, or a feature plus an opportunistic rewrite of touched code.
+**Check:** Does the plan touch files or introduce logic beyond the minimum needed for the stated task?
+**Rule:** One concern per plan. Adjacent cleanups get their own plan. Split before implementation, not after.
+**Cite:** system-prompt "Don't add features, refactor, or introduce abstractions beyond what the task requires"; `feedback_scope_commits_by_concern`
+
+## reversibility
+**Severity:** warning
+**Applies when:** Plan touches CI config, database migrations, shared production state, auth/credential rotation, deployment manifests, or anything with user-visible blast radius.
+**Check:** Is there an explicit rollback plan? Can this be undone in a single revert? Are intermediate states safe (e.g., during a multi-step migration)?
+**Rule:** Risky changes need a documented rollback path. If the change isn't trivially reversible, either split into reversible phases or state how we recover.
+**Cite:** system-prompt "Executing actions with care" / blast-radius section
+
+## test-strategy
+**Severity:** informational
+**Applies when:** Plan involves any non-trivial code change (not doc/comment-only edits).
+**Check:** Does the plan articulate how the change will be verified end-to-end? Can be existing tests, new tests, manual verification steps, or a benchmark — but *something* concrete.
+**Rule:** Every non-trivial plan answers "how will we know this works?" Unverifiable plans are incomplete plans.
+**Cite:** Phase 4 pattern from ExitPlanMode workflow; `feedback_predict_before_testing`

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build output
 dist/
 
+# Plan-review gate marker (user-local; refreshed by plan-reviewer agent)
+.claude/.plan-reviewed
+
 # Local data & auth
 store/
 data/


### PR DESCRIPTION
## Summary

Two review agents backed by versioned rules files — separation of concerns across the dev cycle:

- **`plan-reviewer`** — critiques development plans BEFORE implementation (12 rules at `.claude/wardens/plan-review-rules.md`).
- **`code-reviewer`** — reviews the working-tree + staged diff POST-implementation, PRE-commit, PR-review style (20 rules at `.claude/wardens/code-review-rules.md`).

Both run on Sonnet. Rules are declarative and append-only — add a new rule by appending a section to the rules file; no agent edit needed.

## Invocation

```
Agent(subagent_type="plan-reviewer", prompt="<your plan: what, why, files>")
Agent(subagent_type="code-reviewer",  prompt="review my changes")
```

The `code-reviewer` runs `git diff` and `git diff --cached` and returns a structured report (verdict + blocking/warning/informational + questions).

## Not shipped: enforcement hook

The plan-reviewer is intended to be gated by a PreToolUse hook that blocks Edit/Write/MultiEdit on `~/deus/` unless a marker file is fresh (invalidates on SessionStart, ExitPlanMode, and Plan-subagent invocation). That hook lives in the maintainer's `~/.claude/hooks/` — user-local, not committable.

Other users can either:
- Invoke the agents manually (no enforcement required), or
- Reproduce the hook pattern documented in `.claude/wardens/README.md`.

## Note on `Cite:` fields

Rules cite filenames like `feedback_public_repo_generic.md` and `project_error_discipline_plan.md` — these refer to the maintainer's Claude Code auto-memory system. The rules themselves are self-contained; citations are for traceability only and safe to ignore if you don't have the same memory setup. README documents this.

## Test plan

- [ ] Fresh Claude Code session discovers both agents from `.claude/agents/`
- [ ] `plan-reviewer` returns structured critique against `plan-review-rules.md` on a real plan
- [ ] `code-reviewer` reads the diff via `git diff` + `git diff --cached` and returns structured PR-style review
- [ ] Both agents fail closed ("rules file missing — cannot review") when their rules file is deleted
- [ ] Adding a new rule by appending a section works without agent edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)