### PR TITLE
feat(settings): add locked merge-write contract for settings.json

### DIFF
--- a/scripts/settings_merge.py
+++ b/scripts/settings_merge.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Locked read-merge-write for ~/.claude/settings.json.
+
+Acquires an exclusive flock, reads the current file, deep-merges changes
+(hooks and permission arrays are appended with dedup, never replaced),
+and writes atomically via a temp file + os.replace.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sys
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_PATH = Path("~/.claude/settings.json").expanduser()
+# flock is per-process; this lock serializes threads within the same process.
+_THREAD_LOCK = threading.Lock()
+
+
+def _canonical(item: Any) -> str:
+    if isinstance(item, dict):
+        return json.dumps(item, sort_keys=True)
+    return json.dumps(item)
+
+
+def _array_merge(base: list, override: list) -> list:
+    seen = {_canonical(x) for x in base}
+    merged = list(base)
+    for item in override:
+        key = _canonical(item)
+        if key not in seen:
+            seen.add(key)
+            merged.append(item)
+    return merged
+
+
+def _is_array_merge_key(path: tuple[str, ...]) -> bool:
+    if len(path) >= 2 and path[0] == "hooks":
+        return True
+    if path == ("permissions", "allow") or path == ("permissions", "deny"):
+        return True
+    return False
+
+
+def _deep_merge(
+    base: dict[str, Any],
+    override: dict[str, Any],
+    path: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    result = dict(base)
+    for key, val in override.items():
+        current_path = path + (key,)
+        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
+            result[key] = _deep_merge(result[key], val, current_path)
+        elif (
+            key in result
+            and isinstance(result[key], list)
+            and isinstance(val, list)
+            and _is_array_merge_key(current_path)
+        ):
+            result[key] = _array_merge(result[key], val)
+        else:
+            result[key] = val
+    return result
+
+
+def merge_settings(path: Path, changes: dict[str, Any]) -> dict[str, Any]:
+    """Acquire flock, read current JSON, deep-merge changes, atomic write."""
+    if sys.platform == "win32":
+        raise NotImplementedError("settings_merge requires fcntl (macOS/Linux)")
+
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _THREAD_LOCK:
+        fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            raw = b""
+            while True:
+                chunk = os.read(fd, 8192)
+                if not chunk:
+                    break
+                raw += chunk
+
+            current: dict[str, Any] = {}
+            if raw.strip():
+                current = json.loads(raw)
+
+            merged = _deep_merge(current, changes)
+
+            text = json.dumps(merged, indent=2, ensure_ascii=False) + "\n"
+            tmp_path: Path | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    "w", encoding="utf-8", dir=path.parent, delete=False,
+                    prefix="settings_merge_",
+                ) as tmp:
+                    tmp_path = Path(tmp.name)
+                    tmp.write(text)
+                os.replace(tmp_path, path)
+            except Exception:
+                if tmp_path is not None:
+                    tmp_path.unlink(missing_ok=True)
+                raise
+        finally:
+            os.close(fd)
+
+    return merged
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Merge changes into settings.json")
+    parser.add_argument("--path", type=Path, default=_DEFAULT_PATH)
+    args = parser.parse_args()
+
+    changes = json.load(sys.stdin)
+    result = merge_settings(args.path, changes)
+    print(json.dumps(result, indent=2))

