### PR TITLE
fix(errors): structured attribution on 9 connect sites + 10 false-positives documented (PR #6/10)

### DIFF
--- a/docs/decisions/error-discipline.md
+++ b/docs/decisions/error-discipline.md
@@ -110,6 +110,27 @@ This ADR is PR #1 of a 10-PR series, **ordered by blast-radius ascending**:
 
 Each PR ships independently. If any downstream migration causes regressions, PRs #1–4 stand on their own.
 
+### PR #6 addendum: TrueCourse `missing-error-event-handler` — false-positive inventory
+
+The original plan framed PR #6 as *"stream-error installer + 19 channel wire-ups"* on the assumption that the 19 uniform findings pointed to a missing base-class helper. Source review found that assumption wrong: **0 of the 19 flagged sites are EventEmitter/Stream sites**. The rule's regex over `.connect()` and `createWriteStream()` matches more than the rule's intent.
+
+Breakdown of the 19 findings:
+
+| Category                                              | Count | Disposition                                                                                                                    |
+| ----------------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `provider.connect().catch(console.error)` in `packages/mcp-*/src/index.ts` auto-connect | 6     | **Fixed**: `console.error` → `logger.error({err, source: '<pkg>.auto-connect'})` with structured owner label               |
+| `provider.connect()` in tool handler without try/catch | 2     | **Fixed**: wrap in try/catch, return `{ isError: true, content: [...] }` with owner attribution (whatsapp:83, channel-core:158) |
+| `await channel.connect()` in `src/index.ts:229`       | 1     | **Fixed**: per-channel try/catch with `{err, channel}` log before rethrow; outer `main().catch()` still owns the exit path  |
+| `server.connect(new StdioServerTransport())` in 7× `index.ts` | 7     | **False positive**: the SDK's `StdioServerTransport.start()` registers `this._stdin.on('error', this._onerror)` itself     |
+| `client.connect(new StdioClientTransport())` in `src/channels/mcp-adapter.ts` + `container/agent-runner/src/ipc-mcp-stdio.ts` | 2     | **False positive**: the SDK's `StdioClientTransport` wires `process.stdin.on('error')`, `process.stdout.on('error')`, and `process.on('error')` internally |
+| `pipeline(res.body, createWriteStream(...))` in `src/transcription.ts:71` | 1     | **False positive**: `stream/promises.pipeline()` propagates stream errors as a rejected Promise — `.on('error')` would be redundant |
+
+**Total: 9 real fixes + 10 documented false positives = 19.** (The table above is 6+2+1+7+2+1 = 19 — the "2 false positives in 2 files" row covers mcp-adapter + ipc-mcp-stdio.)
+
+Corollary rule added to `For future contributors` (below): static-analyzer "missing error handler" findings on `.connect()` must be cross-checked against the actual return type. If the call returns `Promise<T>` rather than an `EventEmitter`, the correct fix is structured `.catch()` or try/catch, not `.on('error')`.
+
+No shared `installStreamErrorLogger` helper shipped — YAGNI. If a real EventEmitter site surfaces later, the helper can be added at that time.
+
 ## For future contributors
 
 When you catch or throw an error in Deus:
@@ -118,6 +139,7 @@ When you catch or throw an error in Deus:
 2. **Catching?** Narrow with `instanceof` (or `isDeusError`) and handle each class. `catch (e) { log; throw; }` is fine — swallowing without classification is not.
 3. **Wrapping a third-party error?** Pass it as `cause`. Never stringify it into the message.
 4. **Awaiting a promise you don't plan to block on?** Use `fireAndForget` (PR #4). Don't let it float.
+5. **Static analyzer flagging a `.connect()` site as "missing error handler"?** Check the return type first. `Promise<T>` → structured `.catch()` or try/catch with an owner label (PR #6 pattern). `EventEmitter` → `.on('error', ...)`. SDK-internal transports (e.g. `StdioServerTransport`) wire their own stdin/stdout error listeners — leave them alone.
 
 See `src/errors/index.ts` for the full API and `src/errors/index.test.ts` for examples.
 

--- a/packages/mcp-channel-core/src/server-base.ts
+++ b/packages/mcp-channel-core/src/server-base.ts
@@ -155,7 +155,23 @@ export function registerCommonTools(
   // ── Lifecycle ───────────────────────────────────────────────────────
 
   server.tool('connect', 'Connect to the messaging platform', {}, async () => {
-    await provider.connect();
+    try {
+      await provider.connect();
+    } catch (err: unknown) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'connect failed',
+              detail: err instanceof Error ? err.message : String(err),
+              source: `${provider.name}.connect-tool`,
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
     return { content: [{ type: 'text' as const, text: 'Connected.' }] };
   });
 
@@ -164,7 +180,23 @@ export function registerCommonTools(
     'Disconnect from the messaging platform',
     {},
     async () => {
-      await provider.disconnect();
+      try {
+        await provider.disconnect();
+      } catch (err: unknown) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'disconnect failed',
+                detail: err instanceof Error ? err.message : String(err),
+                source: `${provider.name}.disconnect-tool`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
       return { content: [{ type: 'text' as const, text: 'Disconnected.' }] };
     },
   );

--- a/packages/mcp-discord/src/index.ts
+++ b/packages/mcp-discord/src/index.ts
@@ -14,9 +14,15 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import pino from 'pino';
 import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { DiscordProvider } from './discord.js';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
 
 const server = new McpServer(
   { name: '@deus-ai/discord-mcp', version: '1.0.0' },
@@ -31,8 +37,11 @@ registerCommonTools(server, provider);
 // ── Auto-connect if token is configured ───────────────────────────────
 
 if (provider.hasToken()) {
-  provider.connect().catch((err) => {
-    console.error('[@deus-ai/discord-mcp] Auto-connect failed:', err.message);
+  provider.connect().catch((err: unknown) => {
+    logger.error(
+      { err, source: 'discord.auto-connect' },
+      'provider connect failed at startup',
+    );
   });
 }
 

--- a/packages/mcp-gcal/src/index.ts
+++ b/packages/mcp-gcal/src/index.ts
@@ -15,9 +15,15 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import pino from 'pino';
 import { z } from 'zod';
 
 import { GCalProvider } from './gcal.js';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
 
 const server = new McpServer(
   { name: '@deus-ai/gcal-mcp', version: '1.0.0' },
@@ -153,8 +159,11 @@ server.tool(
 // ── Auto-connect if credentials exist ───────────────────────────────
 
 if (provider.hasCredentials()) {
-  provider.connect().catch((err: Error) => {
-    console.error('[@deus-ai/gcal-mcp] Auto-connect failed:', err.message);
+  provider.connect().catch((err: unknown) => {
+    logger.error(
+      { err, source: 'gcal.auto-connect' },
+      'provider connect failed at startup',
+    );
   });
 }
 

--- a/packages/mcp-gmail/src/index.ts
+++ b/packages/mcp-gmail/src/index.ts
@@ -14,10 +14,16 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import pino from 'pino';
 import { registerCommonTools } from '@deus-ai/channel-core';
 import { z } from 'zod';
 
 import { GmailProvider } from './gmail.js';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
 
 const server = new McpServer(
   { name: '@deus-ai/gmail-mcp', version: '1.0.0' },
@@ -99,8 +105,11 @@ server.tool(
 // ── Auto-connect if credentials exist ────────────────────────────────
 
 if (provider.hasCredentials()) {
-  provider.connect().catch((err) => {
-    console.error('[@deus-ai/gmail-mcp] Auto-connect failed:', err.message);
+  provider.connect().catch((err: unknown) => {
+    logger.error(
+      { err, source: 'gmail.auto-connect' },
+      'provider connect failed at startup',
+    );
   });
 }
 

--- a/packages/mcp-slack/src/index.ts
+++ b/packages/mcp-slack/src/index.ts
@@ -17,9 +17,15 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import pino from 'pino';
 import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { SlackProvider } from './slack.js';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
 
 const server = new McpServer(
   { name: '@deus-ai/slack-mcp', version: '1.0.0' },
@@ -34,8 +40,11 @@ registerCommonTools(server, provider);
 // ── Auto-connect if tokens are configured ────────────────────────────
 
 if (provider.hasTokens()) {
-  provider.connect().catch((err) => {
-    console.error('[@deus-ai/slack-mcp] Auto-connect failed:', err.message);
+  provider.connect().catch((err: unknown) => {
+    logger.error(
+      { err, source: 'slack.auto-connect' },
+      'provider connect failed at startup',
+    );
   });
 }
 

--- a/packages/mcp-telegram/src/index.ts
+++ b/packages/mcp-telegram/src/index.ts
@@ -14,9 +14,15 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import pino from 'pino';
 import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { TelegramProvider } from './telegram.js';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
 
 const server = new McpServer(
   { name: '@deus-ai/telegram-mcp', version: '1.0.0' },
@@ -31,8 +37,11 @@ registerCommonTools(server, provider);
 // ── Auto-connect if token is configured ───────────────────────────────
 
 if (provider.hasToken()) {
-  provider.connect().catch((err) => {
-    console.error('[@deus-ai/telegram-mcp] Auto-connect failed:', err.message);
+  provider.connect().catch((err: unknown) => {
+    logger.error(
+      { err, source: 'telegram.auto-connect' },
+      'provider connect failed at startup',
+    );
   });
 }
 

--- a/packages/mcp-whatsapp/src/index.ts
+++ b/packages/mcp-whatsapp/src/index.ts
@@ -15,10 +15,16 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import pino from 'pino';
 import { z } from 'zod';
 import { registerCommonTools } from '@deus-ai/channel-core';
 
 import { WhatsAppProvider } from './whatsapp.js';
+
+const logger = pino(
+  { level: process.env.LOG_LEVEL || 'info' },
+  pino.destination(2),
+);
 
 const server = new McpServer(
   { name: '@deus-ai/whatsapp-mcp', version: '1.0.0' },
@@ -99,9 +105,12 @@ server.tool(
 // ── Auto-connect if credentials exist ─────────────────────────────────
 
 if (provider.hasAuth()) {
-  provider.connect().catch((err) => {
+  provider.connect().catch((err: unknown) => {
     // Log to stderr — don't crash, stay available for auth tools
-    console.error('[@deus-ai/whatsapp-mcp] Auto-connect failed:', err.message);
+    logger.error(
+      { err, source: 'whatsapp.auto-connect' },
+      'provider connect failed at startup',
+    );
   });
 }
 

--- a/packages/mcp-whatsapp/src/index.ts
+++ b/packages/mcp-whatsapp/src/index.ts
@@ -85,7 +85,27 @@ server.tool(
     // Auth is handled by the connect flow — this tool triggers it.
     // The provider writes QR data to disk; the client reads it.
     if (!provider.isConnected()) {
-      await provider.connect();
+      try {
+        await provider.connect();
+      } catch (err: unknown) {
+        logger.error(
+          { err, source: 'whatsapp.start_auth.connect' },
+          'provider connect failed during start_auth',
+        );
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'connect failed during start_auth',
+                detail: err instanceof Error ? err.message : String(err),
+                source: 'whatsapp.start_auth.connect',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
     }
     const status = provider.getStatus();
     return {

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — packages/ inline .catch pattern (no workspace root → no cross-package src/async/ import); IncomingReaction now re-exported from mcp-channel-core entry point
+last_verified: "2026-04-20"  # re-reviewed for stream-error migration (PR #6/10) — 6 mcp-*/src/index.ts auto-connect .catch blocks upgraded to structured pino logger.error; start_auth + channel-core connect/disconnect tool handlers wrapped in try/catch returning {isError:true, content:[...]} with owner labels
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — deploy rules unchanged, fire-and-forget migration is runtime-only and doesn't alter dist/ shape or deploy semantics
+last_verified: "2026-04-20"  # re-reviewed for stream-error migration (PR #6/10) — deploy rules unchanged; each mcp-* package now initializes its own pino logger in index.ts (pino was already declared dep), no dep additions or dist/ shape changes
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-20"  # re-reviewed for floating-promise migration (PR #5/10) — pattern rules unchanged, ipc.ts + task-scheduler.ts kickoffs now routed through src/async/fireAndForget with named owners
+last_verified: "2026-04-20"  # re-reviewed for stream-error migration (PR #6/10) — pattern rules unchanged, src/index.ts channel-startup loop now logs per-channel {err, channel} before rethrowing so main().catch() sees attributed failures
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,15 @@ async function main(): Promise<void> {
       continue;
     }
     channels.push(channel);
-    await channel.connect();
+    try {
+      await channel.connect();
+    } catch (err: unknown) {
+      logger.error(
+        { err, channel: channelName },
+        'channel connect failed during startup',
+      );
+      throw err;
+    }
   }
   if (channels.length === 0) {
     logger.warn(


### PR DESCRIPTION
## Summary
- PR #6 of the 10-PR Error & Async Discipline initiative
- Migrates **9 real** `missing-error-event-handler` sites to structured pino logging / MCP-error responses with owner-labeled attribution
- Documents **10 false positives** in the ADR so future scans don't re-flag them
- **No `installStreamErrorLogger` helper shipped** — deliberate (YAGNI): the original plan assumed 19 uniform EventEmitter sites, but source review found 0 actual EventEmitter sites. Shipping a helper with zero callsites would be dead code from day one.

## TrueCourse rule audit

19 sites flagged `reliability/deterministic/missing-error-event-handler`. Breakdown after source review:

| Category | Count | Action |
|---|---|---|
| `provider.connect().catch(console.error)` in `packages/mcp-*/src/index.ts` auto-connect | 6 | **Fixed** — structured `logger.error({err, source: '<pkg>.auto-connect'})` |
| `provider.connect()` in tool handler, no try/catch (whatsapp:83, channel-core:158) | 2 | **Fixed** — try/catch returning `{isError: true, content: [...]}` with owner label |
| `await channel.connect()` loop in `src/index.ts:229` | 1 | **Fixed** — per-channel try/catch logs `{err, channel}` before rethrow |
| `server.connect(new StdioServerTransport())` in 7× `index.ts` + `ipc-mcp-stdio.ts` | 8 | **False positive** — SDK wires `process.stdin.on('error')` internally |
| `client.connect(new StdioClientTransport())` in `mcp-adapter.ts` | 1 | **False positive** — SDK wires stdin/stdout/process error listeners internally |
| `pipeline(res.body, createWriteStream(...))` in `src/transcription.ts:71` | 1 | **False positive** — `stream/promises.pipeline()` propagates errors as a rejected promise |

**Total: 9 real fixes + 10 documented false positives = 19.**

## Commits

1. `fix(packages): structured logging for auto-connect failures` — 6 `mcp-*/src/index.ts` edits batched (mechanical, identical across channels)
2. `fix(mcp-whatsapp): try/catch in start_auth tool handler` — returns MCP `isError:true` with `whatsapp.start_auth.connect` attribution
3. `fix(mcp-channel-core): try/catch in connect and disconnect tools` — uses `provider.name` at runtime so the owner label is channel-specific; also closes the matching disconnect case for symmetry
4. `fix(channels): log per-channel attribution before rethrow` — so Telegram OAuth failures stop looking like WhatsApp socket failures in logs
5. `docs(error-discipline): PR #6 false-positive inventory + contributor rule` — ADR addendum + pattern drift bumps + 5th "for future contributors" rule

## Why no shared helper

The original plan (`installStreamErrorLogger(emitter, source)`) assumed the 19 findings pointed to a missing base-class method. Source reading found: **0 sites create a raw EventEmitter or Stream with an uninstalled error listener.** Every site is either:
- A `Promise<T>`-returning method (correct fix: `.catch()` or try/catch), or
- An SDK-internal transport that wires its own error listeners

Shipping a helper for a pattern that doesn't exist would be speculative scaffolding. If a real EventEmitter site surfaces later, the helper can be added then.

## Testing
- [x] `npm run build` root + all 7 mcp-* packages
- [x] `npx vitest run` — 814/814 pass
- [x] `npx tsc --noEmit` — clean
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all patterns OK
- [x] `scripts/token_bench/ci_coverage_gate.sh origin/main` — no gated files touched
- [ ] CI
- [ ] runtime smoke: start WhatsApp without auth, observe structured auto-connect log with source attribution

## References
- `docs/decisions/error-discipline.md` — new PR #6 addendum section
- TrueCourse findings: `.truecourse/analyses/2026-04-19T09-29-22Z_991f21d7.json`, ruleKey `reliability/deterministic/missing-error-event-handler`
- Plan memory: `~/.claude/projects/-Users-liam10play-deus/memory/project_error_discipline_plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)