### PR TITLE
feat(wardens): wire verification-gate as automatic pre-commit gate

### DIFF
--- a/.claude/agents/verification-gate.md
+++ b/.claude/agents/verification-gate.md
@@ -28,12 +28,14 @@ You receive a description of what's being claimed. Your job:
 
 ## Output format
 
+Use the standard Warden verdict header so the verdict-tracker can parse it.
+
 ```
-## Verification: CONFIRMED | FAILED | PARTIAL
+## Verdict: SHIP | REVISE | BLOCK
 
 Claims checked:
-- "tests pass" → `cargo test` → 130/130 pass ✓
-- "builds clean" → `cargo build` → 0 warnings ✓
+- "tests pass" → `npm test` → 42/42 pass ✓
+- "builds clean" → `npm run build` → 0 warnings ✓
 - "no regressions" → NOT VERIFIED (no regression test run) ✗
 
 Evidence:
@@ -42,6 +44,9 @@ Evidence:
 Missing verification:
 - [list any claims that couldn't be verified]
 ```
+
+Mapping: all claims verified with evidence = SHIP. Any claim unverified or
+failed = REVISE. Fundamental gap (wrong feature, missing core requirement) = BLOCK.
 
 ## Red flags you catch
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,6 +59,11 @@
           },
           {
             "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" verification-gate'",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" admin-merge-gate'",
             "timeout": 5
           }
@@ -83,6 +88,11 @@
             "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" path-leak-detector'",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" verification-invalidator'",
+            "timeout": 3
           }
         ]
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Use these instead of rediscovering the system:
 | TUI backends | `tui/src/backend/` | Strategy trait — one file per provider (Claude, Codex, etc.) |
 | Mount/security boundary | `src/container-mounter.ts` | Project/group/vault visibility and isolation |
 | Memory retrieval | `scripts/memory_tree.py`, `scripts/memory_indexer.py` | Personal recall and semantic lookup |
-| Codex Warden hooks | `scripts/codex_warden_hooks.py` | Installs and runs Codex hook equivalents for Warden gates |
+| Codex Warden hooks | `scripts/codex_warden_hooks.py` | Installs and runs Codex hook equivalents for Warden gates (plan-reviewer, code-reviewer, verification-gate, threat-modeler) |
 
 More detailed maps live in [docs/AGENT_DEUS_101.md](docs/AGENT_DEUS_101.md).
 

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -51,6 +51,7 @@ HOOK_SPECS: tuple[HookSpec, ...] = (
         "Invalidating Deus plan review",
     ),
     HookSpec("PreToolUse", "Bash", "code-review-gate", 5, "Checking Deus code review"),
+    HookSpec("PreToolUse", "Bash", "verification-gate", 5, "Checking Deus verification"),
     HookSpec(
         "PreToolUse",
         "Bash",
@@ -71,6 +72,13 @@ HOOK_SPECS: tuple[HookSpec, ...] = (
         "code-review-invalidator",
         3,
         "Invalidating Deus code review",
+    ),
+    HookSpec(
+        "PostToolUse",
+        "Edit|Write|MultiEdit|apply_patch",
+        "verification-invalidator",
+        3,
+        "Invalidating Deus verification",
     ),
     HookSpec(
         "PostToolUse",
@@ -255,7 +263,7 @@ def _is_excluded(path: Path, marker_dir: Path) -> bool:
     if "/.claude/projects/" in path_text and "/memory/" in path_text:
         return True
 
-    marker_names = {".plan-reviewed", ".code-reviewed", ".threat-modeled"}
+    marker_names = {".plan-reviewed", ".code-reviewed", ".threat-modeled", ".verified"}
     return _is_relative_to(path, marker_dir) and path.name in marker_names
 
 
@@ -403,6 +411,7 @@ def run_session_init(repo_root: Path) -> int:
         ".plan-reviewed",
         ".code-reviewed",
         ".threat-modeled",
+        ".verified",
         ".admin-merge-approved",
     ):
         _marker(repo_root, name).unlink(missing_ok=True)
@@ -516,6 +525,59 @@ def run_code_review_gate(event: dict[str, Any], repo_root: Path) -> int:
             f"mark code-reviewed TRIVIAL \"reason\""
         )
     _block_pre_tool(reason)
