### PR TITLE
chore(wardens): add means-end-consistency rule to plan-reviewer

### DIFF
--- a/.claude/wardens/plan-review-rules.md
+++ b/.claude/wardens/plan-review-rules.md
@@ -100,3 +100,16 @@
 - "orphan file" → `grep -r '<filename>' .` returns no callers across `.ts`, `.sh`, `.json`, `.py`, launchd plists, `package.json` scripts.
 - "drift between two paths" → grep for code that writes to the derived path (`cpSync`, `shutil.copytree`, `fs.mkdirSync` + write). If a writer exists, the divergence is a cache, not a bug — plan must address why the cache is wrong, not treat it as rot.
 **Cite:** Slice A postmortem (2026-04-20 — the agent-runner-src cache was wrongly flagged as tracked drift); system-prompt "Trust but verify."
+
+## means-end-consistency
+**Severity:** blocking
+**Applies when:** Plan's stated purpose is to remove, block, protect, redact, or prevent X — where X is personal data, secrets, deprecated APIs, vulnerable patterns, unsafe inputs, or any other value/pattern the plan aims to eliminate from the committed repo.
+**Check:** Does the implementation itself contain, expose, enable, or reproduce X in another form?
+Common traps:
+- "Scrub personal values from repo" — but the CI pattern matching those values is committed inline in a workflow file.
+- "Redact secrets from logs" — but the redactor logs them before masking.
+- "Block deprecated API" — but the blocking rule's usage example calls the API.
+- "Allowlist safe inputs" — but the allowlist itself contains an unsafe value.
+- "Delete file X" — but a new file references X's old path.
+**Rule:** The fix must not reproduce the problem it solves. For patterns/regexes over sensitive values, source them from a GitHub Actions secret, an external gitignored file, a hash-based match, or other indirection — never commit the values inline. Run the fix through the same check it creates: if the implementation would trigger its own gate, revise.
+**Cite:** Slice C round 3 postmortem (2026-04-20 — CI gate was going to hardcode the very personal IDs it was designed to block).


### PR DESCRIPTION
## Summary

- Adds a new blocking rule `means-end-consistency` to `.claude/wardens/plan-review-rules.md`.
- Sibling to `premise-verification` (PR #231).
- Catches plans whose implementation reproduces the problem they are meant to solve (means-end inversion).

## Motivation

Slice C of the 2026-04-20 repo-cleanup sequence proposed "scrub personal IDs from committed files + add a CI gate that blocks future leaks." Rounds 1-3 of plan-review shipped the plan after thorough scrub verification. At implementation time, the CI gate was drafted as:

```yaml
grep -E "(liam10play|315099309|sliamh11@gmail)"
```

…which would commit all three personal identifiers — including an Israeli government ID — into a publicly-visible workflow file. The user caught it pre-commit.

Plan-review missed it because the reviewer's mental model aligned with the stated goal ("block personal IDs") and failed to audit the gate's own content independently. The same shape bit us once before (Slice A — stated goal "delete tracked drift" vs. reality "files weren't tracked").

This is a distinct failure mode from `premise-verification`: here the premise is correct, but the implementation reproduces what it removes. Needs its own rule.

## Test plan

- [x] Regression test: `/tmp/synthetic-means-end-plan.md` (Slice-C-round-3 shape) submitted to the revised reviewer returns **REVISE** citing both `means-end-consistency` and `public-repo-generic`.
- [x] Self-check: the rule's own text contains no personal values or sensitive content inline.
- [ ] CI passes (lint, drift-check, keyword coverage).

## Related

- PR #231 — sibling `premise-verification` rule.
- Slice C (next) — revised to use GitHub Actions secret for the pattern, per this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)