### PR TITLE
feat(security): mcp action audit trail

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -29,6 +29,7 @@ import { bootstrap } from './bootstrap.js';
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { createMemoryRetrievalHook } from './memory-retrieval-hook.js';
 import { runOpenAIConversation } from './openai-backend.js';
+import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 
 type AgentRuntimeId = 'claude' | 'openai';
 
@@ -360,6 +361,20 @@ function createToolSizeLogHook(): HookCallback {
     } catch (err) {
       log(
         `tool-size-log failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return {};
+  };
+}
+
+function createToolAuditHook(): HookCallback {
+  return async (input) => {
+    const hookInput = input as PostToolUseHookInput;
+    if (isAuditedTool(hookInput.tool_name)) {
+      writeAuditEntry(
+        hookInput.tool_name,
+        hookInput.tool_use_id,
+        (hookInput as unknown as Record<string, unknown>).tool_input,
       );
     }
     return {};
@@ -776,9 +791,14 @@ async function runQuery(
         PreCompact: [
           { hooks: [createPreCompactHook(containerInput.assistantName)] },
         ],
-        ...(process.env.DEUS_TOOL_SIZE_LOG !== '0'
-          ? { PostToolUse: [{ hooks: [createToolSizeLogHook()] }] }
-          : {}),
+        ...(() => {
+          const hooks: HookCallback[] = [];
+          if (process.env.DEUS_TOOL_SIZE_LOG !== '0')
+            hooks.push(createToolSizeLogHook());
+          if (process.env.DEUS_TOOL_AUDIT_LOG !== '0')
+            hooks.push(createToolAuditHook());
+          return hooks.length > 0 ? { PostToolUse: [{ hooks }] } : {};
+        })(),
       },
     },
   })) {

--- a/container/agent-runner/src/tool-audit.test.ts
+++ b/container/agent-runner/src/tool-audit.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import {
+  isAuditedTool,
+  writeAuditEntry,
+  generateToolUseId,
+} from './tool-audit.js';
+
+vi.mock('fs');
+
+describe('tool-audit', () => {
+  describe('isAuditedTool', () => {
+    it('matches exact deus tools', () => {
+      expect(isAuditedTool('mcp__deus__send_message')).toBe(true);
+      expect(isAuditedTool('mcp__deus__schedule_task')).toBe(true);
+      expect(isAuditedTool('mcp__deus__update_task')).toBe(true);
+      expect(isAuditedTool('mcp__deus__delete_task')).toBe(true);
+    });
+
+    it('matches google calendar prefix', () => {
+      expect(isAuditedTool('mcp__google_calendar__create_event')).toBe(true);
+      expect(isAuditedTool('mcp__google_calendar__delete_event')).toBe(true);
+    });
+
+    it('matches gmail prefix', () => {
+      expect(isAuditedTool('mcp__gmail__send_email')).toBe(true);
+    });
+
+    it('rejects non-audited tools', () => {
+      expect(isAuditedTool('mcp__deus__list_tasks')).toBe(false);
+      expect(isAuditedTool('Read')).toBe(false);
+      expect(isAuditedTool('Bash')).toBe(false);
+      expect(isAuditedTool('mcp__youtube__get_transcript')).toBe(false);
+    });
+  });
+
+  describe('writeAuditEntry', () => {
+    const env = process.env;
+
+    beforeEach(() => {
+      process.env = { ...env, DEUS_GROUP_FOLDER: 'test-group' };
+      vi.clearAllMocks();
+      vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+      vi.mocked(fs.appendFileSync).mockReturnValue(undefined);
+    });
+
+    afterEach(() => {
+      process.env = env;
+    });
+
+    it('writes JSONL entry with correct fields', () => {
+      writeAuditEntry('mcp__deus__send_message', 'tu-123', { text: 'hello' });
+
+      expect(fs.appendFileSync).toHaveBeenCalledOnce();
+      const written = vi.mocked(fs.appendFileSync).mock.calls[0][1] as string;
+      const entry = JSON.parse(written.trim());
+
+      expect(entry.tool).toBe('mcp__deus__send_message');
+      expect(entry.tool_use_id).toBe('tu-123');
+      expect(entry.group).toBe('test-group');
+      expect(entry.args_preview).toContain('hello');
+      expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('truncates args_preview to 500 chars', () => {
+      const longArgs = { text: 'x'.repeat(1000) };
+      writeAuditEntry('mcp__deus__send_message', 'tu-456', longArgs);
+
+      const written = vi.mocked(fs.appendFileSync).mock.calls[0][1] as string;
+      const entry = JSON.parse(written.trim());
+      expect(entry.args_preview.length).toBeLessThanOrEqual(500);
+    });
+
+    it('uses unknown when DEUS_GROUP_FOLDER is not set', () => {
+      delete process.env.DEUS_GROUP_FOLDER;
+      writeAuditEntry('mcp__deus__send_message', 'tu-789', {});
+
+      const written = vi.mocked(fs.appendFileSync).mock.calls[0][1] as string;
+      const entry = JSON.parse(written.trim());
+      expect(entry.group).toBe('unknown');
+    });
+
+    it('does nothing when DEUS_TOOL_AUDIT_LOG=0', () => {
+      process.env.DEUS_TOOL_AUDIT_LOG = '0';
+      writeAuditEntry('mcp__deus__send_message', 'tu-000', {});
+      expect(fs.appendFileSync).not.toHaveBeenCalled();
+    });
+
+    it('does not throw on fs errors', () => {
+      vi.mocked(fs.appendFileSync).mockImplementation(() => {
+        throw new Error('disk full');
+      });
+      expect(() =>
+        writeAuditEntry('mcp__deus__send_message', 'tu-err', {}),
+      ).not.toThrow();
+    });
+  });
+
+  describe('generateToolUseId', () => {
+    it('returns a string with openai prefix', () => {
+      const id = generateToolUseId();
+      expect(id).toMatch(/^openai-\d+-\d+$/);
+    });
+
+    it('generates unique IDs on successive calls', () => {
+      const ids = new Set(
+        Array.from({ length: 100 }, () => generateToolUseId()),
+      );
+      expect(ids.size).toBe(100);
+    });
+  });
+});

--- a/container/agent-runner/src/tool-audit.ts
+++ b/container/agent-runner/src/tool-audit.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const AUDITED_TOOLS = new Set([
+  'mcp__deus__send_message',
+  'mcp__deus__schedule_task',
+  'mcp__deus__update_task',
+  'mcp__deus__delete_task',
+]);
+
+const AUDITED_PREFIXES = ['mcp__google_calendar__', 'mcp__gmail__'];
+
+const LOG_PATH = '/workspace/group/logs/tool-audit.jsonl';
+
+export function isAuditedTool(name: string): boolean {
+  return (
+    AUDITED_TOOLS.has(name) || AUDITED_PREFIXES.some((p) => name.startsWith(p))
+  );
+}
+
+export function writeAuditEntry(
+  tool: string,
+  toolUseId: string,
+  args: unknown,
+): void {
+  if (process.env.DEUS_TOOL_AUDIT_LOG === '0') return;
+  try {
+    const entry = {
+      ts: new Date().toISOString(),
+      tool,
+      tool_use_id: toolUseId,
+      group: process.env.DEUS_GROUP_FOLDER ?? 'unknown',
+      args_preview: JSON.stringify(args ?? '').slice(0, 500),
+    };
+    fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
+    fs.appendFileSync(LOG_PATH, JSON.stringify(entry) + '\n');
+  } catch {
+    // Audit logging must never crash the tool call
+  }
+}
+
+export function generateToolUseId(): string {
+  return `openai-${Date.now()}-${crypto.randomInt(1e6)}`;
+}

--- a/container/agent-runner/src/tool-broker.ts
+++ b/container/agent-runner/src/tool-broker.ts
@@ -12,6 +12,11 @@ import {
   type StdioServerParameters,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { CronExpressionParser } from 'cron-parser';
+import {
+  isAuditedTool,
+  writeAuditEntry,
+  generateToolUseId,
+} from './tool-audit.js';
 
 export type AgentRuntimeId = 'claude' | 'openai';
 
@@ -619,6 +624,8 @@ export async function createOpenAIMcpToolBridge(
           name: binding.toolName,
           arguments: args,
         });
+        if (isAuditedTool(name))
+          writeAuditEntry(name, generateToolUseId(), args);
         return result as Record<string, unknown>;
       } catch (err) {
         return {


### PR DESCRIPTION
## Summary

- Adds `tool-audit.jsonl` — logs state-changing MCP tool calls with timestamp, group identity, and args preview
- Covers both Claude (PostToolUse hook) and OpenAI/Codex (`tool-broker.ts` execute path)
- Audited tools: `send_message`, `schedule_task`, `update_task`, `delete_task`, all Google Calendar and Gmail tools
- Opt-out: `DEUS_TOOL_AUDIT_LOG=0`

Closes the repudiation gap flagged by threat-modeler: irreversible actions (sending messages, creating/deleting calendar events) now have an audit trail.

## Changes

| File | Change |
|------|--------|
| `container/agent-runner/src/tool-audit.ts` | NEW — shared audit module |
| `container/agent-runner/src/tool-audit.test.ts` | NEW — 11 tests |
| `container/agent-runner/src/index.ts` | Register audit hook in PostToolUse |
| `container/agent-runner/src/tool-broker.ts` | Audit call in OpenAI execute path |

## Test plan

- [x] 11 unit tests: isAuditedTool (exact + prefix match), writeAuditEntry (JSONL structure, truncation, env fallback, opt-out, error resilience), generateToolUseId (format, uniqueness)
- [x] Container agent-runner full suite: 43 tests passing
- [x] Main repo full suite: 1185 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)