### PR TITLE
docs(sql): annotate 10 remaining structural-safe SQL f-string sites (closes backlog)

### DIFF
--- a/docs/decisions/error-discipline.md
+++ b/docs/decisions/error-discipline.md
@@ -186,6 +186,8 @@ TrueCourse flagged 13 `security/deterministic/sql-injection` HIGHs in `evolution
 - **Identifier regex** (`_SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")`) before interpolating a name from `sqlite_master` into DDL. Rejects payloads that survived a corrupted-DB or hostile-environment edge case.
 - **Int-coerce + clamp** for time-window parameters that interpolate into `DATETIME('now', '-N days')`: `max(1, int(days))`. The clamp also prevents `days=0` from silently widening the window to all rows.
 
+PR #11 audited the remaining 10 non-evolution `sql-injection` HIGHs in `scripts/bench/store.py`, `scripts/memory_indexer.py`, and `scripts/memory_tree.py`; all confirmed structural-safe (vec0 dims from module int constants, ALTER TABLE col/coltype from literal tuple-lists, WHERE clauses joined from local literal-string fragments, DELETE FROM iterating a hard-coded schema list). Annotated with `# safe: <reason>` per the PR #9 convention. SQL injection backlog from the TrueCourse 2026-04-19 scan is closed.
+
 ## For future contributors
 
 When you catch or throw an error in Deus:

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-20"  # re-verified for SQL injection hardening in evolution/ (PR #9/10) — eval rules unchanged; allow-list update_interaction kwargs, regex-gate DROP TABLE identifiers, int-clamp DATETIME days; rationale comments added on structural-safe DDL/where-clause f-strings
+last_verified: "2026-04-20"  # re-verified for non-evolution SQL injection annotations (PR #11) — scripts/memory_indexer.py has 5 # safe: comments added; eval rules unchanged
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/bench/store.py
+++ b/scripts/bench/store.py
@@ -203,6 +203,9 @@ def recent_runs(
             params.append(since_ts)
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
         params.append(limit)
+        # safe: `where` is built from local literal-string fragments
+        # ("suite = ?", "ts >= ?"); user values bound through `params`.
+        # See PR #9 in docs/decisions/error-discipline.md.
         rows = con.execute(
             f"SELECT * FROM runs {where} ORDER BY ts DESC LIMIT ?",
             params,
@@ -239,6 +242,11 @@ def resolve_run(arg: str, suite: str | None = None) -> dict[str, Any] | None:
             conditions.append("suite = ?")
             params.append(suite)
         where_suite = ("WHERE " + " AND ".join(conditions) + " AND ") if conditions else "WHERE "
+
+        # safe (3 sites below): `where_suite` is "WHERE suite = ? AND " or
+        # "WHERE " — both built entirely from local literal-string fragments.
+        # The `arg` lookup value is bound through `?` params on every call.
+        # See PR #9 in docs/decisions/error-discipline.md.
 
         # 1. exact run_id
         row = con.execute(

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -185,6 +185,9 @@ def open_db() -> sqlite3.Connection:
             decisions TEXT
         )
     """)
+    # safe: EMBED_DIM is a module-level int constant imported from
+    # evolution.config. SQLite cannot parameterize vec0 dimensions.
+    # See PR #9 in docs/decisions/error-discipline.md.
     db.execute(f"""
         CREATE VIRTUAL TABLE IF NOT EXISTS embeddings
         USING vec0(embedding float[{EMBED_DIM}])
@@ -199,6 +202,8 @@ def open_db() -> sqlite3.Connection:
         ("domain", "TEXT DEFAULT 'general'"),
     ]:
         try:
+            # safe: col + definition come from the literal tuple-list above.
+            # SQLite DDL cannot parameterize identifiers or column types.
             db.execute(f"ALTER TABLE entries ADD COLUMN {col} {definition}")
         except sqlite3.OperationalError:
             pass
@@ -326,6 +331,8 @@ def open_db() -> sqlite3.Connection:
         ("orphan_reason", "TEXT DEFAULT NULL"),
     ]:
         try:
+            # safe: col + definition come from the literal tuple-list above.
+            # SQLite DDL cannot parameterize identifiers or column types.
             db.execute(f"ALTER TABLE entries ADD COLUMN {col} {definition}")
         except sqlite3.OperationalError:
             pass
