### PR TITLE
fix(wardens): plan-review-gate stops over-firing on outside-worktree targets

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -683,12 +683,24 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     # `_managed_paths` returns `(None, [])` outside every worktree;
     # otherwise `(worktree, paths_after_filtering)`. Empty `paths` after
     # filtering must NOT bypass the gate (the pre-fix `not paths` short-
-    # circuit was the ExitPlanMode enforcement gap).
+    # circuit was the ExitPlanMode enforcement gap, PR #430).
     worktree, paths = _managed_paths(event, repo_root)
     if worktree is None:
         return 0
 
-    # BLOCK regardless of `paths` emptiness — filter hit ≠ outside-worktree.
+    # Disambiguate empty-paths: (a) all targets outside worktree → return 0;
+    # (b) in-worktree targets filtered by `_is_excluded`/`_git_ignored` → BLOCK.
+    if not paths:
+        cwd = Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)
+        any_in_worktree = any(
+            _is_relative_to(p, worktree)
+            for p in _event_paths(event, cwd)
+        )
+        if not any_in_worktree:
+            return 0
+
+    # BLOCK: in-worktree edit without marker. `paths` may still be empty
+    # here when all targets were filtered (PR #430 invariant preserved).
     if paths:
         target_list = "\n".join(f"  - {path}" for path in paths[:5])
     else:

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -222,6 +222,78 @@ def test_plan_review_gate_returns_zero_outside_worktree(tmp_path, capsys):
     assert capsys.readouterr().out == ""
 
 
+def test_plan_review_gate_returns_zero_for_outside_worktree_target(tmp_path, capsys):
+    """Regression: cwd-in-worktree + target-outside-worktree must not BLOCK (PR #430 over-fire)."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    outside_target = tmp_path / "outside" / "plan.md"
+    outside_target.parent.mkdir(parents=True)
+    outside_target.write_text("# plan\n", encoding="utf-8")
+    # cwd is inside the worktree (`repo`); target is outside it entirely.
+    # No `.plan-reviewed` marker — pre-fix this would BLOCK.
+
+    rc = hooks.run_plan_review_gate(
+        apply_patch_event(repo, str(outside_target)),
+        repo,
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_plan_review_gate_returns_zero_for_home_plans_target(tmp_path, capsys):
+    """Regression: editing `~/.claude/plans/<plan>.md` from worktree cwd must not BLOCK."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    fake_home = tmp_path / "fake_home"
+    plan_target = fake_home / ".claude" / "plans" / "plan-xyz.md"
+    plan_target.parent.mkdir(parents=True)
+    plan_target.write_text("# plan content\n", encoding="utf-8")
+
+    rc = hooks.run_plan_review_gate(
+        apply_patch_event(repo, str(plan_target)),
+        repo,
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_plan_review_gate_still_blocks_mixed_targets_with_in_worktree_path(
+    tmp_path, capsys,
+):
+    """PR #430 invariant: any in-worktree raw path keeps the gate firing, even when mixed with outside-worktree targets."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / ".gitignore").write_text("*.local.json\n", encoding="utf-8")
+    (repo / "src" / "app.local.json").write_text("{}\n", encoding="utf-8")
+    outside_target = tmp_path / "outside" / "x.md"
+    outside_target.parent.mkdir(parents=True)
+    outside_target.write_text("# x\n", encoding="utf-8")
+    # Build a multi-file apply_patch command — PATCH_FILE_RE extracts
+    # both via the `*** Update File:` regex (codex_warden_hooks.py:234).
+    multi_patch = (
+        "*** Begin Patch\n"
+        f"*** Update File: src/app.local.json\n"
+        "@@\n-{}\n+{\"k\": 1}\n"
+        f"*** Update File: {outside_target}\n"
+        "@@\n-# x\n+# y\n"
+        "*** End Patch\n"
+    )
+    event = tool_event(repo, "apply_patch", {"command": multi_patch})
+
+    rc = hooks.run_plan_review_gate(event, repo)
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "PreToolUse"
+    assert specific["permissionDecision"] == "deny"
+    reason = specific["permissionDecisionReason"]
+    assert "no plan-reviewer approval marker" in reason
+
+
 def test_code_review_gate_blocks_git_commit_without_marker(tmp_path, capsys):
     hooks = load_hooks()
     repo = git_repo(tmp_path)


### PR DESCRIPTION
## Summary

Closes the last empty-paths follow-up from the PR #430/#433/#435 series.

**The regression:** PR #430 (squash `c57c136`) made `run_plan_review_gate` BLOCK whenever cwd is in a worktree AND `_managed_paths` returned empty `paths`. That correctly closed the ExitPlanMode bypass for excluded/gitignored in-worktree targets, but over-fired when all raw event-paths point OUTSIDE the worktree (e.g., editing `~/.claude/plans/<plan>.md` from a worktree session). Those targets are out of the gate's jurisdiction and must not BLOCK.

**The fix:** Disambiguate empty-`paths` via raw `_event_paths` worktree-relativeness:
- **(a)** all targets outside worktree → return 0 (out of jurisdiction)
- **(b)** in-worktree targets filtered by `_is_excluded`/`_git_ignored` → BLOCK (PR #430 invariant preserved)

Same fix-shape rationale as PR #435 (threat-model-gate). Net delta: 10 LOC in the gate + ~50 LOC of new tests.

**Three new tests pin both directions:**
- `test_plan_review_gate_returns_zero_for_outside_worktree_target` — over-fire regression guard
- `test_plan_review_gate_returns_zero_for_home_plans_target` — real session-bug shape
- `test_plan_review_gate_still_blocks_mixed_targets_with_in_worktree_path` — PR #430 invariant guard (mixed event with one in-worktree gitignored path + one outside path → still BLOCK)

## Test plan

- [x] plan-reviewer warden: SHIP
- [x] code-reviewer warden: SHIP (round 2 after `hook-pr-smoke-test` REVISE addressed with real transcript A/B)
- [x] verification-gate warden: SHIP
- [x] 9/9 `plan_review_gate` tests pass
- [x] 108/108 `test_codex_warden_hooks.py` full suite passes
- [x] drift_check OK
- [x] Real Claude Code transcript A/B verified — same Write tool call to `/tmp/smoke-test-outside/plan.md` gave BLOCK pre-fix (hash `28bf5c2…`), silent post-fix (hash `c9141ab…`); main restored to original after smoke
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)