### PR TITLE
feat(multi-agent): thin orchestrator with tiered parallel dispatch

### DIFF
--- a/docs/decisions/multi-agent-orchestration-research.md
+++ b/docs/decisions/multi-agent-orchestration-research.md
@@ -1,0 +1,107 @@
+# Multi-Agent Orchestration & Agent Quality Research
+
+**Status:** Accepted
+**Date:** 2026-05-06
+**Scope:** `src/agent-backends/`, `src/message-orchestrator.ts`, `container/agent-runner/`, `.claude/wardens/`, memory atoms
+**Related:**
+- `backend-neutral-agent-runtime.md` — defines the backend interface contract this ADR proposes renaming; that ADR already deferred agents-js adoption ("Full OpenAI Agents SDK sessions, handoffs, and tracing remain parity work") — this ADR formalizes that deferral as a skip with architectural justification
+- `parallel-agent-orchestration.md` — covers TUI-level parallel agent sessions (independent CLI sessions). This ADR covers container-level multi-agent coordination (subagents within a single request), a different scope
+- `tui-agent-orchestration.md` — covers TUI subprocess lifecycle. Not superseded
+
+## Context
+
+Investigated enhancing Deus's agent performance across three dimensions: input security (prompt injection), multi-agent coordination (parallel subagents, handoffs), and self-improvement loops (structured lesson capture, warden learning). Evaluated external tools and frameworks to determine what to adopt, adapt, or skip.
+
+## Research Conducted
+
+### Repos Evaluated
+
+| Repo | Verdict | Reasoning |
+|------|---------|-----------|
+| `msitarzewski/agency-agents` | **Skip** | Prompt library (147 markdown persona files, zero runtime). No tools, no API. Deus already has real memory and structured skills. |
+| `hesreallyhim/awesome-claude-code` | **Mine selectively** | Curated list of 226 entries. Notable: parry-guard, HCOM, Context Engineering Kit, Trail of Bits security skills. |
+| `obra/superpowers` | **Cherry-pick patterns** | High quality (179k stars) but heavy overlap with existing wardens/patterns/router. Adopt: subagent-driven-development prompt templates, systematic-debugging 4-phase process. |
+| `EveryInc/compound-engineering-plugin` | **Adopt schema** | Structured lesson capture: bug-track (Symptoms / What Didn't Work / Solution / Prevention) and knowledge-track. Complementary to evolution/eval — eval measures outcomes, CE captures qualitative lessons. |
+| `openai/openai-agents-js` | **Adopt concepts only** | v0.9.0, 2.9k stars. Clean guardrail/tracing interfaces. Runner expects to own LLM calls — incompatible with container model (see below). |
+| `openai/openai-agents-python` | **Reference only** | More mature (25.9k stars, SQLite sessions, multi-provider, sandbox). Patterns worth back-porting: prefix-based provider dispatch, model-level retry advice. Wrong language for the real-time dispatch path. |
+| `openai/evals` | **Skip** | Effectively dormant (last real commit Sep 2024). Existing eval system (DSPy + OllamaJudge + Reflexion) is stronger. Optionally mine their dataset registry for additional test cases. |
+| `reporails/cli` | **Run diagnostic** | Lints AI instruction files against 92+ rules. Worth running once. BUSL-1.1 license (can use CLI, cannot fork/embed). Separate pending task. |
+| `vaporif/parry-guard` | **Adopt Layer 2 only** | Substantive Rust scanner (DeBERTa ML, tree-sitter AST exfil detection, 16 languages). Critical gap: `UserPromptSubmit` does NOT scan user prompt text — only audits config directory. Useful for host Claude Code sessions (Layer 2), not for container pre-ingestion (Layer 1). |
+
+### Architectural Finding: Runner vs Container Model
+
+The `@openai/agents-js` Runner assumes it controls LLM calls via its `Model` interface. Deus runs LLM calls **inside isolated containers** (via Claude Agent SDK or OpenAI Responses API). Three integration options evaluated:
+
+| Option | Description | Verdict |
+|--------|-------------|---------|
+| Runner on host, LLM on host | Containers become tool sandboxes. Loses Claude Agent SDK autonomous loop. | **Rejected** — massive rewrite, loses core strength. |
+| Runner on host, LLM in container (bridged) | `Model.getResponse()` wraps entire container run. | **Rejected** — impedance mismatch. Runner cannot orchestrate individual turns inside a container. |
+| Runner inside container | Multi-agent within a single container only. | **Partial** — useful for intra-container subagents, not host-level orchestration. |
+
+**Conclusion:** agents-js Runner does not fit the container-based architecture. Adopt concepts (guardrail interfaces, tracing patterns, handoff semantics, structured return contracts) and build a thin custom orchestrator on top of the existing runtime interface. This is consistent with `backend-neutral-agent-runtime.md`'s prior deferral.
+
+### Multi-Agent Prompt Engineering Patterns
+
+Research across Superpowers, CrewAI, AutoGen, and agents-js yielded four adoptable patterns:
+
+1. **Persona scaffold** — role/goal/backstory triple per subagent
+2. **Structured return contract** — `DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT` status enum [^1]
+
+[^1]: Implementation note (Phase 6): `NEEDS_CONTEXT` was folded into `BLOCKED` with a dependency reason — if a dependency is available, the orchestrator injects it before launch; if unavailable, the task cannot run and is `BLOCKED`.
+3. **Adversarial review framing** — reviewer told to assume implementer's work is incomplete
+4. **Explicit context graph** — each agent declares which prior outputs it needs, not everything
+
+**Key constraint:** Parallel fan-out is for reads (research/retrieval), not writes (implementation). Implementation and review run sequentially.
+
+## Decision
+
+### Adopt
+
+1. **Interface rename:** `AgentBackend` → `AgentRuntime`, `BackendSessionRef` → `RuntimeSession`, `BackendCapabilities` → `RuntimeCapabilities`, `AgentBackendName` → `AgentRuntimeId`. Three-layer naming: Transport (LLM call) → Runtime (session lifecycle) → Runner (orchestration). Code change tracked as its own PR.
+2. **Pre-ingestion scanner:** Guardrail in the message orchestrator that scans untrusted channel messages before container dispatch. Pattern matching (Aho-Corasick injection phrases) + optional ML classifier.
+3. **Parry-guard on host:** Layer 2 defense for host Claude Code sessions via PreToolUse/PostToolUse hooks.
+4. **Thin multi-agent orchestrator:** Dispatches parallel container runs via the runtime interface. Curated isolation (bespoke context per subagent). Structured return contracts.
+5. **Structured lesson capture:** Compound-Engineering-style atoms with bug-track/knowledge-track schema. Auto-surfaced via memory tree during agent context assembly.
+6. **Generalized warden learning:** Extend code-review dismissal→reflection pattern to plan-reviewer and threat-modeler.
+7. **Prompt template system:** Role-specific prompts for subagents using persona scaffold + adversarial review patterns.
+
+### Skip
+
+- Full `@openai/agents-js` framework adoption (Runner incompatible with container model)
+- Full `@openai/agents-python` adoption (wrong language for real-time dispatch path)
+- OpenAI evals framework (dormant, existing system is stronger)
+- agency-agents prompt library (no runtime, no value over existing system)
+- Installing Superpowers as a plugin (fights existing wardens/patterns)
+
+## Implementation Order
+
+Separate PRs by context, infrastructure first:
+
+| PR | Scope | Dependencies |
+|----|-------|--------------|
+| 1 | Interface rename (`AgentBackend` → `AgentRuntime`, etc.) | None — pure refactor |
+| 2 | Pre-ingestion scanner (guardrail in orchestrator) | None |
+| 3 | Parry-guard host installation | None |
+| 4 | Structured lesson capture (atom schema + auto-detection) | None |
+| 5 | Generalized warden learning loop | PR 4 (uses same atom schema) |
+| 6 | Thin multi-agent orchestrator + prompt templates | PR 1 (uses renamed interfaces) |
+
+## Consequences
+
+- Container model preserved — LLM calls stay inside containers. No architectural migration.
+- The thin orchestrator adds a lightweight coordination layer to the host, not a framework dependency.
+- Pre-ingestion scanner covers all channels at the orchestrator level.
+- Structured lessons compound over time as memory atoms, surfaced by existing retrieval.
+- Warden learning extends an already-proven pattern (code-review dismissal→reflection).
+
+## Verification
+
+- Interface rename: `npm run typecheck` + all existing tests pass. grep confirms zero remaining old names.
+- Pre-ingestion scanner: test with known injection payloads (parry-guard's Aho-Corasick phrase list as test corpus).
+- Multi-agent orchestrator: eval bench expanded with multi-step tasks measuring subagent coordination quality.
+- Lesson capture: verify memory tree surfaces solution atoms during relevant context assembly.
+- Warden learning: verify reflection injection reduces false positive rate over 10+ review cycles.
+
+## Rollback
+
+Each PR is independently revertible. The interface rename is a mechanical find-replace — rollback is the same operation in reverse. The multi-agent orchestrator ships behind an env flag (`DEUS_MULTI_AGENT=1`) until validated.

--- a/src/container-mounter.test.ts
+++ b/src/container-mounter.test.ts
@@ -77,7 +77,11 @@ vi.mock('fs', async () => {
 });
 
 import fs from 'fs';
-import { buildVolumeMounts, VolumeMount } from './container-mounter.js';
+import {
+  buildVolumeMounts,
+  buildFanOutMounts,
+  VolumeMount,
+} from './container-mounter.js';
 import { getProjectById } from './db.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
@@ -668,5 +672,60 @@ describe('buildVolumeMounts: agent-runner', () => {
     const appMount = findMount(mounts, '/app/src');
     expect(appMount).toBeDefined();
     expect(appMount!.readonly).toBe(true);
+  });
+});
+
+// ── Multi-agent fan-out mounts ────────────────────────────────────────
+
+describe('buildFanOutMounts', () => {
+  it('returns group dir as read-only and sandbox as writable', () => {
+    mockExistsSync.mockReturnValue(false);
+    const group = makeGroup();
+    const mounts = buildFanOutMounts(group, 'task-abc');
+
+    expect(mounts).toHaveLength(2);
+
+    const groupMount = findMount(mounts, '/workspace/group');
+    expect(groupMount).toBeDefined();
+    expect(groupMount!.readonly).toBe(true);
+    expect(groupMount!.hostPath).toBe(path.join(GROUPS_DIR, 'test-group'));
+
+    const sandboxMount = findMount(mounts, '/workspace/sandbox');
+    expect(sandboxMount).toBeDefined();
+    expect(sandboxMount!.readonly).toBe(false);
+    expect(sandboxMount!.hostPath).toContain('.multi-agent');
+    expect(sandboxMount!.hostPath).toContain('task-abc');
+  });
+
+  it('creates sandbox directory when it does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const group = makeGroup();
+    buildFanOutMounts(group, 'task-xyz');
+
+    expect(mockMkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('task-xyz'),
+      expect.objectContaining({ recursive: true }),
+    );
+  });
+
+  it('does not recreate sandbox directory when it already exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    const group = makeGroup();
+    buildFanOutMounts(group, 'task-existing');
+
+    // mkdirSync should NOT have been called for the sandbox
+    const sandboxMkdirCalls = mockMkdirSync.mock.calls.filter((call) =>
+      String(call[0]).includes('task-existing'),
+    );
+    expect(sandboxMkdirCalls).toHaveLength(0);
+  });
+
+  it('uses hardcoded container paths', () => {
+    mockExistsSync.mockReturnValue(false);
+    const group = makeGroup({ folder: 'custom-group' });
+    const mounts = buildFanOutMounts(group, 'task-1');
+
+    expect(mounts[0].containerPath).toBe('/workspace/group');
+    expect(mounts[1].containerPath).toBe('/workspace/sandbox');
   });
 });

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -366,3 +366,28 @@ export function buildVolumeMounts(
 
   return mounts;
 }
