### PR TITLE
docs(wardens): add Remediation field to blocking-severity rules

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -30,7 +30,7 @@ Return a single markdown report. No preamble.
 1-line reason.
 
 ## Blocking Issues
-(severity=blocking violations. Format: `` `<rule-id>` at `path/to/file.ts:L42` — <one-line observation>``. Empty = "None.")
+(severity=blocking violations. Format: `` `<rule-id>` at `path/to/file.ts:L42` — <one-line observation>. **Fix:** <remediation from the rule>``  Empty = "None.")
 
 ## Warnings
 (severity=warning violations. Same format.)
@@ -47,7 +47,7 @@ Return a single markdown report. No preamble.
 
 ## Rules of engagement
 
-- **Cite rule ids + diff locations.** Every finding ties to a specific rule. Format: `` `<rule-id>` at `path:line` — <observation>``. No generic advice.
+- **Cite rule ids + diff locations.** Every finding ties to a specific rule. Format: `` `<rule-id>` at `path:line` — <observation>. **Fix:** <remediation from the rule>``  No generic advice.
 - **Don't rewrite the code.** Point out the problem; leave the fix to the author.
 - **Skip rules with no match.** If `Applies when` doesn't match any hunk in the diff, don't mention the rule.
 - **Off-rule findings go to Recommendations.** If you spot something worth flagging that no rule covers, put it in Recommendations (not Blocking/Warnings). Keep it rare.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -28,7 +28,7 @@ Return a single markdown report. No preamble, no "I'll review...".
 1-line reason.
 
 ## Blocking Issues
-(rules with severity=blocking violated. Cite rule id + specific reason. Empty section = "None.")
+(rules with severity=blocking violated. Format: `` `<rule-id>` — <specific reason>. **Fix:** <remediation from the rule>``  Empty section = "None.")
 
 ## Warnings
 (severity=warning violations. Empty = "None.")
@@ -43,7 +43,7 @@ Return a single markdown report. No preamble, no "I'll review...".
 ## Rules of engagement
 
 - **Don't invent problems.** If the plan is fine, say "Verdict: SHIP" with empty sections. That's a valid output.
-- **Cite rule ids verbatim.** "Violates `public-repo-generic`" beats "has scoping issues." Reference the rule's `Cite:` field so findings are verifiable against memory/docs.
+- **Cite rule ids verbatim.** "Violates `public-repo-generic`" beats "has scoping issues." For blocking issues, append **Fix:** from the rule's `Remediation:` field. Reference the rule's `Cite:` field so findings are verifiable against memory/docs.
 - **Skip rules with no match.** Mechanical: if a rule's `Applies when` doesn't match this plan, don't mention it. Only list the ones that fired.
 - **Flag unknowns, don't guess.** If a memory file is stale (>14 days for project memories, >60 for reference) or repo state contradicts it, say so rather than asserting.
 - **Stay in critique mode.** If asked to fix, respond: "out of scope for this agent — invoke the `Plan` subagent or implement directly."

--- a/.claude/agents/verification-gate.md
+++ b/.claude/agents/verification-gate.md
@@ -42,7 +42,7 @@ Evidence:
 [paste relevant output snippets]
 
 Missing verification:
