### PR TITLE
feat(memory): group cmd_learnings by category

### DIFF
--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -970,10 +970,24 @@ def cmd_learnings(since_days: int = 7, max_items: int = 3):
     selected = candidates[:max_items]
 
     lines = ["## What's Emerging"]
+    by_cat: dict[str, list[dict]] = {}
     for item in selected:
-        prefix = "Pattern confirmed" if item["is_strengthened"] else "New insight"
-        suffix = f" (seen across {item['corroborations']} sessions)" if item["corroborations"] >= 2 else ""
-        lines.append(f"- {prefix}: {item['body']}{suffix}")
+        by_cat.setdefault(item["category"], []).append(item)
+    for cat_key, (header, _framing) in CATEGORY_SECTIONS.items():
+        bucket = by_cat.pop(cat_key, None)
+        if not bucket:
+            continue
+        lines.append(f"### {header}")
+        for item in bucket:
+            prefix = "Pattern confirmed" if item["is_strengthened"] else "New insight"
+            suffix = f" (seen across {item['corroborations']} sessions)" if item["corroborations"] >= 2 else ""
+            lines.append(f"- {prefix}: {item['body']}{suffix}")
+    for cat_key, bucket in by_cat.items():
+        lines.append(f"### {cat_key.title()}")
+        for item in bucket:
+            prefix = "Pattern confirmed" if item["is_strengthened"] else "New insight"
+            suffix = f" (seen across {item['corroborations']} sessions)" if item["corroborations"] >= 2 else ""
+            lines.append(f"- {prefix}: {item['body']}{suffix}")
 
     print("\n".join(lines))
 

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -406,6 +406,27 @@ def test_cmd_learnings_surfaces_new_insights(mi, fresh_vault, capsys, tmp_path, 
     assert "Playwright" in output
 
 
+def test_cmd_learnings_groups_by_category(mi, fresh_vault, capsys, tmp_path, monkeypatch):
+    """cmd_learnings groups output by category with subheadings."""
+    monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")
+    from datetime import date, timedelta
+    today = date.today()
+    _create_atom(fresh_vault, "constraint-rule.md", "Always use feature branches",
+                 category="constraint", corroborations=2, confidence=0.80,
+                 created_at=str(today - timedelta(days=5)),
+                 updated_at=str(today - timedelta(days=1)))
+    _create_atom(fresh_vault, "fact-new.md", "Deus uses Apple Container",
+                 category="fact", corroborations=1, confidence=0.50,
+                 created_at=str(today - timedelta(days=2)),
+                 updated_at=str(today - timedelta(days=2)))
+
+    mi.cmd_learnings(since_days=7, max_items=5)
+    output = capsys.readouterr().out
+    assert "### Active Constraints" in output
+    assert "### Known Facts" in output
+    assert output.index("Active Constraints") < output.index("Known Facts")
+
+
 def test_cmd_learnings_delta_tracking(mi, fresh_vault, capsys, tmp_path, monkeypatch):
     """Second run skips atoms already shown in first run."""
     monkeypatch.setattr(mi, "LAST_RESUME_LEARNINGS", tmp_path / "last_learnings.txt")


### PR DESCRIPTION
## Summary

- Group "What's Emerging" output into category subheadings using `CATEGORY_SECTIONS` (shipped in #264)
- Constraints appear first, beliefs last — same order as query injection
- Unrecognized categories fall through to a titled bucket
- 1 new test verifying category subheadings and ordering

## Test plan

- [x] All 7 cmd_learnings tests pass (including new grouping test)
- [x] 254/254 memory_indexer tests passing, zero regressions
- [ ] Verify via `python3 scripts/memory_indexer.py --learnings` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)