### PR TITLE
chore(evolution): swap Gemini 3.1 Flash Lite preview → GA

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -78,11 +78,11 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `EVOLUTION_PYTHON` | `python3` | Python binary path for evolution subprocess |
 | `EVOLUTION_REFLECTION_THRESHOLD` | `0.6` | Interactions scoring below this trigger corrective reflections |
 | `EVOLUTION_POSITIVE_THRESHOLD` | `0.85` | Interactions scoring above this trigger positive pattern extraction |
-| `EVOLUTION_JUDGE_MODEL` | `models/gemini-3.1-flash-lite-preview` | Gemini model used for judging and principle extraction |
+| `EVOLUTION_JUDGE_MODEL` | `models/gemini-3.1-flash-lite` | Gemini model used for judging and principle extraction |
 | `EVOLUTION_JUDGE_PROVIDER` | (auto-detect) | Force a specific judge provider: `ollama`, `gemini`, `claude`, `mock` |
 | `EVOLUTION_GEN_PROVIDER` | (auto-detect) | Force a specific generative provider: `gemini`, `ollama`, `mock` |
 | `DEUS_STORAGE_PROVIDER` | (auto-detect) | Force a specific storage provider: `sqlite` |
-| `EVOLUTION_GEN_MODEL` | `models/gemini-3.1-flash-lite-preview` | Default generative model (Gemini) |
+| `EVOLUTION_GEN_MODEL` | `models/gemini-3.1-flash-lite` | Default generative model (Gemini) |
 | `EVOLUTION_MAX_REFLECTIONS` | `3` | Max reflections retrieved per agent query |
 | `EVOLUTION_REFLECTION_DEDUP_L2` | `0.4` | L2 distance threshold for deduplicating similar reflections |
 | `DEUS_EVAL_CONCURRENT` | — | Override eval pre-warm concurrency |

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -25,13 +25,13 @@ OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
 EMBED_DIM = 768
 EMBED_MODELS = ["gemini-embedding-2-preview", "gemini-embedding-001"]
 GEN_MODELS = [
-    "models/gemini-3.1-flash-lite-preview",
+    "models/gemini-3.1-flash-lite",
     "models/gemini-3-flash-preview",
     "models/gemini-2.5-flash",
     "models/gemini-2.5-flash-lite",
 ]
 GEN_MODEL = os.environ.get("EVOLUTION_GEN_MODEL", GEN_MODELS[0])
-JUDGE_MODEL = os.environ.get("EVOLUTION_JUDGE_MODEL", "models/gemini-3.1-flash-lite-preview")
+JUDGE_MODEL = os.environ.get("EVOLUTION_JUDGE_MODEL", "models/gemini-3.1-flash-lite")
 
 # ── Reflexion ─────────────────────────────────────────────────────────────────
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-14" # auto-bump
+last_verified: "2026-05-14" # auto-bump (gemini-3.1-flash-lite GA)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-14" # auto-bump
+last_verified: "2026-05-14" # auto-bump (gemini-3.1-flash-lite GA)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-14" # auto-bump
+last_verified: "2026-05-14" # auto-bump (gemini-3.1-flash-lite GA)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary
- Replaces `gemini-3.1-flash-lite-preview` with `gemini-3.1-flash-lite` (GA) in `evolution/config.py` and `docs/ENVIRONMENT.md`
- Google is discontinuing the preview model on May 25, 2026 — identical architecture, no quality or prompt changes needed
- Affects both `GEN_MODELS` fallback chain and `JUDGE_MODEL` default

## Test plan
- [x] `evolution/config.py` parses correctly with updated model names
- [ ] Verify evolution judge and generative calls succeed with GA model after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)