### PR TITLE
feat(cli): support chrome_default config flag

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -992,7 +992,9 @@ case "$1" in
     # `deus web` launches with --chrome for Claude-in-Chrome browser integration.
     # Otherwise identical to bare `deus` / `deus home`.
     CHROME_FLAG=""
-    [ "$1" = "web" ] && CHROME_FLAG="--chrome"
+    if [ "$1" = "web" ] || [ "$(_read_config_key chrome_default)" = "true" ]; then
+      CHROME_FLAG="--chrome"
+    fi
     TOKEN=$(python3 -c 'import sys,json; print(json.load(open(sys.argv[1]))["claudeAiOauth"]["accessToken"])' "$HOME/.claude/.credentials.json" 2>/dev/null)
     if [ -z "$TOKEN" ]; then
       echo "Error: could not read token from ~/.claude/.credentials.json"


### PR DESCRIPTION
## Summary

- Reads `chrome_default` from `~/.config/deus/config.json`
- When set to `"true"`, `deus` / `deus home` auto-include `--chrome` (same as `deus web`)
- Default is off — no behavior change for existing users
- `deus web` continues to work explicitly as before

## Test plan

- [x] `deus` without config key → no `--chrome` (unchanged)
- [x] `deus` with `chrome_default=true` in config → `--chrome` included
- [x] `deus web` → `--chrome` included (unchanged)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)