### PR TITLE
feat(tui): add per-token syntax highlighting in code blocks

### DIFF
--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +48,30 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -188,6 +221,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "syntect",
  "unicode-bidi",
  "unicode-width 0.1.14",
 ]
@@ -252,6 +286,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +320,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -560,6 +611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +742,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +795,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -860,6 +943,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1036,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1072,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -14,6 +14,7 @@ unicode-bidi = "0.3"
 unicode-width = "0.1"
 arboard = "3"
 image = { version = "0.25", default-features = false, features = ["png"] }
+syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "regex-fancy"] }
 
 [profile.release]
 opt-level = "z"

--- a/tui/src/highlight.rs
+++ b/tui/src/highlight.rs
@@ -1,0 +1,65 @@
+use std::sync::OnceLock;
+
+use ratatui::prelude::*;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Theme, ThemeSet};
+use syntect::parsing::SyntaxSet;
+
+static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
+static THEME: OnceLock<Theme> = OnceLock::new();
+
+fn ss() -> &'static SyntaxSet {
+    SYNTAX_SET.get_or_init(SyntaxSet::load_defaults_newlines)
+}
+
+fn theme() -> &'static Theme {
+    THEME.get_or_init(|| {
+        let ts = ThemeSet::load_defaults();
+        ts.themes["base16-ocean.dark"].clone()
+    })
+}
+
+pub fn highlight_line(text: &str, lang: &str) -> Option<Vec<Span<'static>>> {
+    let syntax = ss().find_syntax_by_token(lang)?;
+    let mut h = HighlightLines::new(syntax, theme());
+    let regions = h.highlight_line(text, ss()).ok()?;
+    let spans = regions
+        .into_iter()
+        .map(|(style, text)| {
+            let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+            Span::styled(text.to_string(), Style::default().fg(fg))
+        })
+        .collect();
+    Some(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_fn_produces_multiple_spans() {
+        let spans = highlight_line("fn main() {}", "rust");
+        assert!(spans.is_some());
+        let spans = spans.unwrap();
+        assert!(
+            spans.len() > 1,
+            "expected multiple spans, got {}",
+            spans.len()
+        );
+    }
+
+    #[test]
+    fn unknown_lang_returns_none() {
+        let result = highlight_line("some text", "madeuplanguage9999");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn python_keyword_highlighted() {
+        let spans = highlight_line("def hello():", "python");
+        assert!(spans.is_some());
+        let spans = spans.unwrap();
+        assert!(spans.len() > 1);
+    }
+}

--- a/tui/src/highlight.rs
+++ b/tui/src/highlight.rs
@@ -19,18 +19,34 @@ fn theme() -> &'static Theme {
     })
 }
 
-pub fn highlight_line(text: &str, lang: &str) -> Option<Vec<Span<'static>>> {
-    let syntax = ss().find_syntax_by_token(lang)?;
-    let mut h = HighlightLines::new(syntax, theme());
-    let regions = h.highlight_line(text, ss()).ok()?;
-    let spans = regions
-        .into_iter()
-        .map(|(style, text)| {
-            let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
-            Span::styled(text.to_string(), Style::default().fg(fg))
+pub struct BlockHighlighter<'a> {
+    inner: HighlightLines<'a>,
+}
+
+impl<'a> BlockHighlighter<'a> {
+    pub fn new(lang: &str) -> Option<Self> {
+        let syntax = ss().find_syntax_by_token(lang)?;
+        Some(Self {
+            inner: HighlightLines::new(syntax, theme()),
         })
-        .collect();
-    Some(spans)
+    }
+
+    pub fn highlight_line(&mut self, text: &str) -> Option<Vec<Span<'static>>> {
+        let regions = self.inner.highlight_line(text, ss()).ok()?;
+        let spans = regions
+            .into_iter()
+            .map(|(style, text)| {
+                let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+                Span::styled(text.to_string(), Style::default().fg(fg))
+            })
+            .collect();
+        Some(spans)
+    }
+}
+
+#[cfg(test)]
+fn highlight_line(text: &str, lang: &str) -> Option<Vec<Span<'static>>> {
+    BlockHighlighter::new(lang)?.highlight_line(text)
 }
 
 #[cfg(test)]

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -3,6 +3,7 @@ mod backend;
 mod bidi;
 mod clipboard;
 mod config;
