### PR TITLE
fix(wardens): close TRIVIAL-bypass hole with bg-session gate and audit log

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -959,6 +959,43 @@ def _audit_log_path(repo_root: Path) -> Path:
     return repo_root / ".claude" / ".warden-log"
 
 
+def _bypass_log_path() -> Path:
+    override = os.environ.get("DEUS_WARDEN_BYPASS_LOG")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude" / ".warden-bypass-log"
+
+
+def _write_bypass_log(
+    warden: str,
+    verdict: str,
+    session_type: str,
+    reason: str,
+    cwd: Path,
+) -> None:
+    try:
+        diff_stats = _git(cwd, "diff", "--stat", "HEAD")
+        entry = {
+            "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "warden": warden,
+            "verdict": verdict,
+            "session_type": session_type,
+            "reason": reason,
+            "cwd": str(cwd),
+            "diff_stats": diff_stats,
+        }
+        path = _bypass_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except OSError:
+        _debug("bypass log write failed")
+
+
+def _is_bg_session() -> bool:
+    return bool(os.environ.get("CLAUDE_JOB_DIR"))
+
+
 def _read_verdicts(repo_root: Path) -> dict[str, Any]:
     path = _verdicts_path(repo_root)
     if not path.exists():
@@ -1069,17 +1106,32 @@ def mark_warden(marker_name: str, verdict: str, reason: str, repo_root: Path) ->
         print(f"Invalid verdict: {verdict}. Must be SHIP or TRIVIAL.", file=sys.stderr)
         return 1
 
+    bg = _is_bg_session()
+    session_type = "bg" if bg else "interactive"
+
+    if verdict == "TRIVIAL" and bg:
+        _write_bypass_log(warden, "REFUSED", "bg", reason, repo_root)
+        print(
+            "[warden-mark] BLOCKED: TRIVIAL bypass is not permitted in background sessions.\n"
+            "Background sessions must run the full warden and get SHIP.",
+            file=sys.stderr,
+        )
+        return 2
+
     if verdict == "TRIVIAL" and _last_verdict_is_blocking(repo_root, warden):
         last = _last_verdict(repo_root, warden)
         if last:
+            _write_bypass_log(warden, "REFUSED", session_type, reason, repo_root)
             print(
                 f"[warden-mark] BLOCKED: last {warden} verdict was {last}.\n"
-                f"Re-run the warden and get SHIP — trivial bypass is not permitted after {last}.",
+                "Re-run the warden and get SHIP — trivial bypass is not permitted after REVISE or BLOCK.",
                 file=sys.stderr,
             )
             return 2
 
     _write_verdict(repo_root, warden, verdict, reason, source="mark")
+    if verdict == "TRIVIAL":
+        _write_bypass_log(warden, "TRIVIAL", session_type, reason, repo_root)
     _marker(repo_root, f".{marker_name}").parent.mkdir(parents=True, exist_ok=True)
     _marker(repo_root, f".{marker_name}").touch()
     print(f"[warden-mark] {marker_name} marked as {verdict}: {reason}")

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -904,10 +904,12 @@ def test_mark_creates_marker_and_audit_log(tmp_path):
     assert "SHIP" in log
 
 
-def test_mark_blocks_trivial_after_revise(tmp_path):
+def test_mark_blocks_trivial_after_revise(tmp_path, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
     (repo / ".claude" / "wardens").mkdir(parents=True)
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(tmp_path / "bypass.jsonl"))
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
 
     hooks._write_verdict(repo, "code-reviewer", "REVISE", "issues found", "agent")
 
