### PR TITLE
fix(hooks): standards_pack cache invalidates on atom content edits

### DIFF
--- a/scripts/standards_pack.py
+++ b/scripts/standards_pack.py
@@ -3,10 +3,14 @@
 
 Scans auto-memory atoms for kind=standard, formats them as condensed
 one-liners, and emits as additionalContext with directive framing.
-Cached by directory mtime to avoid re-scanning 130+ files on every session.
+Cached by content-hash signature (SHA-256 over all .md files in the
+auto-memory dir) so frontmatter edits invalidate the cache. Directory
+mtime is unreliable because POSIX `stat.st_mtime` does not update on
+file-content changes of existing directory members on macOS or ext4.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -86,11 +90,25 @@ def _token_estimate(text: str) -> int:
     return int(len(text.split()) * 1.3)
 
 
-def _dir_mtime(d: Path) -> float:
-    try:
-        return d.stat().st_mtime
-    except OSError:
-        return 0.0
+def _content_signature(d: Path) -> str:
+    """SHA-256 over every .md file's name + bytes, in sorted order.
+
+    Cost: ~3-5ms over ~140 atom files at ~5KB avg on Apple Silicon.
+    Rationale for hashing content (vs. cheaper mtime) is in the module
+    docstring.
+    """
+    h = hashlib.sha256()
+    for f in sorted(d.glob("*.md")):
+        h.update(f.name.encode("utf-8"))
+        h.update(b"\x00")
+        try:
+            h.update(f.read_bytes())
+        except OSError:
+            # File vanished mid-scan — skip silently. Next call will
+            # see a consistent post-vanish state and rebuild from that.
+            continue
+        h.update(b"\x00")
+    return h.hexdigest()
 
 
 def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_BUDGET) -> str:
@@ -106,11 +124,13 @@ def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_B
         )
         return ""
 
-    mtime = _dir_mtime(d)
+    sig = _content_signature(d)
     if CACHE_PATH.exists():
         try:
             cached = json.loads(CACHE_PATH.read_text())
-            if cached.get("mtime") == mtime and cached.get("budget") == token_budget:
+            # Pre-M0.5 caches stored "mtime" instead of "signature"; the
+            # missing-key compare returns None != sig and rebuilds cleanly.
+            if cached.get("signature") == sig and cached.get("budget") == token_budget:
                 return cached.get("context", "")
         except (json.JSONDecodeError, OSError):
             pass
@@ -180,7 +200,7 @@ def load_standards(auto_mem_dir: Path | None = None, token_budget: int = TOKEN_B
     try:
         CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
         CACHE_PATH.write_text(json.dumps({
-            "mtime": mtime,
+            "signature": sig,
             "budget": token_budget,
             "context": context,
             "atom_count": len(lines),

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -1883,3 +1883,35 @@ class TestStandardsPack:
         cache = json.loads(cache_file.read_text())
         assert cache["dropped"] == []
         assert cache["dropped_tokens"] == 0
+
+    def test_load_standards_cache_invalidates_on_content_edit(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Content edit (no create/delete) must invalidate the cache.
+
+        Regression test for the macOS/ext4 mtime bug surfaced post-PR #413:
+        directory `st_mtime` does not update on content changes of existing
+        files, so a cache key based on `_dir_mtime` returned stale results
+        when atoms were edited in place (e.g., adding a `priority:` field
+        via `sed -i` for M2).
+        """
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        import standards_pack as sp
+
+        cache_file = tmp_path / "cache.json"
+        monkeypatch.setattr(sp, "CACHE_PATH", cache_file)
+
+        atom = tmp_path / "atom1.md"
+        atom.write_text(
+            "---\nname: Rule One\ndescription: First version\nkind: standard\n---\n"
+        )
+        first = sp.load_standards(tmp_path, token_budget=10_000)
+        assert "First version" in first
+
+        # Edit the same file in place — no create/delete in the directory.
+        atom.write_text(
+            "---\nname: Rule One\ndescription: Second version\nkind: standard\n---\n"
+        )
+        second = sp.load_standards(tmp_path, token_budget=10_000)
+        assert "Second version" in second
+        assert "First version" not in second


### PR DESCRIPTION
## Summary

`scripts/standards_pack.py` cached its rendered output keyed by `(dir_mtime, budget)`. POSIX `stat.st_mtime` on a directory only updates when a member file is created or deleted — never on content changes of existing files. So editing an atom's frontmatter in place silently returned stale cache.

This affects both macOS (HFS+/APFS) and Linux (ext4); both supported Deus platforms share the limitation. Windows is already fast-failed at `memory_query.py:20`.

This bug predates PR #413. It will be load-bearing for the upcoming M2 work (priority frontmatter field), where atoms get tagged via `sed -i` and the cache would otherwise return stale rank-orderings until the next file create/delete.

## Changes

- `_dir_mtime(d)` deleted (zero external callers, grep-verified).
- `_content_signature(d)` added — SHA-256 over every `.md` file's name + bytes in sorted order. Cost: ~3-5ms over ~140 atom files at ~5KB avg on Apple Silicon. Universal hash chosen over a `sys.platform`-branched fallback because the bug is universal.
- Cache JSON key field renamed `"mtime"` → `"signature"`. Inline comment documents that pre-M0.5 caches with `"mtime"` key fall through the equality check and rebuild cleanly — no manual migration.
- One new test directly exercises the in-place edit path.

## Test plan

- [x] `pytest scripts/tests/test_memory_tree.py` → 123 passed (6 in `TestStandardsPack`)
- [x] Hook-contract smoke test against real atoms dir at 1200 budget: exit 0, no stderr, 4843-byte `additionalContext`, all 27 atoms including the three previously-dropped non-negotiables, cache JSON has `signature` field (not `mtime`)
- [x] plan-reviewer SHIP (1 REVISE cycle on cross-platform-intent), code-reviewer SHIP (1 reconfirm cycle after applying comment-discipline recommendations), verification-gate SHIP
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)