### PR TITLE
feat(memory): add TREC benchmark, embedding shootout, implicit feedback tools

### DIFF
--- a/scripts/embedding_shootout.py
+++ b/scripts/embedding_shootout.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Embedding model shootout: compare discrimination quality across models.
+
+Tests each model on the same set of benchmark queries + target atoms.
+No DB changes, no production code touched - pure in-memory comparison.
+
+Usage:
+  python3 scripts/embedding_shootout.py [--models embeddinggemma,snowflake-arctic-embed2,...]
+"""
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import math
+import os
+import sqlite3
+import struct
+import sys
+import time
+import urllib.parse
+from pathlib import Path
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+FIXTURE_PATH = Path(_PROJECT_ROOT) / "scripts" / "tests" / "fixtures" / "atom_queries.jsonl"
+DB_PATH = Path(os.path.expanduser("~/.deus/memory.db"))
+
+DEFAULT_MODELS = [
+    "embeddinggemma",
+    "snowflake-arctic-embed2",
+    "nomic-embed-text",
+    "bge-m3",
+    "mxbai-embed-large",
+]
+
+PREFIXED_MODELS = {
+    "snowflake-arctic-embed2": "Represent this sentence for searching relevant passages: ",
+    "nomic-embed-text": "search_query: ",
+    "bge-m3": "Represent this sentence: ",
+}
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+
+
+def ollama_embed(texts: list[str], model: str) -> list[list[float]]:
+    parsed = urllib.parse.urlparse(OLLAMA_HOST)
+    hostname = parsed.hostname or "localhost"
+    port = parsed.port or 11434
+
+    payload = json.dumps({"model": model, "input": texts}).encode()
+    conn = http.client.HTTPConnection(hostname, port, timeout=60)
+    conn.request("POST", "/api/embed", body=payload,
+                 headers={"Content-Type": "application/json"})
+    resp = conn.getresponse()
+    body = resp.read()
+    conn.close()
+
+    if resp.status != 200:
+        raise RuntimeError(f"Ollama {model} returned {resp.status}: {body[:200]}")
+
+    data = json.loads(body)
+    return data.get("embeddings", [])
+
+
+def l2_dist(a: list[float], b: list[float]) -> float:
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def cosine_sim(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def load_benchmark() -> tuple[list[dict], dict[int, str]]:
+    """Load benchmark queries and find target atoms in the DB."""
+    import sqlite_vec
+    db = sqlite3.connect(str(DB_PATH))
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+
+    queries = []
+    with open(FIXTURE_PATH) as f:
+        for line in f:
+            q = json.loads(line.strip())
+            if q.get("expected_atoms"):
+                queries.append(q)
+
+    target_atoms: dict[int, str] = {}
+    all_atoms = db.execute(
+        "SELECT id, chunk FROM entries WHERE type = 'atom' AND orphaned_at IS NULL"
+    ).fetchall()
+
+    for q in queries:
+        for exp in q["expected_atoms"]:
+            for aid, chunk in all_atoms:
+                if exp.lower() in chunk.lower() and aid not in target_atoms:
+                    target_atoms[aid] = chunk
+
+    distractor_atoms = {}
+    for aid, chunk in all_atoms:
+        if aid not in target_atoms:
+            distractor_atoms[aid] = chunk
+        if len(distractor_atoms) >= 50:
+            break
+
+    db.close()
+    return queries, target_atoms, distractor_atoms
+
+
+def evaluate_model(
+    model: str,
+    queries: list[dict],
+    target_atoms: dict[int, str],
+    distractor_atoms: dict[int, str],
+    use_prefix: bool = False,
+) -> dict:
+    """Evaluate a single model on discrimination quality."""
+    prefix = PREFIXED_MODELS.get(model, "") if use_prefix else ""
+    label = f"{model}" + (" +prefix" if use_prefix and prefix else "")
+    print(f"\n  Testing {label}...", file=sys.stderr)
+
+    all_atoms = {**target_atoms, **distractor_atoms}
+    atom_texts = list(all_atoms.values())
+    atom_ids = list(all_atoms.keys())
+    target_id_set = set(target_atoms.keys())
+
+    t0 = time.monotonic()
+    try:
+        atom_vecs = ollama_embed(atom_texts, model)
+    except Exception as e:
+        print(f"    ERROR embedding atoms: {e}", file=sys.stderr)
+        return {"model": label, "error": str(e)}
+
+    query_texts = [q["query"] for q in queries]
+    if prefix:
+        query_texts_prefixed = [prefix + qt for qt in query_texts]
+    else:
+        query_texts_prefixed = query_texts
+
+    try:
+        query_vecs = ollama_embed(query_texts_prefixed, model)
+    except Exception as e:
+        print(f"    ERROR embedding queries: {e}", file=sys.stderr)
+        return {"model": label, "error": str(e)}
+
+    embed_time = time.monotonic() - t0
+    dim = len(atom_vecs[0]) if atom_vecs else 0
+    print(f"    dim={dim}, embed_time={embed_time:.1f}s", file=sys.stderr)
+
+    hits = 0
+    score_gaps = []
+    discrimination_ratios = []
+    relevant_dists = []
+    irrelevant_dists = []
+
+    for qi, (q, q_vec) in enumerate(zip(queries, query_vecs)):
+        expected = q["expected_atoms"]
+
+        dists = []
+        for ai, a_vec in enumerate(atom_vecs):
+            dist = l2_dist(q_vec, a_vec)
+            is_target = atom_ids[ai] in target_id_set
+            is_relevant = is_target and any(
+                exp.lower() in atom_texts[ai].lower() for exp in expected
+            )
+            dists.append((dist, atom_ids[ai], is_relevant))
+            if is_relevant:
+                relevant_dists.append(dist)
+            else:
+                irrelevant_dists.append(dist)
+
+        dists.sort(key=lambda x: x[0])
+        top_k = dists[:5]
+
+        hit = any(is_rel for _, _, is_rel in top_k)
+        if hit:
+            hits += 1
+
+        rel_in_results = [d for d, _, is_rel in dists if is_rel]
+        irr_in_results = [d for d, _, is_rel in dists if not is_rel]
+        if rel_in_results and irr_in_results:
+            gap = min(irr_in_results) - min(rel_in_results)
+            score_gaps.append(gap)
+
+        all_dists_vals = [d for d, _, _ in dists]
+        if all_dists_vals:
+            mean_d = sum(all_dists_vals) / len(all_dists_vals)
+            std_d = (sum((d - mean_d) ** 2 for d in all_dists_vals) / len(all_dists_vals)) ** 0.5
+            cv = std_d / mean_d if mean_d > 0 else 0
+            discrimination_ratios.append(cv)
+
+    recall = hits / len(queries) if queries else 0
+
+    def safe_stats(vals):
+        if not vals:
+            return {"mean": 0, "std": 0, "min": 0, "max": 0, "p10": 0}
+        vals_s = sorted(vals)
+        mean = sum(vals_s) / len(vals_s)
+        std = (sum((v - mean) ** 2 for v in vals_s) / len(vals_s)) ** 0.5
+        p10 = vals_s[max(0, len(vals_s) // 10)]
+        return {"mean": round(mean, 4), "std": round(std, 4),
+                "min": round(vals_s[0], 4), "max": round(vals_s[-1], 4),
+                "p10": round(p10, 4)}
+
+    result = {
+        "model": label,
+        "dim": dim,
+        "recall_at_5": round(recall, 4),
+        "hits": hits,
+        "total": len(queries),
+        "embed_time_s": round(embed_time, 1),
+        "score_gap": safe_stats(score_gaps),
+        "discrimination_cv": safe_stats(discrimination_ratios),
+        "relevant_dist": safe_stats(relevant_dists),
+        "irrelevant_dist": safe_stats(irrelevant_dists),
+        "separation": round(
+            safe_stats(irrelevant_dists)["mean"] - safe_stats(relevant_dists)["mean"], 4
+        ),
+    }
+
+    # Z-score analysis
+    if relevant_dists and irrelevant_dists:
+        all_d = relevant_dists + irrelevant_dists
+        mu = sum(all_d) / len(all_d)
+        sigma = (sum((d - mu) ** 2 for d in all_d) / len(all_d)) ** 0.5
+        if sigma > 0:
+            rel_z = [(d - mu) / sigma for d in relevant_dists]
+            irr_z = [(d - mu) / sigma for d in irrelevant_dists]
+            result["zscore_relevant_mean"] = round(sum(rel_z) / len(rel_z), 4)
+            result["zscore_irrelevant_mean"] = round(sum(irr_z) / len(irr_z), 4)
+            result["zscore_separation"] = round(
+                result["zscore_irrelevant_mean"] - result["zscore_relevant_mean"], 4
+            )
+
+    return result
+
+
+def evaluate_cross_encoder(
+    queries: list[dict],
+    target_atoms: dict[int, str],
+    distractor_atoms: dict[int, str],
+    model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
+) -> dict:
+    """Evaluate a cross-encoder reranker on discrimination quality."""
+    print(f"\n  Testing cross-encoder ({model_name})...", file=sys.stderr)
+    try:
+        from sentence_transformers import CrossEncoder
+    except ImportError:
+        return {"model": "cross-encoder", "error": "sentence-transformers not installed"}
+
+    t0 = time.monotonic()
+    ce = CrossEncoder(model_name)
+    load_time = time.monotonic() - t0
+    print(f"    Model loaded in {load_time:.1f}s", file=sys.stderr)
+
+    all_atoms = {**target_atoms, **distractor_atoms}
+    atom_texts = list(all_atoms.values())
+    atom_ids = list(all_atoms.keys())
+    target_id_set = set(target_atoms.keys())
+
+    hits = 0
+    score_gaps = []
+    discrimination_ratios = []
+    relevant_scores = []
+    irrelevant_scores = []
+
+    t0 = time.monotonic()
+    for qi, q in enumerate(queries):
+        query_text = q["query"]
+        expected = q["expected_atoms"]
+
+        pairs = [(query_text, atom_text) for atom_text in atom_texts]
+        scores = ce.predict(pairs).tolist()
+
+        scored = []
+        for ai, score in enumerate(scores):
+            is_target = atom_ids[ai] in target_id_set
+            is_relevant = is_target and any(
+                exp.lower() in atom_texts[ai].lower() for exp in expected
+            )
+            scored.append((score, atom_ids[ai], is_relevant))
+            if is_relevant:
+                relevant_scores.append(score)
+            else:
+                irrelevant_scores.append(score)
+
+        scored.sort(key=lambda x: -x[0])
+        top_k = scored[:5]
+
+        hit = any(is_rel for _, _, is_rel in top_k)
+        if hit:
+            hits += 1
+
+        rel_s = [s for s, _, is_rel in scored if is_rel]
+        irr_s = [s for s, _, is_rel in scored if not is_rel]
+        if rel_s and irr_s:
+            score_gaps.append(max(rel_s) - max(irr_s))
+
+        all_s = [s for s, _, _ in scored]
+        if all_s:
+            mean_s = sum(all_s) / len(all_s)
+            std_s = (sum((s - mean_s) ** 2 for s in all_s) / len(all_s)) ** 0.5
+            cv = std_s / abs(mean_s) if mean_s != 0 else 0
+            discrimination_ratios.append(cv)
+
+    eval_time = time.monotonic() - t0
+    recall = hits / len(queries) if queries else 0
+
+    def safe_stats(vals):
+        if not vals:
+            return {"mean": 0, "std": 0, "min": 0, "max": 0, "p10": 0}
+        vals_s = sorted(vals)
+        mean = sum(vals_s) / len(vals_s)
+        std = (sum((v - mean) ** 2 for v in vals_s) / len(vals_s)) ** 0.5
+        p10 = vals_s[max(0, len(vals_s) // 10)]
+        return {"mean": round(mean, 4), "std": round(std, 4),
+                "min": round(vals_s[0], 4), "max": round(vals_s[-1], 4),
+                "p10": round(p10, 4)}
+
+    result = {
+        "model": "cross-encoder",
+        "dim": "N/A",
+        "recall_at_5": round(recall, 4),
+        "hits": hits,
+        "total": len(queries),
+        "embed_time_s": round(eval_time, 1),
+        "score_gap": safe_stats(score_gaps),
+        "discrimination_cv": safe_stats(discrimination_ratios),
+        "relevant_dist": safe_stats(relevant_scores),
+        "irrelevant_dist": safe_stats(irrelevant_scores),
+        "separation": round(
+            safe_stats(relevant_scores)["mean"] - safe_stats(irrelevant_scores)["mean"], 4
+        ),
+        "zscore_separation": 0,
+    }
+
+    if relevant_scores and irrelevant_scores:
+        all_s = relevant_scores + irrelevant_scores
+        mu = sum(all_s) / len(all_s)
+        sigma = (sum((s - mu) ** 2 for s in all_s) / len(all_s)) ** 0.5
+        if sigma > 0:
+            rel_z = [(s - mu) / sigma for s in relevant_scores]
+            irr_z = [(s - mu) / sigma for s in irrelevant_scores]
+            result["zscore_relevant_mean"] = round(sum(rel_z) / len(rel_z), 4)
+            result["zscore_irrelevant_mean"] = round(sum(irr_z) / len(irr_z), 4)
+            result["zscore_separation"] = round(
+                result["zscore_relevant_mean"] - result["zscore_irrelevant_mean"], 4
+            )
+
+    return result
+
+
+def print_comparison(results: list[dict]):
+    print("\n" + "=" * 90)
+    print(f"{'Model':<30} {'Dim':>4} {'Recall@5':>9} {'Separation':>11} {'Gap(mean)':>10} {'CV(mean)':>9} {'Z-sep':>7} {'Time':>5}")
+    print("-" * 90)
+    for r in sorted(results, key=lambda x: -x.get("recall_at_5", 0)):
+        if "error" in r:
+            print(f"{r['model']:<30} ERROR: {r['error'][:50]}")
+            continue
+        print(
+            f"{r['model']:<30} {r['dim']:>4} {r['recall_at_5']:>9.3f} "
+            f"{r['separation']:>11.4f} {r['score_gap']['mean']:>10.4f} "
+            f"{r['discrimination_cv']['mean']:>9.4f} "
+            f"{r.get('zscore_separation', 0):>7.3f} "
+            f"{r['embed_time_s']:>5.1f}s"
+        )
+    print("=" * 90)
+    print("\nMetrics explained:")
+    print("  Recall@5:    fraction of queries where the correct atom is in top-5 by L2 distance")
+    print("  Separation:  mean(irrelevant_dist) - mean(relevant_dist). Higher = better discrimination")
+    print("  Gap(mean):   mean of per-query (best_wrong - best_right). Higher = more confident correct rankings")
+    print("  CV(mean):    coefficient of variation of distances per query. Higher = more spread (less compression)")
+    print("  Z-sep:       z-score separation (relevant vs irrelevant). Higher = better statistical discrimination")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Embedding model shootout")
+    parser.add_argument("--models", default=",".join(DEFAULT_MODELS),
+                        help="Comma-separated model names")
+    parser.add_argument("--no-prefix", action="store_true",
+                        help="Skip prefix variants")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--no-cross-encoder", action="store_true",
+                        help="Skip cross-encoder evaluation")
+    args = parser.parse_args()
+
+    models = [m.strip() for m in args.models.split(",")]
+
+    print("Loading benchmark data...", file=sys.stderr)
+    queries, target_atoms, distractor_atoms = load_benchmark()
+    print(f"  {len(queries)} queries, {len(target_atoms)} target atoms, {len(distractor_atoms)} distractors", file=sys.stderr)
+
+    results = []
+    for model in models:
+        r = evaluate_model(model, queries, target_atoms, distractor_atoms, use_prefix=False)
+        results.append(r)
+
+        if not args.no_prefix and model in PREFIXED_MODELS:
+            r_prefix = evaluate_model(model, queries, target_atoms, distractor_atoms, use_prefix=True)
+            results.append(r_prefix)
+
+    if not args.no_cross_encoder:
+        r_ce = evaluate_cross_encoder(queries, target_atoms, distractor_atoms)
+        results.append(r_ce)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        print_comparison(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mine_implicit_feedback.py
+++ b/scripts/mine_implicit_feedback.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Mine implicit feedback signals from the production retrieval log.
+
+Identifies:
+1. Wrong abstains: user reformulated after system abstained (same topic, different words)
+2. Positive retrievals: user continued on-topic after successful retrieval
+3. Negative retrievals: user reformulated after retrieval (wasn't satisfied)
+
+Output: JSONL fixture for atom benchmark evaluation.
+
+Usage:
+  python3 scripts/mine_implicit_feedback.py [--output PATH] [--min-confidence 0.6]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import struct
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+LOG_PATH = Path(os.path.expanduser("~/.deus/memory_tree_queries.jsonl"))
+SESSION_GAP = timedelta(minutes=30)
+REFORMULATION_THRESHOLD = 0.65
+CONTINUATION_THRESHOLD = 0.40
+
+
+def load_queries(path: Path) -> list[dict]:
+    queries = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                q = json.loads(line)
+                if len(q.get("query", "")) < 15:
+                    continue
+                if q["query"].startswith("/") or "<task-notification" in q["query"]:
+                    continue
+                if "<system-reminder" in q["query"] or q["query"].startswith("Command running"):
+                    continue
+                queries.append(q)
+            except (json.JSONDecodeError, KeyError):
+                pass
+    return queries
+
+
+def deduplicate_sequential(queries: list[dict]) -> list[dict]:
+    """Remove exact duplicate queries within 5 seconds (hook double-fires)."""
+    result = []
+    for q in queries:
+        if result and result[-1]["query"] == q["query"]:
+            try:
+                t1 = datetime.fromisoformat(result[-1]["ts"])
+                t2 = datetime.fromisoformat(q["ts"])
+                if abs((t2 - t1).total_seconds()) < 5:
+                    continue
+            except (ValueError, TypeError):
+                pass
+        result.append(q)
+    return result
+
+
+def split_sessions(queries: list[dict]) -> list[list[dict]]:
+    """Split queries into sessions based on time gap."""
+    sessions: list[list[dict]] = []
+    current: list[dict] = []
+    for q in queries:
+        if current:
+            try:
+                t_prev = datetime.fromisoformat(current[-1]["ts"])
+                t_curr = datetime.fromisoformat(q["ts"])
+                if (t_curr - t_prev) > SESSION_GAP:
+                    sessions.append(current)
+                    current = []
+            except (ValueError, TypeError):
+                pass
+        current.append(q)
+    if current:
+        sessions.append(current)
+    return sessions
+
+
+def compute_similarity(text_a: str, text_b: str, embed_fn) -> float:
+    """Compute cosine similarity between two texts."""
+    vec_a = embed_fn(text_a)
+    vec_b = embed_fn(text_b)
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = sum(a * a for a in vec_a) ** 0.5
+    norm_b = sum(b * b for b in vec_b) ** 0.5
+    return dot / (norm_a * norm_b) if norm_a and norm_b else 0.0
+
+
+def mine_signals(sessions: list[list[dict]], embed_fn) -> dict:
+    """Mine implicit feedback signals from session query sequences."""
+    wrong_abstains = []
+    positive_retrievals = []
+    negative_retrievals = []
+
+    for session in sessions:
+        for i, q in enumerate(session):
+            if i + 1 >= len(session):
+                continue
+            next_q = session[i + 1]
+
+            sim = compute_similarity(q["query"], next_q["query"], embed_fn)
+
+            if q.get("fell_back"):
+                if sim >= REFORMULATION_THRESHOLD and not next_q.get("fell_back"):
+                    wrong_abstains.append({
+                        "original_query": q["query"],
+                        "reformulated_query": next_q["query"],
+                        "similarity": round(sim, 4),
+                        "original_confidence": q.get("final_confidence", 0),
+                        "reformulated_results": next_q.get("results", []),
+                        "ts": q["ts"],
+                        "signal": "wrong-abstain",
+                    })
+            elif not q.get("fell_back") and q.get("results"):
+                if sim >= REFORMULATION_THRESHOLD:
+                    if next_q.get("fell_back") or next_q["query"] != q["query"]:
+                        negative_retrievals.append({
+                            "query": q["query"],
+                            "reformulated_query": next_q["query"],
+                            "similarity": round(sim, 4),
+                            "retrieved_paths": q.get("results", []),
+                            "ts": q["ts"],
+                            "signal": "negative-retrieval",
+                        })
+                elif sim >= CONTINUATION_THRESHOLD:
+                    positive_retrievals.append({
+                        "query": q["query"],
+                        "next_query": next_q["query"],
+                        "similarity": round(sim, 4),
+                        "retrieved_paths": q.get("results", []),
+                        "ts": q["ts"],
+                        "signal": "positive-retrieval",
+                    })
+
+    return {
+        "wrong_abstains": wrong_abstains,
+        "positive_retrievals": positive_retrievals,
+        "negative_retrievals": negative_retrievals,
+    }
+
+
+def build_fixture(signals: dict, max_per_type: int = 30) -> list[dict]:
+    """Convert mined signals into atom benchmark fixture entries."""
+    fixture = []
+
+    for wa in sorted(signals["wrong_abstains"], key=lambda x: -x["similarity"])[:max_per_type]:
+        fixture.append({
+            "query": wa["original_query"],
+            "expected_atoms": [],
+            "tag": "wrong-abstain",
+            "source": "implicit-feedback",
+            "meta": {
+                "reformulated_to": wa["reformulated_query"],
+                "similarity": wa["similarity"],
+                "confidence": wa["original_confidence"],
+            },
+        })
+
+    for pr in sorted(signals["positive_retrievals"], key=lambda x: -x["similarity"])[:max_per_type]:
+        fixture.append({
+            "query": pr["query"],
+            "expected_atoms": [],
+            "tag": "positive-retrieval",
+            "source": "implicit-feedback",
+            "meta": {
+                "retrieved_paths": pr["retrieved_paths"][:3],
+                "continuation_query": pr["next_query"],
+                "similarity": pr["similarity"],
+            },
+        })
+
+    return fixture
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mine implicit feedback from retrieval log")
+    parser.add_argument("--output", default=None, help="Output fixture path")
+    parser.add_argument("--stats-only", action="store_true", help="Print stats without embedding")
+    parser.add_argument("--max-per-type", type=int, default=30, help="Max entries per signal type")
+    args = parser.parse_args()
+
+    if not LOG_PATH.exists():
+        print(f"ERROR: Log not found: {LOG_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading queries from {LOG_PATH}...", file=sys.stderr)
+    raw = load_queries(LOG_PATH)
+    print(f"  Loaded {len(raw)} clean queries", file=sys.stderr)
+
+    deduped = deduplicate_sequential(raw)
+    print(f"  After dedup: {len(deduped)}", file=sys.stderr)
+
+    sessions = split_sessions(deduped)
+    print(f"  Sessions: {len(sessions)}", file=sys.stderr)
+    multi_query = [s for s in sessions if len(s) >= 2]
+    print(f"  Sessions with 2+ queries: {len(multi_query)}", file=sys.stderr)
+
+    fell_back = sum(1 for q in deduped if q.get("fell_back"))
+    print(f"  Abstain rate: {fell_back}/{len(deduped)} ({100*fell_back/len(deduped):.1f}%)", file=sys.stderr)
+
+    if args.stats_only:
+        return
+
+    print("Computing similarities (this may take a few minutes)...", file=sys.stderr)
+    from evolution.providers.embeddings import embed as provider_embed
+
+    _cache: dict[str, list[float]] = {}
+
+    def cached_embed(text: str) -> list[float]:
+        if text not in _cache:
+            _cache[text] = provider_embed(text)
+        return _cache[text]
+
+    signals = mine_signals(multi_query, cached_embed)
+
+    print(f"\n=== MINED SIGNALS ===", file=sys.stderr)
+    print(f"Wrong abstains:       {len(signals['wrong_abstains'])}", file=sys.stderr)
+    print(f"Positive retrievals:  {len(signals['positive_retrievals'])}", file=sys.stderr)
+    print(f"Negative retrievals:  {len(signals['negative_retrievals'])}", file=sys.stderr)
+
+    if signals["wrong_abstains"]:
+        print(f"\n=== TOP WRONG ABSTAINS ===", file=sys.stderr)
+        for wa in sorted(signals["wrong_abstains"], key=lambda x: -x["similarity"])[:10]:
+            print(f"  [{wa['similarity']:.3f}] \"{wa['original_query'][:60]}\"", file=sys.stderr)
+            print(f"    → reformulated: \"{wa['reformulated_query'][:60]}\"", file=sys.stderr)
+
+    if signals["negative_retrievals"]:
+        print(f"\n=== TOP NEGATIVE RETRIEVALS ===", file=sys.stderr)
+        for nr in sorted(signals["negative_retrievals"], key=lambda x: -x["similarity"])[:10]:
+            print(f"  [{nr['similarity']:.3f}] \"{nr['query'][:60]}\"", file=sys.stderr)
+            print(f"    → reformulated: \"{nr['reformulated_query'][:60]}\"", file=sys.stderr)
+
+    fixture = build_fixture(signals, max_per_type=args.max_per_type)
+    output = json.dumps({"signals": signals, "fixture_count": len(fixture)}, indent=2)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as f:
+            for entry in fixture:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        print(f"\nFixture written to {out_path} ({len(fixture)} entries)", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trec_atom_benchmark.py
+++ b/scripts/trec_atom_benchmark.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""TREC-style pooled atom benchmark builder.
+
+Stage 1: Sample real production queries (stratified, deduped)
+Stage 2: Run multiple retrieval variants, pool all returned atoms
+Stage 3: LLM-judge each (query, atom) pair blind
+Stage 4: Export as frozen benchmark fixture
+
+Usage:
+  python3 scripts/trec_atom_benchmark.py --stage sample   # → ~/.deus/bench/sampled_queries.jsonl
+  python3 scripts/trec_atom_benchmark.py --stage pool      # → ~/.deus/bench/pooled_atoms.jsonl
+  python3 scripts/trec_atom_benchmark.py --stage judge     # → ~/.deus/bench/judged_pairs.jsonl
+  python3 scripts/trec_atom_benchmark.py --stage export    # → scripts/tests/fixtures/atom_queries_trec.jsonl
+  python3 scripts/trec_atom_benchmark.py --stage all       # run all stages
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import sqlite3
+import struct
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+BENCH_DIR = Path(os.path.expanduser("~/.deus/bench"))
+LOG_PATH = Path(os.path.expanduser("~/.deus/memory_tree_queries.jsonl"))
+DB_PATH = Path(os.path.expanduser("~/.deus/memory.db"))
+
+SAMPLE_SIZE = 120
+POOL_DEPTH = 10
+RANDOM_SAMPLE_RATIO = 0.05
+
+
+def _open_db():
+    import sqlite_vec
+    db = sqlite3.connect(str(DB_PATH))
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    return db
+
+
+def _serialize(vec):
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+# ── Stage 1: Sample ─────────────────────────────────────────────────────────
+
+def stage_sample():
+    """Sample real production queries, stratified and deduped."""
+    print("Stage 1: Sampling production queries...", file=sys.stderr)
+
+    raw_queries: dict[str, dict] = {}
+    with open(LOG_PATH, encoding="utf-8") as f:
+        for line in f:
+            try:
+                q = json.loads(line.strip())
+            except (json.JSONDecodeError, ValueError):
+                continue
+            text = q.get("query", "")
+            if len(text) < 15 or len(text) > 500:
+                continue
+            if text.startswith("/") or "<task-notification" in text:
+                continue
+            if "<system-reminder" in text or "Command running" in text:
+                continue
+            key = text.strip().lower()
+            if key not in raw_queries:
+                raw_queries[key] = {
+                    "query": text,
+                    "fell_back": q.get("fell_back", False),
+                    "confidence": q.get("final_confidence", 0),
+                    "results": q.get("results", []),
+                    "ts": q.get("ts", ""),
+                    "count": 0,
+                }
+            raw_queries[key]["count"] += 1
+
+    unique = list(raw_queries.values())
+    print(f"  Unique queries: {len(unique)}", file=sys.stderr)
+
+    abstained = [q for q in unique if q["fell_back"]]
+    retrieved = [q for q in unique if not q["fell_back"]]
+    print(f"  Abstained: {len(abstained)}, Retrieved: {len(retrieved)}", file=sys.stderr)
+
+    random.seed(42)
+
+    target_abstain = min(len(abstained), SAMPLE_SIZE // 4)
+    target_retrieved = SAMPLE_SIZE - target_abstain
+
+    sampled_abstain = random.sample(abstained, min(target_abstain, len(abstained)))
+
+    freq_sorted = sorted(retrieved, key=lambda q: -q["count"])
+    high_freq = freq_sorted[:len(freq_sorted) // 3]
+    mid_freq = freq_sorted[len(freq_sorted) // 3: 2 * len(freq_sorted) // 3]
+    low_freq = freq_sorted[2 * len(freq_sorted) // 3:]
+
+    per_bucket = target_retrieved // 3
+    sampled_retrieved = (
+        random.sample(high_freq, min(per_bucket, len(high_freq)))
+        + random.sample(mid_freq, min(per_bucket, len(mid_freq)))
+        + random.sample(low_freq, min(per_bucket, len(low_freq)))
+    )
+
+    sampled = sampled_abstain + sampled_retrieved
+    random.shuffle(sampled)
+
+    for s in sampled:
+        s["query_hash"] = hashlib.sha256(s["query"].encode()).hexdigest()[:16]
+
+    out_path = BENCH_DIR / "sampled_queries.jsonl"
+    BENCH_DIR.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        for s in sampled:
+            f.write(json.dumps(s, ensure_ascii=False) + "\n")
+
+    print(f"  Sampled {len(sampled)} queries → {out_path}", file=sys.stderr)
+    print(f"    Abstain: {len(sampled_abstain)}, Retrieved: {len(sampled_retrieved)}", file=sys.stderr)
+    return sampled
+
+
+# ── Stage 2: Pool ────────────────────────────────────────────────────────────
+
+def stage_pool():
+    """Run multiple retrieval variants, pool all returned atoms."""
+    print("Stage 2: Pooling atoms from multiple retrieval variants...", file=sys.stderr)
+
+    sample_path = BENCH_DIR / "sampled_queries.jsonl"
+    if not sample_path.exists():
+        print("ERROR: Run --stage sample first", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sample_path, encoding="utf-8") as f:
+        queries = [json.loads(line) for line in f]
+
+    from evolution.providers.embeddings import embed as provider_embed
+    import memory_indexer as mi
+
+    db = _open_db()
+
+    atom_angle_count = int(os.environ.get("DEUS_ATOM_ANGLE_COUNT", "3"))
+
+    pooled: list[dict] = []
+
+    for i, q_entry in enumerate(queries):
+        query = q_entry["query"]
+        q_vec = provider_embed(query)
+        q_blob = _serialize(q_vec)
+
+        atom_pool: dict[int, dict] = {}
+
+        # Variant 1: Raw ANN (no angles)
+        rows = db.execute(
+            """SELECT e.id, e.chunk, v.distance
+               FROM embeddings v JOIN entries e ON e.id = v.rowid
+               WHERE v.embedding MATCH ? AND k = ?
+               AND e.type = 'atom' AND e.orphaned_at IS NULL
+               ORDER BY v.distance LIMIT ?""",
+            [q_blob, POOL_DEPTH * 3, POOL_DEPTH],
+        ).fetchall()
+        for eid, chunk, dist in rows:
+            if eid not in atom_pool:
+                atom_pool[eid] = {"id": eid, "chunk": chunk, "sources": {}}
+            atom_pool[eid]["sources"]["raw"] = round(dist, 4)
+
+        # Variant 2: Angle ANN
+        try:
+            angle_rows = db.execute(
+                """SELECT aa.atom_id, ae.distance
+                   FROM atom_angle_embeddings ae
+                   JOIN atom_approach_angles aa
+                     ON ae.rowid = aa.atom_id * ? + aa.angle_idx
+                   WHERE ae.embedding MATCH ? AND k = ?
+                   ORDER BY ae.distance LIMIT ?""",
+                [atom_angle_count, q_blob, POOL_DEPTH * 3, POOL_DEPTH * 2],
+            ).fetchall()
+            angle_best: dict[int, float] = {}
+            for aid, adist in angle_rows:
+                if aid not in angle_best or adist < angle_best[aid]:
+                    angle_best[aid] = adist
+            for aid, adist in list(angle_best.items())[:POOL_DEPTH]:
+                if aid not in atom_pool:
+                    chunk_row = db.execute(
+                        "SELECT chunk FROM entries WHERE id = ? AND type = 'atom' AND orphaned_at IS NULL",
+                        [aid],
+                    ).fetchone()
+                    if chunk_row:
+                        atom_pool[aid] = {"id": aid, "chunk": chunk_row[0], "sources": {}}
+                if aid in atom_pool:
+                    atom_pool[aid]["sources"]["angle"] = round(adist, 4)
+        except sqlite3.OperationalError:
+            pass
+
+        # Variant 3: FTS5
+        try:
+            fts_rows = db.execute(
+                """SELECT e.id, e.chunk
+                   FROM entries_fts f
+                   JOIN entries e ON e.rowid = f.rowid
+                   WHERE entries_fts MATCH ? AND e.type = 'atom' AND e.orphaned_at IS NULL
+                   LIMIT ?""",
+                [mi._fts_escape(query), POOL_DEPTH],
+            ).fetchall()
+            for eid, chunk in fts_rows:
+                if eid not in atom_pool:
+                    atom_pool[eid] = {"id": eid, "chunk": chunk, "sources": {}}
+                atom_pool[eid]["sources"]["fts"] = 0.0
+        except sqlite3.OperationalError:
+            pass
+
+        # Add random sample of un-pooled atoms (catch blind spots)
+        n_random = max(1, int(len(atom_pool) * RANDOM_SAMPLE_RATIO))
+        pooled_ids = set(atom_pool.keys())
+        random_rows = db.execute(
+            """SELECT id, chunk FROM entries
+               WHERE type = 'atom' AND orphaned_at IS NULL
+               ORDER BY RANDOM() LIMIT ?""",
+            [n_random + len(pooled_ids)],
+        ).fetchall()
+        added_random = 0
+        for eid, chunk in random_rows:
+            if eid not in pooled_ids and added_random < n_random:
+                atom_pool[eid] = {"id": eid, "chunk": chunk, "sources": {"random": 0.0}}
+                added_random += 1
+
+        pooled.append({
+            "query": query,
+            "query_hash": q_entry["query_hash"],
+            "fell_back": q_entry["fell_back"],
+            "atoms": list(atom_pool.values()),
+            "pool_size": len(atom_pool),
+        })
+
+        if (i + 1) % 20 == 0:
+            print(f"  {i+1}/{len(queries)} queries pooled", file=sys.stderr)
+
+    db.close()
+
+    out_path = BENCH_DIR / "pooled_atoms.jsonl"
+    with open(out_path, "w", encoding="utf-8") as f:
+        for p in pooled:
+            f.write(json.dumps(p, ensure_ascii=False) + "\n")
+
+    total_pairs = sum(p["pool_size"] for p in pooled)
+    print(f"  Pooled {total_pairs} (query, atom) pairs across {len(pooled)} queries → {out_path}", file=sys.stderr)
+    return pooled
+
+
+# ── Stage 3: Judge ───────────────────────────────────────────────────────────
+
+JUDGE_PROMPT = (
+    "You are a relevance judge for a personal knowledge retrieval system.\n\n"
+    "Given a user's query and a stored fact about them, rate relevance:\n"
+    "- 2: Directly answers or is essential context for the query\n"
+    "- 1: Tangentially related, might be useful background\n"
+    "- 0: Irrelevant to the query\n\n"
+    "User query: {query}\n"
+    "Stored fact: {atom}\n\n"
+    "Respond with ONLY a single digit: 0, 1, or 2"
+)
+
+
+def stage_judge():
+    """LLM-judge each (query, atom) pair blind."""
+    print("Stage 3: Judging (query, atom) pairs...", file=sys.stderr)
+
+    pool_path = BENCH_DIR / "pooled_atoms.jsonl"
+    if not pool_path.exists():
+        print("ERROR: Run --stage pool first", file=sys.stderr)
+        sys.exit(1)
+
+    with open(pool_path, encoding="utf-8") as f:
+        pooled = [json.loads(line) for line in f]
+
+    cache_path = BENCH_DIR / "judge_cache.json"
+    cache: dict[str, int] = {}
+    if cache_path.exists():
+        cache = json.loads(cache_path.read_text())
+        print(f"  Loaded {len(cache)} cached judgments", file=sys.stderr)
+
+    from google import genai
+    from google.genai import types as genai_types
+    from evolution.config import load_api_key, GEN_MODELS
+
+    client = genai.Client(api_key=load_api_key())
+
+    total_pairs = sum(len(p["atoms"]) for p in pooled)
+    cached_hits = 0
+    api_calls = 0
+    errors = 0
+    consecutive_errors = 0
+
+    for pi, pool_entry in enumerate(pooled):
+        query = pool_entry["query"]
+        for atom_entry in pool_entry["atoms"]:
+            atom_text = atom_entry["chunk"]
+            cache_key = hashlib.sha256(f"{query}|||{atom_text}".encode()).hexdigest()[:24]
+
+            if cache_key in cache:
+                atom_entry["relevance"] = cache[cache_key]
+                cached_hits += 1
+                continue
+
+            prompt = JUDGE_PROMPT.format(query=query, atom=atom_text)
+            score = None
+            for model in GEN_MODELS:
+                try:
+                    resp = client.models.generate_content(
+                        model=model,
+                        contents=prompt,
+                        config=genai_types.GenerateContentConfig(
+                            temperature=0.0,
+                            max_output_tokens=4,
+                        ),
+                    )
+                    text = resp.text.strip()
+                    score = int(text) if text in ("0", "1", "2") else 0
+                    api_calls += 1
+                    break
+                except Exception as e:
+                    if "429" in str(e) or "RESOURCE_EXHAUSTED" in str(e):
+                        time.sleep(2)
+                        continue
+                    errors += 1
+                    break
+
+            if score is None:
+                errors += 1
+                consecutive_errors += 1
+                if consecutive_errors >= 3:
+                    wait = min(60, consecutive_errors * 10)
+                    print(f"  Rate limited ({consecutive_errors}x), waiting {wait}s...", file=sys.stderr)
+                    time.sleep(wait)
+                continue
+            consecutive_errors = 0
+            atom_entry["relevance"] = score
+            cache[cache_key] = score
+
+            if (api_calls + cached_hits) % 50 == 0:
+                cache_path.write_text(json.dumps(cache))
+
+        if (pi + 1) % 10 == 0:
+            print(f"  {pi+1}/{len(pooled)} queries judged ({api_calls} API calls, {cached_hits} cached, {errors} errors)", file=sys.stderr)
+
+    cache_path.write_text(json.dumps(cache))
+    print(f"  Total: {api_calls} API calls, {cached_hits} cached, {errors} errors", file=sys.stderr)
+
+    out_path = BENCH_DIR / "judged_pairs.jsonl"
+    with open(out_path, "w", encoding="utf-8") as f:
+        for p in pooled:
+            f.write(json.dumps(p, ensure_ascii=False) + "\n")
+
+    relevant = sum(
+        1 for p in pooled for a in p["atoms"] if a.get("relevance", 0) >= 2
+    )
+    tangential = sum(
+        1 for p in pooled for a in p["atoms"] if a.get("relevance", 0) == 1
+    )
+    irrelevant = sum(
+        1 for p in pooled for a in p["atoms"] if a.get("relevance", 0) == 0
+    )
+    print(f"  Judgments: {relevant} relevant, {tangential} tangential, {irrelevant} irrelevant", file=sys.stderr)
+    return pooled
+
+
+# ── Stage 4: Export ──────────────────────────────────────────────────────────
+
+def stage_export():
+    """Export judged pairs as a frozen benchmark fixture."""
+    print("Stage 4: Exporting benchmark fixture...", file=sys.stderr)
+
+    judged_path = BENCH_DIR / "judged_pairs.jsonl"
+    if not judged_path.exists():
+        print("ERROR: Run --stage judge first", file=sys.stderr)
+        sys.exit(1)
+
+    with open(judged_path, encoding="utf-8") as f:
+        pooled = [json.loads(line) for line in f]
+
+    fixture = []
+    for p in pooled:
+        relevant_atoms = [
+            a["chunk"] for a in p["atoms"] if a.get("relevance", 0) >= 2
+        ]
+
+        if relevant_atoms:
+            tag = "trec-positive"
+        elif p["fell_back"]:
+            tag = "trec-abstain"
+        else:
+            tag = "trec-no-relevant"
+
+        expected = []
+        for chunk in relevant_atoms:
+            words = chunk.split()
+            if len(words) >= 4:
+                expected.append(" ".join(words[1:5]).lower())
+
+        fixture.append({
+            "query": p["query"],
+            "expected_atoms": expected,
+            "tag": tag,
+            "source": "trec-pooling",
+        })
+
+    out_path = Path(_PROJECT_ROOT) / "scripts" / "tests" / "fixtures" / "atom_queries_trec.jsonl"
+    with open(out_path, "w", encoding="utf-8") as f:
+        for entry in fixture:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    pos = sum(1 for e in fixture if e["tag"] == "trec-positive")
+    abstain = sum(1 for e in fixture if e["tag"] == "trec-abstain")
+    no_rel = sum(1 for e in fixture if e["tag"] == "trec-no-relevant")
+    print(f"  Exported {len(fixture)} queries: {pos} positive, {abstain} abstain, {no_rel} no-relevant", file=sys.stderr)
+    print(f"  → {out_path}", file=sys.stderr)
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="TREC-style pooled atom benchmark")
+    parser.add_argument("--stage", required=True,
+                        choices=["sample", "pool", "judge", "export", "all"],
+                        help="Which stage to run")
+    args = parser.parse_args()
+
+    if args.stage == "sample" or args.stage == "all":
+        stage_sample()
+    if args.stage == "pool" or args.stage == "all":
+        stage_pool()
+    if args.stage == "judge" or args.stage == "all":
+        stage_judge()
+    if args.stage == "export" or args.stage == "all":
+        stage_export()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three new analysis scripts for atom retrieval evaluation:

- **trec_atom_benchmark.py** — TREC-style pooled benchmark builder (4 stages: sample real queries, pool from multiple retrieval variants, LLM-judge each pair, export fixture). Includes rate-limit backoff and cache resumption.
- **embedding_shootout.py** — compare embedding models + cross-encoder on the same queries without touching production DB
- **mine_implicit_feedback.py** — mine wrong-abstain and retrieval quality signals from the production query log

These are evaluation/research tools, not production code. No changes to the retrieval pipeline.

## Test plan

- [x] Scripts run without errors
- [x] TREC stages 1-2 complete (120 queries, 2188 pooled pairs)
- [x] Embedding shootout produces comparison table
- [x] Implicit feedback mining identifies 616 wrong-abstain signals
- [ ] TREC stage 3 (judge) needs Gemini quota - ready to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)