-- [list any claims that couldn't be verified]
+- [claim] — **Fix:** [run the relevant command and paste full stdout/stderr output]
 ```
 
 Mapping: all claims verified with evidence = SHIP. Any claim unverified or

--- a/.claude/wardens/code-review-rules.md
+++ b/.claude/wardens/code-review-rules.md
@@ -12,6 +12,7 @@
 **Check:** Are any `critical:` keys dropped? Are any `**(CRITICAL)**` memory entries removed? Estimate critical-key retention — does it stay ≥95%?
 **Rule:** Never reduce CRITICAL preservation below 95%.
 **Cite:** `feedback_compression_rule`; vault CLAUDE.md `claude-md-gates` line
+**Remediation:** Restore each dropped `critical:` key or `**(CRITICAL)**` entry to the vault file. Re-estimate the retention ratio — add them back until the count stays at or above 95% of the original.
 
 ## ci-coverage-90
 **Severity:** blocking
@@ -19,6 +20,7 @@
 **Check:** Do the canned keyword-coverage queries still hit at ≥90%? Paraphrase misses should be addressed via `kw=` overrides, not by lowering the floor.
 **Rule:** Maintain ≥90% behavioral coverage.
 **Cite:** `feedback_compression_rule`
+**Remediation:** Add `kw=` overrides for any behavioral rule whose keyword now misses, or restore the removed text that covered it. Do not lower the 90% floor — expand coverage instead.
 
 ## ci-drift-check
 **Severity:** blocking
@@ -26,6 +28,7 @@
 **Check:** Was `memory_tree.py check` / `drift_check.py --indexes` run after the edit?
 **Rule:** Vault leaf changes require drift-check validation before commit.
 **Cite:** `feedback_memory_tree_check`
+**Remediation:** Run `python3 memory_tree.py check` (or `python3 drift_check.py --indexes`) and paste the output. Fix any reported drift before committing.
 
 ## cross-platform-actual
 **Severity:** blocking
@@ -33,6 +36,7 @@
 **Check:** Are paths constructed via `src/platform.ts` helpers? Are OS-specific commands (e.g., `pngpaste`, `launchctl`, `osascript`, `sed -i ''`) gated by a platform check or replaced with portable alternatives? Does the diff use `~`/`$HOME` instead of `/Users/...`?
 **Rule:** Default to cross-platform; guard OS-specific code.
 **Cite:** `feedback_cross_platform_default`
+**Remediation:** Replace OS-specific commands with portable equivalents or wrap them in a `platform.ts` guard. Replace any hardcoded `/Users/<name>/...` paths with `os.homedir()` / `$HOME` equivalents.
 
 ## efficiency
 **Severity:** warning
@@ -61,6 +65,7 @@
 **Check:** Is there before/after data in the commit message, session log, or PR body? Was the bench run on a realistic workload (not a short-prompt probe for long-context code)?
 **Rule:** Never ship "improvements" without measurement. Predict the outcome before running the bench.
 **Cite:** `feedback_predict_before_testing`; `feedback_measure_on_real_workload`
+**Remediation:** Run the relevant benchmark on a realistic workload (e.g., `npm run bench` or `deus sweep`) and add the before/after numbers to the PR body or commit message before pushing.
 
 ## pros-cons
 **Severity:** warning
@@ -75,6 +80,7 @@
 **Check:** Conventional-commits format (`type(scope): description`)? Under 70 chars? Matches the CI title-gate expectations?
 **Rule:** Title must pass the CI title-gate on first push.
 **Cite:** `project_error_discipline_plan` (noted #214 was CI-blocked on title)
+**Remediation:** Rewrite the title to match `type(scope): description` (e.g., `fix(auth): handle expired token refresh`), trim it to under 70 characters, and re-push.
 
 ## no-hardcoded-personal
 **Severity:** blocking
@@ -82,6 +88,7 @@
 **Check:** Grep the diff for hardcoded personal values — macOS usernames (e.g. a literal like `<user>`), emails, government IDs, Hebrew names, absolute paths under `/Users/...`, personal project IDs.
 **Rule:** Public-repo code must be user-agnostic in reality, not just in intent.
 **Cite:** `feedback_public_repo_generic`
+**Remediation:** Replace each hardcoded personal value with a placeholder, environment variable, or config-driven lookup. Move personal fixtures to `~/.claude/`, `~/.config/deus/`, or `src/private/` (gitignored).
 
 ## container-reload-noted
 **Severity:** informational
@@ -145,6 +152,7 @@
 **Check:** Shell injection (user input interpolated into `exec`/`child_process.spawn` without sanitization), SQL injection (string concat into queries vs parameterized), path traversal (user input concatenated into file paths without basename/normalize), XSS (user input rendered without escaping), SSRF (user-controllable URLs fetched server-side without host allowlist).
 **Rule:** No classic OWASP vectors. Parameterize queries, escape output, normalize paths, allowlist hosts for user-controlled URLs.
 **Cite:** system-prompt "Be careful not to introduce security vulnerabilities" rule; `feedback_security_first`
+**Remediation:** For each flagged vector: use parameterized queries instead of string concatenation, pass arguments as arrays to `child_process.spawn` instead of shell strings, call `path.normalize` + `path.basename` on file path inputs, escape HTML output, or add a URL host allowlist — whichever applies to the specific finding.
 
 ## hook-schema-source-of-truth
 **Severity:** blocking
@@ -152,6 +160,7 @@
 **Check:** Does the commit message cite a source of truth (Claude Code binary string extraction, SDK source path, or official doc URL)?
 **Rule:** Hook schema changes require a verifiable source-of-truth citation in the commit message. Derivation-from-assumption is rejected.
 **Cite:** `feedback_hook_schema_source_of_truth`
+**Remediation:** Add a source-of-truth citation to the commit message — either the SDK source path you read, a string extracted from the Claude Code binary, or an official doc URL. Do not ship schema changes derived from assumption alone.
 
 ## hook-pr-smoke-test
 **Severity:** blocking
@@ -159,3 +168,4 @@
 **Check:** Does the PR body include evidence of a real-session smoke test (session log link, `claude logs <id>` output, or transcript excerpt)?
 **Rule:** Hook-touching PRs require documented real-session smoke test before marked done. Synthetic tests alone are insufficient.
 **Cite:** `feedback_hook_pr_smoke_test`
+**Remediation:** Run a real Claude Code session that exercises the modified hook, then paste the relevant `claude logs <session-id>` output (or a transcript excerpt) into the PR body before marking it ready.

--- a/.claude/wardens/plan-review-rules.md
+++ b/.claude/wardens/plan-review-rules.md
@@ -12,6 +12,7 @@
 **Check:** Does the plan hardcode personal values (usernames, emails, absolute personal paths, specific IDs, session tokens)?
 **Rule:** Public-repo code must be user-agnostic. Personal fixtures belong in `~/.claude/`, `~/.config/deus/`, or `src/private/`.
 **Cite:** `feedback_public_repo_generic`
+**Remediation:** Replace each hardcoded personal value in the plan with a placeholder, env var reference, or config-file lookup. Move any fixture files that contain personal data to `~/.claude/` or `src/private/` and gitignore them.
 
 ## commit-scoping
 **Severity:** blocking
@@ -19,6 +20,7 @@
 **Check:** Are the changes conceptually one concern, or multiple?
 **Rule:** Split into separate commits/PRs. Never bundle personal-tooling changes into public-repo PRs.
 **Cite:** `feedback_scope_commits_by_concern`
+**Remediation:** Split the plan into two separate branches: one for the public-repo changes and one for the personal-tooling changes. Implement and PR them independently.
 
 ## private-override
 **Severity:** warning
@@ -33,6 +35,7 @@
 **Check:** Does this plan skip ahead in the sequence, contradict a prior commitment, or touch files owned by an open PR in the sequence?
 **Rule:** Finish or explicitly re-plan the active sequence before branching into parallel work on the same surface.
 **Cite:** The relevant active `project_*.md`
+**Remediation:** Either complete the open steps in the active sequence first, or explicitly supersede the sequence by updating the relevant `project_*.md` memory with a new plan — then resubmit.
 
 ## no-db-deletion
 **Severity:** blocking
@@ -40,6 +43,7 @@
 **Check:** Does the plan propose a hard delete?
 **Rule:** Soft-delete only — set a deleted-at field, archive, or tombstone. Never hard-delete user data.
 **Cite:** `docs/decisions/no-db-deletion.md`
+**Remediation:** Replace the hard-delete operation with a soft-delete: add a `deleted_at` timestamp column (or equivalent archive table), set it instead of removing the row, and filter `WHERE deleted_at IS NULL` in queries.
 
 ## cross-platform-intent
 **Severity:** warning
@@ -54,6 +58,7 @@
 **Check:** Does the plan commit secrets to git (anywhere — `.env`, fixtures, tests)? Does it rely on env vars without `.env.example` documentation?
 **Rule:** No credentials in git ever. Use `.env` + `.env.example`; gitignore strictly. For rotation, use the credential-proxy pattern.
 **Cite:** vault CLAUDE.md `security:` line; `feedback_deploy_integrity`
+**Remediation:** Move any credential value to a `.env` file (gitignored), add a corresponding placeholder entry to `.env.example`, and reference it via `process.env.VAR_NAME` in code. Run `git check-ignore -v .env` to confirm it is ignored before committing.
 
 ## commit-preview-rule
 **Severity:** informational
@@ -68,6 +73,7 @@
 **Check:** Scan `docs/decisions/INDEX.md` for any ADR whose subject overlaps the plan. Also cross-check `docs/KNOWN_LIMITATIONS.md` (standing constraints) and `docs/EFFORT_AB_RESULTS.md` (A/B outcomes — "we already tried this"). If an overlapping ADR or result exists, does the plan align with it or contradict it?
 **Rule:** Don't re-litigate settled decisions. If the plan contradicts an existing ADR, either the plan needs revision, or the ADR needs an explicit superseding successor authored alongside the change — never silently diverge.
 **Cite:** `docs/decisions/INDEX.md` + the specific ADR(s); `docs/KNOWN_LIMITATIONS.md`; `docs/EFFORT_AB_RESULTS.md`
+**Remediation:** Either revise the plan to align with the existing ADR, or draft a superseding ADR alongside the change that explicitly records why the prior decision is being reversed. Add a link to both ADRs in the PR body.
 
 ## scope-creep
 **Severity:** warning
@@ -100,6 +106,7 @@
 - "orphan file" → `grep -r '<filename>' .` returns no callers across `.ts`, `.sh`, `.json`, `.py`, launchd plists, `package.json` scripts.
 - "drift between two paths" → grep for code that writes to the derived path (`cpSync`, `shutil.copytree`, `fs.mkdirSync` + write). If a writer exists, the divergence is a cache, not a bug — plan must address why the cache is wrong, not treat it as rot.
 **Cite:** Slice A postmortem (2026-04-20 — the agent-runner-src cache was wrongly flagged as tracked drift); system-prompt "Trust but verify."
+**Remediation:** Run the verification command(s) listed above for each unverified premise and paste the output into the plan. If a premise turns out false, remove or correct that step before resubmitting.
 
 ## means-end-consistency
 **Severity:** blocking
@@ -113,6 +120,7 @@ Common traps:
 - "Delete file X" — but a new file references X's old path.
 **Rule:** The fix must not reproduce the problem it solves. For patterns/regexes over sensitive values, source them from a GitHub Actions secret, an external gitignored file, a hash-based match, or other indirection — never commit the values inline. Run the fix through the same check it creates: if the implementation would trigger its own gate, revise.
 **Cite:** Slice C round 3 postmortem (2026-04-20 — CI gate was going to hardcode the very personal IDs it was designed to block).
+**Remediation:** Move the problematic value out of the committed implementation — use a GitHub Actions secret reference, a gitignored config file, or a hash-based match. Then run the gate the plan creates against its own implementation; if it triggers, revise until it doesn't.
 
 ## design-pattern-selection
 **Severity:** blocking
@@ -120,6 +128,7 @@ Common traps:
 **Check:** Does the plan identify which design pattern(s) apply (Strategy, Observer, Mediator, Factory, etc.) and justify the choice? Does it specify data structures with Big-O rationale where relevant (e.g., HashMap for O(1) lookup vs Vec scan)?
 **Rule:** Every non-trivial plan must name the design pattern(s) it uses and why they fit. Data structure choices must be justified when algorithmic complexity matters. Generic, modular designs are the default — new features should plug in without modifying or risking existing logic. If no standard pattern applies, the plan must state why and describe the custom approach.
 **Cite:** vault CLAUDE.md `design: pattern-driven | modular-generic`
+**Remediation:** Add a "Design" section to the plan that names the pattern(s) used (e.g., "Strategy — each handler implements a common interface") and justifies data structure choices with Big-O rationale. If no standard pattern applies, write a one-sentence explanation of the custom approach.
 
 ## task-granularity
 **Severity:** warning
@@ -148,6 +157,7 @@ Common traps:
 **Check:** Does the plan include `deus sweep` benchmark output (recall, MRR, abstain_accuracy) showing the impact? Was the sweep run BEFORE the PR, not after merge?
 **Rule:** Retrieval pipeline changes must include sweep evidence in the PR description. Ship-then-disable cycles waste two PR reviews and risk leaving harmful defaults in production. The tool already exists — use it.
 **Cite:** RETRO-2026-05-11-01; atom-fallback PR #350→#351 reversal; entity-coverage same-session reversal
+**Remediation:** Run `deus sweep` against the modified retrieval code and paste the recall/MRR/abstain_accuracy output into the plan or PR description. Do not proceed until the sweep shows neutral or improved scores vs the baseline.
 
 ## api-surface-verification
 **Severity:** blocking
@@ -155,3 +165,4 @@ Common traps:
 **Check:** For each function the plan references, has the actual signature been read and verified? Do the parameter names, types, and return types match what the plan assumes?
 **Rule:** Plans must verify the API surface they depend on by reading the source. Wrong method signatures, dead parameters, and phantom APIs are the #1 cause of multi-round plan-reviewer cycles. Read the function, then write the plan — not the reverse.
 **Cite:** RETRO-2026-05-11-02; Phase 5-6 postmortem (6 rounds caused by RuntimeRegistry.resolve() wrong signature, GroupQueue dead parameter)
+**Remediation:** For each referenced function, open the source file and read the actual signature. Update the plan to match the real parameter names, types, and return types. Add a "Verified signatures" note citing the file and line number for each function.

--- a/.claude/wardens/verification-rules.md
+++ b/.claude/wardens/verification-rules.md
@@ -12,6 +12,7 @@
 **Check:** Was the relevant verification command run in this turn (not a previous turn)?
 **Rule:** Every success claim requires fresh command output from the current turn. Prior runs are stale.
 **Cite:** Superpowers verification-before-completion; "If you haven't run the command in this message, you cannot claim it passes."
+**Remediation:** Run the relevant command now (`npm test`, `npm run build`, etc.) and paste its full stdout/stderr output. Do not claim success based on output from a previous turn.
 
 ## full-command
 **Severity:** blocking
@@ -19,6 +20,7 @@
 **Check:** Was the FULL command run (e.g., `cargo test` not `cargo test one_test`), and was the exit code checked?
 **Rule:** Partial verification proves nothing. Run the full suite. Check the exit code, not just the output text.
 **Cite:** Superpowers verification-before-completion
+**Remediation:** Re-run the full test suite without filters (e.g., `npm test` not `npm test -- --grep "foo"`) and confirm the exit code is 0. Paste the full output including the summary line.
 
 ## no-hedging
 **Severity:** blocking
@@ -26,6 +28,7 @@
 **Check:** Does the claim use "should", "probably", "seems to", "looks correct", or "I'm confident"?
 **Rule:** Hedging language = unverified claim. Replace with evidence or state "not yet verified."
 **Cite:** Superpowers verification-before-completion rationalization table
+**Remediation:** Remove the hedging phrase and replace it with the actual command output that proves the claim, or explicitly state "not yet verified — will run `<command>` next."
 
 ## agent-distrust
 **Severity:** warning


### PR DESCRIPTION
## Summary

Adds concrete fix instructions to all 24 blocking-severity warden rules across three rule files, and updates agent output format to surface remediation hints inline in REVISE verdicts.

- **code-review-rules.md**: 10 blocking rules updated (ci-preservation-95, ci-coverage-90, ci-drift-check, cross-platform-actual, benchmark-validation, pr-title-format, no-hardcoded-personal, security-basics, hook-schema-source-of-truth, hook-pr-smoke-test)
- **plan-review-rules.md**: 11 blocking rules updated (public-repo-generic, commit-scoping, active-sequence-conflict, no-db-deletion, secrets-design, prior-decisions, premise-verification, means-end-consistency, design-pattern-selection, retrieval-sweep-gate, api-surface-verification)
- **verification-rules.md**: 3 blocking rules updated (fresh-evidence, full-command, no-hedging)
- **Agent prompts**: code-reviewer.md, plan-reviewer.md, and verification-gate.md updated to include `**Fix:**` suffix on blocking issue output lines

Each `**Remediation:**` is specific and actionable — it tells the author exactly what command to run, what to move, or what section to add. No generic advice.

Inspired by OpenAI's Harness Engineering approach of including remediation instructions in lint error messages.

## Test plan

- [x] `grep -c "Remediation" .claude/wardens/code-review-rules.md` → 10
- [x] `grep -c "Remediation" .claude/wardens/plan-review-rules.md` → 11
- [x] `grep -c "Remediation" .claude/wardens/verification-rules.md` → 3
- [x] `python3 scripts/sync_agent_skills.py` runs clean (98 files synced)
- [x] code-reviewer warden: SHIP (pure markdown doc changes, no rules fired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)