### PR TITLE
fix(tui): write tab title to stdout for proper flush

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -20,7 +20,7 @@ use crossterm::event::{
     MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
-use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen, SetTitle};
 use ratatui::prelude::*;
 
 use app::{App, ChatMessage, Tab};
@@ -52,6 +52,13 @@ fn main() -> io::Result<()> {
 
         app.poll_response();
         terminal.draw(|frame| ui::render(frame, &app))?;
+
+        let tab_icon = if matches!(app.active().chat_state, app::ChatState::Streaming) {
+            app.spinner_frame()
+        } else {
+            "⠿"
+        };
+        execute!(io::stdout(), SetTitle(format!("{} deus", tab_icon)))?;
 
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;


### PR DESCRIPTION
## Summary
- Fixes #319 tab title not appearing in Ghostty — `execute!` through ratatui's backend doesn't flush the OSC escape sequence
- Writes `SetTitle` directly to `io::stdout()` instead of `terminal.backend_mut()`

## Test plan
- [x] 124/124 tests pass
- [ ] Visual: verify Ghostty tab shows `⠿ deus` when idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)