### PR TITLE
feat(agent-runner): doom-loop detection for container agents

### DIFF
--- a/container/agent-runner/src/doom-loop-detector.test.ts
+++ b/container/agent-runner/src/doom-loop-detector.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import {
+  DoomLoopDetector,
+  createDoomLoopHook,
+  normalizeArgs,
+} from './doom-loop-detector.js';
+
+describe('DoomLoopDetector', () => {
+  let detector: DoomLoopDetector;
+
+  beforeEach(() => {
+    detector = new DoomLoopDetector(3);
+  });
+
+  it('detects on the 3rd consecutive identical failure', () => {
+    const call = {
+      toolName: 'Bash',
+      normalizedArgs: 'ls /nonexistent',
+      exitCode: 1,
+      succeeded: false,
+    };
+    expect(detector.record(call).detected).toBe(false);
+    expect(detector.record(call).detected).toBe(false);
+    const result = detector.record(call);
+    expect(result.detected).toBe(true);
+    expect(result.repeatCount).toBe(3);
+  });
+
+  it('success resets streak so 2 failures + 1 success + 2 failures does not detect', () => {
+    const fail = { toolName: 'Bash', normalizedArgs: 'ls', exitCode: 1, succeeded: false };
+    const success = { toolName: 'Bash', normalizedArgs: 'ls', exitCode: 0, succeeded: true };
+    detector.record(fail);
+    detector.record(fail);
+    detector.record(success);
+    expect(detector.record(fail).detected).toBe(false);
+    expect(detector.record(fail).detected).toBe(false);
+  });
+
+  it('3 failures of A then 3 failures of B triggers two detections', () => {
+    const callA = { toolName: 'Bash', normalizedArgs: 'cmd-a', exitCode: 1, succeeded: false };
+    const callB = { toolName: 'Bash', normalizedArgs: 'cmd-b', exitCode: 1, succeeded: false };
+
+    detector.record(callA);
+    detector.record(callA);
+    const firstDetection = detector.record(callA);
+    expect(firstDetection.detected).toBe(true);
+
+    detector.record(callB);
+    detector.record(callB);
+    const secondDetection = detector.record(callB);
+    expect(secondDetection.detected).toBe(true);
+  });
+
+  it('threshold=2 detects on the 2nd failure', () => {
+    const d = new DoomLoopDetector(2);
+    const call = { toolName: 'Read', normalizedArgs: '/a/b', exitCode: 1, succeeded: false };
+    expect(d.record(call).detected).toBe(false);
+    expect(d.record(call).detected).toBe(true);
+  });
+
+  it('different tool names produce different keys so no detection', () => {
+    const args = 'same-args';
+    detector.record({ toolName: 'Bash', normalizedArgs: args, exitCode: 1, succeeded: false });
+    detector.record({ toolName: 'Read', normalizedArgs: args, exitCode: 1, succeeded: false });
+    const result = detector.record({ toolName: 'Write', normalizedArgs: args, exitCode: 1, succeeded: false });
+    expect(result.detected).toBe(false);
+  });
+
+  it('reset() clears state and re-arms the detector', () => {
+    const call = { toolName: 'Bash', normalizedArgs: 'fail', exitCode: 1, succeeded: false };
+    detector.record(call);
+    detector.record(call);
+    detector.reset();
+    expect(detector.record(call).detected).toBe(false);
+    expect(detector.record(call).detected).toBe(false);
+    expect(detector.record(call).detected).toBe(true);
+  });
+
+  it('alternating failures reset each other, no detection', () => {
+    const callA = { toolName: 'Bash', normalizedArgs: 'cmd-a', exitCode: 1, succeeded: false };
+    const callB = { toolName: 'Bash', normalizedArgs: 'cmd-b', exitCode: 1, succeeded: false };
+    for (let i = 0; i < 4; i++) {
+      expect(detector.record(callA).detected).toBe(false);
+      expect(detector.record(callB).detected).toBe(false);
+    }
+  });
+});
+
+describe('normalizeArgs', () => {
+  it('normalizes Bash commands: lowercase, whitespace collapse, 100 char limit', () => {
+    const input = { command: '  LS   -LA   /TMP  ' };
+    expect(normalizeArgs('Bash', input)).toBe('ls -la /tmp');
+  });
+
+  it('truncates Bash command to 100 chars', () => {
+    const long = 'x'.repeat(200);
+    const input = { command: long };
+    expect(normalizeArgs('Bash', input).length).toBe(100);
+  });
+
+  it('uses file_path for Read', () => {
+    expect(normalizeArgs('Read', { file_path: '/some/file.ts' })).toBe('/some/file.ts');
+  });
+
+  it('uses file_path for Write', () => {
+    expect(normalizeArgs('Write', { file_path: '/out/file.js' })).toBe('/out/file.js');
+  });
+
+  it('uses file_path for Edit', () => {
+    expect(normalizeArgs('Edit', { file_path: '/edit/me.ts' })).toBe('/edit/me.ts');
+  });
+
+  it('falls back to JSON.stringify for unknown tools', () => {
+    const input = { query: 'something' };
+    expect(normalizeArgs('WebSearch', input)).toBe(JSON.stringify(input).slice(0, 100));
+  });
+});
+
+describe('createDoomLoopHook', () => {
+  it('PostToolUse with success returns empty object', async () => {
+    const detector = new DoomLoopDetector(3);
+    const hook = createDoomLoopHook(detector);
+    const input = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      tool_response: { exitCode: 0 },
+      tool_use_id: 'abc',
+      session_id: 's1',
+    };
+    const result = await hook(input as Parameters<typeof hook>[0], undefined, {} as Parameters<typeof hook>[2]);
+    expect(result).toEqual({});
+  });
+
+  it('PostToolUse with 3rd consecutive failure returns additionalContext', async () => {
+    const detector = new DoomLoopDetector(3);
+    const hook = createDoomLoopHook(detector);
+    const input = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'fail cmd' },
+      tool_response: { exitCode: 1 },
+      tool_use_id: 'abc',
+      session_id: 's1',
+    };
+    await hook(input as Parameters<typeof hook>[0], undefined, {} as Parameters<typeof hook>[2]);
+    await hook(input as Parameters<typeof hook>[0], undefined, {} as Parameters<typeof hook>[2]);
+    const result = await hook(input as Parameters<typeof hook>[0], undefined, {} as Parameters<typeof hook>[2]);
+    expect(result).toHaveProperty('hookSpecificOutput.hookEventName', 'PostToolUse');
+    expect(result).toHaveProperty('hookSpecificOutput.additionalContext');
+    const output = result as { hookSpecificOutput: { additionalContext: string } };
+    expect(output.hookSpecificOutput.additionalContext).toContain('[LOOP DETECTED]');
+  });
+
+  it('PostToolUseFailure always records as failure', async () => {
+    const detector = new DoomLoopDetector(2);
+    const hook = createDoomLoopHook(detector);
+    const input = {
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Read',
+      tool_input: { file_path: '/missing.ts' },
+      error: 'File not found',
+      tool_use_id: 'xyz',
+      session_id: 's1',
+    };
+    const first = await hook(input as Parameters<typeof hook>[0], undefined, {} as Parameters<typeof hook>[2]);
+    expect(first).toEqual({});
+    const second = await hook(input as Parameters<typeof hook>[0], undefined, {} as Parameters<typeof hook>[2]);
+    expect(second).toHaveProperty('hookSpecificOutput.hookEventName', 'PostToolUseFailure');
+  });
+});

