### PR TITLE
feat(runtime): per-group agent effort level

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -53,6 +53,7 @@ interface ContainerInput {
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
   projectHint?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
 }
 
 interface ImageContentBlock {
@@ -606,19 +607,20 @@ async function runQuery(
   let messageCount = 0;
   let resultCount = 0;
 
-  // Effort level (Opus 4.7): default 'low' for latency-sensitive
-  // personal-assistant traffic. Override via DEUS_AGENT_EFFORT env var.
-  // Valid values: low | medium | high | max | default (unset).
-  // Migration guide: 'low' is recommended for "short, scoped tasks and
-  // latency-sensitive workloads that are not intelligence-sensitive".
-  const effortEnv = (process.env.DEUS_AGENT_EFFORT || 'low').toLowerCase();
+  // 'default' = let SDK pick (effort undefined). Env var is operator escape hatch.
+  const rawEffort =
+    containerInput.effort ??
+    process.env.DEUS_AGENT_EFFORT?.toLowerCase() ??
+    'low';
   const effort =
-    effortEnv === 'default'
+    rawEffort === 'default'
       ? undefined
-      : ['low', 'medium', 'high', 'max'].includes(effortEnv)
-        ? (effortEnv as 'low' | 'medium' | 'high' | 'max')
+      : ['low', 'medium', 'high', 'max'].includes(rawEffort)
+        ? (rawEffort as 'low' | 'medium' | 'high' | 'max')
         : 'low';
-  log(`Effort level: ${effort ?? 'SDK default'}`);
+  log(
+    `Effort level: ${effort ?? 'SDK default'}${containerInput.effort ? ' (per-group)' : ''}`,
+  );
 
   // Detect external project mount: if /workspace/project exists and has content,
   // use it as the primary cwd. The agent works in the user's project directory

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -473,7 +473,7 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
     containerInput.sessionRef?.session_id || containerInput.sessionId;
   let metadataJson = containerInput.sessionRef?.metadata_json;
 
-  // TODO: wire effort into OpenAI Responses API reasoning.effort for o-series models
+  // TODO(2026-Q3): wire effort into OpenAI Responses API reasoning.effort for o-series models
   if (containerInput.effort && containerInput.effort !== 'low') {
     log(
       `Effort level '${containerInput.effort}' requested but not yet supported for OpenAI backend — using model default`,

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -40,6 +40,7 @@ export interface ContainerInput {
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
   projectHint?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
 }
 
 export interface ContainerOutput {
@@ -471,6 +472,13 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
   let sessionId =
     containerInput.sessionRef?.session_id || containerInput.sessionId;
   let metadataJson = containerInput.sessionRef?.metadata_json;
+
+  // TODO: wire effort into OpenAI Responses API reasoning.effort for o-series models
+  if (containerInput.effort && containerInput.effort !== 'low') {
+    log(
+      `Effort level '${containerInput.effort}' requested but not yet supported for OpenAI backend — using model default`,
+    );
+  }
 
   let prompt = containerInput.prompt;
   if (prompt.trim() === '/compact') {

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -26,6 +26,7 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DEUS_AGENT_BACKEND` | `claude` | Default container agent backend: `claude` or `openai` |
+| `DEUS_AGENT_EFFORT` | `low` | Default agent reasoning effort: `low`, `medium`, `high`, or `max`. Per-group override via `/settings effort=X`. |
 | `DEUS_CLI_AGENT` | `DEUS_AGENT_BACKEND` | Default `deus` global command agent: `claude`, `codex`, or `openai` |
 | `DEUS_OPENAI_MODEL` | `gpt-4o` | Default OpenAI model for the `openai` agent backend |
 | `DEUS_CODEX_MODEL` | `DEUS_OPENAI_MODEL` | Optional Codex CLI model override for the `deus codex` launcher |
@@ -134,6 +135,13 @@ Group/task backend overrides:
 - Registered groups can set `containerConfig.agentBackend` to pin a group to `claude` or `openai`.
 - Scheduled tasks can set `agent_backend` to override the group/default backend for that task only.
 - Resolution order is: task override, group override, `DEUS_AGENT_BACKEND`, then `claude`.
+
+Group/task effort overrides:
+
+- Registered groups can set `containerConfig.agentEffort` to pin a group to a specific effort level.
+- Scheduled tasks can set `agent_effort` to override the group/default effort for that task only.
+- Resolution order is: task override, group override, `DEUS_AGENT_EFFORT`, then `low`.
+- Effort currently applies to the Claude backend only. OpenAI backend logs and ignores the value.
 
 ## Safety
 

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-13" # auto-bump
+last_verified: "2026-05-14" # auto-bump
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-13" # auto-bump
+last_verified: "2026-05-14" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/src/agent-runtimes/container-backend.ts
+++ b/src/agent-runtimes/container-backend.ts
@@ -80,7 +80,7 @@ export class ContainerRuntime implements AgentRuntime {
     };
 
     const hasSession = sessionRef.session_id !== '';
-    const effort = resolveAgentEffort(group);
+    const effort = runContext.effort ?? resolveAgentEffort(group);
     const output = await runContainerAgent(
       group,
       {

--- a/src/agent-runtimes/container-backend.ts
+++ b/src/agent-runtimes/container-backend.ts
@@ -15,6 +15,7 @@ import {
   runContainerAgent,
 } from '../container-runner.js';
 import type { RegisteredGroup } from '../types.js';
+import { resolveAgentEffort } from './resolve.js';
 
 export interface ContainerRuntimeDeps {
   resolveGroup: (groupFolder: string) => RegisteredGroup | undefined;
@@ -79,6 +80,7 @@ export class ContainerRuntime implements AgentRuntime {
     };
 
     const hasSession = sessionRef.session_id !== '';
+    const effort = resolveAgentEffort(group);
     const output = await runContainerAgent(
       group,
       {
@@ -91,6 +93,7 @@ export class ContainerRuntime implements AgentRuntime {
         isControlGroup: runContext.isControlGroup,
         isScheduledTask: runContext.isScheduledTask,
         assistantName: this.deps.assistantName,
+        effort,
         ...(runContext.imageInputs?.length && {
           imageAttachments: runContext.imageInputs,
         }),

--- a/src/agent-runtimes/index.ts
+++ b/src/agent-runtimes/index.ts
@@ -10,7 +10,7 @@ export type {
 } from './types.js';
 export { defaultSession } from './types.js';
 export { resolveAgentRuntime, resolveAgentEffort } from './resolve.js';
-export type { AgentEffortLevel } from './resolve.js';
+export type { AgentEffortLevel } from '../types.js';
 export {
   ContainerRuntime,
   type ContainerRuntimeDeps,

--- a/src/agent-runtimes/index.ts
+++ b/src/agent-runtimes/index.ts
@@ -9,7 +9,8 @@ export type {
   RuntimeEventSink,
 } from './types.js';
 export { defaultSession } from './types.js';
-export { resolveAgentRuntime } from './resolve.js';
+export { resolveAgentRuntime, resolveAgentEffort } from './resolve.js';
+export type { AgentEffortLevel } from './resolve.js';
 export {
   ContainerRuntime,
   type ContainerRuntimeDeps,

--- a/src/agent-runtimes/resolve.test.ts
+++ b/src/agent-runtimes/resolve.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
 
-import { resolveAgentRuntime } from './resolve.js';
+import { resolveAgentRuntime, resolveAgentEffort } from './resolve.js';
 import type { RegisteredGroup, ScheduledTask } from '../types.js';
 
 function makeGroup(overrides: Partial<RegisteredGroup> = {}): RegisteredGroup {
@@ -51,5 +51,47 @@ describe('resolveAgentRuntime', () => {
 
   it('falls back to the global default when no override exists', () => {
     expect(resolveAgentRuntime(makeGroup())).toBe('claude');
+  });
+});
+
+describe('resolveAgentEffort', () => {
+  afterEach(() => {
+    delete process.env.DEUS_AGENT_EFFORT;
+  });
+
+  it('prefers the scheduled task effort override', () => {
+    const group = makeGroup({
+      containerConfig: { agentEffort: 'medium' },
+    });
+    const task = makeTask({ agent_effort: 'max' });
+
+    expect(resolveAgentEffort(group, task)).toBe('max');
+  });
+
+  it('falls back to the group effort override', () => {
+    const group = makeGroup({
+      containerConfig: { agentEffort: 'high' },
+    });
+
+    expect(resolveAgentEffort(group)).toBe('high');
+  });
+
+  it('falls back to DEUS_AGENT_EFFORT env var', () => {
+    process.env.DEUS_AGENT_EFFORT = 'medium';
+    expect(resolveAgentEffort(makeGroup())).toBe('medium');
+  });
+
+  it('ignores invalid env var values', () => {
+    process.env.DEUS_AGENT_EFFORT = 'turbo';
+    expect(resolveAgentEffort(makeGroup())).toBe('low');
+  });
+
+  it('is case-insensitive for env var', () => {
+    process.env.DEUS_AGENT_EFFORT = 'HIGH';
+    expect(resolveAgentEffort(makeGroup())).toBe('high');
+  });
+
+  it('defaults to low when no override exists', () => {
+    expect(resolveAgentEffort(makeGroup())).toBe('low');
   });
 });

--- a/src/agent-runtimes/resolve.ts
+++ b/src/agent-runtimes/resolve.ts
@@ -7,8 +7,6 @@ import type {
 } from '../types.js';
 import type { AgentRuntimeId } from './types.js';
 
-export type { AgentEffortLevel };
-
 export function resolveAgentRuntime(
   group: RegisteredGroup,
   task?: ScheduledTask,

--- a/src/agent-runtimes/resolve.ts
+++ b/src/agent-runtimes/resolve.ts
@@ -1,6 +1,13 @@
 import { DEFAULT_AGENT_RUNTIME } from '../config.js';
-import type { RegisteredGroup, ScheduledTask } from '../types.js';
+import { VALID_EFFORT_LEVELS } from '../types.js';
+import type {
+  AgentEffortLevel,
+  RegisteredGroup,
+  ScheduledTask,
+} from '../types.js';
 import type { AgentRuntimeId } from './types.js';
+
+export type { AgentEffortLevel };
 
 export function resolveAgentRuntime(
   group: RegisteredGroup,
@@ -11,4 +18,24 @@ export function resolveAgentRuntime(
     return group.containerConfig.agentBackend;
   }
   return DEFAULT_AGENT_RUNTIME;
+}
+
+const DEFAULT_AGENT_EFFORT: AgentEffortLevel = 'low';
+
+export function resolveAgentEffort(
+  group: RegisteredGroup,
+  task?: ScheduledTask,
+): AgentEffortLevel {
+  if (task?.agent_effort) return task.agent_effort;
+  if (group.containerConfig?.agentEffort) {
+    return group.containerConfig.agentEffort;
+  }
+  const envEffort = process.env.DEUS_AGENT_EFFORT?.toLowerCase();
+  if (
+    envEffort &&
+    (VALID_EFFORT_LEVELS as readonly string[]).includes(envEffort)
+  ) {
+    return envEffort as AgentEffortLevel;
+  }
+  return DEFAULT_AGENT_EFFORT;
 }

--- a/src/agent-runtimes/types.ts
+++ b/src/agent-runtimes/types.ts
@@ -26,6 +26,7 @@ export interface RunContext {
   chatJid: string;
   isControlGroup: boolean;
   isScheduledTask?: boolean;
+  effort?: import('../types.js').AgentEffortLevel;
   backendConfig?: Record<string, unknown>;
   imageInputs?: Array<{ relativePath: string; mediaType: string }>;
   toolBroker?: ToolBroker;

--- a/src/agent-runtimes/types.ts
+++ b/src/agent-runtimes/types.ts
@@ -1,3 +1,4 @@
+import type { AgentEffortLevel } from '../types.js';
 import type { ToolBroker } from '../tool-broker/types.js';
 
 export type AgentRuntimeId = 'claude' | 'openai';
@@ -26,7 +27,7 @@ export interface RunContext {
   chatJid: string;
   isControlGroup: boolean;
   isScheduledTask?: boolean;
-  effort?: import('../types.js').AgentEffortLevel;
+  effort?: AgentEffortLevel;
   backendConfig?: Record<string, unknown>;
   imageInputs?: Array<{ relativePath: string; mediaType: string }>;
   toolBroker?: ToolBroker;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -41,6 +41,7 @@ import {
 import { forceKillProcess } from './platform.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { buildVolumeMounts } from './container-mounter.js';
+import type { AgentEffortLevel } from './types.js';
 import { RegisteredGroup } from './types.js';
 import { detectDomainsWithFallback } from './domain-presets.js';
 import { getReflections, logInteraction } from './evolution-client.js';
@@ -65,6 +66,7 @@ export interface ContainerInput {
   assistantName?: string;
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
   projectHint?: string;
+  effort?: AgentEffortLevel;
 }
 
 export interface ContainerOutput {

--- a/src/session-commands.test.ts
+++ b/src/session-commands.test.ts
@@ -353,3 +353,37 @@ describe('handleSettingsCommand — memory_privacy', () => {
     ]);
   });
 });
+
+describe('handleSettingsCommand — effort', () => {
+  it('sets valid effort level', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand('/settings effort=high', group, 24);
+    expect(result.response).toBe('effort set to high');
+    expect(result.updatedGroup?.containerConfig?.agentEffort).toBe('high');
+  });
+
+  it('rejects invalid effort level', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand('/settings effort=turbo', group, 24);
+    expect(result.response).toContain('Invalid effort level: turbo');
+    expect(result.updatedGroup).toBeUndefined();
+  });
+
+  it('normalizes to lowercase', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand('/settings effort=MAX', group, 24);
+    expect(result.updatedGroup?.containerConfig?.agentEffort).toBe('max');
+  });
+
+  it('displays current effort in settings output', () => {
+    const group = makeGroup({ containerConfig: { agentEffort: 'medium' } });
+    const result = handleSettingsCommand('/settings', group, 24);
+    expect(result.response).toContain('effort: medium');
+  });
+
+  it('displays default when no effort configured', () => {
+    const group = makeGroup();
+    const result = handleSettingsCommand('/settings', group, 24);
+    expect(result.response).toContain('effort: low (default)');
+  });
+});

--- a/src/session-commands.ts
+++ b/src/session-commands.ts
@@ -1,4 +1,5 @@
-import type { NewMessage, RegisteredGroup } from './types.js';
+import type { NewMessage, RegisteredGroup, AgentEffortLevel } from './types.js';
+import { VALID_EFFORT_LEVELS } from './types.js';
 import { logger } from './logger.js';
 
 // ── /settings command ─────────────────────────────────────────────────────────
@@ -31,7 +32,8 @@ const SETTINGS_HELP =
   '  timeout=N             — container timeout in seconds (min 30)\n' +
   '  requires_trigger=true/false  — whether @Name prefix is required\n' +
   '  memory_privacy=level1,level2  — privacy levels this channel can access\n' +
-  '    levels: public, internal, private, sensitive (default: public,internal,private)';
+  '    levels: public, internal, private, sensitive (default: public,internal,private)\n' +
+  '  effort=level  — agent reasoning effort (low, medium, high, max; default: low)';
 
 /**
  * Parse and apply a /settings command.
@@ -48,6 +50,7 @@ export function handleSettingsCommand(
   if (!args) {
     const idleHours = group.containerConfig?.sessionIdleResetHours;
     const timeoutMs = group.containerConfig?.timeout;
+    const effortLevel = group.containerConfig?.agentEffort;
     const lines = [
       `Settings — ${group.name}`,
       `  session_idle_hours: ${
@@ -60,6 +63,7 @@ export function handleSettingsCommand(
       `  timeout: ${timeoutMs !== undefined ? `${Math.round(timeoutMs / 1000)}s` : '300s (default)'}`,
       `  requires_trigger: ${group.requiresTrigger !== false}`,
       `  memory_privacy: ${group.containerConfig?.memoryPrivacy?.join(',') || 'public,internal,private (default)'}`,
+      `  effort: ${effortLevel || 'low (default)'}`,
       '',
       SETTINGS_HELP,
     ];
@@ -145,6 +149,22 @@ export function handleSettingsCommand(
       };
       return {
         response: `memory_privacy set to ${levels.join(',')}`,
+        updatedGroup,
+      };
+    }
+    case 'effort': {
+      const level = value.toLowerCase();
+      if (!(VALID_EFFORT_LEVELS as readonly string[]).includes(level)) {
+        return {
+          response: `Invalid effort level: ${value}. Valid: ${VALID_EFFORT_LEVELS.join(', ')}`,
+        };
+      }
+      updatedGroup.containerConfig = {
+        ...updatedGroup.containerConfig,
+        agentEffort: level as AgentEffortLevel,
+      };
+      return {
+        response: `effort set to ${level}`,
         updatedGroup,
       };
     }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -9,6 +9,7 @@ import {
   type RuntimeEventSink,
 } from './agent-runtimes/types.js';
 import type { RuntimeRegistry } from './agent-runtimes/registry.js';
+import { resolveAgentEffort } from './agent-runtimes/resolve.js';
 import { SCHEDULER_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { writeTasksSnapshot } from './container-runner.js';
 import {
@@ -188,6 +189,7 @@ async function runTask(
     chatJid: task.chat_jid,
     isControlGroup,
     isScheduledTask: true,
+    effort: resolveAgentEffort(group, task),
   };
 
   const currentSessionRef = sessionRef ?? defaultSession('', backend);

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,14 @@ export interface AllowedRoot {
   description?: string;
 }
 
+export type AgentEffortLevel = 'low' | 'medium' | 'high' | 'max';
+export const VALID_EFFORT_LEVELS: readonly AgentEffortLevel[] = [
+  'low',
+  'medium',
+  'high',
+  'max',
+];
+
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000ms (5 minutes). Configurable via /settings timeout=N (seconds).
@@ -36,6 +44,7 @@ export interface ContainerConfig {
   memoryPrivacy?: string[]; // Privacy levels the container can access (e.g. ["public","internal","private"]).
   // Injected as DEUS_MEMORY_PRIVACY env var. Default: all except sensitive.
   agentBackend?: AgentRuntimeId; // Optional override for this group's default backend.
+  agentEffort?: AgentEffortLevel; // Optional override for this group's agent effort level.
 }
 
 export interface ProjectType {
@@ -103,6 +112,7 @@ export interface ScheduledTask {
   status: 'active' | 'paused' | 'completed';
   created_at: string;
   agent_backend?: AgentRuntimeId | null;
+  agent_effort?: AgentEffortLevel | null;
 }
 
 export interface TaskRunLog {


### PR DESCRIPTION
## Summary
- Add per-group agent effort level (`low`/`medium`/`high`/`max`) configurable via `containerConfig.agentEffort` and the `/settings effort=X` chat command
- Effort resolution follows a priority cascade: task override > group config > `DEUS_AGENT_EFFORT` env var > `low` (default). Group config beats the env var — the env var is a fallback for groups without an explicit setting.
- Centralized `AgentEffortLevel` type and `VALID_EFFORT_LEVELS` constant in `src/types.ts`
- Task-level effort overrides are threaded through `RunContext.effort` so they reach the container backend
- Effort currently applies to the Claude backend only. OpenAI backend logs and ignores the value (TODO for `reasoning.effort` on o-series models).

## Changes
- `src/types.ts` — `AgentEffortLevel` type, `VALID_EFFORT_LEVELS` const, `agentEffort` on `ContainerConfig` and `ScheduledTask`
- `src/agent-runtimes/types.ts` — `effort` field on `RunContext`
- `src/agent-runtimes/resolve.ts` — `resolveAgentEffort()` function with task > group > env > default cascade
- `src/agent-runtimes/container-backend.ts` — prefers `RunContext.effort`, falls back to `resolveAgentEffort(group)`
- `src/task-scheduler.ts` — resolves effort with task object, sets on `RunContext`
- `src/container-runner.ts` — `effort` field on `ContainerInput`
- `container/agent-runner/src/index.ts` — reads effort from container input, env var as operator escape hatch
- `container/agent-runner/src/openai-backend.ts` — `effort` on `ContainerInput`, logs when unsupported
- `src/session-commands.ts` — `/settings effort=X` command with validation
- `docs/ENVIRONMENT.md` — `DEUS_AGENT_EFFORT` env var, effort resolution order
- `src/agent-runtimes/resolve.test.ts` — 6 tests for `resolveAgentEffort` cascade
- `src/session-commands.test.ts` — 5 tests for effort settings command

## Notes
- **Container rebuild required** (`./container/build.sh`) to pick up the `effort` field in `ContainerInput`
- All 1033 tests pass, TypeScript compiles clean

## Test plan
- [x] `resolveAgentEffort` returns task effort when set
- [x] `resolveAgentEffort` falls back to group config
- [x] `resolveAgentEffort` falls back to `DEUS_AGENT_EFFORT` env var (case-insensitive)
- [x] `resolveAgentEffort` ignores invalid env var values
- [x] `resolveAgentEffort` defaults to `low`
- [x] `/settings effort=X` sets valid levels
- [x] `/settings effort=X` rejects invalid levels
- [x] `/settings` displays current effort level
- [x] Full test suite passes (1033 tests)

## Warden verdicts
- Plan-reviewer: **SHIP** (round 2 — round 1 REVISE fixed: task effort dead code, OpenAI gap)
- Code-reviewer: **SHIP** (round 2 — round 1 SHIP warnings addressed: import style, TODO date, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)