### PR TITLE
feat(tui): add Ctrl+F search in output

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -452,6 +452,11 @@ pub struct App {
 
     pub file_suggestions: Vec<FileSuggestion>,
     pub file_at_position: Option<usize>,
+
+    pub output_search_mode: bool,
+    pub output_search_query: String,
+    pub output_search_matches: Vec<(usize, usize)>,
+    pub output_search_current: usize,
 }
 
 // StreamChunk and parsing delegated to backend trait — see backend/mod.rs
@@ -520,6 +525,66 @@ impl App {
         self.reverse_search_query.clear();
         self.reverse_search_match_index = 0;
         self.reverse_search_saved_input.clear();
+    }
+
+    pub fn enter_output_search(&mut self) {
+        if self.reverse_search_mode {
+            self.exit_reverse_search();
+        }
+        self.output_search_mode = true;
+        self.output_search_query.clear();
+        self.output_search_matches.clear();
+        self.output_search_current = 0;
+    }
+
+    pub fn exit_output_search(&mut self) {
+        self.output_search_mode = false;
+        self.output_search_query.clear();
+        self.output_search_matches.clear();
+        self.output_search_current = 0;
+        self.mark_chat_changed();
+    }
+
+    pub fn update_output_search(&mut self) {
+        self.output_search_matches.clear();
+        self.output_search_current = 0;
+        let query = self.output_search_query.to_lowercase();
+        if query.is_empty() {
+            return;
+        }
+        let mut matches: Vec<(usize, usize)> = Vec::new();
+        for (msg_idx, msg) in self.active().chat_messages.iter().enumerate() {
+            let text_content: String = msg
+                .blocks
+                .iter()
+                .filter_map(|b| match b {
+                    MessageBlock::Text(t) => Some(t.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let lower = text_content.to_lowercase();
+            for (offset, _) in lower.match_indices(&query) {
+                matches.push((msg_idx, offset));
+            }
+        }
+        self.output_search_matches = matches;
+    }
+
+    pub fn next_search_match(&mut self) {
+        if !self.output_search_matches.is_empty() {
+            self.output_search_current =
+                (self.output_search_current + 1) % self.output_search_matches.len();
+            self.mark_chat_changed();
+        }
+    }
+
+    pub fn prev_search_match(&mut self) {
+        if !self.output_search_matches.is_empty() {
+            let total = self.output_search_matches.len();
+            self.output_search_current = (self.output_search_current + total - 1) % total;
+            self.mark_chat_changed();
+        }
     }
 
     /// Non-Chat panel order used for Tab / Shift+Tab cycling.
@@ -651,6 +716,11 @@ impl App {
 
             file_suggestions: Vec::new(),
             file_at_position: None,
+
+            output_search_mode: false,
+            output_search_query: String::new(),
+            output_search_matches: Vec::new(),
+            output_search_current: 0,
         };
         app.refresh();
         app.load_history();
@@ -3711,5 +3781,48 @@ mod tests {
         app.input_cursor = 6;
         app.update_suggestions();
         assert!(app.file_suggestions.is_empty());
+    }
+
+    #[test]
+    fn output_search_finds_matches() {
+        let mut app = App::new();
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("user", "hello world"));
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("assistant", "Hello back"));
+        app.output_search_query = "hello".to_string();
+        app.update_output_search();
+        assert_eq!(app.output_search_matches.len(), 2);
+    }
+
+    #[test]
+    fn output_search_n_wraps() {
+        let mut app = App::new();
+        app.active_mut()
+            .chat_messages
+            .push(ChatMessage::simple("user", "test test"));
+        app.output_search_query = "test".to_string();
+        app.update_output_search();
+        assert_eq!(app.output_search_matches.len(), 2);
+        assert_eq!(app.output_search_current, 0);
+        app.next_search_match();
+        assert_eq!(app.output_search_current, 1);
+        app.next_search_match();
+        assert_eq!(app.output_search_current, 0);
+    }
+
+    #[test]
+    fn output_search_mutual_exclusion() {
+        let mut app = App::new();
+        app.reverse_search_mode = true;
+        app.reverse_search_query = "old query".to_string();
+        app.enter_output_search();
+        assert!(!app.reverse_search_mode);
+        assert!(app.reverse_search_query.is_empty());
+        assert!(app.output_search_mode);
+        app.exit_output_search();
+        assert!(!app.output_search_mode);
     }
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -141,6 +141,31 @@ fn main() -> io::Result<()> {
                         continue;
                     }
 
+                    if app.output_search_mode {
+                        match key.code {
+                            KeyCode::Esc => app.exit_output_search(),
+                            KeyCode::Char('n')
+                                if !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                            {
+                                app.next_search_match();
+                            }
+                            KeyCode::Char('N') => app.prev_search_match(),
+                            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                app.output_search_query.push(c);
+                                app.update_output_search();
+                                app.mark_chat_changed();
+                            }
+                            KeyCode::Backspace => {
+                                app.output_search_query.pop();
+                                app.update_output_search();
+                                app.mark_chat_changed();
+                            }
+                            KeyCode::Enter => app.exit_output_search(),
+                            _ => {}
+                        }
+                        continue;
+                    }
+
                     if app.reverse_search_mode {
                         let mut consumed = true;
                         match key.code {
@@ -307,10 +332,16 @@ fn main() -> io::Result<()> {
                                         crate::app::ChatState::Streaming
                                     ) =>
                                 {
+                                    if app.output_search_mode {
+                                        app.exit_output_search();
+                                    }
                                     app.reverse_search_mode = true;
                                     app.reverse_search_query.clear();
                                     app.reverse_search_match_index = 0;
                                     app.reverse_search_saved_input = app.input.clone();
+                                }
+                                KeyCode::Char('f') => {
+                                    app.enter_output_search();
                                 }
                                 KeyCode::Char('j') => app.input_newline(),
                                 _ => {}

--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -517,21 +517,68 @@ fn build_message_lines(app: &App) -> (Vec<Line<'static>>, Vec<String>) {
     (lines, code_blocks)
 }
 
+fn highlight_search_matches(lines: Vec<Line<'static>>, query: &str) -> Vec<Line<'static>> {
+    let query_lower = query.to_lowercase();
+    lines
+        .into_iter()
+        .map(|line| {
+            let full_text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+            let lower = full_text.to_lowercase();
+            if !lower.contains(&query_lower) {
+                return line;
+            }
+            let mut result_spans: Vec<Span<'static>> = Vec::new();
+            let mut pos = 0usize;
+            for (match_start, matched) in lower.match_indices(&query_lower) {
+                let match_end = match_start + matched.len();
+                if match_start > pos {
+                    let end = match_start.min(full_text.len());
+                    result_spans.push(Span::raw(full_text[pos..end].to_string()));
+                }
+                let ft_end = match_end.min(full_text.len());
+                if match_start < full_text.len() {
+                    result_spans.push(Span::styled(
+                        full_text[match_start..ft_end].to_string(),
+                        Style::default()
+                            .bg(Color::Yellow)
+                            .fg(Color::Black)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                }
+                pos = ft_end;
+            }
+            if pos < full_text.len() {
+                result_spans.push(Span::raw(full_text[pos..].to_string()));
+            }
+            Line::from(result_spans)
+        })
+        .collect()
+}
+
 fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
     let session = app.active();
     let is_streaming = matches!(session.chat_state, crate::app::ChatState::Streaming);
 
-    let mut lines = LINE_CACHE.with(|cache| {
-        let mut cached = cache.borrow_mut();
-        if cached.0 != app.active_session || cached.1 != session.chat_version {
-            let (built_lines, blocks) = build_message_lines(app);
-            cached.2 = built_lines;
-            cached.3 = blocks;
-            cached.0 = app.active_session;
-            cached.1 = session.chat_version;
+    let mut lines = if app.output_search_mode {
+        let (built_lines, _) = build_message_lines(app);
+        if !app.output_search_query.is_empty() {
+            highlight_search_matches(built_lines, &app.output_search_query)
+        } else {
+            built_lines
         }
-        cached.2.clone()
-    });
+    } else {
+        LINE_CACHE.with(|cache| {
+            let mut cached = cache.borrow_mut();
+            if cached.0 != app.active_session || cached.1 != session.chat_version {
+                let (built_lines, blocks) = build_message_lines(app);
+                cached.2 = built_lines;
+                cached.3 = blocks;
+                cached.0 = app.active_session;
+                cached.1 = session.chat_version;
+            }
+            cached.2.clone()
+        })
+    };
 
     if is_streaming {
         let has_text = session
@@ -660,6 +707,35 @@ fn render_messages(frame: &mut Frame, app: &App, area: Rect) {
         let perm_widget = Paragraph::new(perm_lines).wrap(Wrap { trim: false });
         frame.render_widget(Clear, perm_area);
         frame.render_widget(perm_widget, perm_area);
+    }
+
+    if app.output_search_mode {
+        let match_info = if app.output_search_matches.is_empty() {
+            if app.output_search_query.is_empty() {
+                String::new()
+            } else {
+                " (no matches)".to_string()
+            }
+        } else {
+            format!(
+                " ({}/{})",
+                app.output_search_current + 1,
+                app.output_search_matches.len()
+            )
+        };
+        let bar = Line::from(vec![
+            Span::styled(" Search: ", theme::accent()),
+            Span::raw(app.output_search_query.clone()),
+            Span::styled(match_info, theme::dim()),
+        ]);
+        let bar_area = Rect {
+            x: area.x,
+            y: area.y + area.height.saturating_sub(1),
+            width: area.width,
+            height: 1,
+        };
+        frame.render_widget(Clear, bar_area);
+        frame.render_widget(Paragraph::new(bar), bar_area);
     }
 }
 


### PR DESCRIPTION
## Summary
- Ctrl+F enters search mode with case-insensitive substring matching
- Matches highlighted in yellow with bold, n/N to navigate (wraps around)
- Search bar overlay shows query and match count
- Scans only MessageBlock::Text blocks (skips ToolUse/SubagentBlock metadata)
- Mutually exclusive with Ctrl+R reverse history search
- Cache bypassed during search for live highlighting

## Test plan
- [ ] Ctrl+F opens search bar, typing highlights matches in yellow
- [ ] n/N navigates between matches (wraps)
- [ ] Esc exits search, restores normal rendering
- [ ] Ctrl+F while Ctrl+R active exits reverse search first
- [ ] `cargo test` passes (162 tests)
- [ ] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)