### PR TITLE
feat(memory): add container memory retrieval hooks (Phase 4+5)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'url';
 
 import { bootstrap } from './bootstrap.js';
 import { loadRegisteredContextFiles } from './context-registry.js';
+import { createMemoryRetrievalHook } from './memory-retrieval-hook.js';
 import { runOpenAIConversation } from './openai-backend.js';
 
 type AgentBackendName = 'claude' | 'openai';
@@ -769,6 +770,9 @@ async function runQuery(
           : {}),
       },
       hooks: {
+        UserPromptSubmit: [
+          { hooks: [createMemoryRetrievalHook() as unknown as HookCallback] },
+        ],
         PreCompact: [
           { hooks: [createPreCompactHook(containerInput.assistantName)] },
         ],

--- a/container/agent-runner/src/memory-retrieval-hook.test.ts
+++ b/container/agent-runner/src/memory-retrieval-hook.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchMemoryContext,
+  createMemoryRetrievalHook,
+} from './memory-retrieval-hook.js';
+
+describe('fetchMemoryContext', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.DEUS_PROXY_TOKEN = 'test-token';
+    process.env.CREDENTIAL_PROXY_PORT = '3001';
+    process.env.DEUS_PROXY_HOST = '127.0.0.1';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty string when DEUS_PROXY_TOKEN is not set', async () => {
+    delete process.env.DEUS_PROXY_TOKEN;
+    const result = await fetchMemoryContext('test query');
+    expect(result).toBe('');
+  });
+
+  it('returns context on successful bridge response', async () => {
+    const mockResponse = {
+      context: '=== Auto-retrieved memory ===\ntest content\n=== End ===',
+      paths: ['CLAUDE.md'],
+      confidence: 0.72,
+      fell_back: false,
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const result = await fetchMemoryContext('what is my timezone?');
+    expect(result).toContain('Auto-retrieved memory');
+    expect(result).toContain('test content');
+  });
+
+  it('sends correct headers and body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ context: '', fell_back: true }), {
+        status: 200,
+      }),
+    );
+
+    await fetchMemoryContext('test query', 'container-claude');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:3001/memory/query',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-deus-proxy-token': 'test-token',
+          'x-deus-source': 'container-claude',
+        }),
+        body: JSON.stringify({
+          query: 'test query',
+          source: 'container-claude',
+        }),
+      }),
+    );
+  });
+
+  it('returns empty string on HTTP error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const result = await fetchMemoryContext('test');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await fetchMemoryContext('test');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string on timeout (abort)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            10,
+          );
+        }),
+    );
+
+    const result = await fetchMemoryContext('test');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when fell_back is true', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          context: '',
+          paths: [],
+          confidence: 0.2,
+          fell_back: true,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await fetchMemoryContext('gibberish');
+    expect(result).toBe('');
+  });
+});
+
+describe('createMemoryRetrievalHook', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.DEUS_PROXY_TOKEN = 'test-token';
+    process.env.CREDENTIAL_PROXY_PORT = '3001';
+    process.env.DEUS_PROXY_HOST = '127.0.0.1';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty object when prompt is missing', async () => {
+    const hook = createMemoryRetrievalHook();
+    const result = await hook({});
+    expect(result).toEqual({});
+  });
+
+  it('returns additionalContext on successful retrieval', async () => {
+    const mockResponse = {
+      context: '=== Memory ===\nsome context\n=== End ===',
+      paths: ['test.md'],
+      confidence: 0.7,
+      fell_back: false,
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), { status: 200 }),
+    );
+
+    const hook = createMemoryRetrievalHook();
+    const result = await hook({ prompt: 'hello' });
+
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: '=== Memory ===\nsome context\n=== End ===',
+      },
+    });
+  });
+
+  it('returns empty object when bridge returns empty context', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ context: '', fell_back: true }), {
+        status: 200,
+      }),
+    );
+
+    const hook = createMemoryRetrievalHook();
+    const result = await hook({ prompt: 'hello' });
+    expect(result).toEqual({});
+  });
+});

