### PR TITLE
feat(wardens): generalized warden learning loop

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -53,3 +53,25 @@ Return a single markdown report. No preamble.
 - **Tight output.** Target ≤50 lines. A long review is a signal/noise red flag.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/code-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
 - **Diff is authoritative.** If memory or docs contradict what's in the diff, trust the diff — memory is a snapshot, code is live.
+
+## Dismissal feedback
+
+When the author dismisses a finding from this review, the parent agent logs it via
+`dismiss_warden_finding` (generalized command — the legacy `dismiss_review_finding`
+still works as an alias with `warden="code_review"` injected automatically):
+```bash
+python3 -c "
+import json, subprocess, sys
+payload = json.dumps({
+    'warden': 'code_review',
+    'finding': sys.argv[1],
+    'reason': sys.argv[2],
+    'file': sys.argv[3],
+    'line': int(sys.argv[4]) if sys.argv[4] != 'null' else None,
+    'group_folder': sys.argv[5] if sys.argv[5] != 'null' else None
+})
+subprocess.run([sys.executable, 'evolution/cli.py', 'dismiss_warden_finding', payload])
+" "<title>" "<reason>" "<path>" "<line or null>" "<group or null>"
+```
+
+This creates a reflection that will be retrieved in future reviews, reducing false positive recurrence.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -49,3 +49,23 @@ Return a single markdown report. No preamble, no "I'll review...".
 - **Keep it tight.** A useful review is ≤40 lines. Padding is noise.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/plan-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
 - **Verify premises, not just rule compliance.** When the plan cites repo state as a problem (tracked files, unused deps, orphan files, cache drift, divergence between paths), run the verification commands yourself before approving. The `premise-verification` rule lists the minimum checks per premise type. A rule-compliant plan built on a false premise is REVISE, not SHIP.
+
+## Dismissal feedback
+
+When the author dismisses a finding from this review, the parent agent logs it via:
+```bash
+python3 -c "
+import json, subprocess, sys
+payload = json.dumps({
+    'warden': 'plan_review',
+    'finding': sys.argv[1],
+    'reason': sys.argv[2],
+    'file': sys.argv[3],
+    'line': int(sys.argv[4]) if sys.argv[4] != 'null' else None,
+    'group_folder': sys.argv[5] if sys.argv[5] != 'null' else None
+})
+subprocess.run([sys.executable, 'evolution/cli.py', 'dismiss_warden_finding', payload])
+" "<title>" "<reason>" "<path>" "<line or null>" "<group or null>"
+```
+
+This creates a reflection that will be retrieved in future reviews, reducing false positive recurrence.

--- a/.claude/agents/threat-modeler.md
+++ b/.claude/agents/threat-modeler.md
@@ -62,3 +62,23 @@ Return a single markdown report. No preamble.
 - **Don't invent controls.** Recommend controls that exist or are standard. Don't propose novel mitigations that add complexity.
 - **Fail-closed on missing rules file.** Report "rules file missing -- cannot review" and stop. Do not improvise rules.
 - **Tight output.** Threat matrix + gaps + controls. Not a textbook. Target 40 lines or fewer.
+
+## Dismissal feedback
+
+When the author dismisses a finding from this review, the parent agent logs it via:
+```bash
+python3 -c "
+import json, subprocess, sys
+payload = json.dumps({
+    'warden': 'threat_modeling',
+    'finding': sys.argv[1],
+    'reason': sys.argv[2],
+    'file': sys.argv[3],
+    'line': int(sys.argv[4]) if sys.argv[4] != 'null' else None,
+    'group_folder': sys.argv[5] if sys.argv[5] != 'null' else None
+})
+subprocess.run([sys.executable, 'evolution/cli.py', 'dismiss_warden_finding', payload])
+" "<title>" "<reason>" "<path>" "<line or null>" "<group or null>"
+```
+
+This creates a reflection that will be retrieved in future reviews, reducing false positive recurrence.

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -8,6 +8,7 @@ Usage:
     python evolution/cli.py log_interaction <json>
     python evolution/cli.py reflect <interaction_id>
     python evolution/cli.py dismiss_review_finding <json>
+    python evolution/cli.py dismiss_warden_finding <json>
     python evolution/cli.py optimize [--module qa|tool_selection|summarization|all]
     python evolution/cli.py optimize-params [--trials 200] [--provider ollama|gemini|auto]
     python evolution/cli.py serve
@@ -405,12 +406,37 @@ def cmd_archive_reflections(days: int = 30, dry_run: bool = False) -> None:
 
 
 def cmd_dismiss_review_finding(json_str: str) -> None:
