### PR TITLE
fix(memory): auto-sync atom-kinds at SessionStart

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -406,6 +406,70 @@ def approve_admin_merge(command: str, repo_root: Path) -> int:
     return 0
 
 
+def _sync_atom_kinds_on_init(repo_root: Path) -> None:
+    """Best-effort sync of DB atom_kind from on-disk frontmatter.
+
+    Runs ``memory_tree.py sync-atom-kinds`` at SessionStart so that any
+    kind-field mutations made outside the current session (e.g. via
+    ``migrate_atom_tiers.py --apply`` or direct frontmatter edits) are
+    propagated to the DB before the first retrieval.  Failures are logged
+    to stderr and never block startup — the sync is opportunistic.
+
+    Skips silently when:
+    - ``DEUS_AUTO_MEMORY_DIR`` is unset (memory layer not configured)
+    - the ``memory_tree.py`` script is absent (optional dependency)
+    - the DB file does not yet exist (first-run / cold environment)
+    """
+    ext_dir = os.environ.get("DEUS_AUTO_MEMORY_DIR")
+    if not ext_dir:
+        return
+
+    tree = repo_root / "scripts" / "memory_tree.py"
+    if not tree.exists():
+        return
+
+    db_path = Path(
+        os.environ.get("DEUS_MEMORY_TREE_DB", "~/.deus/memory_tree.db")
+    ).expanduser()
+    if not db_path.exists():
+        return
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(tree), "sync-atom-kinds", "--json"],
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"[session-init] sync-atom-kinds failed: {exc}", file=sys.stderr)
+        return
+
+    if result.returncode != 0:
+        print(
+            f"[session-init] sync-atom-kinds exited {result.returncode}: "
+            f"{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return
+
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    fixed = data.get("fixed", [])
+    if fixed:
+        print(
+            f"[session-init] sync-atom-kinds: reconciled {len(fixed)} stale atom_kind "
+            f"value(s) — {', '.join(name for name, *_ in fixed)}",
+            file=sys.stderr,
+        )
+
+
 def run_session_init(repo_root: Path) -> int:
     for name in (
         ".plan-reviewed",
@@ -415,6 +479,7 @@ def run_session_init(repo_root: Path) -> int:
         ".admin-merge-approved",
     ):
         _marker(repo_root, name).unlink(missing_ok=True)
+    _sync_atom_kinds_on_init(repo_root)
     return 0
 
 

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -1191,3 +1191,152 @@ def test_mark_verified_creates_marker(tmp_path):
 
     verdicts = json.loads((repo / ".claude" / ".warden-verdicts.json").read_text())
     assert verdicts["verification-gate"]["verdict"] == "SHIP"
+
+
+# ── _sync_atom_kinds_on_init tests ────────────────────────────────────────────
+
+def test_sync_atom_kinds_on_init_skips_when_env_unset(tmp_path, monkeypatch):
+    """No subprocess is spawned when DEUS_AUTO_MEMORY_DIR is unset."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    monkeypatch.delenv("DEUS_AUTO_MEMORY_DIR", raising=False)
+
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+    hooks._sync_atom_kinds_on_init(repo)
+
+    assert calls == []
+
+
+def test_sync_atom_kinds_on_init_skips_when_script_missing(tmp_path, monkeypatch):
+    """No subprocess is spawned when memory_tree.py does not exist in repo."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    # Point to a real dir but with no memory_tree.py script
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(tmp_path / "atoms"))
+    # Ensure repo has no scripts/memory_tree.py
+    # (git_repo creates a bare repo in tmp_path/repo — no scripts dir)
+
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+    hooks._sync_atom_kinds_on_init(repo)
+
+    assert calls == []
+
+
+def test_sync_atom_kinds_on_init_skips_when_db_missing(tmp_path, monkeypatch):
+    """No subprocess is spawned when the DB file does not yet exist."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    # Create a fake memory_tree.py so the script-existence check passes
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "memory_tree.py").write_text("# stub")
+
+    atoms_dir = tmp_path / "atoms"
+    atoms_dir.mkdir()
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(atoms_dir))
+    # Point DB to a path that does not exist
+    monkeypatch.setenv("DEUS_MEMORY_TREE_DB", str(tmp_path / "nonexistent.db"))
+
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+    hooks._sync_atom_kinds_on_init(repo)
+
+    assert calls == []
+
+
+def test_sync_atom_kinds_on_init_reports_fixed_atoms(tmp_path, monkeypatch, capsys):
+    """Stderr message emitted when sync reports stale atoms were fixed."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "memory_tree.py").write_text("# stub")
+
+    atoms_dir = tmp_path / "atoms"
+    atoms_dir.mkdir()
+    db_path = tmp_path / "memory_tree.db"
+    db_path.touch()
+
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(atoms_dir))
+    monkeypatch.setenv("DEUS_MEMORY_TREE_DB", str(db_path))
+
+    fake_output = json.dumps({
+        "fixed": [["stale_atom.md", "knowledge", "standard"]],
+        "unchanged": 5,
+        "missing_in_db": [],
+        "no_kind_in_file": [],
+        "read_errors": [],
+    })
+
+    class FakeResult:
+        returncode = 0
+        stdout = fake_output
+        stderr = ""
+
+    monkeypatch.setattr(hooks.subprocess, "run", lambda *a, **kw: FakeResult())
+    hooks._sync_atom_kinds_on_init(repo)
+
+    captured = capsys.readouterr()
+    assert "stale_atom.md" in captured.err
+    assert "1" in captured.err
+
+
+def test_sync_atom_kinds_on_init_silent_on_subprocess_error(tmp_path, monkeypatch, capsys):
+    """Subprocess failure is caught; stderr warning emitted; no exception raised."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "memory_tree.py").write_text("# stub")
+
+    atoms_dir = tmp_path / "atoms"
+    atoms_dir.mkdir()
+    db_path = tmp_path / "memory_tree.db"
+    db_path.touch()
+
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(atoms_dir))
+    monkeypatch.setenv("DEUS_MEMORY_TREE_DB", str(db_path))
+
+    def broken_run(*args, **kwargs):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(hooks.subprocess, "run", broken_run)
+    # Must not raise
+    hooks._sync_atom_kinds_on_init(repo)
+
+    captured = capsys.readouterr()
+    assert "sync-atom-kinds failed" in captured.err
+
+
+def test_run_session_init_still_clears_markers_with_sync(tmp_path, monkeypatch):
+    """run_session_init returns 0 and clears markers even when sync runs."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    marker = repo / ".claude" / ".plan-reviewed"
+    marker.touch()
+
+    # Disable sync by leaving DEUS_AUTO_MEMORY_DIR unset
+    monkeypatch.delenv("DEUS_AUTO_MEMORY_DIR", raising=False)
+
+    assert hooks.run_session_init(repo) == 0
+    assert not marker.exists()


