### PR TITLE
fix(async): migrate 12 floating-promise HIGHs (PR #5/10)

### DIFF
--- a/packages/mcp-channel-core/src/index.ts
+++ b/packages/mcp-channel-core/src/index.ts
@@ -5,4 +5,5 @@ export type {
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
+  IncomingReaction,
 } from './types.js';

--- a/packages/mcp-channel-core/src/server-base.ts
+++ b/packages/mcp-channel-core/src/server-base.ts
@@ -22,21 +22,44 @@ export function registerCommonTools(
   provider.onMessage = (msg: IncomingMessage) => {
     buffer.push(msg);
 
-    // Push to MCP client via logging notification (real-time path)
-    server.server.sendLoggingMessage({
-      level: 'info',
-      logger: 'incoming_message',
-      data: msg,
-    });
+    // Push to MCP client via logging notification (real-time path).
+    // Fire-and-forget: a failed notification must not break ingestion.
+    server.server
+      .sendLoggingMessage({
+        level: 'info',
+        logger: 'incoming_message',
+        data: msg,
+      })
+      .catch((err: unknown) => {
+        console.error(
+          JSON.stringify({
+            level: 'error',
+            task: 'channel-core.onMessage.notify',
+            err: err instanceof Error ? err.message : err,
+            msg: 'floating-promise',
+          }),
+        );
+      });
   };
 
   // Reactions are ephemeral signals — push to client, don't buffer for polling.
   provider.onReaction = (reaction: IncomingReaction) => {
-    server.server.sendLoggingMessage({
-      level: 'info',
-      logger: 'incoming_reaction',
-      data: reaction,
-    });
+    server.server
+      .sendLoggingMessage({
+        level: 'info',
+        logger: 'incoming_reaction',
+        data: reaction,
+      })
+      .catch((err: unknown) => {
+        console.error(
+          JSON.stringify({
+            level: 'error',
+            task: 'channel-core.onReaction.notify',
+            err: err instanceof Error ? err.message : err,
+            msg: 'floating-promise',
+          }),
+        );
+      });
   };
 
   // ── Core messaging ──────────────────────────────────────────────────

--- a/packages/mcp-discord/src/discord.ts
+++ b/packages/mcp-discord/src/discord.ts
@@ -184,7 +184,12 @@ export class DiscordProvider implements ChannelProvider {
         resolve();
       });
 
-      this.client!.login(BOT_TOKEN);
+      this.client!.login(BOT_TOKEN).catch((err: unknown) => {
+        logger.error(
+          { err, task: 'discord.connect.login' },
+          'floating-promise',
+        );
+      });
     });
   }
 