--- a/container/agent-runner/src/memory-retrieval-hook.ts
+++ b/container/agent-runner/src/memory-retrieval-hook.ts
@@ -1,0 +1,78 @@
+/**
+ * Memory retrieval hook for container agents.
+ *
+ * Fetches memory context from the host's memory bridge (POST /memory/query on
+ * the credential proxy). Used by both Claude (UserPromptSubmit additionalContext)
+ * and OpenAI (system prompt prepend) backends.
+ *
+ * Failure mode: bridge unreachable / timeout / error → returns empty object or
+ * empty string. Silent degradation, never crashes the agent.
+ */
+
+const BRIDGE_TIMEOUT_MS = 4000;
+
+interface MemoryBridgeResponse {
+  context: string;
+  paths: string[];
+  confidence: number;
+  fell_back: boolean;
+}
+
+function getBridgeUrl(): string | null {
+  const proxyPort = process.env.CREDENTIAL_PROXY_PORT || '3001';
+  const proxyHost = process.env.DEUS_PROXY_HOST || 'host.docker.internal';
+  if (!process.env.DEUS_PROXY_TOKEN) return null;
+  return `http://${proxyHost}:${proxyPort}/memory/query`;
+}
+
+export async function fetchMemoryContext(
+  query: string,
+  source: string = 'container',
+): Promise<string> {
+  const url = getBridgeUrl();
+  if (!url) return '';
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), BRIDGE_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-deus-proxy-token': process.env.DEUS_PROXY_TOKEN!,
+        'x-deus-source': source,
+      },
+      body: JSON.stringify({ query, source }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return '';
+
+    const data = (await res.json()) as MemoryBridgeResponse;
+    return data.context || '';
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function createMemoryRetrievalHook() {
+  return async (input: {
+    prompt?: string;
+  }): Promise<Record<string, unknown>> => {
+    const prompt = input.prompt;
+    if (!prompt) return {};
+
+    const context = await fetchMemoryContext(prompt, 'container-claude');
+    if (!context) return {};
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: context,
+      },
+    };
+  };
+}

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { loadRegisteredContextFiles } from './context-registry.js';
+import { fetchMemoryContext } from './memory-retrieval-hook.js';
 import {
   createOpenAIMcpToolBridge,
   executeBrokerTool,
@@ -522,7 +523,16 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
   while (true) {
     if (shouldClose()) break;
 
-    const turn = await runSingleTurn(prompt, containerInput, sessionId, log);
+    const memoryContext = await fetchMemoryContext(prompt, 'container-openai');
+    const enrichedPrompt = memoryContext
+      ? `${memoryContext}\n\n${prompt}`
+      : prompt;
+    const turn = await runSingleTurn(
+      enrichedPrompt,
+      containerInput,
+      sessionId,
+      log,
+    );
     sessionId = turn.responseId;
     writeOutput({
       status: 'success',

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""memory_query.py — reusable memory retrieval for all Deus interfaces.
+
+Platform: Linux/macOS only (sqlite_vec + Ollama). Fails fast on Windows.
+
+Log schema: appends to ~/.deus/memory_retrieval_log.jsonl with a `source` field.
+Existing host-hook entries lack this field; per-interface analytics cover only
+entries written by this module until the hook is updated separately.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+if sys.platform == "win32":
+    print("memory_query.py requires Linux or macOS (sqlite_vec + Ollama).", file=sys.stderr)
+    sys.exit(1)
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import memory_tree as mt  # noqa: E402
+
+LOG_FILE = Path(os.environ.get(
+    "DEUS_RETRIEVAL_LOG",
+    "~/.deus/memory_retrieval_log.jsonl",
+)).expanduser()
+
+AUTO_MEM_DIR = Path(os.environ.get(
+    mt.EXTERNAL_DIR_ENV,
+    "~/.deus/auto-memory",
+)).expanduser()
+
+
+def _read_node_file(path: str) -> str | None:
+    if path.startswith(mt.EXTERNAL_NAMESPACE):
+        filename = path[len(mt.EXTERNAL_NAMESPACE):]
+        full = AUTO_MEM_DIR / filename
+    else:
+        vault = mt.resolve_vault_path()
+        full = vault / path
+    try:
+        return full.read_text(encoding="utf-8", errors="replace") if full.is_file() else None
+    except OSError:
+        return None
+
+
+def _format_context(results: list[dict], fell_back: bool) -> str:
+    if fell_back or not results:
+        return ""
+    lines = ["=== Auto-retrieved memory (may not be relevant to your task) ==="]
+    for r in results:
+        content = _read_node_file(r["path"])
+        if content:
+            lines.append(f"--- {r['path']} (score: {r['score']:.4f}) ---")
+            lines.append(content)
+    lines.append("=== End auto-retrieved memory ===")
+    return "\n".join(lines)
+
+
+def _log_retrieval(
+    query: str,
+    result: dict,
+    source: str,
+) -> None:
+    prompt_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
+    entry = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "prompt_hash": prompt_hash,
+        "confidence": result["confidence"],
+        "fell_back": result["fell_back"],
+        "paths": [r["path"] for r in result["results"]],
+        "source": source,
+    }
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError:
+        pass
+
+
+def recall(
+    query: str,
+    *,
+    k: int = 3,
+    abstain_threshold: float | None = None,
+    source: str = "unknown",
+) -> dict:
+    """Retrieve memory context for a query.
+
+    Returns:
+        {
+            "context": str,       # formatted text block (empty on abstain)
+            "paths": [str, ...],  # matched file paths
+            "confidence": float,
+            "fell_back": bool,
+        }
+    """
+    threshold = abstain_threshold if abstain_threshold is not None else mt.DEFAULT_ABSTAIN_THRESHOLD
+
+    db = mt.open_db()
+    try:
+        raw = mt.retrieve(db, query, k=k, abstain_threshold=threshold)
+    finally:
+        db.close()
+
+    context = _format_context(raw["results"], raw["fell_back"])
+    paths = [r["path"] for r in raw["results"]] if not raw["fell_back"] else []
+
+    out = {
+        "context": context,
+        "paths": paths,
+        "confidence": raw["confidence"],
+        "fell_back": raw["fell_back"],
+    }
+
+    _log_retrieval(query, raw, source)
+
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="memory_query",
+        description="Retrieve memory context from the Deus memory tree.",
+    )
+    parser.add_argument("query", help="Query text")
+    parser.add_argument("-k", type=int, default=3, help="Top-K results")
+    parser.add_argument(
+        "--abstain", type=float, default=None,
+        help=f"Abstain threshold (default: {mt.DEFAULT_ABSTAIN_THRESHOLD})",
+    )
+    parser.add_argument("--source", default="cli", help="Source identifier for logging")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--context-only", action="store_true", help="Output only the context block")
+
+    args = parser.parse_args(argv)
+    result = recall(args.query, k=args.k, abstain_threshold=args.abstain, source=args.source)
+
+    if args.context_only:
+        print(result["context"])
+    elif args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        if result["fell_back"]:
+            print(f"Abstained (confidence={result['confidence']:.3f})")
+        else:
+            for p in result["paths"]:
+                print(f"  {p}")
+            print(f"— confidence={result['confidence']:.3f}")
+            if result["context"]:
+                print()
+                print(result["context"])
+    return 0 if not result["fell_back"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_memory_query.py
+++ b/scripts/tests/test_memory_query.py
@@ -1,0 +1,237 @@
+"""Tests for scripts/memory_query.py — offline, stubbed retrieve()."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+if "memory_query" in sys.modules:
+    mq = sys.modules["memory_query"]
+else:
+    _SPEC = importlib.util.spec_from_file_location(
+        "memory_query", _ROOT / "scripts" / "memory_query.py"
+    )
+    mq = importlib.util.module_from_spec(_SPEC)
+    sys.modules["memory_query"] = mq
+    _SPEC.loader.exec_module(mq)
+
+mt = sys.modules["memory_tree"]
+
+
+FAKE_RETRIEVE_HIT = {
+    "results": [
+        {"id": "n1", "path": "CLAUDE.md", "score": 0.72, "route": "flat"},
+        {"id": "n2", "path": "STATE.md", "score": 0.65, "route": "rrf"},
+    ],
+    "confidence": 0.72,
+    "fell_back": False,
+    "trace": ["flat_top=CLAUDE.md:0.720"],
+}
+
+FAKE_RETRIEVE_ABSTAIN = {
+    "results": [],
+    "confidence": 0.20,
+    "fell_back": True,
+    "trace": ["flat_top=X:0.200"],
+}
+
+
+@pytest.fixture
+def fake_vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    (v / "CLAUDE.md").write_text("name: Liam", encoding="utf-8")
+    (v / "STATE.md").write_text("pending: []", encoding="utf-8")
+    return v
+
+
+@pytest.fixture
+def fake_auto_mem(tmp_path):
+    d = tmp_path / "auto_mem"
+    d.mkdir()
+    (d / "feedback_test.md").write_text("some feedback", encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def log_file(tmp_path):
+    return tmp_path / "retrieval.jsonl"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch, fake_vault, fake_auto_mem, log_file):
+    monkeypatch.setattr(mq, "LOG_FILE", log_file)
+    monkeypatch.setattr(mq, "AUTO_MEM_DIR", fake_auto_mem)
+    monkeypatch.setattr(mt, "DB_PATH", tmp_path / "tree.db")
+    monkeypatch.setattr(mt, "_LOG_PATH", tmp_path / "tree_queries.jsonl")
+    monkeypatch.setattr(mt, "_AUDIT_PATH", tmp_path / "tree_audit.jsonl")
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(fake_vault))
+
+
+class TestRecall:
+    def test_hit_returns_context_and_paths(self, fake_vault):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("what timezone?", source="test")
+
+        assert not result["fell_back"]
+        assert result["confidence"] == 0.72
+        assert result["paths"] == ["CLAUDE.md", "STATE.md"]
+        assert "Auto-retrieved memory" in result["context"]
+        assert "name: Liam" in result["context"]
+
+    def test_abstain_returns_empty_context(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("gibberish xyz", source="test")
+
+        assert result["fell_back"]
+        assert result["context"] == ""
+        assert result["paths"] == []
+
+    def test_default_threshold_uses_memory_tree(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN) as mock_ret, \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.recall("test", source="test")
+
+        _, kwargs = mock_ret.call_args
+        assert kwargs["abstain_threshold"] == mt.DEFAULT_ABSTAIN_THRESHOLD
+
+    def test_explicit_threshold_overrides_default(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN) as mock_ret, \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.recall("test", abstain_threshold=0.99, source="test")
+
+        _, kwargs = mock_ret.call_args
+        assert kwargs["abstain_threshold"] == 0.99
+
+    def test_db_closed_after_recall(self):
+        closed = []
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: closed.append(True)
+            mq.recall("test", source="test")
+
+        assert closed
+
+    def test_db_closed_on_retrieve_error(self):
+        closed = []
+        with patch.object(mt, "retrieve", side_effect=RuntimeError("boom")), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: closed.append(True)
+            with pytest.raises(RuntimeError, match="boom"):
+                mq.recall("test", source="test")
+
+        assert closed
+
+
+class TestFileReading:
+    def test_reads_vault_path(self, fake_vault):
+        content = mq._read_node_file("CLAUDE.md")
+        assert content == "name: Liam"
+
+    def test_reads_auto_memory_path(self, fake_auto_mem):
+        content = mq._read_node_file("auto-memory/feedback_test.md")
+        assert content == "some feedback"
+
+    def test_missing_file_returns_none(self):
+        assert mq._read_node_file("nonexistent.md") is None
+
+    def test_missing_auto_memory_returns_none(self):
+        assert mq._read_node_file("auto-memory/nonexistent.md") is None
+
+
+class TestContextFormatting:
+    def test_empty_on_fell_back(self):
+        assert mq._format_context([], fell_back=True) == ""
+
+    def test_empty_on_no_results(self):
+        assert mq._format_context([], fell_back=False) == ""
+
+    def test_includes_header_and_footer(self, fake_vault):
+        ctx = mq._format_context(FAKE_RETRIEVE_HIT["results"], fell_back=False)
+        assert ctx.startswith("=== Auto-retrieved memory")
+        assert ctx.endswith("=== End auto-retrieved memory ===")
+
+    def test_includes_path_and_score(self, fake_vault):
+        ctx = mq._format_context(FAKE_RETRIEVE_HIT["results"], fell_back=False)
+        assert "--- CLAUDE.md (score: 0.7200) ---" in ctx
+
+    def test_skips_unreadable_files(self):
+        results = [{"path": "nonexistent.md", "score": 0.5}]
+        ctx = mq._format_context(results, fell_back=False)
+        assert "nonexistent" not in ctx
+
+
+class TestLogging:
+    def test_writes_log_entry_with_source(self, log_file):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.recall("what timezone?", source="mcp")
+
+        entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "mcp"
+        assert entries[0]["confidence"] == 0.72
+        assert "ts" in entries[0]
+        assert "prompt_hash" in entries[0]
+
+    def test_log_survives_write_failure(self, monkeypatch):
+        monkeypatch.setattr(mq, "LOG_FILE", Path("/nonexistent/dir/log.jsonl"))
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("test", source="test")
+
+        assert result["confidence"] == 0.72
+
+
+class TestCLI:
+    def test_json_output(self, capsys):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["test query", "--json", "--source", "test"])
+
+        assert code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["confidence"] == 0.72
+
+    def test_context_only_output(self, capsys, fake_vault):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["test query", "--context-only"])
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Auto-retrieved memory" in out
+
+    def test_abstain_exit_code(self):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_ABSTAIN), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["gibberish"])
+
+        assert code == 1
+
+    def test_default_source_is_cli(self, log_file):
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            mq.main(["test query"])
+
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["source"] == "cli"


### PR DESCRIPTION
## Summary

- Phases 4+5 of cross-interface memory parity (bundled — same subsystem)
- **Phase 4:** `UserPromptSubmit` hook for Claude backend via `createMemoryRetrievalHook()` in `index.ts`
- **Phase 5:** Memory context prepended to OpenAI prompt before `runSingleTurn()` in `openai-backend.ts`
- Both use shared `fetchMemoryContext()` from new `memory-retrieval-hook.ts`
- Silent degradation: bridge unreachable/timeout/error → no context, agent continues normally
- **Note:** `openai-backend.ts` imports from `memory-retrieval-hook.ts`

## Dependency

- **Depends on:** PR #274 (Phase 1) + Phase 3 (memory bridge route)
- **Merge after:** Phase 3 PR is merged (container needs the bridge to fetch context)

## Test plan

- [x] `vitest run src/memory-retrieval-hook.test.ts` — 10 passed
- [x] Full container `vitest run` — 32 passed (3 test files, 0 regressions)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)