### PR TITLE
feat(memory): add EmbedMode task prefix infrastructure

### DIFF
--- a/docs/decisions/benchmark-regression-gate.md
+++ b/docs/decisions/benchmark-regression-gate.md
@@ -49,6 +49,7 @@ During the investigation, six retrieval improvement levers were smoke-tested and
 | Approach | Result | Why it failed |
 |----------|--------|---------------|
 | Task prefixes (embeddinggemma) | Rankings degraded in 3/3 queries | Prefixed queries live in different vector subspace than non-prefixed documents |
+| Symmetric task prefixes (embeddinggemma) | recall -0.133 (0.743→0.610), abstain +0.318 | Re-embedded both sides (QUERY+DOCUMENT). Model becomes more conservative: better abstain but worse fuzzy recall. Vocab-mismatch -0.265, ambiguous -0.500. Infrastructure kept behind DEUS_EMBED_PREFIX=0 (2026-05-13) |
 | Body-text enrichment for vault nodes | Scores dropped in 4/5 queries | Longer input dilutes the description signal for embeddinggemma |
 | nomic-embed-text model swap | 69.3% vs 78.9% embeddinggemma | Worse on this specific short-description corpus |
 | bge-m3 model swap | Broke 1 hit, recovered 0 misses | Lexical matching on short descriptions |

--- a/evolution/providers/embeddings.py
+++ b/evolution/providers/embeddings.py
@@ -21,8 +21,21 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from abc import ABC, abstractmethod
+from enum import Enum
 
 from ..config import EMBED_DIM, EMBED_MODELS, load_api_key
+
+
+class EmbedMode(Enum):
+    QUERY = "query"
+    DOCUMENT = "document"
+    RAW = "raw"
+
+
+QUERY_PREFIX = "task: search result | query: "
+DOCUMENT_PREFIX = "title: none | text: "
+
+_PREFIXES_ENABLED = os.environ.get("DEUS_EMBED_PREFIX", "0") == "1"
 
 logger = logging.getLogger(__name__)
 
@@ -38,12 +51,18 @@ OLLAMA_EMBED_BATCH_MAX = int(os.environ.get("OLLAMA_EMBED_BATCH_MAX", "32"))
 
 class EmbeddingProvider(ABC):
     @abstractmethod
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str, mode: EmbedMode = EmbedMode.RAW) -> list[float]:
         """Embed a single text string. Returns a vector of EMBED_DIM floats."""
 
-    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+    def embed_batch(self, texts: list[str], mode: EmbedMode = EmbedMode.RAW) -> list[list[float]]:
         """Embed multiple texts. Default: sequential calls to embed()."""
-        return [self.embed(t) for t in texts]
+        return [self.embed(t, mode=mode) for t in texts]
+
+
+_GEMINI_TASK_MAP = {
+    EmbedMode.QUERY: "RETRIEVAL_QUERY",
+    EmbedMode.DOCUMENT: "RETRIEVAL_DOCUMENT",
+}
 
 
 class GeminiEmbeddingProvider(EmbeddingProvider):
@@ -51,15 +70,18 @@ class GeminiEmbeddingProvider(EmbeddingProvider):
         from google import genai
         self._client = genai.Client(api_key=load_api_key())
 
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str, mode: EmbedMode = EmbedMode.RAW) -> list[float]:
         from google.genai import types as genai_types
+        config_kwargs: dict = {"output_dimensionality": EMBED_DIM}
+        if _PREFIXES_ENABLED and mode in _GEMINI_TASK_MAP:
+            config_kwargs["task_type"] = _GEMINI_TASK_MAP[mode]
         last_exc = None
         for model in EMBED_MODELS:
             try:
                 result = self._client.models.embed_content(
                     model=model,
                     contents=text,
-                    config=genai_types.EmbedContentConfig(output_dimensionality=EMBED_DIM),
+                    config=genai_types.EmbedContentConfig(**config_kwargs),
                 )
                 return result.embeddings[0].values
             except Exception as exc:
@@ -160,10 +182,17 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
             return vec + [0.0] * (EMBED_DIM - len(vec))
         return vec
 
