### PR TITLE
docs(adr): refine hook-dispatch ADR — Enforcement/Observer naming + CLI strategy

### DIFF
--- a/docs/decisions/hook-dispatch-system.md
+++ b/docs/decisions/hook-dispatch-system.md
@@ -2,29 +2,41 @@
 
 **Status:** Accepted
 **Date:** 2026-05-14
-**Scope:** `src/message-orchestrator.ts`, `.claude/hooks/`, `scripts/codex_warden_hooks.py`
-**Wardens consulted:** Brainstormer (2 rounds), Architecture Snapshot, Threat Modeler (BLOCK), Plan Agent, Advisor
+**Scope:** `src/message-orchestrator.ts`, `.claude/hooks/`, `scripts/codex_warden_hooks.py`, CLI (asymmetric by model)
+**Wardens consulted:** Brainstormer (2 rounds), Architecture Snapshot, Threat Modeler (BLOCK resolved), Plan Agent, Advisor
 
 ## Context
 
-Deus's 15+ hooks (quality gates, memory retrieval, safety checks, context injection) only work with Claude Code sessions. When users run Deus with OpenAI/Codex backend, local models, or any future backend, zero hooks fire. The hooks need to become model-agnostic.
+Deus's 15+ hooks (quality gates, memory retrieval, safety checks, context injection) only work with Claude Code sessions. When users run Deus with OpenAI/Codex backend, local models, or any future backend, zero hooks fire. The hooks need to become model-agnostic for both container agents and CLI sessions.
+
+**CLI strategy (asymmetric by model):** Claude CLI sessions stay on `claude` interactive (subscription-covered, unlimited, CC hooks). Non-Claude CLI sessions (OpenAI, Ollama, Qwen, future) run the Agent SDK on host with Deus HookPipeline (no subscription concern -- these use API keys or run locally). This gives every model hooks without touching the Claude subscription.
+
+Note: Codex CLI has the same subscription/API split as Claude (ChatGPT auth = subscription allocation, API key = pay-per-token). But unlike Claude, Codex CLI has ZERO hook support, making the SDK path strictly better -- you gain hooks without losing anything. Claude is the only model where subscription economics justify keeping the CLI spawning approach.
+
+**Auth defaults by backend:**
+- Claude: defaults to subscription (interactive CLI). Fallback: API key.
+- Codex: defaults to API key (SDK with Deus hooks). Fallback: subscription (degraded -- no hooks, warn user).
+- Ollama/local: no auth needed.
+- Other API models: API key only.
+
+When a user configures Codex, Deus prompts for an OpenAI API key by default. If declined, falls back to subscription but displays a warning about degraded experience (no guardrails, no memory retrieval, no quality gates).
 
 ## Decision
 
-Implement a Bridge-pattern hook system where Deus owns the hook contract and backends are dumb executors. Two layers with different trust models.
+Implement a Bridge-pattern hook system where Deus owns the hook contract and backends are dumb executors. Two layers with different trust models. For CLI, Claude stays on `claude` interactive (CC hooks); non-Claude CLIs run the Agent SDK on host with the same HookPipeline.
 
 ## Architecture
 
-### The Two Layers
+### Enforcement + Observer Layers
 
-**Layer 1 (Host-Enforced, in orchestrator):**
+**Enforcement Layer (Host-Enforced, in orchestrator):**
 - Fires in `message-orchestrator.ts` before/after container execution
 - Events: `SessionStart`, `UserPromptSubmit`, `Stop`
 - Container CANNOT opt out -- hooks run on the host before the container exists
 - ALL security-critical hooks live here
 - The host decides whether the container turn proceeds
 
-**Layer 2 (Container-Cooperative, in agent loop):**
+**Observer Layer (Container-Cooperative, in agent loop):**
 - Fires inside the container around tool execution
 - Events: `PreToolUse` (observational + context), `PostToolUse` (telemetry)
 - Container calls the HookDispatchService via HTTP bridge
