### PR TITLE
feat(pp): agent-native protocol for mcp-x + mcp-whatsapp + drift_check upgrade

### DIFF
--- a/packages/mcp-channel-core/src/index.ts
+++ b/packages/mcp-channel-core/src/index.ts
@@ -1,7 +1,17 @@
 export { resizeAndEncode } from './image-util.js';
 export { MessageBuffer } from './message-buffer.js';
-export { mcpError, McpErrorCode, mcpResponse } from './response.js';
-export type { McpResponseOptions } from './response.js';
+export {
+  mcpError,
+  McpErrorCode,
+  mcpResponse,
+  withMcpError,
+} from './response.js';
+export type {
+  McpErrorResult,
+  McpResponseOptions,
+  McpTextContent,
+  McpToolResult,
+} from './response.js';
 export { registerCommonTools } from './server-base.js';
 export type {
   ChannelProvider,

--- a/packages/mcp-channel-core/src/response.ts
+++ b/packages/mcp-channel-core/src/response.ts
@@ -12,9 +12,9 @@ export interface McpResponseOptions {
   truncateAt?: number;
 }
 
-type McpTextContent = { type: 'text'; text: string };
-type McpToolResult = { content: McpTextContent[] };
-type McpErrorResult = McpToolResult & { isError: true };
+export type McpTextContent = { type: 'text'; text: string };
+export type McpToolResult = { content: McpTextContent[] };
+export type McpErrorResult = McpToolResult & { isError: true };
 
 function stripNulls(obj: unknown, truncateAt: number): unknown {
   if (Array.isArray(obj)) {
@@ -109,4 +109,25 @@ export function mcpError(
     content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
     isError: true,
   };
+}
+
+/**
+ * Wraps an async tool handler: success → mcpResponse(result, opts);
+ * thrown error → mcpError(API_ERROR, msg, resource).
+ */
+export async function withMcpError<T>(
+  resource: string,
+  fn: () => Promise<T>,
+  opts?: McpResponseOptions,
+): Promise<McpToolResult | McpErrorResult> {
+  try {
+    const result = await fn();
+    return mcpResponse(result, opts);
+  } catch (err: unknown) {
+    return mcpError(
+      McpErrorCode.API_ERROR,
+      err instanceof Error ? err.message : String(err),
+      resource,
+    );
+  }
 }

--- a/packages/mcp-whatsapp/src/index.ts
+++ b/packages/mcp-whatsapp/src/index.ts
@@ -17,7 +17,12 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import pino from 'pino';
 import { z } from 'zod';
-import { registerCommonTools } from '@deus-ai/channel-core';
+import {
+  mcpError,
+  McpErrorCode,
+  mcpResponse,
+  registerCommonTools,
+} from '@deus-ai/channel-core';
 
 import { WhatsAppProvider } from './whatsapp.js';
 
@@ -40,25 +45,24 @@ registerCommonTools(server, provider);
 
 server.tool(
   'get_auth_status',
-  'Check whether WhatsApp credentials exist and the connection is authenticated',
-  {},
-  async () => {
+  'Check whether WhatsApp credentials exist and the connection is authenticated. Pass select="connected" + compact=true for a slimmer response.',
+  {
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
+  },
+  async (args) => {
     const hasAuth = provider.hasAuth();
     const connected = provider.isConnected();
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify({ has_credentials: hasAuth, connected }),
-        },
-      ],
-    };
+    return mcpResponse(
+      { has_credentials: hasAuth, connected },
+      { compact: args.compact, select: args.select },
+    );
   },
 );
 
 server.tool(
   'start_auth',
-  'Begin WhatsApp authentication. Returns QR code data or pairing code.',
+  'Begin WhatsApp authentication. Returns QR code data or pairing code. Pass select="status" + compact=true for a slimmer response.',
   {
     method: z.enum(['qr', 'pairing-code']).describe('Authentication method'),
     phone: z
@@ -67,20 +71,16 @@ server.tool(
       .describe(
         'Phone number (required for pairing-code method, e.g. 14155551234)',
       ),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
   async (args) => {
     if (args.method === 'pairing-code' && !args.phone) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              error: 'Phone number required for pairing-code method',
-            }),
-          },
-        ],
-        isError: true,
-      };
+      return mcpError(
+        McpErrorCode.USAGE,
+        'Phone number required for pairing-code method',
+        'whatsapp.start_auth',
+      );
     }
     // Auth is handled by the connect flow — this tool triggers it.
     // The provider writes QR data to disk; the client reads it.