-    def embed(self, text: str) -> list[float]:
-        return self.embed_batch([text])[0]
+    @staticmethod
+    def _apply_prefix(texts: list[str], mode: EmbedMode) -> list[str]:
+        if not _PREFIXES_ENABLED or mode == EmbedMode.RAW:
+            return texts
+        prefix = QUERY_PREFIX if mode == EmbedMode.QUERY else DOCUMENT_PREFIX
+        return [prefix + t for t in texts]
 
-    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, text: str, mode: EmbedMode = EmbedMode.RAW) -> list[float]:
+        return self.embed_batch([text], mode=mode)[0]
+
+    def embed_batch(self, texts: list[str], mode: EmbedMode = EmbedMode.RAW) -> list[list[float]]:
         """Batch-embed in a single HTTP call, chunked by OLLAMA_EMBED_BATCH_MAX.
 
         Each sub-batch retries independently on socket timeout with exponential
@@ -172,6 +201,7 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
         if not texts:
             return []
 
+        texts = self._apply_prefix(texts, mode)
         out: list[list[float]] = []
         for start in range(0, len(texts), OLLAMA_EMBED_BATCH_MAX):
             chunk = texts[start : start + OLLAMA_EMBED_BATCH_MAX]
@@ -252,19 +282,19 @@ def get_embedding_provider() -> EmbeddingProvider:
     return _provider
 
 
-def embed(text: str) -> list[float]:
+def embed(text: str, mode: EmbedMode = EmbedMode.RAW) -> list[float]:
     """Convenience: embed a single text using the configured provider."""
-    return get_embedding_provider().embed(text)
+    return get_embedding_provider().embed(text, mode=mode)
 
 
-def embed_batch(texts: list[str]) -> list[list[float]]:
+def embed_batch(texts: list[str], mode: EmbedMode = EmbedMode.RAW) -> list[list[float]]:
     """Convenience: batch-embed a list of texts using the configured provider.
 
     Falls through to the provider's `embed_batch`, which is natively batched for
     Ollama (single HTTP call per sub-batch) and sequential for Gemini (the Gemini
     SDK doesn't expose a matching batch primitive at the dim we use).
     """
-    return get_embedding_provider().embed_batch(texts)
+    return get_embedding_provider().embed_batch(texts, mode=mode)
 
 
 def warmup_embedding_provider() -> None:

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-11" # auto-bump
+last_verified: "2026-05-13" # auto-bump
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-11" # auto-bump
+last_verified: "2026-05-13" # auto-bump
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-11" # auto-bump (vault-partition)
+last_verified: "2026-05-13" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-11" # auto-bump
+last_verified: "2026-05-13" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-13" # auto-bump
+last_verified: "2026-05-13T02" # auto-bump
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-11" # auto-bump (vault-partition)
+last_verified: "2026-05-13" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -133,14 +133,29 @@ def load_api_key() -> str:
         sys.exit(1)
 
 
-def embed(text: str) -> list[float]:
+_EmbedMode = None
+
+
+def _embed_mode():
+    global _EmbedMode
+    if _EmbedMode is None:
+        from evolution.providers.embeddings import EmbedMode
+        _EmbedMode = EmbedMode
+    return _EmbedMode
+
+
+def embed(text: str, mode=None) -> list[float]:
     from evolution.providers.embeddings import embed as _provider_embed
-    return _provider_embed(text)
+    if mode is None:
+        mode = _embed_mode().RAW
+    return _provider_embed(text, mode=mode)
 
 
-def embed_batch(texts: list[str]) -> list[list[float]]:
+def embed_batch(texts: list[str], mode=None) -> list[list[float]]:
     from evolution.providers.embeddings import embed_batch as _provider_embed_batch
-    return _provider_embed_batch(texts)
+    if mode is None:
+        mode = _embed_mode().RAW
+    return _provider_embed_batch(texts, mode=mode)
 
 
 def serialize(vec: list[float]) -> bytes:
@@ -571,9 +586,10 @@ def _write_chunks_batched(
     if not flat:
         return 0
 
+    _EM = _embed_mode()
     texts = [ch["chunk"] for _, ch in flat]
     try:
-        vecs = embed_batch(texts)
+        vecs = embed_batch(texts, mode=_EM.DOCUMENT)
     except Exception as exc:
         # If the provider doesn't support true batching (or it failed),
         # fall back to sequential embeds so the caller still makes progress.
@@ -581,7 +597,7 @@ def _write_chunks_batched(
             f"  WARN: batch embed failed ({exc}); falling back to sequential",
             file=sys.stderr,
         )
-        vecs = [embed(t) for t in texts]
+        vecs = [embed(t, mode=_EM.DOCUMENT) for t in texts]
 
     indexed = 0
     for (path, chunk), vec in zip(flat, vecs):
@@ -1117,7 +1133,7 @@ def cmd_query(query: str, top: int = 3, recency_boost: bool = False,
     # Exhaustive mode: widen the search
     effective_top = 20 if resolved_intent == "exhaustive" else top
 
-    q_vec = embed(query)
+    q_vec = embed(query, mode=_embed_mode().QUERY)
 
     # Build query with optional --as-of filter
     where_clauses = [
@@ -2728,7 +2744,7 @@ def reenrich_embeddings(db: sqlite3.Connection) -> dict:
     for i, (entry_id, chunk, source_chunk) in enumerate(rows):
         enriched_input = _enriched_embedding_input(chunk, source_chunk)
         try:
-            vec = embed(enriched_input)
+            vec = embed(enriched_input, mode=_embed_mode().DOCUMENT)
             db.execute("DELETE FROM embeddings WHERE rowid = ?", (entry_id,))
             db.execute(
                 "INSERT INTO embeddings(rowid, embedding) VALUES (?, ?)",
@@ -2856,7 +2872,7 @@ def cmd_extract(session_path: str, no_contradict: bool = False):
 
         # 2. Embedding similarity check
         try:
-            vec = embed(atom["text"])
+            vec = embed(atom["text"], mode=_embed_mode().DOCUMENT)
         except Exception as e:
             print(f"  WARN: embed failed, skipping atom: {e}", file=sys.stderr)
             continue
@@ -3019,7 +3035,7 @@ def cmd_rebuild():
                 ).fetchone()
                 if existing:
                     continue
-                vec = embed(body)
+                vec = embed(body, mode=_embed_mode().DOCUMENT)
                 conf = float(fm.get("confidence", 0.5))
                 corr = int(fm.get("corroborations", 1))
                 date_str = fm.get("created_at", "")

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -106,7 +106,7 @@ def _atom_fallback(query: str, k: int) -> str | None:
             mi_db.close()
             return None
 
-        q_vec = mi.embed(query)
+        q_vec = mi.embed(query, mode=mi._embed_mode().QUERY)
         rows = mi_db.execute(
             """SELECT e.tldr, v.distance
                FROM embeddings v JOIN entries e ON e.id = v.rowid

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -259,16 +259,32 @@ def cosine(u: list[float], v: list[float]) -> float:
     return sum(a * b for a, b in zip(u, v)) / (du * dv)
 
 
-def embed_text(text: str) -> list[float]:
+def embed_text(text: str, mode=None) -> list[float]:
     """Embed via the evolution provider. Monkey-patched in tests."""
-    from evolution.providers.embeddings import embed as _embed
-    return _embed(text)
+    from evolution.providers.embeddings import EmbedMode, embed as _embed
+    if mode is None:
+        mode = EmbedMode.RAW
+    return _embed(text, mode=mode)
 
 
-def embed_batch_text(texts: list[str]) -> list[list[float]]:
+def embed_batch_text(texts: list[str], mode=None) -> list[list[float]]:
     """Batch embed via the evolution provider. Monkey-patched in tests."""
-    from evolution.providers.embeddings import embed_batch as _embed_batch
-    return _embed_batch(texts)
+    from evolution.providers.embeddings import EmbedMode, embed_batch as _embed_batch
+    if mode is None:
+        mode = EmbedMode.RAW
+    return _embed_batch(texts, mode=mode)
+
+
+# Avoids evolution import at module load for test isolation.
+_EmbedMode = None
+
+
+def _get_embed_mode():
+    global _EmbedMode
+    if _EmbedMode is None:
+        from evolution.providers.embeddings import EmbedMode
+        _EmbedMode = EmbedMode
+    return _EmbedMode
 
 
 # ── Approach-angle helpers ──────────────────────────────────────────────────
@@ -986,7 +1002,7 @@ def build_tree(
         vec = None
         if need_embed and not skip_embed:
             try:
-                vec = embed_text(description)
+                vec = embed_text(description, mode=_get_embed_mode().DOCUMENT)
                 counts["embedded"] += 1
             except Exception as exc:
                 print(f"WARN: embed failed for {entry['path']}: {exc}", file=sys.stderr)
@@ -1094,7 +1110,7 @@ def reembed_file(vault: Path, rel_path: str, db: sqlite3.Connection) -> str:
     if old_hash == ch:
         return "unchanged"
     try:
-        vec = embed_text(embed_src)
+        vec = embed_text(embed_src, mode=_get_embed_mode().DOCUMENT)
     except Exception as exc:
         print(f"ERROR: embed failed: {exc}", file=sys.stderr)
         return "embed_failed"
@@ -1153,7 +1169,7 @@ def discover_node(vault: Path, rel_path: str, db: sqlite3.Connection) -> str:
     if existing is not None:
         return "already_tracked"
     try:
-        vec = embed_text(desc)
+        vec = embed_text(desc, mode=_get_embed_mode().DOCUMENT)
     except Exception as exc:
         print(f"ERROR: embed failed: {exc}", file=sys.stderr)
         return "embed_failed"
@@ -1218,7 +1234,7 @@ def retrieve(
 
     Returns {results: [{id, path, score, route}], confidence, fell_back, trace}.
     """
-    qv = query_vec if query_vec is not None else embed_text(query)
+    qv = query_vec if query_vec is not None else embed_text(query, mode=_get_embed_mode().QUERY)
 
     # Phase 1: flat cosine over all active nodes.
     all_nodes = db.execute(
@@ -1817,7 +1833,7 @@ def reindex_external(
         vec = None
         if need_embed and not skip_embed:
             try:
-                vec = embed_text(embed_src)
+                vec = embed_text(embed_src, mode=_get_embed_mode().DOCUMENT)
                 counts["embedded"] += 1
             except Exception as exc:
                 print(f"WARN: embed failed for {ns_path}: {exc}", file=sys.stderr)
@@ -2105,18 +2121,21 @@ def calibrate_sweep(
     import itertools
 
     # Pre-cache query embeddings so Ollama isn't called per-combo.
-    _cache: dict[str, list[float]] = {}
+    _qmode = _get_embed_mode().QUERY
+    _cache: dict[tuple, list[float]] = {}
     for item in dataset:
         q = item["query"]
-        if q not in _cache:
-            _cache[q] = embed_text(q)
+        key = (q, _qmode)
+        if key not in _cache:
+            _cache[key] = embed_text(q, mode=_qmode)
 
     _orig_embed = embed_text
 
-    def _cached_embed(text: str) -> list[float]:
-        if text in _cache:
-            return _cache[text]
-        return _orig_embed(text)
+    def _cached_embed(text: str, mode=None) -> list[float]:
+        key = (text, mode)
+        if key in _cache:
+            return _cache[key]
+        return _orig_embed(text, mode=mode)
 
     import memory_tree as _self
     _self.embed_text = _cached_embed
@@ -2701,7 +2720,7 @@ def backfill_approach_angles(
 
         if len(pending_embeds) >= batch_size:
             texts = [pe[2] for pe in pending_embeds]
-            vecs = embed_batch_text(texts)
+            vecs = embed_batch_text(texts, mode=_get_embed_mode().DOCUMENT)
             now = _utc_iso()
             for (pe_nid, pe_idx, pe_q, pe_hash), vec in zip(pending_embeds, vecs):
                 db.execute(
@@ -2715,7 +2734,7 @@ def backfill_approach_angles(
 
     if pending_embeds:
         texts = [pe[2] for pe in pending_embeds]
-        vecs = embed_batch_text(texts)
+        vecs = embed_batch_text(texts, mode=_get_embed_mode().DOCUMENT)
         now = _utc_iso()
         for (pe_nid, pe_idx, pe_q, pe_hash), vec in zip(pending_embeds, vecs):
             db.execute(

--- a/scripts/tests/test_embedding_provider.py
+++ b/scripts/tests/test_embedding_provider.py
@@ -93,6 +93,79 @@ class TestDefaults:
                 assert isinstance(provider, GeminiEmbeddingProvider)
 
 
+class TestEmbedMode:
+    """Test EmbedMode prefix injection."""
+
+    @staticmethod
+    def _mock_http_response(body: bytes):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = body
+        mock_conn = MagicMock()
+        mock_conn.getresponse.return_value = mock_resp
+        return mock_conn
+
+    @staticmethod
+    def _provider_and_conn(n_vecs=1):
+        from evolution.providers.embeddings import OllamaEmbeddingProvider
+        from evolution.config import EMBED_DIM
+        vecs = [[0.1] * EMBED_DIM for _ in range(n_vecs)]
+        body = json.dumps({"embeddings": vecs}).encode()
+        provider = OllamaEmbeddingProvider(model="test")
+        mock_conn = TestEmbedMode._mock_http_response(body)
+        return provider, mock_conn
+
+    def test_query_mode_prepends_prefix(self, monkeypatch):
+        import evolution.providers.embeddings as mod
+        from evolution.providers.embeddings import EmbedMode, QUERY_PREFIX
+        monkeypatch.setattr(mod, "_PREFIXES_ENABLED", True)
+        provider, mock_conn = self._provider_and_conn()
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
+            provider.embed("hello", mode=EmbedMode.QUERY)
+        call_body = json.loads(mock_conn.request.call_args[1]["body"])
+        assert call_body["input"] == [QUERY_PREFIX + "hello"]
+
+    def test_document_mode_prepends_prefix(self, monkeypatch):
+        import evolution.providers.embeddings as mod
+        from evolution.providers.embeddings import EmbedMode, DOCUMENT_PREFIX
+        monkeypatch.setattr(mod, "_PREFIXES_ENABLED", True)
+        provider, mock_conn = self._provider_and_conn()
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
+            provider.embed("hello", mode=EmbedMode.DOCUMENT)
+        call_body = json.loads(mock_conn.request.call_args[1]["body"])
+        assert call_body["input"] == [DOCUMENT_PREFIX + "hello"]
+
+    def test_raw_mode_no_prefix(self, monkeypatch):
+        import evolution.providers.embeddings as mod
+        from evolution.providers.embeddings import EmbedMode
+        monkeypatch.setattr(mod, "_PREFIXES_ENABLED", True)
+        provider, mock_conn = self._provider_and_conn()
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
+            provider.embed("hello", mode=EmbedMode.RAW)
+        call_body = json.loads(mock_conn.request.call_args[1]["body"])
+        assert call_body["input"] == ["hello"]
+
+    def test_env_var_disables_prefix(self, monkeypatch):
+        import evolution.providers.embeddings as mod
+        from evolution.providers.embeddings import EmbedMode
+        monkeypatch.setattr(mod, "_PREFIXES_ENABLED", False)
+        provider, mock_conn = self._provider_and_conn()
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
+            provider.embed("hello", mode=EmbedMode.QUERY)
+        call_body = json.loads(mock_conn.request.call_args[1]["body"])
+        assert call_body["input"] == ["hello"]
+
+    def test_batch_respects_mode(self, monkeypatch):
+        import evolution.providers.embeddings as mod
+        from evolution.providers.embeddings import EmbedMode, DOCUMENT_PREFIX
+        monkeypatch.setattr(mod, "_PREFIXES_ENABLED", True)
+        provider, mock_conn = self._provider_and_conn(n_vecs=2)
+        with patch.object(provider, "_get_conn", return_value=mock_conn):
+            provider.embed_batch(["a", "b"], mode=EmbedMode.DOCUMENT)
+        call_body = json.loads(mock_conn.request.call_args[1]["body"])
+        assert call_body["input"] == [DOCUMENT_PREFIX + "a", DOCUMENT_PREFIX + "b"]
+
+
 class TestOllamaEmbeddingProvider:
     """Test OllamaEmbeddingProvider vector handling."""
 

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -114,7 +114,7 @@ class StubEmbed:
     def __init__(self):
         self._cache = {}
 
-    def __call__(self, text: str) -> list[float]:
+    def __call__(self, text: str, mode=None) -> list[float]:
         if text in self._cache:
             return self._cache[text]
         import hashlib
@@ -145,8 +145,8 @@ def stub_embed(monkeypatch):
 @pytest.fixture
 def stub_embed_batch(monkeypatch, stub_embed):
     """Stub embed_batch_text using the same StubEmbed instance."""
-    def _batch(texts):
-        return [stub_embed(t) for t in texts]
+    def _batch(texts, mode=None):
+        return [stub_embed(t, mode=mode) for t in texts]
     monkeypatch.setattr(mt, "embed_batch_text", _batch)
     return stub_embed
 
@@ -1259,9 +1259,9 @@ class TestConceptExpansion:
         calls = []
         original_embed = mt.embed_text
 
-        def spy(text):
+        def spy(text, mode=None):
             calls.append(text)
-            return original_embed(text)
+            return original_embed(text, mode=mode)
 
         monkeypatch.setattr(mt, "embed_text", spy)
 

--- a/scripts/tests/test_memory_tree_phase3.py
+++ b/scripts/tests/test_memory_tree_phase3.py
@@ -487,7 +487,7 @@ class TestRetrieveAblation:
             "description: Films Liam enjoys — crime, thrillers.\nlevel: 2\n---\n"
         )
         # Stub embed: predictable scores.
-        def stub_embed(text):
+        def stub_embed(text, mode=None):
             v = [0.0] * mt.EMBED_DIM
             for i, c in enumerate(text[:mt.EMBED_DIM]):
                 v[i] = (ord(c) % 17) / 17.0
@@ -546,7 +546,7 @@ class TestCheckTreeEdges:
         return v
 
     def test_missing_root_node_flagged(self, tmp_db, vault_no_root, monkeypatch):
-        def stub_embed(text):
+        def stub_embed(text, mode=None):
             return [(ord(c) % 17) / 17.0 for c in text[:mt.EMBED_DIM]] + [0.0] * (mt.EMBED_DIM - len(text[:mt.EMBED_DIM]))
         monkeypatch.setattr(mt, "embed_text", stub_embed)
         mt.build_tree(vault_no_root, tmp_db)
@@ -651,7 +651,7 @@ class TestHookEdges:
 
 # ── TestDiscoverNode — auto-discovery path ────────────────────────────────────
 
-def _stub_embed(text):
+def _stub_embed(text, mode=None):
     """Deterministic embedding stub — same shape as embed_text."""
     v = [0.0] * mt.EMBED_DIM
     for i, c in enumerate(text[:mt.EMBED_DIM]):


### PR DESCRIPTION
## Summary
- Adds `EmbedMode` enum (QUERY/DOCUMENT/RAW) to embedding provider with asymmetric task prefixes for embeddinggemma
- Threads mode through all embed callers in memory_tree.py, memory_indexer.py, and memory_query.py
- Disabled by default (`DEUS_EMBED_PREFIX=0`) after benchmarks showed recall regression
- ADR updated with symmetric prefix approach as disproved
- 5 new tests for EmbedMode prefix injection

### Benchmark results (symmetric prefixes)
| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| recall_at_k | 0.7430 | 0.6100 | **-0.1330** |
| mrr_at_k | 0.6280 | 0.5290 | -0.0990 |
| abstain_accuracy | 0.5910 | 0.9090 | **+0.3180** |
| latency_p50_ms | 94.9 | 86.5 | -8.4 |

**Finding**: Symmetric prefixes make the model more conservative - dramatically better abstain accuracy (+0.318) but worse fuzzy recall (-0.133). Vocab-mismatch queries hit hardest (-0.265). The infrastructure is retained behind an env-var gate for future embedding model changes.

### Prior art
ADR `benchmark-regression-gate.md` recorded query-only prefixes as disproved ("prefixed queries live in different vector subspace than non-prefixed documents"). This PR tested the hypothesis that symmetric re-embedding (both sides) would fix the mismatch. It didn't - recall still regresses, though the mechanism is different (excessive conservatism, not space mismatch).

## Test plan
- [x] 198 tests pass (5 new + all existing)
- [x] Benchmark gate: recall verified at baseline after revert to DEUS_EMBED_PREFIX=0
- [x] ADR updated with new disproved-approaches row
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)