+    return 0
+
+
+def run_verification_gate(event: dict[str, Any], repo_root: Path) -> int:
+    config = _wardens_config(repo_root)
+    if not _warden_enabled(config, "verification-gate"):
+        return 0
+
+    cwd = Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)
+    if _worktree_for_cwd(cwd, repo_root) is None:
+        return 0
+
+    tool_input = event.get("tool_input")
+    command = tool_input.get("command") if isinstance(tool_input, dict) else ""
+    if not isinstance(command, str) or not GIT_COMMIT_RE.search(command):
+        return 0
+    if _marker(repo_root, ".verified").exists():
+        return 0
+
+    mark_cmd = (
+        f"  python3 {shlex.quote(str(_active_script_path(repo_root)))} "
+        f"mark verified SHIP \"reason\""
+    )
+
+    if _last_verdict_is_blocking(repo_root, "verification-gate"):
+        last = _last_verdict(repo_root, "verification-gate")
+        reason = (
+            f"[verification-gate] BLOCKED: last verification-gate verdict was {last}.\n\n"
+            "Re-run the verification-gate after fixing the issues. Trivial bypass is "
+            f"not permitted after {last} — no exceptions.\n\n"
+            f"After SHIP:\n{mark_cmd}"
+        )
+    else:
+        reason = (
+            "[verification-gate] BLOCKED: no verification-gate approval marker.\n\n"
+            "Before committing Deus changes, run the verification-gate Warden "
+            "(subagent_type=\"verification-gate\") and wait for VERDICT: SHIP. "
+            "The verification-gate confirms all task requirements were actually "
+            "implemented with evidence. Pass the plan from .claude/.plan-reviewed "
+            "(if present) or the commit message as requirements context.\n\n"
+            f"After SHIP:\n{mark_cmd}\n\n"
+            "Trivial-commit bypass (typos, deps, config-only):\n"
+            f"  python3 {shlex.quote(str(_active_script_path(repo_root)))} "
+            f"mark verified TRIVIAL \"reason\""
+        )
+    _block_pre_tool(reason)
+    return 0
+
+
+def run_verification_invalidator(event: dict[str, Any], repo_root: Path) -> int:
+    _, paths = _managed_paths(event, repo_root)
+    if paths:
+        _marker(repo_root, ".verified").unlink(missing_ok=True)
     return 0
 
 
@@ -1040,7 +1102,7 @@ VERDICT_RE = re.compile(
     re.MULTILINE,
 )
 
-WARDEN_SUBAGENT_TYPES = frozenset({"plan-reviewer", "code-reviewer", "threat-modeler"})
+WARDEN_SUBAGENT_TYPES = frozenset({"plan-reviewer", "code-reviewer", "threat-modeler", "verification-gate"})
 
 
 def run_verdict_tracker(event: dict[str, Any], repo_root: Path) -> int:
