### PR TITLE
feat(security): add shared-secret auth to credential proxy

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -857,6 +857,17 @@ async function main(): Promise<void> {
   // No real secrets exist in the container environment.
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
 
+  // Forward proxy auth token to the Claude SDK via ANTHROPIC_CUSTOM_HEADERS.
+  // The SDK parses this env var as newline-separated "key: value" pairs and
+  // merges them into every upstream API request.
+  if (process.env.DEUS_PROXY_TOKEN) {
+    const existing = sdkEnv.ANTHROPIC_CUSTOM_HEADERS || '';
+    const proxyHeader = `x-deus-proxy-token: ${process.env.DEUS_PROXY_TOKEN}`;
+    sdkEnv.ANTHROPIC_CUSTOM_HEADERS = existing
+      ? `${existing}\n${proxyHeader}`
+      : proxyHeader;
+  }
+
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
 

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -327,6 +327,9 @@ async function createResponse(
     headers: {
       'content-type': 'application/json',
       authorization: `Bearer ${process.env.OPENAI_API_KEY || 'placeholder'}`,
+      ...(process.env.DEUS_PROXY_TOKEN
+        ? { 'x-deus-proxy-token': process.env.DEUS_PROXY_TOKEN }
+        : {}),
     },
     body: JSON.stringify(body),
   });

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-04-25"
+last_verified: "2026-04-26" # proxy-shared-secret-auth
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-04-25"
+last_verified: "2026-04-26" # proxy-shared-secret-auth
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-04-25" # parity-testing
+last_verified: "2026-04-26" # proxy-shared-secret-auth
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-25" # parity-testing
+last_verified: "2026-04-26" # proxy-shared-secret-auth
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-04-25"
+last_verified: "2026-04-26" # proxy-shared-secret-auth
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import path from 'path';
 
 import type { AgentBackendName } from './agent-backends/types.js';
@@ -106,3 +107,9 @@ export const DEUS_CONTEXT_FILE_MAX_CHARS =
   process.env.DEUS_CONTEXT_FILE_MAX_CHARS ||
   envConfig.DEUS_CONTEXT_FILE_MAX_CHARS ||
   '';
+
+// Shared secret for credential proxy authentication.
+// Generated once per process lifetime; injected into containers via env.
+// Set DEUS_PROXY_AUTH=0 to disable enforcement (rollout kill-switch).
+export const DEUS_PROXY_TOKEN = crypto.randomBytes(32).toString('hex');
+export const DEUS_PROXY_AUTH_ENABLED = process.env.DEUS_PROXY_AUTH !== '0';

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -32,11 +32,13 @@ vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/deus-test-data',
   DEUS_CONTEXT_FILE_MAX_CHARS: '12345',
   DEUS_OPENAI_MODEL: 'gpt-test-model',
+  DEUS_PROXY_TOKEN: 'test-proxy-token-for-containers',
   GROUPS_DIR: '/tmp/deus-test-groups',
   HOME_DIR: '/tmp/deus-test-home',
   IDLE_TIMEOUT: 1800000, // 30min
   TIMEZONE: 'America/Los_Angeles',
 }));
