### PR TITLE
feat(skills): add session-log cross-link frontmatter fields

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -56,6 +56,8 @@ Use this format:
 type: session
 date: YYYY-MM-DD
 topics: [topic1, topic2]
+continues: "prior-session-filename.md"
+superseded_by: "later-session-filename.md"
 project_path: "<working directory path, or '~/deus' for home mode>"
 tldr: |
   What happened (1 sentence). Key decision or outcome. Pending: X, Y.
@@ -78,6 +80,12 @@ decisions:
 ## Pending Tasks
 - [ ] ...
 ```
+
+**Cross-linking multi-session investigations (`continues` / `superseded_by`):**
+- Both fields are optional. Omit them for standalone sessions (the common case).
+- Values are bare filenames (e.g. `auto-compress-bg-gate.md`) when the linked session is in the same date folder. For cross-date links, use a relative path from `Session-Logs/` (e.g. `2026-05-13/prior-topic.md`).
+- `continues` — set when this session resumes a prior investigation. Value: the filename of the earlier session. When setting this field, also update the prior session's frontmatter to add `superseded_by` pointing to the new log.
+- `superseded_by` — forward-pointer added retroactively to a prior session when a continuation is created. Not set directly; always set via the `continues` step above.
 
 **External Project Mode — standard memory level redaction:**
 - Do NOT include specific file paths, function names, or code snippets in the session log

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-06" # auto-bump
+last_verified: "2026-05-15" # auto-bump
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Adds `continues` and `superseded_by` optional frontmatter fields to the session-log template in the compress skill
- Adds instruction block explaining when/how to set each field (bare filenames for same-date, relative paths for cross-date)
- Implements RETRO-2026-05-14-11: multi-session investigations are now navigable as linked threads

## Test plan
- [ ] Verify template renders correctly with both new fields between `topics:` and `project_path:`
- [ ] Verify instruction text is clear and follows the `continues` → `superseded_by` causality flow
- [ ] Run `/compress` on a continuation session and confirm both logs get cross-linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)