### PR TITLE
feat(container): per-group vault partitioning

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-11" # auto-bump
+last_verified: "2026-05-11" # auto-bump (vault-partition)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-10" # auto-bump
+last_verified: "2026-05-11" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-11" # auto-bump
+last_verified: "2026-05-11" # auto-bump (vault-partition)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-05-11" # auto-bump
+last_verified: "2026-05-11" # auto-bump (vault-partition)
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/container-mounter.test.ts
+++ b/src/container-mounter.test.ts
@@ -546,7 +546,7 @@ describe('buildVolumeMounts: vault', () => {
     const vaultMount = findMount(mounts, '/workspace/vault');
     expect(vaultMount).toBeDefined();
     expect(vaultMount!.readonly).toBe(false);
-    expect(vaultMount!.hostPath).toBe(path.join(HOME_BASE, 'vault'));
+    expect(vaultMount!.hostPath).toBe(path.resolve(HOME_BASE, 'vault'));
 
     if (originalEnv !== undefined) {
       process.env.DEUS_VAULT_PATH = originalEnv;
@@ -570,18 +570,18 @@ describe('buildVolumeMounts: vault', () => {
     expect(groupMount).toBeDefined();
     expect(groupMount!.readonly).toBe(false);
     expect(groupMount!.hostPath).toBe(
-      path.join(HOME_BASE, 'vault', 'groups', 'custom-group'),
+      path.resolve(HOME_BASE, 'vault', 'groups', 'custom-group'),
     );
 
     const sharedMount = findMount(mounts, '/workspace/vault/shared');
     expect(sharedMount).toBeDefined();
     expect(sharedMount!.readonly).toBe(true);
-    expect(sharedMount!.hostPath).toBe(path.join(HOME_BASE, 'vault'));
+    expect(sharedMount!.hostPath).toBe(path.resolve(HOME_BASE, 'vault'));
 
     expect(groupMount!.readonly).not.toBe(sharedMount!.readonly);
 
     expect(mockMkdirSync).toHaveBeenCalledWith(
-      path.join(HOME_BASE, 'vault', 'groups', 'custom-group'),
+      path.resolve(HOME_BASE, 'vault', 'groups', 'custom-group'),
       { recursive: true },
     );
 

--- a/src/container-mounter.test.ts
+++ b/src/container-mounter.test.ts
@@ -37,6 +37,8 @@ vi.mock('./group-folder.js', async () => {
     resolveGroupIpcPath: vi.fn((folder: string) =>
       p.default.join(tmpBase, 'deus-data', 'ipc', folder),
     ),
+    assertValidGroupFolder: vi.fn(),
+    isValidGroupFolder: vi.fn(() => true),
   };
 });
 
@@ -531,7 +533,7 @@ describe('buildVolumeMounts: OAuth mode', () => {
 // ── Vault mount ─────────────────────────────────────────────────────────
 
 describe('buildVolumeMounts: vault', () => {
-  it('mounts vault when DEUS_VAULT_PATH env var is set and path exists', () => {
+  it('control group gets full rw vault mount', () => {
     const originalEnv = process.env.DEUS_VAULT_PATH;
     process.env.DEUS_VAULT_PATH = path.join(HOME_BASE, 'vault');
     mockExistsSync.mockImplementation((p) => {
@@ -539,13 +541,50 @@ describe('buildVolumeMounts: vault', () => {
       return false;
     });
 
-    const group = makeGroup();
-    const mounts = buildVolumeMounts(group, false);
+    const group = makeGroup({ isControlGroup: true });
+    const mounts = buildVolumeMounts(group, true);
     const vaultMount = findMount(mounts, '/workspace/vault');
     expect(vaultMount).toBeDefined();
     expect(vaultMount!.readonly).toBe(false);
+    expect(vaultMount!.hostPath).toBe(path.join(HOME_BASE, 'vault'));
 
-    // Cleanup
+    if (originalEnv !== undefined) {
+      process.env.DEUS_VAULT_PATH = originalEnv;
+    } else {
+      delete process.env.DEUS_VAULT_PATH;
+    }
+  });
+
+  it('non-control group gets per-group rw + shared ro vault mounts', () => {
+    const originalEnv = process.env.DEUS_VAULT_PATH;
+    process.env.DEUS_VAULT_PATH = path.join(HOME_BASE, 'vault');
+    mockExistsSync.mockImplementation((p) => {
+      if (String(p).includes('vault')) return true;
+      return false;
+    });
+
+    const group = makeGroup({ folder: 'custom-group' });
+    const mounts = buildVolumeMounts(group, false);
+
+    const groupMount = findMount(mounts, '/workspace/vault/group');
+    expect(groupMount).toBeDefined();
+    expect(groupMount!.readonly).toBe(false);
+    expect(groupMount!.hostPath).toBe(
+      path.join(HOME_BASE, 'vault', 'groups', 'custom-group'),
+    );
+
+    const sharedMount = findMount(mounts, '/workspace/vault/shared');
+    expect(sharedMount).toBeDefined();
+    expect(sharedMount!.readonly).toBe(true);
+    expect(sharedMount!.hostPath).toBe(path.join(HOME_BASE, 'vault'));
+
+    expect(groupMount!.readonly).not.toBe(sharedMount!.readonly);
+
+    expect(mockMkdirSync).toHaveBeenCalledWith(
+      path.join(HOME_BASE, 'vault', 'groups', 'custom-group'),
+      { recursive: true },
+    );
+
     if (originalEnv !== undefined) {
       process.env.DEUS_VAULT_PATH = originalEnv;
     } else {
@@ -560,11 +599,10 @@ describe('buildVolumeMounts: vault', () => {
 
     const group = makeGroup();
     const mounts = buildVolumeMounts(group, false);
-    const vaultMount = findMount(mounts, '/workspace/vault');
-    expect(vaultMount).toBeDefined();
-    // Should expand ~ to HOME_DIR
-    expect(vaultMount!.hostPath).toContain(HOME_BASE);
-    expect(vaultMount!.hostPath).toContain('my-vault');
+    const groupMount = findMount(mounts, '/workspace/vault/group');
+    expect(groupMount).toBeDefined();
+    expect(groupMount!.hostPath).toContain(HOME_BASE);
+    expect(groupMount!.hostPath).toContain('my-vault');
 
     if (originalEnv !== undefined) {
       process.env.DEUS_VAULT_PATH = originalEnv;
@@ -588,8 +626,8 @@ describe('buildVolumeMounts: vault', () => {
 
     const group = makeGroup();
     const mounts = buildVolumeMounts(group, false);
-    const vaultMount = findMount(mounts, '/workspace/vault');
-    expect(vaultMount).toBeDefined();
+    const groupMount = findMount(mounts, '/workspace/vault/group');
+    expect(groupMount).toBeDefined();
 
     if (originalEnv !== undefined) {
       process.env.DEUS_VAULT_PATH = originalEnv;

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -15,7 +15,11 @@ import os from 'os';
 import path from 'path';
 
 import { DATA_DIR, GROUPS_DIR, HOME_DIR, CONFIG_DIR } from './config.js';
-import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import {
+  resolveGroupFolderPath,
+  resolveGroupIpcPath,
+  assertValidGroupFolder,
+} from './group-folder.js';
 import { logger } from './logger.js';
 import { getProjectById } from './db.js';
 import { detectAuthMode } from './credential-proxy.js';
@@ -337,21 +341,44 @@ export function buildVolumeMounts(
     readonly: true,
   });
 
-  // Auto-mount the memory vault if configured.
-  // The vault stores session logs, atoms, and checkpoints — agents need read-write
-  // access for /compress, /resume, and /preserve skills.
-  // Mounted at /workspace/vault/ (standard path referenced by container skills).
+  // Vault mount: control group gets full rw at /workspace/vault; non-control
+  // groups get a private rw subdir + shared ro root (skills use /workspace/vault/).
   const vaultPath = resolveVaultPath();
   if (vaultPath && fs.existsSync(vaultPath)) {
-    mounts.push({
-      hostPath: vaultPath,
-      containerPath: '/workspace/vault',
-      readonly: false,
-    });
-    logger.info(
-      { group: group.name, vaultPath },
-      'Vault mounted at /workspace/vault',
-    );
+    if (isControlGroup) {
+      mounts.push({
+        hostPath: vaultPath,
+        containerPath: '/workspace/vault',
+        readonly: false,
+      });
+      logger.info(
+        { group: group.name, vaultPath },
+        'Vault mounted at /workspace/vault (control, rw)',
+      );
+    } else {
+      assertValidGroupFolder(group.folder);
+      const groupVaultDir = path.join(vaultPath, 'groups', group.folder);
+      // Defence-in-depth: assertValidGroupFolder blocks traversal, verify after join
+      const rel = path.relative(vaultPath, groupVaultDir);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`Vault group path escapes base: ${groupVaultDir}`);
+      }
+      fs.mkdirSync(groupVaultDir, { recursive: true });
+      mounts.push({
+        hostPath: groupVaultDir,
+        containerPath: '/workspace/vault/group',
+        readonly: false,
+      });
+      mounts.push({
+        hostPath: vaultPath,
+        containerPath: '/workspace/vault/shared',
+        readonly: true,
+      });
+      logger.info(
+        { group: group.name, vaultPath, groupVaultDir },
+        'Vault mounted: group rw + shared ro',
+      );
+    }
   }
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)


### PR DESCRIPTION
## Summary
- Non-control groups get an isolated rw vault subdir at `/workspace/vault/group/` and a shared ro mount at `/workspace/vault/shared/`
- Control group retains full rw access at `/workspace/vault/` for backward compat
- Includes path-traversal guard via `assertValidGroupFolder` + defence-in-depth `ensureWithinBase` check

## Test plan
- [x] Control group vault mount test (rw at `/workspace/vault`)
- [x] Non-control group mount test (rw group + ro shared, `mkdirSync` called)
- [x] `~` expansion test updated for new mount paths
- [x] Config file fallback test updated
- [x] All 35 container-mounter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)