### PR TITLE
feat(tui): context parity, subprocess visualization, and platform layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,26 @@ jobs:
             echo "::endgroup::"
           done
 
+  test-tui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Build
+        working-directory: tui
+        run: cargo build --release
+      - name: Clippy
+        working-directory: tui
+        run: cargo clippy -- -D warnings
+      - name: Format check
+        working-directory: tui
+        run: cargo fmt -- --check
+      - name: Tests
+        working-directory: tui
+        run: cargo test
+
   test-windows:
     runs-on: windows-latest
     steps:

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -992,9 +992,36 @@ case "$1" in
     # `deus web` launches with --chrome for Claude-in-Chrome browser integration.
     # Otherwise identical to bare `deus` / `deus home`.
     CHROME_FLAG=""
+    TUI_DEFAULT="false"
     if [ "$1" = "web" ] || [ "$(_read_config_key chrome_default)" = "true" ]; then
       CHROME_FLAG="--chrome"
     fi
+    if [ "$1" != "web" ] && [ "$(_read_config_key tui_default)" = "true" ]; then
+      TUI_DEFAULT="true"
+    fi
+
+    _launch_tui_with_context() {
+      local ctx_content="$1"
+      local initial_prompt="$2"
+      local mode="$3"
+      local tui_bin="$SCRIPT_DIR/tui/target/release/deus-tui"
+      if [ ! -x "$tui_bin" ]; then
+        printf "  Building TUI...\r"
+        (cd "$SCRIPT_DIR/tui" && cargo build --release) || { echo "TUI build failed."; exit 1; }
+      fi
+      local ctx_file=""
+      if [ -n "$ctx_content" ]; then
+        ctx_file=$(mktemp "${TMPDIR:-/tmp}/deus-tui-ctx.XXXXXX")
+        chmod 0600 "$ctx_file"
+        printf '%s' "$ctx_content" > "$ctx_file"
+        export DEUS_TUI_CONTEXT_FILE="$ctx_file"
+      fi
+      [ -n "$initial_prompt" ] && export DEUS_TUI_INITIAL_PROMPT="$initial_prompt"
+      export DEUS_TUI_BYPASS="${PREFS_BYPASS:-true}"
+      export DEUS_TUI_MODE="$mode"
+      export DEUS_TUI_BACKEND="$CLI_AGENT"
+      exec "$tui_bin"
+    }
     TOKEN=$(python3 -c 'import sys,json; print(json.load(open(sys.argv[1]))["claudeAiOauth"]["accessToken"])' "$HOME/.claude/.credentials.json" 2>/dev/null)
     if [ -z "$TOKEN" ]; then
       echo "Error: could not read token from ~/.claude/.credentials.json"
@@ -1322,15 +1349,20 @@ $STARTUP_GREETING"
         export $EXTRA_ENV
       fi
 
+      FULL_PROMPT=""
       if [ -n "$CONTEXT" ]; then
-        launch_agent --append-system-prompt "$(printf '%s' "$CONTEXT")
+        FULL_PROMPT="$(printf '%s' "$CONTEXT")
 
 $STARTUP_INSTRUCTION"
-        exit $?
       else
-        launch_agent --append-system-prompt "$STARTUP_INSTRUCTION"
-        exit $?
+        FULL_PROMPT="$STARTUP_INSTRUCTION"
       fi
+
+      if [ "$TUI_DEFAULT" = "true" ]; then
+        cd "$CURRENT_DIR" && _launch_tui_with_context "$FULL_PROMPT" "" "external"
+      fi
+      launch_agent --append-system-prompt "$FULL_PROMPT"
+      exit $?
     fi
 
     # ─── HOME MODE ───
@@ -1345,13 +1377,6 @@ $STARTUP_INSTRUCTION"
     # Running from ~/deus — full startup with optional catch-me-up greeting.
     if [ "$PREFS_CATCH_ME_UP" = "false" ]; then
       STARTUP_INSTRUCTION="STARTUP INSTRUCTION: Context from the memory vault has been pre-loaded above. Wait for the user's instructions."
-      if [ -n "$CONTEXT" ]; then
-        cd "$HOME/deus" && launch_agent --append-system-prompt "$(printf '%s' "$CONTEXT")
-
-$STARTUP_INSTRUCTION"
-      else
-        cd "$HOME/deus" && launch_agent
-      fi
     else
       STARTUP_INSTRUCTION="STARTUP INSTRUCTION: Context from the memory vault has been pre-loaded above, BUT it is a snapshot taken at deus launch and does not refresh across /clear or same-session work.
 
@@ -1371,14 +1396,29 @@ Then catch the user up using exactly this format:
 • Pending: [bullet list of pending tasks, max 3 items]
 
 Then stop and wait for the user."
+    fi
 
-      if [ -n "$CONTEXT" ]; then
-        cd "$HOME/deus" && launch_agent --append-system-prompt "$(printf '%s' "$CONTEXT")
+    FULL_PROMPT=""
+    INITIAL_MSG=""
+    if [ -n "$CONTEXT" ]; then
+      FULL_PROMPT="$(printf '%s' "$CONTEXT")
 
-$STARTUP_INSTRUCTION" "Catch me up."
-      else
-        cd "$HOME/deus" && launch_agent
-      fi
+$STARTUP_INSTRUCTION"
+    fi
+    if [ "$PREFS_CATCH_ME_UP" = "true" ]; then
+      INITIAL_MSG="Catch me up."
+    fi
+
+    if [ "$TUI_DEFAULT" = "true" ]; then
+      cd "$HOME/deus" && _launch_tui_with_context "$FULL_PROMPT" "$INITIAL_MSG" "home"
+    fi
+
+    if [ -n "$FULL_PROMPT" ] && [ -n "$INITIAL_MSG" ]; then
+      cd "$HOME/deus" && launch_agent --append-system-prompt "$FULL_PROMPT" "$INITIAL_MSG"
+    elif [ -n "$FULL_PROMPT" ]; then
+      cd "$HOME/deus" && launch_agent --append-system-prompt "$FULL_PROMPT"
+    else
+      cd "$HOME/deus" && launch_agent
     fi
     ;;
   listen)
@@ -1429,6 +1469,6 @@ $STARTUP_INSTRUCTION" "Catch me up."
     echo "  deus gcal       Google Calendar token management (status|auth|ping)"
     echo "  deus listen     Record from mic, transcribe, and copy to clipboard"
     echo "  deus logs       Review system health logs (rotate|review|summary|pinned)"
-    echo "  deus tui        Interactive terminal UI for managing wardens, services, and channels"
+    echo "  deus tui        Interactive terminal UI (set tui_default=true in config to use by default)"
     ;;
 esac

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1100,10 +1100,12 @@ def check_all(project_root: Path, base_ref: str | None = None) -> int:
     bench_rc = check_bench_labels(project_root)
     print("\n=== backend strategy ===")
     bs_rc = check_backend_strategy(project_root)
+    print("\n=== platform parity ===")
+    pp_rc = check_platform_parity(project_root)
     print("\n=== coverage (informational) ===")
     cov_rc = check_coverage(project_root)
 
-    worst = max(drift_rc, paths_rc, idx_rc, adr_rc, tt_rc, shadow_rc, bm_rc, bench_rc, bs_rc, cov_rc)
+    worst = max(drift_rc, paths_rc, idx_rc, adr_rc, tt_rc, shadow_rc, bm_rc, bench_rc, bs_rc, pp_rc, cov_rc)
     print()
     if worst == 0:
         print("ALL CHECKS PASSED")
@@ -1434,6 +1436,74 @@ def check_backend_strategy(project_root: Path) -> int:
     return 1
 
 
+def check_platform_parity(project_root: Path) -> int:
+    """Verify src/platform.ts and tui/src/platform.rs expose aligned capabilities.
+
+    Extracts exported function/const names from each file and checks that
+    the Rust module covers every capability category in the TypeScript module.
+    Naming conventions differ (camelCase vs snake_case) so we compare normalized
+    category stems rather than exact names.
+    """
+    import re
+
+    ts_file = project_root / "src" / "platform.ts"
+    rs_file = project_root / "tui" / "src" / "platform.rs"
+
+    if not ts_file.exists():
+        print(f"  {ts_file.relative_to(project_root)} not found (skipped)")
+        return 0
+    if not rs_file.exists():
+        print(f"  {rs_file.relative_to(project_root)} not found (skipped)")
+        return 0
+
+    def ts_exports(content: str) -> set[str]:
+        names: set[str] = set()
+        for m in re.finditer(r'export\s+(?:const|function)\s+(\w+)', content):
+            names.add(m.group(1))
+        return names
+
+    def rs_exports(content: str) -> set[str]:
+        names: set[str] = set()
+        for m in re.finditer(r'pub\s+(?:fn|const)\s+(\w+)', content):
+            names.add(m.group(1))
+        return names
+
+    def normalize(name: str) -> str:
+        """camelCase/PascalCase/SCREAMING_SNAKE → lowercase words."""
+        s = re.sub(r'([a-z])([A-Z])', r'\1_\2', name)
+        return s.lower().replace('_', '')
+
+    # Category buckets that must be present in both
+    REQUIRED_CATEGORIES = {
+        "homedir": "Home directory accessor",
+        "ismacos": "macOS platform detection",
+        "iswindows": "Windows platform detection",
+        "islinux": "Linux platform detection",
+    }
+
+    ts_content = ts_file.read_text()
+    rs_content = rs_file.read_text()
+
+    ts_names = {normalize(n) for n in ts_exports(ts_content)}
+    rs_names = {normalize(n) for n in rs_exports(rs_content)}
+
+    missing_in_rust: list[str] = []
+    for cat, desc in REQUIRED_CATEGORIES.items():
+        if cat in ts_names and cat not in rs_names:
+            missing_in_rust.append(f"  Missing in Rust: {cat} ({desc})")
+
+    if missing_in_rust:
+        print(f"Platform parity VIOLATION — {len(missing_in_rust)} gap(s):")
+        for m in missing_in_rust:
+            print(m)
+        print(f"\nFIX: add missing capabilities to tui/src/platform.rs")
+        return 1
+
+    print(f"Platform parity: TS has {len(ts_exports(ts_content))} exports, "
+          f"RS has {len(rs_exports(rs_content))} exports — required categories aligned.")
+    return 0
+
+
 def check_coverage(project_root: Path) -> int:
     """Report docs/ files that are not referenced by any pattern (informational)."""
     patterns_dir = project_root / "patterns"
