### PR TITLE
feat(memory): sync-atom-kinds CLI for lightweight kind reconciliation

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -1876,6 +1876,115 @@ def reindex_external(
     return counts
 
 
+def sync_atom_kinds(
+    db: sqlite3.Connection,
+    external_dir: Path,
+    *,
+    apply: bool = True,
+) -> dict[str, Any]:
+    """Sync DB ``atom_kind`` to match on-disk frontmatter ``kind:``.
+
+    Lightweight reconciliation: parses ``kind:`` from each atom's
+    frontmatter and ``UPDATE``s the DB row where mismatched. Does NOT
+    re-embed (cheap relative to :func:`reindex_external`). Use when a
+    frontmatter edit to ``kind:`` needs to propagate to ``retrieve()``'s
+    ``exclude_kinds`` filter without the overhead of a full reindex pass.
+
+    Skips ``ARCHIVE``/``.git`` directories and ``MEMORY.md`` to match
+    :func:`reindex_external`'s pre-walk skip block. File-read errors are
+    caught and surfaced via the ``read_errors`` bucket rather than
+    aborting the whole sync (a single unreadable atom shouldn't stop
+    reconciliation of the others).
+
+    Args:
+        db: open SQLite connection.
+        external_dir: auto-memory directory root.
+        apply: when True (default), execute the ``UPDATE``s and commit;
+               when False, populate the ``fixed`` bucket with intent
+               only, leaving the DB unchanged.
+
+    Returns:
+        ``{"fixed": [(rel_path, old_kind, new_kind), ...],
+           "unchanged": int,
+           "missing_in_db": [rel_path, ...],
+           "no_kind_in_file": [rel_path, ...],
+           "read_errors": [rel_path, ...]}``
+
+        ``missing_in_db`` may include atoms whose ``description`` field
+        was empty at indexing time — :func:`reindex_external`'s
+        description-guard skips those during the initial walk, leaving
+        them with no DB row. These are legitimate non-rows, not a sync
+        gap — informational only.
+    """
+    external_dir = external_dir.expanduser().resolve()
+    if not external_dir.is_dir():
+        raise FileNotFoundError(
+            f"auto-memory dir not found: {external_dir}"
+        )
+
+    skip_dirs = {"ARCHIVE", ".git"}
+    result: dict[str, Any] = {
+        "fixed": [],
+        "unchanged": 0,
+        "missing_in_db": [],
+        "no_kind_in_file": [],
+        "read_errors": [],
+    }
+
+    for p in sorted(external_dir.rglob("*.md")):
+        try:
+            rel_to_ext = p.relative_to(external_dir)
+        except ValueError:
+            continue
+        if any(part in skip_dirs for part in rel_to_ext.parts):
+            continue
+        if p.name == "MEMORY.md":
+            continue
+
+        rel_str = str(rel_to_ext)
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            result["read_errors"].append(rel_str)
+            continue
+
+        fm = parse_frontmatter(content)
+        file_kind = fm.get("atom_kind")
+        if not file_kind:
+            result["no_kind_in_file"].append(rel_str)
+            continue
+
+        db_path = f"{EXTERNAL_NAMESPACE}{rel_str}"
+        row = db.execute(
+            "SELECT atom_kind FROM nodes WHERE path = ?",
+            (db_path,),
+        ).fetchone()
+        if row is None:
+            result["missing_in_db"].append(rel_str)
+            continue
+
+        db_kind = row[0]
+        if db_kind == file_kind:
+            result["unchanged"] += 1
+            continue
+
+        result["fixed"].append((rel_str, db_kind, file_kind))
+        if apply:
+            db.execute(
+                "UPDATE nodes SET atom_kind = ? WHERE path = ?",
+                (file_kind, db_path),
+            )
+
+    if apply and result["fixed"]:
+        db.commit()
+        _emit_audit({
+            "action": "sync_atom_kinds",
+            "dir": str(external_dir),
+            "fixed_count": len(result["fixed"]),
+        })
+    return result
+
+
 # ── Manifest ─────────────────────────────────────────────────────────────────
 
 # Grouping map: node type → human-readable category for the manifest.
@@ -2845,6 +2954,17 @@ def main(argv: list[str] | None = None) -> int:
     p_ext.add_argument("--skip-embed", action="store_true", help="Skip embedding API calls")
     p_ext.add_argument("--json", action="store_true")
 
+    p_sync = sub.add_parser(
+        "sync-atom-kinds",
+        help="Refresh DB atom_kind from on-disk frontmatter (lightweight, no re-embed)",
+    )
+    p_sync.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing to the DB",
+    )
+    p_sync.add_argument("--json", action="store_true")
+
     p_angles = sub.add_parser("backfill-angles", help="Generate approach-angle embeddings for all nodes")
     p_angles.add_argument("--limit", type=int, help="Process at most N nodes")
     p_angles.add_argument("--regenerate", action="store_true", help="Force regeneration even for fresh nodes")
