### PR TITLE
fix(ci): add --no-stash to truecourse analyze in CI workflow

### DIFF
--- a/.github/workflows/truecourse.yml
+++ b/.github/workflows/truecourse.yml
@@ -88,7 +88,7 @@ jobs:
           git stash push --include-untracked -m "truecourse-config" || true
           git checkout origin/main
           git stash pop || true
-          npx truecourse analyze --no-llm
+          npx truecourse analyze --no-llm --no-stash
           # baseline now lives in .truecourse/analyses/ + LATEST.json points at it
 
       - name: Switch back to PR head + run diff
@@ -104,7 +104,7 @@ jobs:
           git stash push --include-untracked -m "truecourse-baseline" || true
           git checkout "$PR_HEAD"
           git stash pop || true
-          npx truecourse analyze --no-llm --diff | tee /tmp/diff-summary.txt
+          npx truecourse analyze --no-llm --no-stash --diff | tee /tmp/diff-summary.txt
 
       - name: Show new + resolved violations
         if: always()


### PR DESCRIPTION
## Summary
- Adds `--no-stash` flag to both `truecourse analyze` calls in the CI workflow
- Without this flag, truecourse exits with an error in non-interactive mode asking for explicit stash decision
- The workflow already handles stashing manually (lines 88-90, 104-106), so `--no-stash` is correct

This was blocking all PR merges — TrueCourse failed on every PR regardless of code changes.

## Test plan
- [x] This PR's own TrueCourse check should pass (self-validating fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)