### PR TITLE
feat(tui): add Tasks panel with scheduled task dashboard

### DIFF
--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@deus-ai/tui",
+  "version": "1.0.0",
+  "description": "Unified terminal UI for Deus management",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "deus-tui": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.tsx",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "ink": "^5.1.0",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "@types/react": "^18.3.18",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.1.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/tui/src/__tests__/task-data.test.ts
+++ b/packages/tui/src/__tests__/task-data.test.ts
@@ -1,0 +1,173 @@
+import { test, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { loadTasks, mapRow } from '../task-data.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DEPTH_TO_STORE = 4;
+const REAL_DB_PATH = resolve(
+  __dirname,
+  ...Array(DEPTH_TO_STORE).fill('..'),
+  'store',
+  'messages.db',
+);
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE scheduled_tasks (
+    id TEXT PRIMARY KEY,
+    group_folder TEXT NOT NULL,
+    chat_jid TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    schedule_type TEXT NOT NULL,
+    schedule_value TEXT NOT NULL,
+    next_run TEXT,
+    last_run TEXT,
+    last_result TEXT,
+    status TEXT DEFAULT 'active',
+    created_at TEXT NOT NULL,
+    context_mode TEXT DEFAULT 'isolated',
+    agent_backend TEXT
+  );
+`;
+
+function createFixtureDb(dir: string, insertSql: string): string {
+  mkdirSync(dir, { recursive: true });
+  const dbPath = join(dir, 'messages.db');
+  execFileSync('sqlite3', [dbPath], {
+    input: CREATE_TABLE_SQL + insertSql,
+    encoding: 'utf-8',
+  });
+  return dbPath;
+}
+
+test('loadTasks returns tasks from real DB if available', () => {
+  if (!existsSync(REAL_DB_PATH)) {
+    expect(loadTasks()).toEqual([]);
+    return;
+  }
+
+  const tasks = loadTasks();
+  expect(Array.isArray(tasks)).toBe(true);
+  for (const task of tasks) {
+    expect(task).toHaveProperty('id');
+    expect(task).toHaveProperty('prompt');
+    expect(task).toHaveProperty('status');
+    expect(task).toHaveProperty('scheduleType');
+    expect(task).toHaveProperty('scheduleValue');
+    expect(task).toHaveProperty('groupFolder');
+  }
+});
+
+test('loadTasks returns empty array for nonexistent DB path', () => {
+  const tasks = loadTasks('/tmp/nonexistent-deus-test/messages.db');
+  expect(tasks).toEqual([]);
+});
+
+test('loadTasks returns empty array for empty table', () => {
+  const dir = join(tmpdir(), `deus-task-test-empty-${process.pid}`);
+  try {
+    const dbPath = createFixtureDb(dir, '');
+    const tasks = loadTasks(dbPath);
+    expect(tasks).toEqual([]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadTasks loads and maps fixture rows correctly', () => {
+  const dir = join(tmpdir(), `deus-task-test-map-${process.pid}`);
+  try {
+    const dbPath = createFixtureDb(
+      dir,
+      `
+      INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, status, created_at)
+      VALUES ('t1', 'telegram_main', 'j1', 'Check weather', 'cron', '0 8 * * *', 'active', '2026-01-01');
+      INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, status, created_at)
+      VALUES ('t2', 'whatsapp_main', 'j2', 'Send report', 'once', '2026-04-01T10:00:00', 'paused', '2026-01-01');
+    `,
+    );
+
+    const tasks = loadTasks(dbPath);
+    expect(tasks).toHaveLength(2);
+
+    expect(tasks[0]!.id).toBe('t1');
+    expect(tasks[0]!.status).toBe('active');
+    expect(tasks[0]!.scheduleType).toBe('cron');
+    expect(tasks[0]!.groupFolder).toBe('telegram_main');
+
+    expect(tasks[1]!.id).toBe('t2');
+    expect(tasks[1]!.status).toBe('paused');
+    expect(tasks[1]!.scheduleType).toBe('once');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadTasks orders active before paused before completed', () => {
+  const dir = join(tmpdir(), `deus-task-test-order-${process.pid}`);
+  try {
+    const dbPath = createFixtureDb(
+      dir,
+      `
+      INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, status, created_at)
+      VALUES ('t1', 'g1', 'j1', 'Completed', 'once', '2026-01-01', 'completed', '2026-01-01');
+      INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, status, created_at)
+      VALUES ('t2', 'g1', 'j1', 'Active', 'cron', '0 8 * * *', 'active', '2026-01-01');
+      INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, status, created_at)
+      VALUES ('t3', 'g1', 'j1', 'Paused', 'interval', '1h', 'paused', '2026-01-01');
+    `,
+    );
+
+    const tasks = loadTasks(dbPath);
+    expect(tasks).toHaveLength(3);
+    expect(tasks[0]!.status).toBe('active');
+    expect(tasks[1]!.status).toBe('paused');
+    expect(tasks[2]!.status).toBe('completed');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('mapRow validates unknown status/scheduleType to defaults', () => {
+  const row = {
+    id: 't1',
+    prompt: 'Test',
+    status: 'cancelled',
+    schedule_type: 'webhook',
+    schedule_value: '*/5',
+    group_folder: 'g1',
+    next_run: null,
+    last_run: null,
+    last_result: null,
+  };
+
+  const entry = mapRow(row);
+  expect(entry.status).toBe('completed');
+  expect(entry.scheduleType).toBe('once');
+});
+
+test('mapRow preserves valid status/scheduleType', () => {
+  const row = {
+    id: 't2',
+    prompt: 'Valid',
+    status: 'active',
+    schedule_type: 'cron',
+    schedule_value: '0 8 * * *',
+    group_folder: 'g2',
+    next_run: '2026-05-06T08:00:00',
+    last_run: '2026-05-05T08:00:00',
+    last_result: 'OK',
+  };
+
+  const entry = mapRow(row);
+  expect(entry.status).toBe('active');
+  expect(entry.scheduleType).toBe('cron');
+  expect(entry.nextRun).toBe('2026-05-06T08:00:00');
+  expect(entry.lastRun).toBe('2026-05-05T08:00:00');
+  expect(entry.lastResult).toBe('OK');
+});

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import { TabBar } from './components/tab-bar.js';
+import { WardensPanel } from './panels/wardens.js';
+import { ServicesPanel } from './panels/services.js';
+import { ChannelsPanel } from './panels/channels.js';
+import { ConfigPanel } from './panels/config.js';
+import { TasksPanel } from './panels/tasks.js';
+
+const TABS = ['Wardens', 'Services', 'Channels', 'Config', 'Tasks'];
+const TAB_DESCRIPTIONS = [
+  'Toggle safety gates and inspect the selected warden.',
+  'Check local service health and heartbeat freshness.',
+  'See which channel adapters are configured.',
+  'Review resolved Deus runtime configuration.',
+  'View scheduled task status and details.',
+];
+
+export function App() {
+  const { exit } = useApp();
+  const [activeTab, setActiveTab] = useState(0);
+
+  useInput((input, key) => {
+    if (input === 'q' || input === 'Q') exit();
+    if (key.leftArrow && activeTab > 0) setActiveTab(activeTab - 1);
+    if (key.rightArrow && activeTab < TABS.length - 1) setActiveTab(activeTab + 1);
+    if (input === '1') setActiveTab(0);
+    if (input === '2') setActiveTab(1);
+    if (input === '3') setActiveTab(2);
+    if (input === '4') setActiveTab(3);
+    if (input === '5') setActiveTab(4);
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1}>
+      <Box marginTop={1}>
+        <TabBar tabs={TABS} active={activeTab} />
+      </Box>
+
+      <Box marginTop={1} borderStyle="round" borderColor="gray" paddingX={1} paddingY={0} minHeight={14}>
+        <Box flexDirection="column">
+          {activeTab === 0 && <WardensPanel />}
+          {activeTab === 1 && <ServicesPanel />}
+          {activeTab === 2 && <ChannelsPanel />}
+          {activeTab === 3 && <ConfigPanel />}
+          {activeTab === 4 && <TasksPanel />}
+        </Box>
+      </Box>
+
+      <Box marginTop={1} paddingX={1}>
+        <Text dimColor>
+          ←→ tabs  ↑↓ navigate  ⎵ toggle  1-5 jump  q quit · {TAB_DESCRIPTIONS[activeTab]}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/tui/src/channel-status.ts
+++ b/packages/tui/src/channel-status.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+
+export interface ChannelInfo {
+  name: string;
+  configured: boolean;
+}
+
+function envHas(key: string): boolean {
+  if (process.env[key]) return true;
+  const envPath = join(REPO_ROOT, '.env');
+  if (!existsSync(envPath)) return false;
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    return content
+      .split('\n')
+      .some(
+        (line) => line.startsWith(`${key}=`) && line.length > key.length + 1,
+      );
+  } catch {
+    return false;
+  }
+}
+
+export function getChannelStatuses(): ChannelInfo[] {
+  return [
+    {
+      name: 'WhatsApp',
+      configured: existsSync(join(REPO_ROOT, 'store', 'auth', 'creds.json')),
+    },
+    { name: 'Telegram', configured: envHas('TELEGRAM_BOT_TOKEN') },
+    { name: 'Discord', configured: envHas('DISCORD_BOT_TOKEN') },
+    { name: 'Slack', configured: envHas('SLACK_BOT_TOKEN') },
+    {
+      name: 'Gmail',
+      configured: existsSync(
+        join(homedir(), '.config', 'deus', 'gmail-tokens.json'),
+      ),
+    },
+    { name: 'X (Twitter)', configured: envHas('X_API_KEY') },
+  ];
+}

--- a/packages/tui/src/components/status-indicator.tsx
+++ b/packages/tui/src/components/status-indicator.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Text } from 'ink';
+
+interface StatusIndicatorProps {
+  status: 'on' | 'off' | 'stale' | 'unknown' | 'unsupported' | 'completed';
+  label: string;
+}
+
+const COLORS: Record<string, string> = {
+  on: 'green',
+  off: 'red',
+  stale: 'yellow',
+  unknown: 'gray',
+  unsupported: 'gray',
+  completed: 'gray',
+};
+
+const ICONS: Record<string, string> = {
+  on: '●',
+  off: '○',
+  stale: '◐',
+  unknown: '?',
+  unsupported: '—',
+  completed: '✓',
+};
+
+export function StatusIndicator({ status, label }: StatusIndicatorProps) {
+  return (
+    <Text color={COLORS[status]} bold>
+      {ICONS[status]} {label}
+    </Text>
+  );
+}

--- a/packages/tui/src/components/tab-bar.tsx
+++ b/packages/tui/src/components/tab-bar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+interface TabBarProps {
+  tabs: string[];
+  active: number;
+}
+
+export function TabBar({ tabs, active }: TabBarProps) {
+  return (
+    <Box flexDirection="row" flexWrap="wrap">
+      {tabs.map((tab, i) => (
+        <Box key={tab} marginRight={1} marginBottom={1}>
+          <Text
+            bold={i === active}
+            color={i === active ? 'black' : 'gray'}
+            backgroundColor={i === active ? 'cyan' : undefined}
+          >
+            {` ${i + 1}. ${tab} `}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/packages/tui/src/dashboard-preview.ts
+++ b/packages/tui/src/dashboard-preview.ts
@@ -1,0 +1,96 @@
+import { truncate } from './formatting.js';
+import type { ChannelInfo } from './channel-status.js';
+import type { DeusConfig } from './deus-config.js';
+import type { ServiceStatus } from './service-status.js';
+import type { WardensConfig } from './wardens-config.js';
+import { WARDEN_TYPES, triggersLabel } from './wardens-config.js';
+
+interface DashboardPreviewData {
+  wardens: WardensConfig;
+  services: ServiceStatus[];
+  channels: ChannelInfo[];
+  deusConfig: DeusConfig;
+}
+
+export function renderDashboardPreview(
+  data: DashboardPreviewData,
+  width = 72,
+): string[] {
+  const bodyWidth = Math.max(10, width - 4);
+  const line = (text: string) =>
+    `│ ${truncate(text, bodyWidth).padEnd(bodyWidth)} │`;
+  const centered = (text: string) => {
+    const clipped = truncate(text, bodyWidth);
+    const pad = bodyWidth - clipped.length;
+    const left = Math.floor(pad / 2);
+    const right = pad - left;
+    return `│ ${' '.repeat(left)}${clipped}${' '.repeat(right)} │`;
+  };
+
+  const wardens = Object.entries(data.wardens);
+  const enabledWardens = wardens.filter(([, warden]) => warden.enabled).length;
+  const runningServices = data.services.filter(
+    (svc) => svc.status === 'running',
+  ).length;
+  const connectedChannels = data.channels.filter((ch) => ch.configured).length;
+  const configKeys = Object.entries(data.deusConfig).filter(
+    ([, value]) => value !== undefined && value !== null,
+  ).length;
+
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`╭${'─'.repeat(width - 2)}╮`);
+  lines.push(centered('DEUS CONTROL CENTER'));
+  lines.push(
+    line(
+      `Wardens ${enabledWardens}/${wardens.length} enabled · Services ${runningServices}/${data.services.length} running · Channels ${connectedChannels}/${data.channels.length} connected · Config ${configKeys} keys`,
+    ),
+  );
+  lines.push(`├${'─'.repeat(width - 2)}┤`);
+
+  lines.push(line('WARDENS'));
+  for (const [name, warden] of wardens) {
+    const icon = warden.enabled ? '✓' : '✗';
+    const type = WARDEN_TYPES[name] ?? '';
+    const triggers = triggersLabel(warden, name);
+    lines.push(
+      line(
+        `  ${icon} ${truncate(name, 20).padEnd(20)} ${truncate(type, 20).padEnd(20)} ${truncate(triggers, 18)}`,
+      ),
+    );
+  }
+
+  lines.push(line('SERVICES'));
+  for (const svc of data.services) {
+    const icon =
+      svc.status === 'running' ? '✓' : svc.status === 'stale' ? '~' : '✗';
+    const detail = svc.detail ?? svc.status;
+    lines.push(
+      line(
+        `  ${icon} ${truncate(svc.description, 28).padEnd(28)} ${truncate(detail, 18)}`,
+      ),
+    );
+  }
+
+  lines.push(line('CHANNELS'));
+  for (const ch of data.channels) {
+    const icon = ch.configured ? '✓' : '✗';
+    const status = ch.configured ? 'connected' : 'not configured';
+    lines.push(
+      line(
+        `  ${icon} ${truncate(ch.name, 16).padEnd(16)} ${truncate(status, 18)}`,
+      ),
+    );
+  }
+
+  lines.push(line('CONFIG'));
+  for (const [key, value] of Object.entries(data.deusConfig)) {
+    if (value === undefined || value === null) continue;
+    lines.push(
+      line(`  ${truncate(key, 20).padEnd(20)} ${truncate(String(value), 28)}`),
+    );
+  }
+  lines.push(`╰${'─'.repeat(width - 2)}╯`);
+  lines.push('');
+  return lines;
+}

--- a/packages/tui/src/formatting.ts
+++ b/packages/tui/src/formatting.ts
@@ -1,0 +1,9 @@
+export const ELLIPSIS = '…';
+
+export function truncate(text: string, maxWidth: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (maxWidth <= 0) return '';
+  if (normalized.length <= maxWidth) return normalized;
+  if (maxWidth === 1) return ELLIPSIS;
+  return `${normalized.slice(0, maxWidth - 1)}${ELLIPSIS}`;
+}

--- a/packages/tui/src/index.tsx
+++ b/packages/tui/src/index.tsx
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import React from 'react';
+import { render } from 'ink';
+import { App } from './app.js';
+import { renderDashboardPreview } from './dashboard-preview.js';
+
+if (!process.stdout.isTTY) {
+  const { loadWardensConfig } = await import('./wardens-config.js');
+  const { getServiceStatuses } = await import('./service-status.js');
+  const { getChannelStatuses } = await import('./channel-status.js');
+  const { loadDeusConfig } = await import('./deus-config.js');
+  const preview = renderDashboardPreview(
+    {
+      wardens: loadWardensConfig(),
+      services: getServiceStatuses(),
+      channels: getChannelStatuses(),
+      deusConfig: loadDeusConfig(),
+    },
+    80,
+  );
+
+  console.log(preview.join('\n'));
+  process.exit(0);
+}
+
+render(<App />);

--- a/packages/tui/src/panels/channels.tsx
+++ b/packages/tui/src/panels/channels.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { truncate } from '../formatting.js';
+import { StatusIndicator } from '../components/status-indicator.js';
+import { getChannelStatuses, type ChannelInfo } from '../channel-status.js';
+
+export function ChannelsPanel() {
+  const [channels, setChannels] = useState<ChannelInfo[]>([]);
+
+  useEffect(() => {
+    setChannels(getChannelStatuses());
+  }, []);
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>
+          CHANNELS
+        </Text>
+        <Text dimColor>
+          {' '}
+          {channels.filter((ch) => ch.configured).length}/{channels.length} configured
+        </Text>
+      </Box>
+
+      <Box flexDirection="column">
+        {channels.map((ch) => (
+          <Box key={ch.name}>
+            <StatusIndicator status={ch.configured ? 'on' : 'off'} label={truncate(ch.name, 18)} />
+            <Text dimColor>{ch.configured ? 'configured' : 'not configured'}</Text>
+          </Box>
+        ))}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>Use /add-whatsapp, /add-telegram, and friends to bring channels online.</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/tui/src/panels/config.tsx
+++ b/packages/tui/src/panels/config.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { truncate } from '../formatting.js';
+import { loadDeusConfig, type DeusConfig } from '../deus-config.js';
+
+export function ConfigPanel() {
+  const [config, setConfig] = useState<DeusConfig>({});
+
+  useEffect(() => {
+    setConfig(loadDeusConfig());
+  }, []);
+
+  const entries = Object.entries(config).filter(([, v]) => v !== undefined && v !== null);
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>
+          CONFIG
+        </Text>
+        <Text dimColor>
+          {' '}
+          {entries.length} resolved values
+        </Text>
+      </Box>
+
+      <Box flexDirection="column">
+        {entries.map(([key, value]) => (
+          <Box key={key}>
+            <Text color="cyan" bold>
+              {truncate(key, 24)}
+            </Text>
+            <Text>  {truncate(String(value), 42)}</Text>
+          </Box>
+        ))}
+        {entries.length === 0 && <Text dimColor>No config found at ~/.config/deus/config.json</Text>}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>Use /preferences or deus backend set to change settings.</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/tui/src/panels/services.tsx
+++ b/packages/tui/src/panels/services.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { truncate } from '../formatting.js';
+import { StatusIndicator } from '../components/status-indicator.js';
+import { getServiceStatuses, type ServiceStatus } from '../service-status.js';
+
+function statusBadge(status: ServiceStatus['status']): 'on' | 'off' | 'stale' | 'unknown' | 'unsupported' {
+  if (status === 'running') return 'on';
+  if (status === 'stale') return 'stale';
+  if (status === 'unsupported') return 'unsupported';
+  if (status === 'unknown') return 'unknown';
+  return 'off';
+}
+
+export function ServicesPanel() {
+  const [services, setServices] = useState<ServiceStatus[]>([]);
+
+  useEffect(() => {
+    setServices(getServiceStatuses());
+  }, []);
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>
+          SERVICES
+        </Text>
+        <Text dimColor>
+          {' '}
+          {services.filter((svc) => svc.status === 'running').length}/{services.length} running
+        </Text>
+      </Box>
+
+      <Box flexDirection="column">
+        {services.map((svc) => (
+          <Box key={svc.label}>
+            <StatusIndicator status={statusBadge(svc.status)} label={truncate(svc.description, 30)} />
+            <Text dimColor>{truncate(svc.detail ?? svc.status, 28)}</Text>
+          </Box>
+        ))}
+        {services.length === 0 && <Text dimColor>No services configured</Text>}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>Heartbeat jobs stay visible even when the platform cannot inspect launchctl.</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/tui/src/panels/tasks.tsx
+++ b/packages/tui/src/panels/tasks.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { truncate } from '../formatting.js';
+import { StatusIndicator } from '../components/status-indicator.js';
+import { loadTasks, type TaskEntry } from '../task-data.js';
+
+const STATUS_MAP: Record<TaskEntry['status'], 'on' | 'stale' | 'completed'> = {
+  active: 'on',
+  paused: 'stale',
+  completed: 'completed',
+};
+
+const PROMPT_TRUNCATE_WIDTH = 52;
+const SCHEDULE_TRUNCATE_WIDTH = 52;
+const DETAIL_TRUNCATE_WIDTH = 56;
+const ID_TRUNCATE_WIDTH = 24;
+
+function scheduleLabel(task: TaskEntry): string {
+  if (task.scheduleType === 'cron') return `cron: ${task.scheduleValue}`;
+  if (task.scheduleType === 'interval') return `every ${task.scheduleValue}`;
+  return `once: ${task.scheduleValue}`;
+}
+
+export function TasksPanel() {
+  const [tasks] = useState<TaskEntry[]>(loadTasks);
+  const [cursor, setCursor] = useState(0);
+
+  const activeCount = tasks.filter((t) => t.status === 'active').length;
+  const pausedCount = tasks.filter((t) => t.status === 'paused').length;
+
+  useInput((_input, key) => {
+    if (key.upArrow && cursor > 0) setCursor(cursor - 1);
+    if (key.downArrow && cursor < tasks.length - 1) setCursor(cursor + 1);
+  });
+
+  if (tasks.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text color="cyan" bold>TASKS</Text>
+          <Text dimColor> No scheduled tasks</Text>
+        </Box>
+        <Text dimColor>Schedule tasks via chat to see them here.</Text>
+      </Box>
+    );
+  }
+
+  const selected = tasks[cursor];
+  const statusSummary = [
+    `${activeCount}/${tasks.length} active`,
+    pausedCount > 0 ? `${pausedCount} paused` : '',
+  ].filter(Boolean).join(' · ');
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>TASKS</Text>
+        <Text dimColor> {statusSummary}</Text>
+      </Box>
+
+      <Box flexDirection="column">
+        {tasks.map((task, i) => {
+          const isSelected = i === cursor;
+          return (
+            <Box key={task.id}>
+              <StatusIndicator status={STATUS_MAP[task.status]} label={truncate(task.prompt, PROMPT_TRUNCATE_WIDTH)} />
+              <Text color={isSelected ? 'cyan' : undefined} bold={isSelected} dimColor={!isSelected}>
+                {isSelected ? '▸ ' : '  '}
+                {truncate(scheduleLabel(task), SCHEDULE_TRUNCATE_WIDTH)}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {selected && (
+        <Box marginTop={1} borderStyle="round" borderColor="gray" paddingX={1} paddingY={0}>
+          <Box flexDirection="column">
+            <Box>
+              <Text color="cyan" bold>{truncate(selected.id, ID_TRUNCATE_WIDTH)}</Text>
+              <Text dimColor> {selected.groupFolder}</Text>
+            </Box>
+            <Text>
+              <Text dimColor>Schedule: </Text>
+              <Text>{truncate(scheduleLabel(selected), DETAIL_TRUNCATE_WIDTH)}</Text>
+            </Text>
+            <Text>
+              <Text dimColor>Prompt: </Text>
+              <Text>{truncate(selected.prompt, DETAIL_TRUNCATE_WIDTH)}</Text>
+            </Text>
+            {selected.nextRun && (
+              <Text>
+                <Text dimColor>Next run: </Text>
+                <Text>{selected.nextRun}</Text>
+              </Text>
+            )}
+            {selected.lastRun && (
+              <Text>
+                <Text dimColor>Last run: </Text>
+                <Text>{selected.lastRun}</Text>
+              </Text>
+            )}
+            {selected.lastResult && (
+              <Text>
+                <Text dimColor>Result: </Text>
+                <Text>{truncate(selected.lastResult, DETAIL_TRUNCATE_WIDTH)}</Text>
+              </Text>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/tui/src/panels/wardens.tsx
+++ b/packages/tui/src/panels/wardens.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { truncate } from '../formatting.js';
+import { StatusIndicator } from '../components/status-indicator.js';
+import {
+  loadWardensConfig,
+  saveWardensConfig,
+  WARDEN_DESCRIPTIONS,
+  WARDEN_TYPES,
+  BLOCKING_WARDENS,
+  triggersLabel,
+  type WardensConfig,
+} from '../wardens-config.js';
+
+export function WardensPanel() {
+  const [config, setConfig] = useState<WardensConfig>(loadWardensConfig);
+  const [cursor, setCursor] = useState(0);
+  const [warning, setWarning] = useState('');
+
+  const names = Object.keys(config);
+  const enabledCount = names.filter((name) => config[name]?.enabled).length;
+  const blockingActive = names.filter((name) => config[name]?.enabled && BLOCKING_WARDENS.has(name)).length;
+
+  useInput((input, key) => {
+    if (key.upArrow && cursor > 0) setCursor(cursor - 1);
+    if (key.downArrow && cursor < names.length - 1) setCursor(cursor + 1);
+    if (input === ' ' || key.return) {
+      const name = names[cursor]!;
+      const warden = config[name]!;
+      const newEnabled = !warden.enabled;
+
+      if (!newEnabled && BLOCKING_WARDENS.has(name)) {
+        setWarning(`⚠ Disabling ${name} removes a safety gate`);
+        setTimeout(() => setWarning(''), 3000);
+      }
+
+      const updated = { ...config, [name]: { ...warden, enabled: newEnabled } };
+      saveWardensConfig(updated);
+      setConfig(updated);
+    }
+  });
+
+  const selectedName = names[cursor] ?? '';
+  const selected = config[selectedName];
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>
+          WARDENS
+        </Text>
+        <Text dimColor>
+          {' '}
+          {enabledCount}/{names.length} enabled · {blockingActive} blocking active
+        </Text>
+      </Box>
+
+      <Box flexDirection="column">
+        {names.map((name, i) => {
+          const warden = config[name]!;
+          const isSelected = i === cursor;
+          const description = WARDEN_DESCRIPTIONS[name] ?? 'No description available';
+          return (
+            <Box key={name}>
+              <StatusIndicator status={warden.enabled ? 'on' : 'off'} label={truncate(name, 24)} />
+              <Text color={isSelected ? 'cyan' : undefined} bold={isSelected} dimColor={!isSelected}>
+                {isSelected ? '▸ ' : '  '}
+                {truncate(description, 42)}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {warning && (
+        <Box marginTop={1} borderStyle="round" borderColor="yellow" paddingX={1}>
+          <Text color="yellow">{warning}</Text>
+        </Box>
+      )}
+
+      {selected && (
+        <Box marginTop={1} borderStyle="round" borderColor="gray" paddingX={1} paddingY={0}>
+          <Box flexDirection="column">
+            <Box>
+              <Text color="cyan" bold>
+                {truncate(selectedName, 24)}
+              </Text>
+              <Text dimColor>
+                {' '}
+                {truncate(WARDEN_TYPES[selectedName] ?? 'Unknown', 28)}
+              </Text>
+            </Box>
+            <Text>
+              <Text dimColor>Triggers: </Text>
+              <Text>{truncate(triggersLabel(selected, selectedName), 56)}</Text>
+            </Text>
+            {selected.custom_instructions && (
+              <Text>
+                <Text dimColor>Instructions: </Text>
+                <Text>
+                  {truncate(selected.custom_instructions, 56)}
+                </Text>
+              </Text>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/tui/src/service-status.ts
+++ b/packages/tui/src/service-status.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from 'child_process';
+import { existsSync, statSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// TODO: migrate to platform.ts Service API when project_windows_sot_plan Phase 2 lands
+const IS_MACOS = process.platform === 'darwin';
+
+export interface ServiceStatus {
+  label: string;
+  description: string;
+  status: 'running' | 'stopped' | 'stale' | 'unsupported' | 'unknown';
+  detail?: string;
+}
+
+interface HealthcheckJob {
+  label: string;
+  description: string;
+  check: string;
+  heartbeat_path?: string;
+  max_staleness_sec?: number;
+}
+
+function checkLaunchctl(label: string): 'running' | 'stopped' | 'unknown' {
+  if (!IS_MACOS) return 'unsupported' as 'unknown';
+  try {
+    const uid = process.getuid?.() ?? 501;
+    const output = execFileSync('launchctl', ['print', `gui/${uid}/${label}`], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (output.includes('state = running')) return 'running';
+    return 'stopped';
+  } catch {
+    return 'stopped';
+  }
+}
+
+function checkHeartbeat(
+  path: string,
+  maxStaleness: number,
+): 'running' | 'stale' | 'stopped' {
+  if (!existsSync(path)) return 'stopped';
+  const mtime = statSync(path).mtimeMs;
+  const age = (Date.now() - mtime) / 1000;
+  return age <= maxStaleness ? 'running' : 'stale';
+}
+
+export function getServiceStatuses(): ServiceStatus[] {
+  if (!IS_MACOS) {
+    return [
+      {
+        label: 'platform',
+        description: 'Service status',
+        status: 'unsupported',
+        detail: 'Not supported on this platform',
+      },
+    ];
+  }
+
+  const configPath = join(homedir(), '.config', 'deus', 'healthcheck.json');
+  if (!existsSync(configPath)) {
+    return [
+      {
+        label: 'deus',
+        description: 'Main service',
+        status: 'unknown',
+        detail: 'healthcheck.json not found',
+      },
+    ];
+  }
+
+  try {
+    const jobs: HealthcheckJob[] =
+      JSON.parse(readFileSync(configPath, 'utf-8')).jobs ?? [];
+    return jobs.map((job) => {
+      let status: ServiceStatus['status'];
+      let detail: string | undefined;
+
+      if (job.check === 'loaded_and_running') {
+        status = checkLaunchctl(job.label);
+      } else if (job.check === 'heartbeat' && job.heartbeat_path) {
+        const resolved = job.heartbeat_path.replace(/^~/, homedir());
+        status = checkHeartbeat(resolved, job.max_staleness_sec ?? 300);
+        if (status === 'stale') {
+          const age = Math.round(
+            (Date.now() - statSync(resolved).mtimeMs) / 60000,
+          );
+          detail = `heartbeat ${age}m ago`;
+        }
+      } else {
+        status = 'unknown';
+      }
+
+      return { label: job.label, description: job.description, status, detail };
+    });
+  } catch {
+    return [
+      {
+        label: 'deus',
+        description: 'Main service',
+        status: 'unknown',
+        detail: 'Failed to read healthcheck.json',
+      },
+    ];
+  }
+}

--- a/packages/tui/src/task-data.ts
+++ b/packages/tui/src/task-data.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// TODO(liam, 2026-05): cross-package import blocked by tsconfig rootDir — migrate when Phase 2 adds references/composite
+const IS_WINDOWS = process.platform === 'win32';
+
+const DEPTH_TO_REPO_ROOT = 3;
+const DB_RELATIVE_PATH = 'store/messages.db';
+const TASK_QUERY = `SELECT id, prompt, status, schedule_type, schedule_value, group_folder, next_run, last_run, last_result FROM scheduled_tasks ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'paused' THEN 1 ELSE 2 END, next_run ASC`;
+
+const VALID_STATUSES = new Set<TaskEntry['status']>([
+  'active',
+  'paused',
+  'completed',
+]);
+const VALID_SCHEDULE_TYPES = new Set<TaskEntry['scheduleType']>([
+  'cron',
+  'interval',
+  'once',
+]);
+const DEFAULT_STATUS: TaskEntry['status'] = 'completed';
+const DEFAULT_SCHEDULE_TYPE: TaskEntry['scheduleType'] = 'once';
+
+export interface TaskEntry {
+  id: string;
+  prompt: string;
+  status: 'active' | 'paused' | 'completed';
+  scheduleType: 'cron' | 'interval' | 'once';
+  scheduleValue: string;
+  groupFolder: string;
+  nextRun: string | null;
+  lastRun: string | null;
+  lastResult: string | null;
+}
+
+interface RawTaskRow {
+  id: string;
+  prompt: string;
+  status: string;
+  schedule_type: string;
+  schedule_value: string;
+  group_folder: string;
+  next_run: string | null;
+  last_run: string | null;
+  last_result: string | null;
+}
+
+function resolveDbPath(): string {
+  const segments = [
+    __dirname,
+    ...Array(DEPTH_TO_REPO_ROOT).fill('..'),
+    DB_RELATIVE_PATH,
+  ];
+  return resolve(...segments);
+}
+
+export function mapRow(row: RawTaskRow): TaskEntry {
+  return {
+    id: row.id,
+    prompt: row.prompt,
+    status: VALID_STATUSES.has(row.status as TaskEntry['status'])
+      ? (row.status as TaskEntry['status'])
+      : DEFAULT_STATUS,
+    scheduleType: VALID_SCHEDULE_TYPES.has(
+      row.schedule_type as TaskEntry['scheduleType'],
+    )
+      ? (row.schedule_type as TaskEntry['scheduleType'])
+      : DEFAULT_SCHEDULE_TYPE,
+    scheduleValue: row.schedule_value,
+    groupFolder: row.group_folder,
+    nextRun: row.next_run ?? null,
+    lastRun: row.last_run ?? null,
+    lastResult: row.last_result ?? null,
+  };
+}
+
+export function loadTasks(dbPathOverride?: string): TaskEntry[] {
+  if (IS_WINDOWS) return [];
+
+  const dbPath = dbPathOverride ?? resolveDbPath();
+  if (!existsSync(dbPath)) return [];
+
+  try {
+    const output = execFileSync('sqlite3', [dbPath, '-json', TASK_QUERY], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const rows: RawTaskRow[] = JSON.parse(output);
+    return rows.map(mapRow);
+  } catch (e) {
+    process.stderr.write(
+      `[deus-tui] task-data: ${e instanceof Error ? e.message : e}\n`,
+    );
+    return [];
+  }
+}

--- a/packages/tui/src/wardens-config.ts
+++ b/packages/tui/src/wardens-config.ts
@@ -1,0 +1,93 @@
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  mkdirSync,
+} from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const CONFIG_PATH = join(REPO_ROOT, '.claude', 'wardens', 'config.json');
+const EXAMPLE_PATH = join(
+  REPO_ROOT,
+  '.claude',
+  'wardens',
+  'config.json.example',
+);
+
+export interface WardenEntry {
+  enabled: boolean;
+  tools?: string[];
+  auto_threshold?: number;
+  custom_instructions?: string | null;
+  [key: string]: unknown;
+}
+
+export type WardensConfig = Record<string, WardenEntry>;
+
+export const WARDEN_DESCRIPTIONS: Record<string, string> = {
+  'plan-reviewer':
+    'Reviews plans against Deus-specific rules before source edits',
+  'code-reviewer':
+    'Reviews code changes for quality and security before commits',
+  'threat-modeler':
+    'STRIDE/OWASP threat review for auth, data, and trust boundaries',
+  'architecture-snapshot':
+    'Generates architecture overview with Mermaid diagrams',
+  'session-retrospective':
+    'Cross-session pattern analysis and retrospective reports',
+  'data-quality': 'Reviews auto-memory files for retrieval quality',
+};
+
+export const WARDEN_TYPES: Record<string, string> = {
+  'plan-reviewer': 'Validator (blocking)',
+  'code-reviewer': 'Validator (blocking)',
+  'threat-modeler': 'Validator (warning)',
+  'architecture-snapshot': 'Generator',
+  'session-retrospective': 'Generator',
+  'data-quality': 'Validator (manual)',
+};
+
+export const BLOCKING_WARDENS = new Set(['plan-reviewer', 'code-reviewer']);
+
+export function loadWardensConfig(): WardensConfig {
+  if (!existsSync(CONFIG_PATH)) {
+    if (existsSync(EXAMPLE_PATH)) {
+      const dir = join(REPO_ROOT, '.claude', 'wardens');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(CONFIG_PATH, readFileSync(EXAMPLE_PATH, 'utf-8'));
+    } else {
+      return {};
+    }
+  }
+  try {
+    const data = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'));
+    return typeof data === 'object' && data !== null ? data : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveWardensConfig(config: WardensConfig): void {
+  const content = JSON.stringify(config, null, 2) + '\n';
+  const tmpFile = join(
+    tmpdir(),
+    `wardens-config-${process.pid}-${Date.now()}.tmp`,
+  );
+  writeFileSync(tmpFile, content, 'utf-8');
+  renameSync(tmpFile, CONFIG_PATH);
+}
+
+export function triggersLabel(warden: WardenEntry, name: string): string {
+  if (name === 'session-retrospective') {
+    const threshold = warden.auto_threshold ?? 20;
+    return `auto (threshold: ${threshold} sessions), manual`;
+  }
+  const tools = warden.tools;
+  if (!tools || tools.length === 0) return 'manual';
+  return tools.join(', ');
+}

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-03T10:00" # auto-bump
+last_verified: "2026-05-05" # auto-bump
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-03T10:00" # auto-bump
+last_verified: "2026-05-05" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-03" # auto-bump
+last_verified: "2026-05-05" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-03T10:00" # auto-bump
+last_verified: "2026-05-05" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-02" # backend-strategy-trait
+last_verified: "2026-05-05" # auto-bump
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Adds a 5th "Tasks" tab to the TUI dashboard showing scheduled tasks from the SQLite DB
- Loads tasks via `sqlite3` CLI (`execFileSync`), matching the existing `service-status.ts` pattern
- Runtime validation of DB enum fields (`status`, `schedule_type`) with safe defaults
- Cursor navigation and detail view following the Wardens panel UX pattern
- `completed` status variant added to `StatusIndicator` component (✓ gray)
- Also commits the previously-untracked TUI package source (panels, components, config)

## Files
| File | Change |
|------|--------|
| `packages/tui/src/task-data.ts` | NEW — `loadTasks()` + `mapRow()` with sqlite3 CLI |
| `packages/tui/src/panels/tasks.tsx` | NEW — TasksPanel component |
| `packages/tui/src/__tests__/task-data.test.ts` | NEW — 7 vitest tests with fixture DBs |
| `packages/tui/src/app.tsx` | ADD — Tab 5, key binding, render |
| `packages/tui/src/components/status-indicator.tsx` | ADD — `completed` variant |
| `packages/tui/package.json` | ADD — vitest dev dep + test script |

## Test plan
- [x] `npm test` — 7 tests pass (fixture DB creation, field mapping, ordering, validation defaults)
- [x] `npx tsc --noEmit` — clean type check
- [ ] Manual: `npx tsx src/index.tsx`, press `5`, verify task list renders
- [ ] Edge: no tasks → "No scheduled tasks" message
- [ ] Edge: no `sqlite3` binary → graceful empty list with stderr warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)