@@ -1076,10 +1138,12 @@ RUNNERS = {
     "plan-review-gate": run_plan_review_gate,
     "plan-mode-invalidator": run_plan_mode_invalidator,
     "code-review-gate": run_code_review_gate,
+    "verification-gate": run_verification_gate,
     "admin-merge-gate": run_admin_merge_gate,
     "stop-checkpoint": run_stop_checkpoint,
     "memory-tree-hook": run_memory_tree_hook,
     "code-review-invalidator": run_code_review_invalidator,
+    "verification-invalidator": run_verification_invalidator,
     "threat-model-gate": run_threat_model_gate,
     "path-leak-detector": run_path_leak_detector,
     "catchup-freshness": run_catchup_freshness,
@@ -1093,6 +1157,7 @@ MARKER_NAMES = {
     "plan-reviewed": "plan-reviewer",
     "code-reviewed": "code-reviewer",
     "threat-modeled": "threat-modeler",
+    "verified": "verification-gate",
 }
 
 

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -1113,3 +1113,81 @@ def test_bypass_log_written_on_trivial_refusal(tmp_path, monkeypatch):
     assert entry["warden"] == "code-reviewer"
     assert entry["verdict"] == "REFUSED"
     assert entry["session_type"] == "interactive"
+
+
+# ── Verification gate ────────────────────────────────────────────────────────
+
+
+def test_verification_gate_blocks_git_commit_without_marker(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "verification-gate" in reason
+
+
+def test_verification_gate_allows_after_marker(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / ".verified").touch()
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_verification_gate_shows_revise_escalation(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+
+    hooks._write_verdict(repo, "verification-gate", "REVISE", "incomplete", "agent")
+
+    event = bash_event(repo, "git commit -m test")
+    hooks.run_verification_gate(event, repo)
+    out = capsys.readouterr().out
+    assert "REVISE" in out
+    assert "Trivial-commit bypass" not in out
+
+
+def test_verification_invalidator_clears_marker_after_edit(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "app.ts").write_text("old\n", encoding="utf-8")
+    marker = repo / ".claude" / ".verified"
+    marker.touch()
+
+    rc = hooks.run_verification_invalidator(apply_patch_event(repo, "src/app.ts"), repo)
+
+    assert rc == 0
+    assert not marker.exists()
+
+
+def test_session_init_clears_verified_marker(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    marker = repo / ".claude" / ".verified"
+    marker.touch()
+
+    assert hooks.run_session_init(repo) == 0
+
+    assert not marker.exists()
+
+
+def test_mark_verified_creates_marker(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+
+    result = hooks.mark_warden("verified", "SHIP", "all claims verified", repo)
+    assert result == 0
+    assert (repo / ".claude" / ".verified").exists()
+
+    verdicts = json.loads((repo / ".claude" / ".warden-verdicts.json").read_text())
+    assert verdicts["verification-gate"]["verdict"] == "SHIP"


### PR DESCRIPTION
## Summary

- Wires the existing `verification-gate` agent as an automatic pre-commit gate, mirroring the `code-reviewer` pattern
- New `run_verification_gate` and `run_verification_invalidator` functions in `codex_warden_hooks.py` with full registry integration (HOOK_SPECS, RUNNERS, MARKER_NAMES, WARDEN_SUBAGENT_TYPES, `_is_excluded`, `run_session_init`)
- Hook registrations in `settings.json`: verification-gate inserted between code-review-gate and admin-merge-gate; invalidator appended to PostToolUse Edit/Write group
- Agent output format aligned from `## Verification: CONFIRMED|FAILED|PARTIAL` to `## Verdict: SHIP|REVISE|BLOCK` for verdict-tracker compatibility
- 6 new unit tests (55/55 total pass)

## Gate ordering

Pre-commit hooks fire in array order:
1. `code-review-gate` — code correctness
2. `verification-gate` — requirements actually implemented (NEW)
3. `admin-merge-gate` — admin merge approval

## Smoke test transcripts

### Pass case: marker present → commit proceeds

```
$ python3 scripts/codex_warden_hooks.py mark verified SHIP "all claims verified"
[warden-mark] verified marked as SHIP: all claims verified

# git commit proceeds normally — no block
```

### Block case: no marker → commit blocked

```
$ echo '{"cwd": "/repo", "tool_name": "Bash", "tool_input": {"command": "git commit -m test"}}' | \
  python3 scripts/codex_warden_hooks.py run verification-gate --repo-root /repo

{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny",
"permissionDecisionReason":"[verification-gate] BLOCKED: no verification-gate approval marker.\n\n
Before committing Deus changes, run the verification-gate Warden (subagent_type=\"verification-gate\")
and wait for VERDICT: SHIP. ..."}}
```

### REVISE escalation case: previous REVISE → no trivial bypass

```
# After verification-gate returned REVISE:
$ echo '{"cwd": "/repo", "tool_name": "Bash", "tool_input": {"command": "git commit -m test"}}' | \
  python3 scripts/codex_warden_hooks.py run verification-gate --repo-root /repo

{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny",
"permissionDecisionReason":"[verification-gate] BLOCKED: last verification-gate verdict was REVISE.\n\n
Re-run the verification-gate after fixing the issues. Trivial bypass is not permitted after REVISE — no exceptions. ..."}}
```

## Test plan

- [x] All 55 tests pass (`python3 -m pytest scripts/tests/test_codex_warden_hooks.py -v`)
- [x] New tests: block without marker, allow with marker, REVISE escalation, invalidator clears marker, session-init cleanup, mark command
- [x] Plan-reviewer SHIP (3rd pass)
- [x] Code-reviewer SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)