### PR TITLE
feat(tui): add RunMode enum for backend session management

### DIFF
--- a/docs/decisions/parallel-agent-orchestration.md
+++ b/docs/decisions/parallel-agent-orchestration.md
@@ -24,11 +24,24 @@ The TUI currently supports a single chat session. Users need to spawn background
 5. **Cross-platform kill** via `std::process::Child::kill()`, not `libc::kill`.
 6. **Token efficiency:** `--bare` + `--no-session-persistence` for sidechains, `--resume <id>` for multi-turn context management, bounded transcript buffers.
 
+### Cross-Backend Session Asymmetry
+
+Session management capabilities differ between backends:
+
+| Capability | Claude Code | Codex CLI |
+|-----------|-------------|-----------|
+| Pin session ID | `--session-id <uuid>` | Not available — sessions created implicitly |
+| Resume session | `--resume <id>` | `codex exec resume <id> <prompt>` (subcommand) |
+| Ephemeral mode | `--bare` + `--no-session-persistence` | `--ephemeral` |
+| Continuation | `--continue` | Not available in `exec` mode |
+
+The `RunMode` enum abstracts this: each backend maps the enum variant to its own CLI contract. Codex silently ignores `Normal { session_id: Some(_) }` since it has no equivalent flag — callers should not rely on session ID pinning for Codex backends.
+
 ### Implementation Phases
 
 | Phase | PR | Scope |
 |-------|----|-------|
 | 1 | Session extraction | Refactor `App` fields into `Session` struct, zero behavior change |
-| 2 | Backend session mgmt | `--session-id`, `--resume`, `--bare`, `--ephemeral` in RunConfig + backends |
+| 2 | Backend session mgmt | `RunMode` enum (`Normal`/`Resume`/`Ephemeral`) in `RunConfig` + both backends |
 | 3+4 | Spawn + picker UI | Background spawning, session picker, enter mode, commands |
 | 5 | Deferred | Bounded transcripts, dynamic effort, completion summaries, health monitoring (separate plan) |

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -125,6 +125,7 @@ pub struct Session {
     pub scroll_pinned: bool,
     pub chat_dirty: bool,
     pub chat_version: u64,
+    pub run_mode: backend::RunMode,
 }
 
 impl Session {
@@ -151,6 +152,7 @@ impl Session {
             scroll_pinned: true,
             chat_dirty: true,
             chat_version: 0,
+            run_mode: backend::RunMode::default(),
         }
     }
 
@@ -487,6 +489,7 @@ impl App {
                 None
             },
             permissions: session.permissions.clone(),
+            run_mode: session.run_mode.clone(),
         };
         session.turn_count += 1;
         let be = backend::backend_for(&config.model);

--- a/tui/src/backend/claude.rs
+++ b/tui/src/backend/claude.rs
@@ -1,5 +1,6 @@
 use super::{
-    Backend, ChunkKind, ModelDef, PermissionDenial, RunConfig, SUBAGENT_TOOLS_CLAUDE, StreamChunk,
+    Backend, ChunkKind, ModelDef, PermissionDenial, RunConfig, RunMode, SUBAGENT_TOOLS_CLAUDE,
+    StreamChunk,
 };
 use std::process::{Command, Stdio};
 
@@ -72,10 +73,27 @@ impl Backend for ClaudeBackend {
                 cmd.arg(tool);
             }
         }
