### PR TITLE
fix(codex): require approval for admin PR merges

### DIFF
--- a/.claude/wardens/README.md
+++ b/.claude/wardens/README.md
@@ -141,9 +141,20 @@ Codex behavior copied from Claude Code:
 | Reset review markers on new session | `SessionStart` | `SessionStart` |
 | Block source edits before plan-reviewer `SHIP` | `PreToolUse Write\|Edit\|MultiEdit` | `PreToolUse apply_patch` with `Edit\|Write` aliases |
 | Block `git commit` before code-reviewer `SHIP` | `PreToolUse Bash` | `PreToolUse Bash` |
+| Block `gh pr merge --admin` without fresh approval | Claude permission prompt | `PreToolUse Bash` |
 | Invalidate code-review marker after edits | `PostToolUse Write\|Edit\|MultiEdit` | `PostToolUse apply_patch` with `Edit\|Write` aliases |
 | Warn on security-sensitive edits without threat-modeler marker | `PostToolUse Write\|Edit\|MultiEdit` | `PostToolUse apply_patch` with `Edit\|Write` aliases |
 | Warn on personal absolute paths in tracked files | `PostToolUse Write\|Edit\|MultiEdit` | `PostToolUse apply_patch` with `Edit\|Write` aliases |
+
+Admin PR merge rule:
+
+- Normal merge approval does not imply approval to bypass branch policy.
+- `gh pr merge --admin` always needs fresh explicit user approval for the exact
+  command.
+- When blocked, the Codex hook prints an `approve-admin-merge` command. Run it
+  only after the user explicitly approves that exact admin merge command.
+- The approval marker is command-hash scoped, consumed on use, and cleared on
+  session start.
 
 Known Codex gaps are tracked in `docs/agent-agnostic-debt.md`. Most important:
 Codex does not expose an exact `ExitPlanMode`/built-in `Plan` invalidation

--- a/docs/MULTI_BACKEND.md
+++ b/docs/MULTI_BACKEND.md
@@ -125,6 +125,10 @@ python3 scripts/codex_warden_hooks.py uninstall
 Known Codex hook parity gaps are tracked in
 [agent-agnostic-debt.md](agent-agnostic-debt.md).
 
+The hooks also block `gh pr merge --admin` unless the exact command has fresh
+explicit approval. A normal "merge after CI" approval does not approve bypassing
+branch policy.
+
 ## Backend Management
 
 Manage the default backend and model from the command line:

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-04-29" # codex-warden-hooks
+last_verified: "2026-04-30" # codex-admin-merge-gate
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -14,7 +14,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
@@ -271,13 +271,19 @@ def _gh_command_index_after_global_flags(tokens: list[str], gh_index: int) -> in
     return index
 
 
+def _is_gh_executable(token: str) -> bool:
+    token = token.strip("\"'")
+    names = {Path(token).name.lower(), PureWindowsPath(token).name.lower()}
+    return bool(names & {"gh", "gh.exe"})
+
+
 def _is_admin_merge_command(command: str) -> bool:
     tokens = _shell_tokens(command)
-    if "--admin" not in tokens:
+    if not any(token == "--admin" or token.startswith("--admin=") for token in tokens):
         return False
 
     for index, token in enumerate(tokens):
-        if token != "gh":
+        if not _is_gh_executable(token):
             continue
         command_index = _gh_command_index_after_global_flags(tokens, index)
         if tokens[command_index : command_index + 2] == ["pr", "merge"]:

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import datetime as dt
+import hashlib
 import json
 import os
 import re
@@ -42,6 +43,13 @@ HOOK_SPECS: tuple[HookSpec, ...] = (
         "Checking Deus plan review",
     ),
     HookSpec("PreToolUse", "Bash", "code-review-gate", 5, "Checking Deus code review"),
