### PR TITLE
feat(pp): description hints for 4 channel-core common tools

### DIFF
--- a/packages/mcp-channel-core/src/server-base.ts
+++ b/packages/mcp-channel-core/src/server-base.ts
@@ -97,7 +97,7 @@ export function registerCommonTools(
 
   server.tool(
     'get_status',
-    'Get connection status and channel info',
+    'Get connection status and channel info. Pass select="connected,channel" + compact=true for a slimmer response.',
     { compact: z.boolean().optional(), select: z.string().optional() },
     async (args) => {
       // If the provider is still connecting, wait briefly for it to be ready
@@ -117,7 +117,7 @@ export function registerCommonTools(
 
   server.tool(
     'list_chats',
-    'List known chats and groups',
+    'List known chats and groups. Pass select="id,name,is_group" + compact=true to cut payload on list ops.',
     { compact: z.boolean().optional(), select: z.string().optional() },
     async (args) => {
       const chats = provider.listChats ? await provider.listChats() : [];
@@ -127,7 +127,7 @@ export function registerCommonTools(
 
   server.tool(
     'sync_groups',
-    'Refresh group and chat metadata from the platform',
+    'Refresh group and chat metadata from the platform. Pass select="id,name,is_group" + compact=true to slim the returned groups list.',
     {
       force: z.boolean().optional(),
       compact: z.boolean().optional(),
@@ -152,7 +152,7 @@ export function registerCommonTools(
 
   server.tool(
     'get_new_messages',
-    'Poll for incoming messages since the last call. Use the returned cursor for subsequent calls.',
+    'Poll for incoming messages since the last call. Use the returned cursor for subsequent calls. Pass select="messages.sender,messages.content,messages.timestamp,cursor" + compact=true to cut polling-loop payload.',
     {
       since_cursor: z.string().optional(),
       compact: z.boolean().optional(),

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-16" # auto-bump (pp-select)
+last_verified: "2026-05-16" # auto-bump (channel-core-hints)
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-16" # auto-bump (pp-select)
+last_verified: "2026-05-16" # auto-bump (channel-core-hints)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"


### PR DESCRIPTION
## Summary

Follow-up to #438. Closes the 4 informational findings surfaced by `check_mcp_description_hints` in `packages/mcp-channel-core/src/server-base.ts`.

These tools are registered via `registerCommonTools()` for **every channel MCP** (whatsapp, telegram, slack, discord, gmail, x) — a single fix benefits all channels.

## Tools updated

| Line | Tool | Hint added |
|------|------|------------|
| 100 | `get_status` | `select="connected,channel" + compact=true` |
| 120 | `list_chats` | `select="id,name,is_group" + compact=true` |
| 130 | `sync_groups` | `select="id,name,is_group" + compact=true` |
| 155 | `get_new_messages` | `select="messages.sender,messages.content,messages.timestamp,cursor" + compact=true` |

**`get_new_messages` is the highest-volume MCP call in the whole system** — it runs on every poll loop across every channel. Same compounding savings shape as #438's gcal/gmail list payloads (79–91% reduction range).

## Field accuracy

All hint fields verified against `packages/mcp-channel-core/src/types.ts`:
- `ChatInfo = {id, name, is_group}` (v1 plan said `kind` — plan-reviewer caught it)
- `IncomingMessage = {id, chat_id, sender, sender_name, content, timestamp, ...}`
- `ChannelStatus = {connected, channel, identity?, uptime_seconds?}`
- `MessageBuffer.getSince` → `{messages: IncomingMessage[], cursor: string}`

## Test plan

- [x] `python3 scripts/drift_check.py --all --base origin/main` — `All projection-capable MCP tools include description hints.`
- [x] `python3 -m pytest scripts/tests/test_pp_description_hints.py -v` — 4/4 pass
- [x] No schema, behavior, or test changes — descriptions only

## Out of scope

- Schema migrations for `mcp-x` / `mcp-whatsapp` / `mcp-discord` / `mcp-slack` / `mcp-telegram` action tools (need `compact: z.boolean().optional(), select: z.string().optional()` added to schemas — different surface, still tracked in CLAUDE.md pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)