### PR TITLE
chore(bootstrap): mechanical mirror enforcement instead of packages/ extraction (closes #218)

### DIFF
--- a/container/agent-runner/src/bootstrap.ts
+++ b/container/agent-runner/src/bootstrap.ts
@@ -6,11 +6,16 @@
  * and cannot import from src/. Logging goes through the same stderr convention
  * the file's `log()` helper uses elsewhere: `[<entry-name>] <message>`.
  *
- * Drift risk: two copies of the harness must stay behaviorally aligned.
- * Extracting both into a shared packages/ workspace is tracked in issue #218;
- * until then, any change here MUST be mirrored in src/bootstrap.ts (and vice
- * versa).
+ * Drift discipline: structural equivalence with src/bootstrap.ts is enforced
+ * mechanically by `python3 scripts/drift_check.py --bootstrap-mirror` (and via
+ * `--all` in CI). Anything wrapped in `// MIRROR-IGNORE-START / MIRROR-IGNORE-END`
+ * is intentionally divergent (logger calls and the supporting helpers); the
+ * rest must stay byte-for-byte aligned with the src/ copy. See issue #218 for
+ * why these stay as two files instead of one shared package.
  */
+
+// MIRROR-IGNORE-START -- container has no pino dep; uses console.error in the logError helper below (intentionally empty import block to align with src/'s imports section)
+// MIRROR-IGNORE-END
 
 export interface BootstrapOptions {
   /**
@@ -39,9 +44,11 @@ export function bootstrap(
   Promise.resolve()
     .then(() => mainFn())
     .catch((err: unknown) => {
+      // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
       logError(name, `${name} main() failed`, err);
       // eslint-disable-next-line no-restricted-syntax -- harness-managed exit on main() reject; the no-process-exit rule explicitly exempts the bootstrap harness itself
       process.exit(exitCode);
+      // MIRROR-IGNORE-END
     });
 }
 
@@ -53,18 +60,23 @@ function installGlobalHandlers(
   globalHandlersInstalled = true;
 
   process.on('uncaughtException', (err: Error) => {
+    // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
     logError(name, 'uncaughtException', err);
     // eslint-disable-next-line no-restricted-syntax -- harness-managed exit on uncaught exception; safer to crash than continue in undefined state
     process.exit(1);
+    // MIRROR-IGNORE-END
   });
 
   process.on('unhandledRejection', (reason: unknown) => {
+    // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
     logError(name, 'unhandledRejection', reason);
     // eslint-disable-next-line no-restricted-syntax -- harness-managed conditional exit; default is opt-out so this only fires when a caller explicitly chose strict-mode
     if (exitOnUnhandledRejection) process.exit(1);
+    // MIRROR-IGNORE-END
   });
 }
 
+// MIRROR-IGNORE-START -- helpers for the console-based variant; src/ has only `serializeError` and uses pino at the call sites instead
 function logError(name: string, msg: string, err: unknown): void {
   const serialized = serializeError(err);
   console.error(
@@ -78,6 +90,7 @@ function serializeError(err: unknown): unknown {
   }
   return err;
 }
+// MIRROR-IGNORE-END
 
 /** Test-only: reset the install-once guard. Do NOT call in production code. */
 export function __resetBootstrapForTesting(): void {

--- a/docs/decisions/error-discipline.md
+++ b/docs/decisions/error-discipline.md
@@ -188,6 +188,19 @@ TrueCourse flagged 13 `security/deterministic/sql-injection` HIGHs in `evolution
 
 PR #11 audited the remaining 10 non-evolution `sql-injection` HIGHs in `scripts/bench/store.py`, `scripts/memory_indexer.py`, and `scripts/memory_tree.py`; all confirmed structural-safe (vec0 dims from module int constants, ALTER TABLE col/coltype from literal tuple-lists, WHERE clauses joined from local literal-string fragments, DELETE FROM iterating a hard-coded schema list). Annotated with `# safe: <reason>` per the PR #9 convention. SQL injection backlog from the TrueCourse 2026-04-19 scan is closed.
 
+### Issue #218: bootstrap mirror discipline
+
+PR #2 (#215) shipped `src/bootstrap.ts`. PR #3 (#219) wired it into the agent-runner entry point — but `container/agent-runner/` has its own `tsconfig.json` and `node_modules` and cannot import from `src/`. The harness was duplicated as `container/agent-runner/src/bootstrap.ts`, with the only divergence being the logger: pino + `FatalError` discrimination in the main process, plain `console.error` in the container (which has no pino dep). Issue #218 was opened to track extracting both copies into a shared `packages/bootstrap` workspace.
+
+After investigation, **extraction was rejected** in favor of mechanical drift enforcement:
+
+1. **Extraction needs a third logging abstraction.** The container copy was deliberately stripped of pino + `FatalError` to keep the runtime image small and avoid a `src/`-side dep. Sharing one harness requires either (a) the container takes on pino, (b) `src/` downgrades to `console.error` (loses the `FatalError` → `fatal` severity discrimination), or (c) introduce a `LogAdapter` interface and inject the logger. Option (c) is a bigger design call than the duplication itself.
+2. **No workspace tooling.** The repo has no `workspaces` field in root `package.json`. Channel packages use `file:../mcp-channel-core` pseudo-deps that require manual pre-builds. There is no `src/` → `packages/` consumer relationship anywhere today; making `src/bootstrap.ts` consume `packages/bootstrap` would be the first such direction in the repo.
+
+The actual risk — silent drift between the two copies — is closed mechanically by `python3 scripts/drift_check.py --bootstrap-mirror` (also runs as part of `--all` in CI). The check normalizes both files (strips JSDoc, single-line comments, blank lines, and `// MIRROR-IGNORE-START / MIRROR-IGNORE-END` blocks) and asserts byte-equal structural shape. Deliberately divergent regions — imports, logger call sites, and the `console.error` helper — are wrapped in `MIRROR-IGNORE` markers; everything else must mirror exactly. Adding a parameter, removing a function, or changing the control flow on one side now fails CI until the other side mirrors the change.
+
+If a future PR resolves the logger divergence (e.g., a `LogAdapter` shipped in another initiative, or the container gains pino), the extraction becomes straightforward and the mirror check can be retired. Until then, two files + one mechanical check is the proportionate trade-off.
+
 ## For future contributors
 
 When you catch or throw an error in Deus:

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-20"  # re-reviewed for process.exit ban (PR #7/10) — deploy rules unchanged; agent-runner index.ts converts 2 process.exit(1) sites to throws (bootstrap harness now handles structured exit), no dist/ shape change
+last_verified: "2026-04-20"  # re-reviewed for bootstrap mirror enforcement (#218) — deploy rules unchanged; src/bootstrap.ts and container/agent-runner/src/bootstrap.ts now have MIRROR-IGNORE markers around logger divergence; mechanical drift check via `drift_check.py --bootstrap-mirror` (also in --all)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-20"  # re-reviewed for SQL injection hardening in evolution/ (PR #9/10) — pattern rules unchanged; new project conventions documented in ADR (allow-lists for kwarg-driven UPDATE; _SAFE_IDENT regex; int-coerce + clamp for DATETIME days; `# safe:` rationale comments on unavoidable f-string .execute() sites)
+last_verified: "2026-04-20"  # re-reviewed for bootstrap mirror enforcement (#218) — pattern rules unchanged; src/bootstrap.ts gains MIRROR-IGNORE markers wrapping logger divergence; new `# MIRROR-IGNORE-START / MIRROR-IGNORE-END` convention documented in ADR for any future intentionally-divergent mirrored files
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1069,16 +1069,145 @@ def check_all(project_root: Path, base_ref: str | None = None) -> int:
     tt_rc = check_test_tasks(project_root)
     print("\n=== shadow (private overrides) ===")
     shadow_rc = check_shadow(project_root)
+    print("\n=== bootstrap mirror ===")
+    bm_rc = check_bootstrap_mirror(project_root)
     print("\n=== coverage (informational) ===")
     cov_rc = check_coverage(project_root)
 
-    worst = max(drift_rc, paths_rc, idx_rc, adr_rc, tt_rc, shadow_rc, cov_rc)
+    worst = max(drift_rc, paths_rc, idx_rc, adr_rc, tt_rc, shadow_rc, bm_rc, cov_rc)
     print()
     if worst == 0:
         print("ALL CHECKS PASSED")
     else:
         print(f"FAILED (worst exit code: {worst})")
     return worst
+
+
+# Two copies of the bootstrap harness exist by design — `src/bootstrap.ts`
+# logs through pino+FatalError, `container/agent-runner/src/bootstrap.ts`
+# logs through console.error (no pino dep). Issue #218 considered extracting
+# them into a shared package and rejected it: the only divergence is the
+# logger, which would require a third LogAdapter abstraction that's a bigger
+# design call than the duplication is worth. Instead we mechanically enforce
+# structural mirror with this check.
+_BOOTSTRAP_MIRROR_PAIR = (
+    "src/bootstrap.ts",
+    "container/agent-runner/src/bootstrap.ts",
+)
+
+
+def _strip_for_mirror(text: str) -> str:
+    """Normalize a bootstrap.ts file for structural diff against its mirror.
+
+    Strips:
+      1. Lines between `// MIRROR-IGNORE-START` and `// MIRROR-IGNORE-END`
+         (inclusive). These mark the deliberately-divergent sections —
+         logger calls, helper functions for logging, and supporting imports.
+      2. JSDoc blocks (`/** ... */`).
+      3. Single-line `// ...` comments (NOT URLs in code, since they'd be
+         in string literals — bootstrap.ts has no URL strings).
+      4. Blank lines.
+      5. Leading/trailing whitespace on each remaining line.
+
+    The result is a structure-only view: function signatures, control flow,
+    interface definitions, and the harness skeleton. Two mirror copies must
+    produce byte-identical normalized text.
+    """
+    lines = text.splitlines()
+    stripped: list[str] = []
+
+    in_jsdoc = False
+    in_mirror_ignore = False
+    for line in lines:
+        s = line.strip()
+
+        # JSDoc state first — text inside a JSDoc block can mention the
+        # MIRROR-IGNORE keywords (e.g., the file header documenting the
+        # marker convention), and those mentions must not be mistaken for
+        # actual markers.
+        if in_jsdoc:
+            if "*/" in s:
+                in_jsdoc = False
+            continue
+        if s.startswith("/**"):
+            # Handle single-line JSDoc like `/** foo */`.
+            if s.endswith("*/") and len(s) > 3:
+                continue
+            in_jsdoc = True
+            continue
+
+        # Mirror-ignore markers (only outside JSDoc).
+        if not in_mirror_ignore and (
+            s == "// MIRROR-IGNORE-START"
+            or s.startswith("// MIRROR-IGNORE-START ")
+        ):
+            in_mirror_ignore = True
+            continue
+        if in_mirror_ignore:
+            if s == "// MIRROR-IGNORE-END" or s.startswith("// MIRROR-IGNORE-END "):
+                in_mirror_ignore = False
+            continue
+
+        # Single-line comment lines
+        if s.startswith("//"):
+            continue
+        if not s:
+            continue
+
+        stripped.append(s)
+
+    return "\n".join(stripped)
+
+
+def check_bootstrap_mirror(project_root: Path) -> int:
+    """Verify `src/bootstrap.ts` and `container/agent-runner/src/bootstrap.ts`
+    stay structurally aligned. See issue #218.
+
+    Both files must be structurally identical after stripping JSDoc, single-
+    line comments, blank lines, and the deliberately divergent regions
+    bracketed by `// MIRROR-IGNORE-START` / `// MIRROR-IGNORE-END`.
+
+    Returns 0 on match, 1 on diff or missing file.
+    """
+    paths = [project_root / p for p in _BOOTSTRAP_MIRROR_PAIR]
+    for p in paths:
+        if not p.exists():
+            print(f"MISSING: {p.relative_to(project_root)}")
+            return 1
+
+    normalized = [_strip_for_mirror(p.read_text()) for p in paths]
+    if normalized[0] == normalized[1]:
+        print(
+            f"Both bootstrap copies aligned "
+            f"({len(normalized[0].splitlines())} structural lines each)."
+        )
+        return 0
+
+    # Show a unified diff so the failure is actionable.
+    import difflib
+    diff = list(
+        difflib.unified_diff(
+            normalized[0].splitlines(),
+            normalized[1].splitlines(),
+            fromfile=_BOOTSTRAP_MIRROR_PAIR[0] + " (normalized)",
+            tofile=_BOOTSTRAP_MIRROR_PAIR[1] + " (normalized)",
+            lineterm="",
+        )
+    )
+    print("BOOTSTRAP MIRROR DRIFT — structural shape diverges between:")
+    print(f"  {_BOOTSTRAP_MIRROR_PAIR[0]}")
+    print(f"  {_BOOTSTRAP_MIRROR_PAIR[1]}")
+    print()
+    for line in diff:
+        print(line)
+    print()
+    print(
+        "FIX: apply the same change to both files. The two harnesses must "
+        "stay behaviorally aligned — see issue #218 for why they live in "
+        "two places. Wrap deliberately-divergent regions (logger calls and "
+        "their helpers) in `// MIRROR-IGNORE-START` / `// MIRROR-IGNORE-END`."
+    )
+    return 1
 
 
 def check_shadow(project_root: Path) -> int:
@@ -1319,6 +1448,12 @@ if __name__ == "__main__":
         help="Check src/private/ files shadow public equivalents with correct /tmp/ symlinks",
     )
     parser.add_argument(
+        "--bootstrap-mirror",
+        action="store_true",
+        dest="bootstrap_mirror",
+        help="Verify src/bootstrap.ts and container/agent-runner/src/bootstrap.ts stay structurally aligned (issue #218)",
+    )
+    parser.add_argument(
         "--indexes",
         action="store_true",
         help="Check every indexed directory: index file references match on-disk leaves (orphans + dangling)",
@@ -1333,6 +1468,8 @@ if __name__ == "__main__":
 
     if args.shadow:
         sys.exit(check_shadow(PROJECT_ROOT))
+    elif args.bootstrap_mirror:
+        sys.exit(check_bootstrap_mirror(PROJECT_ROOT))
     elif args.indexes:
         sys.exit(check_index_completeness(PROJECT_ROOT))
     elif args.contradictions is not None:

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -854,3 +854,132 @@ class TestCheckIndexCompleteness:
         drift_check.check_all(tmp_path)
         out = capsys.readouterr().out
         assert "index completeness" in out.lower()
+
+
+class TestBootstrapMirror:
+    """Tests for `check_bootstrap_mirror` — issue #218."""
+
+    SRC_TEMPLATE = """\
+/**
+ * Header comment for src copy.
+ */
+
+// MIRROR-IGNORE-START -- src uses pino
+import { logger } from './logger.js';
+// MIRROR-IGNORE-END
+
+export interface BootstrapOptions {
+  readonly name: string;
+}
+
+export function bootstrap(opts: BootstrapOptions): void {
+  // MIRROR-IGNORE-START -- logger call
+  logger.info(opts.name);
+  // MIRROR-IGNORE-END
+  process.exit(0);
+}
+"""
+
+    CONTAINER_TEMPLATE = """\
+/**
+ * Different header for container copy.
+ */
+
+// MIRROR-IGNORE-START -- container has no pino
+// MIRROR-IGNORE-END
+
+export interface BootstrapOptions {
+  readonly name: string;
+}
+
+export function bootstrap(opts: BootstrapOptions): void {
+  // MIRROR-IGNORE-START -- console.error call instead
+  console.error(opts.name);
+  // MIRROR-IGNORE-END
+  process.exit(0);
+}
+"""
+
+    def _build_pair(self, tmp_path: Path, src_text: str, container_text: str) -> None:
+        (tmp_path / "src").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "container" / "agent-runner" / "src").mkdir(
+            parents=True, exist_ok=True
+        )
+        (tmp_path / "src" / "bootstrap.ts").write_text(src_text)
+        (tmp_path / "container" / "agent-runner" / "src" / "bootstrap.ts").write_text(
+            container_text
+        )
+
+    def test_aligned_pair_passes(self, tmp_path, capsys):
+        self._build_pair(tmp_path, self.SRC_TEMPLATE, self.CONTAINER_TEMPLATE)
+        rc = drift_check.check_bootstrap_mirror(tmp_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "aligned" in out.lower()
+
+    def test_signature_drift_fails(self, tmp_path, capsys):
+        # Mutate src to add a parameter; container stays single-arg.
+        mutated = self.SRC_TEMPLATE.replace(
+            "bootstrap(opts: BootstrapOptions): void {",
+            "bootstrap(opts: BootstrapOptions, extra: number): void {",
+        )
+        self._build_pair(tmp_path, mutated, self.CONTAINER_TEMPLATE)
+        rc = drift_check.check_bootstrap_mirror(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "drift" in out.lower()
+        assert "extra: number" in out  # diff body shows the offending line
+
+    def test_extra_function_drift_fails(self, tmp_path):
+        # Insert an entire helper function into the container copy outside
+        # any MIRROR-IGNORE block — should be flagged as drift.
+        mutated = self.CONTAINER_TEMPLATE.replace(
+            "process.exit(0);\n}\n",
+            "process.exit(0);\n}\n\nexport function extra(): void { }\n",
+        )
+        self._build_pair(tmp_path, self.SRC_TEMPLATE, mutated)
+        rc = drift_check.check_bootstrap_mirror(tmp_path)
+        assert rc == 1
+
+    def test_logger_only_diff_inside_ignore_block_passes(self, tmp_path):
+        # Different content inside MIRROR-IGNORE blocks must NOT trip the
+        # check — that's the whole point of the markers.
+        ctn_with_extra_logger = self.CONTAINER_TEMPLATE.replace(
+            "console.error(opts.name);",
+            "console.error('[' + opts.name + ']: ready'); console.error('boot done');",
+        )
+        self._build_pair(tmp_path, self.SRC_TEMPLATE, ctn_with_extra_logger)
+        rc = drift_check.check_bootstrap_mirror(tmp_path)
+        assert rc == 0
+
+    def test_jsdoc_mention_of_marker_keyword_does_not_trip(self, tmp_path):
+        # File header that documents the marker convention must not be
+        # parsed as an actual marker — JSDoc state takes precedence.
+        src_with_doc = self.SRC_TEMPLATE.replace(
+            "Header comment for src copy.",
+            "Header copy. Wrap divergent code in MIRROR-IGNORE-START / MIRROR-IGNORE-END.",
+        )
+        ctn_with_doc = self.CONTAINER_TEMPLATE.replace(
+            "Different header for container copy.",
+            "Container header. Wrap divergent code in MIRROR-IGNORE-START / MIRROR-IGNORE-END.",
+        )
+        self._build_pair(tmp_path, src_with_doc, ctn_with_doc)
+        rc = drift_check.check_bootstrap_mirror(tmp_path)
+        assert rc == 0
+
+    def test_missing_file_returns_one(self, tmp_path, capsys):
+        # Only one of the two files exists — must fail loudly.
+        (tmp_path / "src").mkdir(parents=True)
+        (tmp_path / "src" / "bootstrap.ts").write_text(self.SRC_TEMPLATE)
+        rc = drift_check.check_bootstrap_mirror(tmp_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "missing" in out.lower()
+
+    def test_real_repo_files_align(self):
+        # Sanity check: the actual files in the repo must pass at all times.
+        # If this test breaks, somebody mutated one bootstrap copy without
+        # mirroring the change to the other (or without a MIRROR-IGNORE wrap).
+        repo_root = Path(__file__).resolve().parents[2]
+        rc = drift_check.check_bootstrap_mirror(repo_root)
+        assert rc == 0, "Real bootstrap.ts copies have drifted out of alignment"

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -17,8 +17,10 @@
  * so attribution is correct regardless of import order.
  */
 
+// MIRROR-IGNORE-START -- intentional logger divergence: src/ uses pino + FatalError; container/agent-runner/src/bootstrap.ts uses console.error (no pino dep)
 import { FatalError, isDeusError } from './errors/index.js';
 import { logger } from './logger.js';
+// MIRROR-IGNORE-END
 
 export interface BootstrapOptions {
   /**
@@ -62,12 +64,14 @@ export function bootstrap(
   Promise.resolve()
     .then(() => mainFn())
     .catch((err: unknown) => {
+      // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
       const severity = err instanceof FatalError ? 'fatal' : 'error';
       logger[severity](
         { err: serializeError(err), entry: name },
         `${name} main() failed`,
       );
       process.exit(exitCode);
+      // MIRROR-IGNORE-END
     });
 }
 
@@ -79,22 +83,27 @@ function installGlobalHandlers(
   globalHandlersInstalled = true;
 
   process.on('uncaughtException', (err: Error) => {
+    // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
     logger.fatal(
       { err: serializeError(err), entry: name },
       'uncaughtException',
     );
     process.exit(1);
+    // MIRROR-IGNORE-END
   });
 
   process.on('unhandledRejection', (reason: unknown) => {
+    // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
     logger.error(
       { err: serializeError(reason), entry: name },
       'unhandledRejection',
     );
     if (exitOnUnhandledRejection) process.exit(1);
+    // MIRROR-IGNORE-END
   });
 }
 
+// MIRROR-IGNORE-START -- serializeError body diverges: src/ checks isDeusError; container/ has no DeusError dep so falls through to plain Error handling
 function serializeError(err: unknown): unknown {
   if (isDeusError(err)) return err.toJSON();
   if (err instanceof Error) {
@@ -102,6 +111,7 @@ function serializeError(err: unknown): unknown {
   }
   return err;
 }
+// MIRROR-IGNORE-END
 
 /**
  * Test-only: reset the install-once guard so `bootstrap()` can be exercised


### PR DESCRIPTION
## Summary
- **Closes #218** — bootstrap.ts duplication
- Adds a `--bootstrap-mirror` mode to `scripts/drift_check.py` (also wired into `--all`) that enforces structural equivalence between `src/bootstrap.ts` and `container/agent-runner/src/bootstrap.ts`
- Wraps the deliberately-divergent regions (logger calls + supporting helpers) in `// MIRROR-IGNORE-START / MIRROR-IGNORE-END` markers; the rest must mirror byte-for-byte after JSDoc/comment/blank-line stripping
- 7 new pytest cases under `scripts/tests/test_drift_check.py::TestBootstrapMirror`, including a real-repo regression guard

## Why drift-check, not extraction?

The original framing of #218 was "extract both copies into a shared `packages/bootstrap` workspace." Investigation rejected that:

1. **The two copies diverge intentionally on ONE thing — the logger.** `src/` uses pino + `FatalError` (logs at `fatal` for FatalError, `error` otherwise). `container/agent-runner/` uses `console.error` (no pino dep — kept light by design). Sharing requires either:
   - Container takes on pino → reverses PR #3's deliberate choice
   - `src/` downgrades to console.error → loses fatal-level + FatalError discrimination
   - Introduce a `LogAdapter` abstraction → bigger design call than the duplication itself
2. **No workspace tooling.** Root `package.json` has no `workspaces` field. Channel packages use `file:../mcp-channel-core` pseudo-deps that require manual pre-builds. There is no `src/` → `packages/` consumer relationship anywhere today; `src/bootstrap.ts` would be the first.

The actual risk of #218 is **silent drift**, not the duplication itself. Mechanical mirror enforcement closes that risk at low cost without the abstraction overhead.

## How the check works

`_strip_for_mirror()` normalizes a `bootstrap.ts` file by stripping:
- JSDoc blocks (`/** ... */`)
- Single-line `// ...` comments
- Lines between `// MIRROR-IGNORE-START` and `// MIRROR-IGNORE-END` (inclusive)
- Blank lines and per-line whitespace

The two normalized copies must be byte-equal. After 33 structural lines of normalization, both copies match exactly today.

JSDoc state takes precedence over MIRROR-IGNORE marker detection so the file header documenting the marker convention doesn't accidentally trip the parser.

## Marker placement note (eslint interaction)

The MIRROR-IGNORE blocks enclose the logger call lines AND the immediately-following `process.exit(...)` lines. This is required because container's `// eslint-disable-next-line no-restricted-syntax` directives (introduced by PR #7's process.exit ban) only apply to the next non-blank line. If MIRROR-IGNORE-END landed between the disable comment and `process.exit`, the next-line directive would point at the marker instead of the exit — breaking ESLint. Wrapping `process.exit` inside the MIRROR-IGNORE block keeps the directive contract intact AND keeps the structural diff focused on the genuinely-shared skeleton (Promise chain, handler registrations, function signatures).

## Commits
1. `chore(bootstrap): add MIRROR-IGNORE markers around logger divergence` — annotation prep, no behavior change
2. `feat(drift-check): mechanical bootstrap mirror enforcement (closes #218)` — script + tests
3. `docs(error-discipline): close #218 with mirror discipline rationale` — ADR section explaining the trade-off

## Future-proofing

If a later PR resolves the logger divergence (LogAdapter ships, container gains pino, or some other route), extraction into `packages/bootstrap` becomes straightforward and the mirror check retires cleanly. Until then, two files + one mechanical check is the proportionate trade-off.

## Testing
- [x] `python3 scripts/drift_check.py --bootstrap-mirror` — passes
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all checks pass (new "bootstrap mirror" section visible)
- [x] `python3 -m pytest scripts/tests/test_drift_check.py::TestBootstrapMirror -v` — 7/7 pass
- [x] `npx tsc --noEmit` (root + container/agent-runner) — clean
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run src/bootstrap.test.ts` — 9/9 pass
- [ ] CI

## References
- Issue #218 — original framing of the duplication problem
- `docs/decisions/error-discipline.md` — new "Issue #218: bootstrap mirror discipline" section
- `scripts/drift_check.py` — new `check_bootstrap_mirror` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)