### PR TITLE
docs: scope threshold constraint, update calibration status, clarify atom fallback

### DIFF
--- a/docs/decisions/benchmark-regression-gate.md
+++ b/docs/decisions/benchmark-regression-gate.md
@@ -40,7 +40,7 @@ Retrieval recall is measured over the 75 retrieval-expected queries only. Abstai
 
 The gap-abstain check is a second-order filter: it catches queries where the top score is weak AND indistinguishable from noise. The ceiling must be near the abstain floor (where scores genuinely can't be trusted), not the low-confidence threshold (which is above most Ollama scores).
 
-**Why:** `low_threshold` (0.55) is above the typical in-domain score range for Ollama embeddinggemma (0.30-0.50). `abstain_threshold + gap_threshold` (0.34 for Ollama, 0.56 for Gemini) stays near the noise floor regardless of provider. **Do not revert to `low_threshold`.**
+**Why:** `low_threshold` (0.55) is above the typical in-domain score range for Ollama embeddinggemma (0.30-0.50). `abstain_threshold + gap_threshold` (0.34 for Ollama, 0.56 for Gemini) stays near the noise floor regardless of provider. **Do not revert to `low_threshold` for Ollama embeddinggemma.** Other embedding models may have different score distributions - re-run `deus sweep` when switching providers.
 
 ## Disproved approaches
 

--- a/docs/decisions/memory-tree.md
+++ b/docs/decisions/memory-tree.md
@@ -61,6 +61,6 @@ Existing vault files already use `summary:`. Accepting both as equivalent avoide
 - `MEMORY_TREE.md` (≈425 tokens) is loaded at cold start — small, bounded cost.
 - Cross-branch queries ("what movies should I recommend to my roommate") work without a node being in two places.
 - Re-embeddings run locally — offline-capable, no network dependency, no rate limits.
-- Phase 3 calibration is a **prerequisite for merge**. Shipping defaults without calibration risks either rejecting correct answers (LOW too high) or surfacing garbage (ABSTAIN too low).
+- Phase 3 calibration completed (2026-05-13). Thresholds calibrated via `deus sweep` on 136-query benchmark: abstain=0.30, gap=0.04 for Ollama embeddinggemma. Recall 0.743, abstain accuracy 0.50.
 - `scripts/memory_tree.py` grows from the 1063-LOC scaffold; future changes to retrieval logic must update `docs/research/memory-tree.md` as well — the research doc is load-bearing context for the thresholds and ship criteria.
 - Phase 6 (parallel budget migrations — entity extraction, contradiction detection, domain classifier → Ollama) is intentionally deferred to a separate branch. It is a related RPD-budget win, not part of this feature.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-13" # auto-bump
+last_verified: "2026-05-13T17" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -88,6 +88,8 @@ def _log_retrieval(
         pass
 
 
+# Controls distance-based atom fallback only. Atoms remain indexed for
+# MCP search (memory_indexer --query) and session catch-up (--learnings).
 ATOM_DIST_THRESHOLD = float(os.environ.get("DEUS_ATOM_DIST", "0"))
 
 


### PR DESCRIPTION
## Summary

ADR audit identified 3 medium-severity documentation issues. Fixes:

- **benchmark-regression-gate.md**: Scope "do not revert to low_threshold" to Ollama embeddinggemma specifically. Other models may have different score distributions.
- **memory-tree.md**: Update Phase 3 calibration from "prerequisite for merge" to "completed (2026-05-13)" with actual threshold values (abstain=0.30, gap=0.04, recall=0.743).
- **memory_query.py**: Clarify `DEUS_ATOM_DIST` controls distance-based fallback only. Atoms remain indexed for MCP search and session catch-up.

## Test plan

- [x] No code behavior changes, documentation only + 1 comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)