-    """Create a reflection directly from a dismissed code review finding, bypassing the judge."""
+    """Create a reflection from a dismissed code review finding.
+
+    Backwards-compatible wrapper — delegates to cmd_dismiss_warden_finding
+    with warden="code_review" injected.
+    """
     try:
         params = json.loads(json_str)
     except json.JSONDecodeError:
         print(json.dumps({"error": "Invalid JSON"}))
         return
+
+    params["warden"] = "code_review"
+    cmd_dismiss_warden_finding(json.dumps(params))
+
+
+# Allowlist of valid warden identifiers for dismiss_warden_finding.
+_VALID_WARDENS = frozenset(["plan_review", "threat_modeling", "code_review"])
+
+
+def cmd_dismiss_warden_finding(json_str: str) -> None:
+    """Create a reflection directly from a dismissed warden finding, bypassing the judge."""
+    try:
+        params = json.loads(json_str)
+    except json.JSONDecodeError:
+        print(json.dumps({"error": "Invalid JSON"}))
+        return
+
+    warden = params.get("warden", "")
+    if warden not in _VALID_WARDENS:
+        print(json.dumps({"error": f"Invalid warden '{warden}'. Must be one of: {sorted(_VALID_WARDENS)}"}))
+        sys.exit(1)
 
     finding = params.get("finding", "")
     reason = params.get("reason", "")
@@ -434,10 +460,10 @@ def cmd_dismiss_review_finding(json_str: str) -> None:
 
     # Build a reflection content that serves as a negative example
     content = (
-        f"- What went wrong: Code review flagged '{finding}' at {location} "
+        f"- What went wrong: {warden} flagged '{finding}' at {location} "
         f"but the user dismissed it — this is a false positive.\n"
         f"- Next time: Do NOT flag this pattern. Reason: {reason}\n"
-        f"- Category: code_review"
+        f"- Category: {warden}"
     )
 
     from .reflexion.store import save_reflection
@@ -445,7 +471,7 @@ def cmd_dismiss_review_finding(json_str: str) -> None:
     try:
         rid = save_reflection(
             content=content,
-            category="code_review",
+            category=warden,
             score_at_gen=0.3,  # Low score = negative signal
             interaction_id=None,
             group_folder=group_folder,
@@ -506,9 +532,13 @@ def main() -> None:
     p_archive.add_argument("--days", type=int, default=30, help="Age threshold in days (default: 30)")
     p_archive.add_argument("--dry-run", action="store_true", help="Preview without archiving")
 
-    # dismiss_review_finding
+    # dismiss_review_finding (backwards compat — delegates to dismiss_warden_finding)
     p_dismiss = sub.add_parser("dismiss_review_finding", help="Create reflection from dismissed code review finding")
-    p_dismiss.add_argument("json_str", help='JSON: {"finding": "...", "category": "...", "reason": "...", ...}')
+    p_dismiss.add_argument("json_str", help='JSON: {"finding": "...", "reason": "...", ...}')
+
+    # dismiss_warden_finding (generalized)
+    p_dismiss_w = sub.add_parser("dismiss_warden_finding", help="Create reflection from dismissed warden finding")
+    p_dismiss_w.add_argument("json_str", help='JSON: {"warden": "...", "finding": "...", "reason": "...", ...}')
 
     # optimize-params
     p_optparams = sub.add_parser("optimize-params", help="Optimize memory retrieval thresholds")
@@ -565,6 +595,8 @@ def main() -> None:
         cmd_archive_reflections(days=args.days, dry_run=args.dry_run)
     elif args.cmd == "dismiss_review_finding":
         cmd_dismiss_review_finding(args.json_str)
+    elif args.cmd == "dismiss_warden_finding":
+        cmd_dismiss_warden_finding(args.json_str)
     elif args.cmd == "optimize-params":
         from .optimizer.param_optimizer import optimize_and_save
         provider = args.provider if args.provider != "auto" else None

--- a/evolution/reflexion/retriever.py
+++ b/evolution/reflexion/retriever.py
@@ -20,6 +20,7 @@ def get_reflections(
     group_folder: Optional[str] = None,
     tools_planned: Optional[list[str]] = None,
     top_k: int = MAX_REFLECTIONS_PER_QUERY,
+    category: Optional[str] = None,
 ) -> list[dict]:
     """
     Return top-k reflections most semantically relevant to the query.
@@ -27,6 +28,9 @@ def get_reflections(
     Group-scoped reflections are prioritised over cross-group ones.
     Helpful count applies a log-scaled tiebreaker bonus so frequently-useful
     reflections float up without overriding cosine similarity.
+
+    When *category* is provided, only reflections of that category are returned
+    (e.g. "code_review", "plan_review", "threat_modeling").
     """
     search_text = query
     if tools_planned:
@@ -38,6 +42,7 @@ def get_reflections(
 
     results = store.get_reflections_by_embedding(
         embedding=blob, top_k=top_k, group_folder=group_folder,
+        category=category,
     )
 
     # Re-rank: lower distance = better; subtract helpful bonus to keep unified ordering

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -143,8 +143,15 @@ class StorageProvider(ABC):
         top_k: int,
         group_folder: Optional[str] = None,
         min_score: Optional[float] = None,
+        category: Optional[str] = None,
     ) -> list[dict]:
-        """Retrieve reflections by vector similarity search."""
+        """Retrieve reflections by vector similarity search.
+
+        When *category* is non-None, only reflections with that category value
+        are returned (e.g. warden categories: code_review, plan_review,
+        threat_modeling; or generated categories: tool_use, reasoning, style,
+        safety).
+        """
         ...
 
     @abstractmethod

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -215,7 +215,7 @@ class SQLiteStorageProvider(StorageProvider):
                 timestamp           TEXT NOT NULL,
                 group_folder        TEXT,     -- NULL = applies cross-group
                 content             TEXT NOT NULL,
-                category            TEXT,     -- tool_use|reasoning|style|safety
+                category            TEXT,     -- warden (code_review|plan_review|threat_modeling) or generated (tool_use|reasoning|style|safety)
                 score_at_gen        REAL,
                 times_retrieved     INTEGER DEFAULT 0,
                 times_helpful       INTEGER DEFAULT 0
@@ -555,11 +555,21 @@ class SQLiteStorageProvider(StorageProvider):
         top_k: int,
         group_folder: Optional[str] = None,
         min_score: Optional[float] = None,
+        category: Optional[str] = None,
     ) -> list[dict]:
         db = self._connect()
         try:
