### PR TITLE
feat(memory): auto-classify promoted atoms via classify_atom()

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-14" # auto-bump (gemini-3.1-flash-lite GA)
+last_verified: "2026-05-15" # auto-bump
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -3025,6 +3025,19 @@ def promote_atoms(
         )
 
         filepath.write_text(content, encoding="utf-8")
+        # lazy: migrate_atom_tiers is an optional migration script, not a core dep
+        try:
+            from migrate_atom_tiers import classify_atom
+        except ImportError:
+            classify_atom = None  # type: ignore[assignment]
+        if classify_atom is not None:
+            try:
+                classified_kind, _reason = classify_atom(filepath)
+                if classified_kind != "knowledge":
+                    content = content.replace("kind: knowledge\n", f"kind: {classified_kind}\n", 1)
+                    filepath.write_text(content, encoding="utf-8")
+            except Exception as exc:
+                print(f"  WARN: classify_atom failed for {filepath}: {exc}", file=sys.stderr)
         db.execute(
             "UPDATE entries SET promoted_at = ? WHERE id = ?",
             (now, entry_id),

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -4278,3 +4278,52 @@ def test_entity_overlap_boost_surfaces_entity_atom(mi, fresh_vault, monkeypatch,
     mi.cmd_query("ollama embedding model", top=5)
     output = capsys.readouterr().out
     assert "Ollama" in output
+
+
+# ── promote_atoms: auto-classification via classify_atom ─────────────────────
+
+def _insert_promotable_atom(db, chunk, category="fact", confidence=0.8, corroborations=5):
+    """Insert a DB row that qualifies for promotion."""
+    db.execute(
+        "INSERT INTO entries (path, date, chunk, type, category, confidence, corroborations) "
+        "VALUES (?, ?, ?, 'atom', ?, ?, ?)",
+        ("test.md", "2026-01-01", chunk, category, confidence, corroborations),
+    )
+    db.commit()
+
+
+def test_promote_atoms_default_kind_knowledge(mi, tmp_path):
+    db = mi.open_db()
+    _insert_promotable_atom(db, "Python dict lookup is O(1)")
+    auto_mem = tmp_path / "auto_mem"
+    promoted = mi.promote_atoms(db, auto_mem)
+    assert len(promoted) == 1
+    content = Path(promoted[0]).read_text()
+    assert "kind: knowledge" in content
+    db.close()
+
+
+def test_promote_atoms_classifies_methodology_as_standard(mi, tmp_path):
+    db = mi.open_db()
+    _insert_promotable_atom(
+        db,
+        "Always evaluate execution strategy and verify predictions before testing",
+    )
+    auto_mem = tmp_path / "auto_mem"
+    promoted = mi.promote_atoms(db, auto_mem)
+    assert len(promoted) == 1
+    content = Path(promoted[0]).read_text()
+    assert "kind: standard" in content
+    db.close()
+
+
+def test_promote_atoms_classifier_failure_graceful(mi, tmp_path, monkeypatch):
+    db = mi.open_db()
+    _insert_promotable_atom(db, "Some generic fact about testing")
+    monkeypatch.setitem(sys.modules, "migrate_atom_tiers", None)
+    auto_mem = tmp_path / "auto_mem"
+    promoted = mi.promote_atoms(db, auto_mem)
+    assert len(promoted) == 1
+    content = Path(promoted[0]).read_text()
+    assert "kind: knowledge" in content
+    db.close()


### PR DESCRIPTION
## Summary

- Wires `classify_atom()` from `migrate_atom_tiers.py` into `promote_atoms()` so promoted atoms are auto-tagged with the correct `kind:` frontmatter (`standard` for methodology atoms, `knowledge` otherwise)
- Import is lazy with separated error handling: `ImportError` gracefully degrades to `None`, classification errors log to stderr but never block promotion
- Adds 3 tests: default kind preserved, methodology auto-classified, classifier failure graceful

**Prevents the next "scaffolding-without-payload" cycle** — previously, every promoted atom was hardcoded as `kind: knowledge`, requiring manual reclassification via `migrate_atom_tiers.py --apply`. Now the promotion path itself detects methodology signals (≥2 process verbs in name/description) and sets `kind: standard` automatically.

Closes the migration loop permanently per brainstormer recommendation from the standards_pack resolver work (PR #402).

## Test plan

- [x] `pytest scripts/tests/test_memory_indexer.py -k promote -v` — 3/3 pass
- [x] Full test suite: 266/266 pass
- [ ] Manual: `python3 scripts/memory_indexer.py --promote` on a DB with a methodology-tagged atom → verify `kind: standard` in output file

🤖 Generated with [Claude Code](https://claude.com/claude-code)