### PR TITLE
fix(evolution): harden 13 SQL f-string sites with allow-list + regex + ADR (PR #9/10)

### DIFF
--- a/docs/decisions/error-discipline.md
+++ b/docs/decisions/error-discipline.md
@@ -169,6 +169,23 @@ Both helpers live in `scripts/_time.py` and return tz-aware datetimes. `datetime
 
 **Rule for new Python code in `scripts/`:** never write bare `datetime.now()`. Pick `utc_now()` or `local_now()` explicitly. The choice forces an answer to "is this a moment, or is this a calendar day?".
 
+### PR #9 addendum: SQL injection surface (Python `evolution/`)
+
+TrueCourse flagged 13 `security/deterministic/sql-injection` HIGHs in `evolution/db.py` + `evolution/storage/providers/sqlite.py`. Audit found two distinct categories: **structural-safe** sites that can't be parameterized, and **real risk** sites where blind kwargs / unvalidated ints would let a caller forge SQL.
+
+**SQLite parameterization rules (the "why" behind the policy):**
+
+1. **DDL cannot be parameterized.** `?` placeholders only work in DML expression positions. `CREATE VIRTUAL TABLE ... USING vec0(embedding float[?])` is a syntax error. Same for `ALTER TABLE foo ADD COLUMN ? ?`. When the schema demands an identifier or a type, you must interpolate.
+2. **Identifiers (table/column names) cannot be parameterized.** `SELECT COUNT(*) FROM ?` is invalid. When you need a dynamic table or column name, interpolate from a closed allow-list (a literal tuple in code, or a regex-validated string from `sqlite_master`). Never accept identifier names from untrusted callers.
+3. **Data values must be parameterized.** Anything that's user input or function argument data — strings, ints, floats — goes through `?` bound parameters. The exception is integer values inside SQLite expressions like `DATETIME('now', '-N days')` that don't accept placeholders, in which case explicit `int()` coercion + a sane clamp is mandatory before interpolation.
+
+**Project conventions adopted in PR #9:**
+
+- `# safe: <reason>` comment on f-string `.execute()` sites that are structurally parameterizable-impossible. Examples: vec0 dimension constants, ALTER TABLE column tuples from a literal list, WHERE clauses assembled from local literal-string fragments. The comment is for human reviewers — TrueCourse does not consume inline suppressions; closing the violation happens in the dashboard after merge.
+- **Allow-list module constants** for kwarg-driven UPDATEs. `evolution/storage/providers/sqlite.py:_UPDATABLE_INTERACTION_COLS` enumerates the 5 columns callers actually write after initial insert. `update_interaction(**fields)` raises `ValueError` on unknown keys. Widening the set is intentional and visible in code review.
+- **Identifier regex** (`_SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")`) before interpolating a name from `sqlite_master` into DDL. Rejects payloads that survived a corrupted-DB or hostile-environment edge case.
+- **Int-coerce + clamp** for time-window parameters that interpolate into `DATETIME('now', '-N days')`: `max(1, int(days))`. The clamp also prevents `days=0` from silently widening the window to all rows.
+
 ## For future contributors
 
 When you catch or throw an error in Deus:
@@ -179,6 +196,7 @@ When you catch or throw an error in Deus:
 4. **Awaiting a promise you don't plan to block on?** Use `fireAndForget` (PR #4). Don't let it float.
 5. **Static analyzer flagging a `.connect()` site as "missing error handler"?** Check the return type first. `Promise<T>` → structured `.catch()` or try/catch with an owner label (PR #6 pattern). `EventEmitter` → `.on('error', ...)`. SDK-internal transports (e.g. `StdioServerTransport`) wire their own stdin/stdout error listeners — leave them alone.
 6. **Writing Python in `scripts/`?** Never `datetime.now()`. Use `utc_now()` for internal timestamps, `local_now()` for user-facing strings (PR #8). The naming forces you to answer "moment or calendar day?".
+7. **Building SQL?** Always parameterize data values. Identifiers (table/column names) and DDL must come from a closed allow-list (a literal tuple in code) or pass through `_SAFE_IDENT` regex validation (PR #9). Annotate the unavoidable f-string `.execute()` sites with `# safe: <reason>`.
 
 See `src/errors/index.ts` for the full API and `src/errors/index.test.ts` for examples.
 

--- a/evolution/db.py
+++ b/evolution/db.py
@@ -93,6 +93,9 @@ def _migrate(db: sqlite3.Connection) -> None:
     """)
 
     # Reflection embeddings (vec0 virtual table)
+    # safe: SQLite DDL cannot accept ? placeholders for type dimensions;
+    # EMBED_DIM is a module-level int constant — no user input reaches the
+    # f-string. See docs/decisions/error-discipline.md "PR #9 addendum".
     try:
         db.execute(f"""
             CREATE VIRTUAL TABLE IF NOT EXISTS reflection_embeddings
@@ -108,6 +111,8 @@ def _migrate(db: sqlite3.Connection) -> None:
         ("parse_error", "INTEGER DEFAULT 0"),  # 1 if judge score is a parse-failure fallback
     ]:
         try:
+            # safe: col + coltype come from the literal tuple-list above —
+            # not user input. SQLite DDL cannot parameterize identifiers.
             db.execute(f"ALTER TABLE interactions ADD COLUMN {col} {coltype}")
         except sqlite3.OperationalError:
             pass  # Column already exists

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -10,6 +10,7 @@ the memory indexer's database (memory.db). This prevents the memory indexer's
 interactions, reflections, and other expensive evolution data.
 """
 import logging
+import re
 import sqlite3
 import struct
 import threading
@@ -21,6 +22,25 @@ from ... import config as _config
 from ..provider import StorageProvider
 
 log = logging.getLogger(__name__)
+
+# Identifiers (table/column names) that we have to interpolate into SQL because
+# SQLite cannot parameterize them. Anything from sqlite_master or the schema
+# tuple-list above is implicitly trusted; this regex is defense in depth so a
+# corrupted/poisoned DB row can't sneak a payload through DROP TABLE.
+_SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Allow-list for update_interaction(**fields). Each entry must correspond to a
+# column on `interactions` that the rest of the codebase legitimately writes
+# after initial insert. Adding a new entry is intentional — never widen this
+# to "all column names" or trust kwargs blindly. See PR #9 in
+# docs/decisions/error-discipline.md.
+_UPDATABLE_INTERACTION_COLS = frozenset({
+    "judge_score",
+    "judge_dims",
+    "parse_error",
+    "latency_ms",
+    "timestamp",
+})
 
 # Guard against concurrent schema migrations from multiple threads
 _migration_lock = threading.Lock()
@@ -101,6 +121,8 @@ class SQLiteStorageProvider(StorageProvider):
             has_data = False
             for t in evolution_tables:
                 if t in tables:
+                    # safe: t comes from the literal `evolution_tables` allow-list
+                    # above. SQLite cannot parameterize identifiers in FROM clauses.
                     count = legacy.execute(f"SELECT COUNT(*) FROM [{t}]").fetchone()[0]
                     if count > 0:
                         has_data = True
@@ -123,7 +145,15 @@ class SQLiteStorageProvider(StorageProvider):
             ).fetchall()]
             for t in indexer_tables:
                 if t not in evolution_tables:
+                    # Defense in depth: sqlite_master table names should be
+                    # well-formed, but pin the contract with a regex check
+                    # before interpolating into a DROP statement.
+                    if not _SAFE_IDENT.match(t):
+                        log.warning("Skipping drop of non-identifier table name %r", t)
+                        continue
                     try:
+                        # safe: t passed the _SAFE_IDENT regex above; SQLite
+                        # cannot parameterize identifiers in DROP TABLE.
                         target.execute(f"DROP TABLE IF EXISTS [{t}]")
                     except sqlite3.OperationalError:
                         pass  # virtual tables may need special handling
@@ -133,7 +163,12 @@ class SQLiteStorageProvider(StorageProvider):
                 "SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE '%virtual%'"
             ).fetchall()]:
                 if vt not in ("reflection_embeddings",):
+                    if not _SAFE_IDENT.match(vt):
+                        log.warning("Skipping drop of non-identifier virtual table %r", vt)
+                        continue
                     try:
+                        # safe: vt passed _SAFE_IDENT; identifiers can't be
+                        # parameterized in DROP TABLE.
                         target.execute(f"DROP TABLE IF EXISTS [{vt}]")
                     except sqlite3.OperationalError:
                         pass
@@ -204,6 +239,9 @@ class SQLiteStorageProvider(StorageProvider):
         """)
 
         # Reflection embeddings (vec0 virtual table)
+        # safe: same DDL pattern as evolution/db.py:97 — _config.EMBED_DIM
+        # is a module-level int constant. SQLite cannot parameterize the
+        # vec0 dimension. See PR #9 in docs/decisions/error-discipline.md.
         try:
             db.execute(f"""
                 CREATE VIRTUAL TABLE IF NOT EXISTS reflection_embeddings
@@ -220,6 +258,8 @@ class SQLiteStorageProvider(StorageProvider):
             ("context_tokens", "INTEGER"),
         ]:
             try:
+                # safe: col + coltype come from the literal tuple-list
+                # above. SQLite DDL cannot parameterize identifiers.
                 db.execute(f"ALTER TABLE interactions ADD COLUMN {col} {coltype}")
             except sqlite3.OperationalError:
                 pass  # Column already exists
@@ -299,8 +339,16 @@ class SQLiteStorageProvider(StorageProvider):
     def update_interaction(self, interaction_id: str, **fields) -> None:
         if not fields:
             return
+        unknown = set(fields) - _UPDATABLE_INTERACTION_COLS
+        if unknown:
+            raise ValueError(
+                f"update_interaction: unknown column(s) {sorted(unknown)}; "
+                f"allowed: {sorted(_UPDATABLE_INTERACTION_COLS)}"
+            )
         db = self._connect()
         set_clause = ", ".join(f"{k} = ?" for k in fields)
+        # safe: fields.keys() is gated by _UPDATABLE_INTERACTION_COLS above
+        # (see module-level allow-list); values are bound parameters.
         db.execute(
             f"UPDATE interactions SET {set_clause} WHERE id = ?",
             list(fields.values()) + [interaction_id],
@@ -347,6 +395,8 @@ class SQLiteStorageProvider(StorageProvider):
             params.append(f'%"{domain}"%')
 
         where_clause = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        # safe: where_clause is built from local literal-string clauses
+        # above; user values are bound through `params`.
         rows = db.execute(
             f"SELECT * FROM interactions {where_clause} ORDER BY timestamp DESC LIMIT ?",
             params + [limit],
@@ -388,6 +438,8 @@ class SQLiteStorageProvider(StorageProvider):
                 clauses.append("domain_presets LIKE ?")
                 params.append(f'%"{v}"%')
         where_clause = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        # safe: same pattern as get_recent_interactions — where_clause
+        # built from literal strings, user values bound through params.
         count = db.execute(
             f"SELECT COUNT(*) FROM interactions {where_clause}", params,
         ).fetchone()[0]
@@ -412,12 +464,19 @@ class SQLiteStorageProvider(StorageProvider):
         if domain:
             extra_clauses += " AND domain_presets LIKE ?"
             params.append(f'%"{domain}"%')
+        # Coerce + clamp days to a positive int. SQLite cannot parameterize
+        # a literal inside DATETIME('now', '-? days'), so we interpolate;
+        # the clamp also rejects days <= 0 which would silently widen the
+        # window to all rows.
+        days_clamped = max(1, int(days))
+        # safe: days_clamped is an int (post-clamp); extra_clauses built
+        # from local literal strings above. User values bound via params.
         rows = db.execute(
             f"""
             SELECT DATE(timestamp) AS day, AVG(judge_score) AS avg_score, COUNT(*) AS count
             FROM interactions
             WHERE judge_score IS NOT NULL
-              AND timestamp >= DATETIME('now', '-{days} days')
+              AND timestamp >= DATETIME('now', '-{days_clamped} days')
               {extra_clauses}
             GROUP BY day
             ORDER BY day
@@ -435,6 +494,9 @@ class SQLiteStorageProvider(StorageProvider):
         days: int = 30,
     ) -> list[dict]:
         db = self._connect()
+        # See score_trend for the same int-coerce + clamp rationale.
+        days_clamped = max(1, int(days))
+        # safe: days_clamped is a clamped int; no other interpolation.
         rows = db.execute(
             f"""
             SELECT DATE(timestamp) AS day,
@@ -442,7 +504,7 @@ class SQLiteStorageProvider(StorageProvider):
                    COUNT(*) AS count
             FROM interactions
             WHERE context_tokens IS NOT NULL
-              AND timestamp >= DATETIME('now', '-{days} days')
+              AND timestamp >= DATETIME('now', '-{days_clamped} days')
             GROUP BY day
             ORDER BY day
             """,
@@ -797,6 +859,8 @@ class SQLiteStorageProvider(StorageProvider):
         if domain:
             clauses.append("domain_presets LIKE ?")
             params.append(f'%"{domain}"%')
+        # safe: clauses is built from literal-string fragments above;
+        # user values bound through params.
         count = db.execute(
             f"SELECT COUNT(*) FROM interactions WHERE {' AND '.join(clauses)}",
             params,

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-20"  # re-verified for datetime-TZ migration in memory_indexer.py (PR #8/10) — eval rules unchanged, just UTC vs local-Jerusalem split for DB timestamps vs user-facing date strings
+last_verified: "2026-04-20"  # re-verified for SQL injection hardening in evolution/ (PR #9/10) — eval rules unchanged; allow-list update_interaction kwargs, regex-gate DROP TABLE identifiers, int-clamp DATETIME days; rationale comments added on structural-safe DDL/where-clause f-strings
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-20"  # re-reviewed for stream-error migration (PR #6/10) — pattern rules unchanged, src/index.ts channel-startup loop now logs per-channel {err, channel} before rethrowing so main().catch() sees attributed failures
+last_verified: "2026-04-20"  # re-reviewed for SQL injection hardening in evolution/ (PR #9/10) — pattern rules unchanged; new project conventions documented in ADR (allow-lists for kwarg-driven UPDATE; _SAFE_IDENT regex; int-coerce + clamp for DATETIME days; `# safe:` rationale comments on unavoidable f-string .execute() sites)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary
- PR #9 of 10 in the Error & Async Discipline initiative
- Hardens **5 real-risk SQL f-string sites** in `evolution/storage/providers/sqlite.py` (allow-list + regex + int-clamp)
- Annotates **8 structural-safe sites** (DDL, where-clauses from literal-string fragments) with `# safe: <reason>` so future audits don't re-derive the safety argument
- Adds "PR #9 addendum: SQL injection surface" to the error-discipline ADR + rule #7 for future contributors

## Audit table

| File:Line | Pattern | Real risk? | Action |
|---|---|---|---|
| `db.py:97` | `vec0(embedding float[{EMBED_DIM}])` (DDL) | No | `# safe:` comment |
| `db.py:111` | `ALTER TABLE ... ADD COLUMN {col} {coltype}` (literal list) | No | `# safe:` comment |
| `sqlite.py:104` | `SELECT COUNT(*) FROM [{t}]` (`evolution_tables` allow-list) | No | `# safe:` comment |
| `sqlite.py:127` | `DROP TABLE IF EXISTS [{t}]` (sqlite_master) | Maybe | **`_SAFE_IDENT` regex gate** |
| `sqlite.py:137` | `DROP TABLE IF EXISTS [{vt}]` (sqlite_master virtual) | Maybe | **`_SAFE_IDENT` regex gate** |
| `sqlite.py:208` | `vec0(embedding float[{_config.EMBED_DIM}])` (DDL) | No | `# safe:` comment |
| `sqlite.py:223` | `ALTER TABLE ... ADD COLUMN {col} {coltype}` (literal list) | No | `# safe:` comment |
| `sqlite.py:304` | `UPDATE interactions SET {set_clause}` (`**fields` kwargs) | **Yes** | **`_UPDATABLE_INTERACTION_COLS` allow-list** — raises `ValueError` on unknown key |
| `sqlite.py:350` | `SELECT * FROM interactions {where_clause}` (literal clauses) | No | `# safe:` comment |
| `sqlite.py:391` | `SELECT COUNT(*) FROM interactions {where_clause}` | No | `# safe:` comment |
| `sqlite.py:415` | `DATETIME('now', '-{days} days')` (typed int) | Small | **`max(1, int(days))` coerce + clamp** |
| `sqlite.py:438` | same as 415 | Small | **`max(1, int(days))` coerce + clamp** |
| `sqlite.py:800` | `WHERE {' AND '.join(clauses)}` (literal clauses) | No | `# safe:` comment |

**Total**: 13 sites = 5 hardened + 8 annotated.

## Hardening details

### `_UPDATABLE_INTERACTION_COLS` allow-list (sqlite.py:304)
The `**fields` kwargs were trusted blindly — a malicious key like `judge_score = 0; DROP TABLE` would have flowed straight through `set_clause`. Verified callers (`maintenance.py:371`, `ilog/interaction_log.py:59`, test fixtures) write only 5 columns post-insert; the allow-list enumerates exactly those:

```python
_UPDATABLE_INTERACTION_COLS = frozenset({
    "judge_score", "judge_dims", "parse_error", "latency_ms", "timestamp",
})
```

`update_interaction(**fields)` now raises `ValueError(f"unknown column(s) {sorted(unknown)}; allowed: ...")` on any unknown key. Widening the set is intentional + visible in code review.

### `_SAFE_IDENT` regex (sqlite.py:127, 137)
`DROP TABLE IF EXISTS [{t}]` interpolates `t` from `sqlite_master`. Real-world table names are always identifiers — but a poisoned/corrupted DB row could pass through. The regex `^[A-Za-z_][A-Za-z0-9_]*$` is cheap defense in depth; non-matching names are logged and skipped.

### Int-coerce + clamp (sqlite.py:415, 438)
`days` was type-hinted `int` but nothing prevented a bypass at runtime. `max(1, int(days))` coerces and rejects `0` / negative values that would silently widen the window to all rows.

## Why no `# noqa: S608`?
TrueCourse is a separate tool from ruff/bandit and does NOT consume inline `noqa` suppressions. Using `# noqa: S608` would mislead reviewers into thinking suppression is happening. The `# safe: <reason>` convention is for human readers; the TrueCourse violations close in the dashboard after merge.

## Commits
1. `docs(evolution): annotate db.py SQL f-strings as safe (PR #9/10)` — 2 sites in db.py (DDL only)
2. `fix(evolution): harden 11 SQL f-string sites in sqlite.py (PR #9/10)` — 5 hardened + 6 annotated
3. `docs(error-discipline): SQL injection surface ADR addendum (PR #9/10)` — ADR + pattern bumps + rule #7

## Testing
- [x] `python3 -m pytest evolution/tests/test_storage_provider.py` — 58/58 pass
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all OK
- [x] `python3 -m ast` parse on both touched files
- [ ] CI

## Note
Plan said 23 hits; TrueCourse finds 13 in `evolution/`. The other 10 SQL-injection findings are outside the plan's stated scope (`evolution/db.py + evolution/storage/providers/sqlite.py`) — not in this PR.

## References
- `docs/decisions/error-discipline.md` — new "PR #9 addendum: SQL injection surface" section
- Plan memory: `~/.claude/projects/-Users-liam10play-deus/memory/project_error_discipline_plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)