### PR TITLE
fix(tui): enter sends exact-match commands, deduplicate model names

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1009,12 +1009,12 @@ impl App {
 
     pub fn suggestion_is_exact_match(&self) -> bool {
         if !self.arg_suggestions.is_empty() {
-            if let Some(arg) = self.arg_suggestions.get(self.suggestion_cursor) {
-                if let Some(space_idx) = self.input.find(' ') {
-                    let typed_arg = &self.input[space_idx + 1..];
-                    let arg_value = arg.split_whitespace().next().unwrap_or(arg);
-                    return typed_arg == arg_value;
-                }
+            if let Some(arg) = self.arg_suggestions.get(self.suggestion_cursor)
+                && let Some(space_idx) = self.input.find(' ')
+            {
+                let typed_arg = &self.input[space_idx + 1..];
+                let arg_value = arg.split_whitespace().next().unwrap_or(arg);
+                return typed_arg == arg_value;
             }
             return false;
         }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -943,8 +943,12 @@ impl App {
                         let mut all: Vec<String> = Vec::new();
                         for b in backend::all_backends() {
                             for m in b.models() {
-                                let label = format!("{} — {} ({})", m.id, m.display, m.context);
-                                if label.starts_with(arg_part) || m.id.starts_with(arg_part) {
+                                let label = format!("{} ({})", m.display, m.context);
+                                if m.id.starts_with(arg_part)
+                                    || m.display
+                                        .to_lowercase()
+                                        .starts_with(&arg_part.to_lowercase())
+                                {
                                     all.push(label);
                                 }
                             }
@@ -1003,12 +1007,36 @@ impl App {
         }
     }
 
+    pub fn suggestion_is_exact_match(&self) -> bool {
+        if !self.arg_suggestions.is_empty() {
+            if let Some(arg) = self.arg_suggestions.get(self.suggestion_cursor) {
+                if let Some(space_idx) = self.input.find(' ') {
+                    let typed_arg = &self.input[space_idx + 1..];
+                    let arg_value = arg.split_whitespace().next().unwrap_or(arg);
+                    return typed_arg == arg_value;
+                }
+            }
+            return false;
+        }
+        if let Some(&cmd_idx) = self.suggestions.get(self.suggestion_cursor) {
+            let cmd = &COMMANDS[cmd_idx];
+            return self.input == cmd.name;
+        }
+        false
+    }
+
     pub fn accept_suggestion(&mut self) {
         if !self.arg_suggestions.is_empty() {
             if let Some(arg) = self.arg_suggestions.get(self.suggestion_cursor) {
                 let space_idx = self.input.find(' ').unwrap_or(self.input.len());
-                let arg_value = arg.split_whitespace().next().unwrap_or(arg);
-                self.input = format!("{} {}", &self.input[..space_idx], arg_value);
+                let cmd_part = &self.input[..space_idx];
+                let arg_value = if cmd_part == "/model" {
+                    backend::model_id_from_suggestion(arg)
+                        .unwrap_or_else(|| arg.split_whitespace().next().unwrap_or(arg).to_string())
+                } else {
+                    arg.split_whitespace().next().unwrap_or(arg).to_string()
+                };
+                self.input = format!("{} {}", cmd_part, arg_value);
                 self.input_cursor = self.input.len();
                 self.arg_suggestions.clear();
                 self.suggestions.clear();

--- a/tui/src/backend/mod.rs
+++ b/tui/src/backend/mod.rs
@@ -124,11 +124,23 @@ pub fn models_for_backend(backend: &str) -> Vec<String> {
             return b
                 .models()
                 .iter()
-                .map(|m| format!("{} — {} ({})", m.id, m.display, m.context))
+                .map(|m| format!("{} ({})", m.display, m.context))
                 .collect();
         }
     }
     Vec::new()
+}
+
+pub fn model_id_from_suggestion(suggestion: &str) -> Option<String> {
+    for b in all_backends() {
+        for m in b.models() {
+            let label = format!("{} ({})", m.display, m.context);
+            if label == suggestion {
+                return Some(m.id.to_string());
+            }
+        }
+    }
+    None
 }
 
 pub fn backend_labels() -> Vec<String> {

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -148,9 +148,11 @@ fn main() -> io::Result<()> {
                             KeyCode::Enter => {
                                 if key.modifiers.contains(KeyModifiers::SHIFT) {
                                     app.input_newline();
-                                } else if app.has_suggestions() {
+                                } else if app.has_suggestions() && !app.suggestion_is_exact_match()
+                                {
                                     app.accept_suggestion();
                                 } else {
+                                    app.dismiss_suggestions();
                                     app.send_message();
                                 }
                             }


### PR DESCRIPTION
## Summary
- **Enter on exact match**: typing `/resume` fully then pressing Enter now sends the command instead of re-accepting the suggestion in an infinite loop
- **Model name deduplication**: `/model codex` suggestions now show `GPT-5.5 (1M)` instead of redundant `gpt-5.5 — GPT-5.5 (1M)`. Reverse lookup maps display name back to model ID on accept.

## Test plan
- [x] 38 unit tests pass
- [ ] Manual: type `/resume` fully, press Enter — command sends
- [ ] Manual: `/model codex` — shows clean model names without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)