### PR TITLE
fix(hooks): standards_pack silently dropping non-negotiable atoms

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -77,6 +77,11 @@ DEFAULT_LOW_THRESHOLD = float(os.environ.get("DEUS_TREE_LOW", str(_DEFAULTS["low
 DEFAULT_ABSTAIN_THRESHOLD = float(os.environ.get("DEUS_TREE_ABSTAIN", str(_DEFAULTS["abstain"])))
 DEFAULT_TOP_K = 5
 NEIGHBOR_HOPS = 1
+# Cap on the size of MEMORY_TREE.md (the navigation root of the vault).
+# Enforced by the `check` CLI verifier only — overrun reports a check failure,
+# it does not truncate at runtime. Different system from
+# `standards_pack.py:TOKEN_BUDGET`, which caps the always-on atom one-liner
+# pack injected at SessionStart.
 ROOT_TOKEN_BUDGET = 800  # MEMORY_TREE.md cold-start cap
 
 NODE_TYPES_TRACKED = {"memory-tree-root", "persona-index", "persona-node", "project-node", "infra-node",

--- a/scripts/standards_pack.py
+++ b/scripts/standards_pack.py
@@ -46,7 +46,14 @@ CACHE_PATH = Path(os.environ.get(
     os.path.expanduser("~/.deus/standards_pack_cache.json"),
 ))
 
-TOKEN_BUDGET = int(os.environ.get("DEUS_STANDARDS_TOKEN_BUDGET", "800"))
+# Cap on the total tokens of `kind: standard` atom one-liners injected as
+# always-on context at SessionStart. On overrun, atoms are dropped in
+# directory-sort order and a stderr WARN is emitted — silent drops have
+# historically lost non-negotiable methodology rules.
+#
+# Not to be confused with `memory_tree.py:ROOT_TOKEN_BUDGET` — that caps
+# MEMORY_TREE.md size for the navigation root, a different system.
+TOKEN_BUDGET = int(os.environ.get("DEUS_STANDARDS_TOKEN_BUDGET", "1200"))
 
 _FM_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
 
@@ -121,13 +128,37 @@ def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_B
         if name:
             atoms.append((name, desc))
 
-    for name, desc in atoms:
+    dropped: list[str] = []
+    dropped_tokens = 0
+    truncated_at: int | None = None
+    for idx, (name, desc) in enumerate(atoms):
         oneliner = f"- {name}: {desc}" if desc else f"- {name}"
         cost = _token_estimate(oneliner)
         if total_tokens + cost > token_budget:
+            truncated_at = idx
             break
         lines.append(oneliner)
         total_tokens += cost
+
+    if truncated_at is not None:
+        # Collect every atom that didn't make it in (not just the first overrun).
+        # Second pass over the already-built `atoms` list keeps the include set
+        # exactly what the original first-fit loop produced — we only iterate
+        # past the cutoff to report names.
+        for name, desc in atoms[truncated_at:]:
+            oneliner = f"- {name}: {desc}" if desc else f"- {name}"
+            dropped.append(name)
+            dropped_tokens += _token_estimate(oneliner)
+        # Fail-loud: silent drops previously hid the loss of non-negotiable
+        # methodology rules (e.g. `feedback_warden_loop`). Emit to stderr so
+        # the hook output stays JSON-clean on stdout.
+        print(
+            f"[standards_pack] WARN: budget exceeded — dropped {len(dropped)} atom(s) "
+            f"totalling {dropped_tokens} tokens: {', '.join(dropped)}. "
+            f"Raise DEUS_STANDARDS_TOKEN_BUDGET (current: {token_budget}) or "
+            f"reduce atom count.",
+            file=sys.stderr,
+        )
 
     if not lines:
         # Fail-loud: dir exists but no kind=standard atoms found. Likely classification gap.
@@ -154,6 +185,8 @@ def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_B
             "context": context,
             "atom_count": len(lines),
             "tokens": total_tokens,
+            "dropped": dropped,
+            "dropped_tokens": dropped_tokens,
         }))
     except OSError:
         pass

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -1834,3 +1834,52 @@ class TestStandardsPack:
         assert result != ""
         lines = [l for l in result.split("\n") if l.startswith("- ")]
         assert len(lines) < 20
+
+    def test_load_standards_warns_and_records_on_truncation(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """Fail-loud on budget overrun. Cache records dropped atoms + over-by tokens."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        import standards_pack as sp
+
+        # Isolated cache path so we don't clobber the user's real cache.
+        cache_file = tmp_path / "cache.json"
+        monkeypatch.setattr(sp, "CACHE_PATH", cache_file)
+
+        for i in range(20):
+            (tmp_path / f"atom{i:02d}.md").write_text(
+                f"---\nname: Rule {i}\ndescription: {'word ' * 50}\nkind: standard\n---\n"
+            )
+        sp.load_standards(tmp_path, token_budget=100)
+
+        captured = capsys.readouterr()
+        assert "budget exceeded" in captured.err
+        assert "dropped" in captured.err.lower()
+        assert "totalling" in captured.err
+
+        cache = json.loads(cache_file.read_text())
+        assert isinstance(cache.get("dropped"), list)
+        assert len(cache["dropped"]) > 0
+        assert cache["dropped_tokens"] > 0
+
+    def test_load_standards_no_warn_when_under_budget(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """No stderr noise + empty `dropped` field when everything fits."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        import standards_pack as sp
+
+        cache_file = tmp_path / "cache.json"
+        monkeypatch.setattr(sp, "CACHE_PATH", cache_file)
+
+        (tmp_path / "atom1.md").write_text(
+            "---\nname: Rule One\ndescription: short\nkind: standard\n---\n"
+        )
+        sp.load_standards(tmp_path, token_budget=10_000)
+
+        captured = capsys.readouterr()
+        assert "budget exceeded" not in captured.err
+
+        cache = json.loads(cache_file.read_text())
+        assert cache["dropped"] == []
+        assert cache["dropped_tokens"] == 0


### PR DESCRIPTION
## Summary

- `scripts/standards_pack.py` `TOKEN_BUDGET` 800 → 1200. The 800 default was saturated at 24/27 atoms (779/800 tokens used today); 3 atoms silently dropped including non-negotiables `feedback_warden_loop.md` ("REVISE from any warden means re-run until SHIP") and `feedback_wait_for_approval.md` ("Always wait for explicit approval before executing"). With 1200, all 27 atoms fit (876 tokens used, 324 headroom).
- Silent `break` on overrun replaced with stderr WARN listing dropped atom names + token sum + remediation hint. Cache JSON gains `dropped: list[str]` and `dropped_tokens: int` fields.
- Cross-reference comments connect the two unrelated `800` literals in the codebase (`standards_pack.py:TOKEN_BUDGET` and `memory_tree.py:ROOT_TOKEN_BUDGET`).

## Context

From a brainstorm earlier today on the standards_pack budget. The brainstorm identified this as Quick Win #1 (closes a contract-violating bug today). Subsequent ideas — priority frontmatter field, name-only one-liners, two-tier always-loaded vs on-demand — are queued behind a comprehensive benchmark phase and not bundled here.

Cost impact: +400 tokens to always-on cached system prefix. Empirically verified the prefix is prompt-cached (transcript shows `cache_read=32902` from turn 2 onwards), so cached overhead is ~$0.00012/turn at $0.30/MTok cache-read.

## Test plan

- [x] `pytest scripts/tests/test_memory_tree.py` — 122 passed (5 in `TestStandardsPack`, 2 new)
- [x] Hook-contract smoke test: `echo '{"hook_event_name":"SessionStart",...}' | python3 scripts/standards_pack.py` → exit 0, valid `hookSpecificOutput` JSON, all 27 atoms in `additionalContext`, three previously-dropped atoms now present
- [x] Forced truncation test at `DEUS_STANDARDS_TOKEN_BUDGET=300` → stderr WARN fires with full atom name list and remediation hint
- [x] plan-reviewer SHIP, code-reviewer SHIP (after one REVISE cycle for hook-path smoke-test evidence + `over_by_tokens` → `dropped_tokens` semantic rename), verification-gate SHIP
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)