+
+export function buildFanOutMounts(
+  group: RegisteredGroup,
+  taskId: string,
+): VolumeMount[] {
+  const groupDir = resolveGroupFolderPath(group.folder);
+  const sandboxDir = path.join(groupDir, '.multi-agent', taskId);
+
+  if (!fs.existsSync(sandboxDir)) {
+    fs.mkdirSync(sandboxDir, { recursive: true });
+  }
+
+  return [
+    {
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: true,
+    },
+    {
+      hostPath: sandboxDir,
+      containerPath: '/workspace/sandbox',
+      readonly: false,
+    },
+  ];
+}

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -341,6 +341,8 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       }, IDLE_TIMEOUT);
     };
 
+    // TODO: wire MultiAgentOrchestrator dispatch when task-detection is ready (DEUS_MULTI_AGENT gate)
+
     await channel.setTyping?.(chatJid, true);
     let hadError = false;
     let outputSentToUser = false;

--- a/src/multi-agent/index.ts
+++ b/src/multi-agent/index.ts
@@ -1,0 +1,8 @@
+export { MultiAgentOrchestrator } from './orchestrator.js';
+export type {
+  SubagentTask,
+  SubagentResult,
+  OrchestratorResult,
+  SubagentStatus,
+} from './types.js';
+export { buildPrompt } from './prompt-templates.js';

