### PR TITLE
test: add bypass-permissions regression test

### DIFF
--- a/tests/bypass-permissions-regression.sh
+++ b/tests/bypass-permissions-regression.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Bypass-permissions regression test (macOS only).
+# Dispatches a claude --bg session, verifies Bash tool executes without
+# permission gates. Exits 0 on pass, 1 on failure.
+# Requires: claude CLI, python3. Cannot run in CI (needs live daemon).
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "SKIP: macOS-only test"
+  exit 0
+fi
+
+if ! command -v claude &>/dev/null; then
+  echo "FAIL: claude CLI not found"
+  exit 1
+fi
+
+TIMEOUT=180
+POLL_INTERVAL=5
+NAME="bypass-perm-regtest-$$"
+
+echo "Launching bg session: $NAME"
+RAW=$(claude --bg --name "$NAME" "Run 'ls /tmp/' via Bash and list any 3 entries you see. Keep your response brief." 2>&1)
+SID=$(echo "$RAW" | sed $'s/\x1b\[[0-9;]*[a-zA-Z]//g' | grep -oE '[a-f0-9]{8}' | head -1)
+
+if [[ -z "$SID" ]]; then
+  echo "FAIL: could not extract session ID from claude --bg output"
+  echo "Raw output: $RAW"
+  exit 1
+fi
+
+STATE_FILE="$HOME/.claude/jobs/$SID/state.json"
+echo "Session ID: $SID"
+echo "Polling $STATE_FILE for completion (timeout ${TIMEOUT}s)..."
+
+elapsed=0
+while true; do
+  if [[ -f "$STATE_FILE" ]]; then
+    current_state=$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('state',''))" 2>/dev/null)
+    if [[ "$current_state" == "done" ]]; then
+      break
+    fi
+  fi
+  if (( elapsed >= TIMEOUT )); then
+    echo "FAIL: session did not complete within ${TIMEOUT}s"
+    claude stop "$SID" 2>/dev/null
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL"
+  (( elapsed += POLL_INTERVAL ))
+done
+
+echo "Session completed. Checking criteria..."
+
+TRANSCRIPT=$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('linkScanPath',''))" 2>/dev/null)
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  echo "FAIL: transcript not found (linkScanPath=$TRANSCRIPT)"
+  exit 1
+fi
+
+TRANSCRIPT="$TRANSCRIPT" python3 -c "
+import json, os, sys
+
+transcript = os.environ['TRANSCRIPT']
+bash_invoked = False
+bash_tool_id = None
+tool_executed = False
+permission_gate = False
+
+with open(transcript) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        att = entry.get('attachment', {})
+        if isinstance(att, dict) and att.get('type') == 'hook_blocking_error':
+            hook_event = att.get('hookEvent', '')
+            if hook_event == 'PreToolUse':
+                permission_gate = True
+
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if not isinstance(content, list):
+            continue
+
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            bt = block.get('type', '')
+
+            if bt == 'tool_use' and block.get('name') == 'Bash':
+                cmd = block.get('input', {}).get('command', '')
+                if 'ls /tmp' in cmd or 'ls /tmp/' in cmd:
+                    bash_invoked = True
+                    bash_tool_id = block.get('id', '')
+
+            # tool_result for the Bash ls /tmp call with non-empty content
+            if bt == 'tool_result' and bash_tool_id:
+                if block.get('tool_use_id') == bash_tool_id:
+                    rc = block.get('content', '')
+                    has_content = False
+                    if isinstance(rc, str) and len(rc.strip()) > 0:
+                        has_content = True
+                    elif isinstance(rc, list) and any(
+                        isinstance(b, dict) and b.get('text', '').strip()
+                        for b in rc
+                    ):
+                        has_content = True
+                    if has_content:
+                        tool_executed = True
+
+status = 0
+
+print('Criterion 1: Session completed ........... PASS')
+
+if bash_invoked:
+    print('Criterion 2: Bash tool invoked ........... PASS')
+else:
+    print('Criterion 2: Bash tool invoked ........... FAIL')
+    status = 1
+
+if tool_executed:
+    print('Criterion 3: Tool executed (not gated) ... PASS')
+else:
+    print('Criterion 3: Tool executed (not gated) ... FAIL')
+    status = 1
+
+if not permission_gate:
+    print('Criterion 4: No permission gate .......... PASS')
+else:
+    print('Criterion 4: No permission gate .......... FAIL')
+    status = 1
+
+sys.exit(status)
+"


### PR DESCRIPTION
## Summary

- Adds `tests/bypass-permissions-regression.sh` — a macOS-only integration test that dispatches a `claude --bg` session and verifies Bash tool calls execute without permission gates firing
- Closes RETRO-2026-05-14-08 (4-session bypass-permissions investigation thread)

## Canary results (b-f)

**(b) Bypass canary (90f2793e):** Dispatched bg session with `ls /tmp/` prompt. Session completed in ~15s.

**(c) Pass criteria — ALL PASS:**
1. Session completed (`state: done` in state.json)
2. Bash tool invoked with `ls /tmp/` (tool_use block in JSONL)
3. Tool executed — returned entries: `agent-mission-control`, `gemini_ocr.py`, `zellij-research`
4. No permission gate — no `hook_blocking_error` attachment in transcript (only permission-mode metadata entries)

**(d) Root causes (known):**
- `deus-cmd.sh` agent-view path missing `--dangerously-skip-permissions` (fixed, PR landed)
- `settings.local.json` had `dontAsk` (allowlist auto-deny) instead of `bypassPermissions` (fixed)
- No new root causes discovered

**(e) Regression test:** `tests/bypass-permissions-regression.sh` — verified passing (exit 0, all 4 criteria PASS)

**(f) Compress-gate verification (ed7af326):**
- Stop hook fired with declarative phrasing: `"Policy requires background sessions to run /compress before completion so the session is saved to the vault."`
- Model complied: `Skill(compress)` invoked, full compress workflow executed (session log written, CLAUDE.md updated, memory indexed)
- `.compress_gate` sentinel created in job directory
- Closes the pending verify from [05-14/compress-gate-message-fix]

## Known limitation

Criterion 4 checks for `attachment.type=hook_blocking_error` with `hookEvent=PreToolUse` — this is the schema observed in the compress-gate canary transcript. However, `dontAsk` auto-deny may not route through hooks at all (it may manifest as a tool_use without a matching tool_result, or a different system-level denial). Criterion 3 partially covers this: if a Bash tool_use has no tool_result with content, the test fails. A deliberate negative test (reverting to `dontAsk` + removing `Bash(*)` from allow list) would be needed to verify criterion 4's detection power.

## Post-SHIP note

Criterion 3 logic was rewritten after code-reviewer SHIP to fix a false-negative: the original checked for `/tmp` in tool_result content (but `ls /tmp/` returns filenames without the prefix). The committed version matches tool_result by `tool_use_id` and checks non-empty content. Reviewer should verify lines 95-114 specifically.

## Test plan

- [x] `bash tests/bypass-permissions-regression.sh` exits 0 with all 4 criteria PASS
- [x] Plan-reviewer: SHIP
- [x] Code-reviewer: SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)