### PR TITLE
chore(wardens): add premise-verification rule to plan-reviewer

### DIFF
--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -48,3 +48,4 @@ Return a single markdown report. No preamble, no "I'll review...".
 - **Stay in critique mode.** If asked to fix, respond: "out of scope for this agent — invoke the `Plan` subagent or implement directly."
 - **Keep it tight.** A useful review is ≤40 lines. Padding is noise.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/plan-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
+- **Verify premises, not just rule compliance.** When the plan cites repo state as a problem (tracked files, unused deps, orphan files, cache drift, divergence between paths), run the verification commands yourself before approving. The `premise-verification` rule lists the minimum checks per premise type. A rule-compliant plan built on a false premise is REVISE, not SHIP.

--- a/.claude/wardens/plan-review-rules.md
+++ b/.claude/wardens/plan-review-rules.md
@@ -89,3 +89,14 @@
 **Check:** Does the plan articulate how the change will be verified end-to-end? Can be existing tests, new tests, manual verification steps, or a benchmark — but *something* concrete.
 **Rule:** Every non-trivial plan answers "how will we know this works?" Unverifiable plans are incomplete plans.
 **Cite:** Phase 4 pattern from ExitPlanMode workflow; `feedback_predict_before_testing`
+
+## premise-verification
+**Severity:** blocking
+**Applies when:** Plan cites repo state as the problem — e.g. "X is tracked in git," "dep Y is unused," "dir Z is orphaned," "files are drifting," "A and B have diverged."
+**Check:** For each premise, is there a concrete verification command and its expected output? If absent, run the verification yourself before issuing SHIP.
+**Rule:** Repo-state premises must be verified, not assumed. Minimum checks by premise type:
+- "tracked" / "stop committing X" → `git ls-files <path>` (must return non-empty) and `git check-ignore -v <path>` (must return nothing).
+- "unused dep" → `grep -r '<pkg>' src/ scripts/ container/ packages/` returns no imports.
+- "orphan file" → `grep -r '<filename>' .` returns no callers across `.ts`, `.sh`, `.json`, `.py`, launchd plists, `package.json` scripts.
+- "drift between two paths" → grep for code that writes to the derived path (`cpSync`, `shutil.copytree`, `fs.mkdirSync` + write). If a writer exists, the divergence is a cache, not a bug — plan must address why the cache is wrong, not treat it as rot.
+**Cite:** Slice A postmortem (2026-04-20 — the agent-runner-src cache was wrongly flagged as tracked drift); system-prompt "Trust but verify."


### PR DESCRIPTION
## Summary

- Adds a new blocking rule `premise-verification` to `.claude/wardens/plan-review-rules.md`.
- Adds an active-verification bullet to `.claude/agents/plan-reviewer.md` Rules of engagement: when a plan cites repo state, the reviewer runs the verification commands itself before approving.

## Motivation

During the 2026-04-20 repo cleanup plan, the plan-reviewer approved a slice whose premise was false — a proposed deletion cited "tracked files drifting in git," but `git ls-files` returned empty and the target directory was regenerated at runtime by `src/container-mounter.ts` via `cpSync`. The plan was SHIPPED on round 2 and only caught before any edits when the author manually verified during implementation.

The rule formalizes what should have been done: for each premise-type (tracked, unused dep, orphan, drift), there is a specific verification command that must be run. The active-verification bullet ensures the reviewer does this itself rather than trusting the plan's self-declaration.

## Test plan

- [x] Synthetic plan matching the original Slice A submitted to the revised reviewer → returns **REVISE** citing `premise-verification`, runs `git ls-files`, `git check-ignore -v data/`, and `grep` for `cpSync` writers.
- [ ] CI passes (lint, drift-check, keyword coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)