### PR TITLE
test(router): add RouterState unit tests

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-07" # auto-bump
+last_verified: "2026-05-11" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-09" # auto-bump
+last_verified: "2026-05-11" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/router-state.test.ts
+++ b/src/router-state.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+
+import { RouterState } from './router-state.js';
+import {
+  getRouterState,
+  setRegisteredGroup,
+  getAllBackendSessions,
+  getAllRegisteredGroups,
+} from './db.js';
+
+vi.mock('./config.js', () => ({
+  GROUPS_DIR: '/tmp/test-deus-groups',
+  DATA_DIR: '/tmp/test-deus-data',
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('./db.js', () => ({
+  getRouterState: vi.fn(),
+  setRouterState: vi.fn(),
+  getAllBackendSessions: vi.fn(() => ({})),
+  getAllRegisteredGroups: vi.fn(() => ({})),
+  getAllChats: vi.fn(() => []),
+  setRegisteredGroup: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+const mockGetRouterState = vi.mocked(getRouterState);
+const mockSetRegisteredGroup = vi.mocked(setRegisteredGroup);
+const mockGetAllBackendSessions = vi.mocked(getAllBackendSessions);
+const mockGetAllRegisteredGroups = vi.mocked(getAllRegisteredGroups);
+const mockMkdirSync = vi.mocked(fs.mkdirSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetRouterState.mockReturnValue(undefined);
+  mockGetAllBackendSessions.mockReturnValue({});
+  mockGetAllRegisteredGroups.mockReturnValue({});
+});
+
+describe('RouterState', () => {
+  it('should not persist group when folder path escapes groups dir', () => {
+    const state = new RouterState();
+    state.load();
+
+    state.registerGroup('group@g.us', {
+      name: 'Escaped',
+      folder: '../../etc',
+      trigger: '@bot',
+      added_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    expect(mockSetRegisteredGroup).not.toHaveBeenCalled();
+  });
+
+  it('should reset last_agent_timestamp on corrupt JSON without throwing', () => {
+    mockGetRouterState.mockImplementation((key) => {
+      if (key === 'last_agent_timestamp') return '{bad-json{{';
+      return undefined;
+    });
+
+    const state = new RouterState();
+    expect(() => state.load()).not.toThrow();
+    expect(state.getLastAgentTimestamp('any-group')).toBe('');
+  });
+
+  it('should register group and write folder to FS', () => {
+    const state = new RouterState();
+    state.load();
+
+    const group = {
+      name: 'Test Group',
+      folder: 'testgroup',
+      trigger: '@bot',
+      added_at: '2024-01-01T00:00:00.000Z',
+    };
+
+    state.registerGroup('group@g.us', group);
+
+    expect(mockSetRegisteredGroup).toHaveBeenCalledWith('group@g.us', group);
+    expect(mockMkdirSync).toHaveBeenCalled();
+  });
+
+  it('should load and save session state correctly', () => {
+    const state = new RouterState();
+    const session = {
+      backend: 'claude' as const,
+      session_id: 'test-session-id',
+    };
+
+    state.setSession('my-group', session);
+
+    expect(state.getSession('my-group')).toEqual(session);
+    expect(state.getSession('my-group', 'claude')).toEqual(session);
+    expect(state.getSession('my-group', 'openai')).toBeUndefined();
+  });
+
+  it('should clear session without affecting other groups', () => {
+    const state = new RouterState();
+
+    state.setSession('folder-a', {
+      backend: 'claude',
+      session_id: 'session-a',
+    });
+    state.setSession('folder-b', {
+      backend: 'claude',
+      session_id: 'session-b',
+    });
+
+    state.clearSession('folder-a');
+
+    expect(state.getSession('folder-a')).toBeUndefined();
+    expect(state.getSession('folder-b')).toEqual({
+      backend: 'claude',
+      session_id: 'session-b',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 5 unit tests for RouterState class covering state management, channel tracking, session lifecycle

## Test plan
- [x] `npx vitest run src/router-state.test.ts` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)