### PR TITLE
docs(skills): track host skill inventory

### DIFF
--- a/.claude/skills/add-listen-hotkey/SKILL.md
+++ b/.claude/skills/add-listen-hotkey/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: add-listen-hotkey
+description: Install a global hotkey that triggers `deus listen` from anywhere on the OS. Also installs sox, whisper-cli, and a whisper model.
+---
+
 # /add-listen-hotkey
 
 Install a global hotkey that triggers `deus listen` from anywhere on the OS.

--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: add-parallel
+description: Add Parallel AI MCP integration to Deus for advanced web research capabilities.
+---
+
 # Add Parallel AI Integration
 
 Adds Parallel AI MCP integration to Deus for advanced web research capabilities.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,12 +113,44 @@ Commands that must remain stable across backends:
 Host skills are not chat commands. Never suggest them inside WhatsApp,
 Telegram, Slack, Discord, or Gmail.
 
+Repo-owned host skills live under `.claude/skills/`. Some runtimes consume the
+generated `.agents/skills/` compatibility tree. When adding, removing, or
+renaming a repo-owned skill, update this table in the same change.
+
 | Skill | When to Use |
 |---|---|
-| `/setup` | First-time installation, authentication, service configuration |
-| `/add-llama-cpp` | Install and verify a local `llama.cpp` server for optional Deus local-generation experiments |
-| `/customize` | Adding channels, integrations, changing behavior |
-| `/debug` | Container issues, logs, troubleshooting |
+| `/add-codex` | Add OpenAI/Codex as a backend |
+| `/add-compact` | Add the backend-neutral `/compact` session command |
+| `/add-discord` | Add Discord as a channel |
+| `/add-gmail` | Add Gmail as a tool or channel |
+| `/add-image-vision` | Add image attachment vision to Deus agents |
+| `/add-listen-hotkey` | Add a global hotkey for `deus listen` |
+| `/add-llama-cpp` | Install and verify optional local `llama.cpp` generation |
+| `/add-ollama-tool` | Add Ollama as an MCP tool for local model calls |
+| `/add-parallel` | Add Parallel AI MCP research tools |
+| `/add-pdf-reader` | Add PDF text extraction |
+| `/add-reactions` | Add WhatsApp emoji reaction support |
+| `/add-slack` | Add Slack as a channel |
+| `/add-telegram` | Add Telegram as a channel |
+| `/add-telegram-swarm` | Add Agent Swarm support to Telegram |
+| `/add-voice-transcription` | Add OpenAI Whisper voice transcription |
+| `/add-whatsapp` | Add WhatsApp as a channel |
+| `/add-youtube-transcript` | Add YouTube transcript extraction |
+| `/checkpoint` | Save a mid-session continuity checkpoint |
+| `/code-review` | Run multi-agent code review |
+| `/compress` | Save the session to the vault and update memory indexes |
+| `/convert-to-apple-container` | Switch from Docker to Apple Container |
+| `/customize` | Add channels, integrations, or behavior changes |
+| `/debug` | Debug containers, logs, auth, and runtime issues |
+| `/preferences` | View or modify Deus user preferences |
+| `/preserve` | Save durable memories from the current conversation |
+| `/project-settings` | View or modify external project memory settings |
+| `/resume` | Load recent work and memory context |
+| `/review-logs` | Review Deus system health logs |
+| `/setup` | Run first-time installation and configuration |
+| `/update-skills` | Update installed skill branches from upstream |
+| `/use-local-whisper` | Switch voice transcription to local whisper.cpp |
+| `/x-integration` | Set up or use X/Twitter integration |
 | `/qodo-pr-resolver` | Fetch and fix Qodo PR review issues interactively or in batch |
 | `/get-qodo-rules` | Load org- and repo-level coding rules from Qodo before code tasks |
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Optional host-side runtime skills:
 /add-llama-cpp          # Install llama.cpp and verify a local llama-server endpoint
 ```
 
+The full native host-skill inventory lives in
+[AGENTS.md](AGENTS.md#commands-and-skills). Host skills are for direct
+Claude/Codex sessions, not messaging channels; every new `.claude/skills/`
+entry must be added to that list in the same change.
+
 > **Switching from another AI?** Give Deus a head start. Paste this prompt into your current AI (ChatGPT, Gemini, etc.) and send the output to Deus in your first conversation:
 >
 > ```

