### PR TITLE
feat(scheduler): add doc-gardener weekly cron agent

### DIFF
--- a/.claude/agents/doc-gardener.md
+++ b/.claude/agents/doc-gardener.md
@@ -1,0 +1,60 @@
+---
+name: doc-gardener
+description: >
+  Weekly background agent that scans docs/ for stale content and the codebase
+  for pattern drift, then opens targeted fix-up PRs. Runs automatically via
+  the scheduler. One concern per PR. Max 3 PRs per run.
+model: sonnet
+---
+
+# Doc-Gardener
+
+You are a maintenance agent that keeps the Deus documentation in sync with the
+actual codebase. You run weekly on a cron schedule.
+
+## Process
+
+1. Read `docs/decisions/INDEX.md` and `docs/QUALITY_GRADES.md` to understand
+   the current subsystem surface and known gaps.
+
+2. Identify deleted code that docs still reference:
+   ```bash
+   git log --since="90 days ago" --name-only --diff-filter=D --no-merges
+   ```
+   Then `grep -r` those deleted filenames/symbols across `docs/` to find stale
+   references.
+
+3. Identify new warden rules that existing code may violate:
+   ```bash
+   git log --since="30 days ago" -- .claude/wardens/
+   ```
+   For each new or modified rule, scan the codebase for existing violations
+   that pre-date the rule.
+
+4. For each finding, create one branch and one PR. Keep each PR focused on a
+   single concern. Use conventional commit prefixes (`docs:`, `fix:`, `refactor:`).
+
+5. Update `docs/QUALITY_GRADES.md` Last audited date for any subsystem you
+   reviewed during this run.
+
+## Constraints
+
+- Open at most 3 PRs per run to keep review load manageable.
+- Do not modify application logic -- only documentation, configuration, and
+  trivially fixable patterns (e.g., renaming an import, fixing a broken link).
+- If a finding requires judgment or design decisions, file it as a GitHub issue
+  instead of a PR.
+- If nothing is stale or drifted, report "nothing stale found" and exit cleanly.
+
+## Output
+
+End your run with a summary:
+```
+## Doc-Gardener Run Summary
+- Subsystems audited: [list]
+- Stale references found: N
+- Pattern violations found: N
+- PRs opened: [list with URLs]
+- Issues filed: [list with URLs]
+- QUALITY_GRADES.md updated: yes/no
+```

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-16" # auto-bump (channel-core-hints)
+last_verified: "2026-05-16T21:30:00" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-16" # auto-bump
+last_verified: "2026-05-16T21:30:00" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/doc-gardener-seed.ts
+++ b/src/doc-gardener-seed.ts
@@ -1,0 +1,26 @@
+import { CronExpressionParser } from 'cron-parser';
+
+import { TIMEZONE } from './config.js';
+import { createTask, getTaskById } from './db.js';
+
+const GARDENER_ID = 'doc-gardener-weekly';
+const CRON_EXPR = '0 3 * * 1'; // Monday 03:00 local — low-traffic window
+
+export function seedDocGardener(jid: string, folder: string): void {
+  if (!jid || !folder) return;
+  if (getTaskById(GARDENER_ID)) return;
+  const interval = CronExpressionParser.parse(CRON_EXPR, { tz: TIMEZONE });
+  createTask({
+    id: GARDENER_ID,
+    chat_jid: jid,
+    group_folder: folder,
+    prompt: 'Run the doc-gardener agent per .claude/agents/doc-gardener.md',
+    schedule_type: 'cron',
+    schedule_value: CRON_EXPR,
+    context_mode: 'isolated',
+    next_run: interval.next().toISOString(),
+    status: 'active',
+    created_at: new Date().toISOString(),
+    agent_backend: null,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from './sender-allowlist.js';
 import { runStartupChecks, printStartupReport } from './startup-gate.js';
 import { startSchedulerLoop } from './task-scheduler.js';
+import { seedDocGardener } from './doc-gardener-seed.js';
 import { getAllTasks } from './db.js';
 import { writeGroupsSnapshot, writeTasksSnapshot } from './container-runner.js';
 import { Channel, NewMessage, NewReaction } from './types.js';
@@ -73,6 +74,13 @@ async function main(): Promise<void> {
   const state = new RouterState();
   state.load();
   restoreRemoteControl();
+
+  const controlGroup = Object.entries(state.registeredGroups).find(
+    ([, g]) => g.isControlGroup === true,
+  );
+  if (controlGroup) {
+    seedDocGardener(controlGroup[0], controlGroup[1].folder);
+  }
 
   // Start credential proxy (containers route API calls through this)
   const proxyServer = await startCredentialProxy(


### PR DESCRIPTION
## Summary
- Adds `src/doc-gardener-seed.ts` — idempotent startup seed that registers a weekly background agent in the `scheduled_tasks` table
- Adds `.claude/agents/doc-gardener.md` — agent definition (model: sonnet) that scans for stale docs and pattern drift
- Wires seed call into `src/index.ts` after `state.load()`, before `startSchedulerLoop()`

**Design pattern:** Idempotent Startup Seed — inserts task row at process start if absent. Chosen over IPC-only because no `deus task add` CLI exists. Seeds only when a control group is registered; skips silently on fresh installs and retries on next restart.

**Schedule:** Monday 03:00 local (low-traffic window), isolated context mode, max 3 PRs per run.

Depends on #443 (exec-plans + quality grades) which is already merged.

## Test plan
- [ ] `npx tsc --noEmit --project tsconfig.json` exits 0
- [ ] `python3 scripts/sync_agent_skills.py --check` exits 0
- [ ] After restart with a control group registered: `sqlite3 ~/.deus/deus.db "SELECT id, next_run FROM scheduled_tasks WHERE id='doc-gardener-weekly';"` returns one row
- [ ] Second restart: no duplicate row (idempotency)
- [ ] Manual trigger via `UPDATE scheduled_tasks SET next_run=datetime('now')` causes agent run on next poll

🤖 Generated with [Claude Code](https://claude.ai/code)