### PR TITLE
fix(wardens): plan-review gate fires on empty-paths edits in worktrees

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -517,11 +517,24 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     ):
         return 0
 
-    _, paths = _managed_paths(event, repo_root)
-    if not paths or _marker(repo_root, ".plan-reviewed").exists():
+    # Marker check first — cheapest, satisfies the gate before any
+    # subprocess work in `_managed_paths`.
+    if _marker(repo_root, ".plan-reviewed").exists():
         return 0
 
-    target_list = "\n".join(f"  - {path}" for path in paths[:5])
+    # `_managed_paths` returns `(None, [])` outside every worktree;
+    # otherwise `(worktree, paths_after_filtering)`. Empty `paths` after
+    # filtering must NOT bypass the gate (the pre-fix `not paths` short-
+    # circuit was the ExitPlanMode enforcement gap).
+    worktree, paths = _managed_paths(event, repo_root)
+    if worktree is None:
+        return 0
+
+    # BLOCK regardless of `paths` emptiness — filter hit ≠ outside-worktree.
+    if paths:
+        target_list = "\n".join(f"  - {path}" for path in paths[:5])
+    else:
+        target_list = "  - (filtered target — gate still applies)"
     mark_cmd = (
         f"  python3 {shlex.quote(str(_active_script_path(repo_root)))} "
         f"mark plan-reviewed SHIP \"reason\""

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -124,6 +124,104 @@ def test_plan_review_gate_allows_after_marker(tmp_path, capsys):
     assert capsys.readouterr().out == ""
 
 
+def test_plan_review_gate_blocks_gitignored_target_without_marker(tmp_path, capsys):
+    """Regression: gitignored Edit targets no longer bypass the gate.
+
+    Prior to this fix, `_managed_paths` returned an empty `paths` list when
+    every event-path was filtered (e.g., by `.gitignore`), and the gate
+    short-circuited with `if not paths: return 0`. Now the gate fires
+    regardless of post-filter path emptiness, as long as cwd is inside a
+    worktree and the marker is absent.
+
+    Note: hooks return rc=0 on deny too — the deny decision is communicated
+    via JSON on stdout, not via exit code. `rc == 0` is consistent with both
+    pass-through and BLOCK; the `permissionDecision` field distinguishes them.
+
+    Transitive proof that `_warden_enabled` is True for bare `git_repo`:
+    `test_plan_review_gate_blocks_apply_patch_without_marker` (above) also
+    uses a bare git_repo and reaches the BLOCK path. If the warden were
+    disabled, both tests would silently return 0 with no deny JSON, and
+    the deny-assertion would fail.
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / "src").mkdir()
+    # Pattern matches *.local.json. The file at src/app.local.json is then
+    # gitignored, so _managed_paths filters it out.
+    (repo / ".gitignore").write_text("*.local.json\n", encoding="utf-8")
+    (repo / "src" / "app.local.json").write_text("{}\n", encoding="utf-8")
+    # No `.warden-verdicts.json` (so the no-marker else-branch fires).
+
+    rc = hooks.run_plan_review_gate(apply_patch_event(repo, "src/app.local.json"), repo)
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "PreToolUse"
+    assert specific["permissionDecision"] == "deny"
+    reason = specific["permissionDecisionReason"]
+    assert "no plan-reviewer approval marker" in reason
+    # The new hint surfaces the empty-paths case to the agent.
+    # `filtered target` hint surfaces the empty-paths block (vs the
+    # normal "Targets:" listing when paths survive filtering).
+    assert "filtered target" in reason
+
+
+def test_plan_review_gate_blocks_worktree_excluded_target_without_marker(tmp_path, capsys):
+    """Regression: edits inside .claude/worktrees/ no longer bypass the gate.
+
+    This is the actual session-bug scenario — subagent worktree edits at
+    `.claude/worktrees/<name>/...` were being filtered by `_is_excluded`
+    (which rejects paths under `marker_dir/worktrees`), causing
+    `_managed_paths` to return empty `paths` and the gate to short-circuit.
+    Fixed by re-ordering: marker check first, worktree-presence second,
+    then BLOCK regardless of post-filter path emptiness.
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "worktrees" / "foo" / "src").mkdir(parents=True)
+    (repo / ".claude" / "worktrees" / "foo" / "src" / "file.ts").write_text(
+        "old\n", encoding="utf-8",
+    )
+    # No `.warden-verdicts.json` (so the no-marker else-branch fires).
+
+    rc = hooks.run_plan_review_gate(
+        apply_patch_event(repo, ".claude/worktrees/foo/src/file.ts"),
+        repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "PreToolUse"
+    assert specific["permissionDecision"] == "deny"
+    reason = specific["permissionDecisionReason"]
+    assert "no plan-reviewer approval marker" in reason
+    # `filtered target` hint surfaces the empty-paths block (vs the
+    # normal "Targets:" listing when paths survive filtering).
+    assert "filtered target" in reason
+
+
+def test_plan_review_gate_returns_zero_outside_worktree(tmp_path, capsys):
+    """Event from cwd outside any git worktree → gate passes silently.
+
+    Pins the non-worktree early-exit. Without this, the empty-paths fix
+    could regress in the other direction (firing the gate everywhere).
+    """
+    hooks = load_hooks()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # NOT a git repo. `_managed_paths` returns (None, []) and the gate
+    # short-circuits with return 0. No `.plan-reviewed` marker required.
+
+    event = apply_patch_event(outside, "any/path.ts")
+
+    rc = hooks.run_plan_review_gate(event, outside)
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
 def test_code_review_gate_blocks_git_commit_without_marker(tmp_path, capsys):
     hooks = load_hooks()
     repo = git_repo(tmp_path)


### PR DESCRIPTION
## Summary

Closes the **ExitPlanMode enforcement gap** in \`run_plan_review_gate\` — the empty-paths short-circuit that let Edit/Write events bypass the gate when targets were filtered out by \`.gitignore\` or by \`_is_excluded\` (\`.claude/worktrees/\` etc.).

**Real-session smoke-test evidence:** the bug bit me 5+ times during the night's PR #420 / PR #422 work. Every \`ExitPlanMode\` cleared the \`.plan-reviewed\` marker, and the next worktree Edit (inside \`.claude/worktrees/<name>/\`) silently passed the gate because \`_managed_paths()\` filtered the path and returned empty. Pattern in the session log at \`Session-Logs/2026-05-16/agent-native-cli-v1-and-pending-cleanup.md\`.

## The bug

\`\`\`python
# scripts/codex_warden_hooks.py:520-521 (pre-fix)
_, paths = _managed_paths(event, repo_root)
if not paths or _marker(repo_root, ".plan-reviewed").exists():
    return 0
\`\`\`

\`_managed_paths\` returns empty \`paths\` in two cases:
1. cwd outside any worktree → correctly skipped
2. **All event-paths were filtered out** by \`_is_excluded\` (\`.claude/worktrees/\`, vault dirs, etc.) or by \`.gitignore\` → **incorrectly skipped**

## The fix

Re-order the gate logic:
1. Marker check first (cheapest; before subprocess work in \`_managed_paths\`)
2. \`_managed_paths\` consulted for (a) worktree presence, (b) Targets: list in block message
3. In a worktree + Edit/Write + no marker → BLOCK regardless of \`paths\` emptiness. Empty paths annotated with \"(filtered target — gate still applies)\".

## Behavior change (intentional)

Edits under \`.claude/worktrees/\` and other previously-excluded paths now require the marker. In practice, implementation agents inherit the main thread's marker (it's at the main repo path, not per-worktree). This affects only subagents running without a marker — which is the intended security posture.

## Test plan

- [x] 6 plan-review-gate tests pass (3 existing + 3 new):
  - \`test_plan_review_gate_blocks_gitignored_target_without_marker\` — new regression for gitignored case
  - \`test_plan_review_gate_blocks_worktree_excluded_target_without_marker\` — new regression for \`.claude/worktrees/\` case (the session-bug scenario)
  - \`test_plan_review_gate_returns_zero_outside_worktree\` — new test for non-worktree early-exit
- [x] 70/70 tests pass in \`test_codex_warden_hooks.py\` (up from 67 → +3 new)
- [x] Real-session smoke test: the bug was empirically observed and verified across 5+ separate sessions before this fix; the fix prevents recurrence by-construction.

## Out of scope

Symmetric \`run_verification_invalidator:642-646\` gap (failing-open instead of failing-closed). Different bug, different analysis. Follow-up PR.

## Warden cycle

- plan-reviewer: SHIP after 1 REVISE round (Test 2 redesign to use actual session-bug scenario \`.claude/worktrees/\`, test 3 added for outside-worktree, behavior-change risks documented)
- code-reviewer: SHIP after 1 SHIP-with-warning round (comment trimming, hint string shortening for token efficiency, inline \`_warden_enabled\` transitivity proof)
- verification-gate: SHIP (6/6 plan-review tests + 70/70 file tests verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)