### PR TITLE
fix(memory): make STATE.md on-demand and fix compress fuzzy matching

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -115,8 +115,11 @@ After saving the session log:
         - If `previous:` doesn't exist yet, add it before `pending:`.
       - **Merge** pending tasks (never replace):
         1. Read the current `pending:` block from CLAUDE.md. If missing, treat as empty list.
-        2. Remove any items that match `[x]` completed tasks from the session log (fuzzy match on description).
-        3. Add any new `[ ]` items from the session log that don't already exist in the current pending list (avoid duplicates).
+        2. Remove completed items: for each `[x]` from the session log, find its match in the pending list:
+           - **Match on core identifiers** (file names, feature names, PR numbers, tool names), ignoring parenthetical annotations like `(closed: ...)`, `(done)`, `(PR #N)` and minor wording differences.
+           - **Compound items** (`A + B`): if a pending item has sub-tasks joined by ` + `, match each part independently. All parts matched → remove whole item. Some parts matched → rewrite to keep only unmatched parts. Example: pending `Refactor auth + update docs` with `[x] Refactor auth (done)` → rewrite to `update docs`.
+           - **Dedup pass**: after removals, check each remaining `[ ]` item — if it is semantically covered by any `[x]` (same feature/identifier, different wording), remove it.
+        3. Add any new `[ ]` items from the session log that don't already exist in the pending list and aren't already covered by a `[x]` from this session (avoid duplicates).
         4. Cap at 10 items. If over 10, archive the oldest items to `$VAULT/CLAUDE-Archive.md`.
         5. Write the merged list back to `pending:`.
 

--- a/container/agent-runner/src/context-registry.test.ts
+++ b/container/agent-runner/src/context-registry.test.ts
@@ -198,7 +198,6 @@ describe('context registry', () => {
       '=== PROJECT RULES: AI_AGENT_GUIDELINES.md ===\nproject guidelines',
       '=== VAULT: AGENTS.md ===\nvault agents',
       '=== VAULT: CLAUDE.md ===\nvault claude',
-      '=== VAULT: STATE.md ===\nvault state',
       '=== VAULT: MEMORY_TREE.md ===\nvault tree',
       '=== EXTRA RULES: reference/AGENTS.md ===\nextra agents',
       '=== EXTRA RULES: reference/AI_AGENT_GUIDELINES.md ===\nextra guidelines',

--- a/container/agent-runner/src/context-registry.ts
+++ b/container/agent-runner/src/context-registry.ts
@@ -84,7 +84,8 @@ function baseContextEntries(root: string): ContextEntry[] {
     {
       label: 'VAULT: STATE.md',
       path: workspacePath(root, 'vault', 'STATE.md'),
-      claudeSystemAppend: true,
+      // On-demand only: system-prompt snapshot goes stale across /clear
+      claudeSystemAppend: false,
     },
     {
       label: 'VAULT: MEMORY_TREE.md',

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1189,12 +1189,10 @@ Additional instructions from the user: $PREFS_PERSONA"
 	      printf "  Reading vault...\r"
 	      CLAUDE_MD=$(cat "$VAULT/CLAUDE.md" 2>/dev/null)
 	      AGENTS_MD=$(cat "$VAULT/AGENTS.md" 2>/dev/null)
-	      STATE_MD=$(cat "$VAULT/STATE.md" 2>/dev/null)
 	      STUDY_MD=$(cat "$VAULT/STUDY.md" 2>/dev/null)
 	      INFRA_MD=$(cat "$VAULT/INFRA.md" 2>/dev/null)
 	      [ -n "$CLAUDE_MD" ] && CONTEXT="=== VAULT: CLAUDE.md ===\n$CLAUDE_MD"
 	      [ -n "$AGENTS_MD" ] && CONTEXT="$CONTEXT\n\n=== VAULT: AGENTS.md ===\n$AGENTS_MD"
-	      [ -n "$STATE_MD" ] && CONTEXT="$CONTEXT\n\n=== VAULT: STATE.md ===\n$STATE_MD"
 	      [ -n "$STUDY_MD" ]  && CONTEXT="$CONTEXT\n\n=== VAULT: STUDY.md ===\n$STUDY_MD"
 	      [ -n "$INFRA_MD" ]  && CONTEXT="$CONTEXT\n\n=== VAULT: INFRA.md ===\n$INFRA_MD"
 

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-28" # param-optimizer
+last_verified: "2026-04-29" # contradiction-retry-cap
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-04-29" # memory-mcp-launcher
+last_verified: "2026-04-29" # compress-fuzzy-match-fix
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -1813,8 +1813,9 @@ def detect_contradictions(db: sqlite3.Connection, new_atom_id: int,
         return []
 
     llm_calls = 0
+    consecutive_failures = 0
     for existing_id, existing_text, distance in rows:
-        if distance > 1.2 or llm_calls >= 5:
+        if distance > 1.2 or llm_calls >= 5 or consecutive_failures >= 3:
             break
         try:
             prompt = _contradiction_prompt(existing_text, new_atom_text)
@@ -1827,6 +1828,7 @@ def detect_contradictions(db: sqlite3.Connection, new_atom_id: int,
                 # All models quota-exhausted — stop checking further pairs.
                 break
             llm_calls += 1
+            consecutive_failures = 0
             verdict = response.text.strip().upper().split()[0] if response.text else ""
             if verdict == "CONTRADICT":
                 conflicts.append({"older_id": existing_id, "newer_id": new_atom_id,
@@ -1845,7 +1847,8 @@ def detect_contradictions(db: sqlite3.Connection, new_atom_id: int,
                 print(f"  CONFLICT DETECTED (pending review): atom {existing_id} "
                       f"may be superseded by {new_atom_id} ({existing_text[:60]})")
         except Exception as e:
-            print(f"  WARN: contradiction check failed: {e}", file=sys.stderr)
+            consecutive_failures += 1
+            print(f"  WARN: contradiction check failed ({consecutive_failures}/3): {e}", file=sys.stderr)
             continue
 
     return conflicts


### PR DESCRIPTION
## Summary
- **STATE.md removed from auto-load** — was baked into the system prompt at launch and went stale across `/clear`, causing completed pending tasks to linger. Now on-demand only: catch-up hook injects live pending block, `/resume` reads explicitly, any session can `Read` it directly.
- **Compress fuzzy matching fixed** — replaced vague "fuzzy match on description" with explicit rules: core-identifier matching (ignores annotations), compound task decomposition (`A + B`), and a dedup pass for semantic overlaps.
- **Container parity** — `context-registry.ts` sets `claudeSystemAppend: false` so container agents also don't auto-load STATE.md. Still available in `mode: 'all'` for agents that need full context.

Saves ~300 tokens/turn from the system prompt.

## Test plan
- [x] `context-registry.test.ts` — all 8 tests pass
- [ ] Restart `deus` CLI and verify STATE.md is not in the system prompt
- [ ] Run "catch me up" and verify hook injects live pending block
- [ ] Run `/compress` on a session with annotated `[x]` items and verify they're removed from pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)