--- a/container/agent-runner/src/doom-loop-detector.ts
+++ b/container/agent-runner/src/doom-loop-detector.ts
@@ -1,0 +1,129 @@
+import type {
+  HookCallback,
+  PostToolUseHookInput,
+  PostToolUseFailureHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
+
+export interface ToolCall {
+  toolName: string;
+  normalizedArgs: string;
+  exitCode: number;
+  succeeded: boolean;
+}
+
+export interface DoomLoopDetection {
+  detected: boolean;
+  repeatCount: number;
+  message: string;
+}
+
+export function normalizeArgs(toolName: string, toolInput: unknown): string {
+  if (toolName === 'Bash' || toolName === 'bash') {
+    const input = toolInput as Record<string, unknown>;
+    const cmd = typeof input?.command === 'string' ? input.command : '';
+    return cmd.replace(/\s+/g, ' ').trim().toLowerCase().slice(0, 100);
+  }
+  if (
+    toolName === 'Read' ||
+    toolName === 'Write' ||
+    toolName === 'Edit' ||
+    toolName === 'read' ||
+    toolName === 'write' ||
+    toolName === 'edit'
+  ) {
+    const input = toolInput as Record<string, unknown>;
+    return typeof input?.file_path === 'string' ? input.file_path : '';
+  }
+  return JSON.stringify(toolInput).slice(0, 100);
+}
+
+export class DoomLoopDetector {
+  private streak: { key: string; count: number; warned: boolean } | null = null;
+
+  constructor(private readonly threshold: number = 3) {}
+
+  record(call: ToolCall): DoomLoopDetection {
+    const key = `${call.toolName}:${call.normalizedArgs}`;
+
+    if (call.succeeded) {
+      this.streak = null;
+      return { detected: false, repeatCount: 0, message: '' };
+    }
+
+    if (this.streak && this.streak.key === key) {
+      this.streak.count += 1;
+    } else {
+      this.streak = { key, count: 1, warned: false };
+    }
+
+    if (this.streak.count >= this.threshold && !this.streak.warned) {
+      this.streak.warned = true;
+      const message = `[LOOP DETECTED] You've failed "${key}" ${this.streak.count} times consecutively. STOP. Do not retry. Read the error output, diagnose the root cause, and try a fundamentally different approach.`;
+      return { detected: true, repeatCount: this.streak.count, message };
+    }
+
+    return { detected: false, repeatCount: this.streak.count, message: '' };
+  }
+
+  reset(): void {
+    this.streak = null;
+  }
+}
+
+export function createDoomLoopHook(detector: DoomLoopDetector): HookCallback {
+  return async (input) => {
+    const eventName = (input as { hook_event_name?: string }).hook_event_name;
+
+    if (eventName === 'PostToolUseFailure') {
+      const failInput = input as PostToolUseFailureHookInput;
+      const detection = detector.record({
+        toolName: failInput.tool_name,
+        normalizedArgs: normalizeArgs(failInput.tool_name, failInput.tool_input),
+        exitCode: 1,
+        succeeded: false,
+      });
+      if (detection.detected) {
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PostToolUseFailure' as const,
+            additionalContext: detection.message,
+          },
+        };
+      }
+      return {};
+    }
+
+    const successInput = input as PostToolUseHookInput;
+    const rawResponse = successInput.tool_response;
+    let exitCode = 0;
+    if (typeof rawResponse === 'string') {
+      try {
+        const parsed = JSON.parse(rawResponse) as Record<string, unknown>;
+        exitCode = typeof parsed.exitCode === 'number' ? parsed.exitCode : 0;
+      } catch {
+        exitCode = 0;
+      }
+    } else if (rawResponse !== null && typeof rawResponse === 'object') {
+      const resp = rawResponse as Record<string, unknown>;
+      exitCode = typeof resp.exitCode === 'number' ? resp.exitCode : 0;
+    }
+    const succeeded = exitCode === 0;
+
+    const detection = detector.record({
+      toolName: successInput.tool_name,
+      normalizedArgs: normalizeArgs(successInput.tool_name, successInput.tool_input),
+      exitCode,
+      succeeded,
+    });
+
+    if (detection.detected) {
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse' as const,
+          additionalContext: detection.message,
+        },
+      };
+    }
+    return {};
+  };
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -29,6 +29,7 @@ import { bootstrap } from './bootstrap.js';
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { createMemoryRetrievalHook } from './memory-retrieval-hook.js';
 import { runOpenAIConversation } from './openai-backend.js';
