### PR TITLE
test(router): add routeOutbound and findChannel tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "tsx": "^4.19.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.59.2",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tsx": "^4.19.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.59.2",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.5"
   },
   "lint-staged": {
     "*.ts": [

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-07" # auto-bump
+last_verified: "2026-05-11" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-09" # auto-bump
+last_verified: "2026-05-11" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/router-outbound.test.ts
+++ b/src/router-outbound.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { routeOutbound, findChannel } from './router.js';
+import type { Channel } from './types.js';
+
+function makeChannel(
+  name: string,
+  ownedJids: string[],
+  connected: boolean,
+): Channel {
+  return {
+    name,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: vi.fn(() => connected),
+    ownsJid: vi.fn((jid: string) => ownedJids.includes(jid)),
+    sendMessage: vi.fn(() => Promise.resolve()),
+  };
+}
+
+describe('routeOutbound', () => {
+  it('should throw when no connected channel matches JID', () => {
+    const channels: Channel[] = [
+      makeChannel('whatsapp', ['group-a@g.us'], true),
+    ];
+    expect(() => routeOutbound(channels, 'unknown@g.us', 'hello')).toThrow(
+      'No channel for JID: unknown@g.us',
+    );
+  });
+
+  it('should skip disconnected channels when routing outbound', () => {
+    const jid = 'group-b@g.us';
+    const channels: Channel[] = [
+      makeChannel('connected', ['group-a@g.us'], true),
+      makeChannel('disconnected', [jid], false),
+    ];
+    expect(() => routeOutbound(channels, jid, 'hello')).toThrow(
+      `No channel for JID: ${jid}`,
+    );
+  });
+
+  it('should route to the correct channel when multiple are connected', async () => {
+    const jidA = 'group-a@g.us';
+    const jidB = 'group-b@g.us';
+    const channelA = makeChannel('channelA', [jidA], true);
+    const channelB = makeChannel('channelB', [jidB], true);
+
+    await routeOutbound([channelA, channelB], jidB, 'hello');
+
+    expect(channelB.sendMessage).toHaveBeenCalledWith(jidB, 'hello');
+    expect(channelA.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('findChannel', () => {
+  it('should return the channel matching the JID prefix', () => {
+    const jid = 'group-x@g.us';
+    const match = makeChannel('telegram', [jid], true);
+    const other = makeChannel('whatsapp', ['other@g.us'], true);
+
+    const result = findChannel([other, match], jid);
+
+    expect(result).toBe(match);
+  });
+
+  it('should return undefined when no channel owns the JID', () => {
+    const channels: Channel[] = [
+      makeChannel('whatsapp', ['group-a@g.us'], true),
+    ];
+    expect(findChannel(channels, 'nobody@g.us')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 5 unit tests for routeOutbound and findChannel covering channel routing, fallback behavior

## Test plan
- [x] `npx vitest run src/router-outbound.test.ts` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)