@@ -2988,6 +3108,35 @@ def main(argv: list[str] | None = None) -> int:
                 f"id_written={counts['id_written']} "
                 f"skipped={counts['skipped']}"
             )
+        return 0
+
+    if args.cmd == "sync-atom-kinds":
+        ext_dir = os.environ.get(EXTERNAL_DIR_ENV)
+        if not ext_dir:
+            print(f"ABORT: {EXTERNAL_DIR_ENV} not set", file=sys.stderr)
+            return 2
+        try:
+            result = sync_atom_kinds(
+                db, Path(ext_dir), apply=not args.dry_run,
+            )
+        except FileNotFoundError as exc:
+            print(f"ABORT: {exc}", file=sys.stderr)
+            return 2
+        if args.json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            prefix = "[dry-run] " if args.dry_run else ""
+            print(
+                f"{prefix}sync-atom-kinds: "
+                f"fixed={len(result['fixed'])} "
+                f"unchanged={result['unchanged']} "
+                f"missing_in_db={len(result['missing_in_db'])} "
+                f"no_kind_in_file={len(result['no_kind_in_file'])} "
+                f"read_errors={len(result['read_errors'])}"
+            )
+            for (name, old, new) in result["fixed"]:
+                arrow = "→" if not args.dry_run else "would →"
+                print(f"  {name}: {old!r} {arrow} {new!r}")
         return 0
 
     if args.cmd == "backfill-angles":

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -1858,6 +1858,128 @@ class TestAtomKind:
         assert "kind" not in fm
 
 
