### PR TITLE
fix(hooks): prevent compress gate from blocking repeatedly

### DIFF
--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -285,28 +285,19 @@ def _count_transcript_turns(transcript_path: str) -> int:
     return count
 
 
-def _compress_gate_sentinel() -> Path:
-    """One-shot sentinel so the gate blocks at most once per session."""
-    job_dir = os.environ.get("CLAUDE_JOB_DIR", "")
-    if job_dir:
-        return Path(job_dir) / ".compress_gate_fired"
-    return Path("/tmp/.compress_gate_fired")
-
-
 def _bg_compress_gate(transcript_path: str) -> dict | None:
-    """If this is a bg session that hasn't compressed yet, return block JSON."""
+    """Block once per bg session if /compress hasn't run yet."""
     if not _is_bg_session():
         return None
     if not transcript_path:
         return None
-    sentinel = _compress_gate_sentinel()
+    sentinel = Path(os.environ["CLAUDE_JOB_DIR"]) / ".compress_gate_fired"
     if sentinel.exists():
         return None
     if _count_transcript_turns(transcript_path) < BG_COMPRESS_MIN_TURNS:
         return None
     if _compress_already_ran(transcript_path):
         return None
-    sentinel.write_text("1")
     return {
         "continue": False,
         "stopReason": "Background session must run /compress before completing.",
@@ -341,6 +332,8 @@ def main():
     block = _bg_compress_gate(transcript_path)
     if block:
         print(json.dumps(block))
+        # Write sentinel only after block JSON is delivered
+        Path(os.environ["CLAUDE_JOB_DIR"], ".compress_gate_fired").touch()
         return
 
     if should_checkpoint():

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -291,7 +291,7 @@ def _bg_compress_gate(transcript_path: str) -> dict | None:
         return None
     if not transcript_path:
         return None
-    sentinel = Path(os.environ["CLAUDE_JOB_DIR"]) / ".compress_gate_fired"
+    sentinel = Path(os.environ["CLAUDE_JOB_DIR"]) / ".compress_gate"
     if sentinel.exists():
         return None
     if _count_transcript_turns(transcript_path) < BG_COMPRESS_MIN_TURNS:
@@ -332,8 +332,11 @@ def main():
     block = _bg_compress_gate(transcript_path)
     if block:
         print(json.dumps(block))
-        # Write sentinel only after block JSON is delivered
-        Path(os.environ["CLAUDE_JOB_DIR"], ".compress_gate_fired").touch()
+        # Sentinel after print — crash before delivery doesn't permanently consume the gate
+        try:
+            (Path(os.environ["CLAUDE_JOB_DIR"]) / ".compress_gate").touch()
+        except OSError:
+            pass
         return
 
     if should_checkpoint():

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -296,16 +296,13 @@ def _bg_compress_gate(transcript_path: str) -> dict | None:
     if _compress_already_ran(transcript_path):
         return None
     return {
-        "decision": "block",
-        "reason": "Background session must run /compress before completing.",
-        "hookSpecificOutput": {
-            "hookEventName": "Stop",
-            "additionalContext": (
-                "This is a background session. Before completing, you MUST run "
-                "/compress to save the session to the vault. Invoke the Skill "
-                'tool with skill="compress" now, then re-emit your result: line.'
-            ),
-        },
+        "continue": False,
+        "stopReason": "Background session must run /compress before completing.",
+        "systemMessage": (
+            "This is a background session. Before completing, you MUST run "
+            "/compress to save the session to the vault. Invoke the Skill "
+            'tool with skill="compress" now, then re-emit your result: line.'
+        ),
     }
 
 

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -56,6 +56,7 @@ THROTTLE_MINUTES = 30
 MIN_TURNS = 4       # skip trivial sessions
 KEEP_TURNS = 6      # turns to include in checkpoint (last N with text)
 MAX_TURN_CHARS = 400  # truncate each turn at this length
+BG_COMPRESS_MIN_TURNS = 6  # skip compress gate for trivial bg sessions
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -234,6 +235,80 @@ def _discover_new_files(vault: Path, tracked: set[str], db, mt, *, limit: int) -
     return discovered
 
 
+# ── Background session compress gate ─────────────────────────────────────────
+
+def _is_bg_session() -> bool:
+    return bool(os.environ.get("CLAUDE_JOB_DIR"))
+
+
+def _compress_already_ran(transcript_path: str) -> bool:
+    """Scan transcript JSONL for a Skill tool_use with skill=compress."""
+    p = Path(transcript_path)
+    if not p.exists():
+        return False
+    for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or '"Skill"' not in line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        msg = entry.get("message", {})
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == "Skill"
+                and isinstance(block.get("input"), dict)
+                and block["input"].get("skill") == "compress"
+            ):
+                return True
+    return False
+
+
+def _count_transcript_turns(transcript_path: str) -> int:
+    """Fast turn count without full parsing."""
+    p = Path(transcript_path)
+    if not p.exists():
+        return 0
+    count = 0
+    for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if '"user"' in line or '"assistant"' in line:
+            count += 1
+    return count
+
+
+def _bg_compress_gate(transcript_path: str) -> dict | None:
+    """If this is a bg session that hasn't compressed yet, return block JSON."""
+    if not _is_bg_session():
+        return None
+    if not transcript_path:
+        return None
+    if _count_transcript_turns(transcript_path) < BG_COMPRESS_MIN_TURNS:
+        return None
+    if _compress_already_ran(transcript_path):
+        return None
+    return {
+        "decision": "block",
+        "reason": "Background session must run /compress before completing.",
+        "hookSpecificOutput": {
+            "hookEventName": "Stop",
+            "additionalContext": (
+                "This is a background session. Before completing, you MUST run "
+                "/compress to save the session to the vault. Invoke the Skill "
+                'tool with skill="compress" now, then re-emit your result: line.'
+            ),
+        },
+    }
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 def _maybe_drift_scan():
@@ -252,8 +327,14 @@ def main():
         _maybe_drift_scan()
         return
 
