### PR TITLE
fix(tui): resolve clippy collapsible_if lint

### DIFF
--- a/tui/src/panels/chat.rs
+++ b/tui/src/panels/chat.rs
@@ -460,12 +460,12 @@ fn render_markdown_text(
             }
         } else if code_closed {
             highlighter = None;
-            if let Some(buf) = current_block.take() {
+            let buf = current_block.take();
+            if let Some(buf) = buf {
                 code_blocks.push(buf);
-                let n = code_blocks.len();
                 rendered = Line::from(vec![
                     Span::styled("  ───", theme::muted()),
-                    Span::styled(format!(" [{}]", n), theme::muted()),
+                    Span::styled(format!(" [{}]", code_blocks.len()), theme::muted()),
                 ]);
             }
         }


### PR DESCRIPTION
## Summary
- Fixes clippy `collapsible_if` lint in the markdown parser's code block closing logic
- Splits `if let` binding to satisfy the lint while preserving unconditional `highlighter = None` reset

## Test plan
- [x] `cargo clippy -- -D warnings` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)