+class TestSyncAtomKinds:
+    """Tests for `sync_atom_kinds` — DB-to-frontmatter atom_kind reconciliation."""
+
+    @staticmethod
+    def _write_atom(
+        ext_dir: Path, name: str, kind: str | None, *, description: str = "test"
+    ) -> None:
+        """Write an atom file with optional `kind:` in frontmatter."""
+        kind_line = f"kind: {kind}\n" if kind else ""
+        (ext_dir / name).write_text(
+            f"---\n"
+            f"id: id_{name.replace('.md', '')}\n"
+            f"name: {name}\n"
+            f"description: {description}\n"
+            f"{kind_line}"
+            f"type: feedback\n"
+            f"---\n"
+            f"body\n",
+            encoding="utf-8",
+        )
+
+    def test_sync_atom_kinds_fixes_stale_db_value(self, tmp_db, tmp_path):
+        ext = tmp_path / "auto-memory"
+        ext.mkdir()
+        self._write_atom(ext, "atom_a.md", "standard")
+        # DB row reflects pre-promotion state.
+        mt.upsert_node(
+            tmp_db,
+            node_id="id_atom_a",
+            path=f"{mt.EXTERNAL_NAMESPACE}atom_a.md",
+            title="atom_a",
+            description="test",
+            level=0,
+            node_type="atom",
+            embedding=[0.1] * mt.EMBED_DIM,
+            content_hash_val="h_a",
+            atom_kind="knowledge",
+        )
+        result = mt.sync_atom_kinds(tmp_db, ext, apply=True)
+        assert len(result["fixed"]) == 1
+        assert result["fixed"][0] == ("atom_a.md", "knowledge", "standard")
+        # DB now reflects the on-disk frontmatter.
+        row = tmp_db.execute(
+            "SELECT atom_kind FROM nodes WHERE path = ?",
+            (f"{mt.EXTERNAL_NAMESPACE}atom_a.md",),
+        ).fetchone()
+        assert row[0] == "standard"
+
+    def test_sync_atom_kinds_dry_run_does_not_write(self, tmp_db, tmp_path):
+        ext = tmp_path / "auto-memory"
+        ext.mkdir()
+        self._write_atom(ext, "atom_b.md", "standard")
+        mt.upsert_node(
+            tmp_db,
+            node_id="id_atom_b",
+            path=f"{mt.EXTERNAL_NAMESPACE}atom_b.md",
+            title="atom_b",
+            description="test",
+            level=0,
+            node_type="atom",
+            embedding=[0.1] * mt.EMBED_DIM,
+            content_hash_val="h_b",
+            atom_kind="knowledge",
+        )
+        result = mt.sync_atom_kinds(tmp_db, ext, apply=False)
+        # `fixed` still records the would-be change.
+        assert len(result["fixed"]) == 1
+        assert result["fixed"][0] == ("atom_b.md", "knowledge", "standard")
+        # But the DB is unchanged.
+        row = tmp_db.execute(
+            "SELECT atom_kind FROM nodes WHERE path = ?",
+            (f"{mt.EXTERNAL_NAMESPACE}atom_b.md",),
+        ).fetchone()
+        assert row[0] == "knowledge"
+
+    def test_sync_atom_kinds_skips_already_synced(self, tmp_db, tmp_path):
+        ext = tmp_path / "auto-memory"
+        ext.mkdir()
+        self._write_atom(ext, "atom_c.md", "knowledge")
+        mt.upsert_node(
+            tmp_db,
+            node_id="id_atom_c",
+            path=f"{mt.EXTERNAL_NAMESPACE}atom_c.md",
+            title="atom_c",
+            description="test",
+            level=0,
+            node_type="atom",
+            embedding=[0.1] * mt.EMBED_DIM,
+            content_hash_val="h_c",
+            atom_kind="knowledge",
+        )
+        result = mt.sync_atom_kinds(tmp_db, ext, apply=True)
+        assert result["fixed"] == []
+        assert result["unchanged"] == 1
+
+    def test_sync_atom_kinds_skips_files_without_kind_field(self, tmp_db, tmp_path):
+        ext = tmp_path / "auto-memory"
+        ext.mkdir()
+        self._write_atom(ext, "atom_d.md", None)  # no kind: line
+        mt.upsert_node(
+            tmp_db,
+            node_id="id_atom_d",
+            path=f"{mt.EXTERNAL_NAMESPACE}atom_d.md",
+            title="atom_d",
+            description="test",
+            level=0,
+            node_type="atom",
+            embedding=[0.1] * mt.EMBED_DIM,
+            content_hash_val="h_d",
+            atom_kind="knowledge",
+        )
+        result = mt.sync_atom_kinds(tmp_db, ext, apply=True)
+        assert "atom_d.md" in result["no_kind_in_file"]
+        assert result["fixed"] == []
+        # DB unchanged.
+        row = tmp_db.execute(
+            "SELECT atom_kind FROM nodes WHERE path = ?",
+            (f"{mt.EXTERNAL_NAMESPACE}atom_d.md",),
+        ).fetchone()
+        assert row[0] == "knowledge"
+
+
 class TestStandardsPack:
     """Tests for scripts/standards_pack.py."""
 


### PR DESCRIPTION
## Summary