@@ -1744,6 +1814,12 @@ if __name__ == "__main__":
         help="Check that provider-specific logic stays inside tui/src/backend/ (ADR: backend-strategy-trait.md)",
     )
     parser.add_argument(
+        "--platform-parity",
+        action="store_true",
+        dest="platform_parity",
+        help="Verify src/platform.ts and tui/src/platform.rs expose aligned capabilities",
+    )
+    parser.add_argument(
         "--base",
         metavar="REF",
         help="Only check governed files changed since REF (e.g. origin/main). "
@@ -1757,7 +1833,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.backend_strategy:
+    if args.platform_parity:
+        sys.exit(check_platform_parity(PROJECT_ROOT))
+    elif args.backend_strategy:
         sys.exit(check_backend_strategy(PROJECT_ROOT))
     elif args.bench_labels:
         sys.exit(check_bench_labels(PROJECT_ROOT))

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,106 @@
+# Deus TUI
+
+Ratatui-based terminal interface for Deus that wraps `claude -p` and
+`codex exec` behind a unified chat UI. Ships as a single static binary
+with panels for wardens, services, channels, config, and system status.
+
+## Architecture
+
+```
+src/
+  main.rs          Event loop, terminal setup, key dispatch
+  app.rs           State machine (App struct, tabs, chat, commands)
+  ui.rs            Rendering — draws frames from App state
+  backend/
+    mod.rs         Backend trait + model registry
+    claude.rs      Claude provider (claude -p --output-format stream-json)
+    codex.rs       Codex provider (codex exec)
+  config/
+    mod.rs         Repo root detection
+    wardens.rs     Warden entries from .claude/wardens/
+    healthcheck.rs Service health from healthcheck.json
+    channels.rs    Channel status
+    deus.rs        General config from ~/.config/deus/config.json
+  panels/
+    chat.rs        Chat panel rendering
+    wardens.rs     Warden list + toggle
+    services.rs    Service health dashboard
+    channels.rs    Channel status list
+    config.rs      Config key/value display
+    status.rs      System dashboard
+  widgets/         Reusable TUI widgets
+  platform.rs      OS abstraction (paths, env vars, platform detection)
+  theme.rs         Brand color palette (Ember/Ocean/Teal)
+  bidi.rs          Bidirectional text support
+```
+
+## Adding a New Backend
+
+1. Create `src/backend/yourbackend.rs` implementing the `Backend` trait:
+   - `name()` / `display_name()` -- identifier and label
+   - `models()` -- return `&'static [ModelDef]` with id, display name, context
+   - `build_command()` -- construct the CLI `Command` from `RunConfig`
+   - `parse_line()` -- parse stdout JSON lines into `Vec<StreamChunk>`
+2. Add `pub mod yourbackend;` to `src/backend/mod.rs`.
+3. Add `Box::new(yourbackend::YourBackend)` to `all_backends()` in
+   `src/backend/mod.rs`.
+
+Model routing is automatic -- `find_backend()` matches on model ID.
+
+## Key Bindings
+
+### Chat Panel
+
+| Key              | Action                         |
+|------------------|--------------------------------|
+| Enter            | Send message / accept suggestion |
+| Shift+Enter      | Insert newline                 |
+| Ctrl+J           | Insert newline                 |
+| Esc              | Dismiss suggestions / cancel stream / double-tap to quit |
+| Ctrl+C           | Cancel stream (or quit if idle) |
+| Ctrl+D           | Quit                           |
+| Ctrl+L           | Clear chat                     |
+| Ctrl+U           | Clear input line               |
+| Ctrl+A / Ctrl+E  | Home / End                     |
+| Ctrl+W / Alt+Bksp| Delete word                    |
+| Ctrl+K           | Kill to end of line            |
+| Ctrl+Y           | Yank (paste kill ring)         |
+| Ctrl+O           | Toggle tool visibility         |
+| Alt+B / Alt+F    | Word left / right              |
+| Up / Down        | History prev/next or suggestion nav |
+| PageUp / PageDn  | Scroll chat history            |
+| Cmd+Backspace    | Delete current line (macOS)    |
+| Tab              | Accept suggestion              |
+
+### Panel Navigation
+
+| Key              | Action                         |
+|------------------|--------------------------------|
+| Esc / q          | Return to Chat                 |
+| j / Down         | Next item                      |
+| k / Up           | Previous item                  |
+| Space / Enter    | Toggle item                    |
+| r                | Refresh panel data             |
+
+Panels are opened via slash commands: `/wardens`, `/services`, `/channels`,
+`/config`, `/status`.
+
+## Configuration
+
+The TUI reads `~/.config/deus/config.json` for general settings (displayed in
+the Config panel). Backend and behavior are controlled via environment
+variables:
+
+| Variable                  | Default   | Description                        |
+|---------------------------|-----------|------------------------------------|
+| `DEUS_TUI_BACKEND`       | `claude`  | Default backend (`claude` or `codex`) |
+| `DEUS_TUI_MODE`          | `home`    | Operating mode                     |
+| `DEUS_TUI_CONTEXT_FILE`  | (none)    | Path to system context file        |
+| `DEUS_TUI_BYPASS`        | `false`   | Bypass permission prompts          |
+| `DEUS_TUI_INITIAL_PROMPT`| (none)    | Auto-send a prompt on startup      |
+
+When `DEUS_TUI_BACKEND=codex`, the default model switches to `gpt-5.4`;
+otherwise it defaults to `sonnet`. Models can be changed at runtime via
+`/model <id>`.
+
+If stdout is not a terminal, the TUI prints a static dashboard and exits.

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -42,7 +42,12 @@ pub enum SubagentStatus {
 pub enum MessageBlock {
     Text(String),
     Thinking(String),
-    ToolUse { id: String, tool: String, detail: String },
+    ToolUse {
+        #[allow(dead_code)]
+        id: String,
+        tool: String,
+        detail: String,
+    },
     SubagentBlock {
         id: String,
         subagent_type: String,
@@ -82,28 +87,94 @@ pub struct CommandDef {
 }
 
 use crate::backend::{self, ChunkKind, RunConfig};
-pub use crate::backend::{model_display, model_backend_name as model_backend, model_ids,
-    models_for_backend, backend_labels};
+pub use crate::backend::{
+    backend_labels, model_backend_name as model_backend, model_display, model_ids,
+    models_for_backend,
+};
 
 pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "xhigh", "max"];
 
 pub const COMMANDS: &[CommandDef] = &[
-    CommandDef { name: "/wardens", description: "Quality gates", args: &["enable", "disable", "reset"] },
-    CommandDef { name: "/services", description: "Service health", args: &["refresh"] },
-    CommandDef { name: "/channels", description: "Channel status", args: &[] },
-    CommandDef { name: "/config", description: "Configuration", args: &["backend", "vault"] },
-    CommandDef { name: "/status", description: "System dashboard", args: &["refresh"] },
-    CommandDef { name: "/model", description: "Switch model", args: &["claude", "codex"] },
-    CommandDef { name: "/effort", description: "Reasoning effort", args: &["low", "medium", "high", "xhigh", "max"] },
-    CommandDef { name: "/compress", description: "Save to vault", args: &[] },
-    CommandDef { name: "/checkpoint", description: "Mid-session save", args: &[] },
-    CommandDef { name: "/compact", description: "Compact context", args: &[] },
-    CommandDef { name: "/resume", description: "Load recent work", args: &[] },
-    CommandDef { name: "/history", description: "Past sessions", args: &["today", "yesterday", "week"] },
-    CommandDef { name: "/init", description: "Init CLAUDE.md", args: &[] },
-    CommandDef { name: "/help", description: "Show commands", args: &[] },
-    CommandDef { name: "/clear", description: "Clear chat", args: &[] },
-    CommandDef { name: "/quit", description: "Exit", args: &[] },
+    CommandDef {
+        name: "/wardens",
+        description: "Quality gates",
+        args: &["enable", "disable", "reset"],
+    },
+    CommandDef {
+        name: "/services",
+        description: "Service health",
+        args: &["refresh"],
+    },
+    CommandDef {
+        name: "/channels",
+        description: "Channel status",
+        args: &[],
+    },
+    CommandDef {
+        name: "/config",
+        description: "Configuration",
+        args: &["backend", "vault"],
+    },
+    CommandDef {
+        name: "/status",
+        description: "System dashboard",
+        args: &["refresh"],
+    },
+    CommandDef {
+        name: "/model",
+        description: "Switch model",
+        args: &["claude", "codex"],
+    },
+    CommandDef {
+        name: "/effort",
+        description: "Reasoning effort",
+        args: &["low", "medium", "high", "xhigh", "max"],
+    },
+    CommandDef {
+        name: "/compress",
+        description: "Save to vault",
+        args: &[],
+    },
+    CommandDef {
+        name: "/checkpoint",
+        description: "Mid-session save",
+        args: &[],
+    },
+    CommandDef {
+        name: "/compact",
+        description: "Compact context",
+        args: &[],
+    },
+    CommandDef {
+        name: "/resume",
+        description: "Load recent work",
+        args: &[],
+    },
+    CommandDef {
+        name: "/history",
+        description: "Past sessions",
+        args: &["today", "yesterday", "week"],
+    },
+    CommandDef {
+        name: "/init",
+        description: "Init CLAUDE.md",
+        args: &[],
+    },
+    CommandDef {
+        name: "/help",
+        description: "Show commands",
+        args: &[],
+    },
+    CommandDef {
+        name: "/clear",
+        description: "Clear chat",
+        args: &[],
+    },
+    CommandDef {
+        name: "/quit",
+        description: "Exit",
+        args: &[],
+    },
 ];
 
 pub struct App {
@@ -144,6 +215,8 @@ pub struct App {
     pub bypass_permissions: bool,
     pub mode: String,
     pub active_subagent_ids: HashSet<String>,
+    pub chat_dirty: bool,
+    pub chat_version: u64,
 }
 
 // StreamChunk and parsing delegated to backend trait — see backend/mod.rs
@@ -166,8 +239,16 @@ fn detect_git_branch() -> String {
 pub const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 impl App {
+    pub fn mark_chat_changed(&mut self) {
+        self.chat_version = self.chat_version.wrapping_add(1);
+        self.chat_dirty = true;
+    }
+
     pub fn spinner_frame(&self) -> &'static str {
-        let elapsed = self.turn_start.map(|t| t.elapsed().as_millis()).unwrap_or(0);
+        let elapsed = self
+            .turn_start
+            .map(|t| t.elapsed().as_millis())
+            .unwrap_or(0);
         let idx = (elapsed / 80) as usize % SPINNER_FRAMES.len();
         SPINNER_FRAMES[idx]
     }
@@ -177,7 +258,11 @@ impl App {
         let bypass = platform::env_flag("DEUS_TUI_BYPASS");
         let mode = platform::env_var("DEUS_TUI_MODE").unwrap_or_else(|| "home".to_string());
         let backend = platform::env_var("DEUS_TUI_BACKEND").unwrap_or_else(|| "claude".to_string());
-        let default_model = if backend == "codex" { "gpt-5.4" } else { "sonnet" };
+        let default_model = if backend == "codex" {
+            "gpt-5.4"
+        } else {
+            "sonnet"
+        };
 
         let mut app = Self {
             tab: Tab::Chat,
@@ -191,7 +276,10 @@ impl App {
             suggestions: Vec::new(),
             arg_suggestions: Vec::new(),
             suggestion_cursor: 0,
-            chat_messages: vec![ChatMessage::simple("system", "Welcome to Deus. Type a message or / for commands.")],
+            chat_messages: vec![ChatMessage::simple(
+                "system",
+                "Welcome to Deus. Type a message or / for commands.",
+            )],
             chat_state: ChatState::Idle,
             stream_rx: None,
             turn_count: 0,
@@ -217,13 +305,15 @@ impl App {
             bypass_permissions: bypass,
             mode,
             active_subagent_ids: HashSet::new(),
+            chat_dirty: true,
+            chat_version: 0,
         };
         app.refresh();
 
-        if let Some(prompt) = platform::env_var("DEUS_TUI_INITIAL_PROMPT") {
-            if !prompt.is_empty() {
-                app.dispatch_message(prompt);
-            }
+        if let Some(prompt) = platform::env_var("DEUS_TUI_INITIAL_PROMPT")
+            && !prompt.is_empty()
+        {
+            app.dispatch_message(prompt);
         }
 
         app
@@ -272,12 +362,14 @@ impl App {
             self.input_cursor = 0;
             self.suggestions.clear();
             self.arg_suggestions.clear();
+            self.mark_chat_changed();
             return;
         }
 
         if matches!(self.chat_state, ChatState::Streaming) {
             self.queued_messages.push(msg);
-            self.chat_messages.push(ChatMessage::simple("system", "(queued)"));
+            self.chat_messages
+                .push(ChatMessage::simple("system", "(queued)"));
             self.input.clear();
             self.input_cursor = 0;
             self.suggestions.clear();
@@ -297,6 +389,7 @@ impl App {
         self.chat_state = ChatState::Streaming;
         self.turn_start = Some(Instant::now());
         self.last_thinking_summary = None;
+        self.mark_chat_changed();
         self.scroll_to_bottom();
 
         let (tx, rx) = mpsc::channel();
@@ -306,7 +399,11 @@ impl App {
             message: msg,
             effort: self.effort.clone(),
             is_continuation: self.turn_count > 0,
-            system_context_file: if self.turn_count == 0 { self.system_context_file.clone() } else { None },
+            system_context_file: if self.turn_count == 0 {
+                self.system_context_file.clone()
+            } else {
+                None
+            },
             bypass_permissions: self.bypass_permissions,
         };
         self.turn_count += 1;
@@ -324,7 +421,9 @@ impl App {
                             let mut reader = BufReader::new(stderr);
                             let _ = reader.read_to_string(&mut buf);
                             if !buf.trim().is_empty() {
-                                let _ = tx2.send(backend::StreamChunk { kind: ChunkKind::Error(buf.trim().to_string()) });
+                                let _ = tx2.send(backend::StreamChunk {
+                                    kind: ChunkKind::Error(buf.trim().to_string()),
+                                });
                             }
                         })
                     });
@@ -338,19 +437,29 @@ impl App {
                                     }
                                 }
                                 Err(e) => {
-                                    let _ = tx.send(backend::StreamChunk { kind: ChunkKind::Error(e.to_string()) });
+                                    let _ = tx.send(backend::StreamChunk {
+                                        kind: ChunkKind::Error(e.to_string()),
+                                    });
                                     break;
                                 }
                             }
                         }
                     }
                     let _ = process.wait();
-                    if let Some(h) = stderr_handle { let _ = h.join(); }
-                    let _ = tx.send(backend::StreamChunk { kind: ChunkKind::Done });
+                    if let Some(h) = stderr_handle {
+                        let _ = h.join();
+                    }
+                    let _ = tx.send(backend::StreamChunk {
+                        kind: ChunkKind::Done,
+                    });
                 }
                 Err(e) => {
-                    let _ = tx.send(backend::StreamChunk { kind: ChunkKind::Error(format!("Failed to launch: {}", e)) });
-                    let _ = tx.send(backend::StreamChunk { kind: ChunkKind::Done });
+                    let _ = tx.send(backend::StreamChunk {
+                        kind: ChunkKind::Error(format!("Failed to launch: {}", e)),
+                    });
+                    let _ = tx.send(backend::StreamChunk {
+                        kind: ChunkKind::Done,
+                    });
                 }
             }
         });