--- a/scripts/tests/test_settings_merge.py
+++ b/scripts/tests/test_settings_merge.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "settings_merge.py"
+
+
+def _load_module():
+    if "settings_merge" in sys.modules:
+        return sys.modules["settings_merge"]
+    spec = importlib.util.spec_from_file_location("settings_merge", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["settings_merge"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SM = _load_module()
+
+
+def _write_settings(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_settings(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ── Deep merge unit tests ────────────────────────────────────────────────────
+
+
+def test_deep_merge_preserves_top_level_keys(tmp_path):
+    settings = tmp_path / "s.json"
+    _write_settings(settings, {"model": "opus", "env": {"A": "1"}, "hooks": {}})
+
+    result = SM.merge_settings(settings, {"model": "sonnet"})
+
+    assert result["model"] == "sonnet"
+    assert result["env"] == {"A": "1"}
+    assert result["hooks"] == {}
+
+
+def test_deep_merge_recurses_dicts(tmp_path):
+    settings = tmp_path / "s.json"
+    _write_settings(settings, {"env": {"A": "1", "B": "2"}})
+
+    result = SM.merge_settings(settings, {"env": {"B": "3", "C": "4"}})
+
+    assert result["env"] == {"A": "1", "B": "3", "C": "4"}
+
+
+# ── Hooks array merge ────────────────────────────────────────────────────────
+
+
+def test_hooks_array_merge_appends_unique(tmp_path):
+    settings = tmp_path / "s.json"
+    existing_hook = {
+        "hooks": [{"type": "command", "command": "python3 /path/to/hook_a.py"}]
+    }
+    new_hook = {
+        "hooks": [{"type": "command", "command": "python3 /path/to/hook_b.py"}]
+    }
+    _write_settings(settings, {"hooks": {"Stop": [existing_hook]}})
+
+    result = SM.merge_settings(settings, {"hooks": {"Stop": [new_hook]}})
+    assert len(result["hooks"]["Stop"]) == 2
+    commands = [
+        h["command"]
+        for group in result["hooks"]["Stop"]
+        for h in group["hooks"]
+    ]
+    assert "python3 /path/to/hook_a.py" in commands
+    assert "python3 /path/to/hook_b.py" in commands
+
+    result2 = SM.merge_settings(settings, {"hooks": {"Stop": [new_hook]}})
+    assert len(result2["hooks"]["Stop"]) == 2
+
+
+def test_hooks_preserves_matchers(tmp_path):
+    settings = tmp_path / "s.json"
+    group_a = {"matcher": "Write|Edit", "hooks": [{"type": "command", "command": "a"}]}
+    group_b = {"matcher": "Bash", "hooks": [{"type": "command", "command": "b"}]}
+    _write_settings(settings, {"hooks": {"PreToolUse": [group_a]}})
+
+    result = SM.merge_settings(settings, {"hooks": {"PreToolUse": [group_b]}})
+    assert len(result["hooks"]["PreToolUse"]) == 2
+
+
+# ── Permissions array merge ──────────────────────────────────────────────────
+
+
+def test_permissions_array_merge(tmp_path):
+    settings = tmp_path / "s.json"
+    _write_settings(settings, {"permissions": {"allow": ["Read", "Edit"]}})
+
+    result = SM.merge_settings(settings, {"permissions": {"allow": ["Bash(*)"]}})
+
+    assert result["permissions"]["allow"] == ["Read", "Edit", "Bash(*)"]
+
+
+def test_permissions_dedup(tmp_path):
+    settings = tmp_path / "s.json"
+    _write_settings(settings, {"permissions": {"allow": ["Read", "Edit"]}})
+
+    result = SM.merge_settings(settings, {"permissions": {"allow": ["Read"]}})
+    assert result["permissions"]["allow"] == ["Read", "Edit"]
+
+
+# ── File lifecycle ───────────────────────────────────────────────────────────
+
+
+def test_merge_into_nonexistent_file(tmp_path):
+    settings = tmp_path / "subdir" / "settings.json"
+
+    result = SM.merge_settings(settings, {"model": "opus", "hooks": {}})
+
+    assert settings.exists()
+    assert result == {"model": "opus", "hooks": {}}
+    assert _read_settings(settings) == result
+
+
+# ── Concurrent writes ────────────────────────────────────────────────────────
+
+
+def test_concurrent_write_race_deterministic(tmp_path):
+    """Spawn N threads that each merge a unique key. All keys must survive.
+
+    This is a smoke test for flock serialization. The cross-process guarantee
+    (the load-bearing case) relies on fcntl.flock kernel semantics; this test
+    exercises the read-merge-write cycle under contention.
+    """
+    settings = tmp_path / "s.json"
+    _write_settings(settings, {})
+
+    n = 10
+    errors: list[Exception] = []
+
+    def merge_key(i: int) -> None:
+        try:
+            SM.merge_settings(settings, {f"key_{i}": i})
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=merge_key, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Merge errors: {errors}"
+    final = _read_settings(settings)
+    for i in range(n):
+        assert f"key_{i}" in final, f"key_{i} missing from merged result"
+        assert final[f"key_{i}"] == i
+
+
+# ── Crash consistency ────────────────────────────────────────────────────────
+
+
+def test_atomic_write_crash_leaves_file_consistent(tmp_path):
+    settings = tmp_path / "s.json"
+    original = {"model": "opus", "hooks": {"Stop": []}}
+    _write_settings(settings, original)
+
+    original_text = settings.read_text(encoding="utf-8")
+
+    with patch.object(SM.os, "replace", side_effect=OSError("simulated crash")):
+        with pytest.raises(OSError, match="simulated crash"):
+            SM.merge_settings(settings, {"model": "sonnet"})
+
+    assert settings.read_text(encoding="utf-8") == original_text
+    temps = list(tmp_path.glob("settings_merge_*"))
+    assert not temps, f"orphaned temp files: {temps}"


### PR DESCRIPTION
## Summary

- Implements RETRO-2026-05-14-01 and -12: `scripts/settings_merge.py` provides flock-based file locking, deep-merge (hooks/permission arrays merged by appending unique entries, never replaced), and atomic write via `tempfile.NamedTemporaryFile` + `os.replace` for `~/.claude/settings.json`
- 9 pytest tests covering concurrent-write race, hooks array merge with dedup, atomic write crash consistency, permissions array merge, dict recursion, and nonexistent file creation
- Includes `threading.Lock` for intra-process serialization alongside `fcntl.flock` for inter-process

## Scope guard

Only `scripts/settings_merge.py` + `scripts/tests/test_settings_merge.py`. No CHANGELOG, package.json, package-lock.json, or vault CLAUDE.md touched.

**Note:** Task spec said `tests/test_settings_merge.py` (root `tests/`); placed in `scripts/tests/` to match existing project convention where all script tests live.

## Follow-up (NOT in this PR)

- Migrate existing unprotected write sites to use `merge_settings()`:
  - `~/.claude/hooks/hook-integrity-check.py:82` (personal tooling, not a public-repo PR)
  - `scripts/rename-repo.sh:126` (public repo)
- Add Windows `msvcrt.locking` support if needed

## Test plan

- [x] `python3 -m pytest scripts/tests/test_settings_merge.py -v` — 9/9 pass
- [x] Concurrent-write race with 10 threads produces deterministic merge (all keys survive)
- [x] Hooks array merge appends unique entries, deduplicates on re-merge
- [x] Crash mid-write leaves original file untouched, no orphaned temp files
- [ ] Manual CLI smoke: `echo '{"model":"test"}' | python3 scripts/settings_merge.py --path /tmp/test.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)