+    HookSpec(
+        "PreToolUse",
+        "Bash",
+        "admin-merge-gate",
+        5,
+        "Checking admin merge approval",
+    ),
     HookSpec(
         "PostToolUse",
         "Edit|Write|apply_patch",
@@ -230,8 +238,84 @@ def _marker(repo_root: Path, name: str) -> Path:
     return repo_root / ".claude" / name
 
 
+def _command_hash(command: str) -> str:
+    return hashlib.sha256(command.encode("utf-8")).hexdigest()
+
+
+def _shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=os.name != "nt")
+    except ValueError:
+        return command.split()
+
+
+def _gh_command_index_after_global_flags(tokens: list[str], gh_index: int) -> int:
+    index = gh_index + 1
+    flags_with_values = {
+        "--config-dir",
+        "--hostname",
+        "--repo",
+        "-R",
+    }
+
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return index + 1
+        if not token.startswith("-"):
+            return index
+        if token in flags_with_values and index + 1 < len(tokens):
+            index += 2
+        else:
+            index += 1
+    return index
+
+
+def _is_admin_merge_command(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    if "--admin" not in tokens:
+        return False
+
+    for index, token in enumerate(tokens):
+        if token != "gh":
+            continue
+        command_index = _gh_command_index_after_global_flags(tokens, index)
+        if tokens[command_index : command_index + 2] == ["pr", "merge"]:
+            return True
+    return False
+
+
+def _admin_merge_marker(repo_root: Path) -> Path:
+    return _marker(repo_root, ".admin-merge-approved")
+
+
+def approve_admin_merge(command: str, repo_root: Path) -> int:
+    marker = _admin_merge_marker(repo_root)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(
+        json.dumps(
+            {
+                "command_hash": _command_hash(command),
+                "command": command,
+                "created_at": dt.datetime.now(dt.UTC).isoformat(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Approved one admin merge command for {repo_root}")
+    return 0
+
+
 def run_session_init(repo_root: Path) -> int:
-    for name in (".plan-reviewed", ".code-reviewed", ".threat-modeled"):
+    for name in (
+        ".plan-reviewed",
+        ".code-reviewed",
+        ".threat-modeled",
+        ".admin-merge-approved",
+    ):
         _marker(repo_root, name).unlink(missing_ok=True)
     return 0
 
@@ -271,6 +355,46 @@ def run_code_review_gate(event: dict[str, Any], repo_root: Path) -> int:
         "Before committing Deus changes, run the code-reviewer Warden and wait "
         "for VERDICT: SHIP. Then run:\n\n"
         f"  touch {shlex.quote(str(_marker(repo_root, '.code-reviewed')))}"
+    )
+    _block_pre_tool(reason)
+    return 0
+
+
+def run_admin_merge_gate(event: dict[str, Any], repo_root: Path) -> int:
+    cwd = Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)
+    if _worktree_for_cwd(cwd, repo_root) is None:
+        return 0
+
+    tool_input = event.get("tool_input")
+    command = tool_input.get("command") if isinstance(tool_input, dict) else ""
+    if not isinstance(command, str) or not _is_admin_merge_command(command):
+        return 0
+
+    marker = _admin_merge_marker(repo_root)
+    command_hash = _command_hash(command)
+    if marker.exists():
+        try:
+            approved = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            approved = {}
+        marker.unlink(missing_ok=True)
+        if approved.get("command_hash") == command_hash:
+            return 0
+
+    approval = (
+        f"{_default_python_command()} "
+        f"{_quote_args([str(repo_root / 'scripts' / 'codex_warden_hooks.py'), 'approve-admin-merge', '--repo-root', str(repo_root), '--command', command])}"
+    )
+    reason = (
+        "[admin-merge-gate] BLOCKED: `gh pr merge --admin` bypasses branch "
+        "policy and needs fresh explicit approval.\n\n"
+        "Prior approval to merge after green CI is not approval to bypass branch "
+        "protection. Ask the user for explicit approval to use `--admin` on this "
+        "exact command, then run:\n\n"
+        f"  {approval}\n\n"
+        "Retry the same admin merge command after approval. The approval marker "
+        "is command-scoped and consumed on use.\n\n"
+        f"Command hash: {command_hash}"
     )
     _block_pre_tool(reason)
     return 0
@@ -340,6 +464,7 @@ RUNNERS = {
     "session-init": lambda event, repo: run_session_init(repo),
     "plan-review-gate": run_plan_review_gate,
     "code-review-gate": run_code_review_gate,
+    "admin-merge-gate": run_admin_merge_gate,
     "code-review-invalidator": run_code_review_invalidator,
     "threat-model-gate": run_threat_model_gate,
     "path-leak-detector": run_path_leak_detector,
@@ -687,11 +812,15 @@ def run(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="action", required=True)
 
     run_parser = subparsers.add_parser("run")
     run_parser.add_argument("behavior", choices=sorted(RUNNERS))
     run_parser.add_argument("--repo-root", default=Path(__file__).resolve().parents[1])
+
+    approve_parser = subparsers.add_parser("approve-admin-merge")
+    approve_parser.add_argument("--repo-root", default=Path(__file__).resolve().parents[1])
+    approve_parser.add_argument("--command", dest="admin_command", required=True)
 
     for name in ("install", "check", "uninstall"):
         sub = subparsers.add_parser(name)
@@ -704,18 +833,22 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    if args.command in {"install", "check", "uninstall"}:
+    if args.action in {"install", "check", "uninstall"}:
         _finalize_paths(args)
 
-    if args.command == "run":
+    if args.action == "run":
         return run(args)
-    if args.command == "install":
+    if args.action == "approve-admin-merge":
+        return approve_admin_merge(
+            args.admin_command, Path(args.repo_root).resolve(strict=False)
+        )
+    if args.action == "install":
         return install(args)
-    if args.command == "check":
+    if args.action == "check":
         return check(args)
-    if args.command == "uninstall":
+    if args.action == "uninstall":
         return uninstall(args)
-    raise AssertionError(args.command)
+    raise AssertionError(args.action)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -153,6 +153,60 @@ def test_admin_merge_gate_blocks_with_gh_short_repo_flag(tmp_path, capsys):
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
+def test_admin_merge_gate_blocks_equals_form_admin_flag(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "gh pr merge 294 --squash --admin=true"),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_admin_merge_gate_blocks_absolute_gh_path(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "/opt/homebrew/bin/gh pr merge 294 --squash --admin=true"),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_admin_merge_gate_blocks_windows_gh_exe_path(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(
+            repo,
+            r'"C:\Program Files\GitHub CLI\gh.exe" pr merge 294 --admin',
+        ),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_admin_merge_detection_handles_windows_shell_tokenization(monkeypatch):
+    hooks = load_hooks()
+    monkeypatch.setattr(hooks.os, "name", "nt")
+
+    assert hooks._is_admin_merge_command(
+        r'"C:\Program Files\GitHub CLI\gh.exe" pr merge 294 --admin'
+    )
+
+
 def test_admin_merge_gate_allows_exact_approved_command_and_consumes_marker(
     tmp_path, capsys
 ):

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -108,6 +108,109 @@ def test_code_review_gate_blocks_git_commit_without_marker(tmp_path, capsys):
     assert "code-reviewer" in reason
 
 
+def test_admin_merge_gate_blocks_without_exact_approval(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "gh pr merge 294 --squash --admin"),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "fresh explicit approval" in reason
+    assert "approve-admin-merge" in reason
+
+
+def test_admin_merge_gate_blocks_with_gh_global_repo_flag(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "gh --repo owner/repo pr merge 294 --squash --admin"),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "fresh explicit approval" in reason
+
+
+def test_admin_merge_gate_blocks_with_gh_short_repo_flag(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "gh -R owner/repo pr merge 294 --squash --admin"),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_admin_merge_gate_allows_exact_approved_command_and_consumes_marker(
+    tmp_path, capsys
+):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    command = "gh pr merge 294 --squash --admin"
+
+    assert hooks.approve_admin_merge(command, repo) == 0
+    assert (repo / ".claude" / ".admin-merge-approved").exists()
+    rc = hooks.run_admin_merge_gate(bash_event(repo, command), repo)
+
+    assert rc == 0
+    assert (repo / ".claude" / ".admin-merge-approved").exists() is False
+    output = capsys.readouterr().out
+    assert "Approved one admin merge command" in output
+    assert "permissionDecision" not in output
+
+
+def test_admin_merge_gate_rejects_stale_marker_for_different_command(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    assert hooks.approve_admin_merge("gh pr merge 294 --squash --admin", repo) == 0
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "gh pr merge 295 --squash --admin"),
+        repo,
+    )
+
+    assert rc == 0
+    assert (repo / ".claude" / ".admin-merge-approved").exists() is False
+    output = capsys.readouterr().out
+    assert "permissionDecision" in output
+
+
+def test_admin_merge_gate_ignores_normal_merge_without_admin(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_admin_merge_gate(
+        bash_event(repo, "gh pr merge 294 --squash"),
+        repo,
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_session_init_clears_admin_merge_marker(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    marker = repo / ".claude" / ".admin-merge-approved"
+    marker.write_text("{}", encoding="utf-8")
+
+    assert hooks.run_session_init(repo) == 0
+
+    assert not marker.exists()
+
+
 def test_code_review_invalidator_clears_marker_after_edit(tmp_path):
     hooks = load_hooks()
     repo = git_repo(tmp_path)


### PR DESCRIPTION
## Summary
- block  in Codex hooks unless the exact command has fresh explicit approval
- consume command-scoped approval markers on use and clear them on session start
- cover global Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` flag forms like 
- document that normal merge approval does not imply branch-policy bypass approval

## Verification
- python3 -m pytest scripts/tests/test_codex_warden_hooks.py
- python3 -m py_compile scripts/codex_warden_hooks.py scripts/tests/test_codex_warden_hooks.py
- python3 scripts/sync_agent_skills.py --check
- git diff --check
- python3 scripts/drift_check.py --all --base origin/main
- temp install/check/uninstall smoke