@@ -92,33 +92,21 @@ server.tool(
           { err, source: 'whatsapp.start_auth.connect' },
           'provider connect failed during start_auth',
         );
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                error: 'connect failed during start_auth',
-                detail: err instanceof Error ? err.message : String(err),
-                source: 'whatsapp.start_auth.connect',
-              }),
-            },
-          ],
-          isError: true,
-        };
+        return mcpError(
+          McpErrorCode.API_ERROR,
+          err instanceof Error ? err.message : String(err),
+          'whatsapp.start_auth.connect',
+        );
       }
     }
     const status = provider.getStatus();
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify({
-            status: status.connected ? 'connected' : 'authenticating',
-            identity: status.identity,
-          }),
-        },
-      ],
-    };
+    return mcpResponse(
+      {
+        status: status.connected ? 'connected' : 'authenticating',
+        identity: status.identity,
+      },
+      { compact: args.compact, select: args.select },
+    );
   },
 );
 

--- a/packages/mcp-x/package.json
+++ b/packages/mcp-x/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@deus-ai/channel-core": "file:../mcp-channel-core",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "pino": "^10.3.1",
     "twitter-api-v2": "^1.19.0",

--- a/packages/mcp-x/src/index.ts
+++ b/packages/mcp-x/src/index.ts
@@ -16,6 +16,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { mcpResponse, withMcpError } from '@deus-ai/channel-core';
 import { z } from 'zod';
 
 import { XClient } from './x.js';
@@ -31,44 +32,51 @@ const x = new XClient();
 
 server.tool(
   'post_tweet',
-  'Post a new tweet',
-  { text: z.string().max(280, 'Tweet must be 280 characters or fewer') },
-  async (args) => {
-    const result = await x.postTweet(args.text);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-    };
+  'Post a new tweet. Pass select="id,url" + compact=true to slim the returned TweetResult.',
+  {
+    text: z.string().max(280, 'Tweet must be 280 characters or fewer'),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
+  async (args) =>
+    withMcpError('x.post_tweet', () => x.postTweet(args.text), {
+      compact: args.compact,
+      select: args.select,
+    }),
 );
 
 server.tool(
   'reply_to_tweet',
-  'Reply to an existing tweet',
+  'Reply to an existing tweet. Pass select="id,url" + compact=true to slim the returned TweetResult.',
   {
     tweet_id: z.string(),
     text: z.string().max(280, 'Tweet must be 280 characters or fewer'),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
-  async (args) => {
-    const result = await x.replyToTweet(args.tweet_id, args.text);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-    };
-  },
+  async (args) =>
+    withMcpError(
+      'x.reply_to_tweet',
+      () => x.replyToTweet(args.tweet_id, args.text),
+      { compact: args.compact, select: args.select },
+    ),
 );
 
 server.tool(
   'quote_tweet',
-  'Quote an existing tweet with added commentary',
+  'Quote an existing tweet with added commentary. Pass select="id,url" + compact=true to slim the returned TweetResult.',
   {
     tweet_id: z.string(),
     text: z.string().max(280, 'Tweet must be 280 characters or fewer'),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
-  async (args) => {
-    const result = await x.quoteTweet(args.tweet_id, args.text);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-    };
-  },
+  async (args) =>
+    withMcpError(
+      'x.quote_tweet',
+      () => x.quoteTweet(args.tweet_id, args.text),
+      { compact: args.compact, select: args.select },
+    ),
 );
 
 // ── Engage ────────────────────────────────────────────────────────────
@@ -117,64 +125,79 @@ server.tool(
 
 server.tool(
   'get_timeline',
-  'Get recent tweets from your home timeline',
-  { count: z.number().int().min(1).max(100).optional().default(10) },
-  async (args) => {
-    const tweets = await x.getTimeline(args.count);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(tweets) }],
-    };
+  'Get recent tweets from your home timeline. Pass select="id,url" + compact=true to cut payload on list ops.',
+  {
+    count: z.number().int().min(1).max(100).optional().default(10),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
+  async (args) =>
+    withMcpError('x.get_timeline', () => x.getTimeline(args.count), {
+      compact: args.compact,
+      select: args.select,
+    }),
 );
 
 server.tool(
   'search_tweets',
-  'Search recent tweets by keyword or query',
+  'Search recent tweets by keyword or query. Pass select="id,url" + compact=true to cut payload on list ops.',
   {
     query: z.string(),
     count: z.number().int().min(10).max(100).optional().default(10),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
-  async (args) => {
-    const tweets = await x.searchTweets(args.query, args.count);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(tweets) }],
-    };
-  },
+  async (args) =>
+    withMcpError(
+      'x.search_tweets',
+      () => x.searchTweets(args.query, args.count),
+      { compact: args.compact, select: args.select },
+    ),
 );
 
 server.tool(
   'get_tweet',
-  'Get a single tweet by ID',
-  { tweet_id: z.string() },
-  async (args) => {
-    const tweet = await x.getTweet(args.tweet_id);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(tweet) }],
-    };
+  'Get a single tweet by ID. Pass select="id,url" + compact=true to slim the response.',
+  {
+    tweet_id: z.string(),
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
   },
