### PR TITLE
feat(tui): implement 15 UX improvements from v2 audit

### DIFF
--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -3,16 +3,60 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cassowary"
@@ -36,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,7 +121,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -73,6 +135,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -112,8 +180,10 @@ dependencies = [
 name = "deus-tui"
 version = "0.1.0"
 dependencies = [
+ "arboard",
  "crossterm",
  "dirs",
+ "image",
  "libc",
  "ratatui",
  "serde",
@@ -144,6 +214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,10 +246,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
 
 [[package]]
 name = "getrandom"
@@ -180,6 +301,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -204,6 +336,20 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
 
 [[package]]
 name = "indoc"
@@ -264,6 +410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +465,98 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -341,6 +595,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +621,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -408,8 +693,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -505,6 +803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +880,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +939,12 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -733,7 +1057,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -36,7 +36,23 @@ impl EffortPolicy {
         if words.iter().any(|w| LOW.contains(&w.as_str())) {
             return "low";
         }
-        "medium"
+        Self::configured_default()
+    }
+
+    fn configured_default() -> &'static str {
+        use std::sync::OnceLock;
+        static DEFAULT: OnceLock<&'static str> = OnceLock::new();
+        DEFAULT.get_or_init(|| {
+            if let Some(val) = config::deus::read_key("default_effort") {
+                EFFORT_LEVELS
+                    .iter()
+                    .find(|&&level| level == val)
+                    .copied()
+                    .unwrap_or("medium")
+            } else {
+                "medium"
+            }
+        })
     }
 }
 
@@ -150,6 +166,7 @@ pub struct Session {
     pub chat_messages: Vec<ChatMessage>,
     pub chat_state: ChatState,
     pub stream_rx: Option<mpsc::Receiver<backend::StreamChunk>>,
+    pub kill_tx: Option<mpsc::Sender<()>>,
     pub turn_count: u32,
     pub model: String,
     pub effort: String,
@@ -183,6 +200,7 @@ impl Session {
             )],
             chat_state: ChatState::Idle,
             stream_rx: None,
+            kill_tx: None,
             turn_count: 0,
             model,
             effort,