@@ -32,33 +44,33 @@ Implement a Bridge-pattern hook system where Deus owns the hook contract and bac
 - Used for: memory retrieval, tool-size logging, tool audit, context injection
 - `PreToolUse` CAN return `updatedInput` (rewrite tool args) but NOT `deny`
 
-**Why this split:** The threat model identified an authority inversion -- if containers initiate security hook dispatch, a compromised container can skip it. Layer 1 eliminates this by making security decisions host-initiated. Layer 2 remains useful for non-security hooks where the container cooperates in good faith.
+**Why this split:** The threat model identified an authority inversion -- if containers initiate security hook dispatch, a compromised container can skip it. The Enforcement Layer eliminates this by making security decisions host-initiated. The Observer Layer remains useful for non-security hooks where the container cooperates in good faith.
 
 ### Discriminated HookResult
 
 ```typescript
-// Layer 1 results: can deny operations
-interface Layer1HookResult {
+// Enforcement Layer results: can deny operations
+interface EnforcementHookResult {
   continue: boolean;           // false = block the operation
   stopReason?: string;
   additionalContext?: string;  // injected into the prompt
 }
 
-// Layer 2 results: context and observation only
-interface Layer2HookResult {
+// Observer Layer results: context and observation only
+interface ObserverHookResult {
   additionalContext?: string;
   updatedInput?: Record<string, unknown>;  // rewrite tool args
 }
 ```
 
-No `permissionDecision` field anywhere. Layer 1 uses `continue=false` to deny. Layer 2 cannot deny. This eliminates the anti-pattern of "symmetric permission enforcement across backends."
+No `permissionDecision` field anywhere. Enforcement uses `continue=false` to deny. Observer cannot deny. This eliminates the anti-pattern of "symmetric permission enforcement across backends."
 
 ### HookDispatchService (:3002)
 
-Dedicated HTTP service, completely isolated from credential proxy (:3001).
+Dedicated HTTP service, completely isolated from credential proxy (:3001). Transport is pluggable (HTTP first, interface-based so UDS/gRPC can replace later).
 
 **What it handles:**
-- Hook script execution for Layer 2 events dispatched from containers
+- Hook script execution for Observer Layer events dispatched from containers
 - Memory queries (migrated from credential proxy)
 - No access to API keys, OAuth tokens, or credential files
 
@@ -80,43 +92,43 @@ Dedicated HTTP service, completely isolated from credential proxy (:3001).
 
 | Hook | Target Layer | Rationale |
 |------|-------------|-----------|
-| plan-review-gate.sh | Layer 1 | Security gate: must be host-enforced |
-| code-review-gate.sh | Layer 1 | Security gate: must be host-enforced |
-| threat-model-gate.sh | Layer 1 | Security gate: must be host-enforced |
-| injection-scanner.ts | Layer 1 | Already in the right place |
-| path-leak-detector.sh | Layer 1 | Safety check, host-only |
-| code-review-invalidator.sh | Layer 1 | Marker management, host-only |
-| plan-mode-invalidator.sh | Layer 1 | Marker management, host-only |
-| plan-mode-session-init.sh | Layer 1 | Session lifecycle, host-only |
-| vault-context-hook.py | Layer 1 | Context injection, host-only |
-| standards-pack.py | Layer 1 | Context injection, host-only |
-| catchup-freshness.sh | Layer 1 | Context injection, host-only |
-| memory-cite.sh | Layer 1 | Host filesystem check |
-| memory-cite-seed.sh | Layer 1 | Session lifecycle, host-only |
-| orchestrator-preflight.sh | Layer 1 | Already orchestrator-scoped |
-| plan-revise-logger.sh | Layer 1 | Logging, host-only |
-| memory-retrieval.sh | **Layer 2** | Needs per-turn firing inside agent loop |
+| plan-review-gate.sh | Enforcement | Security gate: must be host-enforced |
+| code-review-gate.sh | Enforcement | Security gate: must be host-enforced |
+| threat-model-gate.sh | Enforcement | Security gate: must be host-enforced |
+| injection-scanner.ts | Enforcement | Already in the right place |
+| path-leak-detector.sh | Enforcement | Safety check, host-only |
+| code-review-invalidator.sh | Enforcement | Marker management, host-only |
+| plan-mode-invalidator.sh | Enforcement | Marker management, host-only |
+| plan-mode-session-init.sh | Enforcement | Session lifecycle, host-only |
+| vault-context-hook.py | Enforcement | Context injection, host-only |
+| standards-pack.py | Enforcement | Context injection, host-only |
+| catchup-freshness.sh | Enforcement | Context injection, host-only |
+| memory-cite.sh | Enforcement | Host filesystem check |
+| memory-cite-seed.sh | Enforcement | Session lifecycle, host-only |
+| orchestrator-preflight.sh | Enforcement | Already orchestrator-scoped |
+| plan-revise-logger.sh | Enforcement | Logging, host-only |
+| memory-retrieval.sh | **Observer** | Needs per-turn firing inside agent loop |
 | sonnet-default-reminder.sh | **DROP** | Claude-specific, not model-agnostic |
 