+  async (args) =>
+    withMcpError('x.get_tweet', () => x.getTweet(args.tweet_id), {
+      compact: args.compact,
+      select: args.select,
+    }),
 );
 
-server.tool('get_my_profile', 'Get your own X profile info', {}, async () => {
-  const profile = await x.getMyProfile();
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(profile) }],
-  };
-});
+server.tool(
+  'get_my_profile',
+  'Get your own X profile info. Pass select="id,username,name" + compact=true for a slimmer response.',
+  {
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
+  },
+  async (args) =>
+    withMcpError('x.get_my_profile', () => x.getMyProfile(), {
+      compact: args.compact,
+      select: args.select,
+    }),
+);
 
 server.tool(
   'get_status',
-  'Check whether X credentials are configured',
-  {},
-  async () => {
+  'Check whether X credentials are configured. Pass select="configured" + compact=true for a minimal response.',
+  {
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
+  },
+  async (args) => {
+    // No try/catch needed — x.isConfigured() is pure (no API call).
     const configured = x.isConfigured();
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify({ configured, channel: 'x' }),
-        },
-      ],
-    };
+    return mcpResponse(
+      { configured, channel: 'x' },
+      { compact: args.compact, select: args.select },
+    );
   },
 );
 

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-16" # auto-bump (channel-core-hints)
+last_verified: "2026-05-16" # auto-bump (channels-agent-native)
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-16T21:30:00" # auto-bump
+last_verified: "2026-05-16T21:30:00" # auto-bump (channels-agent-native)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1099,12 +1099,36 @@ def check_agent_native_mcp(project_root: Path) -> int:
             lines = text.splitlines()
             for i, line in enumerate(lines, 1):
                 if "server.tool(" in line:
-                    # Look at the next 5 lines for compact/select
-                    block = "\n".join(lines[i - 1 : i + 8])
-                    if "compact" not in block and "select" not in block:
-                        # Skip action-only tools (return static strings, not data)
-                        action_markers = ("'Message sent.'", "'OK'", "'Connected.'", "'Disconnected.'", "'Email sent.'", "mcpResponse({")
-                        if any(m in block for m in action_markers):
+                    # Schema check (15-line window): zod schema literals sit in
+                    # the call's third positional arg. 15 lines is wide enough
+                    # for the largest schemas in this codebase (e.g. mcp-gcal
+                    # `create_event` has 6 typed fields plus compact/select)
+                    # while still being narrower than the action-marker scan
+                    # below, so we don't accidentally match handler-body usage.
+                    # Match against `compact:` / `select:` with trailing colon
+                    # (zod schema syntax) so descriptions that mention
+                    # `compact=true` as a usage hint don't cause false-negatives.
+                    block = "\n".join(lines[i - 1 : i + 15])
+                    if "compact:" not in block and "select:" not in block:
+                        # Action-marker scan uses a wider window (30 lines)
+                        # because confirmation strings can appear deep in the
+                        # handler body — e.g., server-base.ts `connect` returns
+                        # 'Connected.' 10 lines below the server.tool() decl;
+                        # `disconnect` returns 'Disconnected.' 14 lines below.
+                        action_block = "\n".join(lines[i - 1 : i + 30])
+                        action_markers = (
+                            "'Message sent.'",
+                            "'OK'",
+                            "'Connected.'",
+                            "'Disconnected.'",
+                            "'Email sent.'",
+                            "'Liked.'",
+                            "'Like removed.'",
+                            "'Retweeted.'",
+                            "'Retweet removed.'",
+                            "mcpResponse({",
+                        )
+                        if any(m in action_block for m in action_markers):
                             continue
                         rel = ts_file.relative_to(project_root)
                         violations.append(f"  {rel}:{i} — server.tool() without compact/select params")