@@ -311,11 +329,6 @@ pub const COMMANDS: &[CommandDef] = &[
         name: "/resume",
         description: "Load recent work",
         args: &[],
-    },
-    CommandDef {
-        name: "/history",
-        description: "Past sessions",
-        args: &["today", "yesterday", "week"],
     },
     CommandDef {
         name: "/init",
@@ -512,6 +525,7 @@ impl App {
             pending_attachments: Vec::new(),
         };
         app.refresh();
+        app.load_history();
 
         if let Some(prompt) = platform::env_var("DEUS_TUI_INITIAL_PROMPT")
             && !prompt.is_empty()
@@ -520,6 +534,31 @@ impl App {
         }
 
         app
+    }
+
+    fn history_path() -> PathBuf {
+        platform::config_dir().join("tui-history.json")
+    }
+
+    fn load_history(&mut self) {
+        let path = Self::history_path();
+        if let Ok(data) = std::fs::read_to_string(&path)
+            && let Ok(items) = serde_json::from_str::<Vec<String>>(&data)
+        {
+            self.input_history = items;
+        }
+    }
+
+    pub fn save_history(&self) {
+        let path = Self::history_path();
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let skip = self.input_history.len().saturating_sub(500);
+        let items: Vec<&String> = self.input_history.iter().skip(skip).collect();
+        if let Ok(json) = serde_json::to_string(&items) {
+            let _ = std::fs::write(&path, json);
+        }
     }
 
     pub fn refresh(&mut self) {
@@ -663,7 +702,9 @@ impl App {
         };
 
         let (tx, rx) = mpsc::channel();
+        let (kill_sender, kill_receiver) = mpsc::channel::<()>();
         session.stream_rx = Some(rx);
+        session.kill_tx = Some(kill_sender);
         let config = RunConfig {
             model: session.model.clone(),
             message: msg,
@@ -687,7 +728,7 @@ impl App {
 
             match child {
                 Ok(mut process) => {
-                    let (kill_rx, cancel_tx) = if is_background {
+                    let (timeout_kill_rx, cancel_tx) = if is_background {
                         let (kill_tx, kill_rx) = mpsc::channel::<()>();
                         let (cancel_tx, cancel_rx) = mpsc::channel::<()>();
                         let timeout_secs: u64 = platform::env_var("DEUS_AGENT_TIMEOUT_SECS")
@@ -722,6 +763,10 @@ impl App {
                     if let Some(stdout) = process.stdout.take() {
                         let reader = BufReader::new(stdout);
                         for line in reader.lines() {
+                            if kill_receiver.try_recv().is_ok() {
+                                let _ = process.kill();
+                                break;
+                            }
                             match line {
                                 Ok(text) => {
                                     for chunk in be.parse_line(&text) {
@@ -744,7 +789,9 @@ impl App {
                         let _ = tx.send(());
                     }
 
-                    let timed_out = kill_rx.as_ref().is_some_and(|rx| rx.try_recv().is_ok());
+                    let timed_out = timeout_kill_rx
+                        .as_ref()
+                        .is_some_and(|rx| rx.try_recv().is_ok());
                     if timed_out {
                         let _ = process.kill();
                     }
@@ -758,7 +805,10 @@ impl App {
                     {
                         let code = s.code().unwrap_or(-1);
                         let _ = tx.send(backend::StreamChunk {
-                            kind: ChunkKind::Error(format!("Process exited with code {}", code)),
+                            kind: ChunkKind::Error(humanize_error(&format!(
+                                "Process exited with code {}",
+                                code
+                            ))),
                         });
                     }
                     let _ = tx.send(backend::StreamChunk {
@@ -767,7 +817,7 @@ impl App {
                 }
                 Err(e) => {
                     let _ = tx.send(backend::StreamChunk {
-                        kind: ChunkKind::Error(format!("Failed to launch: {}", e)),
+                        kind: ChunkKind::Error(humanize_error(&format!("Failed to launch: {}", e))),
                     });
                     let _ = tx.send(backend::StreamChunk {
                         kind: ChunkKind::Done,
@@ -841,6 +891,7 @@ impl App {
             chat_messages: Vec::new(),
             chat_state: ChatState::Idle,
             stream_rx: None,
+            kill_tx: None,
             turn_count: 0,
             model,
             effort,
@@ -901,15 +952,7 @@ impl App {
                 true
             }
             "/clear" => {
-                let session = self.active_mut();
-                session.chat_messages.clear();
-                session.turn_count = 0;
-                session.cost_usd = 0.0;
-                session.token_count = 0;
-                session.last_turn_duration = None;
-                session.last_thinking_summary = None;
-                session.active_subagent_ids.clear();
-                self.scroll_to_bottom();
+                self.handle_clear();
                 true
             }
             "/quit" => {
@@ -1036,14 +1079,7 @@ impl App {
                     .map(|c| format!("  {:16} {}", c.name, c.description))
                     .collect::<Vec<_>>()
                     .join("\n");
-                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+B  Parallel agent / session picker\n  Ctrl+Shift+B  Session picker (direct)\n  Ctrl+L  Clear screen\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history\n  PgUp/Dn Scroll chat\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
-                true
-            }
-            "/history" => {
-                self.active_mut().chat_messages.push(ChatMessage::simple(
-                    "system",
-                    "Session history browsing coming in Phase 2.",
-                ));
+                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+G  Open $EDITOR for long prompts\n  Ctrl+B  Parallel agent / session picker\n  Ctrl+Shift+B  Session picker (direct)\n  Ctrl+L  Clear chat\n  Ctrl+C  Cancel streaming / exit\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+V  Paste clipboard image\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history (persistent)\n  PgUp/Dn Scroll chat\n  Esc     Dismiss suggestions > deny permission > cancel stream > quit (2x, empty input)\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
                 true
             }
             "/permissions" => {
@@ -1095,7 +1131,22 @@ impl App {
                 }
                 true
             }
-            "/init" | "/compress" | "/checkpoint" | "/compact" | "/resume" => false,
+            "/history" => true,
+            "/init" | "/compress" | "/checkpoint" | "/compact" | "/resume" => {
+                let backend = backend::model_backend_name(&self.active().model);
+                if backend == "codex" {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        &format!(
+                            "{} requires the Claude backend. Not available on Codex.",
+                            cmd
+                        ),
+                    ));
+                    self.mark_chat_changed();
+                    return true;
+                }
+                false
+            }
             _ => false,
         }
     }
@@ -1424,6 +1475,7 @@ impl App {
                             ));
                             main.mark_chat_changed();
                         }
+                        eprint!("\x07");
                         if self.active_session == session_id {
                             self.active_session = SessionId::MAIN;
                         }
@@ -1562,6 +1614,9 @@ impl App {
         let session = self.active_mut();
         session.chat_state = ChatState::Idle;
         session.stream_rx = None;
+        if let Some(kill_tx) = session.kill_tx.take() {
+            let _ = kill_tx.send(());
+        }
         if let Some(last) = session.chat_messages.last_mut() {
             if last.role == "assistant" && last.content.is_empty() {
                 session.chat_messages.pop();
@@ -2039,10 +2094,52 @@ impl App {
         }
     }
 
+    pub fn handle_clear(&mut self) {
+        let session = self.active_mut();
+        session.chat_messages.clear();
+        session.turn_count = 0;
+        session.cost_usd = 0.0;
+        session.token_count = 0;
+        session.last_turn_duration = None;
+        session.last_thinking_summary = None;
+        session.active_subagent_ids.clear();
+        self.scroll_to_bottom();
+    }
+
     pub fn cleanup_permissions(&self) {
         if let Some(ref pb) = self.permission_bridge {
             pb.cleanup();
         }
+    }
+}
+
+fn humanize_error(raw: &str) -> String {
+    let lower = raw.to_lowercase();
+    let (msg, include_raw) = if lower.contains("no such file or directory") {
+        (
+            "Backend not found. Install with: npm i -g @anthropic-ai/claude-code",
+            true,
+        )
+    } else if lower.contains("auth")
+        || lower.contains("token expired")
+        || lower.contains("unauthorized")
+    {
+        ("Authentication expired. Run: claude login", true)
+    } else if lower.contains("rate") || lower.contains("429") || lower.contains("too many requests")
+    {
+        ("Rate limited — wait a moment and retry.", true)
+    } else if lower.contains("econnrefused")
+        || lower.contains("timeout")
+        || lower.contains("timed out")
+    {
+        ("Network error — check your connection.", true)
+    } else {
+        return raw.to_string();
+    };
+    if include_raw {
+        format!("{}\n(details: {})", msg, raw)
+    } else {
+        msg.to_string()
     }
 }
 
@@ -2850,5 +2947,29 @@ mod tests {
         app.input = "/help".to_string();
         app.send_message();
         assert!(!app.pending_attachments.is_empty());
+    }
+
+    #[test]
+    fn humanize_error_recognizes_known_patterns() {
+        let result = humanize_error("Failed to launch: No such file or directory");
+        assert!(result.starts_with("Backend not found"));
+        assert!(result.contains("details:"));
+
+        let result = humanize_error("auth token expired");
+        assert!(result.starts_with("Authentication expired"));
+
+        let result = humanize_error("429 too many requests");
+        assert!(result.starts_with("Rate limited"));
+
+        let result = humanize_error("ECONNREFUSED");
+        assert!(result.starts_with("Network error"));
+
+        let result = humanize_error("some unknown error");
+        assert_eq!(result, "some unknown error");
+    }
+
+    #[test]
+    fn history_removed_from_commands() {
+        assert!(!COMMANDS.iter().any(|c| c.name == "/history"));
     }
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -23,7 +23,7 @@ use crossterm::execute;
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::prelude::*;
 
-use app::{App, Tab};
+use app::{App, ChatMessage, Tab};
 
 fn main() -> io::Result<()> {
     if !io::stdout().is_terminal() {
@@ -130,10 +130,6 @@ fn main() -> io::Result<()> {
                                 app.always_allow_first_pending();
                                 continue;
                             }
-                            KeyCode::Esc => {
-                                app.deny_first_pending();
-                                continue;
-                            }
                             _ => {}
                         }
                     }
@@ -151,8 +147,7 @@ fn main() -> io::Result<()> {
                         if key.modifiers.contains(KeyModifiers::CONTROL) {
                             match key.code {
                                 KeyCode::Char('l') => {
-                                    app.active_mut().chat_messages.clear();
-                                    app.scroll_to_bottom();
+                                    app.handle_clear();
                                 }
                                 KeyCode::Char('u') => app.input_clear_line(),
                                 KeyCode::Char('a') => app.input_home(),
@@ -182,6 +177,40 @@ fn main() -> io::Result<()> {
                                     app.show_session_picker = true;
                                     app.picker_cursor = 0;
                                 }
+                                KeyCode::Char('g') => {
+                                    terminal::disable_raw_mode().ok();
+                                    execute!(
+                                        io::stdout(),
+                                        LeaveAlternateScreen,
+                                        DisableMouseCapture
+                                    )
+                                    .ok();
+
+                                    match platform::spawn_editor(&app.input) {
+                                        Ok(new_content) => {
+                                            app.input = new_content.trim_end().to_string();
+                                            app.input_cursor = app.input.len();
+                                        }
+                                        Err(e) => {
+                                            app.active_mut().chat_messages.push(
+                                                ChatMessage::simple(
+                                                    "system",
+                                                    &format!("Editor: {}", e),
+                                                ),
+                                            );
+                                        }
+                                    }
+
+                                    terminal::enable_raw_mode().ok();
+                                    execute!(
+                                        io::stdout(),
+                                        EnterAlternateScreen,
+                                        EnableMouseCapture,
+                                        EnableBracketedPaste
+                                    )
+                                    .ok();
+                                    terminal.clear().ok();
+                                }
                                 KeyCode::Char('v') => {
                                     app.attach_clipboard_image();
                                 }
@@ -203,18 +232,22 @@ fn main() -> io::Result<()> {
                             KeyCode::Esc => {
                                 if app.has_suggestions() {
                                     app.dismiss_suggestions();
+                                } else if app.has_pending_permission() {
+                                    app.deny_first_pending();
                                 } else if matches!(
                                     app.active().chat_state,
                                     crate::app::ChatState::Streaming
                                 ) {
                                     app.cancel_response();
-                                } else if let Some(first) = app.esc_pending {
-                                    if first.elapsed().as_millis() < 500 {
-                                        break;
+                                } else if app.input.is_empty() {
+                                    if let Some(first) = app.esc_pending {
+                                        if first.elapsed().as_millis() < 500 {
+                                            break;
+                                        }
+                                        app.esc_pending = Some(std::time::Instant::now());
+                                    } else {
+                                        app.esc_pending = Some(std::time::Instant::now());
                                     }
-                                    app.esc_pending = Some(std::time::Instant::now());
-                                } else {
-                                    app.esc_pending = Some(std::time::Instant::now());
                                 }
                             }
                             KeyCode::Tab if app.has_suggestions() => {
@@ -281,6 +314,7 @@ fn main() -> io::Result<()> {
         }
     }
 
+    app.save_history();
     app.cleanup_permissions();
     clipboard::cleanup();
 

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -483,9 +483,10 @@ fn build_input_lines(app: &App) -> (Vec<InputLine>, usize, String) {
         }
 
         text.push_str(segment);
+        let display_segment = bidi::visual_reorder(segment);
         let mut spans = vec![
             Span::styled(prefix, theme::accent_bold()),
-            Span::raw(segment.to_string()),
+            Span::raw(display_segment),
         ];
         if i == 0 && !ghost.is_empty() {
             text.push_str(&ghost);
@@ -664,11 +665,22 @@ fn render_suggestions(frame: &mut Frame, app: &App, input_area: Rect) {
         + 4;
     let popup_width = max_item_width.max(30);
 
-    let popup_area = Rect {
-        x: input_area.x + 3,
-        y: input_area.y.saturating_sub(popup_height),
-        width: popup_width.min(input_area.width.saturating_sub(4)),
-        height: popup_height,
+    let min_y = 0u16;
+    let y = input_area.y.saturating_sub(popup_height);
+    let popup_area = if y < min_y {
+        Rect {
+            x: input_area.x + 3,
+            y: input_area.bottom(),
+            width: popup_width.min(input_area.width.saturating_sub(4)),
+            height: popup_height.min(frame.area().height.saturating_sub(input_area.bottom())),
+        }
+    } else {
+        Rect {
+            x: input_area.x + 3,
+            y,
+            width: popup_width.min(input_area.width.saturating_sub(4)),
+            height: popup_height,
+        }
     };
 
     frame.render_widget(Clear, popup_area);

--- a/tui/src/platform.rs
+++ b/tui/src/platform.rs
@@ -45,6 +45,41 @@ pub fn display_path(path: &std::path::Path) -> String {
     }
 }
 
+pub fn spawn_editor(content: &str) -> Result<String, String> {
+    let editor = env_var("VISUAL")
+        .or_else(|| env_var("EDITOR"))
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "windows") {
+                "notepad".to_string()
+            } else {
+                "vim".to_string()
+            }
+        });
+
+    let tmp_dir = std::env::temp_dir();
+    let tmp_path = tmp_dir.join(format!("deus-editor-{}.txt", std::process::id()));
+
+    std::fs::write(&tmp_path, content).map_err(|e| format!("Failed to write temp file: {}", e))?;
+
+    let status = std::process::Command::new(&editor)
+        .arg(&tmp_path)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .map_err(|e| format!("Failed to launch {}: {}", editor, e))?;
+
+    if !status.success() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("Editor exited with {}", status));
+    }
+
+    let result =
+        std::fs::read_to_string(&tmp_path).map_err(|e| format!("Failed to read back: {}", e))?;
+    let _ = std::fs::remove_file(&tmp_path);
+    Ok(result)
+}
+
 pub fn is_macos() -> bool {
     cfg!(target_os = "macos")
 }

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -124,6 +124,9 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             theme::dim(),
         ));
         right.push(Span::styled("│ ", theme::muted()));
+    } else if crate::app::model_backend(&session.model) == "codex" {
+        right.push(Span::styled("cost: n/a ", theme::dim()));
+        right.push(Span::styled("│ ", theme::muted()));
     }
 
     if !app.queued_messages.is_empty() {
@@ -134,25 +137,30 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         right.push(Span::styled("│ ", theme::muted()));
     }
 
-    let elapsed_secs = app.session_start.elapsed().as_secs();
-    let window_secs: u64 = 5 * 3600;
-    let remaining_pct = if elapsed_secs >= window_secs {
-        0
-    } else {
-        (window_secs - elapsed_secs) * 100 / window_secs
-    };
-    let remaining_color = if remaining_pct > 50 {
-        theme::good_color()
-    } else if remaining_pct > 20 {
-        theme::warn_color()
-    } else {
-        theme::bad_color()
-    };
-    right.push(Span::styled(
-        format!("{}%", remaining_pct),
-        Style::default().fg(remaining_color),
-    ));
-    right.push(Span::raw(" "));
+    {
+        let ctx_total = crate::backend::model_context_tokens(&session.model);
+        let ctx_used = session.token_count as u64;
+        let pct = (ctx_used * 100)
+            .checked_div(ctx_total)
+            .unwrap_or(0)
+            .min(100) as u16;
+        let filled = (pct as usize * 10 / 100).min(10);
+        let bar: String = format!(
+            "[{}{}] {}%",
+            "|".repeat(filled),
+            ".".repeat(10 - filled),
+            pct
+        );
+        let bar_color = if pct < 50 {
+            theme::good_color()
+        } else if pct < 75 {
+            theme::warn_color()
+        } else {
+            theme::bad_color()
+        };
+        right.push(Span::styled(bar, Style::default().fg(bar_color)));
+        right.push(Span::raw(" "));
+    }
 
     // Calculate padding
     let left_len: usize = left.iter().map(|s| s.content.chars().count()).sum();
@@ -259,6 +267,7 @@ fn render_session_picker(frame: &mut Frame, app: &App, area: Rect) {
 
 fn render_permission_prompt(frame: &mut Frame, app: &App, area: Rect) {
     let session = app.active();
+    let pending_count = session.pending_permissions.len();
     let req = match session.pending_permissions.first() {
         Some(r) => r,
         None => return,
@@ -291,6 +300,23 @@ fn render_permission_prompt(frame: &mut Frame, app: &App, area: Rect) {
         ]));
     }
 
+    if pending_count > 1 {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  Queue:", theme::dim())));
+        for (i, perm) in session.pending_permissions.iter().enumerate().skip(1) {
+            let preview: String = perm.tool_input_preview.chars().take(30).collect();
+            let label = if preview.len() < perm.tool_input_preview.len() {
+                format!("{}...", preview)
+            } else {
+                preview
+            };
+            lines.push(Line::from(Span::styled(
+                format!("  [{}] {}({})", i + 1, perm.tool_name, label),
+                theme::dim(),
+            )));
+        }
+    }
+
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("  Y", theme::accent_bold()),
@@ -312,7 +338,6 @@ fn render_permission_prompt(frame: &mut Frame, app: &App, area: Rect) {
 
     frame.render_widget(Clear, popup);
 
-    let pending_count = session.pending_permissions.len();
     let title = if pending_count > 1 {
         format!(" Permission Required ({} pending) ", pending_count)
     } else {


### PR DESCRIPTION
## Summary
- **Safety-critical fixes**: Ctrl+L routes through /clear (resets all state), error messages parsed into human-readable guidance with recovery actions, Ctrl+C kills backend process (stops token consumption)
- **Consistency fixes**: BiDi visual reorder in input field, Codex backend blocks unsupported commands, Esc priority chain (suggestions > permission > stream > quit with empty input guard)
- **UX polish**: persistent input history (500 cap), context-fill progress bar `[||||...] 62%`, Ctrl+G opens $EDITOR, permission queue preview, suggestion popup anti-clip, BEL on agent completion, /history removed from autocomplete, EffortPolicy configurable fallback

## Items implemented (15/17)
| # | Item | Files |
|---|------|-------|
| 1 | Ctrl+L routes through handle_clear | main.rs, app.rs |
| 2 | humanize_error parses known patterns | app.rs |
| 3 | Kill channel stops backend on cancel | app.rs |
| 4 | BiDi visual_reorder in input display | panels/chat.rs |
| 7 | Codex blocks forwarded commands | app.rs |
| 8 | Esc priority chain with guards | main.rs |
| 9 | Persistent input history | app.rs, main.rs |
| 10 | Codex shows "cost: n/a" | ui.rs |
| 11 | Permission queue numbered list | ui.rs |
| 12 | Suggestion popup flip on clip | panels/chat.rs |
| 13 | Context-fill progress bar | ui.rs |
| 14 | Ctrl+G → $EDITOR via platform.rs | main.rs, platform.rs |
| 15 | BEL on agent completion | app.rs |
| 16 | /history removed from autocomplete | app.rs |
| 17 | EffortPolicy configurable fallback | app.rs |

**Skipped**: Item 5 (kill_ring per-session — false positive, input is global), Item 6 (clear_pending — feature doesn't exist in committed code)

## Warden verdicts
- Plan-reviewer: SHIP (after REVISE → addressed 3 blockers)
- Code-reviewer: REVISE → all 4 warnings addressed (tombstone for /history, consistent humanize_error, PID-suffixed tempfile, simplified save_history, added 2 unit tests)
- Verification-gate: CONFIRMED (131/131 tests, 0 clippy warnings)

## Test plan
- [x] `cargo build` — exit 0
- [x] `cargo test` — 131/131 pass
- [x] `cargo clippy` — 0 warnings
- [ ] Manual: `deus tui` — verify Ctrl+L confirmation, Ctrl+G editor, persistent history, context bar, error messages
- [ ] Manual: Ctrl+C during streaming — verify backend process killed
- [ ] Manual: Hebrew input — verify BiDi rendering matches post-send

🤖 Generated with [Claude Code](https://claude.com/claude-code)