### PR TITLE
feat(wardens): add STRIDE checklists to threat-modeler

### DIFF
--- a/.claude/agents/threat-modeler.md
+++ b/.claude/agents/threat-modeler.md
@@ -10,10 +10,11 @@ You are the `threat-modeler` Warden -- an architecture-level adversary reviewer.
 ## At invocation, read these (surgical -- stop when you have enough context)
 
 1. **Rules file** -- find the repo root by walking up from `$PWD` until you find `.git/`. Read `$REPO_ROOT/.claude/wardens/threat-modeling-rules.md`. Apply every rule whose `Applies when` matches. Source of truth. Fail-closed if missing.
-2. **The design description** -- provided as the invocation prompt. If the design references specific files, read only those directly relevant to the trust boundary being modeled.
-3. **`$REPO_ROOT/CLAUDE.md`** -- for project-level security posture notes (if present). Skip silently if absent.
-4. **Existing auth/security patterns** -- run `grep -rl "auth\|token\|secret\|session\|credential" $REPO_ROOT/src --include="*.ts" 2>/dev/null | head -5` and read the most relevant 1-2 files for context on current patterns. Adapt the glob to the repo's primary language.
-5. **Memory** -- discover with `ls $HOME/.claude/projects/*/memory/MEMORY.md 2>/dev/null | grep -i $(basename $REPO_ROOT) | head -1`. If found, check for security-related feedback entries. Skip silently if none.
+2. **Checklists** -- read `$REPO_ROOT/.claude/wardens/threat-modeling-checklists.md`. Cross-reference the STRIDE sections against the design. These are depth checks, not additional gates -- they inform the threat matrix, not the verdict rules.
+3. **The design description** -- provided as the invocation prompt. If the design references specific files, read only those directly relevant to the trust boundary being modeled.
+4. **`$REPO_ROOT/CLAUDE.md`** -- for project-level security posture notes (if present). Skip silently if absent.
+5. **Existing auth/security patterns** -- run `grep -rl "auth\|token\|secret\|session\|credential" $REPO_ROOT/src --include="*.ts" 2>/dev/null | head -5` and read the most relevant 1-2 files for context on current patterns. Adapt the glob to the repo's primary language.
+6. **Memory** -- discover with `ls $HOME/.claude/projects/*/memory/MEMORY.md 2>/dev/null | grep -i $(basename $REPO_ROOT) | head -1`. If found, check for security-related feedback entries. Skip silently if none.
 
 Do NOT read all source files. Focus on the system described, not the full codebase. If you find yourself reading >6 files, you're over-researching.
 

