### PR TITLE
docs(wardens): wire code-reviewer pre-commit gate

### DIFF
--- a/.claude/wardens/README.md
+++ b/.claude/wardens/README.md
@@ -5,7 +5,7 @@ Specialized review agents that guard the codebase. Validator wardens check corre
 | Warden | Type | Model | Rules/Schema file | Invocation |
 |--------|------|-------|-------------------|------------|
 | **plan-reviewer** | Validator | Opus | `plan-review-rules.md` | Gated by PreToolUse hook (auto-required for Edit/Write in `~/deus/`) |
-| **code-reviewer** | Validator | Sonnet | `code-review-rules.md` | Manual: `Agent(subagent_type="code-reviewer", prompt="review my changes")` |
+| **code-reviewer** | Validator | Sonnet | `code-review-rules.md` | Gated by PreToolUse hook (auto-required for `git commit` in `~/deus/`) |
 | **threat-modeler** | Validator | Opus | `threat-modeling-rules.md` | Manual: invoke when plan touches auth, credentials, external APIs, or trust boundaries |
 | **architecture-snapshot** | Generator | Sonnet | `architecture-schema.md` | Manual: `Agent(subagent_type="architecture-snapshot", prompt="snapshot the architecture")` |
 | **session-retrospective** | Generator | Opus | `retrospective-schema.md` | Manual (also auto-triggered by /compress when opt-in gate passes): `Agent(subagent_type="session-retrospective", prompt="retrospective for last 20 sessions")` |
@@ -53,9 +53,13 @@ Then on `VERDICT: SHIP`:
 touch ~/deus/.claude/.plan-reviewed
 ```
 
-**code-reviewer (manual, post-implementation):**
+**code-reviewer (required via gate):**
 ```
 Agent(subagent_type="code-reviewer", prompt="review my changes for <task>")
+```
+Then on `VERDICT: SHIP`:
+```
+touch ~/deus/.claude/.code-reviewed
 ```
 The agent runs `git diff` + `git diff --cached` and reviews both.
 
@@ -76,6 +80,28 @@ Rules files are the single source of truth — agents read them at invocation. A
 Keep rules concise. Total file size matters — every rule adds context cost per invocation. If the file exceeds ~300 lines, split by category and index from the main file.
 
 > **Note on `Cite:` fields:** Rules may cite filenames like `feedback_public_repo_generic` or `project_error_discipline_plan.md` — these refer to the maintainer's auto-memory system (Claude Code's per-project memory). Rules themselves are self-contained; citations are for traceability only and safe to ignore if you don't have the same memory setup.
+
+## How the code-review gate works
+
+Before any `git commit` in `~/deus/`, the hook `~/.claude/hooks/code-review-gate.sh` checks for the marker `~/deus/.claude/.code-reviewed`. If missing, the commit is blocked with instructions to invoke `code-reviewer`.
+
+**Marker lifecycle (event-based, no timer):**
+
+- **Invalidated** by:
+  - `SessionStart` hook (`~/.claude/hooks/plan-mode-session-init.sh`) — every new conversation starts clean.
+  - PostToolUse `Edit|Write|MultiEdit` on deus source files (`~/.claude/hooks/code-review-invalidator.sh`) — any edit after review makes the diff stale.
+- **Refreshed** ONLY by:
+  - `code-reviewer` returning `VERDICT: SHIP` → author runs `touch ~/deus/.claude/.code-reviewed`.
+  - Trivial-commit bypass (typos, deps, config-only): same `touch` command, with the judgment call stated aloud in the response so it's visible.
+
+**code-reviewer (required via gate):**
+```
+Agent(subagent_type="code-reviewer", prompt="review my changes for <task>")
+```
+Then on `VERDICT: SHIP`:
+```
+touch ~/deus/.claude/.code-reviewed
+```
 
 ## What's NOT a Warden
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@ node_modules/
 # Build output
 dist/
 
-# Plan-review gate marker (user-local; refreshed by plan-reviewer agent)
+# Warden gate markers (user-local; refreshed by warden agents)
 .claude/.plan-reviewed
+.claude/.code-reviewed
+.claude/.threat-modeled
 
 # Local data & auth
 store/


### PR DESCRIPTION
## Summary
- Code-reviewer Warden is now enforced via PreToolUse hook on `git commit` in ~/deus/, matching the plan-reviewer pattern
- PostToolUse invalidator clears the marker when source files are edited after review (stale-diff guard)
- `.gitignore` updated to cover all three warden markers (.plan-reviewed, .code-reviewed, .threat-modeled)

## Changes
- `.claude/wardens/README.md` — code-reviewer promoted from "Manual" to "Gated", full gate lifecycle docs added
- `.gitignore` — consolidated warden marker exclusions

## Note
Hook scripts live in `~/.claude/hooks/` (user-local, not in repo). This PR documents the gate for contributors.

## Test plan
- [ ] `git commit` without marker → blocked with instructions
- [ ] `touch .claude/.code-reviewed` + `git commit` → passes
- [ ] Edit source file after review → marker cleared, next commit blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)