--- a/docs/AGENT_DEUS_101.md
+++ b/docs/AGENT_DEUS_101.md
@@ -113,8 +113,10 @@ Chat/channel commands must not depend on backend:
 - `/settings requires_trigger=true|false`
 - `/compact`
 
-Host/session skills include `/setup`, `/add-llama-cpp`, `/customize`,
-`/debug`, `/qodo-pr-resolver`, and `/get-qodo-rules`.
+Host/session skills are native slash skills for direct Claude/Codex sessions,
+not commands to suggest inside messaging channels. The canonical inventory is
+the table in [AGENTS.md](../AGENTS.md#commands-and-skills); every new
+`.claude/skills/` entry must be added there in the same change.
 
 ## Warden Gates
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-04-26" # codex-oauth
+last_verified: "2026-04-26" # host skill inventory docs
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-04-26" # add-llama-cpp optional integration skill
+last_verified: "2026-04-26" # skill metadata and inventory enforcement
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/sync_agent_skills.py
+++ b/scripts/sync_agent_skills.py
@@ -89,12 +89,78 @@ def _read_tree(root: Path) -> dict[str, bytes]:
     return files
 
 
+def _skill_inventory(source_root: Path) -> tuple[list[str], list[Path]]:
+    names: list[str] = []
+    invalid: list[Path] = []
+    if not source_root.exists():
+        return names, invalid
+
+    for path in sorted(source_root.rglob("*")):
+        if not path.is_file() or path.name.lower() != "skill.md":
+            continue
+
+        text = path.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            invalid.append(path)
+            continue
+
+        end = text.find("\n---", 4)
+        if end == -1:
+            invalid.append(path)
+            continue
+
+        found_name = False
+        for line in text[4:end].splitlines():
+            if line.startswith("name: "):
+                names.append(line.removeprefix("name: ").strip())
+                found_name = True
+                break
+
+        if not found_name:
+            invalid.append(path)
+
+    return sorted(set(names)), invalid
+
+
+def check_skill_inventory(project_root: Path) -> int:
+    """Verify every repo-owned skill is documented in AGENTS.md."""
+    agents_path = project_root / "AGENTS.md"
+    agents_text = agents_path.read_text(encoding="utf-8")
+    names, invalid = _skill_inventory(SOURCE_ROOT)
+    missing = [
+        name
+        for name in names
+        if f"| `/{name}` |" not in agents_text
+    ]
+
+    if not invalid and not missing:
+        print("Skill inventory documented.")
+        return 0
+
+    if invalid:
+        print("INVALID SKILL FILES — missing YAML frontmatter or name:")
+        for path in invalid:
+            print(f"  {path.relative_to(project_root)}")
+
+    if missing:
+        print("SKILL INVENTORY DRIFT — AGENTS.md is missing skill command(s):")
+        for name in missing:
+            print(f"  /{name}")
+
+    print(
+        "\nFIX: add valid YAML frontmatter, then list each skill in "
+        "AGENTS.md#commands-and-skills."
+    )
+    return 1
+
+
 def check_agents_tree(project_root: Path, dest_root: Path | None = None) -> int:
     """Verify that the local `.agents/` tree matches generated output."""
+    inventory_status = check_skill_inventory(project_root)
     dest_root = dest_root or (project_root / ".agents")
     if not dest_root.exists():
         print("SKIP: .agents/ not present (local generated Codex compatibility tree).")
-        return 0
+        return inventory_status
 
     expected = render_agents_tree(project_root)
     actual = _read_tree(dest_root)
@@ -107,7 +173,7 @@ def check_agents_tree(project_root: Path, dest_root: Path | None = None) -> int:
 
     if not missing and not extra and not changed:
         print(f"Agent tree synced ({len(expected)} files).")
-        return 0
+        return inventory_status
 
     print("AGENT TREE DRIFT — `.agents/` no longer matches generated output.")
     if missing:


### PR DESCRIPTION
## Summary
- add required YAML frontmatter to tracked source skills for listen hotkey and Parallel AI
- document the full native host-skill inventory in AGENTS.md, with README and AGENT_DEUS_101 pointers
- make sync_agent_skills.py --check fail on malformed source skills or missing AGENTS.md inventory entries

## Validation
- python3 scripts/sync_agent_skills.py --check
- python3 -m py_compile scripts/sync_agent_skills.py
- git diff --check