+    transcript_path = hook_data.get("transcript_path", "")
+
+    block = _bg_compress_gate(transcript_path)
+    if block:
+        print(json.dumps(block))
+        return
+
     if should_checkpoint():
-        transcript_path = hook_data.get("transcript_path", "")
         if transcript_path:
             turns = read_transcript(transcript_path)
             if len(turns) >= MIN_TURNS:

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -285,16 +285,28 @@ def _count_transcript_turns(transcript_path: str) -> int:
     return count
 
 
+def _compress_gate_sentinel() -> Path:
+    """One-shot sentinel so the gate blocks at most once per session."""
+    job_dir = os.environ.get("CLAUDE_JOB_DIR", "")
+    if job_dir:
+        return Path(job_dir) / ".compress_gate_fired"
+    return Path("/tmp/.compress_gate_fired")
+
+
 def _bg_compress_gate(transcript_path: str) -> dict | None:
     """If this is a bg session that hasn't compressed yet, return block JSON."""
     if not _is_bg_session():
         return None
     if not transcript_path:
         return None
+    sentinel = _compress_gate_sentinel()
+    if sentinel.exists():
+        return None
     if _count_transcript_turns(transcript_path) < BG_COMPRESS_MIN_TURNS:
         return None
     if _compress_already_ran(transcript_path):
         return None
+    sentinel.write_text("1")
     return {
         "continue": False,
         "stopReason": "Background session must run /compress before completing.",


### PR DESCRIPTION
## Summary
- Adds a sentinel file (`$CLAUDE_JOB_DIR/.compress_gate_fired`) so the auto-compress Stop hook gate blocks at most once per background session
- Prevents infinite loop where the gate fires again during /compress execution (Stop hook fires on every stop event, including mid-session stops)

## Context
The auto-compress gate (added in 1a4b3e3, direct-merged without PR — lesson learned) blocks bg sessions from completing until /compress runs. But the Stop hook fires on *every* stop, including when Claude pauses to process /compress itself, causing repeated blocking.

## Test plan
- [ ] Pipe-test: first call blocks, second call passes (sentinel prevents re-block)
- [ ] Non-bg sessions unaffected (CLAUDE_JOB_DIR unset → gate skipped)
- [ ] Real bg session: gate fires once, compress runs, session completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)