-**Result:** 14 of 15 hooks become Layer 1 (host-enforced). Only memory-retrieval stays Layer 2. 1 dropped.
+**Result:** 14 of 15 hooks become Enforcement (host-enforced). Only memory-retrieval stays Observer. 1 dropped.
 
 ### HookPipeline Interface (Bridge Pattern)
 
 ```typescript
 interface HookPipeline {
-  // Layer 1: fires in orchestrator, can deny
-  dispatchLayer1(
+  // Enforcement Layer: fires in orchestrator, can deny
+  enforce(
     event: 'SessionStart' | 'UserPromptSubmit' | 'Stop',
     context: HookContext,
     payload: Record<string, unknown>,
-  ): Promise<Layer1HookResult>;
+  ): Promise<EnforcementHookResult>;
 
-  // Layer 2: fires in container via HTTP bridge, cannot deny
-  dispatchLayer2(
+  // Observer Layer: fires in container via HTTP bridge, cannot deny
+  observe(
     event: 'PreToolUse' | 'PostToolUse',
     context: HookContext,
     payload: Record<string, unknown>,
-  ): Promise<Layer2HookResult>;
+  ): Promise<ObserverHookResult>;
 }
 ```
 
@@ -127,39 +139,54 @@ Method names make the trust difference explicit. Part of `AgentRuntime` contract
 ```
 Abstraction (Deus-owned)         Implementation (Backend-specific)
 ========================         =================================
-HookPipeline interface    <----> Claude: SDK HookCallback adapter
-                          <----> OpenAI: executeBrokerTool() wrapper
-                          <----> Future: TBD adapter
+HookPipeline interface    <----> Claude: SDK HookCallback adapter (~5 lines)
+                          <----> OpenAI: executeBrokerTool() wrapper (~5 lines)
+                          <----> Ollama/future: tool loop wrapper (~5 lines)
 
-HookDispatcher (host)     <----> ShellHookAdapter (runs scripts)
+HookDispatcher (host)     <----> ShellHookAdapter (runs existing scripts)
 
 HookDispatchService       <----> HookBridge (container HTTP client)
 (host :3002)                     (container-side, fail-open)
 ```
 
+Per-backend work is ~5 lines at the tool call chokepoint, not a full implementation. The hook logic (which scripts fire, how results are processed) is shared.
+
 ### Double-Enforcement (Claude Code sessions)
 
-When using Claude backend, Claude Code's native hooks still fire inside the SDK. Layer 1 hooks ALSO fire in the orchestrator. This is defense-in-depth:
-- Layer 1 catches issues before the container runs (definitive)
+When using Claude backend, Claude Code's native hooks still fire inside the SDK. Enforcement Layer hooks ALSO fire in the orchestrator. This is defense-in-depth:
+- Enforcement Layer catches issues before the container runs (definitive)
 - Claude CC native hooks catch inside the agent loop (backup)
