### PR TITLE
docs(benchmarks): update LongMemEval to fresh 50/50 run

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,16 +319,17 @@ Inspired by [Karpathy's LLM Knowledge Bases](https://x.com/karpathy/status/20398
 
 ### Retrieval benchmarks
 
-Evaluated on [LongMemEval-S](https://arxiv.org/abs/2410.10813) (ICLR 2025):
+Evaluated on [LongMemEval-S](https://arxiv.org/abs/2410.10813) (ICLR 2025), 50 examples, local Ollama embeddings:
 
 | Metric | Score |
 |---|---|
-| Recall@1 | 90% |
-| Recall@3 | 95% |
+| Recall@1 | 94% |
+| Recall@3 | 98% |
+| Recall@5 | 98% |
 | Recall@10 | 100% |
-| MRR | 0.93 |
+| MRR | 0.96 |
 
-Internal recall@3 on real vault sessions: **95%** (sampled 20 sessions, queried by topic).
+Internal memory tree benchmark (90 queries, 7 categories): **0.878 score**, 0% wrong-confident rate. Spot-checks on behavioral queries: 10/10 pass with production hook threshold.
 
 ---
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-04-27" # lighthouse phase 6 docs update
+last_verified: "2026-04-27" # benchmark refresh (Recall@1 94%, MRR 0.96)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary

- Update retrieval benchmarks in ARCHITECTURE.md with fresh 50-example LongMemEval-S run
- All metrics above previous baseline: Recall@1 90%→94%, Recall@3 95%→98%, MRR 0.93→0.96
- Added Recall@5 (98%), memory tree benchmark score (0.878), and behavioral spot-check results

## Test plan

- [x] Full 50/50 LongMemEval-S completed successfully (results in `~/.deus/benchmarks/results.jsonl`)
- [x] Numbers match `python3 scripts/memory_benchmark.py --outbound --limit 50` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)