### PR TITLE
fix(hooks): use declarative message for compress gate block

### DIFF
--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -301,9 +301,9 @@ def _bg_compress_gate(transcript_path: str) -> dict | None:
     return {
         "decision": "block",
         "reason": (
-            "This is a background session. Before completing, you MUST run "
-            "/compress to save the session to the vault. Invoke the Skill "
-            'tool with skill="compress" now, then re-emit your result: line.'
+            "Background session compress gate: /compress has not run yet. "
+            "Policy requires background sessions to run /compress before "
+            "completion so the session is saved to the vault."
         ),
     }
 


### PR DESCRIPTION
## Summary
- Rewords the Stop hook compress gate `reason` from imperative ("you MUST run /compress… Invoke the Skill tool…") to declarative ("Policy requires background sessions to run /compress before completion")
- The old phrasing mimicked prompt injection patterns, causing the model to reject the hook as suspicious instead of complying

## Test plan
- [ ] Trigger a background session that reaches the compress gate and verify the new message is displayed
- [ ] Confirm the model recognizes the gate and runs `/compress` without flagging it as injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)