--- a/.claude/wardens/threat-modeling-checklists.md
+++ b/.claude/wardens/threat-modeling-checklists.md
@@ -1,0 +1,51 @@
+# Threat Modeling Checklists — STRIDE Reference
+
+> Read by `threat-modeler` on every invocation. Architecture-level only.
+> Code-level patterns (regex, sanitization calls) belong to code-reviewer.
+> Sources: OWASP Top 10, CWE Top 25, ASVS L1–L3.
+
+## SPOOFING
+
+- **OAuth flows:** Require `state` parameter (anti-CSRF), PKCE for public clients, exact-match redirect URI allowlist — no wildcards. [CWE-352, OWASP A07:2021]
+- **JWT security:** Lock algorithm explicitly (reject `none`, reject symmetric when expecting asymmetric). Validate `aud`/`iss`/`exp` claims. Keys sourced from server config only — never from token headers (`jku`/`jwk`/`kid`). [CWE-347]
+- **Password storage:** Must use a memory-hard KDF (argon2id, bcrypt, scrypt). Never MD5/SHA-family for passwords. [CWE-327, OWASP A02:2021]
+- **Account enumeration:** Auth endpoints must return identical responses and timing for valid vs invalid credentials. [CWE-287]
+- **WebAuthn/Passkeys:** `userVerification: required`, `rpID` scoped to exact domain, single-use challenges with server-side verification. [CWE-287]
+
+## TAMPERING
+
+- **Mass assignment:** Designs that accept user input into DB writes must specify an explicit field allowlist. Never pass raw request body directly to ORM/storage. [CWE-915]
+- **Supply chain:** Lockfile committed and enforced in CI (`npm ci` not `npm install`). Review `postinstall` scripts for new dependencies. Scoped packages for private deps. [CWE-1357, OWASP A06:2021]
+- **Webhook verification:** Incoming webhooks must verify HMAC/signature before processing. Reject on verification failure — never process optimistically. [CWE-345]
+- **Path traversal:** Any operation that resolves user-supplied paths (file uploads, zip extraction, URL paths) must validate the resolved path stays within the intended directory. [CWE-22]
+
+## REPUDIATION
+
+- **Security event logging:** Log authn success/failure, privilege changes, and resource access with structured fields (who, what, when, from-where). Never embed raw user input into log strings. [CWE-117, CWE-778]
+- **Audit trails:** Irreversible or high-stakes actions (financial, admin, deletion) require immutable audit records with actor identity, timestamp, and input snapshot. [PCI-DSS Req 10]
+
+## INFORMATION DISCLOSURE
+
+- **SSRF prevention:** Server-side URL fetches must validate against a domain allowlist AND block RFC-1918/link-local/loopback ranges. [CWE-918, OWASP A10:2021]
+- **PII in transit:** PII must not appear in logs, URLs, query parameters, or error responses. Serialized objects must exclude sensitive fields (password hashes, tokens, internal IDs). [CWE-200, CWE-312]
+- **Secrets management:** No hardcoded credentials. `.env` never committed. Pre-commit secret scanning. Source maps disabled in production. [CWE-798]
+- **JWT payload minimization:** JWT payloads are base64-encoded (not encrypted). Never include passwords, PII, payment data, or internal secrets in claims. [CWE-312]
+- **RAG/vector search:** User-scoped permission filters must be enforced at query time — a user's query must never return another user's documents. [CWE-862]
+
+## DENIAL OF SERVICE
+
+- **Tiered rate limiting:** Global limit (request ceiling), per-endpoint limits (tighter on auth/login), per-user limits (not just per-IP). Distributed deployments need shared state (Redis/equivalent). [CWE-400, CWE-770]
+- **Request bounds:** Body size limits, request timeouts, connection limits per source. Designs exposing file upload or streaming endpoints must specify max sizes. [CWE-400]
+- **Race conditions:** Financial operations, inventory, and redemption flows require atomic operations or row-level locking. Design must specify concurrency strategy. [CWE-362]
+- **Pagination:** All collection/list endpoints must be paginated. No unbounded queries. [CWE-400]
+- **Numeric validation:** User-supplied numeric values that control iteration, allocation, or recursion depth must have explicit bounds. [CWE-190]
+
+## ELEVATION OF PRIVILEGE
+
+- **IDOR:** Every resource access must verify ownership — the design must specify how `resource.owner == caller` is enforced, not just that auth is present. [CWE-862, OWASP A01:2021]
+- **Session fixation:** Session ID must be regenerated after login, after role/privilege change, and after OAuth callback. [CWE-384]
+- **Session security:** Session cookies require `httpOnly`, `secure`, `sameSite=strict`. Design must specify absolute timeout and inactivity timeout. Logout must destroy server-side session state. [CWE-614]
+- **CSRF defense:** Designs with state-changing endpoints need layered defense: SameSite cookies + origin/referer validation + CSRF token (for legacy browser support). [CWE-352]
+- **AI/LLM tool-calling:** Agent tool invocations require minimal permissions per tool, tool-name validation against an explicit allowlist, and per-call user authorization verification. MCP servers must be explicitly allowlisted. [CWE-269]
+- **File uploads:** Files stored outside web root, filenames randomized server-side, executable extensions blocked. Design must specify storage location and access control. [CWE-434]
+- **Database access:** Application DB user must have least-privilege grants (never root/superuser). Database ports never publicly accessible. [CWE-250]

--- a/.claude/wardens/threat-modeling-rules.md
+++ b/.claude/wardens/threat-modeling-rules.md
@@ -2,6 +2,7 @@
 
 > Applied architecture-level before implementing security-sensitive features.
 > STRIDE categories: S=Spoofing, T=Tampering, R=Repudiation, I=Information Disclosure, D=Denial of Service, E=Elevation of Privilege.
+> Depth references: `threat-modeling-checklists.md` (read on every invocation for per-category checks).
 
 ## auth-surface-documented
 **Severity:** blocking


### PR DESCRIPTION
## Summary

- Adds `.claude/wardens/threat-modeling-checklists.md` — a STRIDE-organized reference file with architecture-level vulnerability checks distilled from OWASP Top 10, CWE Top 25, and ASVS
- Threat-modeler reads it on every invocation (step 2, before the design description) to inform the threat matrix depth
- No new gate rules — same 8 rules, same SHIP/REVISE/BLOCK logic

Covers: OAuth/PKCE/JWT, SSRF, mass assignment, supply chain, session fixation, IDOR, race conditions, AI/LLM tool-call permissions, rate-limit tiering, file upload architecture, and more.

## Test plan

- [x] Wet test: invoked threat-modeler on a realistic "external API proxy for container agents" design
- [x] Confirmed checklist items surfaced in the threat matrix (SSRF deny-list, redirect-following, response size caps, structured audit logs — none of which existed in the old rules-only setup)
- [x] Verdict was BLOCK with 4 blocking gaps and 8 concrete recommended controls
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)