### PR TITLE
feat(tui): dynamic terminal tab title with braille icons

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -19,7 +19,7 @@ use crossterm::event::{
     MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
-use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen, SetTitle};
 use ratatui::prelude::*;
 
 use app::{App, Tab};
@@ -51,6 +51,16 @@ fn main() -> io::Result<()> {
 
         app.poll_response();
         terminal.draw(|frame| ui::render(frame, &app))?;
+
+        let tab_icon = if matches!(app.active().chat_state, app::ChatState::Streaming) {
+            app.spinner_frame()
+        } else {
+            "⠿"
+        };
+        execute!(
+            terminal.backend_mut(),
+            SetTitle(format!("{} deus", tab_icon))
+        )?;
 
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;


### PR DESCRIPTION
## Summary
- Shows `⠿` (idle) or animated braille spinner `⠋⠙⠹...` (streaming) in the terminal tab title
- Replaces the default process name with a dynamic indicator matching the TUI's thinking animation
- Uses crossterm `SetTitle` — updates every frame (50ms) during streaming for smooth animation

## Test plan
- [x] 124/124 tests pass, clippy clean, fmt clean
- [ ] Visual: launch TUI in Ghostty, verify tab shows `⠿ deus` idle and animated spinner while streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)