### PR TITLE
fix(bench): align methodology probes to actual atom filenames

### DIFF
--- a/docs/benchmarks/tiered-methodology-2026-05-15-followup.md
+++ b/docs/benchmarks/tiered-methodology-2026-05-15-followup.md
@@ -1,0 +1,103 @@
+# Tiered Methodology Benchmark Follow-up -- 2026-05-15
+
+RETRO reference: RETRO-2026-05-14-05 (carryover from RETRO-2026-05-13-01)
+
+## Before/After
+
+| Metric | Before | After | Target |
+|--------|--------|-------|--------|
+| **tier1_coverage** | **0.0%** | **100.0%** | >=90% |
+| tier2_recall | 95.0% | 95.0% | -- |
+| combined_recall | 31.7% | 98.3% | -- |
+| tier1_token_cost | 0 | 459 | <800 |
+| tier2_token_cost_avg | 21.2 | 21.2 | -- |
+| baseline_recall | 43.3% | 56.7% | -- |
+| abstain_accuracy | 80.0% | 80.0% | -- |
+
+## Root Cause
+
+The original A5 report (tiered-methodology-2026-05-15.md) found 0% tier1 coverage due to two compounding issues:
+
+1. `standards_pack.py` resolved to `~/.deus/auto-memory/` (non-existent). PR #402 fixes this.
+2. Even with the correct directory, only 2 of 13 existing `kind: standard` atoms had filenames matching probe `expected_path` values. The benchmark does pure string set-membership, so semantic equivalents with different names scored zero.
+
+The task narrative estimated a "13/21 = 62% gap" but the actual overlap was **2/21 = 10%** because the 13 kind=standard atoms used different filenames from the 21 probe expectations.
+
+## Changes Made
+
+### Category 1: Probe alignment (10 path renames, 15 probe lines)
+
+Updated `scripts/tests/fixtures/methodology_probes.jsonl` to reference actual atom filenames where semantically equivalent:
+
+| Probe expected_path (old) | Aligned to (actual atom) | Lines |
+|---------------------------|-------------------------|-------|
+| `feedback_deep_research_first` | `feedback_deep_research_workflow` | 2 |
+| `feedback_diagnosis_before_treatment` | `feedback_debugging_methodology` | 3 |
+| `feedback_one_concern_per_branch` | `feedback_scope_commits_by_concern` | 4, 24, 33 |
+| `feedback_security_audit` | `feedback_security_first` | 5, 20 |
+| `feedback_check_production_logs` | `feedback_check_real_logs_first` | 8 |
+| `feedback_never_speculate` | `feedback_no_speculation` | 16, 37 |
+| `feedback_predict_before_running` | `feedback_predict_before_testing` | 30, 31 |
+| `feedback_never_merge_failing_ci` | `feedback_no_merge_failed_tests` | 10 |
+| `feedback_cross_platform` | `feedback_cross_platform_default` | 21 |
+| `feedback_english_only` | `feedback_chat_english_only` | 27 |
+
+NOT aligned (semantic mismatch caught by plan-reviewer):
+- `feedback_evaluate_alternatives` was NOT aligned to `feedback_evaluate_execution_strategy` because the latter covers execution strategy estimation, not design-alternative evaluation. A new atom was created instead.
+
+### Category 2: Kind promotion (6 atoms, host-local)
+
+Changed `kind: knowledge` to `kind: standard` in frontmatter:
+
+| Atom | Probe coverage |
+|------|---------------|
+| `feedback_data_integrity.md` | 3 probes |
+| `feedback_default_sonnet.md` | 2 probes |
+| `feedback_wait_for_approval.md` | 1 probe |
+| `feedback_cross_platform_default.md` | 1 probe |
+| `feedback_chat_english_only.md` | 1 probe |
+| `feedback_no_merge_failed_tests.md` | 1 probe |
+
+### Category 3: New atoms (6 atoms, host-local)
+
+Created in `~/.claude/projects/<project-slug>/memory/` with `kind: standard`, sourced from `core-behavioral-rules.md`:
+
+| Atom | Rule | Probe coverage |
+|------|------|---------------|
+| `feedback_evaluate_alternatives.md` | Evaluate alternatives before committing | 3 probes |
+| `feedback_no_duplication.md` | Never duplicate content across files | 2 probes |
+| `feedback_no_speculative_hardening.md` | Don't solve problems that don't exist yet | 3 probes |
+| `feedback_quality_over_speed.md` | Quality over speed by default | 2 probes |
+| `feedback_search_memory_first.md` | Search memory before implementing | 2 probes |
+| `feedback_warden_loop.md` | REVISE means re-run until SHIP | 2 probes |
+
+### Category 4: STANDARD_NAMES update (repo)
+
+Added 12 entries to `scripts/migrate_atom_tiers.py` STANDARD_NAMES set (6 promoted + 6 new).
+
+## Atom Count
+
+| State | kind=standard | kind=knowledge/other |
+|-------|--------------|---------------------|
+| Before | 13 | 117 |
+| After | 25 (+12) | 105 (-12) |
+
+## Token Budget
+
+The standards pack token cost is 459 tokens (within the 800-token budget). With 25 atoms, there is 341 tokens of headroom. Follow-up: investigate whether the budget needs adjustment as more atoms are promoted.
+
+## Dependencies
+
+The runtime standards pack (standards_pack.py SessionStart hook) depends on PR #402 being merged to discover atoms from the correct directory. The benchmark-tiered verification uses an explicit standards_file and does not depend on PR #402.
+
+## Benchmark Command
+
+```bash
+grep -l "kind: standard" ~/.claude/projects/<project-slug>/memory/*.md \
+  | xargs -I{} basename {} | sed 's/^/auto-memory\//' > /tmp/standards_paths.txt
+
+python3 scripts/memory_tree.py benchmark-tiered \
+  scripts/tests/fixtures/methodology_probes.jsonl \
+  /tmp/standards_paths.txt \
+  --json
+```

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-14" # verified: portable warden gates
+last_verified: "2026-05-15" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/migrate_atom_tiers.py
+++ b/scripts/migrate_atom_tiers.py
@@ -33,6 +33,18 @@ STANDARD_NAMES = {
     "feedback_security_first.md",
     "feedback_dev_workflow.md",
     "feedback_socratic_mindset.md",
+    "feedback_data_integrity.md",
+    "feedback_default_sonnet.md",
+    "feedback_wait_for_approval.md",
+    "feedback_cross_platform_default.md",
+    "feedback_chat_english_only.md",
+    "feedback_no_merge_failed_tests.md",
+    "feedback_evaluate_alternatives.md",
+    "feedback_no_duplication.md",
+    "feedback_no_speculative_hardening.md",
+    "feedback_quality_over_speed.md",
+    "feedback_search_memory_first.md",
+    "feedback_warden_loop.md",
 }
 
 _FM_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)