--- a/src/multi-agent/orchestrator.test.ts
+++ b/src/multi-agent/orchestrator.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Unit tests for MultiAgentOrchestrator — parallel subagent dispatch,
+ * topological sorting, status marker parsing, and concern propagation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type {
+  AgentRuntime,
+  RunContext,
+  RunResult,
+  RuntimeCapabilities,
+  RuntimeEventSink,
+  RuntimeSession,
+} from '../agent-runtimes/types.js';
+import type { RuntimeRegistry } from '../agent-runtimes/registry.js';
+import type { RegisteredGroup } from '../types.js';
+import type { SubagentTask, OrchestratorResult } from './types.js';
+import { MultiAgentOrchestrator } from './orchestrator.js';
+import { UserError } from '../errors/index.js';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Test helpers ───────────────────────────────────────────────────────
+
+const makeGroup = (
+  overrides: Partial<RegisteredGroup> = {},
+): RegisteredGroup => ({
+  name: 'Test Group',
+  folder: 'test-group',
+  trigger: '@Deus',
+  added_at: '2024-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makeTask = (overrides: Partial<SubagentTask> = {}): SubagentTask => ({
+  id: 'task-1',
+  role: 'researcher',
+  goal: 'Find relevant information',
+  backstory: 'You are a thorough researcher',
+  prompt: 'Research topic X',
+  mode: 'read',
+  ...overrides,
+});
+
+const defaultSession: RuntimeSession = {
+  backend: 'claude',
+  session_id: 'test-session',
+};
+
+function createMockRuntime(
+  outputText: string = 'Done. [STATUS:DONE]',
+  runResultOverrides: Partial<RunResult> = {},
+): AgentRuntime {
+  return {
+    name: () => 'claude' as const,
+    capabilities: () =>
+      ({
+        shell: true,
+        filesystem: true,
+        web: false,
+        multimodal: false,
+        handoffs: false,
+        persistent_sessions: true,
+        tool_streaming: false,
+      }) as RuntimeCapabilities,
+    startOrResume: vi.fn(async () => defaultSession),
+    runTurn: vi.fn(
+      async (
+        _ctx: RunContext,
+        _session: RuntimeSession,
+        eventSink: RuntimeEventSink,
+      ): Promise<RunResult> => {
+        await eventSink({ type: 'output_text', text: outputText });
+        await eventSink({ type: 'turn_complete' });
+        return {
+          status: 'success',
+          result: outputText,
+          sessionRef: defaultSession,
+          ...runResultOverrides,
+        };
+      },
+    ),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function createMockRegistry(runtime: AgentRuntime): RuntimeRegistry {
+  return {
+    resolve: () => runtime,
+    register: vi.fn(),
+    get: vi.fn(() => runtime),
+    has: vi.fn(() => true),
+    list: vi.fn(() => ['claude']),
+  } as unknown as RuntimeRegistry;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('MultiAgentOrchestrator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fan-out with mock runtimes', () => {
+    it('executes parallel tasks and aggregates results', async () => {
+      const runtime = createMockRuntime('Research complete. [STATUS:DONE]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'task-a', prompt: 'Research A' }),
+        makeTask({ id: 'task-b', prompt: 'Research B' }),
+        makeTask({ id: 'task-c', prompt: 'Research C' }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      expect(result.status).toBe('success');
+      expect(result.results).toHaveLength(3);
+      expect(result.results.every((r) => r.status === 'DONE')).toBe(true);
+      // Runtime should have been called for each task
+      expect(runtime.runTurn).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('DONE_WITH_CONCERNS', () => {
+    it('collects concerns into OrchestratorResult', async () => {
+      const runtime = createMockRuntime(
+        'Output here. [STATUS:DONE_WITH_CONCERNS:perf regression;flaky test]',
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.status).toBe('success');
+      expect(result.concerns).toEqual(['perf regression', 'flaky test']);
+      expect(result.results[0].status).toBe('DONE_WITH_CONCERNS');
+      expect(result.results[0].concerns).toEqual([
+        'perf regression',
+        'flaky test',
+      ]);
+    });
+  });
+
+  describe('BLOCKED subagent', () => {
+    it('returns partial status when some tasks are blocked', async () => {
+      let callCount = 0;
+      const runtime = createMockRuntime();
+      (runtime.runTurn as ReturnType<typeof vi.fn>).mockImplementation(
+        async (
+          _ctx: RunContext,
+          _session: RuntimeSession,
+          eventSink: RuntimeEventSink,
+        ) => {
+          callCount++;
+          if (callCount === 2) {
+            await eventSink({
+              type: 'output_text',
+              text: 'Cannot proceed. [STATUS:BLOCKED:missing API key]',
+            });
+            await eventSink({ type: 'turn_complete' });
+            return { status: 'success', result: null } as RunResult;
+          }
+          await eventSink({
+            type: 'output_text',
+            text: 'Done. [STATUS:DONE]',
+          });
+          await eventSink({ type: 'turn_complete' });
+          return { status: 'success', result: null } as RunResult;
+        },
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'a', prompt: 'A' }),
+        makeTask({ id: 'b', prompt: 'B' }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      expect(result.status).toBe('partial');
+      expect(result.results[0].status).toBe('DONE');
+      expect(result.results[1].status).toBe('BLOCKED');
+    });
+  });
+
+  describe('tier-0 fails -> tier-1 blocked with dependency reason', () => {
+    it('blocks dependent tasks when dependency fails', async () => {
+      const runtime = createMockRuntime(
+        'Failed. [STATUS:BLOCKED:out of memory]',
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'fetcher', prompt: 'Fetch data' }),
+        makeTask({
+          id: 'analyzer',
+          prompt: 'Analyze data',
+          contextFrom: ['fetcher'],
+        }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      expect(result.status).toBe('error');
+      // Tier-0 task ran and returned BLOCKED
+      expect(result.results[0].status).toBe('BLOCKED');
+      expect(result.results[0].blockedReason).toBe('out of memory');
+      // Tier-1 task was never launched — BLOCKED with dependency reason
+      expect(result.results[1].status).toBe('BLOCKED');
+      expect(result.results[1].blockedReason).toBe('dependency fetcher failed');
+      // Only the tier-0 task should have been called
+      expect(runtime.runTurn).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks transitive dependents (A→B→C, A blocked → B and C blocked)', async () => {
+      const runtime = createMockRuntime(
+        'Failed. [STATUS:BLOCKED:out of memory]',
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'A', prompt: 'Step A' }),
+        makeTask({ id: 'B', prompt: 'Step B', contextFrom: ['A'] }),
+        makeTask({ id: 'C', prompt: 'Step C', contextFrom: ['B'] }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      expect(result.status).toBe('error');
+      expect(result.results[0].status).toBe('BLOCKED');
+      expect(result.results[1].status).toBe('BLOCKED');
+      expect(result.results[1].blockedReason).toBe('dependency A failed');
+      expect(result.results[2].status).toBe('BLOCKED');
+      expect(result.results[2].blockedReason).toBe('dependency B failed');
+      // Only task A should have been launched
+      expect(runtime.runTurn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('circular dependency', () => {
+    it('throws UserError for circular deps', async () => {
+      const runtime = createMockRuntime();
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'A', prompt: 'A', contextFrom: ['B'] }),
+        makeTask({ id: 'B', prompt: 'B', contextFrom: ['A'] }),
+      ];
+
+      await expect(orchestrator.dispatch(tasks, group)).rejects.toThrow(
+        UserError,
+      );
+      await expect(orchestrator.dispatch(tasks, group)).rejects.toThrow(
+        'Circular dependency in subagent tasks',
+      );
+    });
+  });
+
+  describe('mock throws -> allSettled catches -> BLOCKED', () => {
+    it('catches thrown errors and marks as BLOCKED', async () => {
+      const runtime = createMockRuntime();
+      (runtime.runTurn as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Container crashed'),
+      );
+      // startOrResume still succeeds so the failure is from runTurn
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.status).toBe('error');
+      expect(result.results[0].status).toBe('BLOCKED');
+      expect(result.results[0].blockedReason).toBe('Container crashed');
+    });
+  });
+
+  describe('status mapping', () => {
+    it('all DONE → success', async () => {
+      const runtime = createMockRuntime('OK [STATUS:DONE]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch(
+        [makeTask({ id: 'a' }), makeTask({ id: 'b' })],
+        group,
+      );
+      expect(result.status).toBe('success');
+    });
+
+    it('mixed DONE and BLOCKED → partial', async () => {
+      let callIdx = 0;
+      const runtime = createMockRuntime();
+      (runtime.runTurn as ReturnType<typeof vi.fn>).mockImplementation(
+        async (
+          _ctx: RunContext,
+          _session: RuntimeSession,
+          eventSink: RuntimeEventSink,
+        ) => {
+          callIdx++;
+          const text =
+            callIdx === 1
+              ? 'OK [STATUS:DONE]'
+              : 'Blocked [STATUS:BLOCKED:reason]';
+          await eventSink({ type: 'output_text', text });
+          await eventSink({ type: 'turn_complete' });
+          return { status: 'success', result: null } as RunResult;
+        },
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch(
+        [makeTask({ id: 'a' }), makeTask({ id: 'b' })],
+        group,
+      );
+      expect(result.status).toBe('partial');
+    });
+
+    it('all failed → error', async () => {
+      const runtime = createMockRuntime('[STATUS:BLOCKED:nope]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+      expect(result.status).toBe('error');
+    });
+  });
+
+  describe('status marker parsing', () => {
+    it('parses [STATUS:DONE] and strips it from output', async () => {
+      const runtime = createMockRuntime('The answer is 42. [STATUS:DONE]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('DONE');
+      expect(result.results[0].output).not.toContain('[STATUS:DONE]');
+      expect(result.results[0].output).toContain('The answer is 42');
+    });
+
+    it('defaults to DONE when no marker present', async () => {
+      const runtime = createMockRuntime('Just some output without markers.');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('DONE');
+      expect(result.results[0].output).toBe(
+        'Just some output without markers.',
+      );
+    });
+
+    it('parses DONE_WITH_CONCERNS and extracts concerns', async () => {
+      const runtime = createMockRuntime(
+        'Result. [STATUS:DONE_WITH_CONCERNS:memory leak;race condition]',
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('DONE_WITH_CONCERNS');
+      expect(result.results[0].concerns).toEqual([
+        'memory leak',
+        'race condition',
+      ]);
+    });
+
+    it('parses BLOCKED marker', async () => {
+      const runtime = createMockRuntime(
+        'Cannot. [STATUS:BLOCKED:missing credentials]',
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('BLOCKED');
+      expect(result.results[0].blockedReason).toBe('missing credentials');
+    });
+  });
+
+  describe('maxParallel cap', () => {
+    it('limits concurrent executions to maxParallel', async () => {
+      let concurrentCount = 0;
+      let maxConcurrent = 0;
+
+      const runtime = createMockRuntime();
+      (runtime.startOrResume as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => defaultSession,
+      );
+      (runtime.runTurn as ReturnType<typeof vi.fn>).mockImplementation(
+        async (
+          _ctx: RunContext,
+          _session: RuntimeSession,
+          eventSink: RuntimeEventSink,
+        ) => {
+          concurrentCount++;
+          maxConcurrent = Math.max(maxConcurrent, concurrentCount);
+          // Simulate async work
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          await eventSink({
+            type: 'output_text',
+            text: 'Done. [STATUS:DONE]',
+          });
+          await eventSink({ type: 'turn_complete' });
+          concurrentCount--;
+          return { status: 'success', result: null } as RunResult;
+        },
+      );
+      const registry = createMockRegistry(runtime);
+      // maxParallel = 2
+      const orchestrator = new MultiAgentOrchestrator(registry, 2);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'a' }),
+        makeTask({ id: 'b' }),
+        makeTask({ id: 'c' }),
+        makeTask({ id: 'd' }),
+        makeTask({ id: 'e' }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      expect(result.status).toBe('success');
+      expect(result.results).toHaveLength(5);
+      // Concurrency should never exceed maxParallel
+      expect(maxConcurrent).toBeLessThanOrEqual(2);
+      expect(runtime.runTurn).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('concerns propagation', () => {
+    it('tier-0 concerns appear in tier-1 prompt context', async () => {
+      let tier1Prompt = '';
+      let callIdx = 0;
+
+      const runtime = createMockRuntime();
+      (runtime.runTurn as ReturnType<typeof vi.fn>).mockImplementation(
+        async (
+          ctx: RunContext,
+          _session: RuntimeSession,
+          eventSink: RuntimeEventSink,
+        ) => {
+          callIdx++;
+          if (callIdx === 1) {
+            // Tier-0: return with concerns
+            await eventSink({
+              type: 'output_text',
+              text: 'Findings here. [STATUS:DONE_WITH_CONCERNS:data may be stale;API rate limited]',
+            });
+          } else {
+            // Tier-1: capture the prompt for verification
+            tier1Prompt = ctx.prompt;
+            await eventSink({
+              type: 'output_text',
+              text: 'Analysis done. [STATUS:DONE]',
+            });
+          }
+          await eventSink({ type: 'turn_complete' });
+          return { status: 'success', result: null } as RunResult;
+        },
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'fetcher', prompt: 'Fetch data' }),
+        makeTask({
+          id: 'analyzer',
+          prompt: 'Analyze data',
+          contextFrom: ['fetcher'],
+        }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      expect(result.status).toBe('success');
+      // Tier-1 prompt should include prior concerns
+      expect(tier1Prompt).toContain('Concerns from fetcher');
+      expect(tier1Prompt).toContain('data may be stale');
+      expect(tier1Prompt).toContain('API rate limited');
+    });
+  });
+
+  describe('runtime error status', () => {
+    it('treats RunResult status=error as BLOCKED', async () => {
+      const runtime = createMockRuntime('Some output', {
+        status: 'error',
+        error: 'Timeout',
+      });
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('BLOCKED');
+      expect(result.results[0].blockedReason).toBe('Timeout');
+    });
+  });
+});

--- a/src/multi-agent/orchestrator.ts
+++ b/src/multi-agent/orchestrator.ts
@@ -1,0 +1,286 @@
+/**
+ * Thin multi-agent orchestrator — dispatches parallel container runs for
+ * read-heavy tasks, behind `DEUS_MULTI_AGENT=1` env flag.
+ *
+ * Topologically sorts subagent tasks by their `contextFrom` dependencies,
+ * executes independent tasks in parallel (capped by `maxParallel`), and
+ * injects prior outputs into downstream prompts via prompt-templates.
+ *
+ * See docs/decisions/multi-agent-orchestration-research.md for design rationale.
+ */
+
+import type { RuntimeRegistry } from '../agent-runtimes/registry.js';
+import type {
+  AgentRuntime,
+  RuntimeEvent,
+  RuntimeEventSink,
+} from '../agent-runtimes/types.js';
+import { UserError } from '../errors/index.js';
+import { logger } from '../logger.js';
+import { buildPrompt } from './prompt-templates.js';
+import type { RegisteredGroup } from '../types.js';
+import type {
+  OrchestratorResult,
+  SubagentResult,
+  SubagentTask,
+} from './types.js';
+
+const STATUS_MARKER_RE =
+  /\[STATUS:(DONE_WITH_CONCERNS:[^\]]*|DONE|BLOCKED:[^\]]*)\]/;
+
+function parseStatusMarker(
+  rawOutput: string,
+  taskId: string,
+): Pick<SubagentResult, 'status' | 'concerns' | 'blockedReason'> & {
+  cleanOutput: string;
+} {
+  const tail = rawOutput.slice(-200);
+  const match = STATUS_MARKER_RE.exec(tail);
+
+  if (!match) {
+    logger.info(
+      { taskId },
+      'No status marker found in subagent output — defaulting to DONE',
+    );
+    return { status: 'DONE', cleanOutput: rawOutput };
+  }
+
+  const markerBody = match[1];
+  const markerStart = rawOutput.length - 200 + (match.index ?? 0);
+  const actualStart = Math.max(0, markerStart);
+  const cleanOutput = (
+    rawOutput.slice(0, actualStart) +
+    rawOutput.slice(actualStart).replace(match[0], '')
+  ).trim();
+
+  if (markerBody === 'DONE') {
+    return { status: 'DONE', cleanOutput };
+  }
+
+  if (markerBody.startsWith('DONE_WITH_CONCERNS:')) {
+    const concernsRaw = markerBody.slice('DONE_WITH_CONCERNS:'.length);
+    const concerns = concernsRaw
+      .split(';')
+      .map((c) => c.trim())
+      .filter(Boolean);
+    return { status: 'DONE_WITH_CONCERNS', concerns, cleanOutput };
+  }
+
+  if (markerBody.startsWith('BLOCKED:')) {
+    const reason = markerBody.slice('BLOCKED:'.length).trim();
+    return { status: 'BLOCKED', blockedReason: reason, cleanOutput };
+  }
+
+  // Fallback (should not reach here given the regex)
+  return { status: 'DONE', cleanOutput: rawOutput };
+}
+
+// Throws UserError on circular dependencies.
+function topologicalSort(tasks: SubagentTask[]): string[][] {
+  const taskMap = new Map<string, SubagentTask>();
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, string[]>();
+
+  for (const task of tasks) {
+    taskMap.set(task.id, task);
+    inDegree.set(task.id, 0);
+    adjacency.set(task.id, []);
+  }
+
+  for (const task of tasks) {
+    if (task.contextFrom) {
+      for (const depId of task.contextFrom) {
+        if (!taskMap.has(depId)) {
+          // Dependency references a non-existent task — treat as error
+          throw new UserError(
+            `Task "${task.id}" depends on non-existent task "${depId}"`,
+            { context: { taskId: task.id, depId } },
+          );
+        }
+        // depId → task.id edge (depId must finish before task.id)
+        adjacency.get(depId)!.push(task.id);
+        inDegree.set(task.id, (inDegree.get(task.id) ?? 0) + 1);
+      }
+    }
+  }
+
+  const tiers: string[][] = [];
+  let queue = tasks.filter((t) => inDegree.get(t.id) === 0).map((t) => t.id);
+  let processed = 0;
+
+  while (queue.length > 0) {
+    tiers.push([...queue]);
+    processed += queue.length;
+
+    const nextQueue: string[] = [];
+    for (const nodeId of queue) {
+      for (const neighbor of adjacency.get(nodeId) ?? []) {
+        const newDegree = (inDegree.get(neighbor) ?? 1) - 1;
+        inDegree.set(neighbor, newDegree);
+        if (newDegree === 0) {
+          nextQueue.push(neighbor);
+        }
+      }
+    }
+    queue = nextQueue;
+  }
+
+  if (processed < tasks.length) {
+    const remaining = tasks
+      .filter((t) => (inDegree.get(t.id) ?? 0) > 0)
+      .map((t) => t.id);
+    throw new UserError('Circular dependency in subagent tasks', {
+      context: { taskIds: remaining },
+    });
+  }
+
+  return tiers;
+}
+
+export class MultiAgentOrchestrator {
+  private registry: RuntimeRegistry;
+  private maxParallel: number;
+
+  constructor(registry: RuntimeRegistry, maxParallel: number = 3) {
+    this.registry = registry;
+    this.maxParallel = maxParallel;
+  }
+
+  async dispatch(
+    tasks: SubagentTask[],
+    group: RegisteredGroup,
+  ): Promise<OrchestratorResult> {
+    const runtime = this.registry.resolve(group);
+    const tiers = topologicalSort(tasks);
+    const taskMap = new Map(tasks.map((t) => [t.id, t]));
+    const results = new Map<string, SubagentResult>();
+    const allConcerns: string[] = [];
+
+    for (const tier of tiers) {
+      // Check for tasks whose dependencies failed/blocked — mark them BLOCKED
+      // without launching a runtime call.
+      const runnableTasks: string[] = [];
+      for (const taskId of tier) {
+        const task = taskMap.get(taskId)!;
+        const blockedDep = task.contextFrom?.find((depId) => {
+          const depResult = results.get(depId);
+          return depResult?.status === 'BLOCKED';
+        });
+
+        if (blockedDep) {
+          results.set(taskId, {
+            status: 'BLOCKED',
+            output: '',
+            blockedReason: `dependency ${blockedDep} failed`,
+          });
+        } else {
+          runnableTasks.push(taskId);
+        }
+      }
+
+      // Execute runnable tasks in batches of maxParallel
+      for (let i = 0; i < runnableTasks.length; i += this.maxParallel) {
+        const batch = runnableTasks.slice(i, i + this.maxParallel);
+        const settled = await Promise.allSettled(
+          batch.map((taskId) =>
+            this.executeTask(taskMap.get(taskId)!, group, runtime, results),
+          ),
+        );
+
+        for (let j = 0; j < batch.length; j++) {
+          const taskId = batch[j];
+          const outcome = settled[j];
+
+          if (outcome.status === 'fulfilled') {
+            results.set(taskId, outcome.value);
+            if (outcome.value.concerns?.length) {
+              allConcerns.push(...outcome.value.concerns);
+            }
+          } else {
+            // Promise rejected — treat as BLOCKED
+            results.set(taskId, {
+              status: 'BLOCKED',
+              output: '',
+              blockedReason:
+                outcome.reason instanceof Error
+                  ? outcome.reason.message
+                  : String(outcome.reason),
+            });
+          }
+        }
+      }
+    }
+
+    // Aggregate final status
+    const allResults = tasks.map((t) => results.get(t.id)!);
+    const doneCount = allResults.filter(
+      (r) => r.status === 'DONE' || r.status === 'DONE_WITH_CONCERNS',
+    ).length;
+    const blockedCount = allResults.filter(
+      (r) => r.status === 'BLOCKED',
+    ).length;
+
+    let status: OrchestratorResult['status'];
+    if (blockedCount === 0) {
+      status = 'success';
+    } else if (doneCount > 0) {
+      status = 'partial';
+    } else {
+      status = 'error';
+    }
+
+    return {
+      status,
+      results: allResults,
+      concerns: allConcerns,
+    };
+  }
+
+  private async executeTask(
+    task: SubagentTask,
+    group: RegisteredGroup,
+    runtime: AgentRuntime,
+    priorOutputs: Map<string, SubagentResult>,
+  ): Promise<SubagentResult> {
+    const prompt = buildPrompt(task, priorOutputs);
+    const runContext = {
+      prompt,
+      groupFolder: group.folder,
+      chatJid: `multi-agent-${task.id}`,
+      isControlGroup: false,
+      isScheduledTask: false,
+    };
+
+    const outputParts: string[] = [];
+
+    const eventSink: RuntimeEventSink = async (event: RuntimeEvent) => {
+      if (event.type === 'output_text') {
+        outputParts.push(event.text);
+      }
+      if (event.type === 'error') {
+        throw new Error(event.error);
+      }
+    };
+
+    const session = await runtime.startOrResume(runContext);
+    const runResult = await runtime.runTurn(runContext, session, eventSink);
+
+    const rawOutput = outputParts.join('');
+    const parsed = parseStatusMarker(rawOutput, task.id);
+
+    if (runResult.status === 'error') {
+      return {
+        status: 'BLOCKED',
+        output: rawOutput,
+        blockedReason: runResult.error ?? 'Runtime error',
+      };
+    }
+
+    return {
+      status: parsed.status,
+      output: parsed.cleanOutput,
+      concerns: parsed.concerns,
+      blockedReason: parsed.blockedReason,
+    };
+  }
+}

--- a/src/multi-agent/prompt-templates.ts
+++ b/src/multi-agent/prompt-templates.ts
@@ -1,0 +1,42 @@
+import type { SubagentTask, SubagentResult } from './types.js';
+
+export function buildPrompt(
+  task: SubagentTask,
+  priorOutputs?: Map<string, SubagentResult>,
+): string {
+  const parts: string[] = [];
+
+  parts.push(`You are a ${task.role}.`);
+  parts.push(`Your goal: ${task.goal}`);
+  if (task.backstory) {
+    parts.push(`Background: ${task.backstory}`);
+  }
+  parts.push('');
+
+  // Inject context from prior tasks
+  if (task.contextFrom && priorOutputs) {
+    for (const depId of task.contextFrom) {
+      const dep = priorOutputs.get(depId);
+      if (dep && dep.status !== 'BLOCKED') {
+        parts.push(`--- Context from ${depId} ---`);
+        parts.push(dep.output);
+        if (dep.concerns?.length) {
+          parts.push(`Concerns from ${depId}: ${dep.concerns.join('; ')}`);
+        }
+        parts.push('---');
+        parts.push('');
+      }
+    }
+  }
+
+  parts.push(task.prompt);
+  parts.push('');
+  parts.push('End your response with exactly one of these status markers:');
+  parts.push('- [STATUS:DONE] if you completed the task successfully');
+  parts.push(
+    '- [STATUS:DONE_WITH_CONCERNS:<concern1>;<concern2>] if completed but with concerns',
+  );
+  parts.push('- [STATUS:BLOCKED:<reason>] if you cannot complete the task');
+
+  return parts.join('\n');
+}

--- a/src/multi-agent/types.ts
+++ b/src/multi-agent/types.ts
@@ -1,0 +1,24 @@
+export type SubagentStatus = 'DONE' | 'DONE_WITH_CONCERNS' | 'BLOCKED';
+
+export interface SubagentResult {
+  status: SubagentStatus;
+  output: string;
+  concerns?: string[];
+  blockedReason?: string;
+}
+
+export interface OrchestratorResult {
+  status: 'success' | 'partial' | 'error';
+  results: SubagentResult[];
+  concerns: string[];
+}
+
+export interface SubagentTask {
+  id: string;
+  role: string;
+  goal: string;
+  backstory: string;
+  prompt: string;
+  mode: 'read' | 'write';
+  contextFrom?: string[];
+}


### PR DESCRIPTION
## Summary
- Adds `MultiAgentOrchestrator` that dispatches parallel container runs via `AgentRuntime.runTurn()` interface
- Topological sort (Kahn's algorithm) partitions tasks into dependency tiers — tier-0 parallel, subsequent tiers sequential with output injection
- Status marker parsing (`DONE`/`DONE_WITH_CONCERNS`/`BLOCKED`) from agent output tail
- `buildFanOutMounts`: read-only shared workspace + writable per-task sandbox with hardcoded container paths
- Gated behind `DEUS_MULTI_AGENT=1` env flag (integration point only — task detection deferred)
- ADR updated: `NEEDS_CONTEXT` folded into `BLOCKED` with dependency reason
- 21 new tests (17 orchestrator + 4 mounter)

Phase 6 of the multi-agent orchestration ADR (`docs/decisions/multi-agent-orchestration-research.md`).

## Test plan
- [x] Fan-out with mock runtimes — parallel execution + result aggregation
- [x] DONE_WITH_CONCERNS concerns collected into OrchestratorResult
- [x] BLOCKED subagent → `partial` status when others succeed
- [x] Tier-0 failure propagates BLOCKED to tier-1 dependents (including transitive)
- [x] Circular dependency throws UserError
- [x] Promise rejection caught by allSettled → mapped to BLOCKED
- [x] Status mapping: all DONE → success, mixed → partial, all failed → error
- [x] Status marker parsing: with/without marker, concerns extraction
- [x] maxParallel batching cap verified
- [x] buildFanOutMounts: read-only shared + writable sandbox, hardcoded container paths
- [x] All 991 tests pass across 60 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)