### PR TITLE
fix(hooks): standards_pack.py resolver references non-existent mt.EXTERNAL_DIR

### DIFF
--- a/scripts/standards_pack.py
+++ b/scripts/standards_pack.py
@@ -29,8 +29,10 @@ def _default_auto_mem_dir() -> Path:
         candidate = Path(os.path.expanduser(f"~/.claude/projects/{encoded}/memory"))
         if candidate.is_dir():
             return candidate
-    # 3. Legacy literal default — same path memory_indexer.py:4172 hardcodes.
-    legacy = Path(os.path.expanduser("~/.claude/projects/-Users-liam10play-deus/memory"))
+    # 3. Derive from this script's filesystem location (repo_root/scripts/standards_pack.py).
+    repo_root = Path(__file__).resolve().parent.parent
+    encoded = repo_root.as_posix().replace("/", "-")
+    legacy = Path(os.path.expanduser(f"~/.claude/projects/{encoded}/memory"))
     if legacy.is_dir():
         return legacy
     # 4. Final fallback (will trigger fail-loud warning in load_standards).

--- a/scripts/standards_pack.py
+++ b/scripts/standards_pack.py
@@ -14,16 +14,27 @@ import sys
 from pathlib import Path
 
 def _default_auto_mem_dir() -> Path:
+    # 1. Explicit env override wins (matches memory_tree.EXTERNAL_DIR_ENV).
     env = os.environ.get("DEUS_AUTO_MEMORY_DIR")
     if env:
         return Path(env)
-    try:
-        _scripts = Path(__file__).resolve().parent
-        sys.path.insert(0, str(_scripts))
-        import memory_tree as mt
-        return Path(mt.EXTERNAL_DIR)
-    except Exception:
-        return Path(os.path.expanduser("~/.deus/auto-memory"))
+    # 2. Derive the per-project auto-memory dir from CLAUDE_PROJECT_DIR.
+    #    Mirrors memory_indexer.py promotion target (~/.claude/projects/<encoded>/memory).
+    #    Encoding: leading '-' + slashes replaced with '-'.
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if project_dir:
+        encoded = project_dir.replace("/", "-")
+        if not encoded.startswith("-"):
+            encoded = "-" + encoded
+        candidate = Path(os.path.expanduser(f"~/.claude/projects/{encoded}/memory"))
+        if candidate.is_dir():
+            return candidate
+    # 3. Legacy literal default — same path memory_indexer.py:4172 hardcodes.
+    legacy = Path(os.path.expanduser("~/.claude/projects/-Users-liam10play-deus/memory"))
+    if legacy.is_dir():
+        return legacy
+    # 4. Final fallback (will trigger fail-loud warning in load_standards).
+    return Path(os.path.expanduser("~/.deus/auto-memory"))
 
 
 AUTO_MEM_DIR = _default_auto_mem_dir()
@@ -77,6 +88,13 @@ def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_B
     """Load kind=standard atoms as condensed one-liners within token budget."""
     d = auto_mem_dir or AUTO_MEM_DIR
     if not d.is_dir():
+        # Fail-loud to stderr (never stdout — would pollute the JSON hook output).
+        # Helps catch the silent-empty-pack failure mode that masked PR #380's gap.
+        print(
+            f"[standards_pack] WARN: auto-memory dir not found: {d}. "
+            "Standards pack will be empty. Check DEUS_AUTO_MEMORY_DIR or CLAUDE_PROJECT_DIR.",
+            file=sys.stderr,
+        )
         return ""
 
     mtime = _dir_mtime(d)
@@ -110,6 +128,13 @@ def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_B
         total_tokens += cost
 
     if not lines:
+        # Fail-loud: dir exists but no kind=standard atoms found. Likely classification gap.
+        print(
+            f"[standards_pack] WARN: 0 kind=standard atoms in {d} "
+            f"(scanned {sum(1 for _ in d.glob('*.md'))} .md files). "
+            "Standards pack will be empty.",
+            file=sys.stderr,
+        )
         return ""
 
     context = (


### PR DESCRIPTION
## Summary
- SessionStart `standards_pack` hook silently emitted empty pack for sessions without `DEUS_AUTO_MEMORY_DIR`
- Root cause: resolver referenced `mt.EXTERNAL_DIR` (doesn't exist); only `mt.EXTERNAL_DIR_ENV` exists (and it's the env-var name as a string)
- Bare-except swallowed the `AttributeError`, falling back to `~/.deus/auto-memory/` (never existed) → 0% tier1 coverage in A5 benchmark

The 13 `kind: standard` atoms exist in `~/.claude/projects/-Users-liam10play-deus/memory/` — the payload was always there, just unreachable from the reader. This was the same `bare-except silently degrading to wrong default` shape as the CI-pipe-trap in user's `guardrail-extensions.md`.

## Changes
1. `_default_auto_mem_dir()` now derives the auto-memory dir from `CLAUDE_PROJECT_DIR` (mirrors `memory_indexer.py:4172` promotion target), falls back to historic literal path, then to `~/.deus/auto-memory/` as final
2. Fail-loud stderr warnings when (a) resolved dir missing or (b) dir exists but 0 `kind=standard` atoms — catches the exact silent-fail mode that hid this for ~2 days

## Test plan
Smoke tests (all pass):
- [x] No env vars, no cache: 13 atoms load via legacy default
- [x] `CLAUDE_PROJECT_DIR=/Users/liam10play/deus`: 13 atoms load via per-project path
- [x] `DEUS_AUTO_MEMORY_DIR=/tmp/nonexistent`: fail-loud stderr fires

## Source-of-truth cites (per RETRO-2026-05-14-04 spirit)
- `memory_tree.py:86` — confirms only `EXTERNAL_DIR_ENV` exists, not `EXTERNAL_DIR`
- `memory_indexer.py:4172` — canonical writer-side path matches the new fallback
- `~/.claude/projects/-Users-liam10play-deus/memory/` (mtime 1778617831) — matches the stale cache mtime, confirming the corpus is the real source

## Follow-ups (NOT in this PR)
- Wire `classify_atom()` into `memory_indexer.py` promotion path (zero-maintenance going forward)
- Centralize auto_memory_dir() resolver in `memory_tree.py` so writer + reader share one helper
- Audit other hook scripts for `except Exception:` patterns that mask internal-symbol AttributeErrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)