--- a/scripts/tests/fixtures/methodology_probes.jsonl
+++ b/scripts/tests/fixtures/methodology_probes.jsonl
@@ -1,40 +1,40 @@
 {"query": "run deus sweep for performance regressions", "expected_path": "auto-memory/feedback_parallel_background.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "implement the new feature for telegram channels", "expected_path": "auto-memory/feedback_deep_research_first.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "fix the bug in auth token refresh", "expected_path": "auto-memory/feedback_diagnosis_before_treatment.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "commit these changes to the branch", "expected_path": "auto-memory/feedback_one_concern_per_branch.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "deploy the new version to production", "expected_path": "auto-memory/feedback_security_audit.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "implement the new feature for telegram channels", "expected_path": "auto-memory/feedback_deep_research_workflow.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "fix the bug in auth token refresh", "expected_path": "auto-memory/feedback_debugging_methodology.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "commit these changes to the branch", "expected_path": "auto-memory/feedback_scope_commits_by_concern.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "deploy the new version to production", "expected_path": "auto-memory/feedback_security_first.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "refactor the router module to be cleaner", "expected_path": "auto-memory/feedback_evaluate_alternatives.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "add error handling for edge cases", "expected_path": "auto-memory/feedback_no_speculative_hardening.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "optimize the embedding query latency", "expected_path": "auto-memory/feedback_check_production_logs.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "optimize the embedding query latency", "expected_path": "auto-memory/feedback_check_real_logs_first.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "start working on the calendar integration", "expected_path": "auto-memory/feedback_search_memory_first.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "merge the PR after checks pass", "expected_path": "auto-memory/feedback_never_merge_failing_ci.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "merge the PR after checks pass", "expected_path": "auto-memory/feedback_no_merge_failed_tests.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "run the background jobs in parallel", "expected_path": "auto-memory/feedback_parallel_background.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "write a quick fix for the flaky test", "expected_path": "auto-memory/feedback_quality_over_speed.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "push the hotfix directly to main", "expected_path": "auto-memory/feedback_branch_workflow.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "delete the unused config files", "expected_path": "auto-memory/feedback_data_integrity.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "review the code changes before shipping", "expected_path": "auto-memory/feedback_warden_loop.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "tell the user what the error probably means", "expected_path": "auto-memory/feedback_never_speculate.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "tell the user what the error probably means", "expected_path": "auto-memory/feedback_no_speculation.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "add a caching layer to speed things up", "expected_path": "auto-memory/feedback_no_speculative_hardening.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "update the shared config in both places", "expected_path": "auto-memory/feedback_no_duplication.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "spin up a subagent for this task", "expected_path": "auto-memory/feedback_default_sonnet.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "save the user credentials securely", "expected_path": "auto-memory/feedback_security_audit.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "build the docker container with latest changes", "expected_path": "auto-memory/feedback_cross_platform.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "save the user credentials securely", "expected_path": "auto-memory/feedback_security_first.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "build the docker container with latest changes", "expected_path": "auto-memory/feedback_cross_platform_default.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "implement the abstraction for multiple backends", "expected_path": "auto-memory/feedback_evaluate_alternatives.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "check if the vault has info on this topic", "expected_path": "auto-memory/feedback_search_memory_first.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "amend the last commit with these fixes", "expected_path": "auto-memory/feedback_one_concern_per_branch.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "amend the last commit with these fixes", "expected_path": "auto-memory/feedback_scope_commits_by_concern.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "process the batch job overnight", "expected_path": "auto-memory/feedback_parallel_background.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "clean up the orphaned database entries", "expected_path": "auto-memory/feedback_data_integrity.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "respond to the user in their language", "expected_path": "auto-memory/feedback_english_only.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "respond to the user in their language", "expected_path": "auto-memory/feedback_chat_english_only.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "use opus for this complex analysis", "expected_path": "auto-memory/feedback_default_sonnet.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "ship the feature without full test coverage", "expected_path": "auto-memory/feedback_quality_over_speed.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "predict if the migration will break anything", "expected_path": "auto-memory/feedback_predict_before_running.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "run expensive embeddings on the full corpus", "expected_path": "auto-memory/feedback_predict_before_running.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "predict if the migration will break anything", "expected_path": "auto-memory/feedback_predict_before_testing.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "run expensive embeddings on the full corpus", "expected_path": "auto-memory/feedback_predict_before_testing.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "go ahead and execute the plan now", "expected_path": "auto-memory/feedback_wait_for_approval.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "bundle the telegram fix with the slack refactor", "expected_path": "auto-memory/feedback_one_concern_per_branch.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "bundle the telegram fix with the slack refactor", "expected_path": "auto-memory/feedback_scope_commits_by_concern.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "add defensive checks for future edge cases", "expected_path": "auto-memory/feedback_no_speculative_hardening.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "skip the review since it is a small change", "expected_path": "auto-memory/feedback_warden_loop.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "overwrite the old config with new defaults", "expected_path": "auto-memory/feedback_data_integrity.md", "tag": "methodology", "tier1_should_cover": true}
-{"query": "assume the function is safe and call it directly", "expected_path": "auto-memory/feedback_never_speculate.md", "tag": "methodology", "tier1_should_cover": true}
+{"query": "assume the function is safe and call it directly", "expected_path": "auto-memory/feedback_no_speculation.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "checkout main to test something quickly", "expected_path": "auto-memory/feedback_branch_workflow.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "rewrite the module from scratch for clarity", "expected_path": "auto-memory/feedback_evaluate_alternatives.md", "tag": "methodology", "tier1_should_cover": true}
 {"query": "copy the validation logic into both handlers", "expected_path": "auto-memory/feedback_no_duplication.md", "tag": "methodology", "tier1_should_cover": true}


### PR DESCRIPTION
## Summary

- Aligns 10 probe `expected_path` values in `methodology_probes.jsonl` to match actual atom filenames (e.g., `feedback_never_speculate` -> `feedback_no_speculation`)
- Adds 12 entries to `STANDARD_NAMES` in `migrate_atom_tiers.py` (6 promoted + 6 new atoms)
- Adds benchmark follow-up report: tier1_coverage 0% -> 100% (target was >=90%)

Closes RETRO-2026-05-14-05 (carryover from RETRO-2026-05-13-01). Host-local atom edits (6 kind promotions + 6 new atoms in `~/.claude/projects/<slug>/memory/`) are not in this PR.

## Test plan

- [x] `benchmark-tiered` shows tier1_coverage=1.0 (100%)
- [x] All 21 unique probe expected_paths present in generated standards_paths.txt
- [x] `npm run build` passes (no source changes)
- [x] Plan-reviewer SHIP + code-reviewer SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)