--- a/scripts/tests/test_agent_native_markers.py
+++ b/scripts/tests/test_agent_native_markers.py
@@ -1,0 +1,281 @@
+"""
+Tests for drift_check.check_agent_native_mcp action-marker classification.
+
+Specifically verifies:
+  1. The widened 30-line scan window catches action markers in deep handler
+     bodies (where the prior 8-line window false-positived on
+     server-base.ts send_message/connect/disconnect).
+  2. The four mcp-x engagement markers ('Liked.', 'Like removed.',
+     'Retweeted.', 'Retweet removed.') correctly classify those tools as
+     action-only.
+"""
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts/ is importable.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import drift_check
+
+
+def _make_pkg(root: Path, pkg_name: str, tool_src: str) -> None:
+    src = root / "packages" / pkg_name / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "index.ts").write_text(tool_src)
+
+
+# Action-only tool with marker DEEP in the handler body (line ~14 from
+# server.tool decl) — pre-widening this would false-positive.
+_DEEP_ACTION_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'connect',
+  'Connect to the platform',
+  {},
+  async () => {
+    try {
+      // simulate some work
+      await provider.connect();
+      // more setup
+      const status = provider.getStatus();
+      // assertions
+      if (!status.connected) {
+        throw new Error('not connected');
+      }
+    } catch (err) {
+      return { content: [{ type: 'text', text: 'error' }], isError: true };
+    }
+    return { content: [{ type: 'text', text: 'Connected.' }] };
+  },
+);
+"""
+
+# Action-only tool returning 'Liked.' — new marker in this PR.
+_LIKE_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'like_tweet',
+  'Like a tweet',
+  { tweet_id: z.string() },
+  async (args) => {
+    await x.likeTweet(args.tweet_id);
+    return { content: [{ type: 'text', text: 'Liked.' }] };
+  },
+);
+"""
+
+# Action-only tool returning 'Retweeted.' — new marker in this PR.
+_RETWEET_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'retweet',
+  'Retweet a tweet',
+  { tweet_id: z.string() },
+  async (args) => {
+    await x.retweet(args.tweet_id);
+    return { content: [{ type: 'text', text: 'Retweeted.' }] };
+  },
+);
+"""
+
+# Action-only tool returning 'Like removed.' — new marker in this PR.
+_UNLIKE_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'unlike_tweet',
+  'Remove a like from a tweet',
+  { tweet_id: z.string() },
+  async (args) => {
+    await x.unlikeTweet(args.tweet_id);
+    return { content: [{ type: 'text', text: 'Like removed.' }] };
+  },
+);
+"""
+
+# Action-only tool returning 'Retweet removed.' — new marker in this PR.
+_UNDO_RETWEET_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'undo_retweet',
+  'Undo a retweet',
+  { tweet_id: z.string() },
+  async (args) => {
+    await x.undoRetweet(args.tweet_id);
+    return { content: [{ type: 'text', text: 'Retweet removed.' }] };
+  },
+);
+"""
+
+# Data-returning tool with NO compact/select and NO action marker — should warn.
+_UNMIGRATED_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'get_data',
+  'Fetch some data',
+  { id: z.string() },
+  async (args) => {
+    const data = await provider.fetch(args.id);
+    return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+  },
+);
+"""
+
+# Already-migrated tool with compact + select in schema — should pass cleanly.
+_MIGRATED_TOOL = """\
+import { z } from 'zod';
+
+server.tool(
+  'list_items',
+  'List items',
+  {
+    compact: z.boolean().optional(),
+    select: z.string().optional(),
+  },
+  async (args) => {
+    const items = await provider.list();
+    return mcpResponse(items, { compact: args.compact, select: args.select });
+  },
+);
+"""
+
+
+class TestActionMarkerScanWindow:
+    def test_deep_action_marker_skipped(self, tmp_path: Path) -> None:
+        """Action marker ~14 lines below server.tool() decl is correctly skipped."""
+        _make_pkg(tmp_path, "mcp-deep", _DEEP_ACTION_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+        assert "All MCP tool registrations" in buf.getvalue()
+
+    def test_liked_marker_skipped(self, tmp_path: Path) -> None:
+        """`'Liked.'` is a recognized action marker (mcp-x engagement tools)."""
+        _make_pkg(tmp_path, "mcp-like", _LIKE_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+
+    def test_retweeted_marker_skipped(self, tmp_path: Path) -> None:
+        """`'Retweeted.'` is a recognized action marker."""
+        _make_pkg(tmp_path, "mcp-rt", _RETWEET_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+
+    def test_like_removed_marker_skipped(self, tmp_path: Path) -> None:
+        """`'Like removed.'` is a recognized action marker (mcp-x unlike_tweet)."""
+        _make_pkg(tmp_path, "mcp-unlike", _UNLIKE_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+
+    def test_retweet_removed_marker_skipped(self, tmp_path: Path) -> None:
+        """`'Retweet removed.'` is a recognized action marker (mcp-x undo_retweet)."""
+        _make_pkg(tmp_path, "mcp-undo-rt", _UNDO_RETWEET_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+
+    def test_unmigrated_tool_warns(self, tmp_path: Path) -> None:
+        """Data-returning tool without compact/select or action marker is flagged."""
+        _make_pkg(tmp_path, "mcp-unmig", _UNMIGRATED_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        # Informational — always returns 0.
+        assert rc == 0
+        out = buf.getvalue()
+        assert "missing agent-native params (1)" in out
+        assert "mcp-unmig/src/index.ts" in out
+
+    def test_migrated_tool_passes(self, tmp_path: Path) -> None:
+        """Tool with compact + select in schema is recognized as migrated."""
+        _make_pkg(tmp_path, "mcp-mig", _MIGRATED_TOOL)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+
+    def test_marker_near_window_boundary(self, tmp_path: Path) -> None:
+        """Action marker ~20 lines below decl is comfortably inside 30-line window."""
+        # 20 lines of filler between server.tool() and the return statement.
+        # The action-marker scan window is 30 lines; this marker lands at ~25.
+        filler = "\n".join(f"      // filler line {n}" for n in range(20))
+        boundary_src = f"""\
+import {{ z }} from 'zod';
+
+server.tool(
+  'big_action',
+  'A tool with a deep handler body',
+  {{}},
+  async () => {{
+{filler}
+      return {{ content: [{{ type: 'text', text: 'OK' }}] }};
+  }},
+);
+"""
+        _make_pkg(tmp_path, "mcp-deep-boundary", boundary_src)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0
+        assert "missing agent-native params" not in buf.getvalue()
+
+
+class TestSchemaMatchTightening:
+    """Verify the `compact:` / `select:` match (with colon) catches a regression
+    where a tool's DESCRIPTION mentions the hint but the SCHEMA lacks the params.
+    """
+
+    def test_hint_in_description_alone_does_not_pass(self, tmp_path: Path) -> None:
+        # Description references the params but schema omits them — pre-tightening
+        # the bare "compact"/"select" substring match would let this slip through.
+        sneaky_src = """\
+import { z } from 'zod';
+
+server.tool(
+  'sneaky',
+  'Returns data. Pass select="id" + compact=true to slim payload.',
+  { id: z.string() },
+  async (args) => {
+    const data = await provider.fetch(args.id);
+    return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+  },
+);
+"""
+        _make_pkg(tmp_path, "mcp-sneaky", sneaky_src)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = drift_check.check_agent_native_mcp(tmp_path)
+        assert rc == 0  # informational
+        out = buf.getvalue()
+        # With the tightened `compact:` / `select:` match, this is now flagged.
+        assert "missing agent-native params (1)" in out
+        assert "mcp-sneaky/src/index.ts" in out
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Completes the PP rollout across channel MCPs. **All 19 violations** previously surfaced by `check_agent_native_mcp` are now resolved: 10 tools migrated, 9 (legitimately action-only) skipped via the upgraded check, 0 informational findings on this PR's surface.

After this lands, `drift_check.check_agent_native_mcp` and `check_mcp_description_hints` both report zero violations across all channel MCPs.

## Migrated tools (10)

**mcp-x (8)** — `TweetResult` / `TweetResult[]` / `UserProfile` / status shapes:
- `post_tweet`, `reply_to_tweet`, `quote_tweet`, `get_timeline`, `search_tweets`, `get_tweet`, `get_my_profile`, `get_status`

**mcp-whatsapp (2)**:
- `get_auth_status`, `start_auth` (error paths now use `mcpError(USAGE / API_ERROR, ...)` instead of raw `isError` envelopes)

Each migrated tool: schema `compact`/`select` zod params, threads through `mcpResponse`, wraps API calls in `mcpError(API_ERROR, ...)` on failure, carries a usage hint in its description.

## Action-only tools — untouched (9)

These return fixed confirmation strings and have no projection benefit:
- mcp-x: `like_tweet`, `unlike_tweet`, `retweet`, `undo_retweet`
- mcp-channel-core: `send_message`, `connect`, `disconnect`

## Infrastructure additions

### `withMcpError` helper in `@deus-ai/channel-core`

```ts
async (args) =>
  withMcpError('x.post_tweet', () => x.postTweet(args.text), {
    compact: args.compact, select: args.select,
  })
```

Collapses 7 mcp-x tool handlers from 11-line try/catch blocks to single-line expressions. Types exported alongside (`McpToolResult`, `McpErrorResult`, `McpTextContent`).

### `drift_check.check_agent_native_mcp` upgrade

- Schema-check window: 8 → 15 lines (covers `mcp-gcal create_event` with 6 typed fields before `compact:` at line+11)
- Action-marker window: 8 → 30 lines (caught the 3 false positives: server-base.ts `connect` marker at line+10, `disconnect` at line+14)
- 4 new markers: `'Liked.'`, `'Like removed.'`, `'Retweeted.'`, `'Retweet removed.'`
- Tightened bare-word → colon-suffixed match (`compact:` / `select:`) so description hints containing `compact=true` don't false-negative on unmigrated schemas

## Tests (new file, 9 cases)

`scripts/tests/test_agent_native_markers.py`:
- Deep action marker (~14 lines below decl) correctly skipped
- All 4 new markers correctly classify their tools as action-only
- Boundary case (marker ~25 lines below) still inside the window
- Unmigrated tool correctly warned
- Migrated tool correctly passes
- "Sneaky" case: description hint without schema params is correctly flagged (validates the colon-suffix tightening)

## Verification

- [x] **103/103 tests pass** (94 existing drift_check + pp_description_hints + 9 new in agent_native_markers)
- [x] `drift_check.py --all --base origin/main` → exit 0:
  - `All MCP tool registrations include agent-native params.` (was: 19 violations)
  - `All projection-capable MCP tools include description hints.` (stays at 0)
- [x] tsc clean: mcp-channel-core + mcp-x
- [x] Plan-reviewer v2 SHIP (after v1 caught try/catch + action_markers gaps)
- [x] Code-reviewer v3 SHIP (after v2 caught raw `isError` envelopes in start_auth + duplication of try/catch; v3 polish: docstring trim, type exports, 2 more marker tests)

## Out of scope

- Schema additions to action-only tools (no benefit; they return fixed strings)
- mcp-discord / mcp-slack / mcp-telegram — these are `registerCommonTools`-only with no channel-specific tools; #445 already covered the common tools they inherit

🤖 Generated with [Claude Code](https://claude.com/claude-code)