### PR TITLE
feat(tui): add /rewind command to rewind conversation

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -369,6 +369,11 @@ pub const COMMANDS: &[CommandDef] = &[
         args: &[],
     },
     CommandDef {
+        name: "/rewind",
+        description: "Rewind to message",
+        args: &[],
+    },
+    CommandDef {
         name: "/clear",
         description: "Clear chat",
         args: &[],
@@ -434,6 +439,10 @@ pub struct App {
     pub recap_session: Option<SessionId>,
     pub auto_recap: bool,
     pub last_notification: Instant,
+
+    pub show_rewind_picker: bool,
+    pub rewind_cursor: usize,
+    pub rewind_targets: Vec<usize>,
 }
 
 // StreamChunk and parsing delegated to backend trait — see backend/mod.rs
@@ -626,6 +635,10 @@ impl App {
                 .map(|v| v != "false")
                 .unwrap_or(true),
             last_notification: Instant::now(),
+
+            show_rewind_picker: false,
+            rewind_cursor: 0,
+            rewind_targets: Vec::new(),
         };
         app.refresh();
         app.load_history();
@@ -1296,6 +1309,36 @@ impl App {
                     }
                 }
                 self.mark_chat_changed();
+                true
+            }
+            "/rewind" => {
+                if matches!(self.active().chat_state, ChatState::Streaming) {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        "Cannot rewind while streaming. Cancel first with Ctrl+C.",
+                    ));
+                    self.mark_chat_changed();
+                    return true;
+                }
+                let targets: Vec<usize> = self
+                    .active()
+                    .chat_messages
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, m)| m.role == "user")
+                    .map(|(i, _)| i)
+                    .collect();
+                if targets.is_empty() {
+                    self.active_mut().chat_messages.push(ChatMessage::simple(
+                        "system",
+                        "No user messages to rewind to.",
+                    ));
+                    self.mark_chat_changed();
+                    return true;
+                }
+                self.rewind_targets = targets;
+                self.rewind_cursor = 0;
+                self.show_rewind_picker = true;
                 true
             }
             "/init" | "/compress" | "/checkpoint" | "/compact" | "/resume" => {
@@ -2287,6 +2330,51 @@ impl App {
                 self.show_session_picker = false;
             }
         }
+    }
+
+    pub(crate) fn rewind_next(&mut self) {
+        if self.rewind_cursor + 1 < self.rewind_targets.len() {
+            self.rewind_cursor += 1;
+        }
+    }
+
+    pub(crate) fn rewind_prev(&mut self) {
+        if self.rewind_cursor > 0 {
+            self.rewind_cursor -= 1;
+        }
+    }
+
+    pub(crate) fn rewind_select(&mut self) {
+        let Some(&msg_idx) = self.rewind_targets.get(self.rewind_cursor) else {
+            return;
+        };
+        self.cancel_response();
+        let session = self.active_mut();
+        let preview: String = session
+            .chat_messages
+            .get(msg_idx)
+            .map(|m| {
+                let s: String = m.content.chars().take(80).collect();
+                if m.content.len() > 80 {
+                    format!("{}...", s)
+                } else {
+                    s
+                }
+            })
+            .unwrap_or_default();
+        session.chat_messages.truncate(msg_idx + 1);
+        session.turn_count = 0;
+        session.run_mode = backend::RunMode::Normal { session_id: None };
+        session.chat_messages.push(ChatMessage::simple(
+            "system",
+            &format!(
+                "Rewound to: {}. Next message starts a fresh session.",
+                preview
+            ),
+        ));
+        session.mark_chat_changed();
+        self.show_rewind_picker = false;
+        self.rewind_targets.clear();
     }
 
     pub fn background_session_count(&self) -> usize {
@@ -3358,5 +3446,79 @@ mod tests {
 
         let session = app.active();
         assert!(!session.context_alert_shown);
+    }
+
+    #[test]
+    fn rewind_truncates_to_selected_message() {
+        let mut app = App::new();
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("user", "first question"));
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "first answer"));
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("user", "second question"));
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "second answer"));
+        app.active_mut().turn_count = 2;
+
+        app.handle_command("/rewind");
+        assert!(app.show_rewind_picker);
+        assert_eq!(app.rewind_targets.len(), 2);
+        assert_eq!(app.rewind_targets[0], 1);
+        assert_eq!(app.rewind_targets[1], 3);
+
+        app.rewind_cursor = 0;
+        app.rewind_select();
+
+        assert!(!app.show_rewind_picker);
+        let msgs = &app.active().chat_messages;
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0].role, "system");
+        assert!(msgs[0].content.contains("Welcome"));
+        assert_eq!(msgs[1].role, "user");
+        assert_eq!(msgs[1].content, "first question");
+        assert_eq!(msgs[2].role, "system");
+        assert!(msgs[2].content.contains("Rewound to"));
+        assert_eq!(app.active().turn_count, 0);
+    }
+
+    #[test]
+    fn rewind_blocked_while_streaming() {
+        let mut app = App::new();
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("user", "hello"));
+        app.active_mut().chat_state = ChatState::Streaming;
+
+        app.handle_command("/rewind");
+        assert!(!app.show_rewind_picker);
+        let last = app.active().chat_messages.last().unwrap();
+        assert!(last.content.contains("Cannot rewind while streaming"));
+    }
+
+    #[test]
+    fn rewind_resets_session_run_mode() {
+        let mut app = App::new();
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("user", "test message"));
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "response"));
+        app.active_mut().run_mode = backend::RunMode::Normal {
+            session_id: Some("sess-123".to_string()),
+        };
+
+        app.handle_command("/rewind");
+        app.rewind_select();
+
+        assert_eq!(
+            app.active().run_mode,
+            backend::RunMode::Normal { session_id: None }
+        );
     }
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -127,6 +127,20 @@ fn main() -> io::Result<()> {
                         continue;
                     }
 
