### PR TITLE
fix(wardens): threat-model-gate fires on filtered security paths

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -916,11 +916,24 @@ def run_threat_model_gate(event: dict[str, Any], repo_root: Path) -> int:
     if not _warden_enabled(config, "threat-modeler"):
         return 0
 
-    _, paths = _managed_paths(event, repo_root)
-    if not paths or _marker(repo_root, ".threat-modeled").exists():
+    # Marker first — cheapest exit before any path resolution.
+    if _marker(repo_root, ".threat-modeled").exists():
         return 0
 
-    matched = [path for path in paths if SECURITY_PATH_RE.search(path.as_posix())]
+    cwd = Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)
+    worktree = _worktree_for_cwd(cwd, repo_root)
+    if worktree is None:
+        return 0  # cwd outside any Deus worktree — gate doesn't apply.
+
+    # Run SECURITY_PATH_RE against raw event paths within the worktree,
+    # bypassing `_managed_paths` — its `_is_excluded`/`.gitignore` filters
+    # strip the very subagent-worktree and gitignored security paths we
+    # want to warn about.
+    matched = [
+        path for path in _event_paths(event, cwd)
+        if _is_relative_to(path, worktree)
+        and SECURITY_PATH_RE.search(path.as_posix())
+    ]
     if not matched:
         return 0
 

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -539,6 +539,103 @@ def test_threat_model_gate_warns_for_security_paths(tmp_path, capsys):
     assert "threat-modeler" in output["systemMessage"]
 
 
