### PR TITLE
fix(evolution): lower auto-optimize threshold, optimize all modules

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -165,12 +165,14 @@ def _maybe_auto_optimize(domain_presets: Optional[list] = None) -> None:
 
     try:
         from .optimizer.dspy_optimizer import optimize
-        optimize(module="qa")
-        # Domain-specific optimization if enough domain data
-        for domain in (domain_presets or []):
-            optimize(module="qa", domain=domain)
-    except Exception:
-        pass  # Non-fatal
+        from .optimizer.modules import MODULE_REGISTRY
+        for module_name in MODULE_REGISTRY:
+            optimize(module=module_name)
+            # Domain-specific optimization if enough domain data
+            for domain in (domain_presets or []):
+                optimize(module=module_name, domain=domain)
+    except Exception as exc:
+        log.warning('evolution: auto-optimize failed — %s: %s', type(exc).__name__, exc)
 
 
 def _maybe_batch_judge(domain_presets: Optional[list] = None) -> None:

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -56,7 +56,7 @@ DSPY_MIN_DOMAIN_SAMPLES = int(os.environ.get("EVOLUTION_DSPY_MIN_DOMAIN_SAMPLES"
 # ── Auto-triggers ────────────────────────────────────────────────────────────
 
 # Auto-optimize after this many new scored interactions (0 = disabled).
-AUTO_OPTIMIZE_THRESHOLD = int(os.environ.get("EVOLUTION_AUTO_OPTIMIZE_THRESHOLD", "50"))
+AUTO_OPTIMIZE_THRESHOLD = int(os.environ.get("EVOLUTION_AUTO_OPTIMIZE_THRESHOLD", "15"))
 # Cooldown between principle extractions (hours).
 PRINCIPLES_COOLDOWN_HOURS = int(os.environ.get("EVOLUTION_PRINCIPLES_COOLDOWN_HOURS", "24"))
 # How many times to retry Gemini judge on JSON parse failure before falling back to neutral score.

--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -690,3 +690,103 @@ def test_main_unknown_subcommand_exits_nonzero():
         cwd=str(Path(__file__).resolve().parents[2]),
     )
     assert result.returncode != 0
+
+
+# ── _maybe_auto_optimize tests ──────────────────────────────────────────────
+
+
+def test_auto_optimize_calls_all_modules(monkeypatch):
+    """_maybe_auto_optimize should call optimize() for every module in MODULE_REGISTRY."""
+    import evolution.config as cfg
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+
+    # Mock storage to report enough scored interactions
+    fake_store = MagicMock()
+    fake_store.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake_store.count_scored_since.return_value = 20  # above threshold
+
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake_store)
+
+    optimize_calls = []
+
+    def fake_optimize(module="qa", **kwargs):
+        optimize_calls.append((module, kwargs.get("domain")))
+        return None
+
+    monkeypatch.setattr("evolution.optimizer.dspy_optimizer.optimize", fake_optimize)
+
+    from evolution.cli import _maybe_auto_optimize
+    _maybe_auto_optimize(domain_presets=None)
+
+    called_modules = [m for m, d in optimize_calls]
+    assert "qa" in called_modules
+    assert "tool_selection" in called_modules
+    assert "summarization" in called_modules
+
+
+def test_auto_optimize_includes_domain_presets(monkeypatch):
+    """_maybe_auto_optimize should call optimize() with each domain for every module."""
+    import evolution.config as cfg
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+
+    fake_store = MagicMock()
+    fake_store.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake_store.count_scored_since.return_value = 20
+
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake_store)
+
+    optimize_calls = []
+
+    def fake_optimize(module="qa", **kwargs):
+        optimize_calls.append((module, kwargs.get("domain")))
+        return None
+
+    monkeypatch.setattr("evolution.optimizer.dspy_optimizer.optimize", fake_optimize)
+
+    from evolution.cli import _maybe_auto_optimize
+    _maybe_auto_optimize(domain_presets=["marketing", "engineering"])
+
+    # Each of the 3 modules should have a None-domain call + 2 domain calls = 9 total
+    assert len(optimize_calls) == 9, f"Expected 9 optimize calls (3 modules x 3 variants), got {len(optimize_calls)}: {optimize_calls}"
+
+    # Verify domain calls exist for each module
+    for mod in ["qa", "tool_selection", "summarization"]:
+        mod_calls = [(m, d) for m, d in optimize_calls if m == mod]
+        domains = [d for _, d in mod_calls]
+        assert None in domains, f"{mod} missing cross-domain call"
+        assert "marketing" in domains, f"{mod} missing marketing domain call"
+        assert "engineering" in domains, f"{mod} missing engineering domain call"
+
+
+def test_auto_optimize_disabled_when_threshold_zero(monkeypatch):
+    """EVOLUTION_AUTO_OPTIMIZE_THRESHOLD=0 should disable auto-optimization."""
+    import evolution.config as cfg
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 0)
+
+    optimize_calls = []
+    monkeypatch.setattr("evolution.optimizer.dspy_optimizer.optimize", lambda **kw: optimize_calls.append(kw))
+
+    from evolution.cli import _maybe_auto_optimize
+    _maybe_auto_optimize()
+
+    assert len(optimize_calls) == 0, "optimize should not be called when threshold is 0"
+
+
+def test_auto_optimize_skips_below_threshold(monkeypatch):
+    """_maybe_auto_optimize should skip when scored count is below threshold."""
+    import evolution.config as cfg
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+
+    fake_store = MagicMock()
+    fake_store.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake_store.count_scored_since.return_value = 5  # below threshold
+
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake_store)
+
+    optimize_calls = []
+    monkeypatch.setattr("evolution.optimizer.dspy_optimizer.optimize", lambda **kw: optimize_calls.append(kw))
+
+    from evolution.cli import _maybe_auto_optimize
+    _maybe_auto_optimize()
+
+    assert len(optimize_calls) == 0, "optimize should not be called below threshold"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-14" # auto-bump
+last_verified: "2026-05-14" # auto-bump (auto-optimize)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-14" # auto-bump
+last_verified: "2026-05-14" # auto-bump (auto-optimize)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary

- **Lower default threshold from 50 to 15** — `AUTO_OPTIMIZE_THRESHOLD` was set to 50 scored interactions since the last artifact, which took weeks to accumulate. Lowered to 15 while keeping `EVOLUTION_AUTO_OPTIMIZE_THRESHOLD` env var override for backward compatibility.
- **Auto-optimize all modules, not just `qa`** — `_maybe_auto_optimize()` now iterates over all `MODULE_REGISTRY` entries (`qa`, `tool_selection`, `summarization`) instead of hardcoding `optimize(module="qa")`. Each module's `optimize()` call internally gates on `DSPY_MIN_SAMPLES`, so modules with insufficient data are safely skipped.
- **Replace bare `except: pass` with warning log** — Matches the logging pattern used by `_maybe_auto_extract_principles` for observability.

**Note:** First run after deploy may produce a burst of artifacts (up to 3 modules) since the threshold is lower and all modules are now eligible.

## Test plan

- [x] All 208 existing evolution tests pass
- [x] 4 new tests added for `_maybe_auto_optimize`:
  - Calls optimize for all 3 modules (qa, tool_selection, summarization)
  - Includes domain presets for every module (9 total calls with 2 domains)
  - Disabled when threshold is 0
  - Skips when scored count is below threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)