### PR TITLE
feat(tui): add Ctrl+R reverse history search

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -418,6 +418,11 @@ pub struct App {
     pub auto_compact_threshold: f64,
     pub pending_attachments: Vec<crate::clipboard::Attachment>,
     pub clear_pending: bool,
+
+    pub reverse_search_mode: bool,
+    pub reverse_search_query: String,
+    pub reverse_search_match_index: usize,
+    pub reverse_search_saved_input: String,
 }
 
 // StreamChunk and parsing delegated to backend trait — see backend/mod.rs
@@ -466,6 +471,26 @@ impl App {
     /// within the 500 ms double-tap window.
     pub fn esc_pending_active(&self) -> bool {
         matches!(self.esc_pending, Some(t) if t.elapsed().as_millis() < 500)
+    }
+
+    pub fn find_reverse_match(&self) -> Option<&str> {
+        let query = &self.reverse_search_query;
+        if query.is_empty() {
+            return None;
+        }
+        self.input_history
+            .iter()
+            .rev()
+            .filter(|entry| entry.contains(query.as_str()))
+            .nth(self.reverse_search_match_index)
+            .map(|s| s.as_str())
+    }
+
+    pub fn exit_reverse_search(&mut self) {
+        self.reverse_search_mode = false;
+        self.reverse_search_query.clear();
+        self.reverse_search_match_index = 0;
+        self.reverse_search_saved_input.clear();
     }
 
     /// Non-Chat panel order used for Tab / Shift+Tab cycling.
@@ -575,6 +600,11 @@ impl App {
                 .unwrap_or(0.75),
             pending_attachments: Vec::new(),
             clear_pending: false,
+
+            reverse_search_mode: false,
+            reverse_search_query: String::new(),
+            reverse_search_match_index: 0,
+            reverse_search_saved_input: String::new(),
         };
         app.refresh();
         app.load_history();
@@ -1143,7 +1173,7 @@ impl App {
                     .map(|c| format!("  {:16} {}", c.name, c.description))
                     .collect::<Vec<_>>()
                     .join("\n");
-                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+G  Open $EDITOR for long prompts\n  Ctrl+B  Parallel agent / session picker\n  Ctrl+Shift+B  Session picker (direct)\n  Ctrl+L  Clear chat\n  Ctrl+C  Cancel streaming / exit\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+V  Paste clipboard image\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history (persistent)\n  PgUp/Dn Scroll chat\n  Esc     Dismiss suggestions > deny permission > cancel stream > quit (2x, empty input)\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
+                self.active_mut().chat_messages.push(ChatMessage::simple("system", &format!("Available commands:\n\n{}\n\nKeyboard shortcuts:\n  Ctrl+G  Open $EDITOR for long prompts\n  Ctrl+B  Parallel agent / session picker\n  Ctrl+Shift+B  Session picker (direct)\n  Ctrl+L  Clear chat\n  Ctrl+C  Cancel streaming / exit\n  Ctrl+U  Clear input line\n  Ctrl+K  Kill to end of line\n  Ctrl+Y  Yank (paste killed text)\n  Ctrl+A  Start of line\n  Ctrl+E  End of line\n  Ctrl+J  New line (multi-line input)\n  Ctrl+O  Toggle tool/thinking details\n  Ctrl+V  Paste clipboard image\n  Ctrl+R  Reverse history search\n  Ctrl+D  Exit\n  Alt+B   Word left\n  Alt+F   Word right\n  ↑/↓     Input history (persistent)\n  PgUp/Dn Scroll chat\n  Esc     Dismiss suggestions > deny permission > cancel stream > quit (2x, empty input)\n  Mouse   Scroll chat (Shift+drag to select text)", help)));
                 true
             }
             "/history" => {
@@ -3090,5 +3120,33 @@ mod tests {
         let cmd = COMMANDS.iter().find(|c| c.name == "/copy").unwrap();
         assert_eq!(cmd.description, "Copy code block");
         assert!(cmd.args.is_empty());
+    }
+
+    #[test]
+    fn find_reverse_match_returns_matching_entries() {
+        let mut app = App::new();
+        app.input_history = vec![
+            "hello world".to_string(),
+            "cargo build".to_string(),
+            "cargo test".to_string(),
+            "git status".to_string(),
+        ];
+
+        app.reverse_search_query = "cargo".to_string();
+        app.reverse_search_match_index = 0;
+        assert_eq!(app.find_reverse_match(), Some("cargo test"));
+
+        app.reverse_search_match_index = 1;
+        assert_eq!(app.find_reverse_match(), Some("cargo build"));
+
+        app.reverse_search_match_index = 2;
+        assert_eq!(app.find_reverse_match(), None);
+
+        app.reverse_search_query = "nonexistent".to_string();
+        app.reverse_search_match_index = 0;
+        assert_eq!(app.find_reverse_match(), None);
+
+        app.reverse_search_query.clear();
+        assert_eq!(app.find_reverse_match(), None);
     }
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -123,6 +123,65 @@ fn main() -> io::Result<()> {
                         continue;
                     }
 
+                    if app.reverse_search_mode {
+                        let mut consumed = true;
+                        match key.code {
+                            KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                app.reverse_search_match_index += 1;
+                                if app.find_reverse_match().is_none() {
+                                    app.reverse_search_match_index =
+                                        app.reverse_search_match_index.saturating_sub(1);
+                                }
+                                if let Some(m) = app.find_reverse_match() {
+                                    app.input = m.to_string();
+                                    app.input_cursor = app.input.len();
+                                }
+                            }
+                            KeyCode::Enter => {
+                                if let Some(m) = app.find_reverse_match() {
+                                    app.input = m.to_string();
+                                    app.input_cursor = app.input.len();
+                                }
+                                app.exit_reverse_search();
+                            }
+                            KeyCode::Esc => {
+                                app.input = app.reverse_search_saved_input.clone();
+                                app.input_cursor = app.input.len();
+                                app.exit_reverse_search();
+                            }
+                            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                app.reverse_search_query.push(c);
+                                app.reverse_search_match_index = 0;
+                                if let Some(m) = app.find_reverse_match() {
+                                    app.input = m.to_string();
+                                    app.input_cursor = app.input.len();
+                                }
+                            }
+                            KeyCode::Backspace => {
+                                app.reverse_search_query.pop();
+                                app.reverse_search_match_index = 0;
+                                if let Some(m) = app.find_reverse_match() {
+                                    app.input = m.to_string();
+                                    app.input_cursor = app.input.len();
+                                } else if app.reverse_search_query.is_empty() {
+                                    app.input = app.reverse_search_saved_input.clone();
+                                    app.input_cursor = app.input.len();
+                                }
+                            }
+                            _ => {
+                                if let Some(m) = app.find_reverse_match() {
+                                    app.input = m.to_string();
+                                    app.input_cursor = app.input.len();
+                                }
+                                app.exit_reverse_search();
+                                consumed = false;
+                            }
+                        }
+                        if consumed {
+                            continue;
+                        }
+                    }
+
                     if app.tab == Tab::Chat && app.has_pending_permission() && app.input.is_empty()
                     {
                         match key.code {
@@ -221,6 +280,17 @@ fn main() -> io::Result<()> {
                                 }
                                 KeyCode::Char('v') => {
                                     app.attach_clipboard_image();
+                                }
+                                KeyCode::Char('r')
+                                    if !matches!(
+                                        app.active().chat_state,
+                                        crate::app::ChatState::Streaming
+                                    ) =>
+                                {
+                                    app.reverse_search_mode = true;
+                                    app.reverse_search_query.clear();
+                                    app.reverse_search_match_index = 0;
+                                    app.reverse_search_saved_input = app.input.clone();
                                 }
                                 KeyCode::Char('j') => app.input_newline(),
                                 _ => {}

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -128,13 +128,15 @@ fn main() -> io::Result<()> {
                         match key.code {
                             KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                                 app.reverse_search_match_index += 1;
-                                if app.find_reverse_match().is_none() {
-                                    app.reverse_search_match_index =
-                                        app.reverse_search_match_index.saturating_sub(1);
-                                }
-                                if let Some(m) = app.find_reverse_match() {
-                                    app.input = m.to_string();
-                                    app.input_cursor = app.input.len();
+                                match app.find_reverse_match() {
+                                    Some(m) => {
+                                        app.input = m.to_string();
+                                        app.input_cursor = app.input.len();
+                                    }
+                                    None => {
+                                        app.reverse_search_match_index =
+                                            app.reverse_search_match_index.saturating_sub(1);
+                                    }
                                 }
                             }
                             KeyCode::Enter => {

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -716,6 +716,33 @@ fn input_cursor_position(app: &App, area: Rect, scroll: u16) -> (u16, u16) {
 }
 
 fn render_input(frame: &mut Frame, app: &App, area: Rect) {
+    if app.reverse_search_mode {
+        let cwd = platform::display_path(&platform::current_dir());
+        let title = format!(" {} ", cwd);
+
+        let found = app.find_reverse_match().map(|s| s.to_string());
+
+        let line = Line::from(vec![
+            Span::styled("(reverse-i-search) '", theme::dim()),
+            Span::styled(app.reverse_search_query.clone(), theme::accent()),
+            Span::styled("': ", theme::dim()),
+            match &found {
+                Some(text) => Span::raw(text.clone()),
+                None => Span::styled("no match", theme::dim()),
+            },
+        ]);
+
+        let input = Paragraph::new(line).block(
+            Block::default()
+                .borders(Borders::TOP)
+                .title(title)
+                .title_style(theme::dim())
+                .border_style(theme::accent()),
+        );
+        frame.render_widget(input, area);
+        return;
+    }
+
     let content_width = area.width.max(1) as usize;
     let (lines, cursor_line, cursor_text) = build_input_lines(app, content_width);
 


### PR DESCRIPTION
## Summary
- Add bash-style reverse incremental history search via Ctrl+R
- Display `(reverse-i-search) 'query': matched_entry` in input area
- Ctrl+R cycles matches, Enter accepts, Esc cancels and restores input
- Reuses existing persistent input history (500 items)
- Part of 10-phase TUI UX overhaul (Phase 8)

## Test plan
- [x] `cargo build` compiles
- [x] `cargo test` — all 133 tests pass (1 new: find_reverse_match ordering)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual test: type history entries, Ctrl+R, verify search/accept/cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)