### PR TITLE
fix(tui): remove SetTitle — Ghostty shell integration overrides it

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -57,10 +57,7 @@ fn main() -> io::Result<()> {
         } else {
             "⠿"
         };
-        execute!(
-            terminal.backend_mut(),
-            SetTitle(format!("{} deus", tab_icon))
-        )?;
+        execute!(io::stdout(), SetTitle(format!("{} deus", tab_icon)))?;
 
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -19,7 +19,7 @@ use crossterm::event::{
     MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
-use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen, SetTitle};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::prelude::*;
 
 use app::{App, Tab};
@@ -51,13 +51,6 @@ fn main() -> io::Result<()> {
 
         app.poll_response();
         terminal.draw(|frame| ui::render(frame, &app))?;
-
-        let tab_icon = if matches!(app.active().chat_state, app::ChatState::Streaming) {
-            app.spinner_frame()
-        } else {
-            "⠿"
-        };
-        execute!(io::stdout(), SetTitle(format!("{} deus", tab_icon)))?;
 
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;


### PR DESCRIPTION
## Summary
- Reverts the dynamic tab title feature (PRs #319, #320)
- Ghostty's shell integration overrides OSC 0 title changes with the process name — known limitation ([ghostty-org/ghostty#1026](https://github.com/ghostty-org/ghostty/issues/1026))
- The feature works on other terminals (iTerm2, Terminal.app, Windows Terminal) but is dead code on Ghostty

## Test plan
- [x] Builds clean, tests pass
- [x] Verified: SetTitle has no effect in Ghostty with shell integration active

🤖 Generated with [Claude Code](https://claude.com/claude-code)