@@ -1015,3 +1017,99 @@ def test_code_review_gate_shows_revise_escalation(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "REVISE" in out
     assert "Trivial-commit bypass" not in out
+
+
+# ── TRIVIAL bypass enforcement (B + C + D) ──────────────────────────────────
+
+
+def test_mark_blocks_trivial_after_block(tmp_path, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(tmp_path / "bypass.jsonl"))
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+
+    hooks._write_verdict(repo, "code-reviewer", "BLOCK", "critical issues", "agent")
+
+    result = hooks.mark_warden("code-reviewed", "TRIVIAL", "just a typo", repo)
+    assert result == 2
+    assert not (repo / ".claude" / ".code-reviewed").exists()
+
+
+def test_mark_blocks_trivial_in_bg_session(tmp_path, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(tmp_path / "bypass.jsonl"))
+    monkeypatch.setenv("CLAUDE_JOB_DIR", str(tmp_path / "job"))
+
+    hooks._write_verdict(repo, "plan-reviewer", "SHIP", "all good", "agent")
+
+    result = hooks.mark_warden("plan-reviewed", "TRIVIAL", "just a comment fix", repo)
+    assert result == 2
+    assert not (repo / ".claude" / ".plan-reviewed").exists()
+
+
+def test_mark_allows_trivial_interactive_no_prior_verdict(tmp_path, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(tmp_path / "bypass.jsonl"))
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+
+    result = hooks.mark_warden("plan-reviewed", "TRIVIAL", "typo fix", repo)
+    assert result == 0
+    assert (repo / ".claude" / ".plan-reviewed").exists()
+
+
+def test_mark_allows_trivial_interactive_after_ship(tmp_path, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(tmp_path / "bypass.jsonl"))
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+
+    hooks._write_verdict(repo, "plan-reviewer", "SHIP", "all good", "agent")
+
+    result = hooks.mark_warden("plan-reviewed", "TRIVIAL", "typo fix", repo)
+    assert result == 0
+    assert (repo / ".claude" / ".plan-reviewed").exists()
+
+
+def test_bypass_log_written_on_trivial_success(tmp_path, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    log_path = tmp_path / "bypass.jsonl"
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(log_path))
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+
+    hooks.mark_warden("code-reviewed", "TRIVIAL", "just a typo", repo)
+
+    assert log_path.exists()
+    entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert entry["warden"] == "code-reviewer"
+    assert entry["verdict"] == "TRIVIAL"
+    assert entry["session_type"] == "interactive"
+    assert entry["reason"] == "just a typo"
+    assert "timestamp" in entry
+    assert "cwd" in entry
+    assert "diff_stats" in entry
+
+
+def test_bypass_log_written_on_trivial_refusal(tmp_path, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    log_path = tmp_path / "bypass.jsonl"
+    monkeypatch.setenv("DEUS_WARDEN_BYPASS_LOG", str(log_path))
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+
+    hooks._write_verdict(repo, "code-reviewer", "REVISE", "issues", "agent")
+    hooks.mark_warden("code-reviewed", "TRIVIAL", "just a typo", repo)
+
+    assert log_path.exists()
+    entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert entry["warden"] == "code-reviewer"
+    assert entry["verdict"] == "REFUSED"
+    assert entry["session_type"] == "interactive"


### PR DESCRIPTION
## Summary

- **B: Enforce verdict-state rule** — `mark_warden()` already refused TRIVIAL after REVISE/BLOCK via `_last_verdict_is_blocking()`. Error message now explicitly mentions both REVISE and BLOCK.
- **C: Disable TRIVIAL for bg sessions** — Detects background sessions via `CLAUDE_JOB_DIR` env var. Refuses ALL TRIVIAL marks in bg sessions regardless of verdict state. Check runs before verdict-state check.
- **D: JSONL audit log** — Every TRIVIAL attempt (success or refusal) writes a JSONL line to `~/.claude/.warden-bypass-log` with timestamp, warden, verdict (TRIVIAL/REFUSED), session_type (interactive/bg), reason, cwd, and diff_stats.

### Evidence of the hole

On 2026-05-14, `.warden-verdicts.json` had `plan-reviewer` with `"verdict": "REVISE"` from 21:32:58Z. A bg agent invoked `warden-mark.sh plan-reviewed TRIVIAL` for an unrelated typo fix. The mark succeeded because the shell wrapper only checked REVISE (not BLOCK) and swallowed jq errors via `2>/dev/null`. PR #402 was opened on a bypass that should have been refused.

### Host-local follow-up

`~/.claude/hooks/warden-mark.sh` is personal host-local tooling (not in repo per `local-only-skills` rule). Replace lines 68-97 with:

```bash
exec python3 ~/deus/scripts/codex_warden_hooks.py mark "$MARKER_NAME" "$VERDICT" "$REASON"
```

This makes the shell script delegate to the Python enforcement layer, inheriting bg detection, BLOCK checks, and audit logging.

## Smoke test transcripts

### Test 1: TRIVIAL refused after stale REVISE (interactive)
```
$ echo '{"plan-reviewer": {"verdict": "REVISE", ...}}' > repo/.claude/.warden-verdicts.json
$ python3 scripts/codex_warden_hooks.py mark plan-reviewed TRIVIAL "just a typo fix"
[warden-mark] BLOCKED: last plan-reviewer verdict was REVISE.
Re-run the warden and get SHIP — trivial bypass is not permitted after REVISE or BLOCK.
exit code: 2
bypass log: {"warden":"plan-reviewer","verdict":"REFUSED","session_type":"interactive",...}
```

### Test 2: TRIVIAL allowed with no prior verdict (interactive)
```
$ python3 scripts/codex_warden_hooks.py mark plan-reviewed TRIVIAL "typo fix in readme"
[warden-mark] plan-reviewed marked as TRIVIAL: typo fix in readme
exit code: 0
bypass log: {"warden":"plan-reviewer","verdict":"TRIVIAL","session_type":"interactive",...}
```

### Test 3: TRIVIAL refused in bg session (even with prior SHIP)
```
$ echo '{"plan-reviewer": {"verdict": "SHIP", ...}}' > repo/.claude/.warden-verdicts.json
$ CLAUDE_JOB_DIR=/tmp/fakejob python3 scripts/codex_warden_hooks.py mark plan-reviewed TRIVIAL "bg attempt"
[warden-mark] BLOCKED: TRIVIAL bypass is not permitted in background sessions.
Background sessions must run the full warden and get SHIP.
exit code: 2
bypass log: {"warden":"plan-reviewer","verdict":"REFUSED","session_type":"bg",...}
```

## Test plan

- [x] `python3 -m pytest scripts/tests/test_codex_warden_hooks.py -v` — 55 tests pass
- [x] 6 new tests + 1 updated test covering: TRIVIAL allowed (SHIP/absent + interactive), TRIVIAL refused (REVISE, BLOCK, bg session), bypass log on success, bypass log on refusal
- [x] End-to-end smoke tests (above) confirm exact scenario from today's bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)