-- Non-Claude backends: only Layer 1 fires (still fully protected)
+- Non-Claude backends: only Enforcement Layer fires (still fully protected)
 
 ### Default-Off
 
 No `hooks.json` = zero hooks fire, zero overhead. Non-technical users are unaffected. The HookDispatchService still starts (serves memory queries) but hook dispatch returns empty results.
 
+### CLI/Agent View (Asymmetric by Model)
+
+**Claude CLI:** Spawns `claude` interactive. Subscription-covered (unlimited). Uses Claude Code's native hook system (`~/.claude/hooks/`) for per-tool-call enforcement. Migrating to SDK would shift to credit pool ($100-200/month cap) -- not acceptable.
+
+**Non-Claude CLI (OpenAI, Ollama, Qwen, future):** Runs the Agent SDK directly on the host with Deus HookPipeline. No subscription concern (API key pay-per-token or local/free). Full hook control via the same `enforce()` + `observe()` interface used by container agents.
+
+This means every model gets hooks in CLI:
+- Claude: via CC hooks (existing, proven, subscription-friendly)
+- Everything else: via Deus hooks running SDK on host (full control, no subscription constraint)
+
+Codex CLI specifically has zero hook support, so the SDK path is strictly better -- you gain hooks without losing anything.
+
 ### Incremental Deployment
 
-**Phase 1:** Interface + Layer 1 hooks in orchestrator. All 14 Layer 1 hooks become model-agnostic. No container changes.
+**Phase 1:** Interface + Enforcement Layer hooks in orchestrator. All 14 Enforcement hooks become model-agnostic for container agents. No container changes.
 
-**Phase 2:** HookDispatchService + Layer 2 bridge. Memory retrieval works for OpenAI. Credential proxy loses memory route.
+**Phase 2:** HookDispatchService + Observer Layer bridge. Memory retrieval works for OpenAI backend. Credential proxy loses memory route (reduced attack surface).
 
 **Phase 3:** Configuration (per-group enable/disable), migration guide, documentation.
 
 ## Consequences
 
-- All hooks work across all backends
+- All container agent hooks work across all backends (Claude, OpenAI, Ollama, future)
 - Security hooks are host-enforced (cannot be bypassed by container)
 - Credential proxy attack surface reduced
 - Non-technical users see zero overhead
-- Future backends get hooks by implementing HookPipeline (2 methods)
+- Future backends get hooks by implementing ~5 lines at their tool call chokepoint
+- CLI: Claude stays on CC hooks (subscription-friendly), non-Claude runs SDK with Deus hooks (full control)

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-16"
+last_verified: "2026-05-16" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary

Refines the model-agnostic hook-dispatch ADR (added to main via #408) with:
- **Rename Layer 1/2 → Enforcement/Observer** (more descriptive trust model)
- **CLI strategy section**: asymmetric by model (Claude CLI stays interactive on subscription; non-Claude CLIs run Agent SDK on host with Deus HookPipeline)
- **Auth defaults by backend**: Codex defaults to API key for hook coverage; subscription fallback warns user about degraded experience
- **Codex CLI zero-hook-support note**: SDK path strictly better
- **Bridge Pattern annotations**: ~5 lines per backend at tool-call chokepoint, plus Ollama row
- **Method-name signaling**: `enforce()` vs `observe()` make the trust difference explicit (replaces `dispatchLayer1`/`dispatchLayer2`)
- Updates Incremental Deployment + Consequences to cover CLI hook coverage

**Context:** Originally an *add* PR, but main shipped the same ADR via #408 first. After rebase add/add conflict, converted to refinement: branch reset to origin/main, single refinement commit replacing the original two add commits.

## Test plan

- [x] plan-reviewer warden: SHIP
- [x] code-reviewer warden: SHIP (1 warning on tool-managed `# auto-bump` comment retained; 1 informational on section heading addressed)
- [x] verification-gate warden: SHIP (15 requirements verified, drift_check OK)
- [ ] CI green
- [ ] No outstanding Layer 1 / Layer 2 references (verified locally: 0 legacy refs, 37 Enforcement/Observer refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)