### PR TITLE
feat(tui): background agent spawning with session picker

### DIFF
--- a/docs/decisions/backend-strategy-trait.md
+++ b/docs/decisions/backend-strategy-trait.md
@@ -51,5 +51,5 @@ No other files need changes — model registry, `/model` command, suggestions, d
 - Adding a provider is one file + two lines. No architectural changes needed.
 - Each provider owns its own JSONL contract — no shared parser to break.
 - The trait is `Send + Sync` so providers can be passed to background threads for stream processing.
-- Model selection, effort levels, and continuation semantics are per-provider (each `build_command` handles its own flags).
+- Model selection, effort levels, and continuation semantics are per-provider (each `build_command` handles its own flags). Note: background agent effort classification is centralized in `EffortPolicy` (see `parallel-agent-orchestration.md` §Dynamic Effort Classification). Backends continue to own flag encoding.
 - This convention applies repo-wide: any new provider integration (TUI, container runtime, or host process) should follow the same trait-based strategy pattern.

--- a/docs/decisions/parallel-agent-orchestration.md
+++ b/docs/decisions/parallel-agent-orchestration.md
@@ -72,4 +72,10 @@ Explicit `--effort` flag always overrides the classifier. This supersedes the pe
 
 - **`SessionState::Failed`**: set when `had_error` is true at session completion. Shown as red ✗ in the session picker.
 - **Exit code detection**: non-zero exit codes from the backend process emit an error chunk before Done.
-- **Timeout**: background agents are killed after `DEUS_AGENT_TIMEOUT_SECS` (env var, default 600s). Uses a channel-based kill signal — the spawn thread is the sole owner of `Child`, a timeout thread sends a signal via `mpsc::channel`, and the spawn thread calls `child.kill()` only after stdout/stderr readers have joined (preventing PID reuse races).
+- **Timeout**: background agents are killed after `DEUS_AGENT_TIMEOUT_SECS` (env var, default 600s). The timeout thread uses `recv_timeout` on a cancel channel instead of `thread::sleep` — when the agent finishes (stdout EOF + stderr join), the spawn thread sends a cancel signal, and the timeout thread exits immediately. If no cancel arrives within the timeout window, the timeout thread sends a kill signal via a separate channel. This prevents zombie sleep threads from accumulating for short-lived agents.
+
+### Session Lifecycle (Amendment — Phase 6)
+
+**Auto-cleanup:** Completed/failed background sessions are removed from `sessions` and `session_order` immediately after posting their completion summary to the main session. If the user was viewing the removed session, `active_session` resets to `SessionId::MAIN`. No TTL or deferred GC — sessions are ephemeral by design.
+
+**Concurrent limit:** `max_agents()` returns a configurable cap on concurrently streaming background agents. Precedence (first match wins): env `DEUS_MAX_AGENTS` → config `max_parallel_agents` → runtime `(available_parallelism() / 2).clamp(2, 8)`. Spawn is rejected at the cap with a user-facing error. The cap applies to actively-streaming agents only; once an agent completes and is GC'd, the slot is freed immediately.

--- a/docs/decisions/parallel-agent-orchestration.md
+++ b/docs/decisions/parallel-agent-orchestration.md
@@ -18,7 +18,7 @@ The TUI currently supports a single chat session. Users need to spawn background
 ### Key Rulings
 
 1. **Sessions are backend-scoped 1:1.** A `SessionId` maps to exactly one `Box<dyn Backend>`. Never resume a Claude session on Codex (per `backend-neutral-agent-runtime.md`).
-2. **Hint-driven spawn.** When the AI wants to spawn a subagent (`SubagentStart` event), TUI shows "Ctrl+B to run in background" hint. User presses Ctrl+B to detach to sidechain, or ignores to continue inline. `/agent <prompt>` available as explicit fallback. Full auto-spawn (orchestrator decides without AI signal) deferred.
+2. **Explicit spawn first.** `/agent <prompt>` is the primary spawn mechanism (Phase 3+4). Hint-driven spawn (SubagentStart → "Ctrl+B to detach") requires process re-parenting — transferring an in-flight stream_rx to a new Session — and is deferred to Phase 5. Full auto-spawn (orchestrator decides without AI signal) is also deferred.
 3. **`std::sync::mpsc::sync_channel(256)`** — bounded backpressure, no external crate needed. O(N) `try_recv` per 50ms tick for N sessions.
 4. **`HashMap<SessionId, Session>`** for O(1) lookup by ID. `Vec<SessionId>` for insertion-ordered picker display.
 5. **Cross-platform kill** via `std::process::Child::kill()`, not `libc::kill`.
@@ -43,5 +43,5 @@ The `RunMode` enum abstracts this: each backend maps the enum variant to its own
 |-------|----|-------|
 | 1 | Session extraction | Refactor `App` fields into `Session` struct, zero behavior change |
 | 2 | Backend session mgmt | `RunMode` enum (`Normal`/`Resume`/`Ephemeral`) in `RunConfig` + both backends |
-| 3+4 | Spawn + picker UI | Background spawning, session picker, enter mode, commands |
-| 5 | Deferred | Bounded transcripts, dynamic effort, completion summaries, health monitoring (separate plan) |
+| 3+4 | Spawn + picker UI | `/agent` command, multi-session polling, Ctrl+B session picker, status bar indicator |
+| 5 | Deferred | Hint-driven spawn (process re-parenting), bounded transcripts, dynamic effort, completion summaries |

--- a/docs/decisions/parallel-agent-orchestration.md
+++ b/docs/decisions/parallel-agent-orchestration.md
@@ -53,3 +53,23 @@ The original Phase 5 spec included "process re-parenting" for hint-driven spawn:
 **Revised scope:** Phase 5d provides *discoverability* instead of re-parenting. When `SubagentStart` appears in the stream, the status bar shows a hint ("Ctrl+B: parallel agent"). Pressing Ctrl+B prefills the input with `/agent <description>`, letting the user spawn a new independent agent with the same task. This delivers the UX value (awareness + one-key spawn) without the architectural complexity.
 
 Full process re-parenting is deferred indefinitely — it would require backend CLI support for mid-stream session splitting, which neither Claude Code nor Codex CLI offers.
+
+### Dynamic Effort Classification
+
+**Amendment (Phase 5):** Background agent effort is classified by `EffortPolicy` in `app.rs`, a stateless classifier that maps prompt keywords to effort levels:
+
+| Task Type | Keywords | Effort |
+|-----------|----------|--------|
+| Planning/review | review, plan, analyze, audit, design, architect | high |
+| Lookup/search | find, grep, search, list, show, check, lookup | low |
+| General | (everything else) | medium |
+
+Explicit `--effort` flag always overrides the classifier. This supersedes the per-provider ownership of effort levels from `backend-strategy-trait.md` for the specific case of auto-classifying background agent effort. Backends continue to own flag encoding in `build_command`.
+
+### Health Monitoring
+
+**Amendment (Phase 5):** Background sessions track process health via:
+
+- **`SessionState::Failed`**: set when `had_error` is true at session completion. Shown as red ✗ in the session picker.
+- **Exit code detection**: non-zero exit codes from the backend process emit an error chunk before Done.
+- **Timeout**: background agents are killed after `DEUS_AGENT_TIMEOUT_SECS` (env var, default 600s). Uses a channel-based kill signal — the spawn thread is the sole owner of `Child`, a timeout thread sends a signal via `mpsc::channel`, and the spawn thread calls `child.kill()` only after stdout/stderr readers have joined (preventing PID reuse races).

--- a/docs/decisions/parallel-agent-orchestration.md
+++ b/docs/decisions/parallel-agent-orchestration.md
@@ -44,4 +44,12 @@ The `RunMode` enum abstracts this: each backend maps the enum variant to its own
 | 1 | Session extraction | Refactor `App` fields into `Session` struct, zero behavior change |
 | 2 | Backend session mgmt | `RunMode` enum (`Normal`/`Resume`/`Ephemeral`) in `RunConfig` + both backends |
 | 3+4 | Spawn + picker UI | `/agent` command, multi-session polling, Ctrl+B session picker, status bar indicator |
-| 5 | Deferred | Hint-driven spawn (process re-parenting), bounded transcripts, dynamic effort, completion summaries |
+| 5 | In Progress | Bounded transcripts, dynamic effort, completion summaries, hint-driven spawn (discoverability only — see §Phase 5 Scoping below) |
+
+### Phase 5 Scoping
+
+The original Phase 5 spec included "process re-parenting" for hint-driven spawn: when the AI spawns a subagent via the `Agent` tool, detach the in-flight `stream_rx` into a new background `Session`. This is architecturally infeasible — the subagent runs as a tool call *within* the parent CLI process, sharing the same stdout stream. There is no separate process to re-parent; splitting one `stream_rx` between two Sessions would require protocol-level changes to the backend CLIs.
+
+**Revised scope:** Phase 5d provides *discoverability* instead of re-parenting. When `SubagentStart` appears in the stream, the status bar shows a hint ("Ctrl+B: parallel agent"). Pressing Ctrl+B prefills the input with `/agent <description>`, letting the user spawn a new independent agent with the same task. This delivers the UX value (awareness + one-key spawn) without the architectural complexity.
+
+Full process re-parenting is deferred indefinitely — it would require backend CLI support for mid-stream session splitting, which neither Claude Code nor Codex CLI offers.

