### PR TITLE
feat(tui): clipboard image paste via Ctrl+V

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -12,6 +12,8 @@ dirs = "6"
 libc = "0.2"
 unicode-bidi = "0.3"
 unicode-width = "0.1"
+arboard = "3"
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [profile.release]
 opt-level = "z"

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -393,6 +393,7 @@ pub struct App {
     pub mode: String,
 
     pub auto_compact_threshold: f64,
+    pub pending_attachments: Vec<crate::clipboard::Attachment>,
 }
 
 // StreamChunk and parsing delegated to backend trait — see backend/mod.rs
@@ -508,6 +509,7 @@ impl App {
                         .and_then(|s| s.parse::<f64>().ok())
                 })
                 .unwrap_or(0.75),
+            pending_attachments: Vec::new(),
         };
         app.refresh();
 
@@ -547,9 +549,36 @@ impl App {
         }
     }
 
+    pub fn attach_clipboard_image(&mut self) {
+        match crate::clipboard::probe_image() {
+            Some(img) => match crate::clipboard::save_image(&img) {
+                Ok(attachment) => {
+                    self.pending_attachments.push(attachment);
+                    let n = self.pending_attachments.len();
+                    self.input.push_str(&format!("[Image #{}]", n));
+                    self.input_cursor = self.input.len();
+                    self.mark_chat_changed();
+                }
+                Err(e) => {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!("Image save failed: {}", e),
+                    ));
+                    self.mark_chat_changed();
+                }
+            },
+            None => {
+                self.active_mut()
+                    .chat_messages
+                    .push(ChatMessage::simple("system", "No image in clipboard"));
+                self.mark_chat_changed();
+            }
+        }
+    }
+
     pub fn send_message(&mut self) {
         let msg = self.input.trim().to_string();
-        if msg.is_empty() {
+        if msg.is_empty() && self.pending_attachments.is_empty() {
             return;
         }
 
@@ -566,8 +595,10 @@ impl App {
             return;
         }
 
+        let final_msg = self.build_message_with_attachments(&msg);
+
         if matches!(self.active().chat_state, ChatState::Streaming) {
-            self.queued_messages.push(msg);
+            self.queued_messages.push(final_msg);
             self.active_mut()
                 .chat_messages
                 .push(ChatMessage::simple("system", "(queued)"));
@@ -577,13 +608,31 @@ impl App {
             self.scroll_to_bottom();
             return;
         }
-
         self.active_mut().compact_triggered = false;
         self.input.clear();
         self.input_cursor = 0;
         self.suggestions.clear();
         self.arg_suggestions.clear();
-        self.dispatch_message(msg);
+        self.dispatch_message(final_msg);
+    }
+
+    fn build_message_with_attachments(&mut self, msg: &str) -> String {
+        if self.pending_attachments.is_empty() {
+            return msg.to_string();
+        }
+        let attachments = std::mem::take(&mut self.pending_attachments);
+        let mut result = msg.to_string();
+        for (i, att) in attachments.iter().enumerate() {
+            let marker = format!("[Image #{}]", i + 1);
+            let replacement = format!(
+                "[Image: {} ({}x{})]",
+                att.path.display(),
+                att.width,
+                att.height
+            );
+            result = result.replace(&marker, &replacement);
+        }
+        result
     }
 
     fn dispatch_message(&mut self, msg: String) {
@@ -2757,5 +2806,49 @@ mod tests {
         app.input = "hello".to_string();
         app.send_message();
         assert!(!app.active().compact_triggered);
+    }
+
+    #[test]
+    fn build_message_replaces_image_markers() {
+        let mut app = App::new();
+        app.pending_attachments.push(crate::clipboard::Attachment {
+            path: std::path::PathBuf::from("/tmp/clip-1.png"),
+            width: 800,
+            height: 600,
+        });
+        app.pending_attachments.push(crate::clipboard::Attachment {
+            path: std::path::PathBuf::from("/tmp/clip-2.png"),
+            width: 1024,
+            height: 768,
+        });
+        let result =
+            app.build_message_with_attachments("[Image #1] check this [Image #2] and this");
+        assert!(result.contains("/tmp/clip-1.png"));
+        assert!(result.contains("800x600"));
+        assert!(result.contains("/tmp/clip-2.png"));
+        assert!(result.contains("1024x768"));
+        assert!(!result.contains("[Image #1]"));
+        assert!(!result.contains("[Image #2]"));
+        assert!(app.pending_attachments.is_empty());
+    }
+
+    #[test]
+    fn build_message_no_attachments_passthrough() {
+        let mut app = App::new();
+        let result = app.build_message_with_attachments("hello world");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn slash_command_does_not_consume_attachments() {
+        let mut app = App::new();
+        app.pending_attachments.push(crate::clipboard::Attachment {
+            path: std::path::PathBuf::from("/tmp/clip-1.png"),
+            width: 100,
+            height: 100,
+        });
+        app.input = "/help".to_string();
+        app.send_message();
+        assert!(!app.pending_attachments.is_empty());
     }
 }

--- a/tui/src/clipboard.rs
+++ b/tui/src/clipboard.rs
@@ -1,0 +1,94 @@
+use std::io;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::platform;
+
+pub struct ClipboardImage {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Attachment {
+    pub path: PathBuf,
+    pub width: u32,
+    pub height: u32,
+}
+
+fn cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| platform::home_dir().join(".cache"))
+        .join("deus")
+        .join(format!("clipboard-images-{}", std::process::id()))
+}
+
+pub fn probe_image() -> Option<ClipboardImage> {
+    let mut clipboard = arboard::Clipboard::new().ok()?;
+    let img = clipboard.get_image().ok()?;
+    Some(ClipboardImage {
+        width: img.width as u32,
+        height: img.height as u32,
+        rgba: img.bytes.into_owned(),
+    })
+}
+
+pub fn save_image(img: &ClipboardImage) -> io::Result<Attachment> {
+    let dir = cache_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let path = dir.join(format!("clip-{}.png", ts));
+
+    let rgba_image = image::RgbaImage::from_raw(img.width, img.height, img.rgba.clone())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid RGBA dimensions"))?;
+    rgba_image.save(&path).map_err(io::Error::other)?;
+
+    Ok(Attachment {
+        path,
+        width: img.width,
+        height: img.height,
+    })
+}
+
+// PNGs are kept alive during the session so the agent can Read them at any point.
+pub fn cleanup() {
+    let _ = std::fs::remove_dir_all(cache_dir());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_and_cleanup_roundtrip() {
+        let img = ClipboardImage {
+            width: 2,
+            height: 2,
+            rgba: vec![
+                255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
+            ],
+        };
+        let att = save_image(&img).unwrap();
+        assert!(att.path.exists());
+        assert_eq!(att.width, 2);
+        assert_eq!(att.height, 2);
+
+        cleanup();
+        assert!(!cache_dir().exists());
+    }
+
+    #[test]
+    fn invalid_dimensions_errors() {
+        let img = ClipboardImage {
+            width: 100,
+            height: 100,
+            rgba: vec![0; 4],
+        };
+        assert!(save_image(&img).is_err());
+    }
+}

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod backend;
 mod bidi;
+mod clipboard;
 mod config;
 mod logo;
 mod panels;
@@ -63,11 +64,16 @@ fn main() -> io::Result<()> {
             let ev = event::read()?;
             match ev {
                 Event::Paste(ref text) if app.tab == Tab::Chat => {
-                    for c in text.chars() {
-                        if c == '\n' || c == '\r' {
-                            app.input_newline();
-                        } else {
-                            app.input_char(c);
+                    // Bracketed paste with empty payload = clipboard holds an image, not text
+                    if text.is_empty() {
+                        app.attach_clipboard_image();
+                    } else {
+                        for c in text.chars() {
+                            if c == '\n' || c == '\r' {
+                                app.input_newline();
+                            } else {
+                                app.input_char(c);
+                            }
                         }
                     }
                 }
@@ -183,6 +189,9 @@ fn main() -> io::Result<()> {
                                     app.show_session_picker = true;
                                     app.picker_cursor = 0;
                                 }
+                                KeyCode::Char('v') => {
+                                    app.attach_clipboard_image();
+                                }
                                 KeyCode::Char('j') => app.input_newline(),
                                 _ => {}
                             }
@@ -280,6 +289,7 @@ fn main() -> io::Result<()> {
     }
 
     app.cleanup_permissions();
+    clipboard::cleanup();
 
     terminal::disable_raw_mode()?;
     execute!(

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -57,10 +57,7 @@ fn main() -> io::Result<()> {
         } else {
             "⠿"
         };
-        execute!(
-            terminal.backend_mut(),
-            SetTitle(format!("{} deus", tab_icon))
-        )?;
+        execute!(io::stdout(), SetTitle(format!("{} deus", tab_icon)))?;
 
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;


### PR DESCRIPTION
## Summary
- **Ctrl+V** probes system clipboard for image data via `arboard` (cross-platform: macOS/Linux/Windows)
- Saves as PNG to PID-scoped cache dir (`dirs::cache_dir()/deus/clipboard-images-<pid>/`)
- Inserts `[Image #N]` marker in input buffer; on send, markers replaced with file paths
- Backend-agnostic — the agent uses its own Read tool to view the PNG (works with Claude and Codex)
- Empty `Event::Paste` also triggers image probe (bracketed paste with image-only clipboard)
- PNGs kept alive during session for agent access, cleaned up on exit

## Test plan
- [x] 129/129 tests pass, 0 clippy warnings, fmt clean
- [x] Marker substitution tested (single + multi image)
- [x] Slash commands don't consume pending attachments
- [ ] Manual: paste screenshot via Ctrl+V, verify `[Image #1]` appears, send, verify agent reads the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)