### PR TITLE
feat(agent-runner): smart tool result summarization

### DIFF
--- a/container/agent-runner/src/tool-broker.ts
+++ b/container/agent-runner/src/tool-broker.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { summarizeToolResult } from './tool-summarize.js';
 import dns from 'dns/promises';
 import fs from 'fs';
 import { request as httpRequest } from 'http';
@@ -97,11 +98,7 @@ async function runCommand(
       stderr += chunk.toString();
     });
     proc.on('close', (code) => {
-      resolve({
-        stdout: stdout.slice(0, 60_000),
-        stderr: stderr.slice(0, 20_000),
-        exitCode: code ?? 0,
-      });
+      resolve(summarizeToolResult({ command, stdout, stderr, exitCode: code ?? 0 }));
     });
   });
 }
@@ -132,11 +129,7 @@ async function runProgram(
       });
     });
     proc.on('close', (code) => {
-      resolve({
-        stdout: stdout.slice(0, 60_000),
-        stderr: stderr.slice(0, 20_000),
-        exitCode: code ?? 0,
-      });
+      resolve(summarizeToolResult({ program: command, args, stdout, stderr, exitCode: code ?? 0 }));
     });
   });
 }

--- a/container/agent-runner/src/tool-summarize.test.ts
+++ b/container/agent-runner/src/tool-summarize.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeToolResult, type ToolOutput } from './tool-summarize.js';
+
+function makeOutput(
+  overrides: Partial<ToolOutput> & { stdout: string },
+): ToolOutput {
+  return { stderr: '', exitCode: 0, ...overrides };
+}
+
+function padTo(s: string, minLen: number): string {
+  if (s.length >= minLen) return s;
+  return s + '\n' + 'x'.repeat(minLen - s.length - 1);
+}
+
+describe('summarizeToolResult', () => {
+  it('passes through unchanged when stdout < 10K chars', () => {
+    const input = makeOutput({ command: 'find .', stdout: 'a\nb\nc' });
+    const result = summarizeToolResult(input);
+    expect(result.stdout).toBe('a\nb\nc');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('clamps stderr to 20K chars', () => {
+    const input = makeOutput({ stdout: 'ok', stderr: 'e'.repeat(25_000) });
+    const result = summarizeToolResult(input);
+    expect(result.stderr.length).toBe(20_000);
+  });
+
+  describe('non-zero exit code (tail-heavy)', () => {
+    it('keeps last 200 lines for failed commands', () => {
+      const lines = Array.from({ length: 500 }, (_, i) => `line-${i}-${'z'.repeat(20)}`);
+      const input = makeOutput({
+        command: 'npm install',
+        stdout: lines.join('\n'),
+        exitCode: 1,
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('showing last 200 of 500 lines');
+      expect(result.stdout).toContain('line-499');
+      expect(result.stdout).not.toContain('line-0\n');
+    });
+
+    it('keeps all lines when fewer than 200', () => {
+      const lines = Array.from({ length: 50 }, (_, i) => `err-${i}`);
+      const stdout = lines.join('\n');
+      const padded = 'x'.repeat(10_001) + '\n' + stdout;
+      const input = makeOutput({ command: 'make', stdout: padded, exitCode: 2 });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('err-49');
+    });
+
+    it('takes priority over command-specific strategies', () => {
+      const lines = Array.from({ length: 300 }, (_, i) => `/path/file-${i}-${'z'.repeat(40)}`);
+      const input = makeOutput({
+        command: 'find .',
+        stdout: lines.join('\n'),
+        exitCode: 1,
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('showing last 200');
+      expect(result.stdout).not.toContain('showing 50 of');
+    });
+  });
+
+  describe('git log strategy', () => {
+    it('keeps first 10 + last 5 commits, omits middle', () => {
+      const commits = Array.from({ length: 30 }, (_, i) => {
+        const hash = `${'a'.repeat(39)}${i.toString().padStart(1, '0')}`;
+        return `commit ${hash}\nAuthor: Dev <dev@example.com>\nDate: 2026-01-01 12:00:00 +0000\n\n    message ${i}\n    ${'detail '.repeat(50)}`;
+      });
+      const input = makeOutput({
+        command: 'git log',
+        stdout: commits.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('message 0');
+      expect(result.stdout).toContain('message 9');
+      expect(result.stdout).toContain('message 29');
+      expect(result.stdout).toContain('commits omitted');
+      expect(result.stdout).not.toContain('message 15');
+    });
+
+    it('passes through git log with --oneline', () => {
+      const lines = Array.from({ length: 100 }, (_, i) => `abc${i} msg ${i}`);
+      const stdout = lines.join('\n');
+      const input = makeOutput({
+        command: 'git log --oneline',
+        stdout,
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).not.toContain('omitted');
+    });
+
+    it('does not trigger for piped git log', () => {
+      const lines = Array.from({ length: 200 }, (_, i) => `line-${i}`);
+      const input = makeOutput({
+        command: 'git log | grep fix',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).not.toContain('commits omitted');
+    });
+  });
+
+  describe('find strategy', () => {
+    it('keeps first 50 results and shows total count', () => {
+      const lines = Array.from(
+        { length: 200 },
+        (_, i) => `/path/to/some/deeply/nested/directory/structure/file-${i}.typescript`,
+      );
+      const input = makeOutput({
+        command: 'find . -name "*.ts"',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('file-0');
+      expect(result.stdout).toContain('file-49');
+      expect(result.stdout).not.toContain('file-50\n');
+      expect(result.stdout).toContain('showing 50 of 200 results');
+    });
+
+    it('also works for fd command', () => {
+      const lines = Array.from({ length: 200 }, (_, i) => `/some/very/long/deeply/nested/path/structure/to/file-${i}.rustlang.source`);
+      const input = makeOutput({
+        command: 'fd .rs',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('showing 50 of 200 results');
+    });
+  });
+
+  describe('npm ls / pip list strategy', () => {
+    it('keeps first 30 packages for npm ls', () => {
+      const lines = Array.from(
+        { length: 60 },
+        (_, i) => `├── @scope/really-long-package-name-${i}@1.0.0-beta.${i} ${'extra'.repeat(30)}`,
+      );
+      const input = makeOutput({
+        command: 'npm ls',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('package-name-0');
+      expect(result.stdout).toContain('package-name-29');
+      expect(result.stdout).toContain('30 more packages');
+    });
+
+    it('keeps first 30 for pip list', () => {
+      const lines = Array.from(
+        { length: 50 },
+        (_, i) => `really-long-python-package-name-${i}   1.0.0 ${'info'.repeat(40)}`,
+      );
+      const input = makeOutput({
+        command: 'pip list',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('20 more packages');
+    });
+  });
+
+  describe('cat strategy', () => {
+    it('keeps first 100 + last 20 lines when > 200 lines', () => {
+      const lines = Array.from({ length: 500 }, (_, i) => `line-${i}-${'content'.repeat(5)}`);
+      const input = makeOutput({
+        command: 'cat largefile.txt',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('line-0');
+      expect(result.stdout).toContain('line-99');
+      expect(result.stdout).toContain('line-499');
+      expect(result.stdout).toContain('lines omitted');
+      expect(result.stdout).not.toContain('line-150\n');
+    });
+  });
+
+  describe('ls -R / tree strategy', () => {
+    it('truncates deep directory entries for tree', () => {
+      const shallow: string[] = ['.', '├── src', '│   ├── index.ts'];
+      const deep: string[] = [];
+      for (let i = 0; i < 200; i++) {
+        deep.push(`│                   └── deeply-nested-file-with-long-name-${i}.typescript`);
+      }
+      const stdout = [...shallow, ...deep].join('\n');
+      const input = makeOutput({ command: 'tree', stdout });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('deeper entries omitted');
+    });
+  });
+
+  describe('default strategy', () => {
+    it('head-slices at 60K for unknown commands over limit', () => {
+      const big = 'x'.repeat(70_000);
+      const input = makeOutput({ command: 'some-tool', stdout: big });
+      const result = summarizeToolResult(input);
+      expect(result.stdout.length).toBe(60_000);
+    });
+
+    it('passes through unknown commands under 60K', () => {
+      const medium = 'y'.repeat(15_000);
+      const input = makeOutput({ command: 'some-tool', stdout: medium });
+      const result = summarizeToolResult(input);
+      expect(result.stdout.length).toBe(15_000);
+    });
+  });
+
+  describe('piped commands', () => {
+    it('uses default strategy for piped commands', () => {
+      const lines = Array.from({ length: 200 }, (_, i) => `/file-${i}`);
+      const input = makeOutput({
+        command: 'find . | head -100',
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).not.toContain('showing 50 of');
+    });
+  });
+
+  describe('runProgram interface', () => {
+    it('works with program + args instead of command', () => {
+      const lines = Array.from({ length: 200 }, (_, i) => `/some/very/long/deeply/nested/directory/path/to/file-${i}.typescript`);
+      const input = makeOutput({
+        program: 'find',
+        args: ['.', '-name', '*.ts'],
+        stdout: lines.join('\n'),
+      });
+      const result = summarizeToolResult(input);
+      expect(result.stdout).toContain('showing 50 of 200 results');
+    });
+  });
+});

--- a/container/agent-runner/src/tool-summarize.ts
+++ b/container/agent-runner/src/tool-summarize.ts
@@ -1,0 +1,197 @@
+export interface ToolOutput {
+  command?: string;
+  program?: string;
+  args?: string[];
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface SummarizedOutput {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+const STDOUT_THRESHOLD = 10_000;
+const STDOUT_MAX = 60_000;
+const STDERR_MAX = 20_000;
+
+function commandStr(input: ToolOutput): string {
+  if (input.command !== undefined) return input.command;
+  const parts = [input.program ?? '', ...(input.args ?? [])];
+  return parts.join(' ');
+}
+
+function hasPipe(cmd: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i];
+    if (ch === "'" && !inDouble) { inSingle = !inSingle; continue; }
+    if (ch === '"' && !inSingle) { inDouble = !inDouble; continue; }
+    if (!inSingle && !inDouble && ch === '|') return true;
+  }
+  return false;
+}
+
+function clampStderr(s: string): string {
+  return s.length > STDERR_MAX ? s.slice(0, STDERR_MAX) : s;
+}
+
+function out(input: ToolOutput, stdout: string): SummarizedOutput {
+  return { stdout, stderr: clampStderr(input.stderr), exitCode: input.exitCode };
+}
+
+interface Strategy {
+  test: (input: ToolOutput, cmd: string) => boolean;
+  apply: (input: ToolOutput, cmd: string) => SummarizedOutput;
+}
+
+const strategies: Strategy[] = [
+  // Non-zero exit: tail-heavy — errors tend to appear at the end
+  {
+    test: (input) => input.exitCode !== 0,
+    apply: (input) => {
+      const lines = input.stdout.split('\n');
+      const kept = lines.length > 200 ? lines.slice(-200) : lines;
+      const prefix =
+        lines.length > 200
+          ? `[... showing last 200 of ${lines.length} lines]\n`
+          : '';
+      return out(input, prefix + kept.join('\n'));
+    },
+  },
+
+  // git log (no --oneline): keep first 10 + last 5 commits
+  {
+    test: (_input, cmd) =>
+      /(?:^|\s)git\s+log\b/.test(cmd) &&
+      !cmd.includes('--oneline') &&
+      !hasPipe(cmd),
+    apply: (input) => {
+      const raw = input.stdout;
+      const entries: string[] = [];
+      let current = '';
+      for (const line of raw.split('\n')) {
+        if (/^commit [0-9a-f]{40}/.test(line) && current) {
+          entries.push(current);
+          current = line;
+        } else {
+          current = current ? current + '\n' + line : line;
+        }
+      }
+      if (current) entries.push(current);
+
+      if (entries.length <= 15) return out(input, raw);
+      const omitted = entries.length - 15;
+      const marker = `\n[... ${omitted} commits omitted ...]\n`;
+      const result =
+        entries.slice(0, 10).join('\n') +
+        marker +
+        entries.slice(-5).join('\n');
+      return out(input, result);
+    },
+  },
+
+  // find / fd: keep first 50 lines
+  {
+    test: (_input, cmd) =>
+      /(?:^|\s)(?:find|fd)\b/.test(cmd) && !hasPipe(cmd),
+    apply: (input) => {
+      const lines = input.stdout.split('\n');
+      if (lines.length <= 50) return out(input, input.stdout);
+      const kept = lines.slice(0, 50).join('\n');
+      return out(input, `${kept}\n[... showing 50 of ${lines.length} results]`);
+    },
+  },
+
+  // ls -R / tree: keep first 3 depth levels
+  {
+    test: (_input, cmd) =>
+      (/(?:^|\s)ls\s+.*-[a-zA-Z]*R/.test(cmd) ||
+        /(?:^|\s)tree\b/.test(cmd)) &&
+      !hasPipe(cmd),
+    apply: (input) => {
+      const lines = input.stdout.split('\n');
+      const shallow: string[] = [];
+      const deeper: string[] = [];
+      for (const line of lines) {
+        const prefix = line.match(/^([\s│├└─┬┤┼|]*)/)?.[1].length ?? 0;
+        const depth = Math.floor(prefix / 4) + (line.includes('/') ? line.split('/').length - 1 : 0);
+        if (depth <= 3) {
+          shallow.push(line);
+        } else {
+          deeper.push(line);
+        }
+      }
+      if (deeper.length === 0) return out(input, input.stdout);
+      return out(
+        input,
+        shallow.join('\n') +
+          `\n[... ${deeper.length} deeper entries omitted]`,
+      );
+    },
+  },
+
+  // npm ls / pip list / pip freeze: keep first 30 lines
+  {
+    test: (_input, cmd) =>
+      (/(?:^|\s)npm\s+ls\b/.test(cmd) ||
+        /(?:^|\s)pip\s+(?:list|freeze)\b/.test(cmd)) &&
+      !hasPipe(cmd),
+    apply: (input) => {
+      const lines = input.stdout.split('\n');
+      if (lines.length <= 30) return out(input, input.stdout);
+      const kept = lines.slice(0, 30).join('\n');
+      const more = lines.length - 30;
+      return out(input, `${kept}\n[... ${more} more packages]`);
+    },
+  },
+
+  // cat: when output > 200 lines, keep first 100 + last 20
+  {
+    test: (input, cmd) => {
+      if (!/(?:^|\s)cat\b/.test(cmd) || hasPipe(cmd)) return false;
+      return input.stdout.split('\n').length > 200;
+    },
+    apply: (input) => {
+      const lines = input.stdout.split('\n');
+      const head = lines.slice(0, 100);
+      const tail = lines.slice(-20);
+      const omitted = lines.length - 120;
+      return out(
+        input,
+        head.join('\n') +
+          `\n[... ${omitted} lines omitted ...]\n` +
+          tail.join('\n'),
+      );
+    },
+  },
+
+  // Default over 60K: head-slice
+  {
+    test: (input) => input.stdout.length > STDOUT_MAX,
+    apply: (input) => out(input, input.stdout.slice(0, STDOUT_MAX)),
+  },
+];
+
+export function summarizeToolResult(input: ToolOutput): SummarizedOutput {
+  if (input.stdout.length <= STDOUT_THRESHOLD) {
+    return {
+      stdout: input.stdout,
+      stderr: clampStderr(input.stderr),
+      exitCode: input.exitCode,
+    };
+  }
+
+  const cmd = commandStr(input);
+  for (const strategy of strategies) {
+    if (strategy.test(input, cmd)) {
+      return strategy.apply(input, cmd);
+    }
+  }
+
+  // Under 60K, no specific strategy matched: passthrough with stderr clamp
+  return out(input, input.stdout);
+}


### PR DESCRIPTION
## Summary

- Replace dumb `.slice(0, 60_000)` truncation in `tool-broker.ts` with a Strategy table that dispatches type-aware summarization based on command patterns
- Only triggers when stdout exceeds 10K chars — below that, passthrough with zero overhead
- Strategies: git log (first 10 + last 5 commits), find/fd (first 50 lines), npm ls/pip list (first 30 packages), cat (first 100 + last 20 lines), ls -R/tree (depth-based), non-zero exit (tail-heavy last 200 lines)
- OpenAI backend only (Claude SDK manages native tool output internally via compaction)

## Files

- `container/agent-runner/src/tool-summarize.ts` — Strategy table with 7 summarization patterns (new)
- `container/agent-runner/src/tool-summarize.test.ts` — 18 Vitest tests (new)
- `container/agent-runner/src/tool-broker.ts` — wire `summarizeToolResult()` into `runCommand`/`runProgram`

## Test plan

- [x] `npx vitest run` — 80 tests pass
- [x] `npm run build` — TypeScript compiles clean
- [ ] Rebuild container (`./container/build.sh`)
- [ ] Smoke test: `find /` in container → output summarized (first 50 lines + count)

## Context

Inspired by OpenDev paper review (arXiv 2603.05344v3) — "tool result summarization per-type" identified as low-effort/medium-impact improvement for container agent token efficiency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)