### PR DESCRIPTION
## Summary

- Wires `sync-atom-kinds` into `run_session_init` in `codex_warden_hooks.py` so every Claude Code session reconciles DB `atom_kind` with on-disk frontmatter `kind:` before the first retrieval.
- Adds `_sync_atom_kinds_on_init()` helper that runs `memory_tree.py sync-atom-kinds --json` as a best-effort, non-blocking subprocess.
- Skips silently when memory layer is not configured (`DEUS_AUTO_MEMORY_DIR` unset, `memory_tree.py` absent, or DB not yet created).
- Adds 6 pytest tests covering all skip paths, happy path, error handling, and marker-clearing behavior.

## Context

RETRO-2026-05-16-02: 6 atoms had stale `atom_kind` in the DB vs on-disk `kind:` frontmatter, silently corrupting `exclude_kinds` filtering for days. PR #419 shipped `sync_atom_kinds()` as a CLI primitive but left wiring it as a manual step.

**Option B chosen over Option A** (sync at write time in `migrate_atom_tiers.py`/`classify_atom()`): Option A would require cross-script DB dependency and path resolution in scripts that don't currently have it. Option B is the minimal fix explicitly anticipated in PR #419's commit message ("fast enough to wire into a SessionStart hook").

## Test plan

- [x] `python3 -m pytest scripts/tests/test_codex_warden_hooks.py -v` → 67 passed
- [x] Skip when `DEUS_AUTO_MEMORY_DIR` unset
- [x] Skip when `memory_tree.py` absent from repo
- [x] Skip when DB file does not exist
- [x] Stderr warning when stale atoms are fixed
- [x] Subprocess `OSError` caught, stderr warning, no exception raised
- [x] `run_session_init` still returns 0 and clears all markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>