+mod highlight;
 mod logo;
 mod notify;
 mod panels;

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -288,7 +288,7 @@ fn render_markdown_text(
 ) {
     let mut in_code = false;
     let mut in_diff = false;
-    let mut current_lang: Option<String> = None;
+    let mut highlighter: Option<crate::highlight::BlockHighlighter> = None;
     for line in text.lines() {
         let was_in_code = in_code || in_diff;
         let (mut rendered, new_code, new_diff) = render_markdown_line(line, in_code, in_diff);
@@ -300,10 +300,12 @@ fn render_markdown_text(
 
         if !was_in_code && in_code {
             *current_block = Some(String::new());
-            current_lang = extract_lang(line);
+            // diff blocks have their own coloring, skip syntax highlighting
+            highlighter =
+                extract_lang(line).and_then(|l| crate::highlight::BlockHighlighter::new(&l));
         } else if was_in_code && in_code {
-            if let Some(ref lang) = current_lang
-                && let Some(spans) = crate::highlight::highlight_line(line, lang)
+            if let Some(ref mut h) = highlighter
+                && let Some(spans) = h.highlight_line(line)
             {
                 let mut highlighted = vec![Span::styled("  │ ", theme::muted())];
                 highlighted.extend(spans);
@@ -316,7 +318,7 @@ fn render_markdown_text(
                 buf.push_str(line);
             }
         } else if code_closed {
-            current_lang = None;
+            highlighter = None;
             if let Some(buf) = current_block.take() {
                 code_blocks.push(buf);
                 let n = code_blocks.len();
@@ -343,21 +345,6 @@ fn build_message_lines(app: &App) -> (Vec<Line<'static>>, Vec<String>) {
     for (msg_idx, msg) in session.chat_messages.iter().enumerate() {
         if msg.role == "system" && msg.content.starts_with("Welcome to Deus") {
             render_welcome(&mut lines);
-            continue;
-        }
-
-        if msg.role == "system" && msg.content.starts_with("\u{203B} recap: ") {
-            let summary = &msg.content["\u{203B} recap: ".len()..];
-            lines.push(Line::from(vec![
-                Span::styled("  \u{203B} ", theme::muted()),
-                Span::styled("recap: ", theme::muted()),
-                Span::styled(
-                    summary.to_string(),
-                    Style::default()
-                        .fg(theme::text_dim_color())
-                        .add_modifier(Modifier::ITALIC),
-                ),
-            ]));
             continue;
         }
 

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -271,6 +271,15 @@ fn highlight_verdict(line: &str) -> Line<'static> {
     ])
 }
 
+fn extract_lang(fence_line: &str) -> Option<String> {
+    let lang = fence_line.trim_start_matches('`').trim();
+    if lang.is_empty() || lang == "diff" {
+        None
+    } else {
+        Some(lang.to_string())
+    }
+}
+
 fn render_markdown_text(
     text: &str,
     lines: &mut Vec<Line<'static>>,
@@ -279,6 +288,7 @@ fn render_markdown_text(
 ) {
     let mut in_code = false;
     let mut in_diff = false;
+    let mut current_lang: Option<String> = None;
     for line in text.lines() {
         let was_in_code = in_code || in_diff;
         let (mut rendered, new_code, new_diff) = render_markdown_line(line, in_code, in_diff);
@@ -290,7 +300,15 @@ fn render_markdown_text(
 
         if !was_in_code && in_code {
             *current_block = Some(String::new());
+            current_lang = extract_lang(line);
         } else if was_in_code && in_code {
+            if let Some(ref lang) = current_lang
+                && let Some(spans) = crate::highlight::highlight_line(line, lang)
+            {
+                let mut highlighted = vec![Span::styled("  │ ", theme::muted())];
+                highlighted.extend(spans);
+                rendered = Line::from(highlighted);
+            }
             if let Some(buf) = current_block.as_mut() {
                 if !buf.is_empty() {
                     buf.push('\n');
@@ -298,6 +316,7 @@ fn render_markdown_text(
                 buf.push_str(line);
             }
         } else if code_closed {
+            current_lang = None;
             if let Some(buf) = current_block.take() {
                 code_blocks.push(buf);
                 let n = code_blocks.len();
@@ -324,6 +343,21 @@ fn build_message_lines(app: &App) -> (Vec<Line<'static>>, Vec<String>) {
     for (msg_idx, msg) in session.chat_messages.iter().enumerate() {
         if msg.role == "system" && msg.content.starts_with("Welcome to Deus") {
             render_welcome(&mut lines);
+            continue;
+        }
+
+        if msg.role == "system" && msg.content.starts_with("\u{203B} recap: ") {
+            let summary = &msg.content["\u{203B} recap: ".len()..];
+            lines.push(Line::from(vec![
+                Span::styled("  \u{203B} ", theme::muted()),
+                Span::styled("recap: ", theme::muted()),
+                Span::styled(
+                    summary.to_string(),
+                    Style::default()
+                        .fg(theme::text_dim_color())
+                        .add_modifier(Modifier::ITALIC),
+                ),
+            ]));
             continue;
         }
 
@@ -1006,5 +1040,39 @@ mod tests {
         render_markdown_text(text, &mut lines, &mut code_blocks, &mut current_block);
 
         assert!(code_blocks.is_empty());
+    }
+
+    #[test]
+    fn rust_code_block_uses_syntax_highlighting() {
+        let text = "```rust\nfn main() {}\n```";
+        let mut lines = Vec::new();
+        let mut code_blocks = Vec::new();
+        let mut current_block = None;
+        render_markdown_text(text, &mut lines, &mut code_blocks, &mut current_block);
+
+        let code_line = &lines[1];
+        assert!(
+            code_line.spans.len() > 1,
+            "expected multiple spans from syntax highlighting, got {}",
+            code_line.spans.len()
+        );
+        let prefix: String = code_line.spans[0].content.to_string();
+        assert_eq!(prefix, "  │ ");
+    }
+
+    #[test]
+    fn unknown_lang_code_block_falls_back_to_single_style() {
+        let text = "```madeuplang9999\nsome code here\n```";
+        let mut lines = Vec::new();
+        let mut code_blocks = Vec::new();
+        let mut current_block = None;
+        render_markdown_text(text, &mut lines, &mut code_blocks, &mut current_block);
+
+        let code_line = &lines[1];
+        assert_eq!(
+            code_line.spans.len(),
+            1,
+            "unknown language should fall back to single-span rendering"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add syntect-based syntax highlighting for code blocks with language tags
- Uses base16-ocean.dark theme, lazy-loaded SyntaxSet/Theme via OnceLock
- Falls back to single-color `theme::code()` for unknown languages
- Diff blocks unaffected (handled by separate renderer)
- Part of 10-phase TUI UX overhaul (Phase 1)

## Test plan
- [x] `cargo build` compiles (syntect adds ~2MB to binary)
- [x] `cargo test` — 145 tests pass (5 new: 3 in highlight.rs, 2 in chat.rs)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Visual verification: Rust/Python code blocks show colored keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)