### PR TITLE
docs: add session type contract and tests (RETRO-2026-05-14-02)

### DIFF
--- a/docs/session-type-contract.md
+++ b/docs/session-type-contract.md
@@ -1,0 +1,287 @@
+# Session Type Contract
+
+Implements RETRO-2026-05-14-02. The hook + settings + permissions surface was
+designed against a single session type (primary CLI) but is now consumed by 5
+distinct session types. This document is the authoritative contract specifying
+what each session type guarantees regarding settings loading, hook activation,
+permissions, and environment variables.
+
+## Matrix Overview
+
+| Property | CLI | Agent View (TUI) | Worktree Subagent | Background | Container |
+|---|---|---|---|---|---|
+| Launch mechanism | `deus-cmd.sh` → `claude` | `tui/backend/claude.rs` → `claude -p` | Claude Code Agent tool | `claude --bg` / `run_in_background` | Agent SDK `query()` |
+| Permission mode | `bypassPermissions` via `--dangerously-skip-permissions` | `--permission-mode <mode>` from `tui-permissions.json` | Inherits parent session | Inherits parent session | `bypassPermissions` (hardcoded) |
+| Host `~/.claude/settings.json` | Loaded | Loaded | Loaded | Loaded | **Not loaded** (filesystem isolation) |
+| Project `.claude/settings.json` | Loaded | Loaded | Worktree's own copy (git-tracked snapshot) | Loaded | **Not loaded** |
+| `.claude/settings.local.json` | Loaded | Loaded | Not copied to worktree | Loaded | **Not loaded** |
+| Container session settings | N/A | N/A | N/A | N/A | `data/sessions/<group>/.claude/settings.json` |
+| `CLAUDE_PROJECT_DIR` | Set by Claude Code | Set by Claude Code | Set to worktree path | Set by Claude Code | Set by SDK (`cwd` option) |
+| `CLAUDE_JOB_DIR` | Not set | Not set | Not set | **Set** | Not set |
+| Shell hooks fire | Yes (host + project) | Yes (host + project + TUI permission bridge) | Yes (host + worktree project) | Yes (host + project) | **No** |
+| SDK hooks fire | No | No | No | No | **Yes** (TypeScript) |
+
+## CLI
+
+### Launch path
+
+`deus-cmd.sh` detects home mode (`cwd == ~/deus`) vs external project mode and
+calls `launch_claude()` which invokes `claude --dangerously-skip-permissions`.
+
+### Permission mode
+
+`bypassPermissions` via `--dangerously-skip-permissions` CLI flag. Gated by
+`PREFS_BYPASS` which reads `bypass_permissions` from `~/.config/deus/config.json`.
+When `PREFS_BYPASS=false`, the flag is stripped and the default permission mode
+from settings applies.
+
+### Settings files loaded (in precedence order)
+
+1. `~/.claude/settings.json` (host)
+2. `<project>/.claude/settings.json` (project)
+3. `<project>/.claude/settings.local.json` (project local, gitignored)
+
+### Hook events active
+
+All hook events from both host and project settings fire:
+
+- **SessionStart:** hook-integrity-check, plan-mode-session-init, memory-cite-seed,
+  standards-pack, vault-context (host) + warden-shim session-init (project)
+- **UserPromptSubmit:** catchup-freshness, orchestrator-preflight, memory-retrieval
+  (host) + memory_retrieval_hook.py (project)
+- **PreToolUse:** plan-review-gate, plan-mode-invalidator, sonnet-default-reminder,
+  code-review-gate, memory-cite (host) + plan-review-gate, tdd-test-lock,
+  plan-mode-invalidator, code-review-gate, admin-merge-gate (project)
+- **PostToolUse:** memory-tree-hook, threat-model-gate, code-review-invalidator,
+  path-leak-detector, plan-revise-logger, warden-verdict-tracker (host) +
+  code-review-invalidator, threat-model-gate, path-leak-detector,
+  warden-verdict-tracker (project)
+- **Stop:** stop_hook.py (host)
+
+### Required env vars
+
+None specific to CLI beyond `CLAUDE_PROJECT_DIR` (set automatically).
+
+### Negative contract
+
+- `CLAUDE_JOB_DIR` must NOT be set (would trigger compress gate).
+- `DEUS_TUI_*` vars must NOT be set (would confuse TUI detection).
+
+## Agent View (TUI)
+
+### Launch path
+
+`tui/src/backend/claude.rs` → `build_command()` invokes
+`claude -p --output-format stream-json --verbose --model <model> --effort <level>
+--permission-mode <mode>`.
+
+### Permission mode
+
+`--permission-mode <mode>` loaded from `~/.config/deus/tui-permissions.json`.
+When mode is `bypassPermissions`, also passes `--dangerously-skip-permissions`.
+In non-bypass mode, the TUI permission bridge hook (`tui/hooks/permission-bridge.sh`)
+intercepts `PreToolUse` events via file-based IPC.
+
+### Settings files loaded
+
+Same as CLI, plus TUI-specific `--settings` override when the permission bridge
+is active.
+
+### Hook events active
+
+Same as CLI, plus:
+
+- **PreToolUse:** `permission-bridge.sh` (TUI-specific, only in non-bypass mode)
+
+### Required env vars
+
+| Variable | Set by | Purpose |
+|---|---|---|
+| `DEUS_TUI_BYPASS` | `deus-cmd.sh` | TUI reads to decide `--dangerously-skip-permissions` |
+| `DEUS_TUI_MODE` | `deus-cmd.sh` | `"home"` or `"external"` |
+| `DEUS_TUI_BACKEND` | `deus-cmd.sh` | Backend selection for TUI |
+| `DEUS_TUI_PERMISSIONS_DIR` | TUI Rust backend | Path for permission bridge IPC (non-bypass only) |
+
+### Negative contract
+
+- `CLAUDE_JOB_DIR` must NOT be set.
+
+## Worktree Subagent
+
+### Launch path
+
+Claude Code `Agent` tool with `isolation: "worktree"` creates a git worktree at
+`.claude/worktrees/<name>/` on a new branch. The subagent runs in this directory.
+
+### Permission mode
+
+Inherits the parent session's permission mode. The worktree itself does not
+configure permissions.
+
+### Settings files loaded
+
+1. `~/.claude/settings.json` (host — same as parent)
+2. `.claude/worktrees/<name>/.claude/settings.json` (worktree's own copy)
+
+Note: `.claude/settings.local.json` is NOT copied to the worktree. The worktree's
+`.claude/settings.json` is a git-tracked snapshot from the branch point. Worktrees
+created before the portable warden gates commit (`d43d3e0`) have a reduced hook
+set (only `UserPromptSubmit` + `PreToolUse`). Worktrees created after have the
+full 4-event hook set matching the current project settings.
+
+### Hook events active
+
+Host hooks fire normally. Project hooks fire from the worktree's own settings
+snapshot. The minimum invariant hooks present in all worktrees regardless of age:
+
+- **UserPromptSubmit:** `memory_retrieval_hook.py`
+- **PreToolUse:** `tdd-test-lock.sh` (Write|Edit matcher)
+
+### Required env vars
+
+| Variable | Value |
+|---|---|
+| `CLAUDE_PROJECT_DIR` | Set to the worktree path (e.g., `~/deus/.claude/worktrees/<name>`) |
+
+### Negative contract
+
+- `CLAUDE_JOB_DIR` must NOT be set.
+- `DEUS_TUI_*` vars must NOT be set.
+
+## Background
+
+### Launch path
+
+`claude --bg <prompt>` or Claude Code Agent tool with `run_in_background: true`.
+The session runs asynchronously with output collected in `CLAUDE_JOB_DIR`.
+
+### Permission mode
+
+Inherits the parent session's permission mode and settings.
+
+### Settings files loaded
+
+Same as CLI (host + project + project local).
+
+### Hook events active
+
+Same as CLI. Additionally, the Stop hook has special behavior:
+
+- **Stop:** `stop_hook.py` detects `CLAUDE_JOB_DIR` is set via `_is_bg_session()`
+  and activates the compress gate, which blocks session completion until `/compress`
+  has been run. A `.compress_gate` sentinel file in `CLAUDE_JOB_DIR` prevents
+  double-blocking.
+
+### Required env vars
+
+| Variable | Set by | Purpose |
+|---|---|---|
+| `CLAUDE_JOB_DIR` | Claude Code | Background job output directory. **This is the sole signal** that a session is a background session. |
+
+### Negative contract
+
+- `DEUS_TUI_*` vars must NOT be set.
+
+## Container
+
+### Launch path
+
+`container/agent-runner/src/index.ts` uses the Claude Agent SDK `query()` function.
+This is NOT the `claude` CLI — it is a direct SDK call running inside a Docker
+container with an isolated filesystem.
+
+### Permission mode
+
+Hardcoded in `agent-runner/src/index.ts`:
+```typescript
+permissionMode: 'bypassPermissions',
+allowDangerouslySkipPermissions: true,
+```
+
+### Settings files loaded
+
+The SDK is configured with `settingSources: ['project', 'user']`, which maps to:
+- **project:** `data/sessions/<group>/.claude/settings.json` (env vars only, no hooks)
+- **user:** Container's own `~/.claude/settings.json` (empty — filesystem isolation)
+
+Host `~/.claude/settings.json` is NOT loaded. Project `.claude/settings.json` from
+the repo is NOT loaded.
+
+### Hook events active
+
+Container sessions use TypeScript SDK hooks, NOT shell scripts:
+
+- **UserPromptSubmit:** `createMemoryRetrievalHook()` (imported from `memory-retrieval-hook.ts`)
+- **PreCompact:** `createPreCompactHook()` (archives transcript to `conversations/`)
+- **PostToolUse:** `createToolSizeLogHook()` (opt-out via `DEUS_TOOL_SIZE_LOG=0`),
+  `createToolAuditHook()` (opt-out via `DEUS_TOOL_AUDIT_LOG=0`)
+
+No SessionStart, PreToolUse, or Stop shell hooks fire.
+
+### Required env vars
+
+| Variable | Purpose |
+|---|---|
+| `DEUS_PROXY_TOKEN` | Auth token for credential proxy and HookDispatchService |
+| `DEUS_AGENT_EFFORT` | Override effort level for SDK queries |
+| `ANTHROPIC_CUSTOM_HEADERS` | Injects proxy token for API auth |
+
+### Negative contract
+
+- `CLAUDE_JOB_DIR` must NOT be set (container sessions are not background sessions).
+- `DEUS_TUI_*` vars must NOT be set.
+- No shell hooks from host `~/.claude/` must fire.
+- No warden-shim hooks must fire (wardens are host-enforced, not container-enforced).
+
+## Cross-Cutting Invariants
+
+These 5 invariants hold regardless of session type.
+
+1. **BG detection via env var.** Any session with `CLAUDE_JOB_DIR` set is a
+   Background session. `stop_hook.py._is_bg_session()` uses `os.environ.get("CLAUDE_JOB_DIR")`
+   and only this to detect background sessions. No CLI flag parsing.
+
+2. **Container hook isolation.** Container sessions use TypeScript SDK hooks from
+   `agent-runner/src/index.ts`, never shell scripts from the host. The container's
+   filesystem isolation prevents host `~/.claude/settings.json` hooks from firing.
+
+3. **Container permission hardcode.** Container sessions always run with
+   `permissionMode: 'bypassPermissions'` + `allowDangerouslySkipPermissions: true`,
+   hardcoded in `agent-runner/src/index.ts`.
+
+4. **Memory retrieval universality.** `memory_retrieval_hook.py` fires on
+   `UserPromptSubmit` in all host-side session types (CLI, Agent View, Worktree,
+   Background) via project `.claude/settings.json`. Container sessions have an
+   equivalent TypeScript hook (`createMemoryRetrievalHook`).
+
+5. **TDD test lock universality.** `tdd-test-lock.sh` fires on `PreToolUse`
+   (Write|Edit|MultiEdit|apply_patch|ExitPlanMode) in all host-side session types.
+   Container sessions do not have this hook (containers are not used for TDD
+   development).
+
+## Testing
+
+Run the contract test suite:
+
+```bash
+python3 -m pytest tests/test_session_type_contract.py -v
+```
+
+### What the tests verify (static analysis)
+
+- Hook presence in project `.claude/settings.json` (structural rules, additive-safe)
+- Hook script file existence (all referenced `.sh`/`.py` files resolve on disk)
+- Container permission mode hardcode in TypeScript source
+- Container SDK hook function names in TypeScript source
+- Background detection mechanism (`CLAUDE_JOB_DIR`) in `stop_hook.py`
+- CLI permission flags and TUI env var exports in `deus-cmd.sh`
+- Worktree minimum-invariant hooks (when worktrees exist locally)
+
+### What the tests do NOT verify (requires live testing)
+
+- Host `~/.claude/settings.json` hook presence (file is outside the repo)
+- Whether hooks actually fire at runtime (requires spawning real sessions)
+- Permission mode effective behavior (requires Claude Code binary)
+- Env var values at runtime (requires process inspection)
+- Container filesystem isolation (requires Docker runtime)
+- TUI permission bridge IPC (requires TUI binary)

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-14" # verified: portable warden gates
+last_verified: "2026-05-15" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/tests/test_session_type_contract.py
+++ b/tests/test_session_type_contract.py
@@ -1,0 +1,341 @@
+"""Session type contract tests (RETRO-2026-05-14-02).
+
+Static analysis only — parses settings JSON and greps source files.
+No real Claude Code sessions are spawned.
+
+See docs/session-type-contract.md for the full contract specification.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT_SETTINGS = ROOT / ".claude" / "settings.json"
+CONTAINER_RUNNER = ROOT / "container" / "agent-runner" / "src" / "index.ts"
+STOP_HOOK = ROOT / "scripts" / "stop_hook.py"
+DEUS_CMD = ROOT / "deus-cmd.sh"
+
+
+def _load_project_settings() -> dict:
+    return json.loads(PROJECT_SETTINGS.read_text())
+
+
+def _extract_hook_commands(settings: dict) -> list[str]:
+    """Extract all command strings from the nested hooks structure."""
+    commands: list[str] = []
+    for _event, groups in settings.get("hooks", {}).items():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                cmd = hook.get("command", "")
+                if cmd:
+                    commands.append(cmd)
+    return commands
+
+
+def _extract_hook_commands_for_event(settings: dict, event: str) -> list[str]:
+    """Extract command strings for a specific hook event."""
+    commands: list[str] = []
+    for group in settings.get("hooks", {}).get(event, []):
+        for hook in group.get("hooks", []):
+            cmd = hook.get("command", "")
+            if cmd:
+                commands.append(cmd)
+    return commands
+
+
+def _extract_script_paths(commands: list[str]) -> list[str]:
+    """Extract script paths from hook command strings.
+
+    Handles both:
+      bash -c '"${CLAUDE_PROJECT_DIR:-.}/path/to/script.sh"'
+      bash -c 'python3 "${CLAUDE_PROJECT_DIR:-.}/path/to/script.py"'
+    """
+    paths: list[str] = []
+    for cmd in commands:
+        for m in re.finditer(r'\$\{CLAUDE_PROJECT_DIR:-\.\}/([^\s"\']+)', cmd):
+            paths.append(m.group(1))
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# TestProjectSettingsHooks — structural rules for hook presence
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSettingsHooks:
+    """Validates that .claude/settings.json has the expected hook structure."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.settings = _load_project_settings()
+
+    def test_settings_file_exists(self):
+        assert PROJECT_SETTINGS.exists()
+
+    def test_all_hook_events_present(self):
+        hooks = self.settings.get("hooks", {})
+        for event in ("SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse"):
+            assert event in hooks, f"Missing hook event: {event}"
+
+    def test_session_start_has_warden_shim(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "SessionStart")
+        assert any("warden-shim" in c and "session-init" in c for c in cmds)
+
+    def test_user_prompt_submit_has_memory_retrieval(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "UserPromptSubmit")
+        assert any("memory_retrieval" in c for c in cmds)
+
+    def test_pretooluse_has_plan_review_gate(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PreToolUse")
+        assert any("plan-review-gate" in c for c in cmds)
+
+    def test_pretooluse_has_tdd_test_lock(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PreToolUse")
+        assert any("tdd-test-lock" in c for c in cmds)
+
+    def test_pretooluse_has_code_review_gate(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PreToolUse")
+        assert any("code-review-gate" in c for c in cmds)
+
+    def test_posttooluse_has_code_review_invalidator(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PostToolUse")
+        assert any("code-review-invalidator" in c for c in cmds)
+
+    def test_posttooluse_has_threat_model_gate(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PostToolUse")
+        assert any("threat-model-gate" in c for c in cmds)
+
+    def test_posttooluse_has_path_leak_detector(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PostToolUse")
+        assert any("path-leak-detector" in c for c in cmds)
+
+    def test_posttooluse_has_warden_verdict_tracker(self):
+        cmds = _extract_hook_commands_for_event(self.settings, "PostToolUse")
+        assert any("warden-verdict-tracker" in c for c in cmds)
+
+
+# ---------------------------------------------------------------------------
+# TestProjectHookFilesExist — every referenced script must exist on disk
+# ---------------------------------------------------------------------------
+
+
+class TestProjectHookFilesExist:
+    """Verifies that all scripts referenced in project settings exist."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        settings = _load_project_settings()
+        commands = _extract_hook_commands(settings)
+        self.script_paths = _extract_script_paths(commands)
+
+    def test_at_least_one_script_found(self):
+        assert len(self.script_paths) > 0, "No script paths extracted from settings"
+
+    @pytest.fixture(params=None)
+    def script_path(self):
+        """Dynamically parametrized — see pytest_generate_tests."""
+
+    def test_script_file_exists(self, script_path: str):
+        full_path = ROOT / script_path
+        assert full_path.exists(), f"Hook script not found: {script_path}"
+
+
+def pytest_generate_tests(metafunc):
+    if "script_path" in metafunc.fixturenames:
+        settings = _load_project_settings()
+        commands = _extract_hook_commands(settings)
+        paths = _extract_script_paths(commands)
+        metafunc.parametrize("script_path", paths, ids=paths)
+
+
+# ---------------------------------------------------------------------------
+# TestContainerSession — invariants 2 and 3
+# ---------------------------------------------------------------------------
+
+
+class TestContainerSession:
+    """Validates container session properties in agent-runner/src/index.ts."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.source = CONTAINER_RUNNER.read_text()
+
+    def test_container_runner_exists(self):
+        assert CONTAINER_RUNNER.exists()
+
+    def test_permission_mode_is_bypass(self):
+        assert "permissionMode: 'bypassPermissions'" in self.source
+
+    def test_allow_dangerously_skip_permissions(self):
+        assert "allowDangerouslySkipPermissions: true" in self.source
+
+    def test_settings_sources_project_and_user(self):
+        assert "settingSources: ['project', 'user']" in self.source
+
+    def test_has_memory_retrieval_hook(self):
+        assert "createMemoryRetrievalHook" in self.source
+
+    def test_has_pre_compact_hook(self):
+        assert "createPreCompactHook" in self.source
+
+    def test_has_tool_size_log_hook(self):
+        assert "createToolSizeLogHook" in self.source
+
+    def test_has_tool_audit_hook(self):
+        assert "createToolAuditHook" in self.source
+
+
+# ---------------------------------------------------------------------------
+# TestBackgroundSession — invariant 1
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundSession:
+    """Validates background session detection in stop_hook.py."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.source = STOP_HOOK.read_text()
+
+    def test_stop_hook_exists(self):
+        assert STOP_HOOK.exists()
+
+    def test_has_is_bg_session_function(self):
+        assert "_is_bg_session" in self.source
+
+    def test_bg_detection_uses_claude_job_dir(self):
+        assert 'os.environ.get("CLAUDE_JOB_DIR")' in self.source
+
+    def test_compress_gate_reads_claude_job_dir(self):
+        assert 'os.environ["CLAUDE_JOB_DIR"]' in self.source
+
+    def test_has_compress_gate_function(self):
+        assert "_bg_compress_gate" in self.source
+
+
+# ---------------------------------------------------------------------------
+# TestCLISession — CLI launch properties
+# ---------------------------------------------------------------------------
+
+
+class TestCLISession:
+    """Validates CLI session properties in deus-cmd.sh."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.source = DEUS_CMD.read_text()
+
+    def test_deus_cmd_exists(self):
+        assert DEUS_CMD.exists()
+
+    def test_has_dangerously_skip_permissions_flag(self):
+        assert "--dangerously-skip-permissions" in self.source
+
+    def test_bypass_gated_by_prefs_bypass(self):
+        assert "PREFS_BYPASS" in self.source
+
+    def test_tui_exports_deus_tui_bypass(self):
+        assert "export DEUS_TUI_BYPASS" in self.source
+
+    def test_tui_exports_deus_tui_mode(self):
+        assert "export DEUS_TUI_MODE" in self.source
+
+    def test_tui_exports_deus_tui_backend(self):
+        assert "export DEUS_TUI_BACKEND" in self.source
+
+
+# ---------------------------------------------------------------------------
+# TestWorktreeSettings — invariants 4 and 5 for worktrees
+# ---------------------------------------------------------------------------
+
+
+_worktree_settings = list(
+    (ROOT / ".claude" / "worktrees").glob("*/.claude/settings.json")
+)
+
+
+if _worktree_settings:
+
+    class TestWorktreeSettings:
+        """Validates minimum-invariant hooks in worktree settings."""
+
+        @pytest.fixture(params=_worktree_settings, ids=[str(p.relative_to(ROOT)) for p in _worktree_settings])
+        def wt_settings(self, request) -> dict:
+            return json.loads(request.param.read_text())
+
+        def test_has_memory_retrieval_in_user_prompt_submit(self, wt_settings):
+            cmds = _extract_hook_commands_for_event(wt_settings, "UserPromptSubmit")
+            assert any("memory_retrieval" in c for c in cmds), (
+                "Worktree missing memory_retrieval in UserPromptSubmit"
+            )
+
+        def test_has_tdd_test_lock_in_pretooluse(self, wt_settings):
+            cmds = _extract_hook_commands_for_event(wt_settings, "PreToolUse")
+            assert any("tdd-test-lock" in c for c in cmds), (
+                "Worktree missing tdd-test-lock in PreToolUse"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestCrossSessionInvariants — all 5 cross-cutting invariants
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSessionInvariants:
+    """Cross-cutting contract assertions across session types."""
+
+    def test_bg_detection_is_env_var_not_flag(self):
+        """Invariant 1: bg detection uses CLAUDE_JOB_DIR env var, not CLI flag."""
+        source = STOP_HOOK.read_text()
+        assert "_is_bg_session" in source
+        assert 'os.environ.get("CLAUDE_JOB_DIR")' in source
+        assert "--bg" not in source.split("_is_bg_session")[1].split("\n")[0]
+
+    def test_container_uses_no_shell_hooks(self):
+        """Invariant 2: container hooks are TypeScript, not shell scripts."""
+        source = CONTAINER_RUNNER.read_text()
+        hooks_start = source.index("hooks:")
+        depth, end = 0, hooks_start
+        for i, ch in enumerate(source[hooks_start:], hooks_start):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        hooks_section = source[hooks_start:end]
+        assert "bash -c" not in hooks_section
+        assert ".sh" not in hooks_section
+
+    def test_container_hardcodes_bypass_permissions(self):
+        """Invariant 3: container always uses bypassPermissions."""
+        source = CONTAINER_RUNNER.read_text()
+        assert source.count("permissionMode: 'bypassPermissions'") >= 1
+
+    def test_project_settings_has_memory_retrieval(self):
+        """Invariant 4: memory retrieval in project UserPromptSubmit."""
+        settings = _load_project_settings()
+        cmds = _extract_hook_commands_for_event(settings, "UserPromptSubmit")
+        assert any("memory_retrieval" in c for c in cmds)
+
+    def test_container_has_memory_retrieval_equivalent(self):
+        """Invariant 4: container has TypeScript memory retrieval hook."""
+        source = CONTAINER_RUNNER.read_text()
+        assert "createMemoryRetrievalHook" in source
+
+    def test_project_settings_has_tdd_test_lock(self):
+        """Invariant 5: tdd-test-lock in project PreToolUse."""
+        settings = _load_project_settings()
+        cmds = _extract_hook_commands_for_event(settings, "PreToolUse")
+        assert any("tdd-test-lock" in c for c in cmds)
+
+    def test_container_has_no_tdd_test_lock(self):
+        """Invariant 5: container does NOT have tdd-test-lock."""
+        source = CONTAINER_RUNNER.read_text()
+        assert "tdd-test-lock" not in source


### PR DESCRIPTION
## Summary

- Adds `docs/session-type-contract.md` — the authoritative contract for 5 Deus session types (CLI, Agent View, Worktree Subagent, Background, Container), specifying settings loading, hook activation, permissions, and environment variables for each
- Adds `tests/test_session_type_contract.py` — 49 pytest tests that statically validate the contract by parsing `.claude/settings.json`, grepping `container/agent-runner/src/index.ts`, `scripts/stop_hook.py`, and `deus-cmd.sh`
- Implements RETRO-2026-05-14-02, addressing the 9-of-20-session hook/settings/permissions fragility pattern

## Test plan

- [x] `python3 -m pytest tests/test_session_type_contract.py -v` — 49 passed, 0 failed
- [ ] Verify worktree tests run correctly from main checkout (they conditionally skip when no worktrees exist)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)