+import { DoomLoopDetector, createDoomLoopHook } from './doom-loop-detector.js';
 import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 
 type AgentRuntimeId = 'claude' | 'openai';
@@ -721,6 +722,8 @@ async function runQuery(
     );
   }
 
+  const doomDetector = new DoomLoopDetector();
+
   for await (const message of query({
     prompt: stream,
     options: {
@@ -793,13 +796,15 @@ async function runQuery(
         PreCompact: [
           { hooks: [createPreCompactHook(containerInput.assistantName)] },
         ],
+        PostToolUseFailure: [{ hooks: [createDoomLoopHook(doomDetector)] }],
         ...(() => {
           const hooks: HookCallback[] = [];
+          hooks.push(createDoomLoopHook(doomDetector));
           if (process.env.DEUS_TOOL_SIZE_LOG !== '0')
             hooks.push(createToolSizeLogHook());
           if (process.env.DEUS_TOOL_AUDIT_LOG !== '0')
             hooks.push(createToolAuditHook());
-          return hooks.length > 0 ? { PostToolUse: [{ hooks }] } : {};
+          return { PostToolUse: [{ hooks }] };
         })(),
       },
     },

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { fetchMemoryContext } from './memory-retrieval-hook.js';
+import { DoomLoopDetector, normalizeArgs } from './doom-loop-detector.js';
 import {
   createOpenAIMcpToolBridge,
   executeBrokerTool,
@@ -349,6 +350,7 @@ async function runSingleTurn(
   containerInput: ContainerInput,
   previousResponseId: string | undefined,
   log: (message: string) => void,
+  doomDetector: DoomLoopDetector,
 ): Promise<{ responseId: string; result: string | null }> {
   const { cwd, hasProject, systemInstructions } =
     getRuntimeContext(containerInput);
@@ -385,6 +387,7 @@ async function runSingleTurn(
 
       log(`OpenAI requested ${calls.length} tool call(s)`);
       input = [];
+      let doomLoopWarning: string | null = null;
       for (const call of calls) {
         let parsedArgs: Record<string, unknown> = {};
         try {
@@ -410,10 +413,33 @@ async function runSingleTurn(
             };
           }
         }
+        const exitCode: number =
+          typeof toolResult?.exitCode === 'number'
+            ? toolResult.exitCode
+            : toolResult?.ok === false
+              ? 1
+              : 0;
+        const succeeded = toolResult?.ok !== false && exitCode === 0;
+        const detection = doomDetector.record({
+          toolName: call.name,
+          normalizedArgs: normalizeArgs(call.name, parsedArgs),
+          exitCode,
+          succeeded,
+        });
+        if (detection.detected) {
+          doomLoopWarning = detection.message;
+        }
         input.push({
           type: 'function_call_output',
           call_id: call.call_id,
           output: JSON.stringify(toolResult),
+        });
+      }
+      if (doomLoopWarning) {
+        input.push({
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: doomLoopWarning }],
         });
       }
     }
@@ -528,6 +554,8 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
     prompt += '\n' + pending.join('\n');
   }
 
+  const doomDetector = new DoomLoopDetector();
+
   while (true) {
     if (shouldClose()) break;
 
@@ -540,6 +568,7 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
       containerInput,
       sessionId,
       log,
+      doomDetector,
     );
     sessionId = turn.responseId;
     writeOutput({


### PR DESCRIPTION
## Summary

- Detect when an agent repeats the same failing action 3+ times consecutively and inject a warning breaking the cycle
- Single-streak model: alternating different failures reset each other (agent IS trying different things); only truly stuck repetition triggers
- Warning fires once per streak (warned-once flag prevents repeated injection)
- Cross-backend: Claude SDK `additionalContext` hook + OpenAI user-role message injection

## Files

- `container/agent-runner/src/doom-loop-detector.ts` — `DoomLoopDetector` class, `normalizeArgs`, `createDoomLoopHook` factory (new)
- `container/agent-runner/src/doom-loop-detector.test.ts` — 16 Vitest tests (new)
- `container/agent-runner/src/index.ts` — wire doom-loop hook into PostToolUse + PostToolUseFailure
- `container/agent-runner/src/openai-backend.ts` — 5th param to `runSingleTurn`, user-message injection

## SDK source-of-truth

`PostToolUseHookSpecificOutput.additionalContext` confirmed in `@anthropic-ai/claude-agent-sdk` sdk.d.ts — separate field from `updatedMCPToolOutput`, works for ALL tools including native Bash/Read/Grep.

## ADR alignment

Hook-dispatch-system ADR Phase 2 (HookDispatchService Bridge) has not landed. Doom-loop hook wired directly to SDK config (same pattern as existing `createToolSizeLogHook`/`createToolAuditHook`). All three hooks form the Layer 2 migration set for Phase 2.

## Test plan

- [x] `npx vitest run` — 80 tests pass
- [x] `npm run build` — TypeScript compiles clean
- [ ] Rebuild container (`./container/build.sh`)
- [ ] Smoke test: `cat /nonexistent` 3x in container → doom-loop warning injected

## Context

Inspired by OpenDev paper review (arXiv 2603.05344v3) — "doom-loop detection" identified as low-effort/medium-impact improvement for container agent reliability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)