### PR TITLE
fix(memory-indexer): topic-diverse --recent selection

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-04-29" # contradiction-retry-cap
+last_verified: "2026-05-04" # auto-bump
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -712,6 +712,31 @@ def cmd_add_dir(dir_str: str, extract: bool = True):
 COMPACT_SESSION_THRESHOLD = 12  # auto-enable compact mode above this many sessions
 
 
+_STOP_WORDS = frozenset(
+    "a an the and or but in on of to for with from by at is was were are be "
+    "been has had have do does did will would shall should can could may might "
+    "it its this that these those i we he she they my our his her their "
+    "not no nor so if then than up out about into over after before".split()
+)
+
+
+def _subject_from_tldr(tldr: str) -> str:
+    words = [w for w in re.split(r"[\s\-—:,./]+", tldr.lower()) if w and w not in _STOP_WORDS]
+    return words[0] if words else ""
+
+
+def _first_topic(fm: dict) -> str:
+    topics = fm.get("topics", "") or ""
+    if topics:
+        first = topics.split(",")[0].strip("[] ").lower()
+        if first:
+            return first
+    tldr = fm.get("tldr", "") or ""
+    if tldr:
+        return _subject_from_tldr(tldr)
+    return ""
+
+
 def cmd_recent(n: int = 3, days: bool = False, compact: bool = False):
     """Return recent session frontmatters. Pure filesystem — no API calls.
 
@@ -752,7 +777,18 @@ def cmd_recent(n: int = 3, days: bool = False, compact: bool = False):
         target_dates = set(seen_dates[:n])
         selected = [(d, p) for d, p in dated if d in target_dates]
     else:
-        selected = dated[:n]
+        # Dedup by primary topic so a burst on one subject doesn't bury unrelated contexts.
+        seen_topics: set[str] = set()
+        selected: list[tuple[str, Path]] = []
+        for date, path in dated:
+            content = path.read_text(encoding="utf-8")
+            fm = extract_frontmatter(content)
+            topic = _first_topic(fm)
+            if topic not in seen_topics:
+                seen_topics.add(topic)
+                selected.append((date, path))
+                if len(selected) >= n:
+                    break
 
     # Auto-enable compact when session count exceeds threshold
     if not compact and len(selected) >= COMPACT_SESSION_THRESHOLD:
@@ -3354,7 +3390,7 @@ def main():
     group.add_argument("--extract", metavar="PATH",
                        help="Extract atomic facts from a session log (uses Gemini Flash)")
     group.add_argument("--recent", type=int, metavar="N",
-                       help="Return last N session frontmatters by date (no API call)")
+                       help="Return last N topic-diverse sessions (deduped by primary topic, no API call)")
     group.add_argument("--recent-days", type=int, metavar="N",
                        help="Return ALL sessions from the last N calendar days (no API call)")
     group.add_argument("--learnings", action="store_true",

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -222,13 +222,15 @@ def test_soft_delete_entries_marks_orphaned(mi):
 # ── cmd_recent ───────────────────────────────────────────────────────────
 
 
-def _create_session(vault, date_folder: str, name: str, tldr: str, mtime_offset: float = 0):
+def _create_session(vault, date_folder: str, name: str, tldr: str,
+                    mtime_offset: float = 0, topics: str = ""):
     """Helper to create a session log file with controlled mtime."""
     day_dir = vault / "Session-Logs" / date_folder
     day_dir.mkdir(parents=True, exist_ok=True)
     p = day_dir / f"{name}.md"
+    topics_line = f"topics: [{topics}]\n" if topics else ""
     p.write_text(
-        f"---\ntype: session\ndate: {date_folder}\ntldr: {tldr}\n---\n## Summary\n"
+        f"---\ntype: session\ndate: {date_folder}\ntldr: {tldr}\n{topics_line}---\n## Summary\n"
     )
     # Set mtime: base + offset (higher offset = newer)
     import time
@@ -239,9 +241,12 @@ def _create_session(vault, date_folder: str, name: str, tldr: str, mtime_offset:
 
 def test_cmd_recent_mtime_tiebreaker(mi, fresh_vault, capsys):
     """Sessions on the same day should be ordered by mtime, newest first."""
-    _create_session(fresh_vault, "2024-06-15", "session-a", "first session", mtime_offset=100)
-    _create_session(fresh_vault, "2024-06-15", "session-b", "second session", mtime_offset=200)
-    _create_session(fresh_vault, "2024-06-15", "session-c", "third session", mtime_offset=300)
+    _create_session(fresh_vault, "2024-06-15", "session-a", "first session",
+                    mtime_offset=100, topics="alpha")
+    _create_session(fresh_vault, "2024-06-15", "session-b", "second session",
+                    mtime_offset=200, topics="bravo")
+    _create_session(fresh_vault, "2024-06-15", "session-c", "third session",
+                    mtime_offset=300, topics="charlie")
 
     mi.cmd_recent(2)
     output = capsys.readouterr().out
@@ -351,6 +356,104 @@ def test_cmd_recent_days_mtime_order_within_day(mi, fresh_vault, capsys):
     assert "late" in lines[0]
     assert "middle" in lines[1]
     assert "early" in lines[2]
+
+
+def test_cmd_recent_topic_diversity(mi, fresh_vault, capsys):
+    """--recent N deduplicates by primary topic so a burst on one topic
+    doesn't push unrelated contexts off the edge."""
+    # 6 TUI sessions + 1 interview prep, all on the same day
+    _create_session(fresh_vault, "2024-06-15", "tui-phase1", "phase 1",
+                    mtime_offset=100, topics="tui, parallel-agents")
+    _create_session(fresh_vault, "2024-06-15", "tui-phase2", "phase 2",
+                    mtime_offset=200, topics="tui, parallel-agents")
+    _create_session(fresh_vault, "2024-06-15", "tui-phase3", "phase 3",
+                    mtime_offset=300, topics="tui, session-lifecycle")
+    _create_session(fresh_vault, "2024-06-15", "tui-phase4", "phase 4",
+                    mtime_offset=400, topics="tui, permissions")
+    _create_session(fresh_vault, "2024-06-15", "tui-phase5", "phase 5",
+                    mtime_offset=500, topics="tui, effort-policy")
+    _create_session(fresh_vault, "2024-06-15", "tui-quick-wins", "quick wins",
+                    mtime_offset=600, topics="tui, theme, logo")
+    _create_session(fresh_vault, "2024-06-15", "interview-prep", "mock interview",
+                    mtime_offset=700, topics="interview-prep, career, salary")
+
+    mi.cmd_recent(3)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    # Both distinct topics must surface
+    assert any("interview" in l for l in lines)
+    assert any("tui" in l for l in lines)
+    # TUI cluster must NOT consume all 3 slots
+    tui_count = sum(1 for l in lines if "tui" in l)
+    assert tui_count <= 1
+
+
+def test_cmd_recent_topic_diversity_fewer_clusters_than_n(mi, fresh_vault, capsys):
+    """When fewer distinct topics exist than N, return what's there without padding."""
+    _create_session(fresh_vault, "2024-06-15", "tui-a", "a",
+                    mtime_offset=100, topics="tui, refactor")
+    _create_session(fresh_vault, "2024-06-15", "tui-b", "b",
+                    mtime_offset=200, topics="tui, layout")
+
+    mi.cmd_recent(5)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    # Only 1 distinct topic → only 1 session returned
+    assert len(lines) == 1
+
+
+def test_cmd_recent_topicless_different_subjects(mi, fresh_vault, capsys):
+    """Topicless sessions with distinct tldrs each get their own slot."""
+    _create_session(fresh_vault, "2024-06-15", "session-a", "Interview prep for Cyberpro",
+                    mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "session-b", "Debugging memory leak in TUI",
+                    mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "session-c", "Study notes for linear algebra",
+                    mtime_offset=300)
+
+    mi.cmd_recent(3)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    assert len(lines) == 3
+
+
+def test_cmd_recent_topicless_same_subject_deduped(mi, fresh_vault, capsys):
+    """Topicless sessions about the same subject (similar tldr) are deduped."""
+    _create_session(fresh_vault, "2024-06-15", "tui-part1", "TUI layout phase one",
+                    mtime_offset=100)
+    _create_session(fresh_vault, "2024-06-15", "tui-part2", "TUI refactor of panels",
+                    mtime_offset=200)
+    _create_session(fresh_vault, "2024-06-15", "interview", "Mock interview for job",
+                    mtime_offset=300)
+
+    mi.cmd_recent(3)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    # "TUI layout" and "TUI refactor" both extract "tui" as subject → deduped
+    assert len(lines) == 2
+    assert any("interview" in l for l in lines)
+    assert any("tui" in l for l in lines)
+
+
+def test_cmd_recent_days_not_topic_deduped(mi, fresh_vault, capsys):
+    """--recent-days mode should NOT deduplicate by topic — it's exhaustive."""
+    _create_session(fresh_vault, "2024-06-15", "tui-a", "a",
+                    mtime_offset=100, topics="tui, refactor")
+    _create_session(fresh_vault, "2024-06-15", "tui-b", "b",
+                    mtime_offset=200, topics="tui, layout")
+    _create_session(fresh_vault, "2024-06-15", "tui-c", "c",
+                    mtime_offset=300, topics="tui, perf")
+
+    mi.cmd_recent(1, days=True)
+    output = capsys.readouterr().out
+    lines = [l for l in output.strip().split("\n") if l.startswith("- [")]
+
+    # All 3 returned — no dedup in days mode
+    assert len(lines) == 3
 
 
 # ── cmd_learnings ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `--recent N` now deduplicates by primary topic so a burst of sessions on one subject doesn't bury unrelated contexts at cold start
- Topic key: `topics[0]` from frontmatter when available; first significant word from `tldr` (stop-word filtered) for topicless sessions
- `--recent-days` mode unchanged (exhaustive listing)

## Motivation
Yesterday had 6 TUI sessions + 1 interview prep. `--recent 3` returned 3 TUI sessions — the interview prep was invisible, causing a cold-start miss when "I'm before the interview" was asked.

## Test plan
- [x] 5 new tests: topic diversity, fewer-clusters-than-N, topicless different subjects, topicless same subject deduped, days-mode-not-deduped
- [x] Existing 15 cmd_recent tests pass (1 updated with distinct topics)
- [x] Full suite: 259/259 pass
- [x] Real-data verification: `--recent 3` now returns TUI + vault-architecture + cyberpro interview prep

🤖 Generated with [Claude Code](https://claude.com/claude-code)