### PR TITLE
feat(wardens): wire session-retrospective auto-trigger into /compress

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -144,4 +144,33 @@ After saving the session log:
 6. **Pre-warm semantic cache** (always, background):
    Run: `python3 ~/deus/scripts/memory_indexer.py --query "recent work ongoing tasks" --top 2 --recency-boost > ~/.deus/resume_semantic_cache.txt 2>/dev/null &`
 
-Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, and atom extraction result.
+7. **Trigger session retrospective** (home mode only, background, opt-in):
+   Skip this step entirely unless ALL of the following are true:
+   a. Current mode is **home mode** (~/deus)
+   b. `"$VAULT/Retrospectives"` directory exists (opt-in gate — if absent, never trigger)
+   c. No retrospective file for today exists: `! test -f "$VAULT/Retrospectives/$(date +%Y-%m-%d)-retrospective.md"`
+   d. The number of session log files newer than the most recent retrospective exceeds the threshold
+
+   To check condition (d):
+   ```bash
+   LATEST_RETRO=$(ls -t "$VAULT/Retrospectives"/*.md 2>/dev/null | head -1)
+   if [ -n "$LATEST_RETRO" ]; then
+     NEW_COUNT=$(find "$VAULT/Session-Logs" -name "*.md" -newer "$LATEST_RETRO" | wc -l | tr -d ' ')
+   else
+     NEW_COUNT=$(find "$VAULT/Session-Logs" -name "*.md" | wc -l | tr -d ' ')
+   fi
+   ```
+
+   Read `session_window` from `~/deus/.claude/wardens/retrospective-schema.md` (default: 20).
+   If `NEW_COUNT >= session_window`, dispatch the retrospective agent in the background:
+
+   ```bash
+   command -v claude >/dev/null 2>&1 && \
+     claude -p "Use the session-retrospective subagent. SESSION_LOG_ROOT=\"$VAULT\"" \
+     > /dev/null 2>&1 &
+   ```
+
+   If `claude` CLI is not available (e.g. Codex backend), skip silently.
+   If any check fails, skip silently — the retrospective can always be triggered manually.
+
+Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, atom extraction result, and whether a session retrospective was triggered (home mode only — report "retrospective triggered (background)" or "retrospective skipped: <reason>").

--- a/.claude/wardens/README.md
+++ b/.claude/wardens/README.md
@@ -8,7 +8,7 @@ Specialized review agents that guard the codebase. Validator wardens check corre
 | **code-reviewer** | Validator | Sonnet | `code-review-rules.md` | Manual: `Agent(subagent_type="code-reviewer", prompt="review my changes")` |
 | **threat-modeler** | Validator | Opus | `threat-modeling-rules.md` | Manual: invoke when plan touches auth, credentials, external APIs, or trust boundaries |
 | **architecture-snapshot** | Generator | Sonnet | `architecture-schema.md` | Manual: `Agent(subagent_type="architecture-snapshot", prompt="snapshot the architecture")` |
-| **session-retrospective** | Generator | Opus | `retrospective-schema.md` | Manual: `Agent(subagent_type="session-retrospective", prompt="retrospective for last 20 sessions")` |
+| **session-retrospective** | Generator | Opus | `retrospective-schema.md` | Manual (also auto-triggered by /compress when opt-in gate passes): `Agent(subagent_type="session-retrospective", prompt="retrospective for last 20 sessions")` |
 
 ## Directory
 

--- a/.claude/wardens/retrospective-schema.md
+++ b/.claude/wardens/retrospective-schema.md
@@ -1,21 +1,17 @@
 # Retrospective Schema -- Wardens/session-retrospective
 
 > Output schema and configuration for the session-retrospective generator warden.
-> Edit vault_path once after install. All other fields are optional overrides.
+> vault_path is resolved at runtime. All fields below are optional overrides.
 
-## vault_path
+## vault_path (runtime-resolved)
 
 The root of the Deus vault. Session logs are expected at `<vault_path>/Session-Logs/`.
 Retrospectives are saved to `<vault_path>/Retrospectives/`.
 
-```
-vault_path: ~/Desktop/אישי/Brain Dump/Second Brain/Deus
-```
-
-Override chain (highest priority first):
-1. Invocation-arg `SESSION_LOG_ROOT=<path>` in the prompt
+vault_path is resolved at runtime, NOT hardcoded here. Resolution chain (highest priority first):
+1. Invocation-arg `SESSION_LOG_ROOT=<path>` in the prompt (used by /compress auto-trigger)
 2. `$SESSION_LOG_ROOT` environment variable
-3. This field
+3. `~/.config/deus/config.json` → `vault_path` key (or `DEUS_VAULT_PATH` env var)
 4. `$REPO_ROOT/Session-Logs/` if it exists
 5. Fail loud
 

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-04-28" # drift-sweep
+last_verified: "2026-04-29" # drift-sweep
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Add Step 7 to `/compress` skill: auto-triggers session-retrospective agent in background when enough sessions accumulate since last retrospective
- Opt-in gate: `$VAULT/Retrospectives/` directory must exist (default-off for other users)
- Idempotent: skips if today's retrospective already exists; home mode only
- Remove hardcoded personal vault path from `retrospective-schema.md` — now runtime-resolved via same chain `/compress` uses

## Test plan
- [ ] Verify `grep -r 'Desktop/' .claude/wardens/retrospective-schema.md` returns empty
- [ ] Run `/compress` in home mode with `Retrospectives/` dir present — confirm "retrospective triggered (background)" in output
- [ ] Run `/compress` without `Retrospectives/` dir — confirm "retrospective skipped" message
- [ ] Run `/compress` in external project mode — confirm Step 7 is entirely skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)