- Adds \`memory_tree.sync_atom_kinds()\` function + \`sync-atom-kinds\` CLI subcommand.
- Reconciles DB \`atom_kind\` with on-disk frontmatter \`kind:\` without re-embedding.
- Closes the gap that PR #418's post-merge bench exposed: 6 atoms had stale DB \`atom_kind\` because their \`kind:\` was promoted in frontmatter without a subsequent \`reindex-external\` run.

## Why a new primitive vs re-running \`reindex-external\`

\`reindex-external\` does call \`upsert_node\` which updates \`atom_kind\`. But it also:
- Triggers full Ollama re-embedding (heavy, network-bound, slow)
- Runs \`_backup_db\` (extra I/O)
- Mutates path/title/embedding alongside the column

\`sync-atom-kinds\` is the missing surgical primitive — kind-only, embedding-free, fast enough to wire into a SessionStart hook or watcher in a future change.

## Usage

\`\`\`bash
python3 scripts/memory_tree.py sync-atom-kinds [--dry-run] [--json]
\`\`\`

Reads \`DEUS_AUTO_MEMORY_DIR\` env var (same convention as \`reindex-external\`). Exit 2 on missing/invalid env or dir; exit 0 on normal verdict path.

Output:
\`\`\`
sync-atom-kinds: fixed=6 unchanged=124 missing_in_db=12 no_kind_in_file=0 read_errors=0
  feedback_chat_english_only.md: 'knowledge' → 'standard'
  feedback_data_integrity.md: 'knowledge' → 'standard'
  ...
\`\`\`

## Algorithm

1. Walk \`*.md\` via \`rglob\` (matches \`reindex_external\` recursion)
2. Skip \`ARCHIVE\`/\`.git\` directories and \`MEMORY.md\` (matches the pre-walk skip block)
3. Parse \`kind:\` from frontmatter via existing \`parse_frontmatter()\`
4. Look up DB row by \`path = EXTERNAL_NAMESPACE + str(rel_to_ext)\` (matches reindex write path)
5. Buckets:
   - \`fixed\`: mismatched → UPDATE applied (or recorded in dry-run)
   - \`unchanged\`: file and DB agree
   - \`missing_in_db\`: file has \`kind:\` but no DB row (includes atoms skipped by reindex due to empty description)
   - \`no_kind_in_file\`: file lacks \`kind:\` frontmatter
   - \`read_errors\`: OSError on file read (sync continues for other atoms)

## Tests

4 new tests in \`TestSyncAtomKinds\`:
1. \`test_sync_atom_kinds_fixes_stale_db_value\` — happy path
2. \`test_sync_atom_kinds_dry_run_does_not_write\` — apply=False
3. \`test_sync_atom_kinds_skips_already_synced\` — no-op
4. \`test_sync_atom_kinds_skips_files_without_kind_field\` — no_kind_in_file bucket

Suite: **131 passed** (was 127 → +4 new).

The \`read_errors\` bucket isn't directly tested (chmod 000 is OS-specific; reviewer flagged informational, accepted).

## Sweep baseline note

This PR does NOT change \`retrieve()\` or any scoring/threshold code, so \`retrieval-sweep-gate\` does not apply. However: the next sweep that runs against current production data may show tier2_recall shift, because 6 previously-leaking atoms will now correctly be excluded under \`exclude_kinds={\"standard\"}\`. This is a data correction surfacing through the metric, not a code regression.

## Wardens

- **plan-reviewer**: SHIP after 2 REVISE rounds (premise framing, rglob path-key consistency, MEMORY.md skip, no_kind_in_file test added).
- **code-reviewer**: SHIP with informational warnings (line-number drift in docstring — applied: replaced with function-name anchors; WHAT-comment about reindex semantics — applied: removed).
- **verification-gate**: SHIP — 7/7 acceptance criteria verified (131 tests, CLI works dry-run + --json, env-missing exits 2, nonexistent-dir exits 2).

## Test plan

- [x] \`pytest scripts/tests/test_memory_tree.py -x -q\` → 131 passed
- [x] CLI \`--dry-run\` against production atoms succeeds + reports buckets
- [x] CLI \`--help\` shows new subcommand with both flags
- [x] ABORT on missing DEUS_AUTO_MEMORY_DIR (exit 2)
- [x] ABORT on nonexistent dir (exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)