### PR TITLE
fix(ci): add --no-llm flag for truecourse 0.5.2 compat

### DIFF
--- a/.github/workflows/truecourse.yml
+++ b/.github/workflows/truecourse.yml
@@ -88,7 +88,7 @@ jobs:
           git stash push --include-untracked -m "truecourse-config" || true
           git checkout origin/main
           git stash pop || true
-          npx truecourse analyze
+          npx truecourse analyze --no-llm
           # baseline now lives in .truecourse/analyses/ + LATEST.json points at it
 
       - name: Switch back to PR head + run diff
@@ -104,7 +104,7 @@ jobs:
           git stash push --include-untracked -m "truecourse-baseline" || true
           git checkout "$PR_HEAD"
           git stash pop || true
-          npx truecourse analyze --diff | tee /tmp/diff-summary.txt
+          npx truecourse analyze --no-llm --diff | tee /tmp/diff-summary.txt
 
       - name: Show new + resolved violations
         if: always()


### PR DESCRIPTION
## Summary
- truecourse 0.5.2 introduced a mandatory `--llm`/`--no-llm` CLI flag for non-interactive mode
- The existing `config.json` workaround no longer suppresses the interactive prompt, causing the "Establish baseline" step to fail immediately
- Adds `--no-llm` to both `analyze` calls in the CI workflow

Unblocks PR #239 (truecourse 0.5.0 → 0.5.2 dependabot bump).

## Test plan
- [ ] This PR's own TrueCourse CI step passes (self-validating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)