### PR TITLE
fix(setup): add 3s timeout to commandExists execSync

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-06" # auto-bump
+last_verified: "2026-05-06" # auto-bump (setup fix)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-06" # auto-bump
+last_verified: "2026-05-06" # auto-bump (setup fix)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-06" # auto-bump
+last_verified: "2026-05-06" # auto-bump (setup fix)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/setup/platform.ts
+++ b/setup/platform.ts
@@ -127,7 +127,7 @@ export function commandExists(name: string): boolean {
   try {
     const check =
       os.platform() === 'win32' ? `where ${name}` : `command -v ${name}`;
-    execSync(check, { stdio: 'ignore' });
+    execSync(check, { stdio: 'ignore', timeout: 3000 });
     return true;
   } catch {
     return false;

--- a/setup/platform.windows.test.ts
+++ b/setup/platform.windows.test.ts
@@ -67,6 +67,7 @@ describe('Windows platform (mocked)', () => {
     commandExists('someprogram');
     expect(vi.mocked(execSync)).toHaveBeenCalledWith('where someprogram', {
       stdio: 'ignore',
+      timeout: 3000,
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a 3-second timeout to the `execSync` call in `commandExists()` (`setup/platform.ts`)
- `where` on Windows CI can take >5s scanning a large PATH, causing the `ollama.test.ts` `commandExists integration` test to flake with the default 5000ms vitest timeout
- The timeout makes `commandExists` return `false` (via the catch block) instead of hanging indefinitely

## Test plan
- [ ] Existing `setup/__tests__/ollama.test.ts` `commandExists integration` tests pass
- [ ] `setup/platform.test.ts` tests pass
- [ ] Windows CI `test-windows` job no longer flakes on `commandExists`

🤖 Generated with [Claude Code](https://claude.com/claude-code)