### PR TITLE
fix(skills): replace claude -p with in-session Agent in compress retrospective

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -173,15 +173,13 @@ After saving the session log:
    ```
 
    Read `session_window` from `~/deus/.claude/wardens/retrospective-schema.md` (default: 20).
-   If `NEW_COUNT >= session_window`, dispatch the retrospective agent in the background:
+   If `NEW_COUNT >= session_window`, dispatch the retrospective via an in-session Agent subagent (background):
 
-   ```bash
-   command -v claude >/dev/null 2>&1 && \
-     claude -p "Use the session-retrospective subagent. SESSION_LOG_ROOT=\"$VAULT\"" \
-     > /dev/null 2>&1 &
-   ```
+   Use the Agent tool with `subagent_type: "session-retrospective"`, `run_in_background: true`, and prompt:
+   `"Run a session retrospective. SESSION_LOG_ROOT=$VAULT"` (substitute the resolved `$VAULT` variable).
 
-   If `claude` CLI is not available (e.g. Codex backend), skip silently.
+   This avoids `claude -p` which draws from the Agent SDK credit on subscription plans.
+   If the Agent tool is unavailable (e.g. non-Claude backend), skip silently.
    If any check fails, skip silently — the retrospective can always be triggered manually.
 
 Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, atom extraction result, and whether a session retrospective was triggered (home mode only — report "retrospective triggered (background)" or "retrospective skipped: <reason>").

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-15" # auto-bump
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Replaces `claude -p` shell-out in compress skill's retrospective dispatch (step 7) with an in-session Agent subagent call
- Avoids drawing from the separate Agent SDK credit bucket on subscription plans (effective June 15 2026)
- Preserves fallback/skip-silently behavior for non-Claude backends

## Test plan
- [ ] Run `/compress` in a session where `NEW_COUNT >= session_window` and confirm Agent tool dispatches the retrospective (visible in tool output)
- [ ] Verify no `claude -p` subprocess is spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)