### PR TITLE
fix(memory): add deus-memory MCP launcher

### DIFF
--- a/.claude/skills/add-codex/SKILL.md
+++ b/.claude/skills/add-codex/SKILL.md
@@ -169,6 +169,18 @@ This should launch an interactive Codex session. Exit with Ctrl+C.
 
 > **Recovery:** If `deus codex` says "codex CLI not found", the binary isn't in PATH. Check `which codex` or reinstall.
 
+### Register Deus memory MCP
+
+For direct Codex CLI sessions outside the `deus` launcher, register the memory
+MCP through the repo launcher. Do not point Codex at `python3` directly; the
+launcher selects a Python environment that has the `mcp` package installed and
+prints setup commands if dependencies are missing.
+
+```bash
+codex mcp add deus-memory -- "$(pwd)/scripts/deus-memory-mcp"
+codex mcp get deus-memory
+```
+
 ## Phase 5: Verify
 
 ### Restart the service

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ See [AGENTS.md](AGENTS.md#commands-and-skills) for all available skills.
 | `deus gcal` | Google Calendar token management (`status`, `auth`, `ping`) |
 | `deus listen` | Record from mic, transcribe locally, copy to clipboard |
 
+For direct Codex CLI sessions outside the `deus` launcher, register Deus memory
+recall as an MCP tool through the repo launcher:
+
+```bash
+codex mcp add deus-memory -- /path/to/deus/scripts/deus-memory-mcp
+```
+
 ---
 
 ## Comparison

--- a/docs/MULTI_BACKEND.md
+++ b/docs/MULTI_BACKEND.md
@@ -89,6 +89,19 @@ deus claude       # Force Claude for this session
 deus codex        # Force Codex (OpenAI) for this session
 ```
 
+### Codex CLI memory MCP
+
+To give direct Codex CLI sessions the same Deus memory recall tool, register
+the repo launcher instead of calling `python3` directly:
+
+```bash
+codex mcp add deus-memory -- /path/to/deus/scripts/deus-memory-mcp
+```
+
+The launcher selects `.venv/bin/python` when it has the `mcp` package installed,
+then falls back to another Python with `mcp` available. If dependencies are
+missing, it prints the venv setup commands before exiting.
+
 ## Backend Management
 
 Manage the default backend and model from the command line:

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-04-27" # benchmark refresh (Recall@1 94%, MRR 0.96)
+last_verified: "2026-04-29" # memory-mcp-launcher
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-04-28" # drift-sweep
+last_verified: "2026-04-29" # memory-mcp-launcher
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"
@@ -15,6 +15,12 @@ test_tasks:
 - `SKILL.md` — required
 - `agent.ts` — if the skill adds container-side MCP tools
 
+This pattern governs PRs whose primary change is adding, removing, renaming, or
+substantively changing a skill. A source/script PR may still include a docs-only
+edit to an existing `SKILL.md` when the skill instructions must document the
+changed source behavior. Treat that as a companion documentation edit, not a
+skill PR.
+
 ## What must never be committed in a skill PR
 
 | File | Reason |
@@ -23,7 +29,7 @@ test_tasks:
 | `scripts/` | Subprocess scripts |
 | `node_modules/`, `package-lock.json` | Local dependencies |
 
-**CI rejects skill PRs that also touch `src/`.** This is enforced automatically — do not attempt to bundle skill + source changes in one PR.
+**CI rejects skill PRs that also touch `src/`.** This is enforced automatically — do not attempt to bundle skill + source changes in one PR. If the primary change is source/scripts and the skill file only documents how to use that changed behavior, follow the source pattern for implementation and keep the skill edit documentation-only.
 
 ## Core source changes
 

--- a/scripts/deus-memory-mcp
+++ b/scripts/deus-memory-mcp
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(dirname -- "$SCRIPT_DIR")
+
+python_has_mcp() {
+  "$1" -c 'import mcp' >/dev/null 2>&1
+}
+
+choose_python() {
+  if [ -n "${DEUS_MEMORY_MCP_PYTHON:-}" ]; then
+    printf '%s\n' "$DEUS_MEMORY_MCP_PYTHON"
+    return 0
+  fi
+
+  if [ -x "$REPO_ROOT/.venv/bin/python" ] && python_has_mcp "$REPO_ROOT/.venv/bin/python"; then
+    printf '%s\n' "$REPO_ROOT/.venv/bin/python"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1 && python_has_mcp "$(command -v python3)"; then
+    command -v python3
+    return 0
+  fi
+
+  if command -v python >/dev/null 2>&1 && python_has_mcp "$(command -v python)"; then
+    command -v python
+    return 0
+  fi
+
+  return 1
+}
+
+PYTHON=$(choose_python) || {
+  cat >&2 <<EOF
+ERROR: deus-memory MCP requires a Python environment with the "mcp" package.
+
+From the Deus repo, run:
+  python3 -m venv .venv
+  .venv/bin/pip install -r evolution/requirements.txt
+
+Then register this launcher with your MCP client:
+  $SCRIPT_DIR/deus-memory-mcp
+
+Override interpreter selection with DEUS_MEMORY_MCP_PYTHON=/path/to/python.
+EOF
+  exit 1
+}
+
+if ! python_has_mcp "$PYTHON"; then
+  cat >&2 <<EOF
+ERROR: DEUS_MEMORY_MCP_PYTHON does not provide the "mcp" package: $PYTHON
+
+Install dependencies into that environment or unset DEUS_MEMORY_MCP_PYTHON.
+EOF
+  exit 1
+fi
+
+exec "$PYTHON" "$SCRIPT_DIR/memory_mcp_server.py" "$@"

--- a/scripts/memory_mcp_server.py
+++ b/scripts/memory_mcp_server.py
@@ -8,14 +8,17 @@ retrieval quality as the host hook — closing the cross-interface parity gap.
 Platform: Linux/macOS only (depends on sqlite_vec C extension + Ollama).
 
 Usage:
-    python3 scripts/memory_mcp_server.py   # stdio
+    scripts/deus-memory-mcp   # stdio; selects a Python env with mcp installed
+
+Register with Codex:
+    codex mcp add deus-memory -- /path/to/deus/scripts/deus-memory-mcp
 
 Register in ~/.claude/settings.json:
     {
       "mcpServers": {
         "deus-memory": {
-          "command": "python3",
-          "args": ["/path/to/deus/scripts/memory_mcp_server.py"],
+          "command": "/path/to/deus/scripts/deus-memory-mcp",
+          "args": [],
           "env": {}
         }
       }

--- a/scripts/tests/test_deus_memory_mcp_launcher.py
+++ b/scripts/tests/test_deus_memory_mcp_launcher.py
@@ -1,0 +1,74 @@
+"""Tests for the deus-memory MCP launcher wrapper."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+_LAUNCHER = _ROOT / "scripts" / "deus-memory-mcp"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_launcher_uses_override_python_when_it_has_mcp(tmp_path):
+    fake_python = tmp_path / "python"
+    _write_executable(
+        fake_python,
+        """#!/usr/bin/env sh
+if [ "$1" = "-c" ]; then
+  exit 0
+fi
+printf '%s\\n' "$@"
+""",
+    )
+
+    env = {
+        **os.environ,
+        "DEUS_MEMORY_MCP_PYTHON": str(fake_python),
+    }
+    result = subprocess.run(
+        [str(_LAUNCHER), "--probe"],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    lines = result.stdout.splitlines()
+    assert lines[0] == str(_ROOT / "scripts" / "memory_mcp_server.py")
+    assert lines[1] == "--probe"
+
+
+def test_launcher_rejects_override_python_without_mcp(tmp_path):
+    fake_python = tmp_path / "python"
+    _write_executable(
+        fake_python,
+        """#!/usr/bin/env sh
+if [ "$1" = "-c" ]; then
+  exit 1
+fi
+exit 99
+""",
+    )
+
+    env = {
+        **os.environ,
+        "DEUS_MEMORY_MCP_PYTHON": str(fake_python),
+    }
+    result = subprocess.run(
+        [str(_LAUNCHER)],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "DEUS_MEMORY_MCP_PYTHON does not provide" in result.stderr
+    assert str(fake_python) in result.stderr


### PR DESCRIPTION
## Summary
- add a repo-owned `scripts/deus-memory-mcp` launcher that selects a Python environment with the `mcp` package
- update Codex/Claude registration docs to point at the launcher instead of bare `python3`
- add launcher tests for override success/failure paths

## Verification
- plan-reviewer Warden: SHIP
- code-reviewer Warden: SHIP
- `python3 -m pytest scripts/tests/test_deus_memory_mcp_launcher.py scripts/tests/test_memory_mcp_server.py`
- `python3 scripts/sync_agent_skills.py --check`
- `git diff --check`
- manual MCP initialize + `tools/list` through `scripts/deus-memory-mcp`

## Notes
- leaves unrelated local files unstaged: `.claude/scheduled_tasks.lock`, `.claude/worktrees/`, `.truecourse/`, `finetune/`