+const TEST_PROXY_TOKEN = 'test-proxy-token-for-containers';
 
 // Mock logger
 vi.mock('./logger.js', () => ({
@@ -1442,5 +1444,13 @@ describe.skipIf(onWindows)('Backend parity — system-level equivalence', () => 
 
     expect(claudeEnv.get('ANTHROPIC_BASE_URL')).toContain(':3001');
     expect(openaiEnv.get('OPENAI_BASE_URL')).toContain(':3001');
+  });
+
+  it('both receive DEUS_PROXY_TOKEN for proxy authentication', () => {
+    const claudeEnv = extractEnvVars(claudeArgs);
+    const openaiEnv = extractEnvVars(openaiArgs);
+
+    expect(claudeEnv.get('DEUS_PROXY_TOKEN')).toBe(TEST_PROXY_TOKEN);
+    expect(openaiEnv.get('DEUS_PROXY_TOKEN')).toBe(TEST_PROXY_TOKEN);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -20,6 +20,7 @@ import {
   CREDENTIAL_PROXY_PORT,
   DEUS_CONTEXT_FILE_MAX_CHARS,
   DEUS_OPENAI_MODEL,
+  DEUS_PROXY_TOKEN,
   IDLE_TIMEOUT,
   TIMEZONE,
 } from './config.js';
@@ -78,6 +79,7 @@ function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+  args.push('-e', `DEUS_PROXY_TOKEN=${DEUS_PROXY_TOKEN}`);
   if (DEUS_CONTEXT_FILE_MAX_CHARS) {
     args.push(
       '-e',

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import http from 'http';
 import type { AddressInfo } from 'net';
 
+vi.mock('./config.js', () => ({
+  DEUS_PROXY_TOKEN: 'test-proxy-token-abc123',
+  DEUS_PROXY_AUTH_ENABLED: true,
+}));
+
 const mockEnv: Record<string, string> = {};
 vi.mock('./env.js', () => ({
   readEnvFile: vi.fn(() => ({ ...mockEnv })),
@@ -28,6 +33,9 @@ import {
   _resetCredentialsCacheForTest,
 } from './credential-proxy.js';
 import { AuthProviderRegistry } from './auth-providers/types.js';
+import * as configModule from './config.js';
+
+const TEST_PROXY_TOKEN = 'test-proxy-token-abc123';
 
 const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
 const mockExecFileSync = vi.mocked(execFileSync);
@@ -110,7 +118,21 @@ describe('credential-proxy', () => {
     mockExecFileSync.mockReset();
     _resetCredentialsCacheForTest();
     AuthProviderRegistry.reset();
+    Object.defineProperty(configModule, 'DEUS_PROXY_AUTH_ENABLED', {
+      value: true,
+      writable: true,
+    });
   });
+
+  function withProxyToken(options: http.RequestOptions): http.RequestOptions {
+    return {
+      ...options,
+      headers: {
+        ...options.headers,
+        'x-deus-proxy-token': TEST_PROXY_TOKEN,
+      },
+    };
+  }
 
   async function startProxy(env: Record<string, string>): Promise<number> {
     Object.assign(mockEnv, {
@@ -126,14 +148,14 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/v1/messages',
         headers: {
           'content-type': 'application/json',
           'x-api-key': 'placeholder',
         },
-      },
+      }),
       '{}',
     );
 
@@ -148,7 +170,7 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/openai/v1/responses',
         headers: {
@@ -156,7 +178,7 @@ describe('credential-proxy', () => {
           authorization: 'Bearer placeholder',
           'x-api-key': 'temp-key',
         },
-      },
+      }),
       '{}',
     );
 
@@ -173,14 +195,14 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/api/oauth/claude_cli/create_api_key',
         headers: {
           'content-type': 'application/json',
           authorization: 'Bearer placeholder',
         },
-      },
+      }),
       '{}',
     );
 
@@ -197,14 +219,14 @@ describe('credential-proxy', () => {
     // Post-exchange: container uses x-api-key only, no Authorization header
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/v1/messages',
         headers: {
           'content-type': 'application/json',
           'x-api-key': 'temp-key-from-exchange',
         },
-      },
+      }),
       '{}',
     );
 
@@ -217,7 +239,7 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/v1/messages',
         headers: {
@@ -226,7 +248,7 @@ describe('credential-proxy', () => {
           'keep-alive': 'timeout=5',
           'transfer-encoding': 'chunked',
         },
-      },
+      }),
       '{}',
     );
 
@@ -247,11 +269,11 @@ describe('credential-proxy', () => {
 
     const res = await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/v1/messages',
         headers: { 'content-type': 'application/json' },
-      },
+      }),
       '{}',
     );
 
@@ -273,14 +295,14 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/api/oauth/claude_cli/create_api_key',
         headers: {
           'content-type': 'application/json',
           authorization: 'Bearer placeholder',
         },
-      },
+      }),
       '{}',
     );
 
@@ -303,14 +325,14 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/api/oauth/claude_cli/create_api_key',
         headers: {
           'content-type': 'application/json',
           authorization: 'Bearer placeholder',
         },
-      },
+      }),
       '{}',
     );
 
@@ -341,14 +363,14 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/api/oauth/claude_cli/create_api_key',
         headers: {
           'content-type': 'application/json',
           authorization: 'Bearer placeholder',
         },
-      },
+      }),
       '{}',
     );
     expect(lastUpstreamHeaders['authorization']).toBe('Bearer expiring-token');
