### PR TITLE
ci(workflow): enforce session-type contract tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Pattern tests (Python)
         run: python3 -m pytest scripts/tests/test_drift_check.py -v
 
+      - name: Session type contract tests
+        run: python3 -m pytest tests/test_session_type_contract.py -v
+
       - name: CLAUDE.md keyword coverage
         run: scripts/token_bench/ci_coverage_gate.sh origin/${{ github.base_ref }}
 


### PR DESCRIPTION
## Summary

- Adds a `Session type contract tests` step to the main CI job that runs `python3 -m pytest tests/test_session_type_contract.py -v`
- The tests were shipped in PR #406 but were never wired into CI, making the session-type contract documentation-only rather than enforced
- Closes the enforcement gap flagged in RETRO-2026-05-16-04 (flagged in 2 consecutive retrospectives)

## Why this placement

Placed immediately after `Pattern tests (Python)` — pytest is already installed by the preceding step, so no new dependencies are needed. All files referenced by the tests (`.claude/settings.json`, `container/agent-runner/src/index.ts`, `scripts/stop_hook.py`, `deus-cmd.sh`) are tracked in git and available on a fresh CI checkout.

The `TestWorktreeSettings` class in the test file is guarded by `if _worktree_settings:` — it evaluates to empty on a fresh CI checkout and is correctly skipped.

## Test plan

- [x] `python3 -m pytest tests/test_session_type_contract.py -v` — 51 tests pass on clean checkout (95 with local worktrees)
- [x] All referenced files confirmed tracked: `git ls-files .claude/settings.json container/agent-runner/src/index.ts scripts/stop_hook.py deus-cmd.sh`
- [x] No new pip dependencies — pytest already installed before this step
- [x] `bypass-permissions-regression.sh` in `tests/` is a shell script; pytest ignores it
- [ ] Wait for CI to pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)