@@ -368,17 +477,42 @@ impl App {
         let arg = parts.get(1).unwrap_or(&"").trim();
 
         match cmd {
-            "/wardens" if arg.is_empty() => { self.tab = Tab::Wardens; self.cursor = 0; true }
+            "/wardens" if arg.is_empty() => {
+                self.tab = Tab::Wardens;
+                self.cursor = 0;
+                true
+            }
             "/wardens" => {
                 // /wardens enable|disable|reset <name> → pass to python CLI
                 false
             }
-            "/services" => { self.tab = Tab::Services; self.cursor = 0; true }
-            "/channels" => { self.tab = Tab::Channels; self.cursor = 0; true }
-            "/config" => { self.tab = Tab::Config; self.cursor = 0; true }
-            "/status" => { self.tab = Tab::Status; self.cursor = 0; true }
-            "/clear" => { self.chat_messages.clear(); true }
-            "/quit" => { std::process::exit(0); }
+            "/services" => {
+                self.tab = Tab::Services;
+                self.cursor = 0;
+                true
+            }
+            "/channels" => {
+                self.tab = Tab::Channels;
+                self.cursor = 0;
+                true
+            }
+            "/config" => {
+                self.tab = Tab::Config;
+                self.cursor = 0;
+                true
+            }
+            "/status" => {
+                self.tab = Tab::Status;
+                self.cursor = 0;
+                true
+            }
+            "/clear" => {
+                self.chat_messages.clear();
+                true
+            }
+            "/quit" => {
+                std::process::exit(0);
+            }
             "/model" => {
                 let ids = model_ids();
                 if arg.is_empty() {
@@ -392,16 +526,30 @@ impl App {
                     )));
                 } else if arg == "claude" {
                     let models = models_for_backend("claude");
-                    self.chat_messages.push(ChatMessage::simple("system", &format!(
-                        "Claude models:\n{}",
-                        models.iter().map(|m| format!("  {}", m)).collect::<Vec<_>>().join("\n"),
-                    )));
+                    self.chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!(
+                            "Claude models:\n{}",
+                            models
+                                .iter()
+                                .map(|m| format!("  {}", m))
+                                .collect::<Vec<_>>()
+                                .join("\n"),
+                        ),
+                    ));
                 } else if arg == "codex" {
                     let models = models_for_backend("codex");
-                    self.chat_messages.push(ChatMessage::simple("system", &format!(
-                        "Codex models:\n{}",
-                        models.iter().map(|m| format!("  {}", m)).collect::<Vec<_>>().join("\n"),
-                    )));
+                    self.chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!(
+                            "Codex models:\n{}",
+                            models
+                                .iter()
+                                .map(|m| format!("  {}", m))
+                                .collect::<Vec<_>>()
+                                .join("\n"),
+                        ),
+                    ));
                 } else if ids.contains(&arg) {
                     let prev_backend = model_backend(&self.model);
                     let new_backend = model_backend(arg);
@@ -413,36 +561,57 @@ impl App {
                             model_display(&self.model), new_backend, prev_backend, new_backend
                         )));
                     } else {
-                        self.chat_messages.push(ChatMessage::simple("system", &format!(
-                            "Switched to {} [{}]", model_display(&self.model), new_backend
-                        )));
+                        self.chat_messages.push(ChatMessage::simple(
+                            "system",
+                            &format!(
+                                "Switched to {} [{}]",
+                                model_display(&self.model),
+                                new_backend
+                            ),
+                        ));
                     }
                 } else {
-                    self.chat_messages.push(ChatMessage::simple("system", &format!(
-                        "Unknown model: {}. Try /model to see available models.", arg
-                    )));
+                    self.chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!(
+                            "Unknown model: {}. Try /model to see available models.",
+                            arg
+                        ),
+                    ));
                 }
                 true
             }
             "/effort" => {
                 if arg.is_empty() {
-                    self.chat_messages.push(ChatMessage::simple("system", &format!(
-                        "Current effort: {}. Available: {}", self.effort, EFFORT_LEVELS.join(", ")
-                    )));
+                    self.chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!(
+                            "Current effort: {}. Available: {}",
+                            self.effort,
+                            EFFORT_LEVELS.join(", ")
+                        ),
+                    ));
                 } else if EFFORT_LEVELS.contains(&arg) {
                     self.effort = arg.to_string();
-                    self.chat_messages.push(ChatMessage::simple("system", &format!(
-                        "Effort set to {}", self.effort
-                    )));
+                    self.chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!("Effort set to {}", self.effort),
+                    ));
                 } else {
-                    self.chat_messages.push(ChatMessage::simple("system", &format!(
-                        "Unknown effort: {}. Available: {}", arg, EFFORT_LEVELS.join(", ")
-                    )));
+                    self.chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!(
+                            "Unknown effort: {}. Available: {}",
+                            arg,
+                            EFFORT_LEVELS.join(", ")
+                        ),
+                    ));
                 }
                 true
             }
             "/help" => {
-                let help: String = COMMANDS.iter()
+                let help: String = COMMANDS
+                    .iter()
                     .map(|c| format!("  {:16} {}", c.name, c.description))
                     .collect::<Vec<_>>()
                     .join("\n");
@@ -450,7 +619,10 @@ impl App {
                 true
             }
             "/history" => {
-                self.chat_messages.push(ChatMessage::simple("system", "Session history browsing coming in Phase 2."));
+                self.chat_messages.push(ChatMessage::simple(
+                    "system",
+                    "Session history browsing coming in Phase 2.",
+                ));
                 true
             }
             "/init" | "/compress" | "/checkpoint" | "/compact" | "/resume" => {
@@ -466,74 +638,94 @@ impl App {
 
     pub fn poll_response(&mut self) {
         if let Some(rx) = &self.stream_rx {
+            let mut had_chunks = false;
             while let Ok(chunk) = rx.try_recv() {
+                had_chunks = true;
                 match chunk.kind {
                     ChunkKind::Text(text) => {
-                        if let Some(last) = self.chat_messages.last_mut() {
-                            if last.role == "assistant" {
-                                if !last.content.is_empty() {
-                                    last.content.push('\n');
-                                }
-                                last.content.push_str(&text);
-                                last.blocks.push(MessageBlock::Text(text));
+                        if let Some(last) = self.chat_messages.last_mut()
+                            && last.role == "assistant"
+                        {
+                            if !last.content.is_empty() {
+                                last.content.push('\n');
                             }
+                            last.content.push_str(&text);
+                            last.blocks.push(MessageBlock::Text(text));
                         }
                     }
                     ChunkKind::Thinking(text) => {
                         let summary: String = text.chars().take(100).collect();
-                        self.last_thinking_summary = Some(
-                            if summary.len() < text.len() { format!("{}...", summary) } else { summary }
-                        );
-                        if let Some(last) = self.chat_messages.last_mut() {
-                            if last.role == "assistant" {
-                                last.blocks.push(MessageBlock::Thinking(text));
-                            }
+                        self.last_thinking_summary = Some(if summary.len() < text.len() {
+                            format!("{}...", summary)
+                        } else {
+                            summary
+                        });
+                        if let Some(last) = self.chat_messages.last_mut()
+                            && last.role == "assistant"
+                        {
+                            last.blocks.push(MessageBlock::Thinking(text));
                         }
                     }
                     ChunkKind::ToolUse { id, tool, detail } => {
-                        if let Some(last) = self.chat_messages.last_mut() {
-                            if last.role == "assistant" {
-                                let line = format!("[{}] {}", tool, detail);
-                                if !last.content.is_empty() {
-                                    last.content.push('\n');
-                                }
-                                last.content.push_str(&line);
-                                last.blocks.push(MessageBlock::ToolUse { id, tool, detail });
+                        if let Some(last) = self.chat_messages.last_mut()
+                            && last.role == "assistant"
+                        {
+                            let line = format!("[{}] {}", tool, detail);
+                            if !last.content.is_empty() {
+                                last.content.push('\n');
                             }
+                            last.content.push_str(&line);
+                            last.blocks.push(MessageBlock::ToolUse { id, tool, detail });
                         }
                     }
-                    ChunkKind::SubagentStart { id, subagent_type, description } => {
+                    ChunkKind::SubagentStart {
+                        id,
+                        subagent_type,
+                        description,
+                    } => {
                         let is_warden = self.is_warden_name(&subagent_type);
                         self.active_subagent_ids.insert(id.clone());
-                        if let Some(last) = self.chat_messages.last_mut() {
-                            if last.role == "assistant" {
-                                last.blocks.push(MessageBlock::SubagentBlock {
-                                    id,
-                                    subagent_type,
-                                    description,
-                                    status: SubagentStatus::Running,
-                                    output_preview: None,
-                                    is_warden,
-                                });
-                            }
+                        if let Some(last) = self.chat_messages.last_mut()
+                            && last.role == "assistant"
+                        {
+                            last.blocks.push(MessageBlock::SubagentBlock {
+                                id,
+                                subagent_type,
+                                description,
+                                status: SubagentStatus::Running,
+                                output_preview: None,
+                                is_warden,
+                            });
                         }
                     }
-                    ChunkKind::ToolResult { id, content_preview } => {
-                        if self.active_subagent_ids.remove(&id) {
-                            if let Some(last) = self.chat_messages.last_mut() {
-                                for block in &mut last.blocks {
-                                    if let MessageBlock::SubagentBlock { id: bid, status, output_preview: preview, .. } = block {
-                                        if *bid == id {
-                                            *status = SubagentStatus::Completed;
-                                            *preview = Some(content_preview.clone());
-                                            break;
-                                        }
-                                    }
+                    ChunkKind::ToolResult {
+                        id,
+                        content_preview,
+                    } => {
+                        if self.active_subagent_ids.remove(&id)
+                            && let Some(last) = self.chat_messages.last_mut()
+                        {
+                            for block in &mut last.blocks {
+                                if let MessageBlock::SubagentBlock {
+                                    id: bid,
+                                    status,
+                                    output_preview: preview,
+                                    ..
+                                } = block
+                                    && *bid == id
+                                {
+                                    *status = SubagentStatus::Completed;
+                                    *preview = Some(content_preview.clone());
+                                    break;
                                 }
                             }
                         }
                     }
-                    ChunkKind::CostUpdate { cost_usd, input_tokens, output_tokens } => {
+                    ChunkKind::CostUpdate {
+                        cost_usd,
+                        input_tokens,
+                        output_tokens,
+                    } => {
                         self.cost_usd = cost_usd;
                         self.token_count = (input_tokens + output_tokens) as u32;
                     }
@@ -543,6 +735,7 @@ impl App {
                         self.last_turn_duration = self.turn_start.map(|t| t.elapsed());
                         self.turn_start = None;
                         self.active_subagent_ids.clear();
+                        self.mark_chat_changed();
                         if !self.queued_messages.is_empty() {
                             let next = self.queued_messages.remove(0);
                             self.dispatch_message(next);
@@ -550,13 +743,16 @@ impl App {
                         return;
                     }
                     ChunkKind::Error(e) => {
-                        if let Some(last) = self.chat_messages.last_mut() {
-                            if last.role == "assistant" {
-                                last.content.push_str(&format!("\n[Error: {}]", e));
-                            }
+                        if let Some(last) = self.chat_messages.last_mut()
+                            && last.role == "assistant"
+                        {
+                            last.content.push_str(&format!("\n[Error: {}]", e));
                         }
                     }
                 }
+            }
+            if had_chunks {
+                self.mark_chat_changed();
             }
         }
     }
@@ -596,7 +792,8 @@ impl App {
                         self.arg_suggestions = all;
                     }
                 } else if !cmd.args.is_empty() {
-                    self.arg_suggestions = cmd.args
+                    self.arg_suggestions = cmd
+                        .args
                         .iter()
                         .filter(|a| a.starts_with(arg_part))
                         .map(|a| a.to_string())
@@ -624,7 +821,8 @@ impl App {
     }
 
     pub fn has_suggestions(&self) -> bool {
-        (!self.suggestions.is_empty() || !self.arg_suggestions.is_empty()) && self.input.starts_with('/')
+        (!self.suggestions.is_empty() || !self.arg_suggestions.is_empty())
+            && self.input.starts_with('/')
     }
 
     pub fn dismiss_suggestions(&mut self) {
@@ -717,9 +915,7 @@ impl App {
         }
         let before = &self.input[..self.input_cursor];
         let end = before.trim_end().len();
-        let word_start = before[..end].rfind(' ')
-            .map(|i| i + 1)
-            .unwrap_or(0);
+        let word_start = before[..end].rfind(' ').map(|i| i + 1).unwrap_or(0);
         self.input.drain(word_start..self.input_cursor);
         self.input_cursor = word_start;
         self.update_suggestions();
@@ -766,13 +962,25 @@ impl App {
     }
 
     pub fn input_delete_current_line(&mut self) {
-        let line_start = self.input[..self.input_cursor].rfind('\n').map(|i| i + 1).unwrap_or(0);
-        let line_end = self.input[self.input_cursor..].find('\n')
+        let line_start = self.input[..self.input_cursor]
+            .rfind('\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let line_end = self.input[self.input_cursor..]
+            .find('\n')
             .map(|i| self.input_cursor + i)
             .unwrap_or(self.input.len());
         // Remove the line and the preceding newline if not the first line
-        let drain_start = if line_start > 0 { line_start - 1 } else { line_start };
-        let drain_end = if line_end < self.input.len() && drain_start == line_start { line_end + 1 } else { line_end };
+        let drain_start = if line_start > 0 {
+            line_start - 1
+        } else {
+            line_start
+        };
+        let drain_end = if line_end < self.input.len() && drain_start == line_start {
+            line_end + 1
+        } else {
+            line_end
+        };
         self.input.drain(drain_start..drain_end);
         self.input_cursor = drain_start.min(self.input.len());
         self.update_suggestions();
@@ -819,11 +1027,16 @@ impl App {
         self.update_suggestions();
     }
 
+    #[allow(dead_code)]
     pub fn session_duration(&self) -> String {
         let secs = self.session_start.elapsed().as_secs();
-        if secs < 60 { format!("{}s", secs) }
-        else if secs < 3600 { format!("{}m", secs / 60) }
-        else { format!("{}h{}m", secs / 3600, (secs % 3600) / 60) }
+        if secs < 60 {
+            format!("{}s", secs)
+        } else if secs < 3600 {
+            format!("{}m", secs / 60)
+        } else {
+            format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+        }
     }
 
     pub fn toggle_tools(&mut self) {
@@ -862,20 +1075,24 @@ impl App {
     }
 
     pub fn input_word_left(&mut self) {
-        if self.input_cursor == 0 { return; }
+        if self.input_cursor == 0 {
+            return;
+        }
         let before = &self.input[..self.input_cursor];
         let trimmed = before.trim_end();
-        let pos = trimmed.rfind(|c: char| c == ' ' || c == '\n')
-            .map(|i| i + 1)
-            .unwrap_or(0);
+        let pos = trimmed.rfind([' ', '\n']).map(|i| i + 1).unwrap_or(0);
         self.input_cursor = pos;
     }
 
     pub fn input_word_right(&mut self) {
-        if self.input_cursor >= self.input.len() { return; }
+        if self.input_cursor >= self.input.len() {
+            return;
+        }
         let after = &self.input[self.input_cursor..];
-        let skip_word = after.find(|c: char| c == ' ' || c == '\n').unwrap_or(after.len());
-        let skip_space = after[skip_word..].find(|c: char| c != ' ' && c != '\n').unwrap_or(after.len() - skip_word);
+        let skip_word = after.find([' ', '\n']).unwrap_or(after.len());
+        let skip_space = after[skip_word..]
+            .find(|c: char| !matches!(c, ' ' | '\n'))
+            .unwrap_or(after.len() - skip_word);
         self.input_cursor += skip_word + skip_space;
     }
 
@@ -909,10 +1126,16 @@ impl App {
     pub fn input_line_down(&mut self) {
         let after = &self.input[self.input_cursor..];
         if let Some(nl) = after.find('\n') {
-            let line_start = self.input[..self.input_cursor].rfind('\n').map(|i| i + 1).unwrap_or(0);
+            let line_start = self.input[..self.input_cursor]
+                .rfind('\n')
+                .map(|i| i + 1)
+                .unwrap_or(0);
             let col = self.input_cursor - line_start;
             let next_start = self.input_cursor + nl + 1;
-            let next_end = self.input[next_start..].find('\n').map(|i| next_start + i).unwrap_or(self.input.len());
+            let next_end = self.input[next_start..]
+                .find('\n')
+                .map(|i| next_start + i)
+                .unwrap_or(self.input.len());
             let next_len = next_end - next_start;
             self.input_cursor = next_start + col.min(next_len);
         }
@@ -926,8 +1149,11 @@ impl App {
         };
         dur.map(|d| {
             let secs = d.as_secs();
-            if secs < 60 { format!("{}s", secs) }
-            else { format!("{}m{}s", secs / 60, secs % 60) }
+            if secs < 60 {
+                format!("{}s", secs)
+            } else {
+                format!("{}m{}s", secs / 60, secs % 60)
+            }
         })
     }
 

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,12 +1,13 @@
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read as _};
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::config;
-
-
+use crate::platform;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
@@ -31,11 +32,25 @@ impl Tab {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SubagentStatus {
+    Running,
+    Completed,
+}
+
 #[derive(Clone)]
 pub enum MessageBlock {
     Text(String),
     Thinking(String),
-    ToolUse { tool: String, detail: String },
+    ToolUse { id: String, tool: String, detail: String },
+    SubagentBlock {
+        id: String,
+        subagent_type: String,
+        description: String,
+        status: SubagentStatus,
+        output_preview: Option<String>,
+        is_warden: bool,
+    },
 }
 
 #[derive(Clone)]
@@ -125,6 +140,10 @@ pub struct App {
     pub services: Vec<config::healthcheck::ServiceEntry>,
     pub channels: Vec<config::channels::ChannelEntry>,
     pub deus_config: Vec<(String, String)>,
+    pub system_context_file: Option<PathBuf>,
+    pub bypass_permissions: bool,
+    pub mode: String,
+    pub active_subagent_ids: HashSet<String>,
 }
 
 // StreamChunk and parsing delegated to backend trait — see backend/mod.rs
@@ -154,6 +173,12 @@ impl App {
     }
 
     pub fn new() -> Self {
+        let ctx_file = platform::env_var("DEUS_TUI_CONTEXT_FILE").map(PathBuf::from);
+        let bypass = platform::env_flag("DEUS_TUI_BYPASS");
+        let mode = platform::env_var("DEUS_TUI_MODE").unwrap_or_else(|| "home".to_string());
+        let backend = platform::env_var("DEUS_TUI_BACKEND").unwrap_or_else(|| "claude".to_string());
+        let default_model = if backend == "codex" { "gpt-5.4" } else { "sonnet" };
+
         let mut app = Self {
             tab: Tab::Chat,
             cursor: 0,
@@ -170,7 +195,7 @@ impl App {
             chat_state: ChatState::Idle,
             stream_rx: None,
             turn_count: 0,
-            model: "sonnet".to_string(),
+            model: default_model.to_string(),
             effort: "high".to_string(),
             token_count: 0,
             cost_usd: 0.0,
@@ -188,8 +213,19 @@ impl App {
             services: Vec::new(),
             channels: Vec::new(),
             deus_config: Vec::new(),
+            system_context_file: ctx_file,
+            bypass_permissions: bypass,
+            mode,
+            active_subagent_ids: HashSet::new(),
         };
         app.refresh();
+
+        if let Some(prompt) = platform::env_var("DEUS_TUI_INITIAL_PROMPT") {
+            if !prompt.is_empty() {
+                app.dispatch_message(prompt);
+            }
+        }
+
         app
     }
 
@@ -270,6 +306,8 @@ impl App {
             message: msg,
             effort: self.effort.clone(),
             is_continuation: self.turn_count > 0,
+            system_context_file: if self.turn_count == 0 { self.system_context_file.clone() } else { None },
+            bypass_permissions: self.bypass_permissions,
         };
         self.turn_count += 1;
         let be = backend::backend_for(&config.model);
@@ -295,7 +333,7 @@ impl App {
                         for line in reader.lines() {
                             match line {
                                 Ok(text) => {
-                                    if let Some(chunk) = be.parse_line(&text) {
+                                    for chunk in be.parse_line(&text) {
                                         let _ = tx.send(chunk);
                                     }
                                 }
@@ -422,6 +460,10 @@ impl App {
         }
     }
 
+    fn is_warden_name(&self, name: &str) -> bool {
+        self.wardens.iter().any(|w| w.name == name)
+    }
+
     pub fn poll_response(&mut self) {
         if let Some(rx) = &self.stream_rx {
             while let Ok(chunk) = rx.try_recv() {
@@ -448,7 +490,7 @@ impl App {
                             }
                         }
                     }
-                    ChunkKind::ToolUse { tool, detail } => {
+                    ChunkKind::ToolUse { id, tool, detail } => {
                         if let Some(last) = self.chat_messages.last_mut() {
                             if last.role == "assistant" {
                                 let line = format!("[{}] {}", tool, detail);
@@ -456,11 +498,41 @@ impl App {
                                     last.content.push('\n');
                                 }
                                 last.content.push_str(&line);
-                                last.blocks.push(MessageBlock::ToolUse { tool, detail });
+                                last.blocks.push(MessageBlock::ToolUse { id, tool, detail });
                             }
                         }
                     }
-                    ChunkKind::ToolResult => {}
+                    ChunkKind::SubagentStart { id, subagent_type, description } => {
+                        let is_warden = self.is_warden_name(&subagent_type);
+                        self.active_subagent_ids.insert(id.clone());
+                        if let Some(last) = self.chat_messages.last_mut() {
+                            if last.role == "assistant" {
+                                last.blocks.push(MessageBlock::SubagentBlock {
+                                    id,
+                                    subagent_type,
+                                    description,
+                                    status: SubagentStatus::Running,
+                                    output_preview: None,
+                                    is_warden,
+                                });
+                            }
+                        }
+                    }
+                    ChunkKind::ToolResult { id, content_preview } => {
+                        if self.active_subagent_ids.remove(&id) {
+                            if let Some(last) = self.chat_messages.last_mut() {
+                                for block in &mut last.blocks {
+                                    if let MessageBlock::SubagentBlock { id: bid, status, output_preview: preview, .. } = block {
+                                        if *bid == id {
+                                            *status = SubagentStatus::Completed;
+                                            *preview = Some(content_preview.clone());
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     ChunkKind::CostUpdate { cost_usd, input_tokens, output_tokens } => {
                         self.cost_usd = cost_usd;
                         self.token_count = (input_tokens + output_tokens) as u32;
@@ -470,6 +542,7 @@ impl App {
                         self.stream_rx = None;
                         self.last_turn_duration = self.turn_start.map(|t| t.elapsed());
                         self.turn_start = None;
+                        self.active_subagent_ids.clear();
                         if !self.queued_messages.is_empty() {
                             let next = self.queued_messages.remove(0);
                             self.dispatch_message(next);

--- a/tui/src/backend/claude.rs
+++ b/tui/src/backend/claude.rs
@@ -1,39 +1,71 @@
+use super::{Backend, ChunkKind, ModelDef, RunConfig, SUBAGENT_TOOLS_CLAUDE, StreamChunk};
 use std::process::{Command, Stdio};
-use super::{Backend, ModelDef, RunConfig, StreamChunk, ChunkKind, SUBAGENT_TOOLS_CLAUDE};
 
 pub struct ClaudeBackend;
 
 static MODELS: &[ModelDef] = &[
-    ModelDef { id: "opus-4-7", display: "Opus 4.7", context: "200K" },
-    ModelDef { id: "opus", display: "Opus 4.6", context: "1M" },
-    ModelDef { id: "opus-200k", display: "Opus 4.6", context: "200K" },
-    ModelDef { id: "sonnet", display: "Sonnet 4.6", context: "200K" },
-    ModelDef { id: "haiku", display: "Haiku 4.5", context: "200K" },
+    ModelDef {
+        id: "opus-4-7",
+        display: "Opus 4.7",
+        context: "200K",
+    },
+    ModelDef {
+        id: "opus",
+        display: "Opus 4.6",
+        context: "1M",
+    },
+    ModelDef {
+        id: "opus-200k",
+        display: "Opus 4.6",
+        context: "200K",
+    },
+    ModelDef {
+        id: "sonnet",
+        display: "Sonnet 4.6",
+        context: "200K",
+    },
+    ModelDef {
+        id: "haiku",
+        display: "Haiku 4.5",
+        context: "200K",
+    },
 ];
 
 impl Backend for ClaudeBackend {
-    fn name(&self) -> &'static str { "claude" }
-    fn display_name(&self) -> &'static str { "Anthropic (Claude)" }
-    fn models(&self) -> &'static [ModelDef] { MODELS }
+    fn name(&self) -> &'static str {
+        "claude"
+    }
+    fn display_name(&self) -> &'static str {
+        "Anthropic (Claude)"
+    }
+    fn models(&self) -> &'static [ModelDef] {
+        MODELS
+    }
 
     fn build_command(&self, config: &RunConfig) -> Command {
         let mut cmd = Command::new("claude");
-        cmd.args(["-p", "--output-format", "stream-json", "--verbose",
-            "--model", &config.model, "--effort", &config.effort]);
+        cmd.args([
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--model",
+            &config.model,
+            "--effort",
+            &config.effort,
+        ]);
         if config.bypass_permissions {
             cmd.arg("--dangerously-skip-permissions");
         }
         if config.is_continuation {
             cmd.arg("--continue");
         }
-        if !config.is_continuation {
-            if let Some(ref ctx_file) = config.system_context_file {
-                if let Ok(ctx) = std::fs::read_to_string(ctx_file) {
-                    if !ctx.is_empty() {
-                        cmd.args(["--append-system-prompt", &ctx]);
-                    }
-                }
-            }
+        if !config.is_continuation
+            && let Some(ref ctx_file) = config.system_context_file
+            && let Ok(ctx) = std::fs::read_to_string(ctx_file)
+            && !ctx.is_empty()
+        {
+            cmd.args(["--append-system-prompt", &ctx]);
         }
         cmd.arg(&config.message);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -52,7 +84,11 @@ impl Backend for ClaudeBackend {
 
         match event_type {
             "assistant" => {
-                let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+                let content = match v
+                    .get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                {
                     Some(c) => c,
                     None => return Vec::new(),
                 };
@@ -65,17 +101,28 @@ impl Backend for ClaudeBackend {
                     match block_type {
                         "text" => {
                             if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
-                                chunks.push(StreamChunk { kind: ChunkKind::Text(text.to_string()) });
+                                chunks.push(StreamChunk {
+                                    kind: ChunkKind::Text(text.to_string()),
+                                });
                             }
                         }
                         "thinking" => {
                             if let Some(text) = block.get("thinking").and_then(|t| t.as_str()) {
-                                chunks.push(StreamChunk { kind: ChunkKind::Thinking(text.to_string()) });
+                                chunks.push(StreamChunk {
+                                    kind: ChunkKind::Thinking(text.to_string()),
+                                });
                             }
                         }
                         "tool_use" => {
-                            let id = block.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
-                            let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
+                            let id = block
+                                .get("id")
+                                .and_then(|i| i.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let name = block
+                                .get("name")
+                                .and_then(|n| n.as_str())
+                                .unwrap_or("unknown");
                             let input = block.get("input");
 
                             if SUBAGENT_TOOLS_CLAUDE.contains(&name) {
@@ -90,22 +137,37 @@ impl Backend for ClaudeBackend {
                                     .unwrap_or("")
                                     .to_string();
                                 chunks.push(StreamChunk {
-                                    kind: ChunkKind::SubagentStart { id, subagent_type, description },
+                                    kind: ChunkKind::SubagentStart {
+                                        id,
+                                        subagent_type,
+                                        description,
+                                    },
                                 });
                             } else {
-                                let detail = input.map(|i| {
-                                    if let Some(cmd) = i.get("command").and_then(|c| c.as_str()) {
-                                        cmd.chars().take(80).collect::<String>()
-                                    } else if let Some(path) = i.get("file_path").and_then(|p| p.as_str()) {
-                                        path.to_string()
-                                    } else if let Some(desc) = i.get("description").and_then(|d| d.as_str()) {
-                                        desc.chars().take(80).collect::<String>()
-                                    } else {
-                                        String::new()
-                                    }
-                                }).unwrap_or_default();
+                                let detail = input
+                                    .map(|i| {
+                                        if let Some(cmd) = i.get("command").and_then(|c| c.as_str())
+                                        {
+                                            cmd.chars().take(80).collect::<String>()
+                                        } else if let Some(path) =
+                                            i.get("file_path").and_then(|p| p.as_str())
+                                        {
+                                            path.to_string()
+                                        } else if let Some(desc) =
+                                            i.get("description").and_then(|d| d.as_str())
+                                        {
+                                            desc.chars().take(80).collect::<String>()
+                                        } else {
+                                            String::new()
+                                        }
+                                    })
+                                    .unwrap_or_default();
                                 chunks.push(StreamChunk {
-                                    kind: ChunkKind::ToolUse { id, tool: name.to_string(), detail },
+                                    kind: ChunkKind::ToolUse {
+                                        id,
+                                        tool: name.to_string(),
+                                        detail,
+                                    },
                                 });
                             }
                         }
@@ -115,28 +177,54 @@ impl Backend for ClaudeBackend {
                 chunks
             }
             "user" => {
-                let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+                let content = match v
+                    .get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                {
                     Some(c) => c,
                     None => return Vec::new(),
                 };
                 let mut chunks = Vec::new();
                 for block in content {
                     if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
-                        let id = block.get("tool_use_id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                        let id = block
+                            .get("tool_use_id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or("")
+                            .to_string();
                         let preview = extract_tool_result_preview(block);
                         chunks.push(StreamChunk {
-                            kind: ChunkKind::ToolResult { id, content_preview: preview },
+                            kind: ChunkKind::ToolResult {
+                                id,
+                                content_preview: preview,
+                            },
                         });
                     }
                 }
                 chunks
             }
             "result" => {
-                let cost = v.get("total_cost_usd").and_then(|c| c.as_f64()).unwrap_or(0.0);
+                let cost = v
+                    .get("total_cost_usd")
+                    .and_then(|c| c.as_f64())
+                    .unwrap_or(0.0);
                 let usage = v.get("usage");
-                let input = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                let output = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                vec![StreamChunk { kind: ChunkKind::CostUpdate { cost_usd: cost, input_tokens: input, output_tokens: output } }]
+                let input = usage
+                    .and_then(|u| u.get("input_tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0);
+                let output = usage
+                    .and_then(|u| u.get("output_tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0);
+                vec![StreamChunk {
+                    kind: ChunkKind::CostUpdate {
+                        cost_usd: cost,
+                        input_tokens: input,
+                        output_tokens: output,
+                    },
+                }]
             }
             _ => Vec::new(),
         }
@@ -157,4 +245,91 @@ fn extract_tool_result_preview(block: &serde_json::Value) -> String {
         }
     }
     String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Vec<ChunkKind> {
+        ClaudeBackend
+            .parse_line(json)
+            .into_iter()
+            .map(|c| c.kind)
+            .collect()
+    }
+
+    #[test]
+    fn parse_text_event() {
+        let json = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], ChunkKind::Text(t) if t == "hello"));
+    }
+
+    #[test]
+    fn parse_thinking_event() {
+        let json = r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"reasoning..."}]}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], ChunkKind::Thinking(t) if t == "reasoning..."));
+    }
+
+    #[test]
+    fn parse_tool_use_event() {
+        let json = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], ChunkKind::ToolUse { tool, .. } if tool == "Bash"));
+    }
+
+    #[test]
+    fn parse_subagent_event() {
+        let json = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"a1","name":"Agent","input":{"subagent_type":"Explore","description":"find files"}}]}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            matches!(&chunks[0], ChunkKind::SubagentStart { subagent_type, .. } if subagent_type == "Explore")
+        );
+    }
+
+    #[test]
+    fn parse_multi_block_event() {
+        let json = r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"answer"}]}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 2);
+        assert!(matches!(&chunks[0], ChunkKind::Thinking(_)));
+        assert!(matches!(&chunks[1], ChunkKind::Text(_)));
+    }
+
+    #[test]
+    fn parse_tool_result_with_id() {
+        let json = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            matches!(&chunks[0], ChunkKind::ToolResult { id, content_preview } if id == "t1" && content_preview == "output")
+        );
+    }
+
+    #[test]
+    fn parse_cost_update() {
+        let json = r#"{"type":"result","total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":200}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(
+            &chunks[0],
+            ChunkKind::CostUpdate {
+                input_tokens: 100,
+                output_tokens: 200,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_invalid_json() {
+        let chunks = parse("not json");
+        assert!(chunks.is_empty());
+    }
 }

--- a/tui/src/backend/claude.rs
+++ b/tui/src/backend/claude.rs
@@ -1,5 +1,5 @@
 use std::process::{Command, Stdio};
-use super::{Backend, ModelDef, RunConfig, StreamChunk, ChunkKind};
+use super::{Backend, ModelDef, RunConfig, StreamChunk, ChunkKind, SUBAGENT_TOOLS_CLAUDE};
 
 pub struct ClaudeBackend;
 
@@ -20,67 +20,141 @@ impl Backend for ClaudeBackend {
         let mut cmd = Command::new("claude");
         cmd.args(["-p", "--output-format", "stream-json", "--verbose",
             "--model", &config.model, "--effort", &config.effort]);
+        if config.bypass_permissions {
+            cmd.arg("--dangerously-skip-permissions");
+        }
         if config.is_continuation {
             cmd.arg("--continue");
+        }
+        if !config.is_continuation {
+            if let Some(ref ctx_file) = config.system_context_file {
+                if let Ok(ctx) = std::fs::read_to_string(ctx_file) {
+                    if !ctx.is_empty() {
+                        cmd.args(["--append-system-prompt", &ctx]);
+                    }
+                }
+            }
         }
         cmd.arg(&config.message);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         cmd
     }
 
-    fn parse_line(&self, line: &str) -> Option<StreamChunk> {
-        let v: serde_json::Value = serde_json::from_str(line).ok()?;
-        let event_type = v.get("type")?.as_str()?;
+    fn parse_line(&self, line: &str) -> Vec<StreamChunk> {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        let event_type = match v.get("type").and_then(|t| t.as_str()) {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
 
         match event_type {
             "assistant" => {
-                let content = v.get("message")?.get("content")?.as_array()?;
+                let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+                    Some(c) => c,
+                    None => return Vec::new(),
+                };
+                let mut chunks = Vec::new();
                 for block in content {
-                    let block_type = block.get("type")?.as_str()?;
+                    let block_type = match block.get("type").and_then(|t| t.as_str()) {
+                        Some(t) => t,
+                        None => continue,
+                    };
                     match block_type {
                         "text" => {
-                            let text = block.get("text")?.as_str()?;
-                            return Some(StreamChunk { kind: ChunkKind::Text(text.to_string()) });
+                            if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                                chunks.push(StreamChunk { kind: ChunkKind::Text(text.to_string()) });
+                            }
                         }
                         "thinking" => {
-                            let text = block.get("thinking")?.as_str()?;
-                            return Some(StreamChunk { kind: ChunkKind::Thinking(text.to_string()) });
+                            if let Some(text) = block.get("thinking").and_then(|t| t.as_str()) {
+                                chunks.push(StreamChunk { kind: ChunkKind::Thinking(text.to_string()) });
+                            }
                         }
                         "tool_use" => {
+                            let id = block.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
                             let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
-                            let input = block.get("input").map(|i| {
-                                if let Some(cmd) = i.get("command").and_then(|c| c.as_str()) {
-                                    cmd.chars().take(80).collect::<String>()
-                                } else if let Some(path) = i.get("file_path").and_then(|p| p.as_str()) {
-                                    path.to_string()
-                                } else {
-                                    String::new()
-                                }
-                            }).unwrap_or_default();
-                            return Some(StreamChunk { kind: ChunkKind::ToolUse { tool: name.to_string(), detail: input } });
+                            let input = block.get("input");
+
+                            if SUBAGENT_TOOLS_CLAUDE.contains(&name) {
+                                let subagent_type = input
+                                    .and_then(|i| i.get("subagent_type"))
+                                    .and_then(|s| s.as_str())
+                                    .unwrap_or(name)
+                                    .to_string();
+                                let description = input
+                                    .and_then(|i| i.get("description"))
+                                    .and_then(|d| d.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                chunks.push(StreamChunk {
+                                    kind: ChunkKind::SubagentStart { id, subagent_type, description },
+                                });
+                            } else {
+                                let detail = input.map(|i| {
+                                    if let Some(cmd) = i.get("command").and_then(|c| c.as_str()) {
+                                        cmd.chars().take(80).collect::<String>()
+                                    } else if let Some(path) = i.get("file_path").and_then(|p| p.as_str()) {
+                                        path.to_string()
+                                    } else if let Some(desc) = i.get("description").and_then(|d| d.as_str()) {
+                                        desc.chars().take(80).collect::<String>()
+                                    } else {
+                                        String::new()
+                                    }
+                                }).unwrap_or_default();
+                                chunks.push(StreamChunk {
+                                    kind: ChunkKind::ToolUse { id, tool: name.to_string(), detail },
+                                });
+                            }
                         }
                         _ => {}
                     }
                 }
-                None
+                chunks
             }
             "user" => {
-                let content = v.get("message")?.get("content")?.as_array()?;
+                let content = match v.get("message").and_then(|m| m.get("content")).and_then(|c| c.as_array()) {
+                    Some(c) => c,
+                    None => return Vec::new(),
+                };
+                let mut chunks = Vec::new();
                 for block in content {
-                    if block.get("type")?.as_str()? == "tool_result" {
-                        return Some(StreamChunk { kind: ChunkKind::ToolResult });
+                    if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                        let id = block.get("tool_use_id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                        let preview = extract_tool_result_preview(block);
+                        chunks.push(StreamChunk {
+                            kind: ChunkKind::ToolResult { id, content_preview: preview },
+                        });
                     }
                 }
-                None
+                chunks
             }
             "result" => {
                 let cost = v.get("total_cost_usd").and_then(|c| c.as_f64()).unwrap_or(0.0);
                 let usage = v.get("usage");
                 let input = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
                 let output = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                Some(StreamChunk { kind: ChunkKind::CostUpdate { cost_usd: cost, input_tokens: input, output_tokens: output } })
+                vec![StreamChunk { kind: ChunkKind::CostUpdate { cost_usd: cost, input_tokens: input, output_tokens: output } }]
             }
-            _ => None,
+            _ => Vec::new(),
         }
     }
+}
+
+fn extract_tool_result_preview(block: &serde_json::Value) -> String {
+    if let Some(content) = block.get("content") {
+        if let Some(s) = content.as_str() {
+            return s.chars().take(200).collect();
+        }
+        if let Some(arr) = content.as_array() {
+            for item in arr {
+                if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                    return text.chars().take(200).collect();
+                }
+            }
+        }
+    }
+    String::new()
 }

--- a/tui/src/backend/codex.rs
+++ b/tui/src/backend/codex.rs
@@ -1,20 +1,46 @@
+use super::{Backend, ChunkKind, ModelDef, RunConfig, SUBAGENT_TOOLS_CODEX, StreamChunk};
 use std::process::{Command, Stdio};
-use super::{Backend, ModelDef, RunConfig, StreamChunk, ChunkKind, SUBAGENT_TOOLS_CODEX};
 
 pub struct CodexBackend;
 
 static MODELS: &[ModelDef] = &[
-    ModelDef { id: "gpt-5.5", display: "GPT-5.5", context: "1M" },
-    ModelDef { id: "gpt-5.4", display: "GPT-5.4", context: "1M" },
-    ModelDef { id: "gpt-5.4-mini", display: "GPT-5.4 Mini", context: "1M" },
-    ModelDef { id: "o3", display: "o3", context: "200K" },
-    ModelDef { id: "o4-mini", display: "o4-mini", context: "200K" },
+    ModelDef {
+        id: "gpt-5.5",
+        display: "GPT-5.5",
+        context: "1M",
+    },
+    ModelDef {
+        id: "gpt-5.4",
+        display: "GPT-5.4",
+        context: "1M",
+    },
+    ModelDef {
+        id: "gpt-5.4-mini",
+        display: "GPT-5.4 Mini",
+        context: "1M",
+    },
+    ModelDef {
+        id: "o3",
+        display: "o3",
+        context: "200K",
+    },
+    ModelDef {
+        id: "o4-mini",
+        display: "o4-mini",
+        context: "200K",
+    },
 ];
 
 impl Backend for CodexBackend {
-    fn name(&self) -> &'static str { "codex" }
-    fn display_name(&self) -> &'static str { "OpenAI (GPT/o-series)" }
-    fn models(&self) -> &'static [ModelDef] { MODELS }
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+    fn display_name(&self) -> &'static str {
+        "OpenAI (GPT/o-series)"
+    }
+    fn models(&self) -> &'static [ModelDef] {
+        MODELS
+    }
 
     fn build_command(&self, config: &RunConfig) -> Command {
         let effort_cfg = format!("model_reasoning_effort=\"{}\"", config.effort);
@@ -39,7 +65,9 @@ impl Backend for CodexBackend {
             cmd.arg("--dangerously-bypass-approvals-and-sandbox");
         }
         cmd.arg(&message);
-        cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         cmd
     }
 
@@ -55,57 +83,170 @@ impl Backend for CodexBackend {
 
         match event_type {
             "item.completed" => {
-                if let Some(text) = v.get("item").and_then(|i| i.get("text")).and_then(|t| t.as_str()) {
-                    vec![StreamChunk { kind: ChunkKind::Text(text.to_string()) }]
+                if let Some(text) = v
+                    .get("item")
+                    .and_then(|i| i.get("text"))
+                    .and_then(|t| t.as_str())
+                {
+                    vec![StreamChunk {
+                        kind: ChunkKind::Text(text.to_string()),
+                    }]
                 } else {
                     Vec::new()
                 }
             }
             "function_call" => {
-                let id = v.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                let id = v
+                    .get("id")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("")
+                    .to_string();
                 let name = v.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
                 let args = v.get("arguments").and_then(|a| a.as_str()).unwrap_or("");
                 let detail: String = args.chars().take(80).collect();
 
                 if SUBAGENT_TOOLS_CODEX.contains(&name) {
                     let parsed = serde_json::from_str::<serde_json::Value>(args).ok();
-                    let subagent_type = parsed.as_ref()
+                    let subagent_type = parsed
+                        .as_ref()
                         .and_then(|a| a.get("type").and_then(|t| t.as_str()).map(String::from))
                         .unwrap_or_else(|| name.to_string());
-                    let description = parsed.as_ref()
-                        .and_then(|a| a.get("description").and_then(|d| d.as_str()).map(String::from))
+                    let description = parsed
+                        .as_ref()
+                        .and_then(|a| {
+                            a.get("description")
+                                .and_then(|d| d.as_str())
+                                .map(String::from)
+                        })
                         .unwrap_or_default();
                     vec![StreamChunk {
-                        kind: ChunkKind::SubagentStart { id, subagent_type, description },
+                        kind: ChunkKind::SubagentStart {
+                            id,
+                            subagent_type,
+                            description,
+                        },
                     }]
                 } else {
                     vec![StreamChunk {
-                        kind: ChunkKind::ToolUse { id, tool: name.to_string(), detail },
+                        kind: ChunkKind::ToolUse {
+                            id,
+                            tool: name.to_string(),
+                            detail,
+                        },
                     }]
                 }
             }
             "function_call_output" => {
-                let id = v.get("call_id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                let id = v
+                    .get("call_id")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("")
+                    .to_string();
                 let output = v.get("output").and_then(|o| o.as_str()).unwrap_or("");
                 let preview: String = output.chars().take(200).collect();
                 vec![StreamChunk {
-                    kind: ChunkKind::ToolResult { id, content_preview: preview },
+                    kind: ChunkKind::ToolResult {
+                        id,
+                        content_preview: preview,
+                    },
                 }]
             }
             "turn.completed" => {
                 let usage = v.get("usage");
-                let input = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                let output = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                vec![StreamChunk { kind: ChunkKind::CostUpdate { cost_usd: 0.0, input_tokens: input, output_tokens: output } }]
+                let input = usage
+                    .and_then(|u| u.get("input_tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0);
+                let output = usage
+                    .and_then(|u| u.get("output_tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0);
+                vec![StreamChunk {
+                    kind: ChunkKind::CostUpdate {
+                        cost_usd: 0.0,
+                        input_tokens: input,
+                        output_tokens: output,
+                    },
+                }]
             }
             "turn.failed" => {
-                let msg = v.get("error")
+                let msg = v
+                    .get("error")
                     .and_then(|e| e.get("message"))
                     .and_then(|m| m.as_str())
                     .unwrap_or("unknown error");
-                vec![StreamChunk { kind: ChunkKind::Error(msg.to_string()) }]
+                vec![StreamChunk {
+                    kind: ChunkKind::Error(msg.to_string()),
+                }]
             }
             _ => Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Vec<ChunkKind> {
+        CodexBackend
+            .parse_line(json)
+            .into_iter()
+            .map(|c| c.kind)
+            .collect()
+    }
+
+    #[test]
+    fn parse_item_completed() {
+        let json = r#"{"type":"item.completed","item":{"text":"hello world"}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], ChunkKind::Text(t) if t == "hello world"));
+    }
+
+    #[test]
+    fn parse_turn_failed() {
+        let json = r#"{"type":"turn.failed","error":{"message":"rate limited"}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], ChunkKind::Error(e) if e == "rate limited"));
+    }
+
+    #[test]
+    fn parse_turn_completed() {
+        let json = r#"{"type":"turn.completed","usage":{"input_tokens":50,"output_tokens":100}}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(
+            &chunks[0],
+            ChunkKind::CostUpdate {
+                input_tokens: 50,
+                output_tokens: 100,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_function_call_subagent() {
+        let json = r#"{"type":"function_call","id":"f1","name":"spawn_agent","arguments":"{\"type\":\"explore\",\"description\":\"search\"}"}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            matches!(&chunks[0], ChunkKind::SubagentStart { subagent_type, .. } if subagent_type == "explore")
+        );
+    }
+
+    #[test]
+    fn parse_function_call_regular() {
+        let json = r#"{"type":"function_call","id":"f2","name":"read_file","arguments":"{\"path\":\"/tmp/x\"}"}"#;
+        let chunks = parse(json);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], ChunkKind::ToolUse { tool, .. } if tool == "read_file"));
+    }
+
+    #[test]
+    fn parse_invalid_json() {
+        assert!(parse("garbage").is_empty());
     }
 }

--- a/tui/src/backend/codex.rs
+++ b/tui/src/backend/codex.rs
@@ -1,5 +1,5 @@
 use std::process::{Command, Stdio};
-use super::{Backend, ModelDef, RunConfig, StreamChunk, ChunkKind};
+use super::{Backend, ModelDef, RunConfig, StreamChunk, ChunkKind, SUBAGENT_TOOLS_CODEX};
 
 pub struct CodexBackend;
 
@@ -18,35 +18,94 @@ impl Backend for CodexBackend {
 
     fn build_command(&self, config: &RunConfig) -> Command {
         let effort_cfg = format!("model_reasoning_effort=\"{}\"", config.effort);
+
+        let message = if let Some(ref ctx_file) = config.system_context_file {
+            if let Ok(ctx) = std::fs::read_to_string(ctx_file) {
+                if !ctx.is_empty() {
+                    format!("{}\n\nUSER REQUEST:\n{}", ctx, config.message)
+                } else {
+                    config.message.clone()
+                }
+            } else {
+                config.message.clone()
+            }
+        } else {
+            config.message.clone()
+        };
+
         let mut cmd = Command::new("codex");
-        cmd.args(["exec", "--json", "-m", &config.model, "-c", &effort_cfg, &config.message]);
+        cmd.args(["exec", "--json", "-m", &config.model, "-c", &effort_cfg]);
+        if config.bypass_permissions {
+            cmd.arg("--dangerously-bypass-approvals-and-sandbox");
+        }
+        cmd.arg(&message);
         cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
         cmd
     }
 
-    fn parse_line(&self, line: &str) -> Option<StreamChunk> {
-        let v: serde_json::Value = serde_json::from_str(line).ok()?;
-        let event_type = v.get("type")?.as_str()?;
+    fn parse_line(&self, line: &str) -> Vec<StreamChunk> {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        let event_type = match v.get("type").and_then(|t| t.as_str()) {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
 
         match event_type {
             "item.completed" => {
-                let text = v.get("item")?.get("text")?.as_str()?;
-                Some(StreamChunk { kind: ChunkKind::Text(text.to_string()) })
+                if let Some(text) = v.get("item").and_then(|i| i.get("text")).and_then(|t| t.as_str()) {
+                    vec![StreamChunk { kind: ChunkKind::Text(text.to_string()) }]
+                } else {
+                    Vec::new()
+                }
+            }
+            "function_call" => {
+                let id = v.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                let name = v.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
+                let args = v.get("arguments").and_then(|a| a.as_str()).unwrap_or("");
+                let detail: String = args.chars().take(80).collect();
+
+                if SUBAGENT_TOOLS_CODEX.contains(&name) {
+                    let parsed = serde_json::from_str::<serde_json::Value>(args).ok();
+                    let subagent_type = parsed.as_ref()
+                        .and_then(|a| a.get("type").and_then(|t| t.as_str()).map(String::from))
+                        .unwrap_or_else(|| name.to_string());
+                    let description = parsed.as_ref()
+                        .and_then(|a| a.get("description").and_then(|d| d.as_str()).map(String::from))
+                        .unwrap_or_default();
+                    vec![StreamChunk {
+                        kind: ChunkKind::SubagentStart { id, subagent_type, description },
+                    }]
+                } else {
+                    vec![StreamChunk {
+                        kind: ChunkKind::ToolUse { id, tool: name.to_string(), detail },
+                    }]
+                }
+            }
+            "function_call_output" => {
+                let id = v.get("call_id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                let output = v.get("output").and_then(|o| o.as_str()).unwrap_or("");
+                let preview: String = output.chars().take(200).collect();
+                vec![StreamChunk {
+                    kind: ChunkKind::ToolResult { id, content_preview: preview },
+                }]
             }
             "turn.completed" => {
                 let usage = v.get("usage");
                 let input = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
                 let output = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                Some(StreamChunk { kind: ChunkKind::CostUpdate { cost_usd: 0.0, input_tokens: input, output_tokens: output } })
+                vec![StreamChunk { kind: ChunkKind::CostUpdate { cost_usd: 0.0, input_tokens: input, output_tokens: output } }]
             }
             "turn.failed" => {
                 let msg = v.get("error")
                     .and_then(|e| e.get("message"))
                     .and_then(|m| m.as_str())
                     .unwrap_or("unknown error");
-                Some(StreamChunk { kind: ChunkKind::Error(msg.to_string()) })
+                vec![StreamChunk { kind: ChunkKind::Error(msg.to_string()) }]
             }
-            _ => None,
+            _ => Vec::new(),
         }
     }
 }

--- a/tui/src/backend/mod.rs
+++ b/tui/src/backend/mod.rs
@@ -17,10 +17,25 @@ pub struct StreamChunk {
 pub enum ChunkKind {
     Text(String),
     Thinking(String),
-    ToolUse { id: String, tool: String, detail: String },
-    ToolResult { id: String, content_preview: String },
-    SubagentStart { id: String, subagent_type: String, description: String },
-    CostUpdate { cost_usd: f64, input_tokens: u64, output_tokens: u64 },
+    ToolUse {
+        id: String,
+        tool: String,
+        detail: String,
+    },
+    ToolResult {
+        id: String,
+        content_preview: String,
+    },
+    SubagentStart {
+        id: String,
+        subagent_type: String,
+        description: String,
+    },
+    CostUpdate {
+        cost_usd: f64,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
     Done,
     Error(String),
 }
@@ -55,18 +70,16 @@ pub fn all_backends() -> Vec<Box<dyn Backend>> {
 }
 
 pub fn find_backend(model_id: &str) -> Option<Box<dyn Backend>> {
-    for b in all_backends() {
-        if b.models().iter().any(|m| m.id == model_id) {
-            return Some(b);
-        }
-    }
-    None
+    all_backends()
+        .into_iter()
+        .find(|b| b.models().iter().any(|m| m.id == model_id))
 }
 
 pub fn backend_for(model_id: &str) -> Box<dyn Backend> {
     find_backend(model_id).unwrap_or_else(|| Box::new(claude::ClaudeBackend))
 }
 
+#[allow(dead_code)]
 pub fn all_models() -> Vec<(&'static str, &'static ModelDef)> {
     let mut out = Vec::new();
     for b in all_backends() {
@@ -99,7 +112,9 @@ pub fn model_backend_name(id: &str) -> &'static str {
 pub fn models_for_backend(backend: &str) -> Vec<String> {
     for b in all_backends() {
         if b.name() == backend {
-            return b.models().iter()
+            return b
+                .models()
+                .iter()
                 .map(|m| format!("{} — {} ({})", m.id, m.display, m.context))
                 .collect();
         }
@@ -108,7 +123,8 @@ pub fn models_for_backend(backend: &str) -> Vec<String> {
 }
 
 pub fn backend_labels() -> Vec<String> {
-    all_backends().iter()
+    all_backends()
+        .iter()
         .map(|b| format!("{} — {}", b.name(), b.display_name()))
         .collect()
 }

--- a/tui/src/backend/mod.rs
+++ b/tui/src/backend/mod.rs
@@ -1,6 +1,7 @@
 pub mod claude;
 pub mod codex;
 
+use std::path::PathBuf;
 use std::process::Command;
 
 pub struct ModelDef {
@@ -16,8 +17,9 @@ pub struct StreamChunk {
 pub enum ChunkKind {
     Text(String),
     Thinking(String),
-    ToolUse { tool: String, detail: String },
-    ToolResult,
+    ToolUse { id: String, tool: String, detail: String },
+    ToolResult { id: String, content_preview: String },
+    SubagentStart { id: String, subagent_type: String, description: String },
     CostUpdate { cost_usd: f64, input_tokens: u64, output_tokens: u64 },
     Done,
     Error(String),
@@ -28,14 +30,21 @@ pub struct RunConfig {
     pub message: String,
     pub effort: String,
     pub is_continuation: bool,
+    pub system_context_file: Option<PathBuf>,
+    pub bypass_permissions: bool,
 }
+
+// Tool names that represent subagent/task spawning across providers.
+// Claude uses PascalCase, Codex uses snake_case — both lists here.
+pub const SUBAGENT_TOOLS_CLAUDE: &[&str] = &["Agent", "TaskCreate", "TaskUpdate"];
+pub const SUBAGENT_TOOLS_CODEX: &[&str] = &["spawn_agent", "task_create", "task_update"];
 
 pub trait Backend: Send + Sync {
     fn name(&self) -> &'static str;
     fn display_name(&self) -> &'static str;
     fn models(&self) -> &'static [ModelDef];
     fn build_command(&self, config: &RunConfig) -> Command;
-    fn parse_line(&self, line: &str) -> Option<StreamChunk>;
+    fn parse_line(&self, line: &str) -> Vec<StreamChunk>;
 }
 
 pub fn all_backends() -> Vec<Box<dyn Backend>> {

--- a/tui/src/bidi.rs
+++ b/tui/src/bidi.rs
@@ -4,7 +4,7 @@ pub fn visual_reorder(text: &str) -> String {
     if text.is_empty() {
         return String::new();
     }
-    if !text.chars().any(|c| is_rtl_char(c)) {
+    if text.is_ascii() || !text.chars().any(is_rtl_char) {
         return text.to_string();
     }
     // Force LTR base: Ratatui renders LTR only, so we reorder RTL runs into visual LTR order
@@ -22,4 +22,32 @@ fn is_rtl_char(c: char) -> bool {
     || (0xFB50..=0xFDFF).contains(&cp) // Arabic Presentation A
     || (0xFE70..=0xFEFF).contains(&cp) // Arabic Presentation B
     || (0xFB1D..=0xFB4F).contains(&cp) // Hebrew Presentation
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_passthrough() {
+        assert_eq!(visual_reorder("hello world"), "hello world");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(visual_reorder(""), "");
+    }
+
+    #[test]
+    fn hebrew_reordered() {
+        let result = visual_reorder("שלום");
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn mixed_content() {
+        let result = visual_reorder("hello שלום world");
+        assert!(result.contains("hello"));
+        assert!(result.contains("world"));
+    }
 }

--- a/tui/src/config/channels.rs
+++ b/tui/src/config/channels.rs
@@ -9,21 +9,19 @@ pub struct ChannelEntry {
     pub configured: bool,
 }
 
-fn env_has(key: &str) -> bool {
+fn env_has(key: &str, env_content: &str) -> bool {
     if platform::env_var(key).is_some() {
         return true;
     }
-    let env_path = repo_root().join(".env");
-    let content = match fs::read_to_string(&env_path) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
     let prefix = format!("{}=", key);
-    content.lines().any(|line| line.starts_with(&prefix) && line.len() > prefix.len())
+    env_content
+        .lines()
+        .any(|line| line.starts_with(&prefix) && line.len() > prefix.len())
 }
 
 pub fn load() -> Vec<ChannelEntry> {
     let root = repo_root();
+    let env_content = fs::read_to_string(root.join(".env")).unwrap_or_default();
     vec![
         ChannelEntry {
             name: "WhatsApp".to_string(),
@@ -31,23 +29,23 @@ pub fn load() -> Vec<ChannelEntry> {
         },
         ChannelEntry {
             name: "Telegram".to_string(),
-            configured: env_has("TELEGRAM_BOT_TOKEN"),
+            configured: env_has("TELEGRAM_BOT_TOKEN", &env_content),
         },
         ChannelEntry {
             name: "Discord".to_string(),
-            configured: env_has("DISCORD_BOT_TOKEN"),
+            configured: env_has("DISCORD_BOT_TOKEN", &env_content),
         },
         ChannelEntry {
             name: "Slack".to_string(),
-            configured: env_has("SLACK_BOT_TOKEN"),
+            configured: env_has("SLACK_BOT_TOKEN", &env_content),
         },
         ChannelEntry {
             name: "Gmail".to_string(),
-            configured: env_has("GMAIL_CLIENT_ID"),
+            configured: env_has("GMAIL_CLIENT_ID", &env_content),
         },
         ChannelEntry {
             name: "X (Twitter)".to_string(),
-            configured: env_has("X_API_KEY"),
+            configured: env_has("X_API_KEY", &env_content),
         },
     ]
 }

--- a/tui/src/config/channels.rs
+++ b/tui/src/config/channels.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use super::repo_root;
+use crate::platform;
 
 #[derive(Clone)]
 pub struct ChannelEntry {
@@ -9,7 +10,7 @@ pub struct ChannelEntry {
 }
 
 fn env_has(key: &str) -> bool {
-    if std::env::var(key).is_ok() {
+    if platform::env_var(key).is_some() {
         return true;
     }
     let env_path = repo_root().join(".env");

--- a/tui/src/config/deus.rs
+++ b/tui/src/config/deus.rs
@@ -1,7 +1,7 @@
+use crate::platform;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs;
-use crate::platform;
 
 pub fn load() -> Vec<(String, String)> {
     let path = platform::config_file();

--- a/tui/src/config/deus.rs
+++ b/tui/src/config/deus.rs
@@ -1,11 +1,10 @@
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs;
+use crate::platform;
 
 pub fn load() -> Vec<(String, String)> {
-    let path = dirs::home_dir()
-        .map(|h| h.join(".config").join("deus").join("config.json"))
-        .unwrap_or_default();
+    let path = platform::config_file();
 
     let content = match fs::read_to_string(&path) {
         Ok(c) => c,

--- a/tui/src/config/healthcheck.rs
+++ b/tui/src/config/healthcheck.rs
@@ -1,8 +1,8 @@
+use crate::platform;
 use serde::Deserialize;
 use std::fs;
 use std::process::Command;
 use std::time::SystemTime;
-use crate::platform;
 
 #[derive(Clone)]
 pub struct ServiceEntry {
@@ -30,13 +30,15 @@ fn check_launchctl(label: &str) -> &'static str {
     }
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{}/{}", uid, label);
-    let output = Command::new("launchctl")
-        .args(["print", &target])
-        .output();
+    let output = Command::new("launchctl").args(["print", &target]).output();
     match output {
         Ok(o) if o.status.success() => {
             let stdout = String::from_utf8_lossy(&o.stdout);
-            if stdout.contains("state = running") { "running" } else { "stopped" }
+            if stdout.contains("state = running") {
+                "running"
+            } else {
+                "stopped"
+            }
         }
         _ => "stopped",
     }
@@ -56,7 +58,11 @@ fn check_heartbeat(path: &str, max_staleness: u64) -> &'static str {
         .map(|d| d.as_secs())
         .unwrap_or(u64::MAX);
 
-    if age <= max_staleness { "running" } else { "stale" }
+    if age <= max_staleness {
+        "running"
+    } else {
+        "stale"
+    }
 }
 
 pub fn load() -> Vec<ServiceEntry> {
@@ -64,18 +70,22 @@ pub fn load() -> Vec<ServiceEntry> {
 
     let content = match fs::read_to_string(&config_dir) {
         Ok(c) => c,
-        Err(_) => return vec![ServiceEntry {
-            description: "healthcheck.json not found".to_string(),
-            status: "unknown".to_string(),
-        }],
+        Err(_) => {
+            return vec![ServiceEntry {
+                description: "healthcheck.json not found".to_string(),
+                status: "unknown".to_string(),
+            }];
+        }
     };
 
     let file: HealthcheckFile = match serde_json::from_str(&content) {
         Ok(f) => f,
-        Err(_) => return vec![ServiceEntry {
-            description: "invalid healthcheck.json".to_string(),
-            status: "unknown".to_string(),
-        }],
+        Err(_) => {
+            return vec![ServiceEntry {
+                description: "invalid healthcheck.json".to_string(),
+                status: "unknown".to_string(),
+            }];
+        }
     };
 
     file.jobs
@@ -93,7 +103,10 @@ pub fn load() -> Vec<ServiceEntry> {
                 }
                 _ => "unknown".to_string(),
             };
-            ServiceEntry { description: job.description.clone(), status }
+            ServiceEntry {
+                description: job.description.clone(),
+                status,
+            }
         })
         .collect()
 }

--- a/tui/src/config/healthcheck.rs
+++ b/tui/src/config/healthcheck.rs
@@ -1,8 +1,8 @@
 use serde::Deserialize;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 use std::time::SystemTime;
+use crate::platform;
 
 #[derive(Clone)]
 pub struct ServiceEntry {
@@ -25,7 +25,7 @@ struct HealthcheckFile {
 }
 
 fn check_launchctl(label: &str) -> &'static str {
-    if cfg!(not(target_os = "macos")) {
+    if !platform::is_macos() {
         return "unsupported";
     }
     let uid = unsafe { libc::getuid() };
@@ -43,13 +43,7 @@ fn check_launchctl(label: &str) -> &'static str {
 }
 
 fn check_heartbeat(path: &str, max_staleness: u64) -> &'static str {
-    let expanded = if path.starts_with('~') {
-        dirs::home_dir()
-            .map(|h| h.join(&path[2..]))
-            .unwrap_or_else(|| Path::new(path).to_path_buf())
-    } else {
-        Path::new(path).to_path_buf()
-    };
+    let expanded = platform::expand_tilde(path);
 
     let meta = match fs::metadata(&expanded) {
         Ok(m) => m,
@@ -66,9 +60,7 @@ fn check_heartbeat(path: &str, max_staleness: u64) -> &'static str {
 }
 
 pub fn load() -> Vec<ServiceEntry> {
-    let config_dir = dirs::home_dir()
-        .map(|h| h.join(".config").join("deus").join("healthcheck.json"))
-        .unwrap_or_default();
+    let config_dir = platform::config_dir().join("healthcheck.json");
 
     let content = match fs::read_to_string(&config_dir) {
         Ok(c) => c,

--- a/tui/src/config/mod.rs
+++ b/tui/src/config/mod.rs
@@ -3,12 +3,15 @@ pub mod deus;
 pub mod healthcheck;
 pub mod wardens;
 
-use std::path::PathBuf;
 use crate::platform;
+use std::path::PathBuf;
 
 pub fn repo_root() -> PathBuf {
     let exe = platform::current_exe();
-    let mut dir = exe.parent().unwrap_or(std::path::Path::new(".")).to_path_buf();
+    let mut dir = exe
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .to_path_buf();
     for _ in 0..5 {
         if dir.join(".claude").join("wardens").exists() {
             return dir;

--- a/tui/src/config/mod.rs
+++ b/tui/src/config/mod.rs
@@ -4,11 +4,10 @@ pub mod healthcheck;
 pub mod wardens;
 
 use std::path::PathBuf;
+use crate::platform;
 
 pub fn repo_root() -> PathBuf {
-    let exe = std::env::current_exe().unwrap_or_default();
-    // Binary at tui/target/{debug,release}/deus-tui → repo is 3 levels up
-    // Also handle running from repo root via `cargo run`
+    let exe = platform::current_exe();
     let mut dir = exe.parent().unwrap_or(std::path::Path::new(".")).to_path_buf();
     for _ in 0..5 {
         if dir.join(".claude").join("wardens").exists() {
@@ -18,8 +17,7 @@ pub fn repo_root() -> PathBuf {
             break;
         }
     }
-    // Fallback: try CWD
-    let cwd = std::env::current_dir().unwrap_or_default();
+    let cwd = platform::current_dir();
     for ancestor in cwd.ancestors() {
         if ancestor.join(".claude").join("wardens").exists() {
             return ancestor.to_path_buf();

--- a/tui/src/config/wardens.rs
+++ b/tui/src/config/wardens.rs
@@ -24,12 +24,18 @@ const TYPES: &[(&str, &str)] = &[
 ];
 
 fn config_path() -> PathBuf {
-    repo_root().join(".claude").join("wardens").join("config.json")
+    repo_root()
+        .join(".claude")
+        .join("wardens")
+        .join("config.json")
 }
 
 fn triggers_label(val: &Value, name: &str) -> String {
     if name == "session-retrospective" {
-        let threshold = val.get("auto_threshold").and_then(|v| v.as_u64()).unwrap_or(20);
+        let threshold = val
+            .get("auto_threshold")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(20);
         return format!("auto (threshold: {} sessions), manual", threshold);
     }
     match val.get("tools").and_then(|v| v.as_array()) {
@@ -67,7 +73,13 @@ pub fn load() -> Vec<WardenEntry> {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
-            WardenEntry { name: name.clone(), enabled, warden_type, triggers, custom_instructions }
+            WardenEntry {
+                name: name.clone(),
+                enabled,
+                warden_type,
+                triggers,
+                custom_instructions,
+            }
         })
         .collect()
 }
@@ -84,10 +96,10 @@ pub fn save(entries: &[WardenEntry]) {
     };
 
     for entry in entries {
-        if let Some(val) = map.get_mut(&entry.name) {
-            if let Some(obj) = val.as_object_mut() {
-                obj.insert("enabled".to_string(), Value::Bool(entry.enabled));
-            }
+        if let Some(val) = map.get_mut(&entry.name)
+            && let Some(obj) = val.as_object_mut()
+        {
+            obj.insert("enabled".to_string(), Value::Bool(entry.enabled));
         }
     }
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -11,9 +11,12 @@ mod widgets;
 use std::io::{self, IsTerminal};
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers, EnableBracketedPaste, DisableBracketedPaste, KeyboardEnhancementFlags, PushKeyboardEnhancementFlags, PopKeyboardEnhancementFlags};
-use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::event::{
+    self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind, KeyModifiers,
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
 use crossterm::execute;
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::prelude::*;
 
 use app::{App, Tab};
@@ -26,7 +29,10 @@ fn main() -> io::Result<()> {
 
     terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste,
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableBracketedPaste,
         PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
     )?;
     let backend = CrosstermBackend::new(stdout);
@@ -41,8 +47,7 @@ fn main() -> io::Result<()> {
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;
             match ev {
-            Event::Paste(ref text) => {
-                if app.tab == Tab::Chat {
+                Event::Paste(ref text) if app.tab == Tab::Chat => {
                     for c in text.chars() {
                         if c == '\n' || c == '\r' {
                             app.input_newline();
@@ -51,137 +56,154 @@ fn main() -> io::Result<()> {
                         }
                     }
                 }
-            }
-            Event::Key(key) => {
-                if key.kind != KeyEventKind::Press {
-                    continue;
-                }
+                Event::Key(key) => {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
 
-                // Any non-Esc key clears the pending Esc
-                if key.code != KeyCode::Esc {
-                    app.esc_pending = None;
-                }
+                    // Any non-Esc key clears the pending Esc
+                    if key.code != KeyCode::Esc {
+                        app.esc_pending = None;
+                    }
 
-                // Global Ctrl shortcuts
-                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                    match key.code {
-                        KeyCode::Char('c') => {
-                            if matches!(app.chat_state, crate::app::ChatState::Streaming) {
-                                app.cancel_response();
-                            } else {
-                                break;
+                    // Global Ctrl shortcuts
+                    if key.modifiers.contains(KeyModifiers::CONTROL) {
+                        match key.code {
+                            KeyCode::Char('c') => {
+                                if matches!(app.chat_state, crate::app::ChatState::Streaming) {
+                                    app.cancel_response();
+                                } else {
+                                    break;
+                                }
+                                continue;
+                            }
+                            KeyCode::Char('d') => break,
+                            _ => {}
+                        }
+                    }
+
+                    if app.tab == Tab::Chat {
+                        if key.modifiers.contains(KeyModifiers::SUPER) {
+                            match key.code {
+                                KeyCode::Backspace | KeyCode::Delete => {
+                                    app.input_delete_current_line()
+                                }
+                                _ => {}
                             }
                             continue;
                         }
-                        KeyCode::Char('d') => break,
-                        _ => {}
-                    }
-                }
-
-                if app.tab == Tab::Chat {
-                    if key.modifiers.contains(KeyModifiers::SUPER) {
-                        match key.code {
-                            KeyCode::Backspace | KeyCode::Delete => app.input_delete_current_line(),
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    if key.modifiers.contains(KeyModifiers::CONTROL) {
-                        match key.code {
-                            KeyCode::Char('l') => { app.chat_messages.clear(); app.scroll_to_bottom(); }
-                            KeyCode::Char('u') => app.input_clear_line(),
-                            KeyCode::Char('a') => app.input_home(),
-                            KeyCode::Char('e') => app.input_end(),
-                            KeyCode::Char('w') => app.input_delete_word(),
-                            KeyCode::Char('k') => app.input_kill_to_end(),
-                            KeyCode::Char('y') => app.input_yank(),
-                            KeyCode::Char('o') => app.toggle_tools(),
-                            KeyCode::Char('j') => app.input_newline(),
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    if key.modifiers.contains(KeyModifiers::ALT) {
-                        match key.code {
-                            KeyCode::Backspace => app.input_delete_word(),
-                            KeyCode::Char('b') => app.input_word_left(),
-                            KeyCode::Char('f') => app.input_word_right(),
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    match key.code {
-                        KeyCode::Esc => {
-                            if app.has_suggestions() {
-                                app.dismiss_suggestions();
-                            } else if matches!(app.chat_state, crate::app::ChatState::Streaming) {
-                                app.cancel_response();
-                            } else if let Some(first) = app.esc_pending {
-                                if first.elapsed().as_millis() < 500 {
-                                    break;
+                        if key.modifiers.contains(KeyModifiers::CONTROL) {
+                            match key.code {
+                                KeyCode::Char('l') => {
+                                    app.chat_messages.clear();
+                                    app.scroll_to_bottom();
                                 }
-                                app.esc_pending = Some(std::time::Instant::now());
-                            } else {
-                                app.esc_pending = Some(std::time::Instant::now());
+                                KeyCode::Char('u') => app.input_clear_line(),
+                                KeyCode::Char('a') => app.input_home(),
+                                KeyCode::Char('e') => app.input_end(),
+                                KeyCode::Char('w') => app.input_delete_word(),
+                                KeyCode::Char('k') => app.input_kill_to_end(),
+                                KeyCode::Char('y') => app.input_yank(),
+                                KeyCode::Char('o') => app.toggle_tools(),
+                                KeyCode::Char('j') => app.input_newline(),
+                                _ => {}
                             }
+                            continue;
                         }
-                        KeyCode::Tab => {
-                            if app.has_suggestions() {
+                        if key.modifiers.contains(KeyModifiers::ALT) {
+                            match key.code {
+                                KeyCode::Backspace => app.input_delete_word(),
+                                KeyCode::Char('b') => app.input_word_left(),
+                                KeyCode::Char('f') => app.input_word_right(),
+                                _ => {}
+                            }
+                            continue;
+                        }
+                        match key.code {
+                            KeyCode::Esc => {
+                                if app.has_suggestions() {
+                                    app.dismiss_suggestions();
+                                } else if matches!(app.chat_state, crate::app::ChatState::Streaming)
+                                {
+                                    app.cancel_response();
+                                } else if let Some(first) = app.esc_pending {
+                                    if first.elapsed().as_millis() < 500 {
+                                        break;
+                                    }
+                                    app.esc_pending = Some(std::time::Instant::now());
+                                } else {
+                                    app.esc_pending = Some(std::time::Instant::now());
+                                }
+                            }
+                            KeyCode::Tab if app.has_suggestions() => {
                                 app.accept_suggestion();
                             }
-                        }
-                        KeyCode::Enter => {
-                            if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                app.input_newline();
-                            } else if app.has_suggestions() {
-                                app.accept_suggestion();
-                            } else {
-                                app.send_message();
+                            KeyCode::Enter => {
+                                if key.modifiers.contains(KeyModifiers::SHIFT) {
+                                    app.input_newline();
+                                } else if app.has_suggestions() {
+                                    app.accept_suggestion();
+                                } else {
+                                    app.send_message();
+                                }
                             }
-                        }
-                        KeyCode::Up => {
-                            if app.has_suggestions() { app.prev_suggestion(); }
-                            else if app.is_multiline() && app.input_cursor_line() > 0 {
-                                app.input_line_up();
+                            KeyCode::Up => {
+                                if app.has_suggestions() {
+                                    app.prev_suggestion();
+                                } else if app.is_multiline() && app.input_cursor_line() > 0 {
+                                    app.input_line_up();
+                                } else {
+                                    app.history_prev();
+                                }
                             }
-                            else { app.history_prev(); }
-                        }
-                        KeyCode::Down => {
-                            if app.has_suggestions() { app.next_suggestion(); }
-                            else if app.is_multiline() && app.input_cursor_line() < app.input_line_count() - 1 {
-                                app.input_line_down();
+                            KeyCode::Down => {
+                                if app.has_suggestions() {
+                                    app.next_suggestion();
+                                } else if app.is_multiline()
+                                    && app.input_cursor_line() < app.input_line_count() - 1
+                                {
+                                    app.input_line_down();
+                                } else {
+                                    app.history_next();
+                                }
                             }
-                            else { app.history_next(); }
+                            KeyCode::PageUp => app.scroll_up(10),
+                            KeyCode::PageDown => app.scroll_down(10),
+                            KeyCode::Backspace => app.input_backspace(),
+                            KeyCode::Delete => app.input_delete(),
+                            KeyCode::Left => app.input_left(),
+                            KeyCode::Right => app.input_right(),
+                            KeyCode::Home => app.input_home(),
+                            KeyCode::End => app.input_end(),
+                            KeyCode::Char(c) => app.input_char(c),
+                            _ => {}
                         }
-                        KeyCode::PageUp => app.scroll_up(10),
-                        KeyCode::PageDown => app.scroll_down(10),
-                        KeyCode::Backspace => app.input_backspace(),
-                        KeyCode::Delete => app.input_delete(),
-                        KeyCode::Left => app.input_left(),
-                        KeyCode::Right => app.input_right(),
-                        KeyCode::Home => app.input_home(),
-                        KeyCode::End => app.input_end(),
-                        KeyCode::Char(c) => app.input_char(c),
-                        _ => {}
-                    }
-                } else {
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('q') => { app.tab = Tab::Chat; app.cursor = 0; }
-                        KeyCode::Up | KeyCode::Char('k') => app.prev_item(),
-                        KeyCode::Down | KeyCode::Char('j') => app.next_item(),
-                        KeyCode::Char(' ') | KeyCode::Enter => app.toggle_item(),
-                        KeyCode::Char('r') => app.refresh(),
-                        _ => {}
+                    } else {
+                        match key.code {
+                            KeyCode::Esc | KeyCode::Char('q') => {
+                                app.tab = Tab::Chat;
+                                app.cursor = 0;
+                            }
+                            KeyCode::Up | KeyCode::Char('k') => app.prev_item(),
+                            KeyCode::Down | KeyCode::Char('j') => app.next_item(),
+                            KeyCode::Char(' ') | KeyCode::Enter => app.toggle_item(),
+                            KeyCode::Char('r') => app.refresh(),
+                            _ => {}
+                        }
                     }
                 }
-            }
-            _ => {}
+                _ => {}
             }
         }
     }
 
     terminal::disable_raw_mode()?;
-    execute!(io::stdout(), PopKeyboardEnhancementFlags, LeaveAlternateScreen, DisableBracketedPaste)?;
+    execute!(
+        io::stdout(),
+        PopKeyboardEnhancementFlags,
+        LeaveAlternateScreen,
+        DisableBracketedPaste
+    )?;
 
     if let Some(ctx_file) = platform::env_var("DEUS_TUI_CONTEXT_FILE") {
         let _ = std::fs::remove_file(ctx_file);
@@ -202,7 +224,7 @@ fn print_static() {
     let sep = format!("├{}┤", "─".repeat(w - 2));
     let line = |s: &str| {
         let visible_len = s.chars().count();
-        let pad = if visible_len < w - 4 { w - 4 - visible_len } else { 0 };
+        let pad = (w - 4).saturating_sub(visible_len);
         format!("│ {}{} │", s, " ".repeat(pad))
     };
     let header = |s: &str| {
@@ -248,7 +270,11 @@ fn print_static() {
     println!("{}", line(""));
     for ch in &channels {
         let icon = if ch.configured { "✓" } else { "✗" };
-        let status = if ch.configured { "connected" } else { "not configured" };
+        let status = if ch.configured {
+            "connected"
+        } else {
+            "not configured"
+        };
         let row = format!("  {} {:16} {}", icon, ch.name, status);
         println!("{}", line(&row));
     }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -3,6 +3,7 @@ mod backend;
 mod bidi;
 mod config;
 mod panels;
+mod platform;
 mod theme;
 mod ui;
 mod widgets;
@@ -181,6 +182,11 @@ fn main() -> io::Result<()> {
 
     terminal::disable_raw_mode()?;
     execute!(io::stdout(), PopKeyboardEnhancementFlags, LeaveAlternateScreen, DisableBracketedPaste)?;
+
+    if let Some(ctx_file) = platform::env_var("DEUS_TUI_CONTEXT_FILE") {
+        let _ = std::fs::remove_file(ctx_file);
+    }
+
     Ok(())
 }
 

--- a/tui/src/panels/channels.rs
+++ b/tui/src/panels/channels.rs
@@ -21,7 +21,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Span::styled(format!("{} ", icon), Style::default().fg(color)),
                 Span::styled(
                     format!("{:16}", ch.name),
-                    if i == app.cursor { theme::bold() } else { Style::default() },
+                    if i == app.cursor {
+                        theme::bold()
+                    } else {
+                        Style::default()
+                    },
                 ),
                 Span::styled(status, theme::dim()),
             ]))

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -1,10 +1,16 @@
+use std::cell::RefCell;
+
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use crate::app::{App, MessageBlock, SubagentStatus, COMMANDS};
+use crate::app::{App, COMMANDS, MessageBlock, SubagentStatus};
 use crate::bidi;
 use crate::platform;
 use crate::theme;
+
+thread_local! {
+    static LINE_CACHE: RefCell<(u64, Vec<Line<'static>>)> = const { RefCell::new((u64::MAX, Vec::new())) };
+}
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let input_height = if app.is_multiline() {
@@ -12,11 +18,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         3
     };
-    let layout = Layout::vertical([
-        Constraint::Min(0),
-        Constraint::Length(input_height),
-    ])
-    .split(area);
+    let layout =
+        Layout::vertical([Constraint::Min(0), Constraint::Length(input_height)]).split(area);
 
     render_messages(frame, app, layout[0]);
     render_input(frame, app, layout[1]);
@@ -26,7 +29,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-fn render_markdown_line(text: &str, in_code_block: bool, in_diff: bool) -> (Line<'static>, bool, bool) {
+fn render_markdown_line(
+    text: &str,
+    in_code_block: bool,
+    in_diff: bool,
+) -> (Line<'static>, bool, bool) {
     let mut code_block = in_code_block;
     let mut diff = in_diff;
     let text = bidi::visual_reorder(text);
@@ -36,15 +43,31 @@ fn render_markdown_line(text: &str, in_code_block: bool, in_diff: bool) -> (Line
         if code_block || diff {
             code_block = false;
             diff = false;
-            return (Line::from(Span::styled("  ───", theme::muted())), code_block, diff);
+            return (
+                Line::from(Span::styled("  ───", theme::muted())),
+                code_block,
+                diff,
+            );
         }
         if lang == "diff" {
             diff = true;
-            return (Line::from(Span::styled("  ─── diff", theme::muted())), code_block, diff);
+            return (
+                Line::from(Span::styled("  ─── diff", theme::muted())),
+                code_block,
+                diff,
+            );
         }
         code_block = true;
-        let label = if lang.is_empty() { "───".to_string() } else { format!("─── {}", lang) };
-        return (Line::from(Span::styled(format!("  {}", label), theme::muted())), code_block, diff);
+        let label = if lang.is_empty() {
+            "───".to_string()
+        } else {
+            format!("─── {}", lang)
+        };
+        return (
+            Line::from(Span::styled(format!("  {}", label), theme::muted())),
+            code_block,
+            diff,
+        );
     }
 
     if diff {
@@ -57,14 +80,19 @@ fn render_markdown_line(text: &str, in_code_block: bool, in_diff: bool) -> (Line
         } else {
             theme::dim()
         };
-        return (Line::from(Span::styled(format!("  │ {}", text), style)), code_block, diff);
+        return (
+            Line::from(Span::styled(format!("  │ {}", text), style)),
+            code_block,
+            diff,
+        );
     }
 
     if code_block {
-        return (Line::from(Span::styled(
-            format!("  │ {}", text),
-            theme::code(),
-        )), code_block, diff);
+        return (
+            Line::from(Span::styled(format!("  │ {}", text), theme::code())),
+            code_block,
+            diff,
+        );
     }
 
     if text.contains("**") {
@@ -97,10 +125,7 @@ fn render_markdown_line(text: &str, in_code_block: bool, in_diff: bool) -> (Line
             }
             remaining = remaining[start + 1..].to_string();
             if let Some(end) = remaining.find('`') {
-                spans.push(Span::styled(
-                    remaining[..end].to_string(),
-                    theme::code(),
-                ));
+                spans.push(Span::styled(remaining[..end].to_string(), theme::code()));
                 remaining = remaining[end + 1..].to_string();
             } else {
                 spans.push(Span::raw("`".to_string()));
@@ -112,25 +137,31 @@ fn render_markdown_line(text: &str, in_code_block: bool, in_diff: bool) -> (Line
         return (Line::from(spans), code_block, diff);
     }
 
-    if text.starts_with("## ") {
-        return (Line::from(Span::styled(
-            format!("  {}", &text[3..]),
-            theme::heading2(),
-        )), code_block, diff);
+    if let Some(stripped) = text.strip_prefix("## ") {
+        return (
+            Line::from(Span::styled(format!("  {}", stripped), theme::heading2())),
+            code_block,
+            diff,
+        );
     }
-    if text.starts_with("# ") {
-        return (Line::from(Span::styled(
-            format!("  {}", &text[2..]),
-            theme::heading1(),
-        )), code_block, diff);
+    if let Some(stripped) = text.strip_prefix("# ") {
+        return (
+            Line::from(Span::styled(format!("  {}", stripped), theme::heading1())),
+            code_block,
+            diff,
+        );
     }
 
     if text.starts_with("- ") || text.starts_with("* ") {
-        return (Line::from(vec![
-            Span::raw("  "),
-            Span::styled("• ", theme::bullet()),
-            Span::raw(text[2..].to_string()),
-        ]), code_block, diff);
+        return (
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled("• ", theme::bullet()),
+                Span::raw(text[2..].to_string()),
+            ]),
+            code_block,
+            diff,
+        );
     }
 
     (Line::from(format!("  {}", text)), code_block, diff)
@@ -168,18 +199,30 @@ fn render_subagent_block(
     let (icon, icon_style, name_style) = match (is_warden, status) {
         (true, SubagentStatus::Running) => {
             let spinner = app.spinner_frame();
-            (format!(" ⛨{} ", spinner), theme::warden_name(), theme::warden_name())
+            (
+                format!(" ⛨{} ", spinner),
+                theme::warden_name(),
+                theme::warden_name(),
+            )
         }
-        (true, SubagentStatus::Completed) => {
-            (" ⛨✓ ".to_string(), theme::verdict_ship(), theme::warden_name())
-        }
+        (true, SubagentStatus::Completed) => (
+            " ⛨✓ ".to_string(),
+            theme::verdict_ship(),
+            theme::warden_name(),
+        ),
         (false, SubagentStatus::Running) => {
             let spinner = app.spinner_frame();
-            (format!(" ◈{} ", spinner), theme::agent_name(), theme::agent_name())
+            (
+                format!(" ◈{} ", spinner),
+                theme::agent_name(),
+                theme::agent_name(),
+            )
         }
-        (false, SubagentStatus::Completed) => {
-            (" ◈✓ ".to_string(), Style::default().fg(theme::GOOD), theme::agent_name())
-        }
+        (false, SubagentStatus::Completed) => (
+            " ◈✓ ".to_string(),
+            Style::default().fg(theme::GOOD),
+            theme::agent_name(),
+        ),
     };
 
     let label = if is_warden { "Warden" } else { "Agent" };
@@ -189,23 +232,24 @@ fn render_subagent_block(
         Span::styled(format!("  {}", description), theme::agent_detail()),
     ]));
 
-    if *status == SubagentStatus::Completed && app.show_tools {
-        if let Some(preview) = output_preview {
-            let max_lines = if is_warden { 10 } else { 5 };
-            let total_lines = preview.lines().count();
-            for (i, line) in preview.lines().take(max_lines).enumerate() {
-                let text = if is_warden {
-                    highlight_verdict(line)
-                } else {
-                    Line::from(vec![
-                        Span::styled("   │ ", theme::muted()),
-                        Span::raw(line.to_string()),
-                    ])
-                };
-                lines.push(text);
-                if i == max_lines - 1 && total_lines > max_lines {
-                    lines.push(Line::from(Span::styled("   │ ⋯", theme::muted())));
-                }
+    if *status == SubagentStatus::Completed
+        && app.show_tools
+        && let Some(preview) = output_preview
+    {
+        let max_lines = if is_warden { 10 } else { 5 };
+        let total_lines = preview.lines().count();
+        for (i, line) in preview.lines().take(max_lines).enumerate() {
+            let text = if is_warden {
+                highlight_verdict(line)
+            } else {
+                Line::from(vec![
+                    Span::styled("   │ ", theme::muted()),
+                    Span::raw(line.to_string()),
+                ])
+            };
+            lines.push(text);
+            if i == max_lines - 1 && total_lines > max_lines {
+                lines.push(Line::from(Span::styled("   │ ⋯", theme::muted())));
             }
         }
     }
@@ -237,9 +281,8 @@ fn highlight_verdict(line: &str) -> Line<'static> {
     ])
 }
 
-fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
+fn build_message_lines(app: &App) -> Vec<Line<'static>> {
     let mut lines: Vec<Line> = Vec::new();
-
     for (msg_idx, msg) in app.chat_messages.iter().enumerate() {
         if msg.role == "system" && msg.content.starts_with("Welcome to Deus") {
             render_welcome(&mut lines);
@@ -255,22 +298,22 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
                 }
             }
 
-            if app.show_tools {
-                if let Some(text) = last_thinking {
-                    let line_count = text.lines().count();
-                    for (i, tline) in text.lines().take(5).enumerate() {
-                        let prefix = if i == 0 { " ⟡ " } else { "   " };
-                        lines.push(Line::from(vec![
-                            Span::styled(prefix, theme::muted()),
-                            Span::styled(tline.to_string(), theme::thinking()),
-                        ]));
-                    }
-                    if line_count > 5 {
-                        lines.push(Line::from(Span::styled(
-                            "   ⋯ (Ctrl+O to hide)",
-                            theme::muted(),
-                        )));
-                    }
+            if app.show_tools
+                && let Some(text) = last_thinking
+            {
+                let line_count = text.lines().count();
+                for (i, tline) in text.lines().take(5).enumerate() {
+                    let prefix = if i == 0 { " ⟡ " } else { "   " };
+                    lines.push(Line::from(vec![
+                        Span::styled(prefix, theme::muted()),
+                        Span::styled(tline.to_string(), theme::thinking()),
+                    ]));
+                }
+                if line_count > 5 {
+                    lines.push(Line::from(Span::styled(
+                        "   ⋯ (Ctrl+O to hide)",
+                        theme::muted(),
+                    )));
                 }
             }
 
@@ -284,14 +327,30 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
                             Span::styled(format!(" {}", detail), theme::tool_detail()),
                         ]));
                     }
-                    MessageBlock::SubagentBlock { subagent_type, description, status, output_preview, is_warden, .. } => {
-                        render_subagent_block(&mut lines, app, subagent_type, description, status, output_preview.as_deref(), *is_warden);
+                    MessageBlock::SubagentBlock {
+                        subagent_type,
+                        description,
+                        status,
+                        output_preview,
+                        is_warden,
+                        ..
+                    } => {
+                        render_subagent_block(
+                            &mut lines,
+                            app,
+                            subagent_type,
+                            description,
+                            status,
+                            output_preview.as_deref(),
+                            *is_warden,
+                        );
                     }
                     MessageBlock::Text(text) => {
                         let mut in_code = false;
                         let mut in_diff = false;
                         for line in text.lines() {
-                            let (rendered, new_code, new_diff) = render_markdown_line(line, in_code, in_diff);
+                            let (rendered, new_code, new_diff) =
+                                render_markdown_line(line, in_code, in_diff);
                             in_code = new_code;
                             in_diff = new_diff;
                             lines.push(rendered);
@@ -317,17 +376,37 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
                 lines.push(rendered);
             }
         }
-        // Separator between messages, but not after the last one
         if msg_idx < app.chat_messages.len() - 1 {
             lines.push(Line::from(""));
         }
     }
+    lines
+}
 
-    if matches!(app.chat_state, crate::app::ChatState::Streaming) {
-        let has_text = app.chat_messages.last().is_some_and(|m| m.role == "assistant" && !m.content.is_empty());
+fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
+    let is_streaming = matches!(app.chat_state, crate::app::ChatState::Streaming);
+
+    let mut lines = LINE_CACHE.with(|cache| {
+        let mut cached = cache.borrow_mut();
+        if cached.0 != app.chat_version {
+            cached.1 = build_message_lines(app);
+            cached.0 = app.chat_version;
+        }
+        cached.1.clone()
+    });
+
+    // Streaming spinner appended per-frame (animated, not cached)
+    if is_streaming {
+        let has_text = app
+            .chat_messages
+            .last()
+            .is_some_and(|m| m.role == "assistant" && !m.content.is_empty());
         if !has_text {
             let spinner = app.spinner_frame();
-            let thinking_text = app.last_thinking_summary.as_deref().unwrap_or("thinking...");
+            let thinking_text = app
+                .last_thinking_summary
+                .as_deref()
+                .unwrap_or("thinking...");
             let preview: String = thinking_text.chars().take(60).collect();
             lines.push(Line::from(vec![
                 Span::styled(format!(" {} ", spinner), theme::warn()),
@@ -392,12 +471,13 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect) {
                 Span::raw(line.to_string()),
             ]));
         }
-        let input = Paragraph::new(text_lines)
-            .block(Block::default()
+        let input = Paragraph::new(text_lines).block(
+            Block::default()
                 .borders(Borders::ALL)
                 .title(title)
                 .title_style(theme::dim())
-                .border_style(theme::accent()));
+                .border_style(theme::accent()),
+        );
         frame.render_widget(input, area);
 
         let before_cursor = &app.input[..app.input_cursor];
@@ -408,23 +488,25 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect) {
         let cursor_y = area.y + 1 + cursor_line as u16;
         frame.set_cursor_position((cursor_x, cursor_y));
     } else {
-        let mut spans = vec![
-            Span::styled(" › ", theme::accent_bold()),
-        ];
+        let mut spans = vec![Span::styled(" › ", theme::accent_bold())];
         if app.input.is_empty() && matches!(app.chat_state, crate::app::ChatState::Idle) {
-            spans.push(Span::styled("Type a message or / for commands...", theme::muted()));
+            spans.push(Span::styled(
+                "Type a message or / for commands...",
+                theme::muted(),
+            ));
         } else {
             spans.push(Span::raw(&app.input));
             if !ghost.is_empty() {
                 spans.push(Span::styled(ghost, theme::muted()));
             }
         }
-        let input = Paragraph::new(Line::from(spans))
-            .block(Block::default()
+        let input = Paragraph::new(Line::from(spans)).block(
+            Block::default()
                 .borders(Borders::ALL)
                 .title(title)
                 .title_style(theme::dim())
-                .border_style(theme::accent()));
+                .border_style(theme::accent()),
+        );
         frame.render_widget(input, area);
 
         let cursor_x = area.x + 4 + app.input[..app.input_cursor].chars().count() as u16;
@@ -444,7 +526,8 @@ fn render_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
         } else {
             0
         };
-        let items: Vec<Line> = app.arg_suggestions
+        let items: Vec<Line> = app
+            .arg_suggestions
             .iter()
             .enumerate()
             .skip(scroll_offset)
@@ -472,7 +555,8 @@ fn render_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
         } else {
             0
         };
-        let items: Vec<Line> = app.suggestions
+        let items: Vec<Line> = app
+            .suggestions
             .iter()
             .enumerate()
             .skip(scroll_offset)
@@ -500,10 +584,17 @@ fn render_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
     }
 
     let popup_height = items.len() as u16 + 2;
-    let max_item_width = items.iter()
-        .map(|l| l.spans.iter().map(|s| s.content.chars().count()).sum::<usize>())
+    let max_item_width = items
+        .iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.chars().count())
+                .sum::<usize>()
+        })
         .max()
-        .unwrap_or(30) as u16 + 4;
+        .unwrap_or(30) as u16
+        + 4;
     let popup_width = max_item_width.max(30);
 
     let popup_area = Rect {

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -1,8 +1,9 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use crate::app::{App, MessageBlock, COMMANDS};
+use crate::app::{App, MessageBlock, SubagentStatus, COMMANDS};
 use crate::bidi;
+use crate::platform;
 use crate::theme;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
@@ -155,6 +156,87 @@ fn render_welcome(lines: &mut Vec<Line<'static>>) {
     lines.push(Line::from(""));
 }
 
+fn render_subagent_block(
+    lines: &mut Vec<Line<'static>>,
+    app: &App,
+    subagent_type: &str,
+    description: &str,
+    status: &SubagentStatus,
+    output_preview: Option<&str>,
+    is_warden: bool,
+) {
+    let (icon, icon_style, name_style) = match (is_warden, status) {
+        (true, SubagentStatus::Running) => {
+            let spinner = app.spinner_frame();
+            (format!(" ⛨{} ", spinner), theme::warden_name(), theme::warden_name())
+        }
+        (true, SubagentStatus::Completed) => {
+            (" ⛨✓ ".to_string(), theme::verdict_ship(), theme::warden_name())
+        }
+        (false, SubagentStatus::Running) => {
+            let spinner = app.spinner_frame();
+            (format!(" ◈{} ", spinner), theme::agent_name(), theme::agent_name())
+        }
+        (false, SubagentStatus::Completed) => {
+            (" ◈✓ ".to_string(), Style::default().fg(theme::GOOD), theme::agent_name())
+        }
+    };
+
+    let label = if is_warden { "Warden" } else { "Agent" };
+    lines.push(Line::from(vec![
+        Span::styled(icon, icon_style),
+        Span::styled(format!("{} ({})", label, subagent_type), name_style),
+        Span::styled(format!("  {}", description), theme::agent_detail()),
+    ]));
+
+    if *status == SubagentStatus::Completed && app.show_tools {
+        if let Some(preview) = output_preview {
+            let max_lines = if is_warden { 10 } else { 5 };
+            let total_lines = preview.lines().count();
+            for (i, line) in preview.lines().take(max_lines).enumerate() {
+                let text = if is_warden {
+                    highlight_verdict(line)
+                } else {
+                    Line::from(vec![
+                        Span::styled("   │ ", theme::muted()),
+                        Span::raw(line.to_string()),
+                    ])
+                };
+                lines.push(text);
+                if i == max_lines - 1 && total_lines > max_lines {
+                    lines.push(Line::from(Span::styled("   │ ⋯", theme::muted())));
+                }
+            }
+        }
+    }
+}
+
+fn highlight_verdict(line: &str) -> Line<'static> {
+    let trimmed = line.trim();
+    if trimmed.contains("SHIP") {
+        return Line::from(vec![
+            Span::styled("   │ ", theme::muted()),
+            Span::styled(line.to_string(), theme::verdict_ship()),
+        ]);
+    }
+    if trimmed.contains("REVISE") {
+        return Line::from(vec![
+            Span::styled("   │ ", theme::muted()),
+            Span::styled(line.to_string(), theme::verdict_revise()),
+        ]);
+    }
+    if trimmed.contains("HOLD") {
+        return Line::from(vec![
+            Span::styled("   │ ", theme::muted()),
+            Span::styled(line.to_string(), theme::verdict_hold()),
+        ]);
+    }
+    Line::from(vec![
+        Span::styled("   │ ", theme::muted()),
+        Span::raw(line.to_string()),
+    ])
+}
+
 fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     let mut lines: Vec<Line> = Vec::new();
 
@@ -195,12 +277,15 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
             for block in &msg.blocks {
                 match block {
                     MessageBlock::Thinking(_) => {}
-                    MessageBlock::ToolUse { tool, detail } => {
+                    MessageBlock::ToolUse { tool, detail, .. } => {
                         lines.push(Line::from(vec![
                             Span::styled(" ▸ ", Style::default().fg(theme::FLAME)),
                             Span::styled(tool.clone(), theme::tool_name()),
                             Span::styled(format!(" {}", detail), theme::tool_detail()),
                         ]));
+                    }
+                    MessageBlock::SubagentBlock { subagent_type, description, status, output_preview, is_warden, .. } => {
+                        render_subagent_block(&mut lines, app, subagent_type, description, status, output_preview.as_deref(), *is_warden);
                     }
                     MessageBlock::Text(text) => {
                         let mut in_code = false;
@@ -295,16 +380,7 @@ fn ghost_text(app: &App) -> String {
 fn render_input(frame: &mut Frame, app: &App, area: Rect) {
     let ghost = ghost_text(app);
 
-    let cwd = std::env::current_dir()
-        .map(|p| {
-            let home = dirs::home_dir().unwrap_or_default();
-            if let Ok(rel) = p.strip_prefix(&home) {
-                format!("~/{}", rel.display())
-            } else {
-                p.display().to_string()
-            }
-        })
-        .unwrap_or_default();
+    let cwd = platform::display_path(&platform::current_dir());
     let title = format!(" {} ", cwd);
 
     if app.is_multiline() {

--- a/tui/src/panels/services.rs
+++ b/tui/src/panels/services.rs
@@ -21,7 +21,11 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
                 Span::styled(format!("{} ", icon), Style::default().fg(color)),
                 Span::styled(
                     format!("{:42}", svc.description),
-                    if i == app.cursor { theme::bold() } else { Style::default() },
+                    if i == app.cursor {
+                        theme::bold()
+                    } else {
+                        Style::default()
+                    },
                 ),
                 Span::styled(&svc.status, theme::dim()),
             ]))

--- a/tui/src/panels/status.rs
+++ b/tui/src/panels/status.rs
@@ -38,8 +38,16 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(Span::styled("  CHANNELS", theme::bold())));
     lines.push(Line::from(""));
     for ch in &app.channels {
-        let (icon, color) = if ch.configured { ("●", theme::GOOD) } else { ("○", theme::BAD) };
-        let status = if ch.configured { "connected" } else { "not configured" };
+        let (icon, color) = if ch.configured {
+            ("●", theme::GOOD)
+        } else {
+            ("○", theme::BAD)
+        };
+        let status = if ch.configured {
+            "connected"
+        } else {
+            "not configured"
+        };
         lines.push(Line::from(vec![
             Span::styled(format!("  {} ", icon), Style::default().fg(color)),
             Span::raw(format!("{:16} {}", ch.name, status)),

--- a/tui/src/panels/wardens.rs
+++ b/tui/src/panels/wardens.rs
@@ -5,11 +5,7 @@ use crate::app::App;
 use crate::theme;
 
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
-    let layout = Layout::vertical([
-        Constraint::Min(0),
-        Constraint::Length(6),
-    ])
-    .split(area);
+    let layout = Layout::vertical([Constraint::Min(0), Constraint::Length(6)]).split(area);
 
     let items: Vec<ListItem> = app
         .wardens

--- a/tui/src/platform.rs
+++ b/tui/src/platform.rs
@@ -49,10 +49,12 @@ pub fn is_macos() -> bool {
     cfg!(target_os = "macos")
 }
 
+#[allow(dead_code)]
 pub fn is_linux() -> bool {
     cfg!(target_os = "linux")
 }
 
+#[allow(dead_code)]
 pub fn is_windows() -> bool {
     cfg!(target_os = "windows")
 }

--- a/tui/src/platform.rs
+++ b/tui/src/platform.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+pub fn home_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"))
+}
+
+pub fn config_dir() -> PathBuf {
+    home_dir().join(".config").join("deus")
+}
+
+pub fn config_file() -> PathBuf {
+    config_dir().join("config.json")
+}
+
+pub fn current_dir() -> PathBuf {
+    std::env::current_dir().unwrap_or_default()
+}
+
+pub fn current_exe() -> PathBuf {
+    std::env::current_exe().unwrap_or_default()
+}
+
+pub fn env_var(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+pub fn env_flag(key: &str) -> bool {
+    env_var(key).map(|v| v == "true").unwrap_or(false)
+}
+
+pub fn expand_tilde(path: &str) -> PathBuf {
+    if path.starts_with('~') {
+        home_dir().join(&path[2..])
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+pub fn display_path(path: &std::path::Path) -> String {
+    let home = home_dir();
+    if let Ok(rel) = path.strip_prefix(&home) {
+        format!("~/{}", rel.display())
+    } else {
+        path.display().to_string()
+    }
+}
+
+pub fn is_macos() -> bool {
+    cfg!(target_os = "macos")
+}
+
+pub fn is_linux() -> bool {
+    cfg!(target_os = "linux")
+}
+
+pub fn is_windows() -> bool {
+    cfg!(target_os = "windows")
+}

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -2,11 +2,15 @@ use ratatui::style::{Color, Modifier, Style};
 
 pub const EMBER: Color = Color::Rgb(0xE8, 0x72, 0x3A);
 pub const FLAME: Color = Color::Rgb(0xF4, 0xA2, 0x61);
+#[allow(dead_code)]
 pub const DEEP_TEAL: Color = Color::Rgb(0x1B, 0x7A, 0x6E);
 pub const OCEAN: Color = Color::Rgb(0x2E, 0xC4, 0xB6);
+#[allow(dead_code)]
 pub const SHADOW: Color = Color::Rgb(0xC4, 0x5A, 0x2A);
+#[allow(dead_code)]
 pub const NIGHT: Color = Color::Rgb(0x1A, 0x1A, 0x2E);
 
+#[allow(dead_code)]
 pub const SURFACE: Color = Color::Reset;
 pub const TEXT: Color = Color::White;
 pub const TEXT_DIM: Color = Color::Rgb(0x6C, 0x6C, 0x8A);
@@ -18,7 +22,9 @@ pub const WARN: Color = Color::Rgb(0xF4, 0xA2, 0x61);
 pub const BAD: Color = Color::Rgb(0xE8, 0x5D, 0x5D);
 
 pub const ACCENT: Color = OCEAN;
+#[allow(dead_code)]
 pub const ACCENT_ALT: Color = EMBER;
+#[allow(dead_code)]
 pub const PROMPT: Color = OCEAN;
 
 pub fn accent() -> Style {
@@ -38,7 +44,9 @@ pub fn muted() -> Style {
 }
 
 pub fn bold() -> Style {
-    Style::default().fg(Color::Rgb(0xFF, 0xFF, 0xFF)).add_modifier(Modifier::BOLD)
+    Style::default()
+        .fg(Color::Rgb(0xFF, 0xFF, 0xFF))
+        .add_modifier(Modifier::BOLD)
 }
 
 pub fn good() -> Style {
@@ -49,6 +57,7 @@ pub fn warn() -> Style {
     Style::default().fg(WARN)
 }
 
+#[allow(dead_code)]
 pub fn bad() -> Style {
     Style::default().fg(BAD)
 }
@@ -58,7 +67,9 @@ pub fn border() -> Style {
 }
 
 pub fn user_msg() -> Style {
-    Style::default().fg(Color::Rgb(0xFF, 0xFF, 0xFF)).add_modifier(Modifier::BOLD)
+    Style::default()
+        .fg(Color::Rgb(0xFF, 0xFF, 0xFF))
+        .add_modifier(Modifier::BOLD)
 }
 
 pub fn tool_name() -> Style {

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -100,3 +100,30 @@ pub fn diff_del() -> Style {
 pub fn diff_hunk() -> Style {
     Style::default().fg(OCEAN)
 }
+
+pub const AGENT: Color = Color::Rgb(0x9B, 0x59, 0xB6);
+pub const SHIELD: Color = Color::Rgb(0xD4, 0xAA, 0x00);
+
+pub fn agent_name() -> Style {
+    Style::default().fg(AGENT).add_modifier(Modifier::BOLD)
+}
+
+pub fn agent_detail() -> Style {
+    Style::default().fg(TEXT_DIM).add_modifier(Modifier::ITALIC)
+}
+
+pub fn warden_name() -> Style {
+    Style::default().fg(SHIELD).add_modifier(Modifier::BOLD)
+}
+
+pub fn verdict_ship() -> Style {
+    Style::default().fg(GOOD).add_modifier(Modifier::BOLD)
+}
+
+pub fn verdict_revise() -> Style {
+    Style::default().fg(WARN).add_modifier(Modifier::BOLD)
+}
+
+pub fn verdict_hold() -> Style {
+    Style::default().fg(BAD).add_modifier(Modifier::BOLD)
+}

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -10,11 +10,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     match app.tab {
         Tab::Chat => {
-            let layout = Layout::vertical([
-                Constraint::Min(0),
-                Constraint::Length(1),
-            ])
-            .split(area);
+            let layout = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
             panels::chat::render(frame, app, layout[0]);
             render_status_bar(frame, app, layout[1]);
@@ -87,12 +83,18 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
     let elapsed_secs = app.session_start.elapsed().as_secs();
     let window_secs: u64 = 5 * 3600;
-    let remaining_pct = if elapsed_secs >= window_secs { 0 } else {
-        ((window_secs - elapsed_secs) * 100 / window_secs) as u64
+    let remaining_pct = if elapsed_secs >= window_secs {
+        0
+    } else {
+        (window_secs - elapsed_secs) * 100 / window_secs
     };
-    let remaining_color = if remaining_pct > 50 { theme::GOOD }
-        else if remaining_pct > 20 { theme::WARN }
-        else { theme::BAD };
+    let remaining_color = if remaining_pct > 50 {
+        theme::GOOD
+    } else if remaining_pct > 20 {
+        theme::WARN
+    } else {
+        theme::BAD
+    };
     right.push(Span::styled(
         format!("{}%", remaining_pct),
         Style::default().fg(remaining_color),

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -56,6 +56,11 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         theme::accent(),
     ));
 
+    if app.mode != "home" {
+        left.push(Span::styled("│ ", theme::muted()));
+        left.push(Span::styled("EXT ", theme::warn()));
+    }
+
     if !app.git_branch.is_empty() {
         left.push(Span::styled("│ ", theme::muted()));
         left.push(Span::styled(format!(" {}", app.git_branch), theme::dim()));


### PR DESCRIPTION
## Summary

- **Context parity**: TUI as default launcher via `tui_default` config toggle — full vault context, Deus identity, bypass mode, external project support all flow through env vars to the TUI binary
- **Subprocess visualization**: `ChunkKind` extended with `SubagentStart` + ID-correlated `ToolResult` for start/completion tracking. Animated spinners for running subagents, collapsible output preview (Ctrl+O)
- **Warden visualization**: Detects warden subagent types from loaded config (not hardcoded). Shield icons, gold styling, verdict highlighting (SHIP/REVISE/HOLD in green/amber/red)
- **Platform layer**: New `tui/src/platform.rs` centralizing all OS/path/env calls — mirrors `src/platform.ts` pattern. All raw `dirs::home_dir()`, `std::env::var()`, `std::env::current_dir()` removed from other files
- **CI enforcement**: Platform parity drift check verifies TS and Rust modules expose aligned capabilities. Subagent tool lists shared via `mod.rs` constants across backends
- **Security**: Temp context file uses `$TMPDIR` (per-user on macOS) with `chmod 0600`

## Architecture

- `parse_line` returns `Vec<StreamChunk>` instead of `Option<StreamChunk>` (handles multi-block events)
- Shell wrapper builds context → temp file → env vars → exec TUI binary (no Rust rewrite of memory_indexer.py)
- Backend strategy trait preserved — no provider-specific code outside `tui/src/backend/`

## Test plan

- [ ] Set `tui_default: true` in `~/.config/deus/config.json`, run `deus` from `~/deus` — TUI launches with vault context
- [ ] Run `deus` from external project dir — TUI shows EXT indicator, loads project context
- [ ] `deus web` still launches direct CLI (not TUI)
- [ ] `deus tui` still works as explicit subcommand
- [ ] `python3 scripts/drift_check.py --all` passes (includes platform parity + backend strategy)
- [ ] `cargo build --release` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)