+def test_threat_model_gate_warns_on_worktree_excluded_security_path(tmp_path, capsys):
+    """Regression: subagent worktree edits on security paths now warn.
+
+    Pre-fix: `_managed_paths` filtered `.claude/worktrees/<sub>/...` via
+    `_is_excluded`, so `paths` was empty and the gate short-circuited at
+    `if not paths`. Result: NO `[threat-model-gate]` warning fired even
+    though the user just edited `auth.ts` in a subagent worktree.
+    Post-fix: SECURITY_PATH_RE runs against raw `_event_paths` within the
+    worktree, bypassing `_managed_paths`.
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "worktrees" / "foo" / "src").mkdir(parents=True)
+    (repo / ".claude" / "worktrees" / "foo" / "src" / "auth.ts").write_text(
+        "old\n", encoding="utf-8",
+    )
+
+    rc = hooks.run_threat_model_gate(
+        apply_patch_event(repo, ".claude/worktrees/foo/src/auth.ts"), repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    msg = output["systemMessage"]
+    assert "[threat-model-gate]" in msg
+    assert "auth.ts" in msg
+
+
+def test_threat_model_gate_warns_on_gitignored_security_path(tmp_path, capsys):
+    """Regression: gitignored security file edits now warn.
+
+    Mirror of the worktree-excluded case for the `.gitignore` filter
+    branch — gitignored auth/oauth/credential files (e.g., local
+    dev-only OAuth state) should still trigger the threat-modeler
+    warning.
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / ".gitignore").write_text("*.auth.json\n", encoding="utf-8")
+    (repo / "src" / "oauth.auth.json").write_text("{}\n", encoding="utf-8")
+
+    rc = hooks.run_threat_model_gate(
+        apply_patch_event(repo, "src/oauth.auth.json"), repo,
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    msg = output["systemMessage"]
+    assert "[threat-model-gate]" in msg
+    assert "oauth.auth.json" in msg
+
+
+def test_threat_model_gate_silent_for_non_security_in_filtered_location(tmp_path, capsys):
+    """Regression guard against over-warning.
+
+    A filtered-path edit that does NOT match SECURITY_PATH_RE must NOT
+    fire the warning. Without this test, the empty-paths fix could
+    regress in the other direction by warning on every filtered-path
+    edit regardless of content. README.md doesn't match the regex
+    (no auth/session/credential/token/etc. token).
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "worktrees" / "foo" / "src").mkdir(parents=True)
+    (repo / ".claude" / "worktrees" / "foo" / "src" / "README.md").write_text(
+        "docs\n", encoding="utf-8",
+    )
+
+    rc = hooks.run_threat_model_gate(
+        apply_patch_event(repo, ".claude/worktrees/foo/src/README.md"), repo,
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_threat_model_gate_silent_outside_worktree(tmp_path, capsys):
+    """Event from cwd outside any git worktree → no warning.
+
+    Pins the non-worktree early-exit even when the path name matches
+    SECURITY_PATH_RE — the gate should not fire on edits to non-Deus
+    projects.
+    """
+    hooks = load_hooks()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # NOT a git repo. `_worktree_for_cwd` returns None.
+
+    rc = hooks.run_threat_model_gate(
+        apply_patch_event(outside, "src/auth.ts"), outside,
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
 def test_path_leak_detector_warns_for_home_path(tmp_path, capsys):
     hooks = load_hooks()
     repo = git_repo(tmp_path)


### PR DESCRIPTION
## Summary

Third PR in the warden empty-paths cleanup series (after #430 + #433). `run_threat_model_gate` shared the same `_managed_paths` empty-paths root cause as its siblings — but with a path-CONTENT filter (`SECURITY_PATH_RE`) sitting on top of the path-LOCATION filter. The two work at cross purposes.

**Before:**
```python
def run_threat_model_gate(event, repo_root):
    ...
    _, paths = _managed_paths(event, repo_root)            # strips .claude/worktrees/, gitignored
    if not paths or _marker(...).exists(): return 0
    matched = [p for p in paths if SECURITY_PATH_RE.search(p.as_posix())]
    if not matched: return 0
    ...
```

When a subagent worktree edits `.claude/worktrees/<sub>/src/auth.ts` or a gitignored credential file, `_managed_paths` strips it and the security warning is **never emitted** — even though those are the exact paths the warning should catch.

**After:** Bypass `_managed_paths`. Run `SECURITY_PATH_RE` against raw `_event_paths` within the worktree.

```python
def run_threat_model_gate(event, repo_root):
    ...
    if _marker(repo_root, ".threat-modeled").exists(): return 0   # cheapest exit first
    cwd = ...
    worktree = _worktree_for_cwd(cwd, repo_root)
    if worktree is None: return 0   # outside any Deus worktree
    matched = [
        path for path in _event_paths(event, cwd)
        if _is_relative_to(path, worktree)
        and SECURITY_PATH_RE.search(path.as_posix())
    ]
    if not matched: return 0
    ...
```

## Why bypass `_managed_paths` instead of fixing it

`_managed_paths` applies **path-LOCATION** filters (`_is_excluded` + `_git_ignored`). The threat-model-gate needs **path-CONTENT** narrowing (`SECURITY_PATH_RE`). `_managed_paths` strips exactly the paths SECURITY_PATH_RE wants to inspect — wrong tool, not a broken tool. The other 3 hooks in #430/#433 genuinely want the location filter (they target generic Deus-source edits).

## Real-session smoke (warden-shim.sh A/B)

| Stage | Time (UTC) | Event | warden-shim output |
|---|---|---|---|
| 1 (buggy main) | 09:36:13Z | Edit on `.claude/worktrees/.../auth.ts` | _(empty — bug demonstrated)_ |
| 2 (fixed main) | 09:36:13Z | same event | `{"systemMessage": "[threat-model-gate] WARNING: ... Targets: .../auth.ts"}` |
| 3 (control, fixed main) | 09:36:13Z | Edit on `.claude/worktrees/.../README.md` (non-security) | _(empty — over-warning guard verified)_ |

Invoked via the actual `warden-shim.sh` script (the literal hook entry point Claude Code's runtime invokes). Main script restored after A/B.

## Tests

4 new + 1 existing happy-path = 5 threat-model tests:
- `test_threat_model_gate_warns_on_worktree_excluded_security_path` (pins subagent worktree auth edits)
- `test_threat_model_gate_warns_on_gitignored_security_path` (pins gitignored security files)
- `test_threat_model_gate_silent_for_non_security_in_filtered_location` (over-warning regression guard)
- `test_threat_model_gate_silent_outside_worktree` (non-worktree early-exit; `_warden_enabled` defaults True, so this branch IS reached)

**105/105 tests pass.**

## Wardens

- plan-reviewer SHIP — 2 non-blocking warnings (cross-platform mirrors existing pattern; commit-preview standard)
- code-reviewer SHIP round 1 — 2 non-blocking warnings + 2 recs; rec #1 (worktree-None comment) applied, rec #2 (test-branch verification) was a false alarm
- verification-gate SHIP — all 7 acceptance claims verified

## Out of scope (queued)

- **PR #430 over-firing on outside-worktree targets.** Larger blast radius; deferred to a separate PR after a `/compress` to refresh context.

## Cross-platform note

`Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)` mirrors the existing pattern in `_managed_paths`, `run_code_review_gate`, `run_verification_gate`. No net OS exposure.

## Test plan

- [ ] CI green
- [ ] Admin-merge per standing autonomy grant once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)