@@ -1012,6 +1019,9 @@ def cmd_query(query: str, top: int = 3, recency_boost: bool = False,
         where_clauses.append("e.date <= ?")
         params.append(as_of)
 
+    # safe: where_clauses is built from local literal-string fragments
+    # ("v.embedding MATCH ?", "k = ?", ..., "e.date <= ?"); user values
+    # bound through `params`. See PR #9 in docs/decisions/error-discipline.md.
     rows = db.execute(
         f"""
         SELECT e.path, e.date, e.tldr, e.topics, e.decisions, e.type,
@@ -2724,6 +2734,9 @@ def cmd_rebuild():
         # Derived tables (no primary user data) — safe to clear during rebuild
         for table in ["embeddings", "entries_fts", "entities", "relationships", "atom_entities"]:
             try:
+                # safe: `table` iterates the literal list above; SQLite cannot
+                # parameterize identifiers in DELETE FROM. The `[...]` quoting
+                # is belt-and-suspenders on an already-fixed schema-name set.
                 db.execute(f"DELETE FROM [{table}]")
             except sqlite3.OperationalError:
                 pass

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -297,6 +297,9 @@ def open_db(db_path: Path = None) -> sqlite3.Connection:
     db.execute("CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst_id, kind)")
     db.execute("CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src_id, kind)")
     if sqlite_vec is not None:
+        # safe: EMBED_DIM is a module-level int constant defined at line 49
+        # of this file. SQLite cannot parameterize vec0 dimensions.
+        # See PR #9 in docs/decisions/error-discipline.md.
         db.execute(f"""
             CREATE VIRTUAL TABLE IF NOT EXISTS embeddings
             USING vec0(embedding float[{EMBED_DIM}])


### PR DESCRIPTION
## Summary
- Closes the TrueCourse `security/deterministic/sql-injection` backlog from the 2026-04-19 scan (the 10 sites outside `evolution/` that PR #9 explicitly scoped out)
- All 10 sites verified by an Explore agent as **structural-safe** — interpolated values come from module int constants, literal tuple-lists, or local literal-string fragments; user data is bound through `?` parameters every time
- Annotation-only (no logic changes); mirrors PR #9's `# safe: <reason>` convention exactly

## The 10 sites

| File:Line | Pattern | Why safe |
|---|---|---|
| `scripts/bench/store.py:207, 245, 253, 261` (×4) | `WHERE` clause from local literal-string joins | every condition fragment is a hard-coded string literal; values via `?` params |
| `scripts/memory_indexer.py:191` | `vec0(embedding float[{EMBED_DIM}])` (DDL) | `EMBED_DIM` is a module int constant from `evolution.config`; SQLite cannot parameterize vec0 dimensions |
| `scripts/memory_indexer.py:207, 336` (×2) | `ALTER TABLE entries ADD COLUMN {col} {definition}` | `col`/`definition` from a literal tuple-list immediately above; SQLite DDL cannot parameterize identifiers |
| `scripts/memory_indexer.py:1022` | `SELECT ... WHERE {' AND '.join(where_clauses)}` | `where_clauses` seeded with literal strings; user values via `params` |
| `scripts/memory_indexer.py:2737` | `DELETE FROM [{table}]` | `table` iterates over a hard-coded list of 5 schema names; the `[...]` quoting is belt-and-suspenders |
| `scripts/memory_tree.py:300` | `vec0(embedding float[{EMBED_DIM}])` (DDL) | `EMBED_DIM = 768` module constant defined in the same file |

**0 hardenable** + **10 annotation-only** + **0 false positives**. The trust boundary in `scripts/` is narrower than `evolution/` (which had 5 hardenable sites): every site here either runs over a hard-coded schema or uses `?` placeholders for everything user-controlled. Plan-reviewer Warden spot-checked site `memory_indexer.py:2737` (`for table in ["embeddings", "entries_fts", "entities", "relationships", "atom_entities"]:`) — confirmed the list is hardcoded and unreachable from any user-input or schema-evolution path.

## Why no shared `_safe_sql.py` module?
PR #9 added `_SAFE_IDENT` and `_UPDATABLE_INTERACTION_COLS` inside `evolution/storage/providers/sqlite.py`. PR #11 has zero callers needing those helpers. Promoting them to a shared `scripts/` util now would be YAGNI (same logic that killed `installStreamErrorLogger` in PR #6). When a real-risk site surfaces in `scripts/`, lift the helpers then.

## Commits
1. `docs(bench): annotate 4 SQL f-string sites as structural-safe in store.py`
2. `docs(scripts): annotate 6 SQL f-string sites as structural-safe in memory_indexer + memory_tree`
3. `docs(error-discipline): close SQL injection backlog + bump pattern`

## ADR addendum
Appended a closing paragraph to PR #9's existing "SQL injection surface" section (per Warden's "don't open a new addendum heading for one paragraph" call). The paragraph notes the 10 sites were audited and confirmed structural-safe; the SQL injection backlog from the 2026-04-19 TrueCourse scan is closed.

## Testing
- [x] Python `ast.parse()` on all 3 touched files
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all OK after `eval-change.md` bump
- [x] No logic changes — pure annotation; tests unaffected
- [ ] CI

## References
- `docs/decisions/error-discipline.md` — appended paragraph to "PR #9 addendum: SQL injection surface"
- TrueCourse findings: `.truecourse/analyses/2026-04-19T09-29-22Z_991f21d7.json`, ruleKey `security/deterministic/sql-injection`
- Plan memory: `~/.claude/projects/-Users-liam10play-deus/memory/project_error_discipline_plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)