### PR TITLE
feat(proxy): host-side tool proxy for CLI binary execution

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-13" # auto-bump
+last_verified: "2026-05-16" # auto-bump
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-14" # auto-bump
+last_verified: "2026-05-16" # auto-bump
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-16" # auto-bump
+last_verified: "2026-05-16" # auto-bump (tool-proxy)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-14" # auto-bump (gemini-3.1-flash-lite GA)
+last_verified: "2026-05-16" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,10 @@ export const CREDENTIAL_PROXY_PORT = parseInt(
   process.env.CREDENTIAL_PROXY_PORT || '3001',
   10,
 );
+export const TOOL_PROXY_PORT = parseInt(
+  process.env.TOOL_PROXY_PORT || '3003',
+  10,
+);
 export const IPC_POLL_INTERVAL = 1000;
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
 // Sessions older than this many hours are reset to a fresh start.

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -36,6 +36,7 @@ vi.mock('./config.js', () => ({
   HOME_DIR: '/tmp/deus-test-home',
   IDLE_TIMEOUT: 1800000, // 30min
   TIMEZONE: 'America/Los_Angeles',
+  TOOL_PROXY_PORT: 3003,
 }));
 
 vi.mock('./group-tokens.js', () => ({

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -22,6 +22,7 @@ import {
   DEUS_OPENAI_MODEL,
   IDLE_TIMEOUT,
   TIMEZONE,
+  TOOL_PROXY_PORT,
 } from './config.js';
 import { getOrCreateGroupToken } from './group-tokens.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
@@ -88,6 +89,12 @@ function buildContainerArgs(
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
   args.push('-e', `DEUS_PROXY_TOKEN=${getOrCreateGroupToken(group?.folder)}`);
+  // Tool proxy URL — containers call host CLIs through this endpoint.
+  // Uses CONTAINER_HOST_GATEWAY so the URL resolves to the host from inside the container.
+  args.push(
+    '-e',
+    `DEUS_TOOL_PROXY_URL=http://${CONTAINER_HOST_GATEWAY}:${TOOL_PROXY_PORT}`,
+  );
   if (DEUS_CONTEXT_FILE_MAX_CHARS) {
     args.push(
       '-e',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,10 @@ import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
   MAX_MESSAGE_LENGTH,
+  TOOL_PROXY_PORT,
 } from './config.js';
 import { startCredentialProxy } from './credential-proxy.js';
+import { startToolProxy } from './tool-proxy.js';
 import './channels/index.js';
 import {
   getChannelFactory,
@@ -77,6 +79,12 @@ async function main(): Promise<void> {
     PROXY_BIND_HOST,
   );
 
+  // Start tool proxy (containers call host CLIs through this)
+  const toolProxyServer = await startToolProxy(
+    TOOL_PROXY_PORT,
+    PROXY_BIND_HOST,
+  );
+
   const channels: Channel[] = [];
   const queue = new GroupQueue();
 
@@ -103,6 +111,7 @@ async function main(): Promise<void> {
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutdown signal received');
     proxyServer.close();
+    toolProxyServer.close();
     await queue.shutdown(10000);
     for (const ch of channels) await ch.disconnect();
     process.exit(0);

--- a/src/tool-proxy.ts
+++ b/src/tool-proxy.ts
@@ -1,0 +1,245 @@
+/**
+ * Host-side tool proxy for container agents.
+ *
+ * Containers call POST /tool/:cli-name with { args, compact?, timeout? }.
+ * The proxy executes the registered host binary (never arbitrary commands),
+ * injects credentials from the host environment, and returns:
+ *   { exit: number, stdout: string, stderr: string }
+ *
+ * Exit codes follow the printing-press-adoption ADR typed exit code convention:
+ *   0 = SUCCESS, 2 = USAGE_ERROR, 3 = NOT_FOUND, 4 = AUTH_ERROR, 5 = INTERNAL_ERROR
+ *
+ * Security:
+ *   - Allowlist-only: tool name must be registered in ~/.deus/tool-registry.json
+ *   - Arg sanitization: shell metacharacters rejected (no shell is involved, but
+ *     defense-in-depth against binaries that parse args unsafely)
+ *   - Auth: same x-deus-proxy-token gate as credential-proxy.ts
+ *   - Credentials injected via process.env at spawn time, never passed to containers
+ *
+ * Pattern: mirrors startCredentialProxy in credential-proxy.ts.
+ */
+
+import { createServer, Server } from 'http';
+import { execFile } from 'child_process';
+
+import { DEUS_PROXY_AUTH_ENABLED } from './config.js';
+import { validateGroupToken } from './group-tokens.js';
+import { logger } from './logger.js';
+import { loadRegistry, isAllowed, getToolConfig } from './tool-registry.js';
+
+/** Default per-execution timeout in milliseconds. */
+const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
+
+/** Regex for valid tool names — lowercase letters, digits, hyphens only. */
+const TOOL_NAME_RE = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * Shell metacharacters to reject in args.
+ * execFile does not invoke a shell, but defense-in-depth for binaries that
+ * internally parse args via a shell (e.g., scripts that call eval or system()).
+ */
+const SHELL_META_RE = /[;|&$`\n\r\0]/;
+
+/** Validate a single argument string. Returns error message or null if safe. */
+function validateArg(arg: string): string | null {
+  if (typeof arg !== 'string') return 'all args must be strings';
+  if (SHELL_META_RE.test(arg))
+    return `arg contains forbidden character: ${arg}`;
+  return null;
+}
+
+export function startToolProxy(
+  port: number,
+  host = '127.0.0.1',
+): Promise<Server> {
+  // Warm the registry cache on startup so the first request doesn't cold-load.
+  loadRegistry();
+
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        // ── Auth gate (same as credential-proxy) ──────────────────────────
+        if (DEUS_PROXY_AUTH_ENABLED) {
+          const token = req.headers['x-deus-proxy-token'] as string | undefined;
+          const groupFolder = token ? validateGroupToken(token) : null;
+          if (!groupFolder) {
+            logger.warn(
+              { url: req.url, hasToken: !!token },
+              'Tool proxy rejected unauthenticated request',
+            );
+            res.writeHead(401);
+            res.end('Unauthorized');
+            return;
+          }
+        }
+
+        // ── Route: POST /tool/:name ────────────────────────────────────────
+        if (req.method !== 'POST') {
+          res.writeHead(405, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Method not allowed' }));
+          return;
+        }
+
+        // Parse and validate tool name from URL
+        const urlMatch = (req.url ?? '').match(/^\/tool\/([^/?#]+)$/);
+        if (!urlMatch) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({ error: 'Not found — use POST /tool/:name' }),
+          );
+          return;
+        }
+
+        const rawName = urlMatch[1];
+        if (!TOOL_NAME_RE.test(rawName)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: `Invalid tool name: ${rawName}` }));
+          return;
+        }
+
+        // Allowlist check
+        if (!isAllowed(rawName)) {
+          logger.warn(
+            { tool: rawName },
+            'Tool proxy rejected unregistered tool',
+          );
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: `Tool not allowed: ${rawName}` }));
+          return;
+        }
+
+        // Parse body
+        let body: { args?: unknown; compact?: unknown; timeout?: unknown };
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid JSON body' }));
+          return;
+        }
+
+        // Validate args
+        if (!Array.isArray(body.args)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: '"args" must be an array' }));
+          return;
+        }
+
+        const args = body.args as unknown[];
+        for (const arg of args) {
+          const argErr = validateArg(arg as string);
+          if (argErr) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: argErr }));
+            return;
+          }
+        }
+
+        const safeArgs = args as string[];
+
+        // Resolve tool config (binary path + injected env)
+        const toolConfig = getToolConfig(rawName);
+        if (!toolConfig) {
+          // Should not happen (isAllowed passed), but guard anyway
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: 'Tool config disappeared after allowlist check',
+            }),
+          );
+          return;
+        }
+
+        // Determine timeout: body > tool config > default
+        const timeoutMs =
+          typeof body.timeout === 'number' && body.timeout > 0
+            ? body.timeout
+            : (toolConfig.timeout ?? DEFAULT_TOOL_TIMEOUT_MS);
+
+        // Append --compact if requested
+        const execArgs = [...safeArgs];
+        if (body.compact === true) {
+          execArgs.push('--compact');
+        }
+
+        // Inject tool credentials from process.env (never from container env)
+        const execEnv = { ...process.env, ...toolConfig.env };
+
+        logger.debug(
+          { tool: rawName, args: execArgs, timeout: timeoutMs },
+          'Tool proxy executing',
+        );
+
+        execFile(
+          toolConfig.binary,
+          execArgs,
+          { timeout: timeoutMs, env: execEnv },
+          (err, stdout, stderr) => {
+            const errAny = err as
+              | (NodeJS.ErrnoException & { killed?: boolean; code?: unknown })
+              | null;
+
+            // Timeout
+            if (errAny?.killed || errAny?.code === 'ETIMEDOUT') {
+              logger.warn(
+                { tool: rawName, timeout: timeoutMs },
+                'Tool proxy execution timed out',
+              );
+              res.writeHead(504, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: 'Execution timed out' }));
+              return;
+            }
+
+            // Binary not found or permission error (non-printing-press errors)
+            if (errAny && typeof errAny.code === 'string') {
+              logger.error(
+                { err: errAny, tool: rawName },
+                'Tool proxy spawn error',
+              );
+              res.writeHead(500, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: `Spawn error: ${errAny.code}` }));
+              return;
+            }
+
+            // Normal execution — return exit code + output (even on non-zero exit).
+            // The printing-press typed exit codes (2/3/4/5) are meaningful to callers
+            // and must not be converted to HTTP errors.
+            const exitCode = errAny?.code != null ? Number(errAny.code) : 0;
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ exit: exitCode, stdout, stderr }));
+          },
+        );
+      });
+    });
+
+    // Port-retry loop — matches credential-proxy.ts pattern
+    let retries = 0;
+    const maxRetries = 10;
+    const retryDelay = 2000;
+
+    const tryListen = () => {
+      server.listen(port, host, () => {
+        logger.info({ port, host }, 'Tool proxy started');
+        resolve(server);
+      });
+    };
+
+    server.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE' && retries < maxRetries) {
+        retries++;
+        logger.warn(
+          { port, attempt: retries, maxRetries },
+          'Tool proxy port in use, retrying...',
+        );
+        server.close();
+        setTimeout(tryListen, retryDelay);
+      } else {
+        reject(err);
+      }
+    });
+
+    tryListen();
+  });
+}

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1,0 +1,106 @@
+/**
+ * Tool registry for the host-side tool proxy.
+ *
+ * Reads an allowlist of CLI binaries from ~/.deus/tool-registry.json.
+ * Only tools listed here may be executed via the proxy.
+ *
+ * Registry path: ~/.deus/tool-registry.json
+ * Note: project convention uses CONFIG_DIR (~/.config/deus/) for most config,
+ * but the printing-press adoption ADR specifies ~/.deus/ for this registry so
+ * that it lives alongside evolution.db and memory.db.
+ *
+ * Example registry file:
+ * {
+ *   "tools": {
+ *     "espn": { "binary": "/usr/local/bin/espn-pp-cli", "env": {} },
+ *     "flights": {
+ *       "binary": "/usr/local/bin/flight-goat-pp-cli",
+ *       "env": { "KAYAK_API_KEY": "${KAYAK_API_KEY}" }
+ *     }
+ *   }
+ * }
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { homeDir } from './platform.js';
+import { logger } from './logger.js';
+
+/** Per-tool configuration from the registry. */
+export interface ToolConfig {
+  /** Absolute path to the host binary. */
+  binary: string;
+  /**
+   * Extra environment variables to inject when executing this tool.
+   * Values may contain ${VAR_NAME} placeholders resolved against process.env.
+   */
+  env: Record<string, string>;
+  /** Maximum execution time in milliseconds. Falls back to DEFAULT_TOOL_TIMEOUT. */
+  timeout?: number;
+}
+
+interface ToolRegistryFile {
+  tools: Record<string, ToolConfig>;
+}
+
+const REGISTRY_PATH = path.join(homeDir, '.deus', 'tool-registry.json');
+
+let cachedRegistry: ToolRegistryFile | null = null;
+
+/** Load (or reload) the tool registry from disk. Errors are non-fatal. */
+export function loadRegistry(): ToolRegistryFile {
+  try {
+    const raw = fs.readFileSync(REGISTRY_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as ToolRegistryFile;
+    if (!parsed.tools || typeof parsed.tools !== 'object') {
+      logger.warn({ path: REGISTRY_PATH }, 'Tool registry missing "tools" key');
+      return { tools: {} };
+    }
+    cachedRegistry = parsed;
+    logger.debug(
+      { count: Object.keys(parsed.tools).length, path: REGISTRY_PATH },
+      'Tool registry loaded',
+    );
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.warn({ err, path: REGISTRY_PATH }, 'Failed to load tool registry');
+    }
+    return { tools: {} };
+  }
+}
+
+/**
+ * Resolve ${VAR_NAME} placeholders in a string against process.env.
+ * Unknown variables are substituted with an empty string.
+ */
+function resolveEnvPlaceholders(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_match, name: string) => {
+    return process.env[name] ?? '';
+  });
+}
+
+/** Return true if the named tool is registered in the allowlist. */
+export function isAllowed(name: string): boolean {
+  const registry = cachedRegistry ?? loadRegistry();
+  return Object.prototype.hasOwnProperty.call(registry.tools, name);
+}
+
+/**
+ * Return the resolved configuration for a registered tool, or null if not found.
+ * Resolves ${VAR_NAME} placeholders in env values against process.env at call
+ * time (not load time) so env changes after startup are picked up.
+ */
+export function getToolConfig(name: string): ToolConfig | null {
+  const registry = cachedRegistry ?? loadRegistry();
+  const config = registry.tools[name];
+  if (!config) return null;
+
+  const resolvedEnv: Record<string, string> = {};
+  for (const [key, val] of Object.entries(config.env)) {
+    resolvedEnv[key] = resolveEnvPlaceholders(val);
+  }
+
+  return { ...config, env: resolvedEnv };
+}


### PR DESCRIPTION
## Summary
- Add a host-side HTTP tool proxy (`src/tool-proxy.ts`, 224 lines) that lets container agents execute allowlisted CLI binaries on the host — extends the `credential-proxy.ts` pattern
- JSON-backed tool registry (`src/tool-registry.ts`, 106 lines) at `~/.deus/tool-registry.json` with env-placeholder resolution for credential injection
- Lifecycle integrated in `src/index.ts` (start/stop alongside credential proxy), `DEUS_TOOL_PROXY_URL` injected into container env via `src/container-runner.ts`
- Phase 2 of the printing-press adoption roadmap (`docs/decisions/printing-press-adoption.md`)

## How it works
Container agents call `POST http://<host>:3003/tool/<cli-name>` with `{ args: [...], compact?: bool, timeout?: number }`. The proxy checks the allowlist, spawns the binary with credentials injected from env, and returns `{ exit, stdout, stderr }`. Shell metacharacters in args are rejected.

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual: register a CLI in `~/.deus/tool-registry.json`, call via curl, verify response
- [ ] Manual: verify container can reach proxy via `DEUS_TOOL_PROXY_URL`
- [ ] Verify arg sanitization rejects shell metacharacters

🤖 Generated with [Claude Code](https://claude.com/claude-code)