### PR TITLE
chore: remove dead ollama agent backend type

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A personal AI that lives in your messaging apps, remembers your conversations, a
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (handles WSL 2 on Windows automatically)
 - Node.js 20+, Python 3.11+
 - A [Gemini API key](https://aistudio.google.com/apikey) (free tier is enough)
-- [Ollama](https://ollama.ai/download) for local AI models (memory and scoring) - `/setup` pulls the right models automatically based on your hardware
+- [Ollama](https://ollama.ai/download) for local embeddings and scoring (not an agent backend) - `/setup` pulls the right models automatically based on your hardware
 
 ### Install
 

--- a/src/agent-backends/types.ts
+++ b/src/agent-backends/types.ts
@@ -1,6 +1,6 @@
 import type { ToolBroker } from '../tool-broker/types.js';
 
-export type AgentBackendName = 'claude' | 'openai' | 'ollama';
+export type AgentBackendName = 'claude' | 'openai';
 
 export interface BackendCapabilities {
   shell: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,11 +94,7 @@ const rawAgentBackend = (
   'claude'
 ).toLowerCase();
 export const DEFAULT_AGENT_BACKEND: AgentBackendName =
-  rawAgentBackend === 'openai'
-    ? 'openai'
-    : rawAgentBackend === 'ollama'
-      ? 'ollama'
-      : 'claude';
+  rawAgentBackend === 'openai' ? 'openai' : 'claude';
 
 export const DEUS_OPENAI_MODEL =
   process.env.DEUS_OPENAI_MODEL || envConfig.DEUS_OPENAI_MODEL || '';

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -39,9 +39,7 @@ export interface IpcDeps {
 let ipcWatcherRunning = false;
 
 function parseAgentBackend(value: unknown): AgentBackendName | undefined {
-  return value === 'claude' || value === 'openai' || value === 'ollama'
-    ? value
-    : undefined;
+  return value === 'claude' || value === 'openai' ? value : undefined;
 }
 
 export function startIpcWatcher(deps: IpcDeps): void {


### PR DESCRIPTION
## Summary
- Remove `'ollama'` from `AgentBackendName` type union — no implementation exists
- Clean up config validation and IPC parser that accepted a backend that would crash at runtime
- Clarify README: Ollama is for local embeddings/scoring, not an agent backend

## Changes
- `src/agent-backends/types.ts`: remove 'ollama' from union
- `src/config.ts`: simplify backend validation ternary
- `src/ipc.ts`: remove 'ollama' from parser
- `README.md`: clarify Ollama's role

## Test plan
- [ ] TypeScript compiles cleanly (`npm run build`)
- [ ] Ollama still works for embeddings (`memory_tree.py`) and judge scoring (evolution pipeline)
- [ ] Setting `DEUS_AGENT_BACKEND=ollama` now falls back to `claude` instead of silently accepting

🤖 Generated with [Claude Code](https://claude.com/claude-code)