### PR TITLE
feat(memory): add host memory bridge route (Phase 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,8 @@ DEUS_EVAL_CONCURRENT=
 
 # === Memory ===
 DEUS_VAULT_PATH=
+# Python binary for memory bridge (default: python3)
+# DEUS_PYTHON=python3
 
 # === Safety ===
 # Max characters per incoming message (truncates, doesn't reject)

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""memory_query.py — reusable memory retrieval for all Deus interfaces.
+
+Platform: Linux/macOS only (sqlite_vec + Ollama). Fails fast on Windows.
+
+Log schema: appends to ~/.deus/memory_retrieval_log.jsonl with a `source` field.
+Existing host-hook entries lack this field; per-interface analytics cover only
+entries written by this module until the hook is updated separately.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if sys.platform == "win32":
+    print("memory_query.py requires Linux or macOS (sqlite_vec + Ollama).", file=sys.stderr)
+    sys.exit(1)
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import memory_tree as mt  # noqa: E402
+
+LOG_FILE = Path(os.environ.get(
+    "DEUS_RETRIEVAL_LOG",
+    "~/.deus/memory_retrieval_log.jsonl",
+)).expanduser()
+
+AUTO_MEM_DIR = Path(os.environ.get(
+    mt.EXTERNAL_DIR_ENV,
+    "~/.deus/auto-memory",
+)).expanduser()
+
+
+def _read_node_file(path: str) -> str | None:
+    if path.startswith(mt.EXTERNAL_NAMESPACE):
+        filename = path[len(mt.EXTERNAL_NAMESPACE):]
+        full = AUTO_MEM_DIR / filename
+    else:
+        vault = mt.resolve_vault_path()
+        full = vault / path
+    try:
+        return full.read_text(encoding="utf-8", errors="replace") if full.is_file() else None
+    except OSError:
+        return None
+
+
+def _format_context(results: list[dict], fell_back: bool) -> str:
+    if fell_back or not results:
+        return ""
+    lines = ["=== Auto-retrieved memory (may not be relevant to your task) ==="]
+    for r in results:
+        content = _read_node_file(r["path"])
+        if content:
+            lines.append(f"--- {r['path']} (score: {r['score']:.4f}) ---")
+            lines.append(content)
+    lines.append("=== End auto-retrieved memory ===")
+    return "\n".join(lines)
+
+
+def _log_retrieval(
+    query: str,
+    result: dict,
+    source: str,
+) -> None:
+    prompt_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
+    entry = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "prompt_hash": prompt_hash,
+        "confidence": result["confidence"],
+        "fell_back": result["fell_back"],
+        "paths": [r["path"] for r in result["results"]],
+        "source": source,
+    }
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError:
+        pass
+
+
+def recall(
+    query: str,
+    *,
+    k: int = 3,
+    abstain_threshold: float | None = None,
+    source: str = "unknown",
+) -> dict:
+    """Retrieve memory context for a query.
+
+    Returns:
+        {
+            "context": str,       # formatted text block (empty on abstain)
+            "paths": [str, ...],  # matched file paths
+            "confidence": float,
+            "fell_back": bool,
+        }
+    """
+    threshold = abstain_threshold if abstain_threshold is not None else mt.DEFAULT_ABSTAIN_THRESHOLD
+
+    db = mt.open_db()
+    try:
+        raw = mt.retrieve(db, query, k=k, abstain_threshold=threshold)
+    finally:
+        db.close()
+
+    context = _format_context(raw["results"], raw["fell_back"])
+    paths = [r["path"] for r in raw["results"]] if not raw["fell_back"] else []
+
+    out = {
+        "context": context,
+        "paths": paths,
+        "confidence": raw["confidence"],
+        "fell_back": raw["fell_back"],
+    }
+
+    _log_retrieval(query, raw, source)
+
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="memory_query",
+        description="Retrieve memory context from the Deus memory tree.",
+    )
+    parser.add_argument("query", help="Query text")
+    parser.add_argument("-k", type=int, default=3, help="Top-K results")
+    parser.add_argument(
+        "--abstain", type=float, default=None,
+        help=f"Abstain threshold (default: {mt.DEFAULT_ABSTAIN_THRESHOLD})",
+    )
+    parser.add_argument("--source", default="cli", help="Source identifier for logging")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--context-only", action="store_true", help="Output only the context block")
+
+    args = parser.parse_args(argv)
+    result = recall(args.query, k=args.k, abstain_threshold=args.abstain, source=args.source)
+
+    if args.context_only:
+        print(result["context"])
+    elif args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        if result["fell_back"]:
+            print(f"Abstained (confidence={result['confidence']:.3f})")
+        else:
+            for p in result["paths"]:
+                print(f"  {p}")
+            print(f"— confidence={result['confidence']:.3f}")
+            if result["context"]:
+                print()
+                print(result["context"])
+    return 0 if not result["fell_back"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_memory_query.py
+++ b/scripts/tests/test_memory_query.py
@@ -1,0 +1,237 @@
+"""Tests for scripts/memory_query.py — offline, stubbed retrieve()."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+if "memory_query" in sys.modules:
+    mq = sys.modules["memory_query"]
+else:
+    _SPEC = importlib.util.spec_from_file_location(
+        "memory_query", _ROOT / "scripts" / "memory_query.py"
+    )
+    mq = importlib.util.module_from_spec(_SPEC)
+    sys.modules["memory_query"] = mq
+    _SPEC.loader.exec_module(mq)
+
+mt = sys.modules["memory_tree"]
+
+
+FAKE_RETRIEVE_HIT = {
+    "results": [
+        {"id": "n1", "path": "CLAUDE.md", "score": 0.72, "route": "flat"},
+        {"id": "n2", "path": "STATE.md", "score": 0.65, "route": "rrf"},
+    ],
+    "confidence": 0.72,
+    "fell_back": False,
+    "trace": ["flat_top=CLAUDE.md:0.720"],
+}
+
+FAKE_RETRIEVE_ABSTAIN = {
+    "results": [],
+    "confidence": 0.20,
+    "fell_back": True,
+    "trace": ["flat_top=X:0.200"],
+}
+
+
+@pytest.fixture
+def fake_vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    (v / "CLAUDE.md").write_text("name: Liam", encoding="utf-8")
+    (v / "STATE.md").write_text("pending: []", encoding="utf-8")
+    return v
+
+
+@pytest.fixture
+def fake_auto_mem(tmp_path):
+    d = tmp_path / "auto_mem"
+    d.mkdir()
+    (d / "feedback_test.md").write_text("some feedback", encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def log_file(tmp_path):
+    return tmp_path / "retrieval.jsonl"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch, fake_vault, fake_auto_mem, log_file):
+    monkeypatch.setattr(mq, "LOG_FILE", log_file)
+    monkeypatch.setattr(mq, "AUTO_MEM_DIR", fake_auto_mem)
+    monkeypatch.setattr(mt, "DB_PATH", tmp_path / "tree.db")
+    monkeypatch.setattr(mt, "_LOG_PATH", tmp_path / "tree_queries.jsonl")
+    monkeypatch.setattr(mt, "_AUDIT_PATH", tmp_path / "tree_audit.jsonl")
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(fake_vault))
+
+
+class TestRecall:
+    def test_hit_returns_context_and_paths(self, fake_vault):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("what timezone?", source="test")
+
+        assert not result["fell_back"]
+        assert result["confidence"] == 0.72
+        assert result["paths"] == ["CLAUDE.md", "STATE.md"]
+        assert "Auto-retrieved memory" in result["context"]
+        assert "name: Liam" in result["context"]
+
+    def test_abstain_returns_empty_context(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("gibberish xyz", source="test")
+
+        assert result["fell_back"]
+        assert result["context"] == ""
+        assert result["paths"] == []
+
+    def test_default_threshold_uses_memory_tree(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN) as mock_ret, \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.recall("test", source="test")
+
+        _, kwargs = mock_ret.call_args
+        assert kwargs["abstain_threshold"] == mt.DEFAULT_ABSTAIN_THRESHOLD
+
+    def test_explicit_threshold_overrides_default(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN) as mock_ret, \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.recall("test", abstain_threshold=0.99, source="test")
+
+        _, kwargs = mock_ret.call_args
+        assert kwargs["abstain_threshold"] == 0.99
+
+    def test_db_closed_after_recall(self):
+        closed = []
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: closed.append(True)
+            mq.recall("test", source="test")
+
+        assert closed
+
+    def test_db_closed_on_retrieve_error(self):
+        closed = []
+        with patch.object(mt, "retrieve", side_effect=RuntimeError("boom")), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: closed.append(True)
+            with pytest.raises(RuntimeError, match="boom"):
+                mq.recall("test", source="test")
+
+        assert closed
+
+
+class TestFileReading:
+    def test_reads_vault_path(self, fake_vault):
+        content = mq._read_node_file("CLAUDE.md")
+        assert content == "name: Liam"
+
+    def test_reads_auto_memory_path(self, fake_auto_mem):
+        content = mq._read_node_file("auto-memory/feedback_test.md")
+        assert content == "some feedback"
+
+    def test_missing_file_returns_none(self):
+        assert mq._read_node_file("nonexistent.md") is None
+
+    def test_missing_auto_memory_returns_none(self):
+        assert mq._read_node_file("auto-memory/nonexistent.md") is None
+
+
+class TestContextFormatting:
+    def test_empty_on_fell_back(self):
+        assert mq._format_context([], fell_back=True) == ""
+
+    def test_empty_on_no_results(self):
+        assert mq._format_context([], fell_back=False) == ""
+
+    def test_includes_header_and_footer(self, fake_vault):
+        ctx = mq._format_context(FAKE_RETRIEVE_HIT["results"], fell_back=False)
+        assert ctx.startswith("=== Auto-retrieved memory")
+        assert ctx.endswith("=== End auto-retrieved memory ===")
+
+    def test_includes_path_and_score(self, fake_vault):
+        ctx = mq._format_context(FAKE_RETRIEVE_HIT["results"], fell_back=False)
+        assert "--- CLAUDE.md (score: 0.7200) ---" in ctx
+
+    def test_skips_unreadable_files(self):
+        results = [{"path": "nonexistent.md", "score": 0.5}]
+        ctx = mq._format_context(results, fell_back=False)
+        assert "nonexistent" not in ctx
+
+
+class TestLogging:
+    def test_writes_log_entry_with_source(self, log_file):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.recall("what timezone?", source="mcp")
+
+        entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "mcp"
+        assert entries[0]["confidence"] == 0.72
+        assert "ts" in entries[0]
+        assert "prompt_hash" in entries[0]
+
+    def test_log_survives_write_failure(self, monkeypatch):
+        monkeypatch.setattr(mq, "LOG_FILE", Path("/nonexistent/dir/log.jsonl"))
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("test", source="test")
+
+        assert result["confidence"] == 0.72
+
+
+class TestCLI:
+    def test_json_output(self, capsys):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["test query", "--json", "--source", "test"])
+
+        assert code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["confidence"] == 0.72
+
+    def test_context_only_output(self, capsys, fake_vault):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["test query", "--context-only"])
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Auto-retrieved memory" in out
+
+    def test_abstain_exit_code(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["gibberish"])
+
+        assert code == 1
+
+    def test_default_source_is_cli(self, log_file):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.main(["test query"])
+
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["source"] == "cli"

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -18,6 +18,8 @@
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
+import { execFile } from 'child_process';
+import path from 'path';
 import { DEUS_PROXY_TOKEN, DEUS_PROXY_AUTH_ENABLED } from './config.js';
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
@@ -38,6 +40,62 @@ export interface ProxyConfig {
 /** @internal exposed for testing only */
 export function _resetCredentialsCacheForTest(): void {
   _resetAnthropicCache();
+}
+
+/* ── Memory bridge constants ───────────────────────────────────────── */
+
+const PYTHON_BIN = process.env.DEUS_PYTHON ?? 'python3';
+const MEMORY_QUERY_SCRIPT = path.join(
+  process.cwd(),
+  'scripts',
+  'memory_query.py',
+);
+const MEMORY_QUERY_TIMEOUT_MS = 4_000;
+
+/* ── Rate limiter (in-process, per-source) ─────────────────────────── */
+
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+interface RateBucket {
+  timestamps: number[];
+}
+
+const rateBuckets = new Map<string, RateBucket>();
+
+/** Prune expired entries periodically to prevent unbounded growth. */
+const rateLimitCleanupInterval = setInterval(() => {
+  const now = Date.now();
+  for (const [key, bucket] of rateBuckets) {
+    bucket.timestamps = bucket.timestamps.filter(
+      (t) => now - t < RATE_LIMIT_WINDOW_MS,
+    );
+    if (bucket.timestamps.length === 0) rateBuckets.delete(key);
+  }
+}, RATE_LIMIT_WINDOW_MS);
+
+// Prevent the cleanup timer from keeping Node alive after tests/shutdown
+rateLimitCleanupInterval.unref();
+
+/** @internal exposed for testing only */
+export function _resetRateLimiterForTest(): void {
+  rateBuckets.clear();
+}
+
+function isRateLimited(sourceKey: string): boolean {
+  const now = Date.now();
+  let bucket = rateBuckets.get(sourceKey);
+  if (!bucket) {
+    bucket = { timestamps: [] };
+    rateBuckets.set(sourceKey, bucket);
+  }
+  // Prune expired timestamps for this source
+  bucket.timestamps = bucket.timestamps.filter(
+    (t) => now - t < RATE_LIMIT_WINDOW_MS,
+  );
+  if (bucket.timestamps.length >= RATE_LIMIT_MAX) return true;
+  bucket.timestamps.push(now);
+  return false;
 }
 
 /**
@@ -111,6 +169,96 @@ export function startCredentialProxy(
         // Strip the proxy auth header before forwarding upstream
         delete req.headers['x-deus-proxy-token'];
 
+        /* ── Memory bridge route: POST /memory/query ───────────── */
+        if (req.method === 'POST' && req.url === '/memory/query') {
+          const sourceKey =
+            (req.headers['x-deus-source'] as string) ||
+            req.socket.remoteAddress ||
+            'unknown';
+
+          if (isRateLimited(sourceKey)) {
+            res.writeHead(429, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Rate limit exceeded' }));
+            return;
+          }
+
+          let parsed: { query?: unknown; k?: unknown; source?: unknown };
+          try {
+            parsed = JSON.parse(body.toString('utf-8'));
+          } catch {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Invalid JSON body' }));
+            return;
+          }
+
+          if (typeof parsed.query !== 'string' || parsed.query.length === 0) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(
+              JSON.stringify({ error: 'Missing or empty "query" field' }),
+            );
+            return;
+          }
+
+          const queryArg = parsed.query;
+          const kArg = typeof parsed.k === 'number' ? String(parsed.k) : '3';
+          const sourceArg =
+            typeof parsed.source === 'string' ? parsed.source : 'bridge';
+
+          const args = [
+            MEMORY_QUERY_SCRIPT,
+            queryArg,
+            '--json',
+            '--source',
+            sourceArg,
+            '-k',
+            kArg,
+          ];
+
+          execFile(
+            PYTHON_BIN,
+            args,
+            { timeout: MEMORY_QUERY_TIMEOUT_MS },
+            (err, stdout, _stderr) => {
+              const errAny = err as NodeJS.ErrnoException & {
+                killed?: boolean;
+                signal?: string;
+              };
+              if (
+                errAny &&
+                (errAny.killed ||
+                  errAny.signal === 'SIGTERM' ||
+                  errAny.code === 'ETIMEDOUT')
+              ) {
+                logger.warn('Memory query timed out');
+                res.writeHead(504, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'Memory query timed out' }));
+                return;
+              }
+              if (err) {
+                logger.error({ err }, 'Memory query failed');
+                res.writeHead(500, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'Memory query failed' }));
+                return;
+              }
+
+              try {
+                const result = JSON.parse(stdout);
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(result));
+              } catch {
+                logger.error({ stdout }, 'Memory query returned invalid JSON');
+                res.writeHead(500, { 'Content-Type': 'application/json' });
+                res.end(
+                  JSON.stringify({
+                    error: 'Memory query returned invalid output',
+                  }),
+                );
+              }
+            },
+          );
+          return;
+        }
+
         // Resolve which provider handles this request
         let provider: AuthProvider;
         let upstreamPath: string;
@@ -177,6 +325,10 @@ export function startCredentialProxy(
         upstream.write(body);
         upstream.end();
       });
+    });
+
+    server.on('close', () => {
+      clearInterval(rateLimitCleanupInterval);
     });
 
     let retries = 0;

--- a/src/memory-bridge.test.ts
+++ b/src/memory-bridge.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+/* ── Mocks (must precede imports from the module under test) ───────── */
+
+vi.mock('./config.js', () => ({
+  DEUS_PROXY_TOKEN: 'test-proxy-token-abc123',
+  DEUS_PROXY_AUTH_ENABLED: true,
+}));
+
+vi.mock('./env.js', () => ({
+  readEnvFile: vi.fn(() => ({})),
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: vi.fn(),
+    execFileSync: vi.fn(),
+    execSync: vi.fn(),
+  };
+});
+
+import { readFileSync } from 'fs';
+import { execFile, execFileSync } from 'child_process';
+import {
+  startCredentialProxy,
+  _resetCredentialsCacheForTest,
+  _resetRateLimiterForTest,
+} from './credential-proxy.js';
+import { AuthProviderRegistry } from './auth-providers/types.js';
+
+const TEST_TOKEN = 'test-proxy-token-abc123';
+const mockExecFile = vi.mocked(execFile);
+const mockExecFileSync = vi.mocked(execFileSync);
+const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
+
+/* ── Helpers ───────────────────────────────────────────────────────── */
+
+function makeRequest(
+  port: number,
+  options: http.RequestOptions,
+  body = '',
+): Promise<{
+  statusCode: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { ...options, hostname: '127.0.0.1', port },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function memoryRequest(
+  port: number,
+  body: string,
+  headers: Record<string, string> = {},
+) {
+  return makeRequest(
+    port,
+    {
+      method: 'POST',
+      path: '/memory/query',
+      headers: {
+        'x-deus-proxy-token': TEST_TOKEN,
+        'content-type': 'application/json',
+        ...headers,
+      },
+    },
+    body,
+  );
+}
+
+async function closeServer(server: http.Server | undefined): Promise<void> {
+  if (!server) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/* ── Test suite ────────────────────────────────────────────────────── */
+
+describe('memory bridge — POST /memory/query', () => {
+  let proxyServer: http.Server | undefined;
+  let proxyPort: number;
+
+  beforeEach(async () => {
+    AuthProviderRegistry.reset();
+    _resetCredentialsCacheForTest();
+    _resetRateLimiterForTest();
+    mockReadFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    // Block keychain lookups to prevent real credentials in tests
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('no keychain (test isolation)');
+    });
+    // Default: execFile succeeds with valid JSON
+    mockExecFile.mockImplementation(
+      (_file: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+        const callback = cb as (
+          err: Error | null,
+          stdout: string,
+          stderr: string,
+        ) => void;
+        callback(
+          null,
+          JSON.stringify({
+            context: 'test memory context',
+            paths: ['Atoms/test.md'],
+            confidence: 0.85,
+            fell_back: false,
+          }),
+          '',
+        );
+        return {} as ReturnType<typeof execFile>;
+      },
+    );
+
+    proxyServer = await startCredentialProxy(0, '127.0.0.1');
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    await closeServer(proxyServer);
+    _resetCredentialsCacheForTest();
+    _resetRateLimiterForTest();
+    AuthProviderRegistry.reset();
+    vi.restoreAllMocks();
+  });
+
+  it('returns 200 with JSON on valid query', async () => {
+    const res = await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'what is my timezone?' }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('application/json');
+    const json = JSON.parse(res.body);
+    expect(json.confidence).toBe(0.85);
+    expect(json.paths).toContain('Atoms/test.md');
+
+    // Verify execFile was called with expected args
+    expect(mockExecFile).toHaveBeenCalledWith(
+      expect.any(String), // python binary
+      expect.arrayContaining([
+        expect.stringContaining('memory_query.py'),
+        'what is my timezone?',
+        '--json',
+        '--source',
+        'bridge',
+        '-k',
+        '3',
+      ]),
+      expect.objectContaining({ timeout: 4_000 }),
+      expect.any(Function),
+    );
+  });
+
+  it('returns 401 without auth token', async () => {
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/memory/query',
+        headers: { 'content-type': 'application/json' },
+      },
+      JSON.stringify({ query: 'test' }),
+    );
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const res = await memoryRequest(proxyPort, 'not json at all');
+    expect(res.statusCode).toBe(400);
+    const json = JSON.parse(res.body);
+    expect(json.error).toMatch(/Invalid JSON/i);
+  });
+
+  it('returns 400 when query field is missing', async () => {
+    const res = await memoryRequest(proxyPort, JSON.stringify({ k: 5 }));
+    expect(res.statusCode).toBe(400);
+    const json = JSON.parse(res.body);
+    expect(json.error).toMatch(/query/i);
+  });
+
+  it('returns 400 when query is empty string', async () => {
+    const res = await memoryRequest(proxyPort, JSON.stringify({ query: '' }));
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 500 on execFile spawn failure', async () => {
+    mockExecFile.mockImplementation(
+      (_file: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+        const callback = cb as (
+          err: Error | null,
+          stdout: string,
+          stderr: string,
+        ) => void;
+        callback(
+          Object.assign(new Error('spawn ENOENT'), {
+            code: 'ENOENT',
+          }) as Error,
+          '',
+          '',
+        );
+        return {} as ReturnType<typeof execFile>;
+      },
+    );
+
+    const res = await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'test' }),
+    );
+    expect(res.statusCode).toBe(500);
+    const json = JSON.parse(res.body);
+    expect(json.error).toMatch(/failed/i);
+  });
+
+  it('returns 504 on timeout (killed process)', async () => {
+    mockExecFile.mockImplementation(
+      (_file: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+        const callback = cb as (
+          err: Error | null,
+          stdout: string,
+          stderr: string,
+        ) => void;
+        callback(
+          Object.assign(new Error('process timed out'), {
+            killed: true,
+            signal: 'SIGTERM',
+          }) as Error,
+          '',
+          '',
+        );
+        return {} as ReturnType<typeof execFile>;
+      },
+    );
+
+    const res = await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'test' }),
+    );
+    expect(res.statusCode).toBe(504);
+    const json = JSON.parse(res.body);
+    expect(json.error).toMatch(/timed out/i);
+  });
+
+  it('returns 429 when rate limit is exceeded (6 rapid requests)', async () => {
+    const results: number[] = [];
+
+    for (let i = 0; i < 6; i++) {
+      const res = await memoryRequest(
+        proxyPort,
+        JSON.stringify({ query: `query ${i}` }),
+        { 'x-deus-source': 'rate-limit-test' },
+      );
+      results.push(res.statusCode);
+    }
+
+    // First 5 should succeed, 6th should be rate limited
+    expect(results.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+    expect(results[5]).toBe(429);
+  });
+
+  it('passes custom k and source to the script', async () => {
+    await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'test', k: 10, source: 'telegram' }),
+    );
+
+    expect(mockExecFile).toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.arrayContaining(['--source', 'telegram', '-k', '10']),
+      expect.objectContaining({ timeout: 4_000 }),
+      expect.any(Function),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Phase 3 of cross-interface memory parity
- `POST /memory/query` route on credential proxy (`src/credential-proxy.ts`)
- Spawns `memory_query.py` via `child_process.execFile` with 4s timeout
- In-process rate limiting: 5 req/min per source, 429 on exceed
- Proper error codes: 400 (bad request), 401 (no auth), 429 (rate limit), 500 (spawn fail), 504 (timeout)
- `DEUS_PYTHON` env var added to `.env.example`
- Platform: **Linux/macOS only** (Python spawn → 500 on Windows)

## Dependency

- **Depends on:** PR #274 (Phase 1 — `memory_query.py`)
- **Blocks:** Phase 4+5 (container hooks need this bridge)

## Test plan

- [x] `vitest run src/memory-bridge.test.ts` — 9 passed
- [x] Full `vitest run` — 883 passed (57 test files, 0 regressions)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)