@@ -356,14 +378,14 @@ describe('credential-proxy', () => {
     // Cache is stale (token about to expire) — re-read on next request
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/api/oauth/claude_cli/create_api_key',
         headers: {
           'content-type': 'application/json',
           authorization: 'Bearer placeholder',
         },
-      },
+      }),
       '{}',
     );
     expect(lastUpstreamHeaders['authorization']).toBe('Bearer refreshed-token');
@@ -376,7 +398,7 @@ describe('credential-proxy', () => {
 
     await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/v1/sessions',
         headers: {
@@ -384,7 +406,7 @@ describe('credential-proxy', () => {
           authorization: 'Bearer placeholder',
           'anthropic-beta': 'ccr-byoc-2025-07-29',
         },
-      },
+      }),
       '{}',
     );
 
@@ -400,18 +422,91 @@ describe('credential-proxy', () => {
 
     const res = await makeRequest(
       proxyPort,
-      {
+      withProxyToken({
         method: 'POST',
         path: '/api/oauth/claude_cli/create_api_key',
         headers: {
           'content-type': 'application/json',
           authorization: 'Bearer placeholder',
         },
-      },
+      }),
       '{}',
     );
 
     expect(res.statusCode).toBe(200);
     expect(lastUpstreamHeaders['authorization']).toBeUndefined();
+  });
+
+  it('rejects request without proxy token', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toBe('Unauthorized');
+  });
+
+  it('rejects request with wrong proxy token', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-deus-proxy-token': 'wrong-token',
+        },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toBe('Unauthorized');
+  });
+
+  it('does not forward x-deus-proxy-token to upstream', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    await makeRequest(
+      proxyPort,
+      withProxyToken({
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      }),
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['x-deus-proxy-token']).toBeUndefined();
+  });
+
+  it('allows requests when auth is disabled via kill-switch', async () => {
+    Object.defineProperty(configModule, 'DEUS_PROXY_AUTH_ENABLED', {
+      value: false,
+      writable: true,
+    });
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -18,6 +18,7 @@
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
+import { DEUS_PROXY_TOKEN, DEUS_PROXY_AUTH_ENABLED } from './config.js';
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 import {
@@ -93,6 +94,22 @@ export function startCredentialProxy(
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
         const body = Buffer.concat(chunks);
+
+        if (DEUS_PROXY_AUTH_ENABLED) {
+          const token = req.headers['x-deus-proxy-token'];
+          if (token !== DEUS_PROXY_TOKEN) {
+            logger.warn(
+              { url: req.url, hasToken: !!token },
+              'Credential proxy rejected unauthenticated request',
+            );
+            res.writeHead(401);
+            res.end('Unauthorized');
+            return;
+          }
+        }
+
+        // Strip the proxy auth header before forwarding upstream
+        delete req.headers['x-deus-proxy-token'];
 
         // Resolve which provider handles this request
         let provider: AuthProvider;


### PR DESCRIPTION
## Summary
- Credential proxy now requires `X-Deus-Proxy-Token` header on every request — rejects with 401 if missing/wrong
- Token generated via `crypto.randomBytes(32)` at startup, injected into containers via env
- Claude SDK forwards token via `ANTHROPIC_CUSTOM_HEADERS`; OpenAI backend adds it to fetch headers
- Kill-switch: `DEUS_PROXY_AUTH=0` disables enforcement for rollback
- Closes threat-modeler BLOCK from warden audit 2026-04-25

## Files changed
| File | Change |
|------|--------|
| `src/config.ts` | `DEUS_PROXY_TOKEN` + `DEUS_PROXY_AUTH_ENABLED` exports |
| `src/credential-proxy.ts` | Auth check + header stripping before upstream |
| `src/container-runner.ts` | Injects `DEUS_PROXY_TOKEN` env into all containers |
| `container/agent-runner/src/index.ts` | Sets `ANTHROPIC_CUSTOM_HEADERS` for Claude SDK |
| `container/agent-runner/src/openai-backend.ts` | Adds header to OpenAI fetch calls |
| `src/credential-proxy.test.ts` | 4 new tests (reject no token, reject wrong token, strip header, kill-switch) |
| `src/container-runner.test.ts` | 1 new test (both backends receive token) |

## Test plan
- [x] 15 credential-proxy tests pass (11 existing + 4 new)
- [x] 33 container-runner tests pass (32 existing + 1 new)
- [ ] Container rebuild needed (`./container/build.sh`) before live testing
- [ ] Smoke test: send message via WhatsApp, verify proxy logs show authenticated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)