+            # Build optional category filter
+            category_clause = ""
+            params: list = [embedding, top_k * 2, group_folder]
+            if category is not None:
+                category_clause = "AND r.category = ?"
+                params.append(category)
+
+            # safe: category_clause is either empty or a literal string
+            # fragment; user values are bound through params.
             rows = db.execute(
-                """
+                f"""
                 SELECT r.id, r.content, r.category, r.score_at_gen,
                        r.times_helpful, r.times_retrieved,
                        re.distance
@@ -568,9 +578,10 @@ class SQLiteStorageProvider(StorageProvider):
                 WHERE re.embedding MATCH ? AND k = ?
                   AND (r.group_folder = ? OR r.group_folder IS NULL)
                   AND r.archived_at IS NULL
+                  {category_clause}
                 ORDER BY re.distance, r.times_helpful DESC
                 """,
-                [embedding, top_k * 2, group_folder],
+                params,
             ).fetchall()
         except Exception:
             rows = []

--- a/evolution/tests/test_warden_learning_loop.py
+++ b/evolution/tests/test_warden_learning_loop.py
@@ -1,0 +1,283 @@
+"""
+Tests for Phase 5: Generalized Warden Learning Loop.
+
+Covers:
+- dismiss_warden_finding with each valid warden type
+- Invalid warden raises SystemExit
+- dismiss_review_finding backwards compat (delegates to dismiss_warden_finding)
+- Category filter on get_reflections_by_embedding (SQLite provider)
+- No-category returns all reflections
+"""
+import json
+import struct
+
+import pytest
+
+import evolution.config as config_mod
+import evolution.db as db_mod
+import evolution.providers.embeddings as embed_mod
+from evolution.cli import (
+    _VALID_WARDENS,
+    cmd_dismiss_review_finding,
+    cmd_dismiss_warden_finding,
+)
+from evolution.storage.provider import StorageRegistry
+from evolution.storage.providers.sqlite import SQLiteStorageProvider, _migrated_paths
+
+EMBED_DIM = 768
+VECTOR_A = [1.0] + [0.0] * (EMBED_DIM - 1)
+VECTOR_B = [0.0] * (EMBED_DIM - 1) + [1.0]
+
+
+def _serialize_vec(vec: list[float]) -> bytes:
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def patch_db_and_embed(tmp_path, monkeypatch):
+    """Redirect DB to temp dir and mock embeddings to avoid real API calls."""
+    test_db = tmp_path / "test_warden.db"
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
+    monkeypatch.setattr(embed_mod, "_provider", None)
+    monkeypatch.setattr(
+        "evolution.reflexion.store._embed",
+        lambda text: VECTOR_A,
+    )
+    # Clear migration cache so each test gets a fresh schema migration
+    _migrated_paths.discard(str(test_db))
+    # Ensure the SQLite provider is registered (other test files may reset the registry)
+    registry = StorageRegistry.default()
+    if "sqlite" not in registry.list_providers():
+        registry.register(SQLiteStorageProvider())
+    yield test_db
+    _migrated_paths.discard(str(test_db))
+
+
+@pytest.fixture
+def sqlite_provider(tmp_path, monkeypatch):
+    """Return a SQLiteStorageProvider backed by a temp DB."""
+    test_db = tmp_path / "test_provider.db"
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
+    return SQLiteStorageProvider()
+
+
+# ── dismiss_warden_finding tests ────────────────────────────────────────────
+
+
+class TestDismissWardenFinding:
+    @pytest.mark.parametrize("warden", sorted(_VALID_WARDENS))
+    def test_valid_warden_creates_reflection(self, warden, capsys):
+        payload = json.dumps({
+            "warden": warden,
+            "finding": "False alarm in test",
+            "reason": "Not applicable here",
+            "file": "src/test.ts",
+            "line": 42,
+        })
+        cmd_dismiss_warden_finding(payload)
+        raw = capsys.readouterr().out
+        out = json.loads(raw)
+        assert out.get("status") == "ok", f"Unexpected output for {warden}: {raw}"
+        assert out["id"] is not None
+        assert warden in out["content"]
+
+    def test_invalid_warden_exits(self):
+        payload = json.dumps({
+            "warden": "nonexistent_warden",
+            "finding": "test",
+            "reason": "test",
+        })
+        with pytest.raises(SystemExit):
+            cmd_dismiss_warden_finding(payload)
+
+    def test_missing_finding_returns_error(self, capsys):
+        payload = json.dumps({
+            "warden": "code_review",
+            "finding": "",
+            "reason": "some reason",
+        })
+        cmd_dismiss_warden_finding(payload)
+        out = json.loads(capsys.readouterr().out)
+        assert "error" in out
+        assert "finding" in out["error"]
+
+    def test_missing_reason_returns_error(self, capsys):
+        payload = json.dumps({
+            "warden": "code_review",
+            "finding": "some finding",
+            "reason": "",
+        })
+        cmd_dismiss_warden_finding(payload)
+        out = json.loads(capsys.readouterr().out)
+        assert "error" in out
+        assert "reason" in out["error"]
+
+    def test_invalid_json_returns_error(self, capsys):
+        cmd_dismiss_warden_finding("not json")
+        out = json.loads(capsys.readouterr().out)
+        assert "error" in out
+
+    def test_reflection_content_includes_warden_name(self, capsys):
+        payload = json.dumps({
+            "warden": "plan_review",
+            "finding": "Missing rollback step",
+            "reason": "Rollback is handled upstream",
+            "file": "docs/plan.md",
+            "line": 10,
+        })
+        cmd_dismiss_warden_finding(payload)
+        out = json.loads(capsys.readouterr().out)
+        assert "plan_review" in out["content"]
+        assert "Missing rollback step" in out["content"]
+        assert "docs/plan.md:10" in out["content"]
+
+    def test_group_folder_passed_through(self, capsys):
+        payload = json.dumps({
+            "warden": "threat_modeling",
+            "finding": "Unencrypted channel",
+            "reason": "Internal-only service",
+            "file": "src/api.ts",
+            "group_folder": "test-group",
+        })
+        cmd_dismiss_warden_finding(payload)
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+
+
+# ── dismiss_review_finding backwards compat ─────────────────────────────────
+
+
+class TestDismissReviewFindingCompat:
+    def test_delegates_to_warden_with_code_review(self, capsys):
+        """dismiss_review_finding should produce a code_review reflection."""
+        payload = json.dumps({
+            "finding": "Unused import",
+            "reason": "Required for type-only usage",
+            "file": "src/index.ts",
+            "line": 5,
+        })
+        cmd_dismiss_review_finding(payload)
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+        assert "code_review" in out["content"]
+
+    def test_invalid_json_returns_error(self, capsys):
+        cmd_dismiss_review_finding("not json")
+        out = json.loads(capsys.readouterr().out)
+        assert "error" in out
+
+
+# ── Category filter on get_reflections_by_embedding ─────────────────────────
+
+
+class TestCategoryFilter:
+    def test_category_filter_returns_only_matching(self, sqlite_provider):
+        """When category is set, only reflections of that category are returned."""
+        # Save two reflections with different categories
+        sqlite_provider.save_reflection(
+            reflection_id="ref_cr",
+            content="Code review lesson",
+            category="code_review",
+            score_at_gen=0.3,
+            timestamp="2024-01-01T00:00:00Z",
+            embedding=_serialize_vec(VECTOR_A),
+            group_folder="g",
+        )
+        sqlite_provider.save_reflection(
+            reflection_id="ref_pr",
+            content="Plan review lesson",
+            category="plan_review",
+            score_at_gen=0.3,
+            timestamp="2024-01-02T00:00:00Z",
+            embedding=_serialize_vec(VECTOR_A),
+            group_folder="g",
+        )
+
+        # Filter by code_review
+        results = sqlite_provider.get_reflections_by_embedding(
+            embedding=_serialize_vec(VECTOR_A),
+            top_k=10,
+            group_folder="g",
+            category="code_review",
+        )
+        assert len(results) == 1
+        assert results[0]["category"] == "code_review"
+        assert results[0]["id"] == "ref_cr"
+
+    def test_no_category_returns_all(self, sqlite_provider):
+        """When category is None, all reflections are returned regardless of category."""
+        for i, cat in enumerate(["code_review", "plan_review", "threat_modeling"]):
+            sqlite_provider.save_reflection(
+                reflection_id=f"ref_{i}",
+                content=f"Lesson for {cat}",
+                category=cat,
+                score_at_gen=0.3,
+                timestamp=f"2024-01-0{i+1}T00:00:00Z",
+                embedding=_serialize_vec(VECTOR_A),
+                group_folder="g",
+            )
+
+        results = sqlite_provider.get_reflections_by_embedding(
+            embedding=_serialize_vec(VECTOR_A),
+            top_k=10,
+            group_folder="g",
+            category=None,
+        )
+        assert len(results) == 3
+
+    def test_category_filter_with_no_matches(self, sqlite_provider):
+        """Category filter with no matching reflections returns empty list."""
+        sqlite_provider.save_reflection(
+            reflection_id="ref_only",
+            content="Only code review",
+            category="code_review",
+            score_at_gen=0.3,
+            timestamp="2024-01-01T00:00:00Z",
+            embedding=_serialize_vec(VECTOR_A),
+            group_folder="g",
+        )
+
+        results = sqlite_provider.get_reflections_by_embedding(
+            embedding=_serialize_vec(VECTOR_A),
+            top_k=10,
+            group_folder="g",
+            category="threat_modeling",
+        )
+        assert len(results) == 0
+
+    def test_category_filter_threat_modeling(self, sqlite_provider):
+        """Verify threat_modeling category filter works correctly."""
+        sqlite_provider.save_reflection(
+            reflection_id="ref_tm",
+            content="Threat modeling false positive",
+            category="threat_modeling",
+            score_at_gen=0.3,
+            timestamp="2024-01-01T00:00:00Z",
+            embedding=_serialize_vec(VECTOR_A),
+            group_folder="g",
+        )
+        sqlite_provider.save_reflection(
+            reflection_id="ref_other",
+            content="Reasoning lesson",
+            category="reasoning",
+            score_at_gen=0.4,
+            timestamp="2024-01-02T00:00:00Z",
+            embedding=_serialize_vec(VECTOR_A),
+            group_folder="g",
+        )
+
+        results = sqlite_provider.get_reflections_by_embedding(
+            embedding=_serialize_vec(VECTOR_A),
+            top_k=10,
+            group_folder="g",
+            category="threat_modeling",
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "ref_tm"


### PR DESCRIPTION
## Summary
- Extends the code-review dismissal→reflection pattern to plan-reviewer and threat-modeler wardens
- Adds `dismiss_warden_finding` CLI command with allowlist validation (`plan_review`, `threat_modeling`, `code_review`)
- Adds `category` filter to `get_reflections_by_embedding()` so warden-specific dismissals only surface in their own context
- Keeps `dismiss_review_finding` as a backwards-compatible alias
- 15 new tests covering all warden types, validation, category filtering, and backwards compat

Phase 5 of the multi-agent orchestration ADR (`docs/decisions/multi-agent-orchestration-research.md`).

## Test plan
- [x] `dismiss_warden_finding` with each valid warden type creates correctly-categorized reflection
- [x] Invalid warden value raises `SystemExit(1)`
- [x] `dismiss_review_finding` alias produces identical output to `dismiss_warden_finding` with `code_review`
- [x] Category filter returns only matching reflections through concrete SQLite provider
- [x] No-category query returns all reflections (backwards compat)
- [x] All 204 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)