### PR TITLE
feat(drift): flip agent-native + description-hints checks to blocking

### DIFF
--- a/docs/decisions/printing-press-adoption.md
+++ b/docs/decisions/printing-press-adoption.md
@@ -105,4 +105,4 @@ MCP responses MUST be JSON per protocol. Wide structured records (calendar event
 
 ### Drift enforcement
 
-A sibling check `check_mcp_description_hints` in `scripts/drift_check.py` warns (informational) when any `server.tool()` whose schema accepts BOTH `compact` and `select` lacks a hint in its description. The existing `check_agent_native_mcp` continues to enforce schema-level adoption.
+Both `check_agent_native_mcp` and `check_mcp_description_hints` in `scripts/drift_check.py` are blocking: any `server.tool()` registration that lacks `compact`/`select` schema params (without a recognized action-marker) — or that has the schema params but no `select`/`compact`/`payload` hint in its description — fails CI. Both gates started informational and were activated after PR #448 cleared the baseline across mcp-channel-core, mcp-gcal, mcp-gmail, mcp-x, and mcp-whatsapp. See `git log --follow scripts/drift_check.py` for the activation commit.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-16" # auto-bump
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1080,8 +1080,9 @@ def check_agent_native_mcp(project_root: Path) -> int:
     """Verify new MCP tool registrations include compact/select params.
 
     Scans packages/mcp-*/src/ for server.tool() calls and checks that
-    each has compact and select in its schema. Informational — warns but
-    does not fail CI (new integrations in progress may not have it yet).
+    each has compact and select in its schema. Blocking — fails CI on
+    any violation. Baseline was cleared by PR #448 before this gate
+    was activated; see git history for the activation commit.
     """
     packages_dir = project_root / "packages"
     if not packages_dir.exists():
@@ -1139,7 +1140,7 @@ def check_agent_native_mcp(project_root: Path) -> int:
             print(v)
         print("\nFIX: add compact: z.boolean().optional(), select: z.string().optional() to tool schemas.")
         print("See docs/decisions/printing-press-adoption.md and patterns/channel-add.md.")
-        return 0  # informational until pre-existing violations are cleaned up
+        return 1  # blocking — fails CI on any new violation
     else:
         print(f"All MCP tool registrations include agent-native params.")
     return 0
@@ -1159,8 +1160,10 @@ def check_mcp_description_hints(project_root: Path) -> int:
       - Multi-line descriptions (e.g., 'foo ' + 'bar') are not supported;
         only the first quoted-string line after the tool name is checked.
 
-    Informational — warns but does not fail CI. See
-    docs/decisions/printing-press-adoption.md "Empirical findings".
+    Blocking — fails CI on any violation. Baseline was cleared by PR
+    #448 before this gate was activated alongside its agent-native
+    sibling; see git history for the activation commit.
+    See docs/decisions/printing-press-adoption.md "Empirical findings".
     """
     packages_dir = project_root / "packages"
     if not packages_dir.exists():
@@ -1210,7 +1213,7 @@ def check_mcp_description_hints(project_root: Path) -> int:
             "'List events. Pass select=\"id,start,summary\" + compact=true to cut payload.'"
         )
         print("See docs/decisions/printing-press-adoption.md and patterns/channel-add.md.")
-        return 0  # informational
+        return 1  # blocking — fails CI on any new violation
     print("All projection-capable MCP tools include description hints.")
     return 0
 

--- a/scripts/tests/test_agent_native_markers.py
+++ b/scripts/tests/test_agent_native_markers.py
@@ -198,14 +198,14 @@ class TestActionMarkerScanWindow:
         assert rc == 0
         assert "missing agent-native params" not in buf.getvalue()
 
-    def test_unmigrated_tool_warns(self, tmp_path: Path) -> None:
-        """Data-returning tool without compact/select or action marker is flagged."""
+    def test_unmigrated_tool_is_blocked(self, tmp_path: Path) -> None:
+        """Data-returning tool without compact/select or action marker is flagged AND blocks."""
         _make_pkg(tmp_path, "mcp-unmig", _UNMIGRATED_TOOL)
         buf = io.StringIO()
         with redirect_stdout(buf):
             rc = drift_check.check_agent_native_mcp(tmp_path)
-        # Informational — always returns 0.
-        assert rc == 0
+        # Blocking — non-zero on any violation.
+        assert rc == 1
         out = buf.getvalue()
         assert "missing agent-native params (1)" in out
         assert "mcp-unmig/src/index.ts" in out
@@ -270,7 +270,7 @@ server.tool(
         buf = io.StringIO()
         with redirect_stdout(buf):
             rc = drift_check.check_agent_native_mcp(tmp_path)
-        assert rc == 0  # informational
+        assert rc == 1  # blocking — gate active
         out = buf.getvalue()
         # With the tightened `compact:` / `select:` match, this is now flagged.
         assert "missing agent-native params (1)" in out

--- a/scripts/tests/test_pp_description_hints.py
+++ b/scripts/tests/test_pp_description_hints.py
@@ -84,13 +84,13 @@ class TestCheckMcpDescriptionHints:
         assert "missing description hints" not in buf.getvalue()
         assert "All projection-capable MCP tools" in buf.getvalue()
 
-    def test_warns_when_hint_missing(self, tmp_path: Path) -> None:
+    def test_hint_missing_is_blocked(self, tmp_path: Path) -> None:
         _make_pkg(tmp_path, "mcp-unhinted", _UNHINTED_TOOL)
         buf = io.StringIO()
         with redirect_stdout(buf):
             rc = drift_check.check_mcp_description_hints(tmp_path)
-        # Informational only — always returns 0.
-        assert rc == 0
+        # Blocking — non-zero on any violation.
+        assert rc == 1
         out = buf.getvalue()
         assert "missing description hints (1)" in out
         assert "mcp-unhinted/src/index.ts" in out


### PR DESCRIPTION
## Summary

Both `check_agent_native_mcp` and `check_mcp_description_hints` in `scripts/drift_check.py` are flipped from informational (always `return 0`) to blocking (`return 1` on violation). Closes the agent-native cleanup series: PR A → superseded by #448; PR B + C → done by #448; PR D (this) → the gate flip.

## Why now

Pre-#448, both checks reported violations across mcp-channel-core, mcp-gcal, mcp-gmail, mcp-x, and mcp-whatsapp. The "informational" status was a deliberate deferral until the baseline was cleared. PR #448 (`4b41b06`) migrated 10 tools, added 4 new action markers, and tightened the schema matcher — both checks now report zero violations. The pre-existing-violations caveat no longer applies; future regressions can safely be gated.

## Verification

- `python3 -m pytest scripts/tests/test_drift_check.py scripts/tests/test_agent_native_markers.py scripts/tests/test_pp_description_hints.py -q` → **103/103 passing**
- `python3 scripts/drift_check.py --base origin/main` → `ALL PATTERNS UP-TO-DATE`, exit 0
- Synthetic violation injected → `check_agent_native_mcp` returns `1` (gate active)
- CI workflow already invokes `drift_check.py --all` — non-zero exits will fail the job
- Plan-reviewer SHIP (round 2), code-reviewer SHIP (round 3 after reviewing the correct diff), verification-gate SHIP

## Changes

| File | Change |
|------|--------|
| `scripts/drift_check.py` | 2 × `return 0` → `return 1` + 2 docstrings updated |
| `scripts/tests/test_agent_native_markers.py` | 2 assertion flips + 1 test rename |
| `scripts/tests/test_pp_description_hints.py` | 1 assertion flip + 1 test rename |
| `docs/decisions/printing-press-adoption.md` | "Drift enforcement" paragraph amended to record both checks blocking |
| `patterns/documentation.md` | drift-bump (separate commit) |

## Test plan
- [x] All updated tests pass
- [x] `drift_check.py --all` exits 0 on clean repo
- [x] Synthetic violation produces non-zero exit
- [x] ADR amendment documents the policy change
- [x] CI workflow unchanged (no edits needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)