@@ -230,7 +235,12 @@ export class DiscordProvider implements ChannelProvider {
 
   async disconnect(): Promise<void> {
     if (this.client) {
-      this.client.destroy();
+      this.client.destroy().catch((err: unknown) => {
+        logger.error(
+          { err, task: 'discord.disconnect.destroy' },
+          'floating-promise',
+        );
+      });
       this.client = null;
       logger.info('Discord bot stopped');
     }

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -82,14 +82,26 @@ export class TelegramProvider implements ChannelProvider {
         chatType === 'private'
           ? ctx.from?.first_name || 'Private'
           : (ctx.chat as any).title || 'Unknown';
-      ctx.reply(
-        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
-        { parse_mode: 'Markdown' },
-      );
+      ctx
+        .reply(
+          `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+          { parse_mode: 'Markdown' },
+        )
+        .catch((err: unknown) => {
+          logger.error(
+            { err, task: 'telegram.command.chatid.reply' },
+            'floating-promise',
+          );
+        });
     });
 
     this.bot.command('ping', (ctx) => {
-      ctx.reply(`${ASSISTANT_NAME} is online.`);
+      ctx.reply(`${ASSISTANT_NAME} is online.`).catch((err: unknown) => {
+        logger.error(
+          { err, task: 'telegram.command.ping.reply' },
+          'floating-promise',
+        );
+      });
     });
 
     const BOT_COMMANDS = new Set(['chatid', 'ping']);
@@ -287,7 +299,12 @@ export class TelegramProvider implements ChannelProvider {
       );
 
       if (this.consecutiveErrors >= MAX_CONSECUTIVE_ERRORS && !this.resetting) {
-        this.resetPolling();
+        this.resetPolling().catch((err: unknown) => {
+          logger.error(
+            { err, task: 'telegram.error-handler.resetPolling' },
+            'floating-promise',
+          );
+        });
       }
     });
 
@@ -322,7 +339,12 @@ export class TelegramProvider implements ChannelProvider {
     );
 
     const bot = this.bot;
-    bot.stop();
+    bot.stop().catch((err: unknown) => {
+      logger.error(
+        { err, task: 'telegram.resetPolling.stop.pre-retry' },
+        'floating-promise',
+      );
+    });
     this.consecutiveErrors = 0;
 
     for (let attempt = 0; attempt < MAX_RECONNECT_RETRIES; attempt++) {
@@ -361,7 +383,12 @@ export class TelegramProvider implements ChannelProvider {
           { attempt: attempt + 1, err },
           'Polling reset attempt failed',
         );
-        bot.stop();
+        bot.stop().catch((stopErr: unknown) => {
+          logger.error(
+            { err: stopErr, task: 'telegram.resetPolling.stop.post-error' },
+            'floating-promise',
+          );
+        });
       }
     }
 
@@ -411,7 +438,12 @@ export class TelegramProvider implements ChannelProvider {
     if (this.bot) {
       this.resetting = false;
       this.consecutiveErrors = 0;
-      this.bot.stop();
+      this.bot.stop().catch((err: unknown) => {
+        logger.error(
+          { err, task: 'telegram.disconnect.stop' },
+          'floating-promise',
+        );
+      });
       this.bot = null;
       logger.info('Telegram bot stopped');
     }

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-04-19"  # re-reviewed for error-discipline ADR (PR #214) — channel patterns unaffected by error taxonomy
+last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — packages/ inline .catch pattern (no workspace root → no cross-package src/async/ import); IncomingReaction now re-exported from mcp-channel-core entry point
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-19"  # re-reviewed for entry-point bootstrap wiring (PR #3/10) — deploy rules unchanged, harness adds attribution + crash logging without changing dist/ shape
+last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — deploy rules unchanged, fire-and-forget migration is runtime-only and doesn't alter dist/ shape or deploy semantics
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-19"  # re-reviewed for entry-point bootstrap wiring (PR #3/10) — pattern rules unchanged, drop-in main()→bootstrap() replacements at three call sites
+last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — pattern rules unchanged, ipc.ts + task-scheduler.ts kickoffs now routed through src/async/fireAndForget with named owners
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-04-09"
+last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — src/ipc.ts kickoff now routed through fireAndForget; no security-surface change (authorization checks untouched)
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { CronExpressionParser } from 'cron-parser';
 
+import { fireAndForget } from './async/index.js';
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { getSkillIpcHandlers } from './skills/registry.js';
 import { AvailableGroup } from './container-runner.js';
@@ -159,7 +160,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
     setTimeout(processIpcFiles, IPC_POLL_INTERVAL);
   };
 
-  processIpcFiles();
+  fireAndForget(() => processIpcFiles(), { name: 'ipc.poller' });
   logger.info('IPC watcher started (per-group namespaces)');
 }
 

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -2,6 +2,7 @@ import { ChildProcess } from 'child_process';
 import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
 
+import { fireAndForget } from './async/index.js';
 import { ASSISTANT_NAME, SCHEDULER_POLL_INTERVAL, TIMEZONE } from './config.js';
 import {
   ContainerOutput,
@@ -273,7 +274,7 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
     setTimeout(loop, SCHEDULER_POLL_INTERVAL);
   };
 
-  loop();
+  fireAndForget(() => loop(), { name: 'scheduler.loop' });
 }
 
 /** @internal - for tests only. */


### PR DESCRIPTION
## Summary
- PR #5 of the 10-PR Error & Async Discipline initiative (TrueCourse-driven)
- Migrates 12 of 16 TrueCourse HIGH `reliability/deterministic/floating-promise` findings so unhandled rejections land in logs (with an owner label) instead of becoming uncaught rejections that crash the daemon post-bootstrap-harness
- Ships a side-fix for a pre-existing, invisible build break in `mcp-channel-core` surfaced by this PR

## Migrated sites (12)

### `src/` — uses `fireAndForget` helper (PR #4, #216)
| File | Line | Owner |
|---|---|---|
| `src/ipc.ts` | 162 | `ipc.poller` |
| `src/task-scheduler.ts` | 276 | `scheduler.loop` |

### `packages/mcp-*/` — inline `.catch()` (no workspace root → no cross-package `src/async/` import)
| Package / File | Line | Owner |
|---|---|---|
| `mcp-channel-core/server-base.ts` | 26 | `channel-core.onMessage.notify` |
| `mcp-channel-core/server-base.ts` | 35 | `channel-core.onReaction.notify` |
| `mcp-discord/discord.ts` | 187 | `discord.connect.login` |
| `mcp-discord/discord.ts` | 233 | `discord.disconnect.destroy` |
| `mcp-telegram/telegram.ts` | 85 | `telegram.command.chatid.reply` |
| `mcp-telegram/telegram.ts` | 92 | `telegram.command.ping.reply` |
| `mcp-telegram/telegram.ts` | 290 | `telegram.error-handler.resetPolling` |
| `mcp-telegram/telegram.ts` | 325 | `telegram.resetPolling.stop.pre-retry` |
| `mcp-telegram/telegram.ts` | 364 | `telegram.resetPolling.stop.post-error` |
| `mcp-telegram/telegram.ts` | 414 | `telegram.disconnect.stop` |

## Deliberately not migrated (2/16 sites)

`mcp-telegram/telegram.ts:295` and `:343` — both `bot.start(...)` calls inside `new Promise((resolve, reject) => ...)` wrappers where resolution is gated on the `onStart` callback (the `start()` promise itself resolves only when polling stops, i.e. forever). Adding `.catch()` would be misleading: the float is structural, not accidental. The real hazard (outer promise hangs if start throws pre-`onStart`) is a design fix, not a floating-promise fix, and is out of scope for this PR. Call by the plan-reviewer Warden.

The other 2 of 16 (`container/agent-runner/src/index.ts:945`, `setup/index.ts:76`) were closed by PR #3 (#219) — they're now `bootstrap()` calls, not floating promises.

## Drive-by fix: `IncomingReaction` export

`packages/mcp-channel-core/src/types.ts` defined `IncomingReaction` in PR #194 but never re-exported it from `src/index.ts`. Consumer packages (mcp-telegram, mcp-whatsapp) have been importing it via a broken module-graph fall-through; every fresh `tsc` in those packages fails with `TS2305: no exported member 'IncomingReaction'`. CI's `test-packages` job runs only when files under `packages/**` change (dorny/paths-filter), and no PR has touched that tree since #194 — so main has been invisibly broken for ~2 days. One-line fix shipped here so this PR can pass CI.

## Pattern drift bumps

Drift check flagged 4 patterns whose `governs:` list contains a path touched here. Bumped `last_verified` on each with a PR #5 context note. No rule changes.

## Test plan
- [x] `npm run build` root
- [x] `npm run build` in mcp-channel-core, mcp-telegram, mcp-discord, mcp-whatsapp, mcp-gcal, mcp-gmail, mcp-slack, mcp-x
- [x] `npx vitest run` — 814/814 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (178 pre-existing warnings)
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all patterns OK
- [ ] CI
- [ ] runtime smoke: scheduler kickoff, IPC watcher poll, Telegram ping command

## References
- `docs/decisions/error-discipline.md` (PR #1, #214)
- `src/async/index.ts` (PR #4, #216)
- `src/bootstrap.ts` (PR #2, #215)
- Plan memory: `~/.claude/projects/-Users-liam10play-deus/memory/project_error_discipline_plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)