### PR TITLE
feat(wardens): add hook schema citation and smoke test rules

### DIFF
--- a/.claude/wardens/code-review-rules.md
+++ b/.claude/wardens/code-review-rules.md
@@ -145,3 +145,17 @@
 **Check:** Shell injection (user input interpolated into `exec`/`child_process.spawn` without sanitization), SQL injection (string concat into queries vs parameterized), path traversal (user input concatenated into file paths without basename/normalize), XSS (user input rendered without escaping), SSRF (user-controllable URLs fetched server-side without host allowlist).
 **Rule:** No classic OWASP vectors. Parameterize queries, escape output, normalize paths, allowlist hosts for user-controlled URLs.
 **Cite:** system-prompt "Be careful not to introduce security vulnerabilities" rule; `feedback_security_first`
+
+## hook-schema-source-of-truth
+**Severity:** blocking
+**Applies when:** Diff modifies hook output schema (any return shape from Stop/PreToolUse/PostToolUse/SessionStart hooks).
+**Check:** Does the commit message cite a source of truth (Claude Code binary string extraction, SDK source path, or official doc URL)?
+**Rule:** Hook schema changes require a verifiable source-of-truth citation in the commit message. Derivation-from-assumption is rejected.
+**Cite:** `feedback_hook_schema_source_of_truth`
+
+## hook-pr-smoke-test
+**Severity:** blocking
+**Applies when:** Diff modifies a hook script (Stop/PreToolUse/PostToolUse/SessionStart category).
+**Check:** Does the PR body include evidence of a real-session smoke test (session log link, `claude logs <id>` output, or transcript excerpt)?
+**Rule:** Hook-touching PRs require documented real-session smoke test before marked done. Synthetic tests alone are insufficient.
+**Cite:** `feedback_hook_pr_smoke_test`


### PR DESCRIPTION
## Summary

- Adds `hook-schema-source-of-truth` (blocking): hook schema changes require a verifiable source-of-truth citation in the commit message (binary extraction, SDK path, or doc URL). Prevents derivation-from-assumption.
- Adds `hook-pr-smoke-test` (blocking): hook-touching PRs require documented real-session smoke test evidence in the PR body. Synthetic tests alone are insufficient.

Both rules address the multi-pass fix pattern from RETRO-2026-05-14: the compress-gate needed 3 PRs in one day (#397, #398, #399) because each pass tested only the bug it was fixing without verifying against source-of-truth or in a real session.

**References:** RETRO-2026-05-14-04 (`feedback_hook_schema_source_of_truth`), RETRO-2026-05-14-09 (`feedback_hook_pr_smoke_test`)

## Test plan

- [x] `grep -c 'hook-schema-source-of-truth\|hook-pr-smoke-test'` returns 2
- [x] `grep -c '^## '` returns 22 (was 20)
- [x] Plan-reviewer: SHIP
- [x] Code-reviewer: SHIP
- [x] Scope guard: only `.claude/wardens/code-review-rules.md` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)