### PR TITLE
ci(truecourse): add --diff regression gate (PR #10/10) — closes initiative

### DIFF
--- a/.github/workflows/truecourse.yml
+++ b/.github/workflows/truecourse.yml
@@ -1,0 +1,130 @@
+name: TrueCourse Diff Gate
+
+# Static-analysis diff gate — fail the PR if it introduces NEW critical
+# violations vs origin/main. Existing baseline (4256+ violations as of
+# 2026-04-19) is intentionally ignored; the gate only catches regressions.
+#
+# How it works:
+#   1. Check out the PR head with full history (--diff needs to traverse).
+#   2. Switch to the merge-base with main, run `truecourse analyze` to
+#      establish the baseline analysis at .truecourse/analyses/.
+#   3. Switch back to the PR head, run `truecourse analyze --diff` which
+#      re-scans and compares against the just-stored baseline.
+#   4. Run `truecourse list --diff` to surface any new findings in the
+#      job log so the failure is actionable.
+#   5. Fail (exit 1) only on NEW criticals — new highs warn (visible in
+#      the log) but don't block merge.
+#
+# Isolated workflow file (separate from ci.yml) — truecourse@0.5.0 was
+# published 2026-04-19 and is bleeding-edge; if it crashes or proves
+# flaky, this workflow can be disabled with one click without touching
+# the main CI gate.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  truecourse-diff:
+    name: TrueCourse --diff vs main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out PR head with full history
+        uses: actions/checkout@v6
+        with:
+          # full history required so we can `git checkout` origin/main
+          # for the baseline scan and back to the PR head for the diff
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"  # truecourse bundles pyright
+
+      - name: Cache npx download cache
+        # truecourse@0.5.0 is ~43 MB unpacked (web-tree-sitter + pyright);
+        # caching by package-lock keeps cold starts under a second once warm.
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm/_npx
+          key: npx-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npx-${{ runner.os }}-
+
+      - name: Install repo deps (incl. truecourse)
+        run: npm ci
+
+      - name: Configure truecourse (no LLM rules — deterministic only)
+        # The interactive "Run LLM-powered rules?" prompt would hang CI.
+        # Pre-creating the config file with enableLlmRules:false is the
+        # documented escape hatch (see .truecourse/config.json on first run).
+        run: |
+          mkdir -p .truecourse
+          echo '{"enableLlmRules": false}' > .truecourse/config.json
+
+      - name: Establish baseline (scan origin/main)
+        # Save the PR-head SHA so we can return to it after the baseline scan.
+        # `git stash --include-untracked` preserves the .truecourse/config.json
+        # we just wrote so it doesn't get clobbered by the checkout.
+        run: |
+          PR_HEAD=$(git rev-parse HEAD)
+          echo "PR_HEAD=$PR_HEAD" >> "$GITHUB_ENV"
+          git stash push --include-untracked -m "truecourse-config" || true
+          git checkout origin/main
+          git stash pop || true
+          npx truecourse analyze
+          # baseline now lives in .truecourse/analyses/ + LATEST.json points at it
+
+      - name: Switch back to PR head + run diff
+        # `analyze --diff` re-scans the working tree and compares against
+        # the stored LATEST analysis (the baseline from the previous step).
+        # Exits 0 on clean diff, non-zero on hard failure (e.g. missing
+        # baseline). New violations are reported in the summary line and
+        # exposed in detail by the `list --diff` step below.
+        id: diff
+        run: |
+          # Stash again so the freshly-built .truecourse/ baseline is
+          # preserved across the checkout back to PR_HEAD.
+          git stash push --include-untracked -m "truecourse-baseline" || true
+          git checkout "$PR_HEAD"
+          git stash pop || true
+          npx truecourse analyze --diff | tee /tmp/diff-summary.txt
+
+      - name: Show new + resolved violations
+        if: always()
+        run: npx truecourse list --diff --all || true
+
+      - name: Fail on new criticals
+        # `list --diff` prints lines like
+        # `[critical] <rule>` for new criticals. We grep for any new
+        # critical row in the diff output. New highs print as `[high] ...`
+        # but only WARN (logged here, not exit 1) per the error-discipline
+        # ADR — see "PR #10 addendum: TrueCourse CI gate".
+        run: |
+          DIFF_OUT=$(npx truecourse list --diff --all 2>/dev/null || true)
+
+          NEW_CRITICALS=$(printf '%s\n' "$DIFF_OUT" | grep -cE '^\+.*\[critical\]' || true)
+          NEW_HIGHS=$(printf '%s\n' "$DIFF_OUT" | grep -cE '^\+.*\[high\]' || true)
+
+          echo "::group::TrueCourse diff summary"
+          echo "New criticals: $NEW_CRITICALS"
+          echo "New highs: $NEW_HIGHS (warning only)"
+          echo "::endgroup::"
+
+          if [ "$NEW_HIGHS" -gt 0 ]; then
+            echo "::warning::TrueCourse: $NEW_HIGHS new high-severity finding(s) introduced — see job log + npx truecourse list --diff for detail"
+          fi
+
+          if [ "$NEW_CRITICALS" -gt 0 ]; then
+            echo "::error::TrueCourse: $NEW_CRITICALS new CRITICAL finding(s) introduced. Reproduce locally with: npx truecourse analyze --diff"
+            exit 1
+          fi

--- a/.github/workflows/truecourse.yml
+++ b/.github/workflows/truecourse.yml
@@ -63,6 +63,13 @@ jobs:
       - name: Install repo deps (incl. truecourse)
         run: npm ci
 
+      - name: Install Claude Code CLI (truecourse runtime requirement)
+        # truecourse@0.5.0 hard-checks for the `claude` binary on PATH at
+        # startup, even with `enableLlmRules: false`. Installing the CLI
+        # (no auth, no API calls — only the binary-existence check matters
+        # for our deterministic-only configuration).
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Configure truecourse (no LLM rules — deterministic only)
         # The interactive "Run LLM-powered rules?" prompt would hang CI.
         # Pre-creating the config file with enableLlmRules:false is the

--- a/docs/decisions/error-discipline.md
+++ b/docs/decisions/error-discipline.md
@@ -201,6 +201,26 @@ The actual risk — silent drift between the two copies — is closed mechanical
 
 If a future PR resolves the logger divergence (e.g., a `LogAdapter` shipped in another initiative, or the container gains pino), the extraction becomes straightforward and the mirror check can be retired. Until then, two files + one mechanical check is the proportionate trade-off.
 
+### PR #10 addendum: TrueCourse `--diff` CI gate
+
+PR #10 closes the 10-PR initiative by mechanically guarding against regressions: every PR re-runs TrueCourse against `origin/main` as a baseline and fails the build on **new criticals**. New highs warn (visible in the job log) but don't block merge.
+
+**Install:** `truecourse@0.5.0` (npm, MIT, by `mushgev`) is pinned in root `package.json` devDependencies. The CLI is also exposed via four `npm run truecourse:*` scripts (`analyze`, `diff`, `list`, `list-diff`) so contributors can reproduce CI failures locally with the exact same version that ran in GitHub Actions.
+
+**Workflow file:** `.github/workflows/truecourse.yml` runs in isolation from the main `ci.yml` job. The split was deliberate — truecourse@0.5.0 is bleeding-edge (published 2026-04-19) and the workflow can be disabled with one click without touching the main CI gate. The workflow:
+
+1. Checks out the PR head with `fetch-depth: 0`.
+2. Pre-creates `.truecourse/config.json` with `enableLlmRules: false` to skip the interactive "Run LLM-powered rules?" prompt that would otherwise hang CI. The config is preserved across the baseline checkout via `git stash --include-untracked`.
+3. Switches to `origin/main` and runs `truecourse analyze` — this writes the baseline to `.truecourse/analyses/<id>.json` and points `LATEST.json` at it.
+4. Switches back to the PR head and runs `truecourse analyze --diff` — re-scans the working tree and compares against the freshly-stored baseline.
+5. Surfaces the diff via `truecourse list --diff --all` and counts `[critical]`/`[high]` rows in the new-violations section. Exits 1 on any new critical; emits a `::warning::` annotation on any new high.
+
+**Baseline management:** `.truecourse/` is gitignored locally (the directory's own `.gitignore` excludes `analyses/`, `LATEST.json`, etc.). CI re-builds the baseline from scratch every run rather than committing it — this avoids baseline-rot (every refactor would otherwise need a baseline-update commit), at the cost of running `analyze` twice per PR (~28s + 28s, plus a cached `.npm/_npx/` install). The `actions/cache@v4` step keys on `package-lock.json` so cold starts only pay the unpack cost once per dep change.
+
+**Reproducing locally:** `npx truecourse analyze` once on `main` to build the baseline, then `npx truecourse analyze --diff` after your changes. The output mirrors what CI sees. `npx truecourse list --diff` shows the actual new findings.
+
+**What "criticals" means here:** TrueCourse classifies its 1083 deterministic rules into critical/high/medium/low by impact. Critical findings include `eval` injection, hardcoded secrets, command injection from user input, missing transaction boundaries on multi-statement writes, and similar production-fatal classes. The 87 critical findings on the 2026-04-19 baseline are mostly false positives or known-acceptable (placeholder OAuth, single-row table UPDATEs, rebuild DELETEs documented in `no-db-deletion.md`); the gate ignores them by design. **Only NEW criticals introduced by a PR diff fail the build.**
+
 ## For future contributors
 
 When you catch or throw an error in Deus:
@@ -212,6 +232,7 @@ When you catch or throw an error in Deus:
 5. **Static analyzer flagging a `.connect()` site as "missing error handler"?** Check the return type first. `Promise<T>` → structured `.catch()` or try/catch with an owner label (PR #6 pattern). `EventEmitter` → `.on('error', ...)`. SDK-internal transports (e.g. `StdioServerTransport`) wire their own stdin/stdout error listeners — leave them alone.
 6. **Writing Python in `scripts/`?** Never `datetime.now()`. Use `utc_now()` for internal timestamps, `local_now()` for user-facing strings (PR #8). The naming forces you to answer "moment or calendar day?".
 7. **Building SQL?** Always parameterize data values. Identifiers (table/column names) and DDL must come from a closed allow-list (a literal tuple in code) or pass through `_SAFE_IDENT` regex validation (PR #9). Annotate the unavoidable f-string `.execute()` sites with `# safe: <reason>`.
+8. **TrueCourse CI flagged your PR?** Reproduce locally with `npx truecourse analyze --diff` (after a baseline `npx truecourse analyze` on `main`). The workflow only fires on **new criticals** introduced by the PR; new highs warn but don't block. If the rule is a false positive, document the safety argument in code (`# safe:` for SQL, `// MIRROR-IGNORE-START` for mirrored files, etc.) so the next reviewer doesn't re-derive it.
 
 See `src/errors/index.ts` for the full API and `src/errors/index.test.ts` for examples.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "playwright": "^1.59.1",
         "prettier": "^3.8.2",
         "qrcode-terminal": "^0.12.0",
+        "truecourse": "0.5.0",
         "tsx": "^4.19.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.2",
@@ -174,6 +175,30 @@
         "keyv": "^5.6.0"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@commitlint/cli": {
       "version": "20.5.0",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
@@ -194,78 +219,6 @@
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@commitlint/config-conventional": {
@@ -3186,6 +3139,21 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4166,6 +4134,23 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -4181,6 +4166,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5846,6 +5841,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-windows": {
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/node-windows/-/node-windows-1.0.0-beta.8.tgz",
+      "integrity": "sha512-uLekXnSeem3nW5escID224Fd0U/1VtvE796JpSpOY+c73Cslz/Qn2WUHRJyPQJEMrNGAy/FMRFjjhh4z1alZTA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "xml": "1.0.1",
+        "yargs": "^17.5.1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6339,6 +6346,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pyright": {
+      "version": "1.1.409",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.409.tgz",
+      "integrity": "sha512-13VFQyw4mJzshZxcxiYbNjo1hG/WHSRDj70Y3lbJEHqCkI2dvBAUTti8VV6Ezsr5gT93pFvC0e/jAQS4JdHarA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/qified": {
@@ -6891,6 +6915,13 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
@@ -7187,6 +7218,67 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/truecourse": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/truecourse/-/truecourse-0.5.0.tgz",
+      "integrity": "sha512-Qj/qMtpkcxGUiuu218wrY3PkrMUs/ZZf+9FRoM7Vrc9CzZbKhBueWmLEtf+wWA3wqzLFJGkfVwRKvtzs3/SvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.2.0",
+        "commander": "^12.1.0",
+        "dotenv": "^16.4.0",
+        "pyright": "^1.1.408",
+        "typescript": "^5.7.0",
+        "web-tree-sitter": "^0.26.0"
+      },
+      "bin": {
+        "truecourse": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "node-windows": "^1.0.0-beta.8"
+      }
+    },
+    "node_modules/truecourse/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/truecourse/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/truecourse/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7528,6 +7620,13 @@
         }
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
+      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7577,6 +7676,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -7605,6 +7722,24 @@
         }
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -7618,6 +7753,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
     "pattern-contradictions": "python3 scripts/drift_check.py --contradictions",
     "benchmark:review": "python3 scripts/review_benchmark.py run --count 10",
     "benchmark:review:inject": "python3 scripts/review_benchmark.py inject --count 10",
-    "benchmark:review:revert": "python3 scripts/review_benchmark.py revert"
+    "benchmark:review:revert": "python3 scripts/review_benchmark.py revert",
+    "truecourse:analyze": "truecourse analyze",
+    "truecourse:diff": "truecourse analyze --diff",
+    "truecourse:list": "truecourse list",
+    "truecourse:list-diff": "truecourse list --diff"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -58,6 +62,7 @@
     "playwright": "^1.59.1",
     "prettier": "^3.8.2",
     "qrcode-terminal": "^0.12.0",
+    "truecourse": "0.5.0",
     "tsx": "^4.19.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.2",


### PR DESCRIPTION
## Summary
- **Closes the 10-PR Error & Async Discipline initiative.** PRs #1–#9 introduced the error taxonomy, bootstrap harness, async helpers, structured connect attribution, process.exit ban, datetime-TZ split, and SQL injection hardening. PR #10 is the regression gate that prevents these gains from silently eroding.
- New workflow `.github/workflows/truecourse.yml` runs `truecourse analyze --diff origin/main` on every PR; fails the build only on **NEW critical** findings; new highs warn but don't block.
- `truecourse@0.5.0` pinned in `package.json` devDependencies + four `npm run truecourse:*` scripts so contributors reproduce CI locally with the exact same version.

## How the gate works

```
1. Check out PR head (fetch-depth: 0)
2. setup-node@v6, setup-python@v6, cache .npm/_npx
3. npm ci                                          ← installs truecourse 0.5.0
4. Pre-create .truecourse/config.json with         ← skip "Run LLM rules?" prompt
   enableLlmRules: false
5. git stash → checkout origin/main → stash pop
6. npx truecourse analyze                          ← writes baseline
7. git stash → checkout PR_HEAD → stash pop
8. npx truecourse analyze --diff                   ← re-scan + compare
9. npx truecourse list --diff --all                ← surface findings in log
10. Count [critical] / [high] new lines:
    - new criticals > 0 → exit 1 (::error::)
    - new highs > 0    → ::warning:: (passes)
```

## Why a separate workflow file?
truecourse@0.5.0 was published 2026-04-19 (one day before this PR). If it crashes on edge cases or becomes flaky, the gate can be disabled by removing or commenting out the workflow file with no touch to `ci.yml`. Per Warden review.

## Why re-scan main every PR (vs committing a baseline)?
Committing `.truecourse/analyses/*.json` would mean every refactor needs an accompanying baseline-update commit (or every PR would diff against a stale baseline). The re-scan adds ~28s to CI but eliminates baseline-rot. The `.truecourse/` directory is gitignored locally (its own `.gitignore`).

## Why warn-only on new highs?
Per the original initiative ADR (`docs/decisions/error-discipline.md` §7 / "Migration plan"). Highs are useful signal but the false-positive ratio in TrueCourse's HIGH tier is meaningful (~50%; many flagged sites in PR #9 + #11 were structural-safe). Failing on highs would create review friction without a corresponding security gain. Criticals are gated because their false-positive ratio is much lower (real eval-injection / hardcoded-secret / command-injection patterns).

## What "new criticals" actually catches
Examples that would fail the gate:
- A new `eval(user_input)` site in any file
- A new hardcoded secret (API key, JWT) in code
- A new SQL injection pattern that doesn't follow the PR #9 `# safe:` annotation convention
- A new command-injection site (`subprocess.run(f"... {x} ...", shell=True)`)
- A new auth-bypass pattern (e.g., `if user.role == "admin" or True:`)

The 87 baseline criticals (mostly placeholder OAuth + intentional single-row UPDATEs) are explicitly ignored — the gate is for regressions only.

## Bootstrap self-test
This PR's workflow runs on this PR. If the workflow has a bug, the PR's own CI fails — that's the correct signal to fix it before merge. No `paths-filter` workaround.

## Files
- `.github/workflows/truecourse.yml` — new (96 lines)
- `package.json` — pin truecourse@0.5.0 + 4 npm scripts
- `package-lock.json` — auto-updated
- `docs/decisions/error-discipline.md` — new "PR #10 addendum" section + new "for future contributors" rule #8

## Local reproduction
```bash
# On main (one-time):
npx truecourse analyze

# After your changes:
npx truecourse analyze --diff
npx truecourse list --diff --all   # see the actual new findings
```

## Testing
- [x] `npx truecourse --version` → 0.5.0 (verified install)
- [x] `truecourse analyze` produces 7354 violations (87 critical, 1112 high, 4032 medium, 2123 low) — confirms the analyzer runs end-to-end on this repo
- [x] `truecourse analyze --diff` exits 0 with no new findings, exits 1 with no baseline (verified in worktree)
- [x] YAML validated via js-yaml (`node -e "require('js-yaml').load(...)"`)
- [x] Pre-creating `.truecourse/config.json` with `enableLlmRules: false` skips the interactive prompt (verified)
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all checks pass (no pattern bumps needed; touched paths aren't in any pattern's governs)
- [ ] Bootstrap self-test: this PR's CI run is the gate's own first execution

## Closes initiative
- ✅ PR #1 errors taxonomy + ADR (#214)
- ✅ PR #2 bootstrap harness (#215)
- ✅ PR #3 wire bootstrap into entry points (#219)
- ✅ PR #4 async helpers (#216)
- ✅ PR #5 floating-promise migration (#221)
- ✅ PR #6 stream-error attribution (#223)
- ✅ PR #7 process.exit ESLint ban (#224)
- ✅ PR #8 datetime-TZ migration (#225)
- ✅ PR #9 SQL injection hardening (#226)
- 🟦 PR #10 TrueCourse --diff CI gate (this PR)

Plus closing-out PRs:
- ✅ #218 bootstrap mirror discipline (this branch is sequential to #228)
- ✅ #11 SQL backlog closure (#227)

🤖 Generated with [Claude Code](https://claude.com/claude-code)