### PR TITLE
fix(hooks): use decision:block for Stop hook compress gate

### DIFF
--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -299,9 +299,8 @@ def _bg_compress_gate(transcript_path: str) -> dict | None:
     if _compress_already_ran(transcript_path):
         return None
     return {
-        "continue": False,
-        "stopReason": "Background session must run /compress before completing.",
-        "systemMessage": (
+        "decision": "block",
+        "reason": (
             "This is a background session. Before completing, you MUST run "
             "/compress to save the session to the vault. Invoke the Skill "
             'tool with skill="compress" now, then re-emit your result: line.'


### PR DESCRIPTION
## Summary
- Stop hook compress gate was using `continue: false`/`stopReason`/`systemMessage` — wrong schema for Stop hooks
- Changed to `decision: "block"`/`reason` per Claude Code v2.1.141 binary documentation
- `continue: false` semantically prevents continuation (stops Claude), while `decision: "block"` blocks the stop (keeps Claude working to run /compress)

## Evidence
Extracted from `strings` of Claude Code v2.1.141 binary:
- `decision` — "block" for **PostToolUse/Stop/UserPromptSubmit** hooks
- `continue` — "Set to `false` to block/stop (default: true)" — prevents continuation, opposite intent

## Test plan
- [x] Manual test: simulated bg session, confirmed `decision: "block"` + `reason` in output
- [x] Negative tests: non-bg session and low-turn session correctly skip the gate
- [ ] Live verification: next bg session crossing 6 turns without /compress should trigger the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)