### PR TITLE
feat(channels): add image vision across all MCP channels

### DIFF
--- a/packages/mcp-channel-core/package.json
+++ b/packages/mcp-channel-core/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/mcp-channel-core/src/image-util.ts
+++ b/packages/mcp-channel-core/src/image-util.ts
@@ -1,0 +1,23 @@
+import sharp from 'sharp';
+
+const MAX_DIMENSION = 1024;
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+/** Resize raw image bytes to JPEG base64. Returns null on invalid/oversized input. */
+export async function resizeAndEncode(raw: Buffer): Promise<string | null> {
+  if (raw.length === 0 || raw.length > MAX_FILE_SIZE) return null;
+
+  try {
+    const resized = await sharp(raw)
+      .resize(MAX_DIMENSION, MAX_DIMENSION, {
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .jpeg({ quality: 85 })
+      .toBuffer();
+
+    return resized.toString('base64');
+  } catch {
+    return null;
+  }
+}

--- a/packages/mcp-channel-core/src/index.ts
+++ b/packages/mcp-channel-core/src/index.ts
@@ -1,3 +1,4 @@
+export { resizeAndEncode } from './image-util.js';
 export { MessageBuffer } from './message-buffer.js';
 export { registerCommonTools } from './server-base.js';
 export type {

--- a/packages/mcp-discord/src/discord.ts
+++ b/packages/mcp-discord/src/discord.ts
@@ -13,12 +13,15 @@ import {
 } from 'discord.js';
 import pino from 'pino';
 
+import https from 'https';
+
 import type {
   ChannelProvider,
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
 } from '@deus-ai/channel-core';
+import { resizeAndEncode } from '@deus-ai/channel-core';
 
 const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Deus';
 const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN || '';
@@ -30,6 +33,28 @@ const logger = pino(
 );
 
 const MAX_MESSAGE_LENGTH = 2000;
+
+function fetchBytes(url: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (
+          res.statusCode &&
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
+          fetchBytes(res.headers.location).then(resolve, reject);
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
 
 export class DiscordProvider implements ChannelProvider {
   readonly name = 'discord';
@@ -104,26 +129,38 @@ export class DiscordProvider implements ChannelProvider {
         }
       }
 
-      // Handle attachments — store placeholders
+      // Handle attachments — download first image, placeholders for rest
+      let imageData: string | undefined;
       if (message.attachments.size > 0) {
-        const attachmentDescriptions = [...message.attachments.values()].map(
-          (att) => {
-            const contentType = att.contentType || '';
-            if (contentType.startsWith('image/')) {
-              return `[Image: ${att.name || 'image'}]`;
-            } else if (contentType.startsWith('video/')) {
-              return `[Video: ${att.name || 'video'}]`;
-            } else if (contentType.startsWith('audio/')) {
-              return `[Audio: ${att.name || 'audio'}]`;
-            } else {
-              return `[File: ${att.name || 'file'}]`;
+        const descriptions: string[] = [];
+        for (const att of message.attachments.values()) {
+          const contentType = att.contentType || '';
+          if (contentType.startsWith('image/') && !imageData) {
+            try {
+              const raw = await fetchBytes(att.url);
+              imageData = (await resizeAndEncode(raw)) ?? undefined;
+            } catch (err) {
+              logger.warn(
+                { err, name: att.name },
+                'Discord image download failed',
+              );
             }
-          },
-        );
-        if (content) {
-          content = `${content}\n${attachmentDescriptions.join('\n')}`;
-        } else {
-          content = attachmentDescriptions.join('\n');
+            if (!imageData)
+              descriptions.push(`[Image: ${att.name || 'image'}]`);
+          } else if (contentType.startsWith('video/')) {
+            descriptions.push(`[Video: ${att.name || 'video'}]`);
+          } else if (contentType.startsWith('audio/')) {
+            descriptions.push(`[Audio: ${att.name || 'audio'}]`);
+          } else if (!contentType.startsWith('image/')) {
+            descriptions.push(`[File: ${att.name || 'file'}]`);
+          } else {
+            descriptions.push(`[Image: ${att.name || 'image'}]`);
+          }
+        }
+        if (descriptions.length > 0) {
+          content = content
+            ? `${content}\n${descriptions.join('\n')}`
+            : descriptions.join('\n');
         }
       }
 
@@ -160,6 +197,7 @@ export class DiscordProvider implements ChannelProvider {
         is_group: isGroup,
         chat_name: chatName,
         metadata: {
+          ...(imageData && { imageData }),
           reply_to_message_id: replyToMessageId,
           reply_to_content: replyToContent,
           reply_to_sender_name: replyToSenderName,

--- a/packages/mcp-gmail/src/gmail.ts
+++ b/packages/mcp-gmail/src/gmail.ts
@@ -21,6 +21,7 @@ import type {
   ChatInfo,
   IncomingMessage,
 } from '@deus-ai/channel-core';
+import { resizeAndEncode } from '@deus-ai/channel-core';
 
 const CREDENTIALS_DIR =
   process.env.GMAIL_CREDENTIALS_DIR || path.join(os.homedir(), '.gmail-mcp');
@@ -420,7 +421,29 @@ export class GmailProvider implements ChannelProvider {
     // Extract body text
     const body = this.extractTextBody(msg.data.payload);
 
-    if (!body) {
+    // Extract first image attachment
+    let imageData: string | undefined;
+    const imagePart = this.findImagePart(msg.data.payload);
+    if (imagePart?.body?.attachmentId && this.gmail) {
+      try {
+        const att = await this.gmail.users.messages.attachments.get({
+          userId: 'me',
+          messageId,
+          id: imagePart.body.attachmentId,
+        });
+        if (att.data.data) {
+          const raw = Buffer.from(att.data.data, 'base64url');
+          imageData = (await resizeAndEncode(raw)) ?? undefined;
+        }
+      } catch (err) {
+        logger.warn(
+          { messageId, err },
+          'Gmail image attachment download failed',
+        );
+      }
+    }
+
+    if (!body && !imageData) {
       logger.debug({ messageId, subject }, 'Skipping email with no text body');
       return;
     }
@@ -438,7 +461,9 @@ export class GmailProvider implements ChannelProvider {
     // Track chat
     this.knownChats.set(chatJid, { name: subject, isGroup: false });
 
-    const content = `[Email from ${senderName} <${senderEmail}>]\nSubject: ${subject}\n\n${body}`;
+    const content = body
+      ? `[Email from ${senderName} <${senderEmail}>]\nSubject: ${subject}\n\n${body}`
+      : `[Email from ${senderName} <${senderEmail}>]\nSubject: ${subject}`;
 
     this.onMessage({
       id: messageId,
@@ -451,6 +476,7 @@ export class GmailProvider implements ChannelProvider {
       is_group: false,
       chat_name: subject,
       metadata: {
+        ...(imageData && { imageData }),
         thread_id: threadId,
         subject,
       },
@@ -499,5 +525,21 @@ export class GmailProvider implements ChannelProvider {
     }
 
     return '';
+  }
+
+  private findImagePart(
+    payload: gmail_v1.Schema$MessagePart | undefined,
+  ): gmail_v1.Schema$MessagePart | null {
+    if (!payload) return null;
+    if (payload.mimeType?.startsWith('image/') && payload.body?.attachmentId) {
+      return payload;
+    }
+    if (payload.parts) {
+      for (const part of payload.parts) {
+        const found = this.findImagePart(part);
+        if (found) return found;
+      }
+    }
+    return null;
   }
 }

--- a/packages/mcp-slack/src/slack.ts
+++ b/packages/mcp-slack/src/slack.ts
@@ -10,12 +10,15 @@ import { App, LogLevel } from '@slack/bolt';
 
 import pino from 'pino';
 
+import https from 'https';
+
 import type {
   ChannelProvider,
   ChannelStatus,
   ChatInfo,
   IncomingMessage,
 } from '@deus-ai/channel-core';
+import { resizeAndEncode } from '@deus-ai/channel-core';
 
 // Read env vars lazily so tests can set them before connect()
 function getAssistantName(): string {
@@ -33,6 +36,25 @@ const logger = pino(
   { level: process.env.LOG_LEVEL || 'info' },
   pino.destination(2),
 );
+
+function fetchBytesWithAuth(url: string, token: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const opts = {
+      hostname: parsed.hostname,
+      path: parsed.pathname + parsed.search,
+      headers: { Authorization: `Bearer ${token}` },
+    };
+    https
+      .get(opts, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
 
 // Slack's chat.postMessage API limits text to ~4000 characters per call.
 const MAX_MESSAGE_LENGTH = 4000;
@@ -102,9 +124,36 @@ export class SlackProvider implements ChannelProvider {
         ts: string;
         thread_ts?: string;
         bot_id?: string;
+        files?: Array<{
+          mimetype?: string;
+          url_private_download?: string;
+          name?: string;
+        }>;
       };
 
-      if (!msg.text) return;
+      // Download first image attachment if present
+      let imageData: string | undefined;
+      if (msg.files) {
+        const imageFile = msg.files.find((f) =>
+          f.mimetype?.startsWith('image/'),
+        );
+        if (imageFile?.url_private_download) {
+          try {
+            const raw = await fetchBytesWithAuth(
+              imageFile.url_private_download,
+              getBotToken(),
+            );
+            imageData = (await resizeAndEncode(raw)) ?? undefined;
+          } catch (err) {
+            logger.warn(
+              { err, name: imageFile.name },
+              'Slack image download failed',
+            );
+          }
+        }
+      }
+
+      if (!msg.text && !imageData) return;
 
       const chatId = `slack:${msg.channel}`;
       const timestamp = new Date(parseFloat(msg.ts) * 1000).toISOString();
@@ -126,7 +175,7 @@ export class SlackProvider implements ChannelProvider {
       this.knownChats.set(chatId, { name: senderName, isGroup });
 
       // Translate Slack <@UBOTID> mentions into @AssistantName format
-      let content = msg.text;
+      let content = msg.text || '';
       if (this.botUserId && !isBotMessage) {
         const mentionPattern = `<@${this.botUserId}>`;
         if (content.includes(mentionPattern)) {
@@ -144,6 +193,7 @@ export class SlackProvider implements ChannelProvider {
         is_from_me: isBotMessage,
         is_group: isGroup,
         metadata: {
+          ...(imageData && { imageData }),
           thread_ts: msg.thread_ts,
           is_bot_message: isBotMessage,
         },

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -16,6 +16,7 @@ import type {
   IncomingMessage,
   IncomingReaction,
 } from '@deus-ai/channel-core';
+import { resizeAndEncode } from '@deus-ai/channel-core';
 
 const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Deus';
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || '';
@@ -30,6 +31,19 @@ const MAX_MESSAGE_LENGTH = 4096;
 const MAX_CONSECUTIVE_ERRORS = 5;
 const MAX_RECONNECT_RETRIES = 3;
 const BASE_BACKOFF_MS = 1000;
+
+function fetchBytes(url: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
 
 /**
  * Send a message with Telegram Markdown parse mode, falling back to plain text.
@@ -212,7 +226,56 @@ export class TelegramProvider implements ChannelProvider {
       });
     };
 
-    this.bot.on('message:photo', (ctx) => storeMedia(ctx, '[Photo]'));
+    this.bot.on('message:photo', async (ctx) => {
+      try {
+        const photos = ctx.message.photo;
+        if (photos && photos.length > 0) {
+          const largest = photos[photos.length - 1];
+          const file = await ctx.api.getFile(largest.file_id);
+          if (file.file_path) {
+            const url = `https://api.telegram.org/file/bot${BOT_TOKEN}/${file.file_path}`;
+            const raw = await fetchBytes(url);
+            const imageData = await resizeAndEncode(raw);
+            if (imageData) {
+              const chatJid = `tg:${ctx.chat.id}`;
+              const timestamp = new Date(ctx.message.date * 1000).toISOString();
+              const senderName =
+                ctx.from?.first_name ||
+                ctx.from?.username ||
+                ctx.from?.id?.toString() ||
+                'Unknown';
+              const caption = ctx.message.caption || '';
+              const isGroup =
+                ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+
+              this.knownChats.set(chatJid, {
+                name:
+                  ctx.chat.type === 'private'
+                    ? senderName
+                    : (ctx.chat as any).title || chatJid,
+                isGroup,
+              });
+
+              this.onMessage({
+                id: ctx.message.message_id.toString(),
+                chat_id: chatJid,
+                sender: ctx.from?.id?.toString() || '',
+                sender_name: senderName,
+                content: caption,
+                timestamp,
+                is_from_me: false,
+                is_group: isGroup,
+                metadata: { imageData },
+              });
+              return;
+            }
+          }
+        }
+      } catch (err) {
+        logger.warn({ err }, 'Telegram photo download failed');
+      }
+      storeMedia(ctx, '[Photo]');
+    });
     this.bot.on('message:video', (ctx) => storeMedia(ctx, '[Video]'));
     this.bot.on('message:voice', (ctx) => storeMedia(ctx, '[Voice message]'));
     this.bot.on('message:audio', (ctx) => storeMedia(ctx, '[Audio]'));

--- a/packages/mcp-whatsapp/src/whatsapp.ts
+++ b/packages/mcp-whatsapp/src/whatsapp.ts
@@ -11,11 +11,13 @@ import {
   makeWASocket,
   Browsers,
   DisconnectReason,
+  downloadContentFromMessage,
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   normalizeMessageContent,
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys';
+import type { DownloadableMessage } from '@whiskeysockets/baileys';
 import type {
   GroupMetadata,
   WAMessageKey,
@@ -35,8 +37,9 @@ import type {
   IncomingMessage,
   IncomingReaction,
 } from '@deus-ai/channel-core';
+import { resizeAndEncode } from '@deus-ai/channel-core';
 
-// ── Config from env vars ────────────────────────────────────────────────
+// ── Config from env vars ──────────────────────────────────────────────────────
 
 const AUTH_DIR =
   process.env.WHATSAPP_AUTH_DIR || path.resolve(process.cwd(), 'store', 'auth');
@@ -341,7 +344,24 @@ export class WhatsAppProvider implements ChannelProvider {
             );
           }
 
-          if (!content) continue;
+          // Download + resize image if present
+          let imageData: string | undefined;
+          if (normalized.imageMessage) {
+            try {
+              const stream = await downloadContentFromMessage(
+                normalized.imageMessage as DownloadableMessage,
+                'image',
+              );
+              const chunks: Buffer[] = [];
+              for await (const chunk of stream) chunks.push(chunk);
+              const raw = Buffer.concat(chunks);
+              imageData = (await resizeAndEncode(raw)) ?? undefined;
+            } catch (err) {
+              logger.warn({ err, msgId: msg.key.id }, 'Image download failed');
+            }
+          }
+
+          if (!content && !imageData) continue;
 
           const sender = msg.key.participant || msg.key.remoteJid || '';
           const senderName = msg.pushName || sender.split('@')[0];
@@ -350,7 +370,11 @@ export class WhatsAppProvider implements ChannelProvider {
             ? fromMe
             : content.startsWith(`${ASSISTANT_NAME}:`);
 
-          // Forward ALL messages — the host decides which to act on
+          const metadata: Record<string, unknown> = {
+            is_bot_message: isBotMessage,
+          };
+          if (imageData) metadata.imageData = imageData;
+
           this.onMessage({
             id: msg.key.id || '',
             chat_id: chatJid,
@@ -360,7 +384,7 @@ export class WhatsAppProvider implements ChannelProvider {
             timestamp,
             is_from_me: fromMe,
             is_group: isGroup,
-            metadata: { is_bot_message: isBotMessage },
+            metadata,
           });
         } catch (err) {
           logger.error(

--- a/src/channels/mcp-adapter.ts
+++ b/src/channels/mcp-adapter.ts
@@ -90,6 +90,7 @@ export class McpChannelAdapter implements Channel {
         if (params.logger !== 'incoming_message') return;
 
         const chatJid = data.chat_id as string;
+        const meta = data.metadata as Record<string, unknown> | undefined;
         const msg: NewMessage = {
           id: data.id as string,
           chat_jid: chatJid,
@@ -98,8 +99,8 @@ export class McpChannelAdapter implements Channel {
           content: data.content as string,
           timestamp: data.timestamp as string,
           is_from_me: data.is_from_me as boolean | undefined,
-          is_bot_message: (data.metadata as Record<string, unknown>)
-            ?.is_bot_message as boolean | undefined,
+          is_bot_message: meta?.is_bot_message as boolean | undefined,
+          imageData: meta?.imageData as string | undefined,
         };
 
         opts.onMessage(chatJid, msg);

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -14,6 +14,7 @@ vi.mock('sharp', () => {
 vi.mock('fs');
 
 import { processImage, parseImageReferences, isImageMessage } from './image.js';
+import type { NewMessage } from './types.js';
 
 describe('image processing', () => {
   beforeEach(() => {
@@ -98,6 +99,46 @@ describe('image processing', () => {
     it('returns empty array when no images', () => {
       const messages = [{ content: 'just text' }];
       expect(parseImageReferences(messages as any)).toEqual([]);
+    });
+  });
+
+  describe('host-side image flow', () => {
+    it('processImage rewrites content with image reference from base64', async () => {
+      const imageBase64 = Buffer.from('fake-jpeg-data').toString('base64');
+      const msg: NewMessage = {
+        id: 'msg-1',
+        chat_jid: '123@g.us',
+        sender: 'user@s.whatsapp.net',
+        sender_name: 'User',
+        content: 'Check this',
+        timestamp: new Date().toISOString(),
+        imageData: imageBase64,
+      };
+
+      const result = await processImage(
+        Buffer.from(msg.imageData!, 'base64'),
+        '/tmp/groups/test',
+        msg.content,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.content).toMatch(
+        /^\[Image: attachments\/img-.*\.jpg\] Check this$/,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('processImage handles image-only messages (no caption)', async () => {
+      const imageBase64 = Buffer.from('fake-jpeg-data').toString('base64');
+
+      const result = await processImage(
+        Buffer.from(imageBase64, 'base64'),
+        '/tmp/groups/test',
+        '',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.content).toMatch(/^\[Image: attachments\/img-.*\.jpg\]$/);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ import { getAllTasks } from './db.js';
 import { writeGroupsSnapshot, writeTasksSnapshot } from './container-runner.js';
 import { Channel, NewMessage, NewReaction } from './types.js';
 import { logReactionSignal } from './evolution-client.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { processImage } from './image.js';
 import { logger } from './logger.js';
 import { initBackendRegistry } from './agent-backends/registry.js';
 import { createClaudeBackend } from './agent-backends/claude-backend.js';
@@ -171,7 +173,7 @@ async function main(): Promise<void> {
 
   // Channel callbacks (shared by all channels)
   const channelOpts = {
-    onMessage: (chatJid: string, msg: NewMessage) => {
+    onMessage: async (chatJid: string, msg: NewMessage) => {
       // Remote control commands — intercept before storage
       const trimmed = msg.content.trim();
       if (trimmed === '/remote-control' || trimmed === '/remote-control-end') {
@@ -215,6 +217,31 @@ async function main(): Promise<void> {
         msg.content =
           msg.content.slice(0, MAX_MESSAGE_LENGTH) +
           '\n\n[Message truncated — exceeded maximum length]';
+      }
+
+      if (msg.imageData) {
+        const group = state.registeredGroups[chatJid];
+        if (group) {
+          const groupDir = resolveGroupFolderPath(group.folder);
+          try {
+            const result = await processImage(
+              Buffer.from(msg.imageData, 'base64'),
+              groupDir,
+              msg.content,
+            );
+            if (result) {
+              msg.content = result.content;
+              logger.info(
+                { chatJid, path: result.relativePath },
+                'Processed image attachment',
+              );
+            }
+          } catch (err) {
+            logger.warn({ err, chatJid }, 'Image processing failed');
+          }
+        }
+        delete msg.imageData;
+        if (!msg.content) return;
       }
 
       storeMessage(msg);

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,8 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+  /** Resized JPEG as base64. Ephemeral — not stored in DB. */
+  imageData?: string;
 }
 
 export interface NewReaction {


### PR DESCRIPTION
## Summary
- Add shared `resizeAndEncode` utility in `@deus-ai/channel-core` (sharp resize to 1024px max, JPEG q85, base64 output)
- Wire image download + resize into all 5 channel MCP packages:
  - **WhatsApp**: Baileys `downloadContentFromMessage`
  - **Telegram**: Bot API `getFile` + HTTPS fetch
  - **Discord**: CDN URL fetch (public, no auth)
  - **Slack**: `url_private_download` with bearer token
  - **Gmail**: `messages.attachments.get` API
- Host-side (`src/index.ts`): async `onMessage` decodes base64, calls `processImage()` to save to group `attachments/`, rewrites `msg.content` with `[Image: ...]` reference
- Fix silent drop of image-only messages (no caption) across WhatsApp and Slack
- Add ephemeral `imageData?: string` to `NewMessage` for MCP-to-host transit (not stored in DB)
- 2 new host-side tests for the base64 decode + processImage flow

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run src/image.test.ts` — 10/10 pass
- [x] Full test suite — 1174/1174 pass
- [ ] Send image in WhatsApp group, verify agent responds with image understanding
- [ ] Check logs for "Processed image attachment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)