### PR TITLE
fix(memory): exclude_kinds honored in graph-expansion neighbors

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -1344,6 +1344,19 @@ def retrieve(
             for (other_id,) in forward + backward:
                 if other_id in expanded:
                     continue
+                # `exclude_kinds` must apply to graph-expansion neighbors too.
+                # `node_lookup` is the union of all nodes that already passed
+                # both filters above: orphan-exclusion (L1230 SQL `WHERE
+                # orphaned_at IS NULL`) AND kind-exclusion (L1236 Python
+                # check). A neighbor's `other_id` not being in `node_lookup`
+                # therefore means it's either orphaned OR has an excluded
+                # kind — skip both at the loop top to keep the contract
+                # uniform across phases. Without this guard `see_also` /
+                # `alias_of` edges silently re-inject excluded-kind atoms
+                # (e.g. `kind: standard` neighbors of methodology seeds,
+                # surfaced empirically in M4-prereq #417).
+                if other_id not in node_lookup:
+                    continue
                 nrow = db.execute(
                     "SELECT path, title FROM nodes WHERE id = ? AND orphaned_at IS NULL",
                     (other_id,),

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -1788,6 +1788,67 @@ class TestAtomKind:
         assert "ek_know" in returned_ids
         assert "ek_std" not in returned_ids
 
+    def test_retrieve_excludes_standard_atoms_through_see_also_expansion(
+        self, tmp_db, stub_embed,
+    ):
+        """Graph expansion must honor `exclude_kinds`.
+
+        Regression test for the M4-prereq #417 finding: a methodology-kind
+        seed atom with a `see_also` edge to a `kind: standard` neighbor
+        would silently re-inject the standard atom into top-K results when
+        callers passed `exclude_kinds={"standard"}`. The cosine filter at
+        line 1236 protected Phase 1, but Phase 2 graph expansion
+        (memory_tree.py:1326-1369) was unfiltered.
+        """
+        # Methodology-kind seed atom — the cosine match target.
+        mt.upsert_node(
+            tmp_db,
+            node_id="seek_meth",
+            path="atoms/methodology.md",
+            title="Methodology Seed",
+            description="rules about workflow methodology for development tasks",
+            level=0,
+            node_type="atom",
+            embedding=stub_embed("rules about workflow methodology for development tasks"),
+            content_hash_val="h_seek_meth",
+            atom_kind="knowledge",  # non-standard, eligible under default filter
+        )
+        # Standard-kind neighbor reachable via `see_also` — must NOT leak.
+        mt.upsert_node(
+            tmp_db,
+            node_id="seek_std",
+            path="atoms/standard.md",
+            title="Standard Neighbor",
+            description="unrelated cooking text that would not cosine-match the query",
+            level=0,
+            node_type="atom",
+            embedding=stub_embed("unrelated cooking text that would not cosine-match the query"),
+            content_hash_val="h_seek_std",
+            atom_kind="standard",
+        )
+        mt.upsert_edge(tmp_db, src="seek_meth", dst="seek_std", kind="see_also")
+        # `use_see_also=True` is the retrieve() default. Set explicitly here
+        # so the regression intent is visible: this test fails without the
+        # graph-expansion guard. `low_threshold=0.0` forces Phase 2 to run.
+        result = mt.retrieve(
+            tmp_db, "rules about workflow methodology",
+            k=5,
+            use_see_also=True,
+            low_threshold=0.0,
+            use_abstain=False,
+            use_fts=False,
+            use_approach_angles=False,
+            exclude_kinds={"standard"},
+        )
+        returned_ids = {r["id"] for r in result["results"]}
+        assert "seek_meth" in returned_ids, (
+            "methodology seed should pass the cosine filter and surface"
+        )
+        assert "seek_std" not in returned_ids, (
+            "kind: standard neighbor must not leak through see_also expansion "
+            "when exclude_kinds={'standard'}"
+        )
+
     def test_parse_frontmatter_maps_kind_to_atom_kind(self):
         fm = mt.parse_frontmatter(
             "---\nid: xyz\nkind: standard\ndescription: test\n---\n"


### PR DESCRIPTION
## Summary

- `memory_tree.retrieve(..., exclude_kinds={'standard'})` silently leaked `kind: standard` atoms through Phase 2 graph expansion. Empirically surfaced by PR #417's M4-prereq benchmark (22.5% leak rate under `exclude_kinds={'standard'}`).
- Root cause: Phase 1 cosine filter rejected standards from the seed pool, but the `see_also` / `alias_of` neighbor expansion loop re-injected them without checking `exclude_kinds`.
- Fix: one-line guard using the already-filtered `node_lookup` as a membership gate. Test exercises the specific code path.

## What the fix does

```python
# scripts/memory_tree.py:1358 (new line, after `if other_id in expanded: continue`)
if other_id not in node_lookup:
    continue
```

`node_lookup` was populated at L1232-1238 after both filters: orphan (L1230 SQL `WHERE orphaned_at IS NULL`) AND kind (L1236 Python check). A neighbor not in `node_lookup` is therefore either orphaned or has an excluded kind — both should be skipped at the loop top to keep the contract uniform across phases.

## Behavior change scope

| Caller's `exclude_kinds` | Behavior change |
|--------------------------|-----------------|
| `None` (sweep default)   | **Bit-identical.** `node_lookup` contains every non-orphaned node; new guard only short-circuits orphaned/non-existent neighbors that the downstream `WHERE orphaned_at IS NULL` already rejected. |
| `frozenset({"standard"})` (production `memory_query.recall()` default) | **Fixed.** Standards no longer re-inject via see_also neighbors. M4-prereq's empirically-observed 22.5% leak rate drops to 0% for this code path. |

## Why no `deus sweep` evidence in this PR

Plan-reviewer initially flagged `retrieval-sweep-gate`. Resolved analytically: the sweep CLI uses `exclude_kinds=None`, in which case my fix is provably bit-identical (see table above). The relevant regression target is `exclude_kinds={"standard"}` callers — covered directly by the new unit test. Plan-reviewer (agent `ab938d2f54414c8f6`) accepted the argument and SHIPped.

## Wardens

- **plan-reviewer**: SHIP after 1 REVISE (analytically resolved sweep-gate, fixed test-class name `TestAtomKind`, made `use_see_also=True` explicit in test, expanded comment to cite both filter locations).
- **code-reviewer**: SHIP (note: line-number hallucination in informational warning — the comment cites L1230 and L1236, not the L1356 the reviewer thought).
- **verification-gate**: SHIP (127 tests pass — was 126, +1 regression test; new test isolates Phase 2 with use_fts=False, use_approach_angles=False, low_threshold=0.0).

## Test plan

- [x] `pytest scripts/tests/test_memory_tree.py -x -q` → 127 passed
- [x] New test `test_retrieve_excludes_standard_atoms_through_see_also_expansion` passes on its own
- [x] Pre-existing `test_retrieve_excludes_standard_atoms` (Phase 1 cosine filter) still passes
- [x] Drift check clean locally

## Followup

The redundant `WHERE orphaned_at IS NULL` at L1361 is now strictly dead for any node already validated via `node_lookup`. Cleanup is out of scope here — file as a separate ticket if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)