--- a/packages/tui/src/deus-config.ts
+++ b/packages/tui/src/deus-config.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export interface DeusConfig {
+  vault_path?: string;
+  agent_backend?: string;
+  agent_backend_model?: string;
+  chrome_default?: string;
+  name?: string;
+  catch_me_up?: boolean;
+  bypass_permissions?: boolean;
+  persona?: string;
+  max_parallel_agents?: number;
+  [key: string]: unknown;
+}
+
+export function loadDeusConfig(): DeusConfig {
+  const configPath = join(homedir(), '.config', 'deus', 'config.json');
+  if (!existsSync(configPath)) return {};
+  try {
+    const data = JSON.parse(readFileSync(configPath, 'utf-8'));
+    return typeof data === 'object' && data !== null ? data : {};
+  } catch {
+    return {};
+  }
+}

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-03" # auto-bump
+last_verified: "2026-05-03T10:00" # auto-bump
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-03" # auto-bump
+last_verified: "2026-05-03T10:00" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-03" # auto-bump
+last_verified: "2026-05-03T09:40" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-03" # auto-bump
+last_verified: "2026-05-03T10:00" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/setup/memory.ts
+++ b/setup/memory.ts
@@ -9,7 +9,7 @@
  *   5. Memory database initialized
  *   6. Gemini API key (suggested, not required)
  */
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -291,6 +291,33 @@ export async function run(args: string[]): Promise<void> {
   // ── 4. Write config ──────────────────────────────────────────────────────
   fs.mkdirSync(CONFIG_DIR, { recursive: true });
   config.vault_path = vaultPath;
+
+  if (!config.max_parallel_agents) {
+    try {
+      const hw = spawnSync(pythonCmd, ['-m', 'evolution.hardware'], {
+        encoding: 'utf-8',
+        cwd: process.cwd(),
+        env: process.env,
+      });
+      if (hw.status === 0 && hw.stdout) {
+        const report = JSON.parse(hw.stdout.trim());
+        const cores: number = report?.hardware?.cores ?? 0;
+        if (cores > 0) {
+          config.max_parallel_agents = Math.max(
+            2,
+            Math.min(8, Math.floor(cores / 2)),
+          );
+          logger.info(
+            { cores, max_parallel_agents: config.max_parallel_agents },
+            'Agent limit set from hardware',
+          );
+        }
+      }
+    } catch {
+      // Hardware detection is optional — no failure on exotic platforms
+    }
+  }
+
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
   logger.info({ configPath: CONFIG_PATH }, 'Config written');
 

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -2192,24 +2192,21 @@ mod tests {
 
     #[test]
     fn spawn_agent_effort_from_policy() {
-        let mut app = App::new();
-        let id = app
-            .spawn_agent("review the code".to_string(), None, None)
-            .unwrap();
-        assert_eq!(app.sessions.get(&id).unwrap().effort, "high");
-
-        let id2 = app
-            .spawn_agent("find the config file".to_string(), None, None)
-            .unwrap();
-        assert_eq!(app.sessions.get(&id2).unwrap().effort, "low");
-
-        // Complete a session to free a slot on low-core CI runners
-        complete_session(&mut app, id);
-
-        let id3 = app
-            .spawn_agent("summarize this".to_string(), None, None)
-            .unwrap();
-        assert_eq!(app.sessions.get(&id3).unwrap().effort, "medium");
+        let cases = [
+            ("review the code", "high"),
+            ("find the config file", "low"),
+            ("summarize this", "medium"),
+        ];
+        for (prompt, expected) in cases {
+            let mut app = App::new();
+            let id = app.spawn_agent(prompt.to_string(), None, None).unwrap();
+            assert_eq!(
+                app.sessions.get(&id).unwrap().effort,
+                expected,
+                "prompt: {}",
+                prompt
+            );
+        }
     }
 
     #[test]

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -15,7 +15,28 @@ use crate::platform;
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 
 pub const TRANSCRIPT_CAP: usize = 200;
-pub const DEFAULT_AGENT_EFFORT: &str = "medium";
+
+pub struct EffortPolicy;
+
+impl EffortPolicy {
+    /// Centralized here (not per-backend) because task classification is a UX concern;
+    /// backends own only the flag encoding in build_command.
+    pub fn for_prompt(prompt: &str) -> &'static str {
+        let words: Vec<String> = prompt.to_lowercase()
+            .split_whitespace()
+            .map(|w| w.to_string())
+            .collect();
+        const HIGH: &[&str] = &["review", "plan", "analyze", "audit", "design", "architect"];
+        const LOW: &[&str] = &["find", "grep", "search", "list", "show", "check", "lookup"];
+        if words.iter().any(|w| HIGH.contains(&w.as_str())) {
+            return "high";
+        }
+        if words.iter().any(|w| LOW.contains(&w.as_str())) {
+            return "low";
+        }
+        "medium"
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SessionId(pub u64);
@@ -106,10 +127,11 @@ pub enum ChatState {
     Streaming,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SessionState {
     Running,
     Completed,
+    Failed,
 }
 
 pub struct AgentArgs {
@@ -137,6 +159,7 @@ pub struct Session {
     pub permissions: PermissionsConfig,
     pub active_subagent_ids: HashSet<String>,
     pub last_subagent_hint: Option<String>,
+    pub had_error: bool,
     pub scroll_offset: u16,
     pub scroll_pinned: bool,
     pub chat_dirty: bool,
@@ -167,6 +190,7 @@ impl Session {
             permissions,
             active_subagent_ids: HashSet::new(),
             last_subagent_hint: None,
+            had_error: false,
             scroll_offset: 0,
             scroll_pinned: true,
             chat_dirty: true,
@@ -564,11 +588,26 @@ impl App {
         session.turn_count += 1;
         let be = backend::backend_for(&config.model);
 
+        let is_background = session_id != SessionId::MAIN;
         thread::spawn(move || {
             let child = be.build_command(&config).spawn();
 
             match child {
                 Ok(mut process) => {
+                    let kill_rx = if is_background {
+                        let (kill_tx, rx) = mpsc::channel::<()>();
+                        let timeout_secs: u64 = platform::env_var("DEUS_AGENT_TIMEOUT_SECS")
+                            .and_then(|s| s.parse().ok())
+                            .unwrap_or(600);
+                        thread::spawn(move || {
+                            thread::sleep(Duration::from_secs(timeout_secs));
+                            let _ = kill_tx.send(());
+                        });
+                        Some(rx)
+                    } else {
+                        None
+                    };
+
                     let stderr_handle = process.stderr.take().map(|stderr| {
                         let tx2 = tx.clone();
                         thread::spawn(move || {
@@ -600,9 +639,31 @@ impl App {
                             }
                         }
                     }
-                    let _ = process.wait();
                     if let Some(h) = stderr_handle {
                         let _ = h.join();
+                    }
+
+                    let timed_out = kill_rx
+                        .as_ref()
+                        .is_some_and(|rx| rx.try_recv().is_ok());
+                    if timed_out {
+                        let _ = process.kill();
+                    }
+                    let status = process.wait();
+                    if timed_out {
+                        let _ = tx.send(backend::StreamChunk {
+                            kind: ChunkKind::Error("Agent timed out".to_string()),
+                        });
+                    } else if let Ok(s) = &status
+                        && !s.success()
+                    {
+                        let code = s.code().unwrap_or(-1);
+                        let _ = tx.send(backend::StreamChunk {
+                            kind: ChunkKind::Error(format!(
+                                "Process exited with code {}",
+                                code
+                            )),
+                        });
                     }
                     let _ = tx.send(backend::StreamChunk {
                         kind: ChunkKind::Done,
@@ -630,7 +691,7 @@ impl App {
     pub fn spawn_agent(&mut self, prompt: String, model: Option<String>, effort: Option<String>) -> SessionId {
         let id = SessionId::next();
         let model = model.unwrap_or_else(|| self.active().model.clone());
-        let effort = effort.unwrap_or_else(|| DEFAULT_AGENT_EFFORT.to_string());
+        let effort = effort.unwrap_or_else(|| EffortPolicy::for_prompt(&prompt).to_string());
         let preview: String = prompt.chars().take(50).collect();
         let label = if preview.len() < prompt.len() {
             format!("{}...", preview)
@@ -656,6 +717,7 @@ impl App {
             permissions: self.active().permissions.clone(),
             active_subagent_ids: HashSet::new(),
             last_subagent_hint: None,
+            had_error: false,
             scroll_offset: 0,
             scroll_pinned: true,
             chat_dirty: true,
@@ -836,7 +898,7 @@ impl App {
                     .map(|c| format!("  {:16} {}", c.name, c.description))
                     .collect::<Vec<_>>()
                     .join("\n");
-                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+B  Session picker\n  Ctrl+L  Clear screen\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history\n  PgUp/Dn Scroll chat\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
+                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+B  Parallel agent / session picker\n  Ctrl+Shift+B  Session picker (direct)\n  Ctrl+L  Clear screen\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history\n  PgUp/Dn Scroll chat\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
                 true
             }
             "/history" => {
@@ -863,7 +925,7 @@ impl App {
                 let effort_label = args
                     .effort
                     .as_deref()
-                    .unwrap_or(DEFAULT_AGENT_EFFORT)
+                    .unwrap_or_else(|| EffortPolicy::for_prompt(&args.prompt))
                     .to_string();
                 self.spawn_agent(args.prompt, args.model, args.effort);
                 self.active_mut().chat_messages.push(ChatMessage::simple(
@@ -1178,14 +1240,23 @@ impl App {
                     session.last_subagent_hint = None;
                     session.mark_chat_changed();
                     if session_id != SessionId::MAIN {
-                        session.session_state = SessionState::Completed;
+                        session.session_state = if session.had_error {
+                            SessionState::Failed
+                        } else {
+                            SessionState::Completed
+                        };
                         session.trim_transcript();
                         let label = session.label.clone();
                         let summary = session.completion_summary();
+                        let prefix = if session.had_error {
+                            "Agent failed"
+                        } else {
+                            "Agent completed"
+                        };
                         if let Some(main) = self.sessions.get_mut(&SessionId::MAIN) {
                             main.chat_messages.push(ChatMessage::simple(
                                 "system",
-                                &format!("[Agent completed: {}] {}", label, summary),
+                                &format!("[{}: {}] {}", prefix, label, summary),
                             ));
                             main.mark_chat_changed();
                         }
@@ -1198,6 +1269,7 @@ impl App {
                 }
                 ChunkKind::Error(e) => {
                     let session = self.sessions.get_mut(&session_id).unwrap();
+                    session.had_error = true;
                     if let Some(last) = session.chat_messages.last_mut()
                         && last.role == "assistant"
                     {
@@ -1676,7 +1748,7 @@ impl App {
                 return;
             }
             if let Some(session) = self.sessions.get(&id)
-                && session.session_state != SessionState::Completed
+                && session.session_state == SessionState::Running
             {
                 return;
             }
@@ -2041,10 +2113,16 @@ mod tests {
     }
 
     #[test]
-    fn spawn_agent_uses_default_effort() {
+    fn spawn_agent_effort_from_policy() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
-        assert_eq!(app.sessions.get(&id).unwrap().effort, DEFAULT_AGENT_EFFORT);
+        let id = app.spawn_agent("review the code".to_string(), None, None);
+        assert_eq!(app.sessions.get(&id).unwrap().effort, "high");
+
+        let id2 = app.spawn_agent("find the config file".to_string(), None, None);
+        assert_eq!(app.sessions.get(&id2).unwrap().effort, "low");
+
+        let id3 = app.spawn_agent("summarize this".to_string(), None, None);
+        assert_eq!(app.sessions.get(&id3).unwrap().effort, "medium");
     }
 
     #[test]
@@ -2162,5 +2240,105 @@ mod tests {
         app.poll_response();
 
         assert!(app.active().last_subagent_hint.is_none());
+    }
+
+    // --- EffortPolicy ---
+
+    #[test]
+    fn effort_policy_review_is_high() {
+        assert_eq!(EffortPolicy::for_prompt("review the code"), "high");
+        assert_eq!(EffortPolicy::for_prompt("plan the migration"), "high");
+        assert_eq!(EffortPolicy::for_prompt("analyze performance"), "high");
+    }
+
+    #[test]
+    fn effort_policy_find_is_low() {
+        assert_eq!(EffortPolicy::for_prompt("find the config file"), "low");
+        assert_eq!(EffortPolicy::for_prompt("grep for TODO"), "low");
+        assert_eq!(EffortPolicy::for_prompt("search for imports"), "low");
+    }
+
+    #[test]
+    fn effort_policy_general_is_medium() {
+        assert_eq!(EffortPolicy::for_prompt("summarize this"), "medium");
+        assert_eq!(EffortPolicy::for_prompt("refactor the module"), "medium");
+    }
+
+    #[test]
+    fn effort_policy_case_insensitive() {
+        assert_eq!(EffortPolicy::for_prompt("REVIEW the CODE"), "high");
+        assert_eq!(EffortPolicy::for_prompt("Find Files"), "low");
+    }
+
+    #[test]
+    fn spawn_agent_effort_explicit_overrides_policy() {
+        let mut app = App::new();
+        let id = app.spawn_agent("review the code".to_string(), None, Some("low".to_string()));
+        assert_eq!(app.sessions.get(&id).unwrap().effort, "low");
+    }
+
+    // --- Health monitoring ---
+
+    #[test]
+    fn error_chunk_sets_had_error() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_messages.push(ChatMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+            blocks: Vec::new(),
+        });
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Error("something failed".to_string()),
+        })
+        .unwrap();
+        app.poll_response();
+
+        assert!(app.sessions.get(&id).unwrap().had_error);
+    }
+
+    #[test]
+    fn done_after_error_sets_failed() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_messages.push(ChatMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+            blocks: Vec::new(),
+        });
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Error("crash".to_string()),
+        })
+        .unwrap();
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
+        app.poll_response();
+
+        assert_eq!(
+            app.sessions.get(&id).unwrap().session_state,
+            SessionState::Failed
+        );
+    }
+
+    #[test]
+    fn failed_session_is_dismissible() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.session_state = SessionState::Failed;
+        session.chat_state = ChatState::Idle;
+        session.stream_rx = None;
+
+        app.picker_cursor = 1;
+        app.dismiss_session();
+        assert!(!app.sessions.contains_key(&id));
     }
 }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -12,16 +12,14 @@ use crate::config;
 use crate::config::permissions::PermissionsConfig;
 use crate::platform;
 
-#[allow(dead_code)]
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SessionId(pub u64);
 
 impl SessionId {
     pub const MAIN: Self = Self(0);
 
-    #[allow(dead_code)]
     pub fn next() -> Self {
         Self(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed))
     }
@@ -105,9 +103,17 @@ pub enum ChatState {
     Streaming,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    Running,
+    Completed,
+}
+
 pub struct Session {
     #[allow(dead_code)]
     pub id: SessionId,
+    pub label: String,
+    pub session_state: SessionState,
     pub chat_messages: Vec<ChatMessage>,
     pub chat_state: ChatState,
     pub stream_rx: Option<mpsc::Receiver<backend::StreamChunk>>,
@@ -132,6 +138,8 @@ impl Session {
     fn new_main(model: String, effort: String, permissions: PermissionsConfig) -> Self {
         Self {
             id: SessionId::MAIN,
+            label: "main".to_string(),
+            session_state: SessionState::Running,
             chat_messages: vec![ChatMessage::simple(
                 "system",
                 "Welcome to Deus. Type a message or / for commands.",
@@ -253,6 +261,16 @@ pub const COMMANDS: &[CommandDef] = &[
         args: &["mode", "allow", "deny", "remove", "reset"],
     },
     CommandDef {
+        name: "/agent",
+        description: "Spawn background agent",
+        args: &[],
+    },
+    CommandDef {
+        name: "/sessions",
+        description: "Session picker",
+        args: &[],
+    },
+    CommandDef {
         name: "/clear",
         description: "Clear chat",
         args: &[],
@@ -268,6 +286,9 @@ pub struct App {
     // Session management
     pub sessions: HashMap<SessionId, Session>,
     pub active_session: SessionId,
+    pub session_order: Vec<SessionId>,
+    pub show_session_picker: bool,
+    pub picker_cursor: usize,
 
     // Global UI state
     pub tab: Tab,
@@ -362,6 +383,9 @@ impl App {
         let mut app = Self {
             sessions,
             active_session: main_id,
+            session_order: vec![main_id],
+            show_session_picker: false,
+            picker_cursor: 0,
 
             tab: Tab::Chat,
             cursor: 0,
@@ -464,8 +488,12 @@ impl App {
     }
 
     fn dispatch_message(&mut self, msg: String) {
+        self.dispatch_message_for(self.active_session, msg);
+    }
+
+    fn dispatch_message_for(&mut self, session_id: SessionId, msg: String) {
         let ctx_file = self.system_context_file.clone();
-        let session = self.active_mut();
+        let session = self.sessions.get_mut(&session_id).unwrap();
         session
             .chat_messages
             .push(ChatMessage::simple("user", &msg));
@@ -549,11 +577,52 @@ impl App {
             }
         });
 
-        self.active_mut().chat_messages.push(ChatMessage {
+        let session = self.sessions.get_mut(&session_id).unwrap();
+        session.chat_messages.push(ChatMessage {
             role: "assistant".to_string(),
             content: String::new(),
             blocks: Vec::new(),
         });
+    }
+
+    pub fn spawn_agent(&mut self, prompt: String, model: Option<String>) -> SessionId {
+        let id = SessionId::next();
+        let model = model.unwrap_or_else(|| self.active().model.clone());
+        let preview: String = prompt.chars().take(50).collect();
+        let label = if preview.len() < prompt.len() {
+            format!("{}...", preview)
+        } else {
+            preview
+        };
+
+        let session = Session {
+            id,
+            label,
+            session_state: SessionState::Running,
+            chat_messages: Vec::new(),
+            chat_state: ChatState::Idle,
+            stream_rx: None,
+            turn_count: 0,
+            model,
+            effort: "high".to_string(),
+            token_count: 0,
+            cost_usd: 0.0,
+            turn_start: None,
+            last_turn_duration: None,
+            last_thinking_summary: None,
+            permissions: self.active().permissions.clone(),
+            active_subagent_ids: HashSet::new(),
+            scroll_offset: 0,
+            scroll_pinned: true,
+            chat_dirty: true,
+            chat_version: 0,
+            run_mode: backend::RunMode::Ephemeral,
+        };
+
+        self.sessions.insert(id, session);
+        self.session_order.push(id);
+        self.dispatch_message_for(id, prompt);
+        id
     }
 
     fn handle_command(&mut self, msg: &str) -> bool {
@@ -723,7 +792,7 @@ impl App {
                     .map(|c| format!("  {:16} {}", c.name, c.description))
                     .collect::<Vec<_>>()
                     .join("\n");
-                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+L  Clear screen\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history\n  PgUp/Dn Scroll chat\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
+                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+B  Session picker\n  Ctrl+L  Clear screen\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history\n  PgUp/Dn Scroll chat\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
                 true
             }
             "/history" => {
@@ -735,6 +804,33 @@ impl App {
             }
             "/permissions" => {
                 self.handle_permissions_command(arg);
+                true
+            }
+            "/agent" if !arg.is_empty() => {
+                let preview: String = arg.chars().take(60).collect();
+                self.spawn_agent(arg.to_string(), None);
+                self.active_mut().chat_messages.push(ChatMessage::simple(
+                    "system",
+                    &format!("Agent spawned: {}", preview),
+                ));
+                true
+            }
+            "/agent" => {
+                self.active_mut()
+                    .chat_messages
+                    .push(ChatMessage::simple("system", "Usage: /agent <prompt>"));
+                true
+            }
+            "/sessions" => {
+                if self.session_order.len() <= 1 {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        "No background sessions. Use /agent <prompt> to spawn one.",
+                    ));
+                } else {
+                    self.show_session_picker = true;
+                    self.picker_cursor = 0;
+                }
                 true
             }
             "/init" | "/compress" | "/checkpoint" | "/compact" | "/resume" => false,
@@ -869,157 +965,180 @@ impl App {
     }
 
     pub fn poll_response(&mut self) {
-        let session = self.active_mut();
+        let ids: Vec<SessionId> = self.sessions.keys().copied().collect();
+        for id in ids {
+            self.poll_session(id);
+        }
+    }
+
+    fn poll_session(&mut self, session_id: SessionId) {
+        let session = match self.sessions.get(&session_id) {
+            Some(s) => s,
+            None => return,
+        };
+        if session.stream_rx.is_none() {
+            return;
+        }
+
+        let mut chunks: Vec<backend::StreamChunk> = Vec::new();
         if let Some(rx) = &session.stream_rx {
-            let mut had_chunks = false;
-            let mut chunks: Vec<backend::StreamChunk> = Vec::new();
             while let Ok(chunk) = rx.try_recv() {
-                had_chunks = true;
                 chunks.push(chunk);
             }
-            for chunk in chunks {
-                match chunk.kind {
-                    ChunkKind::Text(text) => {
-                        let session = self.active_mut();
-                        if let Some(last) = session.chat_messages.last_mut()
-                            && last.role == "assistant"
-                        {
-                            if !last.content.is_empty() {
-                                last.content.push('\n');
-                            }
-                            last.content.push_str(&text);
-                            last.blocks.push(MessageBlock::Text(text));
+        }
+        if chunks.is_empty() {
+            return;
+        }
+
+        for chunk in chunks {
+            match chunk.kind {
+                ChunkKind::Text(text) => {
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    if let Some(last) = session.chat_messages.last_mut()
+                        && last.role == "assistant"
+                    {
+                        if !last.content.is_empty() {
+                            last.content.push('\n');
                         }
+                        last.content.push_str(&text);
+                        last.blocks.push(MessageBlock::Text(text));
                     }
-                    ChunkKind::Thinking(text) => {
-                        let summary: String = text.chars().take(100).collect();
-                        let session = self.active_mut();
-                        session.last_thinking_summary = Some(if summary.len() < text.len() {
-                            format!("{}...", summary)
-                        } else {
-                            summary
+                }
+                ChunkKind::Thinking(text) => {
+                    let summary: String = text.chars().take(100).collect();
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    session.last_thinking_summary = Some(if summary.len() < text.len() {
+                        format!("{}...", summary)
+                    } else {
+                        summary
+                    });
+                    if let Some(last) = session.chat_messages.last_mut()
+                        && last.role == "assistant"
+                    {
+                        last.blocks.push(MessageBlock::Thinking(text));
+                    }
+                }
+                ChunkKind::ToolUse { id, tool, detail } => {
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    if let Some(last) = session.chat_messages.last_mut()
+                        && last.role == "assistant"
+                    {
+                        let line = format!("[{}] {}", tool, detail);
+                        if !last.content.is_empty() {
+                            last.content.push('\n');
+                        }
+                        last.content.push_str(&line);
+                        last.blocks.push(MessageBlock::ToolUse { id, tool, detail });
+                    }
+                }
+                ChunkKind::SubagentStart {
+                    id,
+                    subagent_type,
+                    description,
+                } => {
+                    let is_warden = self.is_warden_name(&subagent_type);
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    session.active_subagent_ids.insert(id.clone());
+                    if let Some(last) = session.chat_messages.last_mut()
+                        && last.role == "assistant"
+                    {
+                        last.blocks.push(MessageBlock::SubagentBlock {
+                            id,
+                            subagent_type,
+                            description,
+                            status: SubagentStatus::Running,
+                            output_preview: None,
+                            is_warden,
                         });
-                        if let Some(last) = session.chat_messages.last_mut()
-                            && last.role == "assistant"
-                        {
-                            last.blocks.push(MessageBlock::Thinking(text));
-                        }
                     }
-                    ChunkKind::ToolUse { id, tool, detail } => {
-                        let session = self.active_mut();
-                        if let Some(last) = session.chat_messages.last_mut()
-                            && last.role == "assistant"
-                        {
-                            let line = format!("[{}] {}", tool, detail);
-                            if !last.content.is_empty() {
-                                last.content.push('\n');
+                }
+                ChunkKind::ToolResult {
+                    id,
+                    content_preview,
+                } => {
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    if session.active_subagent_ids.remove(&id)
+                        && let Some(last) = session.chat_messages.last_mut()
+                    {
+                        for block in &mut last.blocks {
+                            if let MessageBlock::SubagentBlock {
+                                id: bid,
+                                status,
+                                output_preview: preview,
+                                ..
+                            } = block
+                                && *bid == id
+                            {
+                                *status = SubagentStatus::Completed;
+                                *preview = Some(content_preview.clone());
+                                break;
                             }
-                            last.content.push_str(&line);
-                            last.blocks.push(MessageBlock::ToolUse { id, tool, detail });
-                        }
-                    }
-                    ChunkKind::SubagentStart {
-                        id,
-                        subagent_type,
-                        description,
-                    } => {
-                        let is_warden = self.is_warden_name(&subagent_type);
-                        let session = self.active_mut();
-                        session.active_subagent_ids.insert(id.clone());
-                        if let Some(last) = session.chat_messages.last_mut()
-                            && last.role == "assistant"
-                        {
-                            last.blocks.push(MessageBlock::SubagentBlock {
-                                id,
-                                subagent_type,
-                                description,
-                                status: SubagentStatus::Running,
-                                output_preview: None,
-                                is_warden,
-                            });
-                        }
-                    }
-                    ChunkKind::ToolResult {
-                        id,
-                        content_preview,
-                    } => {
-                        let session = self.active_mut();
-                        if session.active_subagent_ids.remove(&id)
-                            && let Some(last) = session.chat_messages.last_mut()
-                        {
-                            for block in &mut last.blocks {
-                                if let MessageBlock::SubagentBlock {
-                                    id: bid,
-                                    status,
-                                    output_preview: preview,
-                                    ..
-                                } = block
-                                    && *bid == id
-                                {
-                                    *status = SubagentStatus::Completed;
-                                    *preview = Some(content_preview.clone());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    ChunkKind::CostUpdate {
-                        cost_usd,
-                        input_tokens,
-                        output_tokens,
-                    } => {
-                        let session = self.active_mut();
-                        session.cost_usd = cost_usd;
-                        session.token_count = (input_tokens + output_tokens) as u32;
-                    }
-                    ChunkKind::PermissionDenials(denials) => {
-                        let denied_list: Vec<String> = denials
-                            .iter()
-                            .map(|d| {
-                                if d.tool_input_preview.is_empty() {
-                                    d.tool_name.clone()
-                                } else {
-                                    format!("{}({})", d.tool_name, d.tool_input_preview)
-                                }
-                            })
-                            .collect();
-                        self.active_mut()
-                            .chat_messages
-                            .push(ChatMessage::simple(
-                                "system",
-                                &format!(
-                                    "Permission denied for: {}\nUse /permissions allow <tool> to approve.",
-                                    denied_list.join(", ")
-                                ),
-                            ));
-                    }
-                    ChunkKind::Done => {
-                        let session = self.active_mut();
-                        session.chat_state = ChatState::Idle;
-                        session.stream_rx = None;
-                        session.last_turn_duration = session.turn_start.map(|t| t.elapsed());
-                        session.turn_start = None;
-                        session.active_subagent_ids.clear();
-                        session.mark_chat_changed();
-                        if !self.queued_messages.is_empty() {
-                            let next = self.queued_messages.remove(0);
-                            self.dispatch_message(next);
-                        }
-                        return;
-                    }
-                    ChunkKind::Error(e) => {
-                        let session = self.active_mut();
-                        if let Some(last) = session.chat_messages.last_mut()
-                            && last.role == "assistant"
-                        {
-                            last.content.push_str(&format!("\n[Error: {}]", e));
                         }
                     }
                 }
+                ChunkKind::CostUpdate {
+                    cost_usd,
+                    input_tokens,
+                    output_tokens,
+                } => {
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    session.cost_usd = cost_usd;
+                    session.token_count = (input_tokens + output_tokens) as u32;
+                }
+                ChunkKind::PermissionDenials(denials) => {
+                    let denied_list: Vec<String> = denials
+                        .iter()
+                        .map(|d| {
+                            if d.tool_input_preview.is_empty() {
+                                d.tool_name.clone()
+                            } else {
+                                format!("{}({})", d.tool_name, d.tool_input_preview)
+                            }
+                        })
+                        .collect();
+                    self.sessions
+                        .get_mut(&session_id)
+                        .unwrap()
+                        .chat_messages
+                        .push(ChatMessage::simple(
+                            "system",
+                            &format!(
+                                "Permission denied for: {}\nUse /permissions allow <tool> to approve.",
+                                denied_list.join(", ")
+                            ),
+                        ));
+                }
+                ChunkKind::Done => {
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    session.chat_state = ChatState::Idle;
+                    session.stream_rx = None;
+                    session.last_turn_duration = session.turn_start.map(|t| t.elapsed());
+                    session.turn_start = None;
+                    session.active_subagent_ids.clear();
+                    session.mark_chat_changed();
+                    if session_id != SessionId::MAIN {
+                        session.session_state = SessionState::Completed;
+                    }
+                    if session_id == self.active_session && !self.queued_messages.is_empty() {
+                        let next = self.queued_messages.remove(0);
+                        self.dispatch_message(next);
+                    }
+                    return;
+                }
+                ChunkKind::Error(e) => {
+                    let session = self.sessions.get_mut(&session_id).unwrap();
+                    if let Some(last) = session.chat_messages.last_mut()
+                        && last.role == "assistant"
+                    {
+                        last.content.push_str(&format!("\n[Error: {}]", e));
+                    }
+                }
             }
-            if had_chunks {
-                self.mark_chat_changed();
-            }
+        }
+        if session_id == self.active_session {
+            self.mark_chat_changed();
+        } else if let Some(s) = self.sessions.get_mut(&session_id) {
+            s.mark_chat_changed();
         }
     }
 
@@ -1454,6 +1573,66 @@ impl App {
         })
     }
 
+    pub fn switch_to_session(&mut self, id: SessionId) {
+        if self.sessions.contains_key(&id) {
+            self.active_session = id;
+            self.show_session_picker = false;
+            self.mark_chat_changed();
+        }
+    }
+
+    pub fn picker_next(&mut self) {
+        if self.picker_cursor + 1 < self.session_order.len() {
+            self.picker_cursor += 1;
+        }
+    }
+
+    pub fn picker_prev(&mut self) {
+        if self.picker_cursor > 0 {
+            self.picker_cursor -= 1;
+        }
+    }
+
+    pub fn picker_select(&mut self) {
+        if let Some(&id) = self.session_order.get(self.picker_cursor) {
+            self.switch_to_session(id);
+        }
+    }
+
+    pub fn dismiss_session(&mut self) {
+        if let Some(&id) = self.session_order.get(self.picker_cursor) {
+            if id == SessionId::MAIN {
+                return;
+            }
+            if let Some(session) = self.sessions.get(&id)
+                && session.session_state != SessionState::Completed
+            {
+                return;
+            }
+            self.sessions.remove(&id);
+            self.session_order.retain(|&sid| sid != id);
+            if self.picker_cursor >= self.session_order.len() && self.picker_cursor > 0 {
+                self.picker_cursor -= 1;
+            }
+            if self.session_order.len() <= 1 {
+                self.show_session_picker = false;
+            }
+        }
+    }
+
+    pub fn background_session_count(&self) -> usize {
+        self.session_order.len().saturating_sub(1)
+    }
+
+    pub fn streaming_background_count(&self) -> usize {
+        self.sessions
+            .iter()
+            .filter(|(id, s)| {
+                **id != self.active_session && matches!(s.chat_state, ChatState::Streaming)
+            })
+            .count()
+    }
+
     fn item_count(&self) -> usize {
         match self.tab {
             Tab::Chat | Tab::Status => 0,
@@ -1478,5 +1657,167 @@ mod tests {
 
         assert!(app.show_tools);
         assert_ne!(app.active().chat_version, before);
+    }
+
+    #[test]
+    fn spawn_agent_creates_background_session() {
+        let mut app = App::new();
+        assert_eq!(app.session_order.len(), 1);
+        assert_eq!(app.background_session_count(), 0);
+
+        let id = app.spawn_agent("test task".to_string(), None);
+
+        assert_eq!(app.session_order.len(), 2);
+        assert_eq!(app.background_session_count(), 1);
+        assert_ne!(id, SessionId::MAIN);
+        assert_eq!(app.active_session, SessionId::MAIN);
+
+        let session = app.sessions.get(&id).unwrap();
+        assert_eq!(session.run_mode, backend::RunMode::Ephemeral);
+        assert_eq!(session.label, "test task");
+    }
+
+    #[test]
+    fn spawn_agent_truncates_long_prompts() {
+        let mut app = App::new();
+        let long_prompt = "a".repeat(100);
+        let id = app.spawn_agent(long_prompt, None);
+
+        let session = app.sessions.get(&id).unwrap();
+        assert!(session.label.len() <= 54);
+        assert!(session.label.ends_with("..."));
+    }
+
+    #[test]
+    fn spawn_agent_inherits_model() {
+        let mut app = App::new();
+        let main_model = app.active().model.clone();
+        let id = app.spawn_agent("test".to_string(), None);
+
+        assert_eq!(app.sessions.get(&id).unwrap().model, main_model);
+    }
+
+    #[test]
+    fn spawn_agent_accepts_custom_model() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), Some("haiku".to_string()));
+
+        assert_eq!(app.sessions.get(&id).unwrap().model, "haiku");
+    }
+
+    #[test]
+    fn session_picker_navigation() {
+        let mut app = App::new();
+        app.spawn_agent("task 1".to_string(), None);
+        app.spawn_agent("task 2".to_string(), None);
+
+        app.show_session_picker = true;
+        app.picker_cursor = 0;
+
+        app.picker_next();
+        assert_eq!(app.picker_cursor, 1);
+
+        app.picker_next();
+        assert_eq!(app.picker_cursor, 2);
+
+        app.picker_next();
+        assert_eq!(app.picker_cursor, 2);
+
+        app.picker_prev();
+        assert_eq!(app.picker_cursor, 1);
+    }
+
+    #[test]
+    fn session_picker_select_switches_active() {
+        let mut app = App::new();
+        let id = app.spawn_agent("task".to_string(), None);
+
+        app.show_session_picker = true;
+        app.picker_cursor = 1;
+        app.picker_select();
+
+        assert_eq!(app.active_session, id);
+        assert!(!app.show_session_picker);
+    }
+
+    #[test]
+    fn dismiss_only_removes_completed_sessions() {
+        let mut app = App::new();
+        let id = app.spawn_agent("task".to_string(), None);
+        assert_eq!(app.session_order.len(), 2);
+
+        app.picker_cursor = 1;
+        app.dismiss_session();
+        assert_eq!(app.session_order.len(), 2);
+
+        app.sessions.get_mut(&id).unwrap().session_state = SessionState::Completed;
+        app.dismiss_session();
+        assert_eq!(app.session_order.len(), 1);
+        assert!(!app.sessions.contains_key(&id));
+    }
+
+    #[test]
+    fn cannot_dismiss_main_session() {
+        let mut app = App::new();
+        app.spawn_agent("task".to_string(), None);
+
+        app.picker_cursor = 0;
+        app.dismiss_session();
+        assert!(app.sessions.contains_key(&SessionId::MAIN));
+    }
+
+    #[test]
+    fn switched_to_session_still_becomes_completed() {
+        let mut app = App::new();
+        let id = app.spawn_agent("task".to_string(), None);
+
+        app.switch_to_session(id);
+        assert_eq!(app.active_session, id);
+
+        {
+            let session = app.sessions.get_mut(&id).unwrap();
+            session.chat_state = ChatState::Idle;
+            session.stream_rx = None;
+            session.session_state = SessionState::Completed;
+        }
+
+        app.switch_to_session(SessionId::MAIN);
+        app.picker_cursor = 1;
+        app.dismiss_session();
+        assert!(!app.sessions.contains_key(&id));
+    }
+
+    #[test]
+    fn agent_command_spawns_session() {
+        let mut app = App::new();
+        let handled = app.handle_command("/agent do something");
+        assert!(handled);
+        assert_eq!(app.session_order.len(), 2);
+    }
+
+    #[test]
+    fn agent_command_empty_shows_usage() {
+        let mut app = App::new();
+        let handled = app.handle_command("/agent");
+        assert!(handled);
+        assert_eq!(app.session_order.len(), 1);
+    }
+
+    #[test]
+    fn sessions_command_shows_picker_when_agents_exist() {
+        let mut app = App::new();
+        app.spawn_agent("task".to_string(), None);
+
+        let handled = app.handle_command("/sessions");
+        assert!(handled);
+        assert!(app.show_session_picker);
+    }
+
+    #[test]
+    fn sessions_command_shows_hint_when_no_agents() {
+        let mut app = App::new();
+        let handled = app.handle_command("/sessions");
+        assert!(handled);
+        assert!(!app.show_session_picker);
     }
 }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -22,7 +22,8 @@ impl EffortPolicy {
     /// Centralized here (not per-backend) because task classification is a UX concern;
     /// backends own only the flag encoding in build_command.
     pub fn for_prompt(prompt: &str) -> &'static str {
-        let words: Vec<String> = prompt.to_lowercase()
+        let words: Vec<String> = prompt
+            .to_lowercase()
             .split_whitespace()
             .map(|w| w.to_string())
             .collect();
@@ -603,7 +604,9 @@ impl App {
                         thread::spawn(move || {
                             match cancel_rx.recv_timeout(Duration::from_secs(timeout_secs)) {
                                 Ok(()) => {}
-                                Err(_) => { let _ = kill_tx.send(()); }
+                                Err(_) => {
+                                    let _ = kill_tx.send(());
+                                }
                             }
                         });
                         (Some(kill_rx), Some(cancel_tx))
@@ -649,9 +652,7 @@ impl App {
                         let _ = tx.send(());
                     }
 
-                    let timed_out = kill_rx
-                        .as_ref()
-                        .is_some_and(|rx| rx.try_recv().is_ok());
+                    let timed_out = kill_rx.as_ref().is_some_and(|rx| rx.try_recv().is_ok());
                     if timed_out {
                         let _ = process.kill();
                     }
@@ -665,10 +666,7 @@ impl App {
                     {
                         let code = s.code().unwrap_or(-1);
                         let _ = tx.send(backend::StreamChunk {
-                            kind: ChunkKind::Error(format!(
-                                "Process exited with code {}",
-                                code
-                            )),
+                            kind: ChunkKind::Error(format!("Process exited with code {}", code)),
                         });
                     }
                     let _ = tx.send(backend::StreamChunk {
@@ -695,23 +693,36 @@ impl App {
     }
 
     pub fn max_agents() -> usize {
-        if let Some(val) = platform::env_var("DEUS_MAX_AGENTS")
-            .and_then(|s| s.parse::<usize>().ok())
+        if let Some(val) =
+            platform::env_var("DEUS_MAX_AGENTS").and_then(|s| s.parse::<usize>().ok())
         {
             return val.max(1);
         }
-        if let Some(val) = config::deus::read_key("max_parallel_agents")
-            .and_then(|s| s.parse::<usize>().ok())
+        if let Some(val) =
+            config::deus::read_key("max_parallel_agents").and_then(|s| s.parse::<usize>().ok())
         {
             return val.max(1);
         }
-        (thread::available_parallelism().map(|n| n.get()).unwrap_or(4) / 2).clamp(2, 8)
+        (thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            / 2)
+        .clamp(2, 8)
     }
 
-    pub fn spawn_agent(&mut self, prompt: String, model: Option<String>, effort: Option<String>) -> Option<SessionId> {
+    pub fn spawn_agent(
+        &mut self,
+        prompt: String,
+        model: Option<String>,
+        effort: Option<String>,
+    ) -> Option<SessionId> {
         let limit = Self::max_agents();
-        let active_agents = self.sessions.iter()
-            .filter(|(id, s)| **id != SessionId::MAIN && matches!(s.chat_state, ChatState::Streaming))
+        let active_agents = self
+            .sessions
+            .iter()
+            .filter(|(id, s)| {
+                **id != SessionId::MAIN && matches!(s.chat_state, ChatState::Streaming)
+            })
             .count();
         if active_agents >= limit {
             self.active_mut().chat_messages.push(ChatMessage::simple(
@@ -959,7 +970,10 @@ impl App {
                     .as_deref()
                     .unwrap_or_else(|| EffortPolicy::for_prompt(&args.prompt))
                     .to_string();
-                if self.spawn_agent(args.prompt, args.model, args.effort).is_some() {
+                if self
+                    .spawn_agent(args.prompt, args.model, args.effort)
+                    .is_some()
+                {
                     self.active_mut().chat_messages.push(ChatMessage::simple(
                         "system",
                         &format!("Agent spawned (effort: {}): {}", effort_label, preview),
@@ -968,9 +982,10 @@ impl App {
                 true
             }
             "/agent" => {
-                self.active_mut()
-                    .chat_messages
-                    .push(ChatMessage::simple("system", "Usage: /agent [--effort <level>] [--model <id>] <prompt>"));
+                self.active_mut().chat_messages.push(ChatMessage::simple(
+                    "system",
+                    "Usage: /agent [--effort <level>] [--model <id>] <prompt>",
+                ));
                 true
             }
             "/sessions" => {
@@ -1298,8 +1313,7 @@ impl App {
                         }
                         self.sessions.remove(&session_id);
                         self.session_order.retain(|&sid| sid != session_id);
-                        if self.picker_cursor >= self.session_order.len()
-                            && self.picker_cursor > 0
+                        if self.picker_cursor >= self.session_order.len() && self.picker_cursor > 0
                         {
                             self.picker_cursor -= 1;
                         }
@@ -1884,7 +1898,9 @@ mod tests {
         assert_eq!(app.session_order.len(), 1);
         assert_eq!(app.background_session_count(), 0);
 
-        let id = app.spawn_agent("test task".to_string(), None, None).unwrap();
+        let id = app
+            .spawn_agent("test task".to_string(), None, None)
+            .unwrap();
 
         assert_eq!(app.session_order.len(), 2);
         assert_eq!(app.background_session_count(), 1);
@@ -1919,7 +1935,9 @@ mod tests {
     #[test]
     fn spawn_agent_accepts_custom_model() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), Some("haiku".to_string()), None).unwrap();
+        let id = app
+            .spawn_agent("test".to_string(), Some("haiku".to_string()), None)
+            .unwrap();
 
         assert_eq!(app.sessions.get(&id).unwrap().model, "haiku");
     }
@@ -2161,20 +2179,28 @@ mod tests {
     #[test]
     fn spawn_agent_effort_from_policy() {
         let mut app = App::new();
-        let id = app.spawn_agent("review the code".to_string(), None, None).unwrap();
+        let id = app
+            .spawn_agent("review the code".to_string(), None, None)
+            .unwrap();
         assert_eq!(app.sessions.get(&id).unwrap().effort, "high");
 
-        let id2 = app.spawn_agent("find the config file".to_string(), None, None).unwrap();
+        let id2 = app
+            .spawn_agent("find the config file".to_string(), None, None)
+            .unwrap();
         assert_eq!(app.sessions.get(&id2).unwrap().effort, "low");
 
-        let id3 = app.spawn_agent("summarize this".to_string(), None, None).unwrap();
+        let id3 = app
+            .spawn_agent("summarize this".to_string(), None, None)
+            .unwrap();
         assert_eq!(app.sessions.get(&id3).unwrap().effort, "medium");
     }
 
     #[test]
     fn spawn_agent_accepts_custom_effort() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, Some("max".to_string())).unwrap();
+        let id = app
+            .spawn_agent("test".to_string(), None, Some("max".to_string()))
+            .unwrap();
         assert_eq!(app.sessions.get(&id).unwrap().effort, "max");
     }
 
@@ -2218,7 +2244,9 @@ mod tests {
     #[test]
     fn completion_injects_notification_into_main() {
         let mut app = App::new();
-        let id = app.spawn_agent("find bugs".to_string(), None, None).unwrap();
+        let id = app
+            .spawn_agent("find bugs".to_string(), None, None)
+            .unwrap();
 
         let session = app.sessions.get_mut(&id).unwrap();
         session
@@ -2319,7 +2347,9 @@ mod tests {
     #[test]
     fn spawn_agent_effort_explicit_overrides_policy() {
         let mut app = App::new();
-        let id = app.spawn_agent("review the code".to_string(), None, Some("low".to_string())).unwrap();
+        let id = app
+            .spawn_agent("review the code".to_string(), None, Some("low".to_string()))
+            .unwrap();
         assert_eq!(app.sessions.get(&id).unwrap().effort, "low");
     }
 
@@ -2371,7 +2401,10 @@ mod tests {
         // Session is auto-GC'd — verify via main notification
         assert!(!app.sessions.contains_key(&id));
         let main = app.sessions.get(&SessionId::MAIN).unwrap();
-        let has_failed = main.chat_messages.iter().any(|m| m.content.contains("Agent failed"));
+        let has_failed = main
+            .chat_messages
+            .iter()
+            .any(|m| m.content.contains("Agent failed"));
         assert!(has_failed);
     }
 
@@ -2382,10 +2415,15 @@ mod tests {
         let mut app = App::new();
         let id = app.spawn_agent("test gc".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
-        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "done"));
         let (tx, rx) = std::sync::mpsc::channel();
         session.stream_rx = Some(rx);
-        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
 
         app.poll_response();
 
@@ -2401,10 +2439,15 @@ mod tests {
         assert_eq!(app.active_session, id);
 
         let session = app.sessions.get_mut(&id).unwrap();
-        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "done"));
         let (tx, rx) = std::sync::mpsc::channel();
         session.stream_rx = Some(rx);
-        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
 
         app.poll_response();
 
@@ -2420,10 +2463,15 @@ mod tests {
         app.picker_cursor = 1;
 
         let session = app.sessions.get_mut(&id).unwrap();
-        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "done"));
         let (tx, rx) = std::sync::mpsc::channel();
         session.stream_rx = Some(rx);
-        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
 
         app.poll_response();
 
@@ -2464,10 +2512,15 @@ mod tests {
         // Complete one agent — auto-GC frees the slot
         let first = ids[0];
         let session = app.sessions.get_mut(&first).unwrap();
-        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "done"));
         let (tx, rx) = std::sync::mpsc::channel();
         session.stream_rx = Some(rx);
-        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
         app.poll_response();
 
         let after_gc = app.spawn_agent("now allowed".to_string(), None, None);

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -594,18 +594,21 @@ impl App {
 
             match child {
                 Ok(mut process) => {
-                    let kill_rx = if is_background {
-                        let (kill_tx, rx) = mpsc::channel::<()>();
+                    let (kill_rx, cancel_tx) = if is_background {
+                        let (kill_tx, kill_rx) = mpsc::channel::<()>();
+                        let (cancel_tx, cancel_rx) = mpsc::channel::<()>();
                         let timeout_secs: u64 = platform::env_var("DEUS_AGENT_TIMEOUT_SECS")
                             .and_then(|s| s.parse().ok())
                             .unwrap_or(600);
                         thread::spawn(move || {
-                            thread::sleep(Duration::from_secs(timeout_secs));
-                            let _ = kill_tx.send(());
+                            match cancel_rx.recv_timeout(Duration::from_secs(timeout_secs)) {
+                                Ok(()) => {}
+                                Err(_) => { let _ = kill_tx.send(()); }
+                            }
                         });
-                        Some(rx)
+                        (Some(kill_rx), Some(cancel_tx))
                     } else {
-                        None
+                        (None, None)
                     };
 
                     let stderr_handle = process.stderr.take().map(|stderr| {
@@ -641,6 +644,9 @@ impl App {
                     }
                     if let Some(h) = stderr_handle {
                         let _ = h.join();
+                    }
+                    if let Some(tx) = cancel_tx {
+                        let _ = tx.send(());
                     }
 
                     let timed_out = kill_rx
@@ -688,7 +694,33 @@ impl App {
         });
     }
 
-    pub fn spawn_agent(&mut self, prompt: String, model: Option<String>, effort: Option<String>) -> SessionId {
+    pub fn max_agents() -> usize {
+        if let Some(val) = platform::env_var("DEUS_MAX_AGENTS")
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            return val.max(1);
+        }
+        if let Some(val) = config::deus::read_key("max_parallel_agents")
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            return val.max(1);
+        }
+        (thread::available_parallelism().map(|n| n.get()).unwrap_or(4) / 2).clamp(2, 8)
+    }
+
+    pub fn spawn_agent(&mut self, prompt: String, model: Option<String>, effort: Option<String>) -> Option<SessionId> {
+        let limit = Self::max_agents();
+        let active_agents = self.sessions.iter()
+            .filter(|(id, s)| **id != SessionId::MAIN && matches!(s.chat_state, ChatState::Streaming))
+            .count();
+        if active_agents >= limit {
+            self.active_mut().chat_messages.push(ChatMessage::simple(
+                "system",
+                &format!("At agent limit ({} streaming). Wait for one to finish or adjust DEUS_MAX_AGENTS.", limit),
+            ));
+            return None;
+        }
+
         let id = SessionId::next();
         let model = model.unwrap_or_else(|| self.active().model.clone());
         let effort = effort.unwrap_or_else(|| EffortPolicy::for_prompt(&prompt).to_string());
@@ -728,7 +760,7 @@ impl App {
         self.sessions.insert(id, session);
         self.session_order.push(id);
         self.dispatch_message_for(id, prompt);
-        id
+        Some(id)
     }
 
     fn handle_command(&mut self, msg: &str) -> bool {
@@ -927,11 +959,12 @@ impl App {
                     .as_deref()
                     .unwrap_or_else(|| EffortPolicy::for_prompt(&args.prompt))
                     .to_string();
-                self.spawn_agent(args.prompt, args.model, args.effort);
-                self.active_mut().chat_messages.push(ChatMessage::simple(
-                    "system",
-                    &format!("Agent spawned (effort: {}): {}", effort_label, preview),
-                ));
+                if self.spawn_agent(args.prompt, args.model, args.effort).is_some() {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!("Agent spawned (effort: {}): {}", effort_label, preview),
+                    ));
+                }
                 true
             }
             "/agent" => {
@@ -1259,6 +1292,19 @@ impl App {
                                 &format!("[{}: {}] {}", prefix, label, summary),
                             ));
                             main.mark_chat_changed();
+                        }
+                        if self.active_session == session_id {
+                            self.active_session = SessionId::MAIN;
+                        }
+                        self.sessions.remove(&session_id);
+                        self.session_order.retain(|&sid| sid != session_id);
+                        if self.picker_cursor >= self.session_order.len()
+                            && self.picker_cursor > 0
+                        {
+                            self.picker_cursor -= 1;
+                        }
+                        if self.session_order.len() <= 1 {
+                            self.show_session_picker = false;
                         }
                     }
                     if session_id == self.active_session && !self.queued_messages.is_empty() {
@@ -1838,7 +1884,7 @@ mod tests {
         assert_eq!(app.session_order.len(), 1);
         assert_eq!(app.background_session_count(), 0);
 
-        let id = app.spawn_agent("test task".to_string(), None, None);
+        let id = app.spawn_agent("test task".to_string(), None, None).unwrap();
 
         assert_eq!(app.session_order.len(), 2);
         assert_eq!(app.background_session_count(), 1);
@@ -1854,7 +1900,7 @@ mod tests {
     fn spawn_agent_truncates_long_prompts() {
         let mut app = App::new();
         let long_prompt = "a".repeat(100);
-        let id = app.spawn_agent(long_prompt, None, None);
+        let id = app.spawn_agent(long_prompt, None, None).unwrap();
 
         let session = app.sessions.get(&id).unwrap();
         assert!(session.label.len() <= 54);
@@ -1865,7 +1911,7 @@ mod tests {
     fn spawn_agent_inherits_model() {
         let mut app = App::new();
         let main_model = app.active().model.clone();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
 
         assert_eq!(app.sessions.get(&id).unwrap().model, main_model);
     }
@@ -1873,7 +1919,7 @@ mod tests {
     #[test]
     fn spawn_agent_accepts_custom_model() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), Some("haiku".to_string()), None);
+        let id = app.spawn_agent("test".to_string(), Some("haiku".to_string()), None).unwrap();
 
         assert_eq!(app.sessions.get(&id).unwrap().model, "haiku");
     }
@@ -1881,8 +1927,8 @@ mod tests {
     #[test]
     fn session_picker_navigation() {
         let mut app = App::new();
-        app.spawn_agent("task 1".to_string(), None, None);
-        app.spawn_agent("task 2".to_string(), None, None);
+        app.spawn_agent("task 1".to_string(), None, None).unwrap();
+        app.spawn_agent("task 2".to_string(), None, None).unwrap();
 
         app.show_session_picker = true;
         app.picker_cursor = 0;
@@ -1903,7 +1949,7 @@ mod tests {
     #[test]
     fn session_picker_select_switches_active() {
         let mut app = App::new();
-        let id = app.spawn_agent("task".to_string(), None, None);
+        let id = app.spawn_agent("task".to_string(), None, None).unwrap();
 
         app.show_session_picker = true;
         app.picker_cursor = 1;
@@ -1916,7 +1962,7 @@ mod tests {
     #[test]
     fn dismiss_only_removes_completed_sessions() {
         let mut app = App::new();
-        let id = app.spawn_agent("task".to_string(), None, None);
+        let id = app.spawn_agent("task".to_string(), None, None).unwrap();
         assert_eq!(app.session_order.len(), 2);
 
         app.picker_cursor = 1;
@@ -1932,7 +1978,7 @@ mod tests {
     #[test]
     fn cannot_dismiss_main_session() {
         let mut app = App::new();
-        app.spawn_agent("task".to_string(), None, None);
+        app.spawn_agent("task".to_string(), None, None).unwrap();
 
         app.picker_cursor = 0;
         app.dismiss_session();
@@ -1942,7 +1988,7 @@ mod tests {
     #[test]
     fn switched_to_session_still_becomes_completed() {
         let mut app = App::new();
-        let id = app.spawn_agent("task".to_string(), None, None);
+        let id = app.spawn_agent("task".to_string(), None, None).unwrap();
 
         app.switch_to_session(id);
         assert_eq!(app.active_session, id);
@@ -1979,7 +2025,7 @@ mod tests {
     #[test]
     fn sessions_command_shows_picker_when_agents_exist() {
         let mut app = App::new();
-        app.spawn_agent("task".to_string(), None, None);
+        app.spawn_agent("task".to_string(), None, None).unwrap();
 
         let handled = app.handle_command("/sessions");
         assert!(handled);
@@ -1999,7 +2045,7 @@ mod tests {
     #[test]
     fn trim_transcript_removes_old_messages() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         session.chat_state = ChatState::Idle;
         let pre_existing = session.chat_messages.len();
@@ -2032,7 +2078,7 @@ mod tests {
     #[test]
     fn trim_transcript_noop_while_streaming() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         for _ in 0..(TRANSCRIPT_CAP + 50) {
             session
@@ -2046,7 +2092,7 @@ mod tests {
     #[test]
     fn trim_transcript_bumps_version() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         session.chat_state = ChatState::Idle;
         for _ in 0..(TRANSCRIPT_CAP + 10) {
@@ -2115,20 +2161,20 @@ mod tests {
     #[test]
     fn spawn_agent_effort_from_policy() {
         let mut app = App::new();
-        let id = app.spawn_agent("review the code".to_string(), None, None);
+        let id = app.spawn_agent("review the code".to_string(), None, None).unwrap();
         assert_eq!(app.sessions.get(&id).unwrap().effort, "high");
 
-        let id2 = app.spawn_agent("find the config file".to_string(), None, None);
+        let id2 = app.spawn_agent("find the config file".to_string(), None, None).unwrap();
         assert_eq!(app.sessions.get(&id2).unwrap().effort, "low");
 
-        let id3 = app.spawn_agent("summarize this".to_string(), None, None);
+        let id3 = app.spawn_agent("summarize this".to_string(), None, None).unwrap();
         assert_eq!(app.sessions.get(&id3).unwrap().effort, "medium");
     }
 
     #[test]
     fn spawn_agent_accepts_custom_effort() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, Some("max".to_string()));
+        let id = app.spawn_agent("test".to_string(), None, Some("max".to_string())).unwrap();
         assert_eq!(app.sessions.get(&id).unwrap().effort, "max");
     }
 
@@ -2137,7 +2183,7 @@ mod tests {
     #[test]
     fn completion_summary_extracts_last_assistant_message() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         session.chat_messages.push(ChatMessage::simple(
             "assistant",
@@ -2150,7 +2196,7 @@ mod tests {
     #[test]
     fn completion_summary_returns_no_output_when_empty() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get(&id).unwrap();
         let summary = session.completion_summary();
         assert_eq!(summary, "(no output)");
@@ -2159,7 +2205,7 @@ mod tests {
     #[test]
     fn completion_summary_truncates_long_lines() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         session
             .chat_messages
@@ -2172,7 +2218,7 @@ mod tests {
     #[test]
     fn completion_injects_notification_into_main() {
         let mut app = App::new();
-        let id = app.spawn_agent("find bugs".to_string(), None, None);
+        let id = app.spawn_agent("find bugs".to_string(), None, None).unwrap();
 
         let session = app.sessions.get_mut(&id).unwrap();
         session
@@ -2273,7 +2319,7 @@ mod tests {
     #[test]
     fn spawn_agent_effort_explicit_overrides_policy() {
         let mut app = App::new();
-        let id = app.spawn_agent("review the code".to_string(), None, Some("low".to_string()));
+        let id = app.spawn_agent("review the code".to_string(), None, Some("low".to_string())).unwrap();
         assert_eq!(app.sessions.get(&id).unwrap().effort, "low");
     }
 
@@ -2282,7 +2328,7 @@ mod tests {
     #[test]
     fn error_chunk_sets_had_error() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         session.chat_messages.push(ChatMessage {
             role: "assistant".to_string(),
@@ -2301,9 +2347,9 @@ mod tests {
     }
 
     #[test]
-    fn done_after_error_sets_failed() {
+    fn done_after_error_notifies_main_as_failed() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
         let session = app.sessions.get_mut(&id).unwrap();
         session.chat_messages.push(ChatMessage {
             role: "assistant".to_string(),
@@ -2322,23 +2368,109 @@ mod tests {
         .unwrap();
         app.poll_response();
 
-        assert_eq!(
-            app.sessions.get(&id).unwrap().session_state,
-            SessionState::Failed
-        );
+        // Session is auto-GC'd — verify via main notification
+        assert!(!app.sessions.contains_key(&id));
+        let main = app.sessions.get(&SessionId::MAIN).unwrap();
+        let has_failed = main.chat_messages.iter().any(|m| m.content.contains("Agent failed"));
+        assert!(has_failed);
+    }
+
+    // --- Session auto-GC ---
+
+    #[test]
+    fn auto_gc_removes_completed_session() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test gc".to_string(), None, None).unwrap();
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+
+        app.poll_response();
+
+        assert!(!app.sessions.contains_key(&id));
+        assert_eq!(app.session_order.len(), 1);
     }
 
     #[test]
-    fn failed_session_is_dismissible() {
+    fn auto_gc_resets_active_session_to_main() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), None, None);
-        let session = app.sessions.get_mut(&id).unwrap();
-        session.session_state = SessionState::Failed;
-        session.chat_state = ChatState::Idle;
-        session.stream_rx = None;
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
+        app.switch_to_session(id);
+        assert_eq!(app.active_session, id);
 
-        app.picker_cursor = 1;
-        app.dismiss_session();
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+
+        app.poll_response();
+
+        assert_eq!(app.active_session, SessionId::MAIN);
         assert!(!app.sessions.contains_key(&id));
+    }
+
+    #[test]
+    fn auto_gc_closes_picker_when_no_sessions_remain() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None).unwrap();
+        app.show_session_picker = true;
+        app.picker_cursor = 1;
+
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+
+        app.poll_response();
+
+        assert!(!app.show_session_picker);
+        assert_eq!(app.picker_cursor, 0);
+    }
+
+    // --- Concurrent session limit ---
+
+    #[test]
+    fn max_agents_returns_positive() {
+        assert!(App::max_agents() >= 1);
+    }
+
+    #[test]
+    fn spawn_agent_rejects_at_limit() {
+        let mut app = App::new();
+        let limit = App::max_agents();
+        for i in 0..limit {
+            let result = app.spawn_agent(format!("task {}", i), None, None);
+            assert!(result.is_some(), "spawn {} should succeed", i);
+        }
+
+        let rejected = app.spawn_agent("one too many".to_string(), None, None);
+        assert!(rejected.is_none());
+    }
+
+    #[test]
+    fn spawn_agent_allows_after_gc() {
+        let mut app = App::new();
+        let limit = App::max_agents();
+        let mut ids = Vec::new();
+        for i in 0..limit {
+            ids.push(app.spawn_agent(format!("task {}", i), None, None).unwrap());
+        }
+        assert!(app.spawn_agent("blocked".to_string(), None, None).is_none());
+
+        // Complete one agent — auto-GC frees the slot
+        let first = ids[0];
+        let session = app.sessions.get_mut(&first).unwrap();
+        session.chat_messages.push(ChatMessage::simple("assistant", "done"));
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk { kind: ChunkKind::Done }).unwrap();
+        app.poll_response();
+
+        let after_gc = app.spawn_agent("now allowed".to_string(), None, None);
+        assert!(after_gc.is_some());
     }
 }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -14,6 +14,9 @@ use crate::platform;
 
 static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 
+pub const TRANSCRIPT_CAP: usize = 200;
+pub const DEFAULT_AGENT_EFFORT: &str = "medium";
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SessionId(pub u64);
 
@@ -109,6 +112,12 @@ pub enum SessionState {
     Completed,
 }
 
+pub struct AgentArgs {
+    pub prompt: String,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+}
+
 pub struct Session {
     #[allow(dead_code)]
     pub id: SessionId,
@@ -127,6 +136,7 @@ pub struct Session {
     pub last_thinking_summary: Option<String>,
     pub permissions: PermissionsConfig,
     pub active_subagent_ids: HashSet<String>,
+    pub last_subagent_hint: Option<String>,
     pub scroll_offset: u16,
     pub scroll_pinned: bool,
     pub chat_dirty: bool,
@@ -156,12 +166,44 @@ impl Session {
             last_thinking_summary: None,
             permissions,
             active_subagent_ids: HashSet::new(),
+            last_subagent_hint: None,
             scroll_offset: 0,
             scroll_pinned: true,
             chat_dirty: true,
             chat_version: 0,
             run_mode: backend::RunMode::default(),
         }
+    }
+
+    pub fn trim_transcript(&mut self) -> usize {
+        if self.id == SessionId::MAIN {
+            return 0;
+        }
+        if matches!(self.chat_state, ChatState::Streaming) {
+            return 0;
+        }
+        let len = self.chat_messages.len();
+        if len <= TRANSCRIPT_CAP {
+            return 0;
+        }
+        let to_remove = len - TRANSCRIPT_CAP;
+        self.chat_messages.drain(..to_remove);
+        self.mark_chat_changed();
+        to_remove
+    }
+
+    pub fn completion_summary(&self) -> String {
+        for msg in self.chat_messages.iter().rev() {
+            if msg.role == "assistant" && !msg.content.is_empty() {
+                let first_line = msg.content.lines().next().unwrap_or("");
+                let preview: String = first_line.chars().take(120).collect();
+                if preview.len() < first_line.len() {
+                    return format!("{}...", preview);
+                }
+                return preview;
+            }
+        }
+        "(no output)".to_string()
     }
 
     pub fn mark_chat_changed(&mut self) {
@@ -263,7 +305,7 @@ pub const COMMANDS: &[CommandDef] = &[
     CommandDef {
         name: "/agent",
         description: "Spawn background agent",
-        args: &[],
+        args: &["--effort", "--model"],
     },
     CommandDef {
         name: "/sessions",
@@ -585,9 +627,10 @@ impl App {
         });
     }
 
-    pub fn spawn_agent(&mut self, prompt: String, model: Option<String>) -> SessionId {
+    pub fn spawn_agent(&mut self, prompt: String, model: Option<String>, effort: Option<String>) -> SessionId {
         let id = SessionId::next();
         let model = model.unwrap_or_else(|| self.active().model.clone());
+        let effort = effort.unwrap_or_else(|| DEFAULT_AGENT_EFFORT.to_string());
         let preview: String = prompt.chars().take(50).collect();
         let label = if preview.len() < prompt.len() {
             format!("{}...", preview)
@@ -604,7 +647,7 @@ impl App {
             stream_rx: None,
             turn_count: 0,
             model,
-            effort: "high".to_string(),
+            effort,
             token_count: 0,
             cost_usd: 0.0,
             turn_start: None,
@@ -612,6 +655,7 @@ impl App {
             last_thinking_summary: None,
             permissions: self.active().permissions.clone(),
             active_subagent_ids: HashSet::new(),
+            last_subagent_hint: None,
             scroll_offset: 0,
             scroll_pinned: true,
             chat_dirty: true,
@@ -807,18 +851,31 @@ impl App {
                 true
             }
             "/agent" if !arg.is_empty() => {
-                let preview: String = arg.chars().take(60).collect();
-                self.spawn_agent(arg.to_string(), None);
+                let args = parse_agent_args(arg);
+                if args.prompt.is_empty() {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        "Usage: /agent [--effort <level>] [--model <id>] <prompt>",
+                    ));
+                    return true;
+                }
+                let preview: String = args.prompt.chars().take(60).collect();
+                let effort_label = args
+                    .effort
+                    .as_deref()
+                    .unwrap_or(DEFAULT_AGENT_EFFORT)
+                    .to_string();
+                self.spawn_agent(args.prompt, args.model, args.effort);
                 self.active_mut().chat_messages.push(ChatMessage::simple(
                     "system",
-                    &format!("Agent spawned: {}", preview),
+                    &format!("Agent spawned (effort: {}): {}", effort_label, preview),
                 ));
                 true
             }
             "/agent" => {
                 self.active_mut()
                     .chat_messages
-                    .push(ChatMessage::simple("system", "Usage: /agent <prompt>"));
+                    .push(ChatMessage::simple("system", "Usage: /agent [--effort <level>] [--model <id>] <prompt>"));
                 true
             }
             "/sessions" => {
@@ -1039,6 +1096,9 @@ impl App {
                     let is_warden = self.is_warden_name(&subagent_type);
                     let session = self.sessions.get_mut(&session_id).unwrap();
                     session.active_subagent_ids.insert(id.clone());
+                    if !description.is_empty() {
+                        session.last_subagent_hint = Some(description.clone());
+                    }
                     if let Some(last) = session.chat_messages.last_mut()
                         && last.role == "assistant"
                     {
@@ -1115,9 +1175,20 @@ impl App {
                     session.last_turn_duration = session.turn_start.map(|t| t.elapsed());
                     session.turn_start = None;
                     session.active_subagent_ids.clear();
+                    session.last_subagent_hint = None;
                     session.mark_chat_changed();
                     if session_id != SessionId::MAIN {
                         session.session_state = SessionState::Completed;
+                        session.trim_transcript();
+                        let label = session.label.clone();
+                        let summary = session.completion_summary();
+                        if let Some(main) = self.sessions.get_mut(&SessionId::MAIN) {
+                            main.chat_messages.push(ChatMessage::simple(
+                                "system",
+                                &format!("[Agent completed: {}] {}", label, summary),
+                            ));
+                            main.mark_chat_changed();
+                        }
                     }
                     if session_id == self.active_session && !self.queued_messages.is_empty() {
                         let next = self.queued_messages.remove(0);
@@ -1644,6 +1715,36 @@ impl App {
     }
 }
 
+pub fn parse_agent_args(args: &str) -> AgentArgs {
+    let mut effort: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut prompt_parts: Vec<&str> = Vec::new();
+    let tokens: Vec<&str> = args.split_whitespace().collect();
+    let ids = model_ids();
+    let mut i = 0;
+    while i < tokens.len() {
+        match tokens[i] {
+            "--effort" if i + 1 < tokens.len() && EFFORT_LEVELS.contains(&tokens[i + 1]) => {
+                effort = Some(tokens[i + 1].to_string());
+                i += 2;
+            }
+            "--model" if i + 1 < tokens.len() && ids.contains(&tokens[i + 1]) => {
+                model = Some(tokens[i + 1].to_string());
+                i += 2;
+            }
+            _ => {
+                prompt_parts.extend_from_slice(&tokens[i..]);
+                break;
+            }
+        }
+    }
+    AgentArgs {
+        prompt: prompt_parts.join(" "),
+        model,
+        effort,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1665,7 +1766,7 @@ mod tests {
         assert_eq!(app.session_order.len(), 1);
         assert_eq!(app.background_session_count(), 0);
 
-        let id = app.spawn_agent("test task".to_string(), None);
+        let id = app.spawn_agent("test task".to_string(), None, None);
 
         assert_eq!(app.session_order.len(), 2);
         assert_eq!(app.background_session_count(), 1);
@@ -1681,7 +1782,7 @@ mod tests {
     fn spawn_agent_truncates_long_prompts() {
         let mut app = App::new();
         let long_prompt = "a".repeat(100);
-        let id = app.spawn_agent(long_prompt, None);
+        let id = app.spawn_agent(long_prompt, None, None);
 
         let session = app.sessions.get(&id).unwrap();
         assert!(session.label.len() <= 54);
@@ -1692,7 +1793,7 @@ mod tests {
     fn spawn_agent_inherits_model() {
         let mut app = App::new();
         let main_model = app.active().model.clone();
-        let id = app.spawn_agent("test".to_string(), None);
+        let id = app.spawn_agent("test".to_string(), None, None);
 
         assert_eq!(app.sessions.get(&id).unwrap().model, main_model);
     }
@@ -1700,7 +1801,7 @@ mod tests {
     #[test]
     fn spawn_agent_accepts_custom_model() {
         let mut app = App::new();
-        let id = app.spawn_agent("test".to_string(), Some("haiku".to_string()));
+        let id = app.spawn_agent("test".to_string(), Some("haiku".to_string()), None);
 
         assert_eq!(app.sessions.get(&id).unwrap().model, "haiku");
     }
@@ -1708,8 +1809,8 @@ mod tests {
     #[test]
     fn session_picker_navigation() {
         let mut app = App::new();
-        app.spawn_agent("task 1".to_string(), None);
-        app.spawn_agent("task 2".to_string(), None);
+        app.spawn_agent("task 1".to_string(), None, None);
+        app.spawn_agent("task 2".to_string(), None, None);
 
         app.show_session_picker = true;
         app.picker_cursor = 0;
@@ -1730,7 +1831,7 @@ mod tests {
     #[test]
     fn session_picker_select_switches_active() {
         let mut app = App::new();
-        let id = app.spawn_agent("task".to_string(), None);
+        let id = app.spawn_agent("task".to_string(), None, None);
 
         app.show_session_picker = true;
         app.picker_cursor = 1;
@@ -1743,7 +1844,7 @@ mod tests {
     #[test]
     fn dismiss_only_removes_completed_sessions() {
         let mut app = App::new();
-        let id = app.spawn_agent("task".to_string(), None);
+        let id = app.spawn_agent("task".to_string(), None, None);
         assert_eq!(app.session_order.len(), 2);
 
         app.picker_cursor = 1;
@@ -1759,7 +1860,7 @@ mod tests {
     #[test]
     fn cannot_dismiss_main_session() {
         let mut app = App::new();
-        app.spawn_agent("task".to_string(), None);
+        app.spawn_agent("task".to_string(), None, None);
 
         app.picker_cursor = 0;
         app.dismiss_session();
@@ -1769,7 +1870,7 @@ mod tests {
     #[test]
     fn switched_to_session_still_becomes_completed() {
         let mut app = App::new();
-        let id = app.spawn_agent("task".to_string(), None);
+        let id = app.spawn_agent("task".to_string(), None, None);
 
         app.switch_to_session(id);
         assert_eq!(app.active_session, id);
@@ -1806,7 +1907,7 @@ mod tests {
     #[test]
     fn sessions_command_shows_picker_when_agents_exist() {
         let mut app = App::new();
-        app.spawn_agent("task".to_string(), None);
+        app.spawn_agent("task".to_string(), None, None);
 
         let handled = app.handle_command("/sessions");
         assert!(handled);
@@ -1819,5 +1920,247 @@ mod tests {
         let handled = app.handle_command("/sessions");
         assert!(handled);
         assert!(!app.show_session_picker);
+    }
+
+    // --- 5a: Bounded transcripts ---
+
+    #[test]
+    fn trim_transcript_removes_old_messages() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_state = ChatState::Idle;
+        let pre_existing = session.chat_messages.len();
+        for i in 0..(TRANSCRIPT_CAP + 50) {
+            session
+                .chat_messages
+                .push(ChatMessage::simple("assistant", &format!("msg {}", i)));
+        }
+        let total = pre_existing + TRANSCRIPT_CAP + 50;
+        let expected_removed = total - TRANSCRIPT_CAP;
+        let removed = session.trim_transcript();
+        assert_eq!(removed, expected_removed);
+        assert_eq!(session.chat_messages.len(), TRANSCRIPT_CAP);
+    }
+
+    #[test]
+    fn trim_transcript_noop_for_main() {
+        let mut app = App::new();
+        let session = app.sessions.get_mut(&SessionId::MAIN).unwrap();
+        session.chat_state = ChatState::Idle;
+        for i in 0..(TRANSCRIPT_CAP + 50) {
+            session
+                .chat_messages
+                .push(ChatMessage::simple("assistant", &format!("msg {}", i)));
+        }
+        let removed = session.trim_transcript();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn trim_transcript_noop_while_streaming() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        for _ in 0..(TRANSCRIPT_CAP + 50) {
+            session
+                .chat_messages
+                .push(ChatMessage::simple("assistant", "x"));
+        }
+        let removed = session.trim_transcript();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn trim_transcript_bumps_version() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_state = ChatState::Idle;
+        for _ in 0..(TRANSCRIPT_CAP + 10) {
+            session
+                .chat_messages
+                .push(ChatMessage::simple("assistant", "x"));
+        }
+        let version_before = session.chat_version;
+        session.trim_transcript();
+        assert_ne!(session.chat_version, version_before);
+    }
+
+    // --- 5b: Dynamic effort + flag parsing ---
+
+    #[test]
+    fn parse_agent_args_plain_prompt() {
+        let args = parse_agent_args("do something useful");
+        assert_eq!(args.prompt, "do something useful");
+        assert_eq!(args.model, None);
+        assert_eq!(args.effort, None);
+    }
+
+    #[test]
+    fn parse_agent_args_with_effort() {
+        let args = parse_agent_args("--effort low find the bug");
+        assert_eq!(args.prompt, "find the bug");
+        assert_eq!(args.model, None);
+        assert_eq!(args.effort, Some("low".to_string()));
+    }
+
+    #[test]
+    fn parse_agent_args_with_model() {
+        let args = parse_agent_args("--model haiku summarize this");
+        assert_eq!(args.prompt, "summarize this");
+        assert_eq!(args.model, Some("haiku".to_string()));
+        assert_eq!(args.effort, None);
+    }
+
+    #[test]
+    fn parse_agent_args_with_both_flags() {
+        let args = parse_agent_args("--effort medium --model haiku do it");
+        assert_eq!(args.prompt, "do it");
+        assert_eq!(args.model, Some("haiku".to_string()));
+        assert_eq!(args.effort, Some("medium".to_string()));
+    }
+
+    #[test]
+    fn parse_agent_args_invalid_effort_becomes_prompt() {
+        let args = parse_agent_args("--effort bogus find files");
+        assert_eq!(args.prompt, "--effort bogus find files");
+        assert_eq!(args.effort, None);
+    }
+
+    #[test]
+    fn parse_agent_args_unknown_flag_becomes_prompt() {
+        let args = parse_agent_args("--something that is not a flag");
+        assert_eq!(args.prompt, "--something that is not a flag");
+    }
+
+    #[test]
+    fn parse_agent_args_empty_returns_empty_prompt() {
+        let args = parse_agent_args("");
+        assert_eq!(args.prompt, "");
+    }
+
+    #[test]
+    fn spawn_agent_uses_default_effort() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        assert_eq!(app.sessions.get(&id).unwrap().effort, DEFAULT_AGENT_EFFORT);
+    }
+
+    #[test]
+    fn spawn_agent_accepts_custom_effort() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, Some("max".to_string()));
+        assert_eq!(app.sessions.get(&id).unwrap().effort, "max");
+    }
+
+    // --- 5c: Completion summaries ---
+
+    #[test]
+    fn completion_summary_extracts_last_assistant_message() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session.chat_messages.push(ChatMessage::simple(
+            "assistant",
+            "I found 3 bugs in the code.\nHere are the details...",
+        ));
+        let summary = session.completion_summary();
+        assert_eq!(summary, "I found 3 bugs in the code.");
+    }
+
+    #[test]
+    fn completion_summary_returns_no_output_when_empty() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get(&id).unwrap();
+        let summary = session.completion_summary();
+        assert_eq!(summary, "(no output)");
+    }
+
+    #[test]
+    fn completion_summary_truncates_long_lines() {
+        let mut app = App::new();
+        let id = app.spawn_agent("test".to_string(), None, None);
+        let session = app.sessions.get_mut(&id).unwrap();
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", &"x".repeat(200)));
+        let summary = session.completion_summary();
+        assert!(summary.len() <= 124);
+        assert!(summary.ends_with("..."));
+    }
+
+    #[test]
+    fn completion_injects_notification_into_main() {
+        let mut app = App::new();
+        let id = app.spawn_agent("find bugs".to_string(), None, None);
+
+        let session = app.sessions.get_mut(&id).unwrap();
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "Found 2 issues"));
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
+        session.stream_rx = Some(rx);
+
+        app.poll_response();
+
+        let main = app.sessions.get(&SessionId::MAIN).unwrap();
+        let last_system = main
+            .chat_messages
+            .iter()
+            .rev()
+            .find(|m| m.role == "system" && m.content.contains("Agent completed"));
+        assert!(last_system.is_some());
+        assert!(last_system.unwrap().content.contains("Found 2 issues"));
+    }
+
+    // --- 5d: Hint-driven spawn ---
+
+    #[test]
+    fn subagent_start_sets_hint() {
+        let mut app = App::new();
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.active_mut().stream_rx = Some(rx);
+        app.active_mut().chat_state = ChatState::Streaming;
+        app.active_mut().chat_messages.push(ChatMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+            blocks: Vec::new(),
+        });
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::SubagentStart {
+                id: "a1".to_string(),
+                subagent_type: "Explore".to_string(),
+                description: "search for config files".to_string(),
+            },
+        })
+        .unwrap();
+        app.poll_response();
+
+        assert_eq!(
+            app.active().last_subagent_hint.as_deref(),
+            Some("search for config files")
+        );
+    }
+
+    #[test]
+    fn done_clears_subagent_hint() {
+        let mut app = App::new();
+        app.active_mut().last_subagent_hint = Some("test hint".to_string());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.active_mut().stream_rx = Some(rx);
+        app.active_mut().chat_state = ChatState::Streaming;
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
+        app.poll_response();
+
+        assert!(app.active().last_subagent_hint.is_none());
     }
 }

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1881,6 +1881,20 @@ pub fn parse_agent_args(args: &str) -> AgentArgs {
 mod tests {
     use super::*;
 
+    fn complete_session(app: &mut App, id: SessionId) {
+        let session = app.sessions.get_mut(&id).unwrap();
+        session
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "done"));
+        let (tx, rx) = std::sync::mpsc::channel();
+        session.stream_rx = Some(rx);
+        tx.send(backend::StreamChunk {
+            kind: ChunkKind::Done,
+        })
+        .unwrap();
+        app.poll_response();
+    }
+
     #[test]
     fn toggle_tools_invalidates_the_chat_cache() {
         let mut app = App::new();
@@ -2188,6 +2202,9 @@ mod tests {
             .spawn_agent("find the config file".to_string(), None, None)
             .unwrap();
         assert_eq!(app.sessions.get(&id2).unwrap().effort, "low");
+
+        // Complete a session to free a slot on low-core CI runners
+        complete_session(&mut app, id);
 
         let id3 = app
             .spawn_agent("summarize this".to_string(), None, None)

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -140,6 +140,14 @@ fn main() -> io::Result<()> {
                                         app.update_suggestions();
                                     }
                                 }
+                                // Ctrl+Shift+B: direct session picker (CSI u encodes as Char('B') with CONTROL|SHIFT)
+                                KeyCode::Char('B')
+                                    if key.modifiers.contains(KeyModifiers::SHIFT)
+                                        && app.background_session_count() > 0 =>
+                                {
+                                    app.show_session_picker = true;
+                                    app.picker_cursor = 0;
+                                }
                                 KeyCode::Char('j') => app.input_newline(),
                                 _ => {}
                             }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -92,6 +92,18 @@ fn main() -> io::Result<()> {
                         }
                     }
 
+                    if app.show_session_picker {
+                        match key.code {
+                            KeyCode::Esc => app.show_session_picker = false,
+                            KeyCode::Up | KeyCode::Char('k') => app.picker_prev(),
+                            KeyCode::Down | KeyCode::Char('j') => app.picker_next(),
+                            KeyCode::Enter => app.picker_select(),
+                            KeyCode::Char('d') | KeyCode::Delete => app.dismiss_session(),
+                            _ => {}
+                        }
+                        continue;
+                    }
+
                     if app.tab == Tab::Chat {
                         if key.modifiers.contains(KeyModifiers::SUPER) {
                             match key.code {
@@ -115,6 +127,10 @@ fn main() -> io::Result<()> {
                                 KeyCode::Char('k') => app.input_kill_to_end(),
                                 KeyCode::Char('y') => app.input_yank(),
                                 KeyCode::Char('o') => app.toggle_tools(),
+                                KeyCode::Char('b') if app.background_session_count() > 0 => {
+                                    app.show_session_picker = true;
+                                    app.picker_cursor = 0;
+                                }
                                 KeyCode::Char('j') => app.input_newline(),
                                 _ => {}
                             }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -127,9 +127,18 @@ fn main() -> io::Result<()> {
                                 KeyCode::Char('k') => app.input_kill_to_end(),
                                 KeyCode::Char('y') => app.input_yank(),
                                 KeyCode::Char('o') => app.toggle_tools(),
-                                KeyCode::Char('b') if app.background_session_count() > 0 => {
-                                    app.show_session_picker = true;
-                                    app.picker_cursor = 0;
+                                KeyCode::Char('b')
+                                    if app.background_session_count() > 0
+                                        || app.active().last_subagent_hint.is_some() =>
+                                {
+                                    if app.background_session_count() > 0 {
+                                        app.show_session_picker = true;
+                                        app.picker_cursor = 0;
+                                    } else if let Some(ref hint) = app.active().last_subagent_hint {
+                                        app.input = format!("/agent {}", hint);
+                                        app.input_cursor = app.input.len();
+                                        app.update_suggestions();
+                                    }
                                 }
                                 KeyCode::Char('j') => app.input_newline(),
                                 _ => {}

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -1,7 +1,7 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
-use crate::app::{App, Tab};
+use crate::app::{App, ChatState, SessionState, Tab};
 use crate::panels;
 use crate::theme;
 
@@ -34,6 +34,10 @@ pub fn render(frame: &mut Frame, app: &App) {
             }
             render_panel_footer(frame, app, layout[2]);
         }
+    }
+
+    if app.show_session_picker {
+        render_session_picker(frame, app, area);
     }
 }
 
@@ -70,6 +74,18 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     if let Some(hint) = chat_activity_hint(app) {
         left.push(Span::styled("│ ", theme::muted()));
         left.push(Span::styled(hint, theme::thinking()));
+    }
+
+    let bg_count = app.background_session_count();
+    if bg_count > 0 {
+        left.push(Span::styled("│ ", theme::muted()));
+        let streaming = app.streaming_background_count();
+        let label = if streaming > 0 {
+            format!("{} bg ({} active) ", bg_count, streaming)
+        } else {
+            format!("{} bg ", bg_count)
+        };
+        left.push(Span::styled(label, theme::dim()));
     }
 
     if app.mode != "home" {
@@ -156,6 +172,68 @@ fn render_panel_header(frame: &mut Frame, app: &App, area: Rect) {
         .title(title)
         .border_style(theme::accent());
     frame.render_widget(block, area);
+}
+
+fn render_session_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let session_count = app.session_order.len();
+    let height = (session_count as u16 + 4).min(area.height.saturating_sub(4));
+    let width = 60u16.min(area.width.saturating_sub(4));
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let popup = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, popup);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, &id) in app.session_order.iter().enumerate() {
+        let session = match app.sessions.get(&id) {
+            Some(s) => s,
+            None => continue,
+        };
+        let is_selected = i == app.picker_cursor;
+        let is_active = id == app.active_session;
+        let marker = if is_active { ">" } else { " " };
+
+        let state_icon = match (&session.session_state, &session.chat_state) {
+            (SessionState::Completed, _) => Span::styled("✓", theme::good()),
+            (_, ChatState::Streaming) => Span::styled("●", theme::warn()),
+            _ => Span::styled("○", theme::dim()),
+        };
+
+        let label = Span::styled(
+            format!(
+                " {} {} ",
+                &session.label,
+                crate::app::model_display(&session.model)
+            ),
+            if is_selected {
+                Style::default().bg(theme::ACCENT).fg(Color::Black)
+            } else {
+                Style::default()
+            },
+        );
+
+        let cost = if session.cost_usd > 0.0 {
+            Span::styled(format!(" ${:.2}", session.cost_usd), theme::dim())
+        } else {
+            Span::raw("")
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw(marker),
+            Span::raw(" "),
+            state_icon,
+            label,
+            cost,
+        ]));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Sessions — ↑↓ enter d:dismiss esc ")
+        .border_style(theme::accent());
+    let picker = Paragraph::new(lines).block(block);
+    frame.render_widget(picker, popup);
 }
 
 fn render_panel_footer(frame: &mut Frame, app: &App, area: Rect) {

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -203,6 +203,7 @@ fn render_session_picker(frame: &mut Frame, app: &App, area: Rect) {
 
         let state_icon = match (&session.session_state, &session.chat_state) {
             (SessionState::Completed, _) => Span::styled("✓", theme::good()),
+            (SessionState::Failed, _) => Span::styled("✗", theme::bad()),
             (_, ChatState::Streaming) => Span::styled("●", theme::warn()),
             _ => Span::styled("○", theme::dim()),
         };

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -154,12 +154,19 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn chat_activity_hint(app: &App) -> Option<String> {
-    if matches!(app.active().chat_state, crate::app::ChatState::Streaming) {
-        Some(if app.show_tools {
-            "thinking... Ctrl+O hide".to_string()
+    let session = app.active();
+    if matches!(session.chat_state, crate::app::ChatState::Streaming) {
+        let tool_hint = if app.show_tools {
+            "thinking... Ctrl+O hide"
         } else {
-            "thinking... Ctrl+O show".to_string()
-        })
+            "thinking... Ctrl+O show"
+        };
+        let subagent_hint = if !session.active_subagent_ids.is_empty() {
+            " | Ctrl+B: parallel agent"
+        } else {
+            ""
+        };
+        Some(format!("{}{}", tool_hint, subagent_hint))
     } else {
         None
     }


### PR DESCRIPTION
## Summary
- **Phase 3+4** of parallel agent orchestration (ADR: `parallel-agent-orchestration.md`)
- `/agent <prompt>` spawns ephemeral background agents (inherits model from main session, uses `RunMode::Ephemeral`)
- Multi-session polling: `poll_response` fans out across ALL sessions, not just active
- `Ctrl+B` opens session picker overlay when background agents exist
- `/sessions` command opens picker (or shows hint if no agents)
- Session picker: `↑↓` navigate, `Enter` switch, `d` dismiss completed, `Esc` close
- Status bar shows `N bg (M active)` when background sessions exist
- `SessionState` enum (Running/Completed) — non-main sessions auto-complete on stream finish
- ADR ruling #2 amended: explicit spawn (`/agent`) is primary; hint-driven spawn deferred to Phase 5

### Design Pattern
**Mediator (extended):** `App` coordinates session lifecycle — spawn, poll, switch, dismiss — through the existing `HashMap<SessionId, Session>` with a new `session_order: Vec<SessionId>` for insertion-ordered picker display. Each session is self-contained with its own `stream_rx` channel.

### Stacked on
PR #313 (`feat/tui-backend-session-mgmt`) — merge that first, then this auto-retargets to main.

### What's Next (Phase 5, separate plan)
- Hint-driven spawn (process re-parenting for SubagentStart detach)
- Bounded transcripts, dynamic effort, completion summaries

## Test plan
- [x] `cargo test` — 62 tests pass (13 new covering spawn, picker, dismiss, commands)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual smoke: `/agent "summarize README"` → verify status bar shows `1 bg (1 active)` → `Ctrl+B` to open picker → Enter to switch → view output → `d` to dismiss after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)