### PR TITLE
fix(tests): resolve 4 pre-existing script test failures

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-25" # parity-testing
+last_verified: "2026-04-26" # fix-pre-existing-test-failures
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-04-26" # proxy-shared-secret-auth
+last_verified: "2026-04-26" # fix-pre-existing-test-failures
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -592,6 +592,28 @@ def cmd_add(path_str: str, extract: bool = True):
     db.commit()
     print(f"Indexed {indexed} chunk(s) from {path.name}")
 
+    if extract:
+        try:
+            cmd_extract(str(path))
+        except SystemExit:
+            pass
+        except Exception as exc:
+            print(f"  WARN: atom extraction failed for {path.name}: {exc}", file=sys.stderr)
+
+    try:
+        stale_count = 0
+        articles = db.execute(
+            "SELECT ea.entity_id, ea.source_hash FROM entity_articles ea"
+        ).fetchall()
+        for entity_id, old_hash in articles:
+            new_hash = _compute_entity_source_hash(db, entity_id)
+            if new_hash != old_hash:
+                stale_count += 1
+        if stale_count > 0:
+            print(f"  [stale] {stale_count} entity article(s) need recompile (run --compile)")
+    except (sqlite3.OperationalError, Exception):
+        pass
+
 
 def cmd_add_dir(dir_str: str, extract: bool = True):
     """Batch-index every .md file under a directory.

--- a/scripts/tests/test_embedding_provider.py
+++ b/scripts/tests/test_embedding_provider.py
@@ -96,6 +96,16 @@ class TestDefaults:
 class TestOllamaEmbeddingProvider:
     """Test OllamaEmbeddingProvider vector handling."""
 
+    @staticmethod
+    def _mock_http_response(body: bytes):
+        """Create a mock HTTPConnection whose getresponse() returns body."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = body
+        mock_conn = MagicMock()
+        mock_conn.getresponse.return_value = mock_resp
+        return mock_conn
+
     def test_truncates_long_vectors(self):
         from evolution.providers.embeddings import OllamaEmbeddingProvider
         from evolution.config import EMBED_DIM
@@ -104,13 +114,8 @@ class TestOllamaEmbeddingProvider:
         fake_response = json.dumps({"embeddings": [long_vec]}).encode()
 
         provider = OllamaEmbeddingProvider(model="test")
-        with patch("urllib.request.urlopen") as mock_open:
-            mock_resp = MagicMock()
-            mock_resp.read.return_value = fake_response
-            mock_resp.__enter__ = lambda s: s
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            mock_open.return_value = mock_resp
-
+        mock_conn = self._mock_http_response(fake_response)
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
             result = provider.embed("test")
             assert len(result) == EMBED_DIM
 
@@ -122,13 +127,8 @@ class TestOllamaEmbeddingProvider:
         fake_response = json.dumps({"embeddings": [short_vec]}).encode()
 
         provider = OllamaEmbeddingProvider(model="test")
-        with patch("urllib.request.urlopen") as mock_open:
-            mock_resp = MagicMock()
-            mock_resp.read.return_value = fake_response
-            mock_resp.__enter__ = lambda s: s
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            mock_open.return_value = mock_resp
-
+        mock_conn = self._mock_http_response(fake_response)
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
             result = provider.embed("test")
             assert len(result) == EMBED_DIM
             assert result[:10] == [1.0] * 10


### PR DESCRIPTION
## Summary
- Fix Ollama embedding tests: mock `http.client.HTTPConnection` (the actual transport) instead of `urllib.request.urlopen` (unused by the provider)
- Fix memory_indexer `cmd_add`: port extract call and stale-entity-article check from `cmd_add_dir`, matching test expectations and restoring intended behavior

## Details

**Ollama tests** (`test_embedding_provider.py`): `OllamaEmbeddingProvider` uses `http.client.HTTPConnection.request()` directly, not `urllib.request.urlopen`. Tests patched the wrong module, so the mock never intercepted the real HTTP call, hitting a live Ollama instance with a nonexistent "test" model.

**Indexer tests** (`test_memory_indexer.py`): `cmd_add` had an `extract: bool = True` parameter but never used it — the extract call and stale-entity-article check only existed in `cmd_add_dir`. Ported the missing logic to `cmd_add` so both paths behave consistently.

## Test plan
- [x] 4 previously failing tests now pass
- [x] Full scripts test suite: 717/717 passed (was 713/717)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)