### PR TITLE
feat(memory): add Aider wrapper with memory injection (Phase 6)

### DIFF
--- a/scripts/deus-aider
+++ b/scripts/deus-aider
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# deus-aider — Aider wrapper with Deus memory context injection.
+# Platform: Unix-only (Aider has no Windows support).
+# Parity gap: retrieves context once at launch, not per-prompt like host hooks.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MEMORY_QUERY="$SCRIPT_DIR/memory_query.py"
+CONTEXT_FILE="$(mktemp /tmp/deus-memory-context-XXXXXX)"
+
+cleanup() { rm -f "$CONTEXT_FILE"; }
+trap cleanup EXIT
+
+# Retrieve memory context (silent on failure)
+if python3 "$MEMORY_QUERY" "aider session start" --context-only --source aider > "$CONTEXT_FILE" 2>/dev/null; then
+    if [ -s "$CONTEXT_FILE" ]; then
+        exec aider --read "$CONTEXT_FILE" "$@"
+    fi
+fi
+
+# Fallback: launch aider without memory context
+exec aider "$@"


### PR DESCRIPTION
## Summary

- Phase 6 of cross-interface memory parity
- `scripts/deus-aider` — shell script wrapping Aider with Deus memory context
- Retrieves context once at launch via `memory_query.py --context-only --source aider`
- Passes to Aider via `--read <tempfile>`, falls back gracefully on failure
- Platform: **Unix-only** (Aider has no Windows support)
- **Parity gap:** session-start only (documented), not per-prompt like host hooks

## Dependency

- **Depends on:** PR #274 (Phase 1 — `memory_query.py`)
- **Blocked by:** nothing after Phase 1 merges
- **Blocks:** nothing

## Test plan

- [x] `bash -n scripts/deus-aider` — syntax valid
- [x] Executable permissions set (755)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)