### PR TITLE
feat(solutions): add structured lesson capture with bug-track and knowledge-track schemas

### DIFF
--- a/container/agent-runner/src/context-registry.test.ts
+++ b/container/agent-runner/src/context-registry.test.ts
@@ -153,6 +153,46 @@ describe('context registry', () => {
     expect(claudeAppendContext).toEqual(allContext);
   });
 
+  it('includes solution atoms in full-context mode', () => {
+    writeContextFile(
+      'vault/solutions/fix-timeout-abc12345.md',
+      '---\nid: abc12345\ntype: solution\ntitle: "Fix timeout"\ntags: [docker]\nproblem_type: bug\nseverity: high\nupdated: 2026-05-01\n---\n\n## Symptoms\nTimeout after 30s\n\n## Solution\nIncrease IPC poll',
+    );
+
+    const all = loadRegisteredContextFiles({
+      isControlGroup: false,
+      hasProject: false,
+      workspaceRoot,
+    });
+    expect(
+      all.some((b) => b.includes('SOLUTION:') && b.includes('Fix timeout')),
+    ).toBe(true);
+  });
+
+  it('excludes solution atoms in claude-system-append mode', () => {
+    writeContextFile(
+      'vault/solutions/fix-timeout-abc12345.md',
+      '---\nid: abc12345\ntype: solution\ntitle: "Fix timeout"\n---\n\n## Symptoms\nTimeout',
+    );
+
+    const appendOnly = loadRegisteredContextFiles({
+      isControlGroup: false,
+      hasProject: false,
+      mode: 'claude-system-append',
+      workspaceRoot,
+    });
+    expect(appendOnly.some((b) => b.includes('SOLUTION:'))).toBe(false);
+  });
+
+  it('returns no solutions when vault/solutions/ is missing', () => {
+    const all = loadRegisteredContextFiles({
+      isControlGroup: false,
+      hasProject: false,
+      workspaceRoot,
+    });
+    expect(all.some((b) => b.includes('SOLUTION:'))).toBe(false);
+  });
+
   it('honors DEUS_CONTEXT_FILE_MAX_CHARS for registered context surfaces', () => {
     process.env.DEUS_CONTEXT_FILE_MAX_CHARS = '8';
     writeContextFile('group/CLAUDE.md', '1234567890');

--- a/container/agent-runner/src/context-registry.ts
+++ b/container/agent-runner/src/context-registry.ts
@@ -146,6 +146,38 @@ function formatContextFile(label: string, filePath: string): string {
   return content ? `=== ${label} ===\n${content}` : '';
 }
 
+/**
+ * Load the N most recently modified solution atoms from the vault's
+ * solutions/ directory. Returns formatted context blocks suitable for
+ * inclusion in the agent's context window. Silently returns [] if the
+ * directory is missing or empty.
+ */
+function loadSolutionBlocks(root: string, limit = 3): string[] {
+  const solDir = workspacePath(root, 'vault', 'solutions');
+  if (!fs.existsSync(solDir)) return [];
+
+  let files: { name: string; mtime: number }[];
+  try {
+    files = fs
+      .readdirSync(solDir)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => {
+        const stat = fs.statSync(path.join(solDir, f));
+        return { name: f, mtime: stat.mtimeMs };
+      })
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, limit);
+  } catch {
+    return [];
+  }
+
+  return files.flatMap(({ name }) => {
+    const content = readOptionalFile(path.join(solDir, name));
+    if (!content) return [];
+    return [`=== SOLUTION: ${name} ===\n${content}`];
+  });
+}
+
 export function loadRegisteredContextFiles(options: {
   isControlGroup: boolean;
   hasProject: boolean;
@@ -154,7 +186,7 @@ export function loadRegisteredContextFiles(options: {
 }): string[] {
   const root = options.workspaceRoot || WORKSPACE_ROOT;
   const entries = [...baseContextEntries(root), ...extraContextEntries(root)];
-  return entries.flatMap((entry) => {
+  const blocks = entries.flatMap((entry) => {
     if (options.mode === 'claude-system-append' && !entry.claudeSystemAppend)
       return [];
     if (entry.skipForControlGroup && options.isControlGroup) return [];
@@ -162,4 +194,12 @@ export function loadRegisteredContextFiles(options: {
     const block = formatContextFile(entry.label, entry.path);
     return block ? [block] : [];
   });
+
+  // Append solution context in full-context mode only (not claude-system-append).
+  // Solutions are advisory — they inform but don't instruct like rules files.
+  if (options.mode !== 'claude-system-append') {
+    blocks.push(...loadSolutionBlocks(root));
+  }
+
+  return blocks;
 }

--- a/container/agent-runner/src/context-registry.ts
+++ b/container/agent-runner/src/context-registry.ts
@@ -151,6 +151,10 @@ function formatContextFile(label: string, filePath: string): string {
  * solutions/ directory. Returns formatted context blocks suitable for
  * inclusion in the agent's context window. Silently returns [] if the
  * directory is missing or empty.
+ *
+ * Container agent-runner builds separately from src/ — cannot import
+ * host-side modules. Reads solution markdown files directly from the
+ * vault mount rather than using src/solutions/store.ts.
  */
 function loadSolutionBlocks(root: string, limit = 3): string[] {
   const solDir = workspacePath(root, 'vault', 'solutions');

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1447,6 +1447,11 @@ $STARTUP_INSTRUCTION"
         ;;
     esac
     ;;
+  solution)
+    # Solution atom management — structured lesson capture.
+    shift
+    exec node "$SCRIPT_DIR/dist/solutions/cli.js" "$@"
+    ;;
   tui)
     shift
     local tui_bin="$SCRIPT_DIR/tui/target/release/deus-tui"
@@ -1457,7 +1462,7 @@ $STARTUP_INSTRUCTION"
     exec "$tui_bin" "$@"
     ;;
   *)
-    echo "Usage: deus [claude|codex] [home|auth|web|backend|gcal|listen|logs|tui]"
+    echo "Usage: deus [claude|codex] [home|auth|web|backend|gcal|listen|logs|solution|tui]"
     echo ""
     echo "  deus            Launch in current directory (external project mode if not ~/deus)"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
@@ -1469,6 +1474,7 @@ $STARTUP_INSTRUCTION"
     echo "  deus gcal       Google Calendar token management (status|auth|ping)"
     echo "  deus listen     Record from mic, transcribe, and copy to clipboard"
     echo "  deus logs       Review system health logs (rotate|review|summary|pinned)"
+    echo "  deus solution   Manage solution atoms (list|search|add)"
     echo "  deus tui        Interactive terminal UI (set tui_default=true in config to use by default)"
     ;;
 esac

--- a/docs/solution-atom-schema.md
+++ b/docs/solution-atom-schema.md
@@ -1,0 +1,120 @@
+# Solution Atom Schema
+
+Solution atoms capture operational learnings — bug fixes, dead ends, discovered
+patterns — so future agent runs benefit from past experience. They follow the
+existing memory atom format (YAML frontmatter + markdown body) and live in the
+vault's `solutions/` directory.
+
+## Frontmatter
+
+```yaml
+---
+id: <UUID>
+type: solution                    # atom type identifier
+title: "<short description>"
+tags: [module, category, ...]
+problem_type: bug | knowledge | pattern
+module: <affected module path>    # optional
+severity: low | medium | high
+updated: <YYYY-MM-DD>
+---
+```
+
+## Body — Bug / Pattern type
+
+```markdown
+## Symptoms
+What the user/agent observed.
+
+## What Didn't Work
+Dead ends — often the most valuable section. What was tried
+that turned out to be wrong and why.
+
+## Solution
+What actually fixed the problem.
+
+## Prevention
+How to avoid hitting this in the future.
+```
+
+## Body — Knowledge type
+
+For learnings that are not bug fixes but operational knowledge:
+
+```markdown
+## Context
+When this knowledge applies.
+
+## Guidance
+What to do — the actionable instruction.
+
+## When to Apply
+Triggers or conditions that should prompt recall of this knowledge.
+```
+
+## Storage
+
+- **Location**: `<vault>/solutions/` directory
+- **Filename**: `<slugified-title>-<id-prefix>.md`
+- **Append-only**: once written, never deleted or overwritten
+- **Encoding**: UTF-8 markdown with YAML frontmatter
+
+## Discovery
+
+Solutions are discoverable through:
+
+1. **Text/tag search**: `searchSolutions(query, tags?)` — substring matching
+2. **Context injection**: The container context registry loads the 3 most
+   recent solutions and injects them into agent context
+3. **CLI**: `deus solution list|search|add` subcommands
+
+### Memory Indexer Compatibility
+
+Solution files use the same markdown-with-frontmatter format as session logs
+and atoms. However, the memory indexer's `--add-dir` walks `.md` files
+under the given directory, so solutions can be indexed via:
+
+```bash
+python3 scripts/memory_indexer.py --add <vault>/solutions/my-fix.md
+```
+
+**Note**: The indexer's `--rebuild` command does not automatically walk the
+`solutions/` directory (it walks `Session-Logs/` and `Atoms/`). A future PR
+should add `solutions/` to the rebuild walk list so solutions are included in
+full re-indexes. The memory tree will surface solutions once they are indexed.
+
+## Example
+
+```yaml
+---
+id: 3f8a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+type: solution
+title: "OAuth token frozen in .env causes login loop"
+tags: [auth, oauth, credentials]
+problem_type: bug
+module: src/credential-proxy.ts
+severity: high
+updated: 2026-05-05
+---
+
+## Symptoms
+Container agent enters a login loop after ~1 hour. The OAuth access token
+in the environment is stale but the CLI keeps using it instead of refreshing
+from credentials.json.
+
+## What Didn't Work
+- Increasing IDLE_TIMEOUT — unrelated to the token lifecycle
+- Clearing .env and restarting — worked temporarily but recurred
+- Setting DEUS_PROXY_AUTH=0 — masked the symptom, broke auth entirely
+
+## Solution
+The `deus auth` command was writing the access token to `.env`, freezing it.
+The credential proxy's `getDynamicOAuthToken()` reads credentials.json with a
+5-minute cache and auto-refreshes. Removed the `.env` write from the auth
+command so the proxy always reads the live token.
+
+## Prevention
+Never write OAuth tokens to .env or export them as env vars. The credential
+proxy reads credentials.json directly — env vars freeze the token and bypass
+the refresh mechanism.
+```

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-06" # auto-bump (codeql-fix)
+last_verified: "2026-05-06" # auto-bump (fmt-fix)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-06" # auto-bump (injection-scanner)
+last_verified: "2026-05-06" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-06" # auto-bump
+last_verified: "2026-05-06" # auto-bump (codeql-fix)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-06" # auto-bump (setup fix)
+last_verified: "2026-05-06" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-06" # auto-bump
+last_verified: "2026-05-06" # auto-bump (codeql-fix)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-06" # auto-bump (injection-scanner)
+last_verified: "2026-05-06" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-06" # auto-bump (codeql-fix)
+last_verified: "2026-05-06" # auto-bump (fmt-fix)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/solutions/cli.ts
+++ b/src/solutions/cli.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * CLI for solution atom management.
+ *
+ * Usage:
+ *   deus solution list                    List recent solutions
+ *   deus solution search <query>          Search by text/tags
+ *   deus solution search --tag <tag> <q>  Search with tag filter
+ *   deus solution add                     Add from JSON on stdin
+ *   deus solution get <id>                Get a single solution by ID
+ */
+
+import {
+  getSolution,
+  listSolutions,
+  searchSolutions,
+  writeSolution,
+} from './store.js';
+
+import type { ProblemType, Severity, Solution } from './store.js';
+
+function printSolution(sol: Solution): void {
+  const tags = sol.tags.length > 0 ? ` [${sol.tags.join(', ')}]` : '';
+  console.log(`${sol.id}  ${sol.title}${tags}`);
+  console.log(`  type: ${sol.problemType}  severity: ${sol.severity}`);
+  if (sol.module) console.log(`  module: ${sol.module}`);
+}
+
+function printSolutionFull(sol: Solution): void {
+  printSolution(sol);
+  console.log('');
+  if (sol.problemType === 'knowledge') {
+    console.log(`  Context: ${sol.symptoms}`);
+    console.log(`  Guidance: ${sol.solution}`);
+    console.log(`  When to Apply: ${sol.prevention}`);
+  } else {
+    console.log(`  Symptoms: ${sol.symptoms}`);
+    if (sol.deadEnds) console.log(`  Dead Ends: ${sol.deadEnds}`);
+    console.log(`  Solution: ${sol.solution}`);
+    console.log(`  Prevention: ${sol.prevention}`);
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+    // If stdin is a TTY (no piped input), prompt the user
+    if (process.stdin.isTTY) {
+      console.error(
+        'Paste JSON on stdin and press Ctrl+D, or pipe from a file:\n' +
+          '  echo \'{"title":"...","tags":[...],...}\' | deus solution add',
+      );
+    }
+  });
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args[0] || 'list';
+
+  switch (command) {
+    case 'list': {
+      const limit = parseInt(args[1] || '20', 10);
+      const solutions = listSolutions(limit);
+      if (solutions.length === 0) {
+        console.log('No solutions found.');
+        return;
+      }
+      for (const sol of solutions) {
+        printSolution(sol);
+        console.log('');
+      }
+      break;
+    }
+
+    case 'search': {
+      const tagIdx = args.indexOf('--tag');
+      let tags: string[] | undefined;
+      let query: string;
+      if (tagIdx > 0 && args[tagIdx + 1]) {
+        tags = [args[tagIdx + 1]];
+        // Query is everything except --tag and its value
+        const remaining = [...args.slice(1, tagIdx), ...args.slice(tagIdx + 2)];
+        query = remaining.join(' ');
+      } else {
+        query = args.slice(1).join(' ');
+      }
+      const results = searchSolutions(query, tags);
+      if (results.length === 0) {
+        console.log('No matching solutions.');
+        return;
+      }
+      for (const sol of results) {
+        printSolution(sol);
+        console.log('');
+      }
+      break;
+    }
+
+    case 'get': {
+      const id = args[1];
+      if (!id) {
+        console.error('Usage: deus solution get <id>');
+        process.exit(1);
+      }
+      const sol = getSolution(id);
+      if (!sol) {
+        console.error(`Solution not found: ${id}`);
+        process.exit(1);
+      }
+      printSolutionFull(sol);
+      break;
+    }
+
+    case 'add': {
+      try {
+        const raw = await readStdin();
+        const data = JSON.parse(raw) as {
+          title: string;
+          tags?: string[];
+          problemType?: ProblemType;
+          problem_type?: ProblemType;
+          module?: string;
+          severity?: Severity;
+          symptoms: string;
+          deadEnds?: string;
+          dead_ends?: string;
+          solution: string;
+          prevention: string;
+        };
+
+        if (!data.title || !data.symptoms || !data.solution) {
+          console.error(
+            'Required fields: title, symptoms, solution, prevention',
+          );
+          process.exit(1);
+        }
+
+        const id = writeSolution({
+          title: data.title,
+          tags: data.tags || [],
+          problemType: data.problemType || data.problem_type || 'bug',
+          module: data.module,
+          severity: data.severity || 'medium',
+          symptoms: data.symptoms,
+          deadEnds: data.deadEnds || data.dead_ends || '',
+          solution: data.solution,
+          prevention: data.prevention || '',
+        });
+
+        console.log(`Solution written: ${id}`);
+      } catch (err) {
+        console.error(
+          `Failed to add solution: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+      break;
+    }
+
+    default:
+      console.log('Usage: deus solution <list|search|add|get>');
+      console.log('');
+      console.log('  deus solution list [limit]       List recent solutions');
+      console.log(
+        '  deus solution search <query>     Search solutions by text',
+      );
+      console.log('  deus solution search --tag <t>   Search with tag filter');
+      console.log('  deus solution add                Add from JSON stdin');
+      console.log(
+        '  deus solution get <id>           Show full solution details',
+      );
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/solutions/index.ts
+++ b/src/solutions/index.ts
@@ -1,0 +1,11 @@
+export {
+  writeSolution,
+  searchSolutions,
+  getSolution,
+  listSolutions,
+  loadSolutionContext,
+  resolveVaultPath,
+  solutionsDir,
+} from './store.js';
+
+export type { Solution, ProblemType, Severity } from './store.js';

--- a/src/solutions/store.test.ts
+++ b/src/solutions/store.test.ts
@@ -1,0 +1,326 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getSolution,
+  listSolutions,
+  loadSolutionContext,
+  searchSolutions,
+  writeSolution,
+} from './store.js';
+
+let tmpDir: string;
+
+describe('solution store', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-solutions-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a bug solution and reads it back by ID', () => {
+    const id = writeSolution(
+      {
+        title: 'Fix container timeout',
+        tags: ['docker', 'timeout'],
+        problemType: 'bug',
+        module: 'src/container-runner.ts',
+        severity: 'high',
+        symptoms: 'Container hangs after 30s',
+        deadEnds: 'Tried increasing CONTAINER_TIMEOUT env — no effect',
+        solution: 'The timeout was in the IPC polling loop, not the container',
+        prevention: 'Check IPC_POLL_INTERVAL when debugging container timeouts',
+      },
+      tmpDir,
+    );
+
+    expect(id).toBeTruthy();
+
+    const sol = getSolution(id, tmpDir);
+    expect(sol).not.toBeNull();
+    expect(sol!.title).toBe('Fix container timeout');
+    expect(sol!.tags).toEqual(['docker', 'timeout']);
+    expect(sol!.problemType).toBe('bug');
+    expect(sol!.severity).toBe('high');
+    expect(sol!.symptoms).toBe('Container hangs after 30s');
+    expect(sol!.solution).toBe(
+      'The timeout was in the IPC polling loop, not the container',
+    );
+  });
+
+  it('writes a knowledge solution with correct sections', () => {
+    const id = writeSolution(
+      {
+        title: 'Memory indexer batch API limits',
+        tags: ['memory', 'api'],
+        problemType: 'knowledge',
+        severity: 'medium',
+        symptoms: 'Gemini embedding API has a 100-text batch limit',
+        deadEnds: '',
+        solution: 'Split into chunks of 100 before calling embed_batch',
+        prevention: 'When processing > 100 documents at once',
+      },
+      tmpDir,
+    );
+
+    const sol = getSolution(id, tmpDir);
+    expect(sol).not.toBeNull();
+    expect(sol!.problemType).toBe('knowledge');
+    // Knowledge type reads Context/Guidance/When to Apply sections
+    expect(sol!.symptoms).toBe(
+      'Gemini embedding API has a 100-text batch limit',
+    );
+    expect(sol!.solution).toBe(
+      'Split into chunks of 100 before calling embed_batch',
+    );
+    expect(sol!.prevention).toBe('When processing > 100 documents at once');
+  });
+
+  it('searches by text query', () => {
+    writeSolution(
+      {
+        title: 'OAuth token refresh loop',
+        tags: ['auth'],
+        problemType: 'bug',
+        severity: 'high',
+        symptoms: 'Login loop after token expiry',
+        deadEnds: 'Tried clearing .env',
+        solution: 'Read credentials.json directly',
+        prevention: 'Never freeze tokens in .env',
+      },
+      tmpDir,
+    );
+    writeSolution(
+      {
+        title: 'Container mount paths',
+        tags: ['docker'],
+        problemType: 'pattern',
+        severity: 'low',
+        symptoms: 'Mounts fail on relative paths',
+        deadEnds: 'None',
+        solution: 'Always use path.resolve',
+        prevention: 'Use absolute paths for mounts',
+      },
+      tmpDir,
+    );
+
+    const results = searchSolutions('token', undefined, tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('OAuth token refresh loop');
+  });
+
+  it('filters by tags', () => {
+    writeSolution(
+      {
+        title: 'Auth bug',
+        tags: ['auth', 'oauth'],
+        problemType: 'bug',
+        severity: 'medium',
+        symptoms: 'x',
+        deadEnds: 'y',
+        solution: 'z',
+        prevention: 'w',
+      },
+      tmpDir,
+    );
+    writeSolution(
+      {
+        title: 'Docker bug',
+        tags: ['docker'],
+        problemType: 'bug',
+        severity: 'medium',
+        symptoms: 'x',
+        deadEnds: 'y',
+        solution: 'z',
+        prevention: 'w',
+      },
+      tmpDir,
+    );
+
+    const authResults = searchSolutions('', ['auth'], tmpDir);
+    expect(authResults).toHaveLength(1);
+    expect(authResults[0].title).toBe('Auth bug');
+
+    const allResults = searchSolutions('', undefined, tmpDir);
+    expect(allResults).toHaveLength(2);
+  });
+
+  it('returns null for nonexistent ID', () => {
+    expect(getSolution('nonexistent-id', tmpDir)).toBeNull();
+  });
+
+  it('lists solutions sorted by mtime (newest first)', () => {
+    writeSolution(
+      {
+        title: 'First',
+        tags: [],
+        problemType: 'bug',
+        severity: 'low',
+        symptoms: 'a',
+        deadEnds: 'b',
+        solution: 'c',
+        prevention: 'd',
+      },
+      tmpDir,
+    );
+    // Slight delay to ensure different mtime
+    const files = fs.readdirSync(tmpDir);
+    const firstFile = path.join(tmpDir, files[0]);
+    // Backdate the first file
+    const past = new Date(Date.now() - 10_000);
+    fs.utimesSync(firstFile, past, past);
+
+    writeSolution(
+      {
+        title: 'Second',
+        tags: [],
+        problemType: 'bug',
+        severity: 'low',
+        symptoms: 'a',
+        deadEnds: 'b',
+        solution: 'c',
+        prevention: 'd',
+      },
+      tmpDir,
+    );
+
+    const list = listSolutions(10, tmpDir);
+    expect(list).toHaveLength(2);
+    expect(list[0].title).toBe('Second');
+    expect(list[1].title).toBe('First');
+  });
+
+  it('limits results in listSolutions', () => {
+    for (let i = 0; i < 5; i++) {
+      writeSolution(
+        {
+          title: `Solution ${i}`,
+          tags: [],
+          problemType: 'bug',
+          severity: 'low',
+          symptoms: 'a',
+          deadEnds: 'b',
+          solution: 'c',
+          prevention: 'd',
+        },
+        tmpDir,
+      );
+    }
+
+    expect(listSolutions(3, tmpDir)).toHaveLength(3);
+  });
+
+  it('loadSolutionContext returns formatted strings', () => {
+    writeSolution(
+      {
+        title: 'Test solution',
+        tags: ['test'],
+        problemType: 'bug',
+        severity: 'medium',
+        symptoms: 'Test fails intermittently',
+        deadEnds: 'Tried retries',
+        solution: 'Race condition in setup',
+        prevention: 'Use beforeEach isolation',
+      },
+      tmpDir,
+    );
+
+    const ctx = loadSolutionContext(3, tmpDir);
+    expect(ctx).toHaveLength(1);
+    expect(ctx[0]).toContain('Solution: Test solution [test]');
+    expect(ctx[0]).toContain('Symptoms: Test fails intermittently');
+    expect(ctx[0]).toContain('Fix: Race condition in setup');
+  });
+
+  it('loadSolutionContext formats knowledge type differently', () => {
+    writeSolution(
+      {
+        title: 'API rate limits',
+        tags: ['api'],
+        problemType: 'knowledge',
+        severity: 'low',
+        symptoms: 'Rate limit is 100/min',
+        deadEnds: '',
+        solution: 'Use exponential backoff',
+        prevention: 'When calling external APIs',
+      },
+      tmpDir,
+    );
+
+    const ctx = loadSolutionContext(3, tmpDir);
+    expect(ctx).toHaveLength(1);
+    expect(ctx[0]).toContain('Knowledge: API rate limits [api]');
+    expect(ctx[0]).toContain('Context: Rate limit is 100/min');
+    expect(ctx[0]).toContain('Guidance: Use exponential backoff');
+  });
+
+  it('returns empty results for empty directory', () => {
+    expect(searchSolutions('anything', undefined, tmpDir)).toEqual([]);
+    expect(listSolutions(10, tmpDir)).toEqual([]);
+    expect(getSolution('any-id', tmpDir)).toBeNull();
+  });
+
+  it('preserves solution files (append-only)', () => {
+    const id = writeSolution(
+      {
+        title: 'Append only test',
+        tags: [],
+        problemType: 'bug',
+        severity: 'low',
+        symptoms: 'a',
+        deadEnds: 'b',
+        solution: 'c',
+        prevention: 'd',
+      },
+      tmpDir,
+    );
+
+    // File should exist
+    const files = fs.readdirSync(tmpDir);
+    expect(files).toHaveLength(1);
+
+    // Writing another solution should create a new file, not overwrite
+    writeSolution(
+      {
+        title: 'Second solution',
+        tags: [],
+        problemType: 'bug',
+        severity: 'low',
+        symptoms: 'e',
+        deadEnds: 'f',
+        solution: 'g',
+        prevention: 'h',
+      },
+      tmpDir,
+    );
+
+    expect(fs.readdirSync(tmpDir)).toHaveLength(2);
+    // Original still intact
+    expect(getSolution(id, tmpDir)).not.toBeNull();
+  });
+
+  it('handles solutions with special characters in title', () => {
+    const id = writeSolution(
+      {
+        title: 'Fix "quoted" title & special <chars>',
+        tags: ['special'],
+        problemType: 'bug',
+        severity: 'low',
+        symptoms: 'a',
+        deadEnds: 'b',
+        solution: 'c',
+        prevention: 'd',
+      },
+      tmpDir,
+    );
+
+    const sol = getSolution(id, tmpDir);
+    expect(sol).not.toBeNull();
+    expect(sol!.title).toBe('Fix "quoted" title & special <chars>');
+  });
+});

--- a/src/solutions/store.ts
+++ b/src/solutions/store.ts
@@ -23,6 +23,25 @@ import { CONFIG_DIR, HOME_DIR } from '../config.js';
 export type ProblemType = 'bug' | 'knowledge' | 'pattern';
 export type Severity = 'low' | 'medium' | 'high';
 
+const VALID_PROBLEM_TYPES: ProblemType[] = ['bug', 'knowledge', 'pattern'];
+const VALID_SEVERITIES: Severity[] = ['low', 'medium', 'high'];
+
+function isValidProblemType(v: string | undefined): v is ProblemType {
+  return (
+    typeof v === 'string' && VALID_PROBLEM_TYPES.includes(v as ProblemType)
+  );
+}
+
+function isValidSeverity(v: string | undefined): v is Severity {
+  return typeof v === 'string' && VALID_SEVERITIES.includes(v as Severity);
+}
+
+/**
+ * A single solution atom. Field semantics depend on `problemType`:
+ * - bug: symptoms/deadEnds/solution/prevention map directly.
+ * - knowledge|pattern: `symptoms` holds context, `solution` holds guidance,
+ *   `prevention` holds when-to-apply. `deadEnds` is unused.
+ */
 export interface Solution {
   id: string;
   title: string;
@@ -120,13 +139,13 @@ function toBugBody(sol: Solution): string {
 function toKnowledgeBody(sol: Solution): string {
   return [
     '## Context',
-    sol.symptoms, // reuse symptoms field as context
+    sol.symptoms,
     '',
     '## Guidance',
-    sol.solution, // reuse solution field as guidance
+    sol.solution,
     '',
     '## When to Apply',
-    sol.prevention, // reuse prevention field as triggers
+    sol.prevention,
   ].join('\n');
 }
 
@@ -180,14 +199,17 @@ function parseSolution(content: string, filePath: string): Solution | null {
   const fm = parseFrontmatter(content);
   if (!fm || fm.type !== 'solution') return null;
 
-  const problemType = (fm.problem_type || 'bug') as ProblemType;
+  const problemType = isValidProblemType(fm.problem_type)
+    ? fm.problem_type
+    : 'bug';
+  const severity = isValidSeverity(fm.severity) ? fm.severity : 'medium';
   return {
     id: fm.id || path.basename(filePath, '.md'),
     title: (fm.title || '').replace(/^["']|["']$/g, '').replace(/\\"/g, '"'),
     tags: parseTags(fm.tags || '[]'),
     problemType,
     module: fm.module || undefined,
-    severity: (fm.severity || 'medium') as Severity,
+    severity,
     symptoms:
       problemType === 'knowledge'
         ? parseSection(content, 'Context')

--- a/src/solutions/store.ts
+++ b/src/solutions/store.ts
@@ -1,0 +1,339 @@
+/**
+ * Solution atom store — structured lesson capture.
+ *
+ * Stores operational learnings (bug fixes, dead ends, patterns) as markdown
+ * files with YAML frontmatter in the vault's solutions/ directory. These are
+ * append-only: once written, never deleted or overwritten. File-based storage
+ * ensures compatibility with the memory tree and indexer.
+ *
+ * Solutions are discoverable via:
+ *   1. Text/tag grep search (this module)
+ *   2. Memory indexer --add (indexes the markdown file for semantic search)
+ *   3. Context injection into container agents (context-registry.ts)
+ */
+
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { CONFIG_DIR, HOME_DIR } from '../config.js';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type ProblemType = 'bug' | 'knowledge' | 'pattern';
+export type Severity = 'low' | 'medium' | 'high';
+
+export interface Solution {
+  id: string;
+  title: string;
+  tags: string[];
+  problemType: ProblemType;
+  module?: string;
+  severity: Severity;
+  symptoms: string;
+  deadEnds: string;
+  solution: string;
+  prevention: string;
+}
+
+// ── Vault path resolution ──────────────────────────────────────────────────
+
+/**
+ * Resolve the vault path from DEUS_VAULT_PATH env or ~/.config/deus/config.json.
+ * Mirrors the logic in container-mounter.ts resolveVaultPath().
+ */
+export function resolveVaultPath(): string | null {
+  const envPath = process.env.DEUS_VAULT_PATH;
+  if (envPath) {
+    const resolved = envPath.startsWith('~')
+      ? path.join(HOME_DIR, envPath.slice(1))
+      : envPath;
+    return path.resolve(resolved);
+  }
+  const configPath = path.join(CONFIG_DIR, 'config.json');
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if (cfg.vault_path) {
+      const vp = cfg.vault_path as string;
+      const resolved = vp.startsWith('~')
+        ? path.join(HOME_DIR, vp.slice(1))
+        : vp;
+      return path.resolve(resolved);
+    }
+  } catch {
+    // No config file or parse error
+  }
+  return null;
+}
+
+/**
+ * Return the solutions directory path inside the vault.
+ * Creates it if it does not exist and the vault is configured.
+ */
+export function solutionsDir(): string | null {
+  const vault = resolveVaultPath();
+  if (!vault) return null;
+  const dir = path.join(vault, 'solutions');
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+// ── Serialization helpers ──────────────────────────────────────────────────
+
+function toFrontmatter(sol: Solution): string {
+  const tagList = sol.tags.map((t) => `"${t}"`).join(', ');
+  const lines = [
+    '---',
+    `id: ${sol.id}`,
+    'type: solution',
+    `title: "${sol.title.replace(/"/g, '\\"')}"`,
+    `tags: [${tagList}]`,
+    `problem_type: ${sol.problemType}`,
+  ];
+  if (sol.module) {
+    lines.push(`module: ${sol.module}`);
+  }
+  lines.push(`severity: ${sol.severity}`);
+  lines.push(`updated: ${new Date().toISOString().slice(0, 10)}`);
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function toBugBody(sol: Solution): string {
+  return [
+    '## Symptoms',
+    sol.symptoms,
+    '',
+    "## What Didn't Work",
+    sol.deadEnds,
+    '',
+    '## Solution',
+    sol.solution,
+    '',
+    '## Prevention',
+    sol.prevention,
+  ].join('\n');
+}
+
+function toKnowledgeBody(sol: Solution): string {
+  return [
+    '## Context',
+    sol.symptoms, // reuse symptoms field as context
+    '',
+    '## Guidance',
+    sol.solution, // reuse solution field as guidance
+    '',
+    '## When to Apply',
+    sol.prevention, // reuse prevention field as triggers
+  ].join('\n');
+}
+
+function toMarkdown(sol: Solution): string {
+  const fm = toFrontmatter(sol);
+  const body =
+    sol.problemType === 'knowledge' ? toKnowledgeBody(sol) : toBugBody(sol);
+  return `${fm}\n\n${body}\n`;
+}
+
+/** Generate a filename-safe slug from the title. */
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 60);
+}
+
+// ── Parsing ────────────────────────────────────────────────────────────────
+
+function parseFrontmatter(content: string): Record<string, string> | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const kv: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      kv[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+  }
+  return kv;
+}
+
+function parseSection(content: string, heading: string): string {
+  const regex = new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`);
+  const match = content.match(regex);
+  return match ? match[1].trim() : '';
+}
+
+function parseTags(raw: string): string[] {
+  // Parse [tag1, tag2, ...] or ["tag1", "tag2", ...]
+  const inner = raw.replace(/^\[|\]$/g, '');
+  return inner
+    .split(',')
+    .map((t) => t.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
+}
+
+function parseSolution(content: string, filePath: string): Solution | null {
+  const fm = parseFrontmatter(content);
+  if (!fm || fm.type !== 'solution') return null;
+
+  const problemType = (fm.problem_type || 'bug') as ProblemType;
+  return {
+    id: fm.id || path.basename(filePath, '.md'),
+    title: (fm.title || '').replace(/^["']|["']$/g, '').replace(/\\"/g, '"'),
+    tags: parseTags(fm.tags || '[]'),
+    problemType,
+    module: fm.module || undefined,
+    severity: (fm.severity || 'medium') as Severity,
+    symptoms:
+      problemType === 'knowledge'
+        ? parseSection(content, 'Context')
+        : parseSection(content, 'Symptoms'),
+    deadEnds: parseSection(content, "What Didn't Work"),
+    solution:
+      problemType === 'knowledge'
+        ? parseSection(content, 'Guidance')
+        : parseSection(content, 'Solution'),
+    prevention:
+      problemType === 'knowledge'
+        ? parseSection(content, 'When to Apply')
+        : parseSection(content, 'Prevention'),
+  };
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Write a new solution atom to the vault. Returns the generated ID.
+ * Append-only: never overwrites an existing file.
+ */
+export function writeSolution(
+  data: Omit<Solution, 'id'>,
+  dir?: string,
+): string {
+  const targetDir = dir ?? solutionsDir();
+  if (!targetDir) {
+    throw new Error(
+      'No vault configured. Set DEUS_VAULT_PATH or vault_path in ~/.config/deus/config.json',
+    );
+  }
+
+  const id = randomUUID();
+  const sol: Solution = { id, ...data };
+  const filename = `${slugify(sol.title)}-${id.slice(0, 8)}.md`;
+  const filePath = path.join(targetDir, filename);
+
+  // Append-only guard: never overwrite
+  if (fs.existsSync(filePath)) {
+    throw new Error(`Solution file already exists: ${filePath}`);
+  }
+
+  fs.writeFileSync(filePath, toMarkdown(sol), 'utf-8');
+  return id;
+}
+
+/**
+ * Search solutions by text query and optional tag filter.
+ * Uses simple substring matching (grep-style) for v1.
+ */
+export function searchSolutions(
+  query: string,
+  tags?: string[],
+  dir?: string,
+): Solution[] {
+  const targetDir = dir ?? solutionsDir();
+  if (!targetDir || !fs.existsSync(targetDir)) return [];
+
+  const files = fs
+    .readdirSync(targetDir)
+    .filter((f) => f.endsWith('.md'))
+    .sort()
+    .reverse(); // newest first (filenames are slug-uuid, but sort is stable)
+
+  const lowerQuery = query.toLowerCase();
+  const lowerTags = tags?.map((t) => t.toLowerCase());
+
+  const results: Solution[] = [];
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(targetDir, file), 'utf-8');
+    const sol = parseSolution(content, file);
+    if (!sol) continue;
+
+    // Tag filter: all specified tags must be present
+    if (lowerTags && lowerTags.length > 0) {
+      const solTags = sol.tags.map((t) => t.toLowerCase());
+      if (!lowerTags.every((t) => solTags.includes(t))) continue;
+    }
+
+    // Text match: query appears anywhere in the content
+    if (lowerQuery && !content.toLowerCase().includes(lowerQuery)) continue;
+
+    results.push(sol);
+  }
+
+  return results;
+}
+
+/**
+ * Retrieve a single solution by its ID.
+ */
+export function getSolution(id: string, dir?: string): Solution | null {
+  const targetDir = dir ?? solutionsDir();
+  if (!targetDir || !fs.existsSync(targetDir)) return null;
+
+  const files = fs.readdirSync(targetDir).filter((f) => f.endsWith('.md'));
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(targetDir, file), 'utf-8');
+    const sol = parseSolution(content, file);
+    if (sol && sol.id === id) return sol;
+  }
+  return null;
+}
+
+/**
+ * List all solutions sorted by file modification time (newest first).
+ */
+export function listSolutions(limit = 20, dir?: string): Solution[] {
+  const targetDir = dir ?? solutionsDir();
+  if (!targetDir || !fs.existsSync(targetDir)) return [];
+
+  const files = fs
+    .readdirSync(targetDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => ({
+      name: f,
+      mtime: fs.statSync(path.join(targetDir, f)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, limit);
+
+  const results: Solution[] = [];
+  for (const { name } of files) {
+    const content = fs.readFileSync(path.join(targetDir, name), 'utf-8');
+    const sol = parseSolution(content, name);
+    if (sol) results.push(sol);
+  }
+  return results;
+}
+
+/**
+ * Load the N most recently modified solutions as formatted context strings.
+ * Used by the context registry to inject solutions into agent runs.
+ */
+export function loadSolutionContext(limit = 3, dir?: string): string[] {
+  const solutions = listSolutions(limit, dir);
+  return solutions.map((sol) => {
+    const typeLabel =
+      sol.problemType === 'knowledge' ? 'Knowledge' : 'Solution';
+    const tagStr = sol.tags.length > 0 ? ` [${sol.tags.join(', ')}]` : '';
+    const header = `${typeLabel}: ${sol.title}${tagStr}`;
+    const body =
+      sol.problemType === 'knowledge'
+        ? `Context: ${sol.symptoms}\nGuidance: ${sol.solution}`
+        : `Symptoms: ${sol.symptoms}\nFix: ${sol.solution}\nPrevention: ${sol.prevention}`;
+    return `${header}\n${body}`;
+  });
+}

--- a/src/solutions/store.ts
+++ b/src/solutions/store.ts
@@ -102,12 +102,12 @@ export function solutionsDir(): string | null {
 // ── Serialization helpers ──────────────────────────────────────────────────
 
 function toFrontmatter(sol: Solution): string {
-  const tagList = sol.tags.map((t) => `"${t}"`).join(', ');
+  const tagList = sol.tags.map((t) => `"${t.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(', ');
   const lines = [
     '---',
     `id: ${sol.id}`,
     'type: solution',
-    `title: "${sol.title.replace(/"/g, '\\"')}"`,
+    `title: "${sol.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
     `tags: [${tagList}]`,
     `problem_type: ${sol.problemType}`,
   ];

--- a/src/solutions/store.ts
+++ b/src/solutions/store.ts
@@ -102,7 +102,9 @@ export function solutionsDir(): string | null {
 // ── Serialization helpers ──────────────────────────────────────────────────
 
 function toFrontmatter(sol: Solution): string {
-  const tagList = sol.tags.map((t) => `"${t.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(', ');
+  const tagList = sol.tags
+    .map((t) => `"${t.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)
+    .join(', ');
   const lines = [
     '---',
     `id: ${sol.id}`,


### PR DESCRIPTION
## Summary

- Add a solution atom system for capturing operational learnings (bug fixes, dead ends, discovered patterns) as markdown files with YAML frontmatter in the vault's `solutions/` directory
- Integrate solution context injection into container agent runs — the 3 most recent solutions are loaded into agent context (full-context mode only)
- Add `deus solution` CLI subcommand for listing, searching, adding, and retrieving solution atoms
- Document the solution atom schema including memory indexer compatibility notes

## Details

### Solution Store (`src/solutions/store.ts`)
- `writeSolution()` — append-only file creation with UUID-based IDs
- `searchSolutions()` — grep-style text + tag filtering
- `getSolution()` / `listSolutions()` — retrieval by ID or mtime-sorted listing
- `loadSolutionContext()` — formatted context strings for agent injection

### Container Context (`container/agent-runner/src/context-registry.ts`)
- `loadSolutionBlocks()` scans `/workspace/vault/solutions/` for the 3 most recent `.md` files
- Solutions are included in full-context mode only (excluded from `claude-system-append` to keep system prompt lean)

### CLI (`src/solutions/cli.ts` + `deus-cmd.sh`)
- `deus solution list [limit]` — list recent solutions
- `deus solution search <query> [--tag <t>]` — search by text/tags  
- `deus solution add` — create from JSON stdin
- `deus solution get <id>` — show full solution details

### Memory Indexer Note
The indexer's `--rebuild` does not auto-walk `solutions/`. Individual files can be indexed via `--add`. Adding `solutions/` to the rebuild walk list is documented as a follow-up.

## Test plan
- [x] 12 unit tests for solution store (write, read, search, list, tag filter, special chars, append-only)
- [x] 3 new tests for context-registry (solution inclusion, exclusion in append mode, missing dir)
- [x] All 895 existing tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] ESLint passes with no new warnings
- [x] Build produces `dist/solutions/cli.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)