### PR TITLE
feat(evolution): add parameter optimizer for memory retrieval

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -9,6 +9,7 @@ Usage:
     python evolution/cli.py reflect <interaction_id>
     python evolution/cli.py dismiss_review_finding <json>
     python evolution/cli.py optimize [--module qa|tool_selection|summarization|all]
+    python evolution/cli.py optimize-params [--trials 200] [--provider ollama|gemini|auto]
     python evolution/cli.py serve
 """
 import argparse
@@ -509,6 +510,14 @@ def main() -> None:
     p_dismiss = sub.add_parser("dismiss_review_finding", help="Create reflection from dismissed code review finding")
     p_dismiss.add_argument("json_str", help='JSON: {"finding": "...", "category": "...", "reason": "...", ...}')
 
+    # optimize-params
+    p_optparams = sub.add_parser("optimize-params", help="Optimize memory retrieval thresholds")
+    p_optparams.add_argument("--trials", type=int, default=200, help="Number of random trials (default: 200)")
+    p_optparams.add_argument("--provider", choices=["ollama", "gemini", "auto"], default="auto",
+                             help="Embedding provider (default: auto-detect)")
+    p_optparams.add_argument("--db", help="Path to memory_tree.db (default: ~/.deus/memory_tree.db)")
+    p_optparams.add_argument("--force", action="store_true", help="Save artifact even if score regressed")
+
     # serve
     sub.add_parser("serve", help="Start MCP stdio server")
 
@@ -556,6 +565,15 @@ def main() -> None:
         cmd_archive_reflections(days=args.days, dry_run=args.dry_run)
     elif args.cmd == "dismiss_review_finding":
         cmd_dismiss_review_finding(args.json_str)
+    elif args.cmd == "optimize-params":
+        from .optimizer.param_optimizer import optimize_and_save
+        provider = args.provider if args.provider != "auto" else None
+        aid = optimize_and_save(
+            db_path=args.db, trials=args.trials, provider=provider,
+            force=args.force,
+        )
+        if not aid:
+            sys.exit(1)
     elif args.cmd == "serve":
         cmd_serve()
     elif args.cmd == "backfill":

--- a/evolution/optimizer/__init__.py
+++ b/evolution/optimizer/__init__.py
@@ -1,4 +1,5 @@
 from .artifacts import save_artifact, get_active, list_artifacts
 from .dspy_optimizer import optimize
+from .param_optimizer import optimize_and_save as optimize_params
 
-__all__ = ["save_artifact", "get_active", "list_artifacts", "optimize"]
+__all__ = ["save_artifact", "get_active", "list_artifacts", "optimize", "optimize_params"]

--- a/evolution/optimizer/param_optimizer.py
+++ b/evolution/optimizer/param_optimizer.py
@@ -1,0 +1,380 @@
+"""
+Parameter optimizer for memory retrieval thresholds.
+
+Systematically searches for optimal values of the 5 retrieval parameters
+(low_threshold, abstain_threshold, gap_threshold, top_k, rrf_k) using the
+labeled benchmark as the objective function.
+
+Extends the heuristic-based `memory_tree.py calibrate` to cover all 5 params
+with provider-aware systematic search. Uses the existing benchmark() function
+which keeps retrieval recall and abstain accuracy as separate metrics
+(per ADR benchmark-regression-gate.md Decision 3).
+
+No external dependencies — uses random search with smart seeding.
+"""
+from __future__ import annotations
+
+import json
+import random
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+SEARCH_SPACE = {
+    "low_threshold": (0.20, 0.80),
+    "abstain_threshold": (0.10, 0.70),
+    "gap_threshold": (0.005, 0.10),
+    "top_k": (2, 10),
+    "rrf_k": (20, 120),
+}
+
+INT_PARAMS = {"top_k", "rrf_k"}
+
+BENCH_LABELS = (
+    Path(__file__).resolve().parent.parent.parent
+    / "scripts" / "tests" / "fixtures" / "memory_tree_queries.jsonl"
+)
+
+DEFAULT_TRIALS = 200
+
+
+def _load_labels(path: Path = BENCH_LABELS) -> list[dict[str, Any]]:
+    labels = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                labels.append(json.loads(line))
+    return labels
+
+
+def _sample_params(rng: random.Random) -> dict[str, float | int]:
+    params: dict[str, float | int] = {}
+    for name, (lo, hi) in SEARCH_SPACE.items():
+        if name in INT_PARAMS:
+            params[name] = rng.randint(int(lo), int(hi))
+        else:
+            params[name] = round(rng.uniform(lo, hi), 3)
+    return params
+
+
+def _seed_from_defaults() -> list[dict[str, float | int]]:
+    """Include current hardcoded defaults as seed candidates."""
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        from memory_tree import (
+            DEFAULT_ABSTAIN_THRESHOLD,
+            DEFAULT_LOW_THRESHOLD,
+            DEFAULT_RRF_K,
+            DEFAULT_SCORE_GAP_THRESHOLD,
+            DEFAULT_TOP_K,
+        )
+        return [{
+            "low_threshold": DEFAULT_LOW_THRESHOLD,
+            "abstain_threshold": DEFAULT_ABSTAIN_THRESHOLD,
+            "gap_threshold": DEFAULT_SCORE_GAP_THRESHOLD,
+            "top_k": DEFAULT_TOP_K,
+            "rrf_k": DEFAULT_RRF_K,
+        }]
+    except ImportError:
+        return []
+    finally:
+        if str(_SCRIPTS_DIR) in sys.path:
+            sys.path.remove(str(_SCRIPTS_DIR))
+
+
+def _open_db(db_path: Optional[str] = None) -> sqlite3.Connection:
+    """Open memory_tree DB with sqlite-vec loaded."""
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        from memory_tree import open_db
+        from pathlib import Path as _P
+        return open_db(_P(db_path) if db_path else None)
+    finally:
+        if str(_SCRIPTS_DIR) in sys.path:
+            sys.path.remove(str(_SCRIPTS_DIR))
+
+
+def _precompute_embeddings(queries: list[str]) -> dict[str, list[float]]:
+    """Embed all queries once upfront. Avoids re-embedding per trial."""
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        from memory_tree import embed_text
+        cache: dict[str, list[float]] = {}
+        for q in queries:
+            if q not in cache:
+                cache[q] = embed_text(q)
+        return cache
+    finally:
+        if str(_SCRIPTS_DIR) in sys.path:
+            sys.path.remove(str(_SCRIPTS_DIR))
+
+
+def _run_trial(
+    db: sqlite3.Connection,
+    dataset: list[dict[str, Any]],
+    params: dict[str, float | int],
+    vec_cache: dict[str, list[float]],
+) -> dict[str, Any]:
+    """Run one trial: retrieve each query with candidate params, compute metrics.
+
+    Uses cached embeddings so only DB lookups + scoring happen per trial.
+    Keeps retrieval recall and abstain accuracy separate per ADR Decision 3.
+    """
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        from memory_tree import retrieve
+    finally:
+        if str(_SCRIPTS_DIR) in sys.path:
+            sys.path.remove(str(_SCRIPTS_DIR))
+
+    n = len(dataset)
+    recall_hits = 0
+    mrr_sum = 0.0
+    abstain_correct = 0
+    abstain_total = 0
+    by_tag: dict[str, dict[str, Any]] = {}
+
+    k = int(params["top_k"])
+
+    for item in dataset:
+        q = item["query"]
+        expected = item.get("expected_paths") or (
+            [item["expected_path"]] if item.get("expected_path") else []
+        )
+        tag = item.get("tag", "abstain" if item.get("abstain") else "single")
+        expect_abstain = bool(item.get("abstain"))
+
+        bucket = by_tag.setdefault(tag, {"n": 0, "hits": 0, "mrr": 0.0,
+                                         "abstain_correct": 0})
+        bucket["n"] += 1
+
+        result = retrieve(
+            db, q,
+            k=k,
+            low_threshold=float(params["low_threshold"]),
+            abstain_threshold=float(params["abstain_threshold"]),
+            gap_threshold=float(params["gap_threshold"]),
+            rrf_k=int(params["rrf_k"]),
+            query_vec=vec_cache.get(q),
+            use_fts=True,
+        )
+
+        returned = [r["path"] for r in result["results"]]
+        hit = any(p in returned for p in expected) if expected else False
+
+        if hit:
+            recall_hits += 1
+            bucket["hits"] += 1
+            for idx, r in enumerate(result["results"]):
+                if r["path"] in expected:
+                    reciprocal = 1.0 / (idx + 1)
+                    mrr_sum += reciprocal
+                    bucket["mrr"] += reciprocal
+                    break
+
+        if expect_abstain:
+            abstain_total += 1
+            if result["fell_back"]:
+                abstain_correct += 1
+                bucket["abstain_correct"] += 1
+
+    tag_report = {}
+    for tag, s in by_tag.items():
+        entry: dict[str, Any] = {"n": s["n"]}
+        if s["n"] > 0 and not tag.startswith("abstain"):
+            entry["recall_at_k"] = round(s["hits"] / s["n"], 3)
+            entry["mrr_at_k"] = round(s["mrr"] / s["n"], 3)
+        elif tag.startswith("abstain"):
+            entry["abstain_accuracy"] = round(s["abstain_correct"] / s["n"], 3) if s["n"] else None
+        tag_report[tag] = entry
+
+    return {
+        "n": n,
+        "recall_at_k": round(recall_hits / n, 3) if n else 0,
+        "mrr_at_k": round(mrr_sum / n, 3) if n else 0,
+        "abstain_accuracy": round(abstain_correct / abstain_total, 3) if abstain_total else None,
+        "by_tag": tag_report,
+    }
+
+
+def _score_result(result: dict[str, Any], min_abstain: float = 0.8) -> float | None:
+    """Score a benchmark result. Returns None if abstain accuracy regressed.
+
+    Per ADR benchmark-regression-gate.md Decision 3, retrieval recall and
+    abstain accuracy are kept separate. We optimize for recall but constrain
+    abstain accuracy to not regress below min_abstain.
+    """
+    if "error" in result:
+        return None
+    abstain_acc = result.get("abstain_accuracy")
+    if abstain_acc is not None and abstain_acc < min_abstain:
+        return None
+    recall = result.get("recall_at_k", 0.0)
+    mrr = result.get("mrr_at_k", 0.0)
+    return recall * 0.8 + mrr * 0.2
+
+
+def optimize_params(
+    db_path: Optional[str] = None,
+    trials: int = DEFAULT_TRIALS,
+    seed: int = 42,
+    min_abstain: float = 0.8,
+    verbose: bool = True,
+) -> Optional[dict[str, Any]]:
+    """Run parameter optimization against the labeled benchmark.
+
+    Returns dict with best params, scores, and metadata. None if benchmark
+    data is missing or no valid trial found.
+    """
+    if not BENCH_LABELS.exists():
+        print(f"[param-optimizer] Benchmark labels not found: {BENCH_LABELS}")
+        return None
+
+    dataset = _load_labels()
+    if not dataset:
+        print("[param-optimizer] No benchmark labels loaded")
+        return None
+
+    db = _open_db(db_path)
+
+    # Pre-embed all queries once (the expensive step)
+    queries = list({item["query"] for item in dataset})
+    if verbose:
+        print(f"[param-optimizer] Pre-embedding {len(queries)} unique queries...")
+    t0 = time.monotonic()
+    vec_cache = _precompute_embeddings(queries)
+    if verbose:
+        print(f"[param-optimizer] Embeddings cached in {time.monotonic() - t0:.1f}s")
+
+    rng = random.Random(seed)
+
+    candidates = _seed_from_defaults()
+    for _ in range(trials - len(candidates)):
+        candidates.append(_sample_params(rng))
+
+    best_score: float = -1.0
+    best_params: dict[str, float | int] = {}
+    best_result: dict[str, Any] = {}
+    baseline_score: float = -1.0
+
+    t_start = time.monotonic()
+    for i, params in enumerate(candidates):
+        result = _run_trial(db, dataset, params, vec_cache)
+        score = _score_result(result, min_abstain=min_abstain)
+
+        if i == 0:
+            recall = result.get("recall_at_k", 0.0)
+            mrr = result.get("mrr_at_k", 0.0)
+            baseline_score = recall * 0.8 + mrr * 0.2
+            if verbose:
+                print(
+                    f"[param-optimizer] Baseline: recall={recall:.3f} "
+                    f"abstain={result.get('abstain_accuracy', 'N/A')} "
+                    f"score={baseline_score:.4f}"
+                )
+
+        if score is not None and score > best_score:
+            best_score = score
+            best_params = params
+            best_result = result
+            if verbose and i > 0:
+                print(
+                    f"[param-optimizer] Trial {i}/{len(candidates)}: "
+                    f"new best score={score:.4f} "
+                    f"recall={result.get('recall_at_k', 0):.3f}"
+                )
+
+        if verbose and (i + 1) % 50 == 0:
+            elapsed = time.monotonic() - t_start
+            print(f"[param-optimizer] Progress: {i + 1}/{len(candidates)} trials ({elapsed:.1f}s)")
+
+    db.close()
+
+    if best_score < 0:
+        print("[param-optimizer] No valid trial found")
+        return None
+
+    delta = best_score - baseline_score
+    total_time = time.monotonic() - t_start
+
+    if verbose:
+        print(
+            f"\n[param-optimizer] Done in {total_time:.1f}s. "
+            f"baseline={baseline_score:.4f} → best={best_score:.4f} "
+            f"({'+'if delta >= 0 else ''}{delta:.4f})"
+        )
+        print(f"[param-optimizer] Best params: {json.dumps(best_params, indent=2)}")
+        print(f"[param-optimizer] Recall@K: {best_result.get('recall_at_k', 0):.3f}")
+        print(f"[param-optimizer] Abstain accuracy: {best_result.get('abstain_accuracy', 'N/A')}")
+
+    return {
+        "params": best_params,
+        "score": best_score,
+        "baseline_score": baseline_score,
+        "delta": delta,
+        "recall_at_k": best_result.get("recall_at_k"),
+        "abstain_accuracy": best_result.get("abstain_accuracy"),
+        "mrr_at_k": best_result.get("mrr_at_k"),
+        "trials": len(candidates),
+        "by_tag": best_result.get("by_tag"),
+    }
+
+
+def optimize_and_save(
+    db_path: Optional[str] = None,
+    trials: int = DEFAULT_TRIALS,
+    provider: Optional[str] = None,
+    verbose: bool = True,
+    force: bool = False,
+) -> Optional[str]:
+    """Run optimization and save result as an evolution artifact.
+
+    Refuses to save if optimized score is worse than baseline (unless force=True).
+    Returns artifact ID on success, None on failure or regression.
+    """
+    result = optimize_params(db_path=db_path, trials=trials, verbose=verbose)
+    if result is None:
+        return None
+
+    if result["delta"] < 0 and not force:
+        if verbose:
+            print(
+                f"[param-optimizer] No improvement found "
+                f"(delta={result['delta']:.4f}). Not saving artifact. "
+                f"Use --force to save anyway."
+            )
+        return None
+
+    from .artifacts import save_artifact
+
+    provider_tag = provider or _detect_provider()
+    module = f"memory_retrieval_{provider_tag}"
+
+    aid = save_artifact(
+        module=module,
+        content=json.dumps(result["params"], indent=2),
+        baseline_score=result["baseline_score"],
+        optimized_score=result["score"],
+        sample_count=result["trials"],
+    )
+
+    if verbose:
+        print(f"[param-optimizer] Saved artifact {aid[:8]} for module={module}")
+
+    return aid
+
+
+def _detect_provider() -> str:
+    import os
+    provider = os.environ.get("EMBEDDING_PROVIDER", "auto").lower()
+    if provider in ("gemini", "ollama"):
+        return provider
+    if provider == "auto":
+        if not os.environ.get("OLLAMA_HOST") and os.environ.get("GEMINI_API_KEY"):
+            return "gemini"
+    return "ollama"

--- a/evolution/tests/test_param_optimizer.py
+++ b/evolution/tests/test_param_optimizer.py
@@ -1,0 +1,99 @@
+"""Tests for parameter optimizer — unit tests that don't require a live DB."""
+import json
+import random
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evolution.optimizer.param_optimizer import (
+    BENCH_LABELS,
+    INT_PARAMS,
+    SEARCH_SPACE,
+    _load_labels,
+    _sample_params,
+    _score_result,
+)
+
+
+def test_load_labels():
+    """Benchmark labels file exists and is parseable."""
+    assert BENCH_LABELS.exists(), f"Benchmark labels not found: {BENCH_LABELS}"
+    labels = _load_labels()
+    assert len(labels) == 90
+    for label in labels:
+        assert "query" in label
+        assert "tag" in label
+
+
+def test_sample_params_ranges():
+    """Sampled params stay within defined search space."""
+    rng = random.Random(42)
+    for _ in range(50):
+        params = _sample_params(rng)
+        for name, (lo, hi) in SEARCH_SPACE.items():
+            assert lo <= params[name] <= hi, f"{name}={params[name]} out of [{lo}, {hi}]"
+        for name in INT_PARAMS:
+            assert isinstance(params[name], int), f"{name} should be int"
+
+
+def test_sample_params_deterministic():
+    """Same seed produces same params."""
+    p1 = _sample_params(random.Random(123))
+    p2 = _sample_params(random.Random(123))
+    assert p1 == p2
+
+
+def test_score_result_filters_bad_abstain():
+    """Results with abstain accuracy below threshold return None."""
+    result = {
+        "recall_at_k": 0.9,
+        "mrr_at_k": 0.85,
+        "abstain_accuracy": 0.5,
+    }
+    assert _score_result(result, min_abstain=0.8) is None
+
+
+def test_score_result_passes_good_abstain():
+    """Results meeting abstain threshold get a positive score."""
+    result = {
+        "recall_at_k": 0.9,
+        "mrr_at_k": 0.85,
+        "abstain_accuracy": 0.9,
+    }
+    score = _score_result(result, min_abstain=0.8)
+    assert score is not None
+    assert score > 0
+
+
+def test_score_result_weights():
+    """Score = 0.8 * recall + 0.2 * mrr."""
+    result = {
+        "recall_at_k": 1.0,
+        "mrr_at_k": 1.0,
+        "abstain_accuracy": 1.0,
+    }
+    assert _score_result(result) == pytest.approx(1.0)
+
+    result2 = {
+        "recall_at_k": 0.5,
+        "mrr_at_k": 0.0,
+        "abstain_accuracy": 1.0,
+    }
+    assert _score_result(result2) == pytest.approx(0.4)
+
+
+def test_score_result_error():
+    """Error results return None."""
+    assert _score_result({"error": "empty dataset"}) is None
+
+
+def test_score_result_no_abstain():
+    """Results without abstain data still score (abstain constraint skipped)."""
+    result = {
+        "recall_at_k": 0.8,
+        "mrr_at_k": 0.7,
+    }
+    score = _score_result(result)
+    assert score is not None
+    assert score == pytest.approx(0.8 * 0.8 + 0.7 * 0.2)

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -91,6 +91,30 @@ DEFAULT_SCORE_GAP_THRESHOLD = float(os.environ.get("DEUS_TREE_GAP", str(_DEFAULT
 DEFAULT_USE_FTS = os.environ.get("DEUS_TREE_FTS", "1") == "1"
 DEFAULT_RRF_K = int(os.environ.get("DEUS_TREE_RRF_K", "60"))
 
+# Optimized params: load from evolution artifact if DEUS_TREE_PARAMS=1.
+if os.environ.get("DEUS_TREE_PARAMS") == "1":
+    _project_root = str(Path(__file__).resolve().parent.parent)
+    _added_to_path = _project_root not in sys.path
+    try:
+        if _added_to_path:
+            sys.path.insert(0, _project_root)
+        from evolution.optimizer.artifacts import get_active as _get_active_artifact
+        _provider_tag = "gemini" if _IS_GEMINI else "ollama"
+        _artifact = _get_active_artifact(f"memory_retrieval_{_provider_tag}")
+        if _artifact:
+            import json as _json
+            _learned = _json.loads(_artifact["content"])
+            DEFAULT_LOW_THRESHOLD = float(_learned.get("low_threshold", DEFAULT_LOW_THRESHOLD))
+            DEFAULT_ABSTAIN_THRESHOLD = float(_learned.get("abstain_threshold", DEFAULT_ABSTAIN_THRESHOLD))
+            DEFAULT_SCORE_GAP_THRESHOLD = float(_learned.get("gap_threshold", DEFAULT_SCORE_GAP_THRESHOLD))
+            DEFAULT_TOP_K = int(_learned.get("top_k", DEFAULT_TOP_K))
+            DEFAULT_RRF_K = int(_learned.get("rrf_k", DEFAULT_RRF_K))
+    except Exception:
+        pass  # Fall back to env/hardcoded defaults
+    finally:
+        if _added_to_path and _project_root in sys.path:
+            sys.path.remove(_project_root)
+
 _LOG_PATH = Path(os.environ.get(
     "DEUS_TREE_LOG", "~/.deus/memory_tree_queries.jsonl"
 )).expanduser()
@@ -959,6 +983,7 @@ def retrieve(
     use_abstain: bool = True,
     use_fts: bool = DEFAULT_USE_FTS,
     rrf_k: int = DEFAULT_RRF_K,
+    gap_threshold: float = DEFAULT_SCORE_GAP_THRESHOLD,
 ) -> dict[str, Any]:
     """4-phase retrieval: flat cosine → FTS5 BM25 → graph expansion → abstain.
 
@@ -1075,7 +1100,6 @@ def retrieve(
     elif use_abstain and len(cosine_sorted) >= 2:
         others_avg = sum(cosine_sorted[1:k + 1]) / min(len(cosine_sorted) - 1, k)
         gap = best - others_avg
-        gap_threshold = DEFAULT_SCORE_GAP_THRESHOLD
         if gap < gap_threshold and best < abstain_threshold + gap_threshold:
             fell_back = True
             trace.append(f"abstain:gap={gap:.3f}<{gap_threshold}")
@@ -1765,6 +1789,8 @@ def benchmark(
     k: int = 5,
     low_threshold: float = DEFAULT_LOW_THRESHOLD,
     abstain_threshold: float = DEFAULT_ABSTAIN_THRESHOLD,
+    gap_threshold: float = DEFAULT_SCORE_GAP_THRESHOLD,
+    rrf_k: int = DEFAULT_RRF_K,
     use_see_also: bool = True,
     use_abstain: bool = True,
     use_fts: bool = DEFAULT_USE_FTS,
@@ -1807,6 +1833,8 @@ def benchmark(
             db, q, k=k,
             low_threshold=low_threshold,
             abstain_threshold=abstain_threshold,
+            gap_threshold=gap_threshold,
+            rrf_k=rrf_k,
             use_see_also=use_see_also,
             use_abstain=use_abstain,
             use_fts=use_fts,
@@ -1861,6 +1889,8 @@ def benchmark(
             "k": k,
             "low_threshold": low_threshold,
             "abstain_threshold": abstain_threshold,
+            "gap_threshold": gap_threshold,
+            "rrf_k": rrf_k,
             "use_see_also": use_see_also,
             "use_abstain": use_abstain,
             "use_fts": use_fts,


### PR DESCRIPTION
## Summary

- Adds `evolution/optimizer/param_optimizer.py` — systematic search over 5 retrieval params (`low_threshold`, `abstain_threshold`, `gap_threshold`, `top_k`, `rrf_k`) against the 90-query benchmark
- Pre-caches all query embeddings upfront so trials run ~1s each (200 trials in ~3min)
- Regression guard: refuses to save artifacts worse than baseline unless `--force`
- Exposes `gap_threshold` and `rrf_k` as params on `retrieve()` and `benchmark()` (previously hardcoded inside `retrieve()`)
- Artifact loader in `memory_tree.py` gated behind `DEUS_TREE_PARAMS=1` env var
- CLI: `python evolution/cli.py optimize-params [--trials 200] [--provider ollama|gemini|auto] [--force]`
- 8 unit tests, all 189 evolution tests pass

## Context

The existing `calibrate` subcommand fits only `low_threshold` and `abstain_threshold` via heuristics. This optimizer covers all 5 params with systematic search, using the same benchmark infrastructure. Current calibrated baseline (0.800 recall on raw retrieve, 0.467 abstain) is already near-optimal for recall — the primary improvement opportunity is in abstain accuracy.

## Test plan

- [x] `pytest evolution/tests/test_param_optimizer.py` — 8 tests pass
- [x] `pytest evolution/tests/` — all 189 tests pass
- [x] End-to-end: `optimize_params(trials=200)` completes in ~3min, finds params with improved abstain accuracy
- [x] Regression guard: verified `optimize_and_save()` refuses to save when delta < 0
- [x] Canonical `benchmark()` baseline matches `_run_trial` baseline (both 0.800)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)