### PR TITLE
fix(memory-tree): check embedding existence in reindex_external

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -1478,7 +1478,10 @@ def reindex_external(
         existing = db.execute(
             "SELECT content_hash FROM nodes WHERE id = ?", (node_id,)
         ).fetchone()
-        need_embed = existing is None or existing[0] != ch
+        has_embedding = sqlite_vec is not None and db.execute(
+            "SELECT 1 FROM embeddings WHERE rowid = ?", (_rowid_for(node_id),)
+        ).fetchone() is not None
+        need_embed = existing is None or existing[0] != ch or not has_embedding
 
         vec = None
         if need_embed and not skip_embed:

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -630,6 +630,29 @@ class TestReindexExternal:
             counts2 = mt.reindex_external(tmp_db, ext_dir)
         assert counts2["id_written"] == 0
 
+    @pytest.mark.skipif(mt.sqlite_vec is None, reason="sqlite_vec not available")
+    def test_reembeds_when_embedding_row_missing(self, tmp_db, ext_dir):
+        """Nodes with a matching content_hash but no embedding row must be re-embedded."""
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
+            mt.reindex_external(tmp_db, ext_dir)
+
+        # Manually delete all embedding rows to simulate a failed embed run.
+        node_ids = [
+            r[0] for r in tmp_db.execute(
+                "SELECT id FROM nodes WHERE orphaned_at IS NULL"
+            ).fetchall()
+        ]
+        for nid in node_ids:
+            rowid = mt._rowid_for(nid)
+            tmp_db.execute("DELETE FROM embeddings WHERE rowid = ?", (rowid,))
+        tmp_db.commit()
+
+        # Second run: content_hash unchanged, but embedding row is gone.
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM) as mock_embed:
+            counts = mt.reindex_external(tmp_db, ext_dir)
+
+        assert counts["embedded"] > 0, "Expected re-embedding when embedding rows were deleted"
+
     def test_orphans_deleted_files(self, tmp_db, ext_dir):
         with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
             mt.reindex_external(tmp_db, ext_dir)


### PR DESCRIPTION
## Summary
- `reindex_external()` only checked `content_hash` to decide re-embedding, missing nodes whose hash matched but embedding row was absent (failed prior embed, sqlite_vec unavailability, or table clear)
- Now queries the `embeddings` table directly — mirrors what `build_tree()` does via its `rebuild` flag
- Added test `test_reembeds_when_embedding_row_missing` that deletes embedding rows and verifies re-embedding on rerun

## Test plan
- [x] 88/88 tests pass including new test
- [ ] Verify CI passes (drift check, eval, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)