-        if config.is_continuation {
-            cmd.arg("--continue");
+
+        match &config.run_mode {
+            RunMode::Resume { session_id } => {
+                cmd.args(["--resume", session_id]);
+            }
+            RunMode::Ephemeral => {
+                cmd.arg("--bare");
+                cmd.arg("--no-session-persistence");
+            }
+            RunMode::Normal { session_id } => {
+                if let Some(id) = session_id {
+                    cmd.args(["--session-id", id]);
+                }
+                if config.is_continuation {
+                    cmd.arg("--continue");
+                }
+            }
         }
-        if !config.is_continuation
+
+        if !matches!(config.run_mode, RunMode::Resume { .. })
+            && !config.is_continuation
             && let Some(ref ctx_file) = config.system_context_file
             && let Ok(ctx) = std::fs::read_to_string(ctx_file)
             && !ctx.is_empty()
@@ -298,6 +316,7 @@ fn extract_tool_result_preview(block: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::permissions::PermissionsConfig;
 
     fn parse(json: &str) -> Vec<ChunkKind> {
         ClaudeBackend
@@ -406,26 +425,45 @@ mod tests {
         assert!(matches!(&chunks[0], ChunkKind::CostUpdate { .. }));
     }
 
-    #[test]
-    fn build_command_sets_permission_flags() {
-        use crate::config::permissions::PermissionsConfig;
-        let config = RunConfig {
+    fn default_permissions() -> PermissionsConfig {
+        PermissionsConfig {
+            mode: "default".to_string(),
+            allowed_tools: vec![],
+            disallowed_tools: vec![],
+        }
+    }
+
+    fn base_config() -> RunConfig {
+        RunConfig {
             model: "sonnet".to_string(),
             message: "test".to_string(),
             effort: "high".to_string(),
             is_continuation: false,
             system_context_file: None,
+            permissions: default_permissions(),
+            run_mode: RunMode::default(),
+        }
+    }
+
+    fn args_of(config: &RunConfig) -> Vec<String> {
+        ClaudeBackend
+            .build_command(config)
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn build_command_sets_permission_flags() {
+        let config = RunConfig {
             permissions: PermissionsConfig {
                 mode: "acceptEdits".to_string(),
                 allowed_tools: vec!["Read".to_string(), "Bash(git *)".to_string()],
                 disallowed_tools: vec!["Write".to_string()],
             },
+            ..base_config()
         };
-        let cmd = ClaudeBackend.build_command(&config);
-        let args: Vec<_> = cmd
-            .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
+        let args = args_of(&config);
         assert!(args.contains(&"--permission-mode".to_string()));
         assert!(args.contains(&"acceptEdits".to_string()));
         assert!(args.contains(&"--allowedTools".to_string()));
@@ -438,25 +476,90 @@ mod tests {
 
     #[test]
     fn build_command_bypass_adds_skip_flag() {
-        use crate::config::permissions::PermissionsConfig;
         let config = RunConfig {
-            model: "sonnet".to_string(),
-            message: "test".to_string(),
-            effort: "high".to_string(),
-            is_continuation: false,
-            system_context_file: None,
             permissions: PermissionsConfig {
                 mode: "bypassPermissions".to_string(),
                 allowed_tools: vec![],
                 disallowed_tools: vec![],
             },
+            ..base_config()
         };
-        let cmd = ClaudeBackend.build_command(&config);
-        let args: Vec<_> = cmd
-            .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
+        let args = args_of(&config);
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert!(args.contains(&"bypassPermissions".to_string()));
+    }
+
+    #[test]
+    fn build_command_normal_mode_no_session_flags() {
+        let args = args_of(&base_config());
+        assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+        assert!(!args.contains(&"--bare".to_string()));
+        assert!(!args.contains(&"--no-session-persistence".to_string()));
+        assert!(!args.contains(&"--continue".to_string()));
+    }
+
+    #[test]
+    fn build_command_normal_with_session_id() {
+        let config = RunConfig {
+            run_mode: RunMode::Normal {
+                session_id: Some("abc-123".to_string()),
+            },
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"abc-123".to_string()));
+    }
+
+    #[test]
+    fn build_command_resume_mode() {
+        let config = RunConfig {
+            run_mode: RunMode::Resume {
+                session_id: "sess-42".to_string(),
+            },
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"sess-42".to_string()));
+        assert!(!args.contains(&"--continue".to_string()));
+    }
+
+    #[test]
+    fn build_command_resume_suppresses_continue() {
+        let config = RunConfig {
+            is_continuation: true,
+            run_mode: RunMode::Resume {
+                session_id: "sess-42".to_string(),
+            },
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(!args.contains(&"--continue".to_string()));
+    }
+
+    #[test]
+    fn build_command_ephemeral_mode() {
+        let config = RunConfig {
+            run_mode: RunMode::Ephemeral,
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--bare".to_string()));
+        assert!(args.contains(&"--no-session-persistence".to_string()));
+        assert!(!args.contains(&"--continue".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+    }
+
+    #[test]
+    fn build_command_continuation_in_normal_mode() {
+        let config = RunConfig {
+            is_continuation: true,
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--continue".to_string()));
     }
 }

--- a/tui/src/backend/codex.rs
+++ b/tui/src/backend/codex.rs
@@ -1,4 +1,4 @@
-use super::{Backend, ChunkKind, ModelDef, RunConfig, SUBAGENT_TOOLS_CODEX, StreamChunk};
+use super::{Backend, ChunkKind, ModelDef, RunConfig, RunMode, SUBAGENT_TOOLS_CODEX, StreamChunk};
 use std::process::{Command, Stdio};
 
 pub struct CodexBackend;
@@ -60,11 +60,40 @@ impl Backend for CodexBackend {
         };
 
         let mut cmd = Command::new("codex");
-        cmd.args(["exec", "--json", "-m", &config.model, "-c", &effort_cfg]);
-        if config.permissions.is_bypass() {
-            cmd.arg("--dangerously-bypass-approvals-and-sandbox");
+
+        match &config.run_mode {
+            RunMode::Resume { session_id } => {
+                cmd.args([
+                    "exec",
+                    "resume",
+                    "--json",
+                    "-m",
+                    &config.model,
+                    "-c",
+                    &effort_cfg,
+                ]);
+                if config.permissions.is_bypass() {
+                    cmd.arg("--dangerously-bypass-approvals-and-sandbox");
+                }
+                cmd.args([session_id.as_str(), &message]);
+            }
+            RunMode::Ephemeral => {
+                cmd.args(["exec", "--json", "-m", &config.model, "-c", &effort_cfg]);
+                cmd.arg("--ephemeral");
+                if config.permissions.is_bypass() {
+                    cmd.arg("--dangerously-bypass-approvals-and-sandbox");
+                }
+                cmd.arg(&message);
+            }
+            RunMode::Normal { .. } => {
+                cmd.args(["exec", "--json", "-m", &config.model, "-c", &effort_cfg]);
+                if config.permissions.is_bypass() {
+                    cmd.arg("--dangerously-bypass-approvals-and-sandbox");
+                }
+                cmd.arg(&message);
+            }
         }
-        cmd.arg(&message);
+
         cmd.stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -375,5 +404,100 @@ mod tests {
     #[test]
     fn parse_invalid_json() {
         assert!(parse("garbage").is_empty());
+    }
+
+    fn default_permissions() -> crate::config::permissions::PermissionsConfig {
+        crate::config::permissions::PermissionsConfig {
+            mode: "default".to_string(),
+            allowed_tools: vec![],
+            disallowed_tools: vec![],
+        }
+    }
+
+    fn base_config() -> RunConfig {
+        RunConfig {
+            model: "gpt-5.4".to_string(),
+            message: "test".to_string(),
+            effort: "high".to_string(),
+            is_continuation: false,
+            system_context_file: None,
+            permissions: default_permissions(),
+            run_mode: RunMode::default(),
+        }
+    }
+
+    fn args_of(config: &RunConfig) -> Vec<String> {
+        CodexBackend
+            .build_command(config)
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn build_command_normal_mode() {
+        let args = args_of(&base_config());
+        assert_eq!(args[0], "exec");
+        assert!(args.contains(&"--json".to_string()));
+        assert!(args.contains(&"test".to_string()));
+        assert!(!args.contains(&"resume".to_string()));
+        assert!(!args.contains(&"--ephemeral".to_string()));
+    }
+
+    #[test]
+    fn build_command_normal_ignores_session_id() {
+        let config = RunConfig {
+            run_mode: RunMode::Normal {
+                session_id: Some("abc-123".to_string()),
+            },
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"abc-123".to_string()));
+    }
+
+    #[test]
+    fn build_command_resume_mode() {
+        let config = RunConfig {
+            run_mode: RunMode::Resume {
+                session_id: "sess-42".to_string(),
+            },
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert_eq!(args[0], "exec");
+        assert_eq!(args[1], "resume");
+        assert!(args.contains(&"sess-42".to_string()));
+        assert!(args.contains(&"test".to_string()));
+    }
+
+    #[test]
+    fn build_command_ephemeral_mode() {
+        let config = RunConfig {
+            run_mode: RunMode::Ephemeral,
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--ephemeral".to_string()));
+        assert!(!args.contains(&"resume".to_string()));
+    }
+
+    #[test]
+    fn build_command_bypass_in_resume() {
+        let config = RunConfig {
+            run_mode: RunMode::Resume {
+                session_id: "s1".to_string(),
+            },
+            permissions: crate::config::permissions::PermissionsConfig {
+                mode: "bypassPermissions".to_string(),
+                allowed_tools: vec![],
+                disallowed_tools: vec![],
+            },
+            ..base_config()
+        };
+        let args = args_of(&config);
+        assert!(args.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+        assert!(args.contains(&"resume".to_string()));
     }
 }

--- a/tui/src/backend/mod.rs
+++ b/tui/src/backend/mod.rs
@@ -49,6 +49,30 @@ pub struct PermissionDenial {
     pub tool_input_preview: String,
 }
 
+/// How a backend session should be launched.
+///
+/// Enum makes illegal states unrepresentable: you can't accidentally set both
+/// `resume` and `ephemeral` at the same time. Each variant carries only the
+/// data relevant to that mode.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum RunMode {
+    /// Normal session — optionally pinned to a backend-scoped UUID.
+    /// `session_id` is None for the main session (backend picks its own).
+    Normal { session_id: Option<String> },
+    /// Resume an existing session by its backend-scoped ID.
+    Resume { session_id: String },
+    /// Lightweight sidechain — no persistence, minimal startup overhead.
+    /// Claude: --bare --no-session-persistence. Codex: --ephemeral.
+    Ephemeral,
+}
+
+impl Default for RunMode {
+    fn default() -> Self {
+        Self::Normal { session_id: None }
+    }
+}
+
 pub struct RunConfig {
     pub model: String,
     pub message: String,
@@ -56,6 +80,7 @@ pub struct RunConfig {
     pub is_continuation: bool,
     pub system_context_file: Option<PathBuf>,
     pub permissions: PermissionsConfig,
+    pub run_mode: RunMode,
 }
 
 // Tool names that represent subagent/task spawning across providers.


### PR DESCRIPTION
## Summary
- **Phase 2** of parallel agent orchestration (ADR: `parallel-agent-orchestration.md`)
- Adds `RunMode` enum (`Normal`/`Resume`/`Ephemeral`) to `RunConfig` — makes illegal state combinations unrepresentable (can't set both resume and ephemeral)
- Claude: `Normal{id}` → `--session-id`, `Resume` → `--resume` (suppresses `--continue`), `Ephemeral` → `--bare` + `--no-session-persistence`
- Codex: `Resume` → `codex exec resume <id> <prompt>` (subcommand restructure), `Ephemeral` → `--ephemeral`, `Normal{id}` → no-op (Codex has no `--session-id`)
- Adds `run_mode` field to `Session`, wired through `dispatch_message` → `RunConfig`
- Documents cross-backend session asymmetry in ADR
- Zero behavior change — main session defaults to `RunMode::Normal { session_id: None }`
- 49 tests pass (11 new), clippy clean, fmt clean

### Design Pattern
**Strategy (continued):** each backend's `build_command` owns its CLI contract. `RunMode` is the shared vocabulary; backends map variants to their own flags/subcommands. Codex's `resume` being a subcommand (not a flag) is handled inside the Codex strategy without leaking into the caller.

### What's Next (separate PRs)
- Phase 3+4: Background agent spawning, session picker UI, enter mode, `/agent` command
- Phase 5: Bounded transcripts, dynamic effort, completion summaries

## Test plan
- [x] `cargo test` — 49 tests pass (11 new covering all RunMode × backend combinations)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual smoke: launch TUI, send message, `/clear`, send another — behavior identical to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)