+                    if app.show_rewind_picker {
+                        match key.code {
+                            KeyCode::Esc => {
+                                app.show_rewind_picker = false;
+                                app.rewind_targets.clear();
+                            }
+                            KeyCode::Up | KeyCode::Char('k') => app.rewind_prev(),
+                            KeyCode::Down | KeyCode::Char('j') => app.rewind_next(),
+                            KeyCode::Enter => app.rewind_select(),
+                            _ => {}
+                        }
+                        continue;
+                    }
+
                     if app.reverse_search_mode {
                         let mut consumed = true;
                         match key.code {

--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -39,6 +39,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.show_session_picker {
         render_session_picker(frame, app, area);
     }
+
+    if app.show_rewind_picker {
+        render_rewind_picker(frame, app, area);
+    }
 }
 
 fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
@@ -263,6 +267,52 @@ fn render_session_picker(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Sessions — ↑↓ enter d:dismiss esc ")
+        .border_style(theme::accent());
+    let picker = Paragraph::new(lines).block(block);
+    frame.render_widget(picker, popup);
+}
+
+fn render_rewind_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let target_count = app.rewind_targets.len();
+    let height = (target_count as u16 + 4).min(area.height.saturating_sub(4));
+    let width = 70u16.min(area.width.saturating_sub(4));
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let popup = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, popup);
+
+    let session = app.active();
+    let inner_width = width.saturating_sub(4) as usize;
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, &msg_idx) in app.rewind_targets.iter().enumerate() {
+        let is_selected = i == app.rewind_cursor;
+        let msg = match session.chat_messages.get(msg_idx) {
+            Some(m) => m,
+            None => continue,
+        };
+        let preview: String = msg
+            .content
+            .chars()
+            .take(inner_width.saturating_sub(4))
+            .map(|c| if c == '\n' { ' ' } else { c })
+            .collect();
+
+        let style = if is_selected {
+            Style::default().bg(theme::accent_color()).fg(Color::Black)
+        } else {
+            Style::default()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(if is_selected { "> " } else { "  " }, style),
+            Span::styled(preview, style),
+        ]));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Rewind — ↑↓ enter esc ")
         .border_style(theme::accent());
     let picker = Paragraph::new(lines).block(block);
     frame.render_widget(picker, popup);


### PR DESCRIPTION
## Summary
- Adds `/rewind` command with a picker overlay showing past user messages
- Selecting a message truncates conversation to that point, resets session state for a fresh start
- Streaming guard prevents rewind during active responses
- 3 unit tests covering truncation, streaming guard, and run_mode reset

## Test plan
- [ ] `/rewind` shows picker with user messages listed
- [ ] Selecting a message keeps it + system "Rewound to" message, removes everything after
- [ ] `/rewind` during streaming shows "Cannot rewind" error
- [ ] Esc dismisses picker without changes
- [ ] `cargo test` passes (148 tests)
- [ ] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)