### PR TITLE
feat(backends): add llama.cpp as third agent backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ OPENAI_API_KEY=
 OPENAI_BASE_URL=
 GEMINI_API_KEY=
 
+# llama.cpp local backend (set DEUS_AGENT_BACKEND=llama-cpp to use).
+# Install + run llama-server on the host via /add-llama-cpp skill first.
+# See docs/MULTI_BACKEND.md for the full setup flow.
+# Note: LLAMA_CPP_BASE_URL is reserved for future advanced overrides; the
+# container today routes via CONTAINER_HOST_GATEWAY + LLAMA_CPP_PORT.
+LLAMA_CPP_BASE_URL=
+LLAMA_CPP_PORT=8080
+LLAMA_CPP_MODEL=
+
 # === Voice Transcription ===
 WHISPER_LANG=en
 WHISPER_BIN=whisper-cli

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -29,10 +29,10 @@ import { bootstrap } from './bootstrap.js';
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { createMemoryRetrievalHook } from './memory-retrieval-hook.js';
 import { runOpenAIConversation } from './openai-backend.js';
+import { runLlamaCppConversation } from './llama-cpp-backend.js';
 import { DoomLoopDetector, createDoomLoopHook } from './doom-loop-detector.js';
 import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
-
-type AgentRuntimeId = 'claude' | 'openai';
+import type { AgentRuntimeId } from './tool-broker.js';
 
 interface RuntimeSession {
   backend: AgentRuntimeId;
@@ -917,6 +917,24 @@ async function main(): Promise<void> {
 
   if (backend === 'openai') {
     await runOpenAIConversation({
+      containerInput: {
+        ...containerInput,
+        backend,
+      },
+      log,
+      writeOutput,
+      drainIpcInput,
+      waitForIpcMessage,
+      shouldClose,
+    });
+    return;
+  }
+
+  if (backend === 'llama-cpp') {
+    // Dispatch to the chat/completions driver. llama-server speaks the
+    // OpenAI chat-completions wire protocol but NOT the Responses API, so
+    // we cannot reuse runOpenAIConversation (it calls /v1/responses).
+    await runLlamaCppConversation({
       containerInput: {
         ...containerInput,
         backend,

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -11,6 +11,8 @@ import fs from 'fs';
 import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
 
+import { VALID_BACKENDS } from './tool-broker.js';
+
 const IPC_DIR = '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
@@ -119,7 +121,7 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
         '(Main group only) JID of the group to schedule the task for. Defaults to the current group.',
       ),
     agent_backend: z
-      .enum(['claude', 'openai'])
+      .enum(VALID_BACKENDS)
       .optional()
       .describe(
         'Optional backend override for this task. Omit to inherit the group/default backend.',
@@ -372,7 +374,7 @@ server.tool(
       .optional()
       .describe('New schedule value (see schedule_task for format)'),
     agent_backend: z
-      .enum(['claude', 'openai'])
+      .enum(VALID_BACKENDS)
       .optional()
       .describe(
         'Optional backend override for this task. Omit to leave unchanged.',
@@ -462,7 +464,7 @@ Use available_groups.json to find the JID for a group. The folder name must be c
       ),
     trigger: z.string().describe('Trigger word (e.g., "@Deus")'),
     agent_backend: z
-      .enum(['claude', 'openai'])
+      .enum(VALID_BACKENDS)
       .optional()
       .describe(
         'Optional default backend override for this group. Omit to use the global default backend.',

--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -19,6 +19,7 @@
  * summary-based compaction is tracked as a follow-up.
  */
 
+import { randomBytes } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -424,11 +425,10 @@ export async function runLlamaCppConversation(
   const messages: ChatMessage[] = [
     { role: 'system', content: systemInstructions },
   ];
-  // Synthetic session id so the host can correlate; not tied to a server
-  // response id (llama.cpp has no server-side response state).
-  const sessionId = `llama-cpp-${Date.now()}-${Math.random()
-    .toString(36)
-    .slice(2, 8)}`;
+  // Synthetic correlation id (not a security token). Use crypto.randomBytes
+  // — Math.random() triggered a CodeQL insecure-randomness warning here and
+  // is inexpensive to resolve.
+  const sessionId = `llama-cpp-${Date.now()}-${randomBytes(4).toString('hex')}`;
 
   let prompt = containerInput.prompt;
 

--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -1,0 +1,523 @@
+/**
+ * llama.cpp container-side driver.
+ *
+ * Connects the Deus container agent to a local `llama-server` via the
+ * OpenAI-compatible `/v1/chat/completions` endpoint. Distinct from
+ * `runOpenAIConversation` (which targets the OpenAI Responses API).
+ *
+ * Reused plumbing (transport-agnostic):
+ *   - `createOpenAIMcpToolBridge`, `getOpenAIToolDefinitions`,
+ *     `executeBrokerTool` from `tool-broker.ts`
+ *   - `loadRegisteredContextFiles` for system instructions
+ *   - `fetchMemoryContext` for per-turn memory injection
+ *   - `DoomLoopDetector` and `normalizeArgs` for repeated-call detection
+ *
+ * Session continuity: messages array kept in-memory across turns within a
+ * single container lifecycle. Cross-restart resume is a follow-up.
+ *
+ * `/compact`: simple history truncation (system + last N turns). A future
+ * summary-based compaction is tracked as a follow-up.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { loadRegisteredContextFiles } from './context-registry.js';
+import { fetchMemoryContext } from './memory-retrieval-hook.js';
+import { DoomLoopDetector, normalizeArgs } from './doom-loop-detector.js';
+import {
+  type AgentRuntimeId,
+  createOpenAIMcpToolBridge,
+  executeBrokerTool,
+  getOpenAIToolDefinitions,
+  resolveGroupAttachmentPath as resolveBrokerGroupAttachmentPath,
+} from './tool-broker.js';
+
+export interface RuntimeSession {
+  backend: AgentRuntimeId;
+  session_id: string;
+  resume_cursor?: string;
+  metadata_json?: string;
+}
+
+export interface ContainerInput {
+  prompt: string;
+  backend?: AgentRuntimeId;
+  sessionId?: string;
+  sessionRef?: RuntimeSession;
+  groupFolder: string;
+  chatJid: string;
+  isMain?: boolean;
+  isControlGroup?: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
+  projectHint?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+}
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionRef?: RuntimeSession;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface LlamaCppContext {
+  containerInput: ContainerInput;
+  log: (message: string) => void;
+  writeOutput: (output: ContainerOutput) => void;
+  drainIpcInput: () => string[];
+  waitForIpcMessage: () => Promise<string | null>;
+  shouldClose: () => boolean;
+}
+
+// OpenAI chat-completions message shapes. Defined here (not imported)
+// because llama.cpp's response format diverges from the Responses API.
+type ChatRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface ChatToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+interface ChatMessage {
+  role: ChatRole;
+  content?: string | Array<Record<string, unknown>> | null;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: ChatToolCall[];
+}
+
+interface ChatCompletionResponse {
+  id: string;
+  choices: Array<{
+    message: ChatMessage;
+    finish_reason?: string;
+  }>;
+}
+
+const COMPACT_KEEP_TURNS = 8;
+
+function isControlGroup(containerInput: ContainerInput): boolean {
+  return containerInput.isControlGroup ?? containerInput.isMain ?? false;
+}
+
+function getRuntimeContext(containerInput: ContainerInput): {
+  cwd: string;
+  hasProject: boolean;
+  systemInstructions: string;
+} {
+  const projectDir = '/workspace/project';
+  let cwd = '/workspace/group';
+  let hasProject = false;
+  try {
+    const stat = fs.statSync(projectDir);
+    if (stat.isDirectory()) {
+      const realProjectDir = fs.realpathSync(projectDir);
+      if (
+        realProjectDir.startsWith('/workspace/') &&
+        fs.readdirSync(projectDir).some((f) => !f.startsWith('.'))
+      ) {
+        cwd = projectDir;
+        hasProject = true;
+      }
+    }
+  } catch {
+    // No project mount — use group workspace.
+  }
+
+  const instructions = [
+    'You are running inside the Deus backend-neutral llama.cpp adapter.',
+    'Preserve the same Deus user experience as the Claude and OpenAI backends: same tone, memory, privacy boundaries, chat commands, and long-term personal context.',
+    'Use the provided Deus tools for shell, filesystem, web, browser, and IPC actions.',
+    `Primary working directory: ${cwd}`,
+    ...loadRegisteredContextFiles({
+      isControlGroup: isControlGroup(containerInput),
+      hasProject: cwd === projectDir,
+    }),
+    containerInput.projectHint || '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  return { cwd, hasProject, systemInstructions: instructions };
+}
+
+function getOptionalMcpServerConfigs(containerInput: ContainerInput): Array<{
+  serverName: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  required?: boolean;
+}> {
+  const configs: Array<{
+    serverName: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    required?: boolean;
+  }> = [];
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+  configs.push({
+    serverName: 'deus',
+    command: 'node',
+    args: [path.join(__dirname, 'ipc-mcp-stdio.js')],
+    env: {
+      DEUS_CHAT_JID: containerInput.chatJid,
+      DEUS_GROUP_FOLDER: containerInput.groupFolder,
+      DEUS_IS_MAIN: isControlGroup(containerInput) ? '1' : '0',
+    },
+    required: true,
+  });
+
+  const projectDir = '/workspace/project';
+  const gcalDistPath = path.join(projectDir, 'packages/mcp-gcal/dist/index.js');
+  const gcalCredsPath = path.join(
+    projectDir,
+    'integrations/gcal/credentials.json',
+  );
+  const gcalTokensPath = path.join(projectDir, 'integrations/gcal/tokens.json');
+  if (
+    fs.existsSync(gcalDistPath) &&
+    fs.existsSync(gcalCredsPath) &&
+    fs.existsSync(gcalTokensPath)
+  ) {
+    configs.push({
+      serverName: 'gcal',
+      command: 'node',
+      args: [gcalDistPath],
+      env: {
+        DEUS_PROJECT_ROOT: projectDir,
+        LOG_LEVEL: process.env.LOG_LEVEL || 'info',
+      },
+      required: false,
+    });
+  }
+
+  return configs;
+}
+
+export function buildInitialMessages(
+  prompt: string,
+  containerInput: ContainerInput,
+  systemInstructions: string,
+): ChatMessage[] {
+  // For image attachments we use the OpenAI chat-completions vision shape
+  // (content array with `image_url`). llama-server with a multimodal GGUF
+  // accepts this; text-only GGUFs ignore the image content. The Deus
+  // capability flag `multimodal: false` documents the default.
+  const content: Array<Record<string, unknown>> = [
+    { type: 'text', text: prompt },
+  ];
+  for (const img of containerInput.imageAttachments || []) {
+    const imgPath = resolveBrokerGroupAttachmentPath(img.relativePath);
+    try {
+      const data = fs.readFileSync(imgPath).toString('base64');
+      content.push({
+        type: 'image_url',
+        image_url: { url: `data:${img.mediaType};base64,${data}` },
+      });
+    } catch {
+      // Ignore broken image reads — text prompt still proceeds.
+    }
+  }
+
+  // When there are no images we can use the simpler string-content form for
+  // smaller GGUF chat templates that don't handle structured content arrays.
+  const userMessage: ChatMessage =
+    containerInput.imageAttachments &&
+    containerInput.imageAttachments.length > 0
+      ? { role: 'user', content }
+      : { role: 'user', content: prompt };
+
+  return [{ role: 'system', content: systemInstructions }, userMessage];
+}
+
+async function createChatCompletion(body: {
+  model: string;
+  messages: ChatMessage[];
+  tools?: Array<Record<string, unknown>>;
+  tool_choice?: 'auto' | 'none' | Record<string, unknown>;
+}): Promise<ChatCompletionResponse> {
+  const baseUrl = process.env.LLAMA_CPP_BASE_URL || 'http://127.0.0.1:8080/v1';
+  const normalizedBase = baseUrl.endsWith('/v1')
+    ? baseUrl
+    : `${baseUrl.replace(/\/$/, '')}/v1`;
+  const res = await fetch(`${normalizedBase}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${process.env.LLAMA_CPP_API_KEY || 'placeholder'}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `llama.cpp chat completion failed (${res.status}): ${text.slice(0, 300)}`,
+    );
+  }
+  return (await res.json()) as ChatCompletionResponse;
+}
+
+function compactMessages(messages: ChatMessage[]): ChatMessage[] {
+  // Keep the system prompt and the most recent N turns. A turn is loosely
+  // a user→assistant exchange (counted as one user message); tool messages
+  // attach to the assistant turn that triggered them.
+  if (messages.length <= 1) return messages;
+  const system = messages[0]?.role === 'system' ? messages[0] : undefined;
+  const rest = system ? messages.slice(1) : messages;
+  const userIndices: number[] = [];
+  for (let i = 0; i < rest.length; i += 1) {
+    if (rest[i].role === 'user') userIndices.push(i);
+  }
+  if (userIndices.length <= COMPACT_KEEP_TURNS) return messages;
+  const startUserIdx = userIndices[userIndices.length - COMPACT_KEEP_TURNS];
+  const truncated = rest.slice(startUserIdx);
+  return system ? [system, ...truncated] : truncated;
+}
+
+async function runSingleTurn(
+  prompt: string,
+  containerInput: ContainerInput,
+  messages: ChatMessage[],
+  log: (message: string) => void,
+  doomDetector: DoomLoopDetector,
+): Promise<{ result: string | null }> {
+  const { cwd, hasProject } = getRuntimeContext(containerInput);
+  const mcpBridge = await createOpenAIMcpToolBridge(
+    getOptionalMcpServerConfigs(containerInput).filter(
+      (config) => config.serverName !== 'gcal' || hasProject,
+    ),
+    log,
+  );
+
+  // Append the new user prompt to the running messages array.
+  messages.push({ role: 'user', content: prompt });
+
+  try {
+    while (true) {
+      const response = await createChatCompletion({
+        model: process.env.LLAMA_CPP_MODEL || 'gpt-3.5-turbo',
+        messages,
+        tools: getOpenAIToolDefinitions(mcpBridge.definitions).map((def) => ({
+          type: 'function',
+          function: {
+            name: def.name,
+            description: def.description,
+            parameters: def.parameters,
+          },
+        })),
+        tool_choice: 'auto',
+      });
+
+      const choice = response.choices?.[0];
+      if (!choice?.message) {
+        throw new Error('llama.cpp response missing assistant message');
+      }
+      const assistantMessage = choice.message;
+      messages.push(assistantMessage);
+
+      const calls = assistantMessage.tool_calls ?? [];
+      if (calls.length === 0) {
+        const text =
+          typeof assistantMessage.content === 'string'
+            ? assistantMessage.content
+            : Array.isArray(assistantMessage.content)
+              ? assistantMessage.content
+                  .map((b) =>
+                    b && typeof b === 'object' && typeof b.text === 'string'
+                      ? b.text
+                      : '',
+                  )
+                  .join('\n')
+              : '';
+        return { result: text || null };
+      }
+
+      log(`llama.cpp requested ${calls.length} tool call(s)`);
+      for (const call of calls) {
+        let parsedArgs: Record<string, unknown> = {};
+        try {
+          parsedArgs = JSON.parse(call.function.arguments || '{}') as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          parsedArgs = {};
+        }
+
+        let toolResult =
+          (await mcpBridge.execute(call.function.name, parsedArgs)) ??
+          undefined;
+        if (!toolResult) {
+          try {
+            toolResult = await executeBrokerTool(
+              call.function.name,
+              parsedArgs,
+              {
+                cwd,
+                containerInput,
+              },
+            );
+          } catch (err) {
+            toolResult = {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+
+        const exitCode: number =
+          typeof toolResult?.exitCode === 'number'
+            ? toolResult.exitCode
+            : toolResult?.ok === false
+              ? 1
+              : 0;
+        const succeeded = toolResult?.ok !== false && exitCode === 0;
+        doomDetector.record({
+          toolName: call.function.name,
+          normalizedArgs: normalizeArgs(call.function.name, parsedArgs),
+          exitCode,
+          succeeded,
+        });
+
+        messages.push({
+          role: 'tool',
+          tool_call_id: call.id,
+          content: JSON.stringify(toolResult ?? {}),
+        });
+      }
+    }
+  } finally {
+    await mcpBridge.close();
+  }
+}
+
+export async function runLlamaCppConversation(
+  ctx: LlamaCppContext,
+): Promise<void> {
+  const {
+    containerInput,
+    writeOutput,
+    log,
+    drainIpcInput,
+    waitForIpcMessage,
+    shouldClose,
+  } = ctx;
+
+  if (containerInput.effort && containerInput.effort !== 'low') {
+    log(
+      `Effort level '${containerInput.effort}' requested but not yet supported for llama-cpp backend — using model default`,
+    );
+  }
+
+  const { systemInstructions } = getRuntimeContext(containerInput);
+  // Session continuity within a single container lifecycle: keep messages
+  // in-memory. Cross-restart resume is a follow-up (would persist via
+  // sessionRef.metadata_json).
+  const messages: ChatMessage[] = [
+    { role: 'system', content: systemInstructions },
+  ];
+  // Synthetic session id so the host can correlate; not tied to a server
+  // response id (llama.cpp has no server-side response state).
+  const sessionId = `llama-cpp-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+
+  let prompt = containerInput.prompt;
+
+  if (prompt.trim() === '/compact') {
+    const before = messages.length;
+    const truncated = compactMessages(messages);
+    messages.length = 0;
+    messages.push(...truncated);
+    const noopCompact = before <= 1 || before === messages.length;
+    const result = noopCompact
+      ? 'Nothing to compact — conversation is already at the start.'
+      : `Conversation compacted (history truncated ${before} → ${messages.length} messages).`;
+    log(`llama.cpp /compact: ${result}`);
+    writeOutput({
+      status: 'success',
+      result,
+      newSessionId: sessionId,
+      newSessionRef: {
+        backend: 'llama-cpp',
+        session_id: sessionId,
+      },
+    });
+    return;
+  }
+
+  if (containerInput.isScheduledTask) {
+    prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+  }
+  const pending = drainIpcInput();
+  if (pending.length > 0) {
+    prompt += '\n' + pending.join('\n');
+  }
+
+  const doomDetector = new DoomLoopDetector();
+
+  while (true) {
+    if (shouldClose()) break;
+
+    const memoryContext = await fetchMemoryContext(
+      prompt,
+      'container-llama-cpp',
+    );
+    const enrichedPrompt = memoryContext
+      ? `${memoryContext}\n\n${prompt}`
+      : prompt;
+
+    try {
+      const turn = await runSingleTurn(
+        enrichedPrompt,
+        containerInput,
+        messages,
+        log,
+        doomDetector,
+      );
+
+      writeOutput({
+        status: 'success',
+        result: turn.result,
+        newSessionId: sessionId,
+        newSessionRef: {
+          backend: 'llama-cpp',
+          session_id: sessionId,
+        },
+      });
+      writeOutput({
+        status: 'success',
+        result: null,
+        newSessionId: sessionId,
+        newSessionRef: {
+          backend: 'llama-cpp',
+          session_id: sessionId,
+        },
+      });
+    } catch (err) {
+      writeOutput({
+        status: 'error',
+        result: null,
+        error: err instanceof Error ? err.message : String(err),
+        newSessionId: sessionId,
+        newSessionRef: {
+          backend: 'llama-cpp',
+          session_id: sessionId,
+        },
+      });
+    }
+
+    if (shouldClose()) break;
+    const nextMessage = await waitForIpcMessage();
+    if (nextMessage === null) break;
+    prompt = nextMessage;
+  }
+}

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -6,6 +6,7 @@ import { loadRegisteredContextFiles } from './context-registry.js';
 import { fetchMemoryContext } from './memory-retrieval-hook.js';
 import { DoomLoopDetector, normalizeArgs } from './doom-loop-detector.js';
 import {
+  type AgentRuntimeId,
   createOpenAIMcpToolBridge,
   executeBrokerTool,
   getOpenAIToolDefinitions,
@@ -22,7 +23,7 @@ export {
 } from './tool-broker.js';
 
 export interface RuntimeSession {
-  backend: 'claude' | 'openai';
+  backend: AgentRuntimeId;
   session_id: string;
   resume_cursor?: string;
   metadata_json?: string;
@@ -30,7 +31,7 @@ export interface RuntimeSession {
 
 export interface ContainerInput {
   prompt: string;
-  backend?: 'claude' | 'openai';
+  backend?: AgentRuntimeId;
   sessionId?: string;
   sessionRef?: RuntimeSession;
   groupFolder: string;

--- a/container/agent-runner/src/tool-broker.ts
+++ b/container/agent-runner/src/tool-broker.ts
@@ -19,7 +19,17 @@ import {
   generateToolUseId,
 } from './tool-audit.js';
 
-export type AgentRuntimeId = 'claude' | 'openai';
+// Container-side mirror of the host AgentRuntimeId union. Keep in sync
+// when adding backends.
+export const VALID_BACKENDS = ['claude', 'openai', 'llama-cpp'] as const;
+export type AgentRuntimeId = (typeof VALID_BACKENDS)[number];
+
+export function isValidAgentBackend(value: unknown): value is AgentRuntimeId {
+  return (
+    typeof value === 'string' &&
+    (VALID_BACKENDS as readonly string[]).includes(value)
+  );
+}
 
 export interface ToolBrokerContainerInput {
   groupFolder: string;
@@ -98,7 +108,9 @@ async function runCommand(
       stderr += chunk.toString();
     });
     proc.on('close', (code) => {
-      resolve(summarizeToolResult({ command, stdout, stderr, exitCode: code ?? 0 }));
+      resolve(
+        summarizeToolResult({ command, stdout, stderr, exitCode: code ?? 0 }),
+      );
     });
   });
 }
@@ -129,7 +141,15 @@ async function runProgram(
       });
     });
     proc.on('close', (code) => {
-      resolve(summarizeToolResult({ program: command, args, stdout, stderr, exitCode: code ?? 0 }));
+      resolve(
+        summarizeToolResult({
+          program: command,
+          args,
+          stdout,
+          stderr,
+          exitCode: code ?? 0,
+        }),
+      );
     });
   });
 }
@@ -458,7 +478,7 @@ export function getOpenAIToolDefinitions(
           schedule_value: { type: 'string' },
           context_mode: { type: 'string', enum: ['group', 'isolated'] },
           target_group_jid: { type: 'string' },
-          agent_backend: { type: 'string', enum: ['claude', 'openai'] },
+          agent_backend: { type: 'string', enum: [...VALID_BACKENDS] },
         },
         ['prompt', 'schedule_type', 'schedule_value'],
       ),
@@ -497,7 +517,7 @@ export function getOpenAIToolDefinitions(
           prompt: { type: 'string' },
           schedule_type: { type: 'string', enum: ['cron', 'interval', 'once'] },
           schedule_value: { type: 'string' },
-          agent_backend: { type: 'string', enum: ['claude', 'openai'] },
+          agent_backend: { type: 'string', enum: [...VALID_BACKENDS] },
         },
         ['task_id'],
       ),
@@ -512,7 +532,7 @@ export function getOpenAIToolDefinitions(
           name: { type: 'string' },
           folder: { type: 'string' },
           trigger: { type: 'string' },
-          agent_backend: { type: 'string', enum: ['claude', 'openai'] },
+          agent_backend: { type: 'string', enum: [...VALID_BACKENDS] },
         },
         ['jid', 'name', 'folder', 'trigger'],
       ),
@@ -844,10 +864,9 @@ export async function executeBrokerTool(
           isControlGroup(containerInput) && args.target_group_jid
             ? String(args.target_group_jid)
             : containerInput.chatJid,
-        agent_backend:
-          args.agent_backend === 'openai' || args.agent_backend === 'claude'
-            ? args.agent_backend
-            : undefined,
+        agent_backend: isValidAgentBackend(args.agent_backend)
+          ? args.agent_backend
+          : undefined,
         createdBy: containerInput.groupFolder,
         timestamp: new Date().toISOString(),
       });
@@ -875,10 +894,9 @@ export async function executeBrokerTool(
         prompt: args.prompt,
         schedule_type: args.schedule_type,
         schedule_value: args.schedule_value,
-        agent_backend:
-          args.agent_backend === 'openai' || args.agent_backend === 'claude'
-            ? args.agent_backend
-            : undefined,
+        agent_backend: isValidAgentBackend(args.agent_backend)
+          ? args.agent_backend
+          : undefined,
         groupFolder: containerInput.groupFolder,
         isMain: isControlGroup(containerInput),
         timestamp: new Date().toISOString(),
@@ -895,10 +913,9 @@ export async function executeBrokerTool(
         name: String(args.name || ''),
         folder: String(args.folder || ''),
         trigger: String(args.trigger || ''),
-        containerConfig:
-          args.agent_backend === 'openai' || args.agent_backend === 'claude'
-            ? { agentBackend: args.agent_backend }
-            : undefined,
+        containerConfig: isValidAgentBackend(args.agent_backend)
+          ? { agentBackend: args.agent_backend }
+          : undefined,
         timestamp: new Date().toISOString(),
       });
       return { ok: true };

--- a/deus-cmd.ps1
+++ b/deus-cmd.ps1
@@ -85,10 +85,11 @@ function Get-DeusCliAgent {
              else { Read-ConfigKey "agent_backend" }
     if (-not $agent) { $agent = "claude" }
     switch ($agent.ToLower()) {
-        "openai" { return "codex" }
-        "codex"  { return "codex" }
-        "ollama" { return "ollama" }
-        default  { return "claude" }
+        "openai"    { return "codex" }
+        "codex"     { return "codex" }
+        "ollama"    { return "ollama" }
+        "llama-cpp" { return "llama-cpp" }
+        default     { return "claude" }
     }
 }
 
@@ -138,6 +139,10 @@ function Invoke-Agent {
     switch ($cliAgent) {
         "ollama" {
             Write-Error "Ollama backend is not yet available as a CLI agent. Use 'deus backend set claude' or 'deus backend set openai' instead."
+            return
+        }
+        "llama-cpp" {
+            Write-Error "llama-cpp backend is not yet available as a CLI agent. It works for channel messages and scheduled tasks once the host llama-server is running (see /add-llama-cpp). For an interactive session, run 'deus backend set claude' or 'deus backend set codex'."
             return
         }
         "codex" { Invoke-Codex $ExtraArgs }
@@ -519,7 +524,7 @@ switch ($Command.ToLower()) {
                 if ($env:DEUS_AGENT_BACKEND) { Write-Host "(env override: DEUS_AGENT_BACKEND=$($env:DEUS_AGENT_BACKEND))" }
             }
             "list" {
-                foreach ($b in @("claude", "codex", "ollama")) {
+                foreach ($b in @("claude", "codex", "ollama", "llama-cpp")) {
                     if ($b -eq $currentDisplay) {
                         Write-Host "* $b (active)"
                     } else {
@@ -529,13 +534,13 @@ switch ($Command.ToLower()) {
             }
             "set" {
                 if ($args.Count -lt 2) {
-                    Write-Host "Usage: deus backend set <claude|codex|ollama>"
+                    Write-Host "Usage: deus backend set <claude|codex|ollama|llama-cpp>"
                     exit 1
                 }
                 $input = $args[1].ToLower()
-                if ($input -notin @("claude", "codex", "ollama")) {
+                if ($input -notin @("claude", "codex", "ollama", "llama-cpp")) {
                     Write-Host "Unknown backend: $($args[1])"
-                    Write-Host "Available: claude, codex, ollama"
+                    Write-Host "Available: claude, codex, ollama, llama-cpp"
                     exit 1
                 }
                 $internalMap = @{ "codex" = "openai" }
@@ -567,7 +572,7 @@ switch ($Command.ToLower()) {
                 Write-Host "Usage: deus backend [show|set|model|list]"
                 Write-Host ""
                 Write-Host "  deus backend           Show current backend and model"
-                Write-Host "  deus backend set <be>  Set default backend (claude|codex|ollama)"
+                Write-Host "  deus backend set <be>  Set default backend (claude|codex|ollama|llama-cpp)"
                 Write-Host "  deus backend model <m> Set model for current backend (e.g. gpt-4o)"
                 Write-Host "  deus backend list      List available backends"
             }

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -82,6 +82,7 @@ _normalize_cli_agent() {
   case "$agent" in
     openai|codex) echo "codex" ;;
     ollama) echo "ollama" ;;
+    llama-cpp) echo "llama-cpp" ;;
     *) echo "claude" ;;
   esac
 }
@@ -912,7 +913,7 @@ case "$1" in
         fi
         ;;
       list)
-        for b in claude codex ollama; do
+        for b in claude codex ollama llama-cpp; do
           if [ "$b" = "$CURRENT_DISPLAY" ]; then
             echo "* $b (active)"
           else
@@ -922,15 +923,15 @@ case "$1" in
         ;;
       set)
         if [ -z "$2" ]; then
-          echo "Usage: deus backend set <claude|codex|ollama>"
+          echo "Usage: deus backend set <claude|codex|ollama|llama-cpp>"
           exit 1
         fi
         INPUT="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
         case "$INPUT" in
-          claude|codex|ollama) ;;
+          claude|codex|ollama|llama-cpp) ;;
           *)
             echo "Unknown backend: $2"
-            echo "Available: claude, codex, ollama"
+            echo "Available: claude, codex, ollama, llama-cpp"
             exit 1
             ;;
         esac
@@ -981,7 +982,7 @@ case "$1" in
         echo "Usage: deus backend [show|set|model|list|bench]"
         echo ""
         echo "  deus backend           Show current backend and model"
-        echo "  deus backend set <be>  Set default backend (claude|codex|ollama)"
+        echo "  deus backend set <be>  Set default backend (claude|codex|ollama|llama-cpp)"
         echo "  deus backend model <m> Set model for current backend (e.g. gpt-4o)"
         echo "  deus backend list      List available backends"
         echo "  deus backend bench     Run parity benchmark (claude vs openai)"
@@ -1076,6 +1077,13 @@ case "$1" in
       if [ "$CLI_AGENT" = "ollama" ]; then
         echo "Error: Ollama backend is not yet available as a CLI agent."
         echo "Use 'deus backend set claude' or 'deus backend set openai' instead."
+        return 1
+      fi
+      if [ "$CLI_AGENT" = "llama-cpp" ]; then
+        echo "Error: llama-cpp backend is not yet available as a CLI agent."
+        echo "It works for channel messages and scheduled tasks once the host"
+        echo "llama-server is running (see /add-llama-cpp). For an interactive"
+        echo "session, run 'deus backend set claude' or 'deus backend set codex'."
         return 1
       fi
       if [ "$CLI_AGENT" != "codex" ]; then

--- a/docs/MULTI_BACKEND.md
+++ b/docs/MULTI_BACKEND.md
@@ -64,13 +64,16 @@ Regardless of backend, Deus preserves:
 
 ## What Differs
 
-| Feature | Claude | OpenAI |
-|---------|--------|--------|
-| Tool streaming | Yes (live output) | No (batch response) |
-| Session protocol | Claude Code SDK | OpenAI Responses API |
-| Model default | Claude (via SDK) | gpt-4o (configurable via `DEUS_OPENAI_MODEL`) |
-| Handoffs | Not yet | Not yet |
-| MCP tools | Native | Bridged via tool-broker |
+| Feature | Claude | OpenAI | llama.cpp |
+|---------|--------|--------|-----------|
+| Tool streaming | Yes (live output) | No (batch response) | No (batch response) |
+| Session protocol | Claude Code SDK | OpenAI Responses API | OpenAI chat-completions (in-memory history) |
+| Model default | Claude (via SDK) | gpt-4o (configurable via `DEUS_OPENAI_MODEL`) | configured via `LLAMA_CPP_MODEL` (default Gemma-3-1B GGUF from the `/add-llama-cpp` skill) |
+| Handoffs | Not yet | Not yet | Not yet |
+| MCP tools | Native | Bridged via tool-broker | Bridged via tool-broker (same path as OpenAI) |
+| Multimodal | Yes | Yes (gpt-4o) | No (default GGUF is text-only) |
+| `/compact` | Native | LLM-summary via Responses | Truncation (system + last N turns); summary-based is a follow-up |
+| Credential routing | Through credential proxy | Through credential proxy (`/openai` route) | No proxy — direct call to local `llama-server` (no auth) |
 
 ## Known Parity Gaps
 
@@ -80,6 +83,7 @@ Key gaps as of this writing:
 - OpenAI backend has not been verified end-to-end in production containers
 - Dynamic skill parity depends on skills exposing MCP-style tools
 - Agents SDK handoffs/tracing not yet implemented for OpenAI
+- llama.cpp backend: no `deus llama` foreground CLI shorthand yet (use `deus backend set llama-cpp` and channel messages or scheduled tasks); `/compact` is history truncation only; multimodal default is off; tool-call reliability varies by GGUF model
 
 ## CLI Usage
 
@@ -173,26 +177,47 @@ The backend is resolved in this order (first non-empty wins):
 
 `deus backend set` writes to both config.json and `.env` so both the CLI and background service pick up the change.
 
+## llama.cpp local backend
+
+llama.cpp is a third backend that runs as a local `llama-server` HTTP service on the host. The container talks to it via the OpenAI-compatible `/v1/chat/completions` endpoint — no API key, no credential proxy hop, no per-turn cost.
+
+### Setup
+
+1. Run the `/add-llama-cpp` skill on the host to install `llama-server` and configure the LaunchAgent (macOS) or run it manually (Linux/Windows). See [`.claude/skills/add-llama-cpp/SKILL.md`](../.claude/skills/add-llama-cpp/SKILL.md).
+2. Confirm the local endpoint: `curl -fsS http://127.0.0.1:8080/v1/models`.
+3. **Rebuild the agent container** if upgrading from a pre-llama-cpp Deus build: `./container/build.sh`. Without this, the container won't have the new `llama-cpp-backend.js` module.
+4. Switch backend: `deus backend set llama-cpp`.
+5. Trigger a session: send a channel message, schedule a task, or set `agent_backend: 'llama-cpp'` on a specific group/task.
+6. For an interactive REPL (`deus`), use Claude or Codex — `deus` foreground TUI for llama-cpp is a follow-up (PR #6).
+
+**Scope of this integration:** chat-backend only. Eval-side providers (text generation for the evolution harness, the local judge, and embedding) are tracked as follow-ups per ADR `docs/decisions/llama-cpp-optional-integration.md`. The embedding swap in particular is gated on a full re-embed + threshold recalibration + benchmark snapshot.
+
+### `LLAMA_CPP_PORT` precedence
+
+`process.env.LLAMA_CPP_PORT > .env file > '8080' default`. Keep this aligned with `~/.config/deus/llama-cpp.env` (which the skill writes). Default in both: `8080`.
+
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DEUS_AGENT_BACKEND` | `claude` | Global default: `claude` or `openai` |
+| `DEUS_AGENT_BACKEND` | `claude` | Global default: `claude`, `openai`, or `llama-cpp` |
 | `DEUS_OPENAI_MODEL` | `gpt-4o` | Model for the OpenAI backend |
 | `OPENAI_API_KEY` | -- | Required unless Codex OAuth is available (`~/.codex/auth.json` from `codex login`) |
 | `DEUS_CODEX_MODEL` | `DEUS_OPENAI_MODEL` | Optional model override for `deus codex` |
+| `LLAMA_CPP_BASE_URL` | -- | Optional explicit host-side llama-server URL (advanced) |
+| `LLAMA_CPP_PORT` | `8080` | Port that `llama-server` listens on the host |
+| `LLAMA_CPP_MODEL` | -- | GGUF model alias to send in `chat/completions` requests |
 
 ## Supported Backend Boundary
 
-Claude and OpenAI/Codex are the two implemented agent backends. The `ollama` entry in the `AgentRuntimeId` type union is a forward reservation with no runtime implementation — Ollama is used for eval judging and embeddings, not as a container agent backend.
-
-The architecture supports adding new backends, but the current product scope is deliberately limited to two adapters. This boundary is a conscious scope decision, not a technical limitation.
+Three implemented agent backends: Claude (default), OpenAI/Codex (opt-in via API key or Codex OAuth), and llama.cpp (opt-in via the `/add-llama-cpp` skill). The `ollama` entry in the `AgentRuntimeId`-style CLI display alias is a forward reservation with no runtime implementation — Ollama is used for eval judging and embeddings, not as a container agent backend.
 
 ## Adding a New Backend (for contributors)
 
-1. Create a factory function in `src/agent-runtimes/` (see `claude-backend.ts` as template)
+1. Create a factory function in `src/agent-runtimes/` (see `claude-backend.ts` or `llama-cpp-backend.ts` as templates)
 2. Define capabilities in a `RuntimeCapabilities` constant
 3. Register it in `src/index.ts` via `registry.register(createYourRuntime(deps))`
 4. Add container-side dispatch in `container/agent-runner/src/index.ts`
-5. Add the backend name to `AgentRuntimeId` union in `src/agent-runtimes/types.ts`
-6. Update `parseAgentBackend()` in `src/ipc.ts` and `DEFAULT_AGENT_RUNTIME` in `src/config.ts`
+5. Add the backend name to `AgentRuntimeId` union in `src/agent-runtimes/types.ts` AND to `VALID_BACKENDS` in `container/agent-runner/src/tool-broker.ts` (container-side single source of truth)
+6. Update `parseAgentBackend()` in `src/agent-runtimes/types.ts` (host SoT) — used by `src/config.ts` `DEFAULT_AGENT_RUNTIME` and `src/db.ts` `rowToSessionRef`
+7. If the new backend bypasses the credential proxy (like llama.cpp), restructure the parity test suite in `src/container-runner.test.ts` into shared-env / remote-proxy / local-bypass tiers

--- a/docs/decisions/backend-neutral-agent-runtime.md
+++ b/docs/decisions/backend-neutral-agent-runtime.md
@@ -55,16 +55,16 @@ At minimum, run TypeScript checks plus targeted backend/session/auth/container t
 
 ## Parity Matrix
 
-| Surface | Claude Default | OpenAI/Codex Opt-In |
-|---|---|---|
-| Selection | Fallback/default backend | `DEUS_AGENT_BACKEND=openai`, group override, or task override |
-| Sessions | Existing Claude session ids wrapped as backend refs | Responses id stored as an OpenAI backend ref |
-| Backend mismatch | Starts fresh instead of resuming wrong backend | Starts fresh instead of resuming wrong backend |
-| Credentials | Placeholder Anthropic credentials via proxy | Placeholder OpenAI credentials via `/openai` proxy route |
-| Context files | Native Claude loading plus registry-managed non-native surfaces | Registry-managed `CLAUDE.md`, `AGENTS.md`, `AI_AGENT_GUIDELINES.md`, and `MEMORY_TREE.md` surfaces |
-| Tools | Existing Claude/MCP tool path | Container ToolBroker-backed function tools |
-| Scheduling | Existing IPC task tools | Same IPC task file contract with optional backend override |
-| Global CLI | `deus` / `deus claude` | `deus codex`, `deus openai`, or `DEUS_CLI_AGENT=codex deus` |
+| Surface | Claude Default | OpenAI/Codex Opt-In | Llama.cpp Local Opt-In |
+|---|---|---|---|
+| Selection | Fallback/default backend | `DEUS_AGENT_BACKEND=openai`, group override, or task override | `DEUS_AGENT_BACKEND=llama-cpp`, group override, or task override |
+| Sessions | Existing Claude session ids wrapped as backend refs | Responses id stored as an OpenAI backend ref | Client-side messages array (no server-side response state); synthetic session id |
+| Backend mismatch | Starts fresh instead of resuming wrong backend | Starts fresh instead of resuming wrong backend | Starts fresh instead of resuming wrong backend |
+| Credentials | Placeholder Anthropic credentials via proxy | Placeholder OpenAI credentials via `/openai` proxy route | Placeholder `LLAMA_CPP_API_KEY` injected; no proxy hop (llama-server has no auth) |
+| Context files | Native Claude loading plus registry-managed non-native surfaces | Registry-managed `CLAUDE.md`, `AGENTS.md`, `AI_AGENT_GUIDELINES.md`, and `MEMORY_TREE.md` surfaces | Same as OpenAI — registry-managed surfaces |
+| Tools | Existing Claude/MCP tool path | Container ToolBroker-backed function tools | Container ToolBroker-backed function tools (same path as OpenAI; reuses MCP bridge) |
+| Scheduling | Existing IPC task tools | Same IPC task file contract with optional backend override | Same IPC task file contract with optional backend override |
+| Global CLI | `deus` / `deus claude` | `deus codex`, `deus openai`, or `DEUS_CLI_AGENT=codex deus` | `deus backend set llama-cpp` (foreground `deus llama` shorthand is a follow-up) |
 
 ## Rollback
 

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-16" # auto-bump
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-16" # auto-bump
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-16T21:30:00" # auto-bump (channels-agent-native)
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T01:30:00" # auto-bump (llama-cpp-backend)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-16T21:30:00" # auto-bump
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-05-16" # auto-bump
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/__tests__/parse-agent-backend.test.ts
+++ b/src/__tests__/parse-agent-backend.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseAgentBackend } from '../agent-runtimes/types.js';
+
+describe('parseAgentBackend', () => {
+  it('accepts the three valid backend IDs verbatim', () => {
+    expect(parseAgentBackend('claude')).toBe('claude');
+    expect(parseAgentBackend('openai')).toBe('openai');
+    expect(parseAgentBackend('llama-cpp')).toBe('llama-cpp');
+  });
+
+  it('rejects unknown strings', () => {
+    expect(parseAgentBackend('gpt-4')).toBeUndefined();
+    expect(parseAgentBackend('ollama')).toBeUndefined();
+    expect(parseAgentBackend('llama')).toBeUndefined();
+    expect(parseAgentBackend('')).toBeUndefined();
+  });
+
+  it('rejects non-string types', () => {
+    expect(parseAgentBackend(null)).toBeUndefined();
+    expect(parseAgentBackend(undefined)).toBeUndefined();
+    expect(parseAgentBackend(42)).toBeUndefined();
+    expect(parseAgentBackend({})).toBeUndefined();
+    expect(parseAgentBackend([])).toBeUndefined();
+    expect(parseAgentBackend(true)).toBeUndefined();
+  });
+
+  it('is case-sensitive (no automatic lowercasing)', () => {
+    // Callers must lowercase first; the function is a strict gate.
+    expect(parseAgentBackend('Claude')).toBeUndefined();
+    expect(parseAgentBackend('OPENAI')).toBeUndefined();
+    expect(parseAgentBackend('Llama-CPP')).toBeUndefined();
+  });
+});

--- a/src/agent-runtimes/index.ts
+++ b/src/agent-runtimes/index.ts
@@ -17,4 +17,5 @@ export {
 } from './container-backend.js';
 export { createClaudeRuntime } from './claude-backend.js';
 export { createOpenAIRuntime } from './openai-backend.js';
+export { createLlamaCppRuntime } from './llama-cpp-backend.js';
 export { RuntimeRegistry, initRuntimeRegistry } from './registry.js';

--- a/src/agent-runtimes/llama-cpp-backend.test.ts
+++ b/src/agent-runtimes/llama-cpp-backend.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+
+import { createLlamaCppRuntime } from './llama-cpp-backend.js';
+import type { ContainerRuntimeDeps } from './container-backend.js';
+
+const stubDeps: ContainerRuntimeDeps = {
+  resolveGroup: () => undefined,
+  assistantName: 'Deus',
+  registerProcess: () => {},
+};
+
+describe('LlamaCppBackend', () => {
+  const backend = createLlamaCppRuntime(stubDeps);
+
+  it('returns correct name', () => {
+    expect(backend.name()).toBe('llama-cpp');
+  });
+
+  it('returns correct capabilities', () => {
+    const caps = backend.capabilities();
+    expect(caps.shell).toBe(true);
+    expect(caps.filesystem).toBe(true);
+    // llama-cpp default GGUF is text-only and offline — no web browsing,
+    // no multimodal. Documented parity gap; matches docs/MULTI_BACKEND.md.
+    expect(caps.web).toBe(false);
+    expect(caps.multimodal).toBe(false);
+    expect(caps.handoffs).toBe(false);
+    // Cross-restart session resume is intentionally not yet supported —
+    // the container keeps history in-memory only. `persistent_sessions:
+    // false` tells the host not to try replaying a stored session id.
+    expect(caps.persistent_sessions).toBe(false);
+    expect(caps.tool_streaming).toBe(false);
+  });
+
+  it('startOrResume returns default session ref', async () => {
+    const ref = await backend.startOrResume({
+      prompt: 'test',
+      groupFolder: 'test-folder',
+      chatJid: 'test@g.us',
+      isControlGroup: false,
+    });
+
+    expect(ref.backend).toBe('llama-cpp');
+    expect(ref.session_id).toBe('');
+  });
+
+  it('close resolves without error', async () => {
+    await expect(
+      backend.close({ backend: 'llama-cpp', session_id: 'llama-cpp-abc' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('runTurn returns error when group not found', async () => {
+    const result = await backend.runTurn(
+      {
+        prompt: 'test',
+        groupFolder: 'nonexistent',
+        chatJid: 'test@g.us',
+        isControlGroup: false,
+      },
+      { backend: 'llama-cpp', session_id: '' },
+      () => {},
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Group not found');
+  });
+});

--- a/src/agent-runtimes/llama-cpp-backend.ts
+++ b/src/agent-runtimes/llama-cpp-backend.ts
@@ -1,0 +1,30 @@
+import type { RuntimeCapabilities } from './types.js';
+import {
+  ContainerRuntime,
+  type ContainerRuntimeDeps,
+} from './container-backend.js';
+
+// Capabilities of the llama.cpp local backend.
+// - web/multimodal: false. Default Gemma-3-1B GGUF is text-only.
+// - handoffs: false. Same parity gap as OpenAI runtime today.
+// - tool_streaming: false. Mirrors OpenAI runtime.
+// - persistent_sessions: false. The container driver keeps the message
+//   history in-memory across turns within a single container lifecycle,
+//   but cross-restart resume is NOT supported in this PR — `sessionRef`
+//   metadata is ignored on resume. Setting this to `false` prevents the
+//   host from assuming a stored session id can be replayed.
+const LLAMA_CPP_CAPABILITIES: RuntimeCapabilities = {
+  shell: true,
+  filesystem: true,
+  web: false,
+  multimodal: false,
+  handoffs: false,
+  persistent_sessions: false,
+  tool_streaming: false,
+};
+
+export function createLlamaCppRuntime(
+  deps: ContainerRuntimeDeps,
+): ContainerRuntime {
+  return new ContainerRuntime('llama-cpp', LLAMA_CPP_CAPABILITIES, deps);
+}

--- a/src/agent-runtimes/registry.test.ts
+++ b/src/agent-runtimes/registry.test.ts
@@ -72,11 +72,20 @@ describe('RuntimeRegistry', () => {
   it('lists registered backends', () => {
     registry.register(stubBackend('claude'));
     registry.register(stubBackend('openai'));
+    registry.register(stubBackend('llama-cpp'));
 
     expect(registry.list()).toEqual(
-      expect.arrayContaining(['claude', 'openai']),
+      expect.arrayContaining(['claude', 'openai', 'llama-cpp']),
     );
-    expect(registry.list()).toHaveLength(2);
+    expect(registry.list()).toHaveLength(3);
+  });
+
+  it('registers and retrieves llama-cpp backend', () => {
+    const llama = stubBackend('llama-cpp');
+    registry.register(llama);
+
+    expect(registry.get('llama-cpp')).toBe(llama);
+    expect(registry.has('llama-cpp')).toBe(true);
   });
 
   it('resolves backend from group config', () => {

--- a/src/agent-runtimes/resolve.test.ts
+++ b/src/agent-runtimes/resolve.test.ts
@@ -52,6 +52,23 @@ describe('resolveAgentRuntime', () => {
   it('falls back to the global default when no override exists', () => {
     expect(resolveAgentRuntime(makeGroup())).toBe('claude');
   });
+
+  it('resolves the llama-cpp task override', () => {
+    const group = makeGroup({
+      containerConfig: { agentBackend: 'claude' },
+    });
+    const task = makeTask({ agent_backend: 'llama-cpp' });
+
+    expect(resolveAgentRuntime(group, task)).toBe('llama-cpp');
+  });
+
+  it('resolves the llama-cpp group override', () => {
+    const group = makeGroup({
+      containerConfig: { agentBackend: 'llama-cpp' },
+    });
+
+    expect(resolveAgentRuntime(group)).toBe('llama-cpp');
+  });
 });
 
 describe('resolveAgentEffort', () => {

--- a/src/agent-runtimes/types.ts
+++ b/src/agent-runtimes/types.ts
@@ -1,7 +1,16 @@
 import type { AgentEffortLevel } from '../types.js';
 import type { ToolBroker } from '../tool-broker/types.js';
 
-export type AgentRuntimeId = 'claude' | 'openai';
+export type AgentRuntimeId = 'claude' | 'openai' | 'llama-cpp';
+
+// Canonical accepted-value gate for AgentRuntimeId. Defined here (next to
+// the type) so both `src/config.ts` and `src/ipc.ts` can import it without
+// creating a circular dependency (`ipc.ts` already depends on `config.ts`).
+export function parseAgentBackend(value: unknown): AgentRuntimeId | undefined {
+  return value === 'claude' || value === 'openai' || value === 'llama-cpp'
+    ? value
+    : undefined;
+}
 
 export interface RuntimeCapabilities {
   shell: boolean;

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -61,6 +61,9 @@ export function hasApiCredentials(): boolean {
     env.DEUS_AGENT_BACKEND ||
     'claude'
   ).toLowerCase();
+  // llama-cpp runs as a local server with no host-side auth — no credential
+  // check needed. See docs/decisions/llama-cpp-optional-integration.md.
+  if (backend === 'llama-cpp') return true;
   if (backend === 'openai') {
     if (env.OPENAI_API_KEY || process.env.OPENAI_API_KEY) return true;
     return hasCodexAuthFile();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
 import path from 'path';
 
-import type { AgentRuntimeId } from './agent-runtimes/types.js';
+import {
+  parseAgentBackend,
+  type AgentRuntimeId,
+} from './agent-runtimes/types.js';
 import { readEnvFile } from './env.js';
 import type { InjectionScannerConfig } from './guardrails/injection-scanner.js';
 import { homeDir } from './platform.js';
@@ -14,6 +17,9 @@ const envConfig = readEnvFile([
   'DEUS_AGENT_BACKEND',
   'DEUS_CONTEXT_FILE_MAX_CHARS',
   'DEUS_OPENAI_MODEL',
+  'LLAMA_CPP_BASE_URL',
+  'LLAMA_CPP_PORT',
+  'LLAMA_CPP_MODEL',
 ]);
 
 export const ASSISTANT_NAME =
@@ -97,11 +103,24 @@ const rawAgentBackend = (
   envConfig.DEUS_AGENT_BACKEND ||
   'claude'
 ).toLowerCase();
+// Use `parseAgentBackend` from agent-runtimes/types.ts (host SoT) as the
+// canonical accepted-value gate. Avoids the circular `ipc.ts` import path
+// AND eliminates the prior silent-coercion ternary for new backend IDs.
 export const DEFAULT_AGENT_RUNTIME: AgentRuntimeId =
-  rawAgentBackend === 'openai' ? 'openai' : 'claude';
+  parseAgentBackend(rawAgentBackend) ?? 'claude';
 
 export const DEUS_OPENAI_MODEL =
   process.env.DEUS_OPENAI_MODEL || envConfig.DEUS_OPENAI_MODEL || '';
+
+// llama.cpp local-server endpoint configuration. Host-side values only —
+// the container receives translated values via OPENAI_BASE_URL-style env
+// var injection in container-runner.ts. See docs/MULTI_BACKEND.md.
+export const LLAMA_CPP_BASE_URL =
+  process.env.LLAMA_CPP_BASE_URL || envConfig.LLAMA_CPP_BASE_URL || '';
+export const LLAMA_CPP_PORT =
+  process.env.LLAMA_CPP_PORT || envConfig.LLAMA_CPP_PORT || '8080';
+export const LLAMA_CPP_MODEL =
+  process.env.LLAMA_CPP_MODEL || envConfig.LLAMA_CPP_MODEL || '';
 
 export const DEUS_CONTEXT_FILE_MAX_CHARS =
   process.env.DEUS_CONTEXT_FILE_MAX_CHARS ||

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -35,6 +35,8 @@ vi.mock('./config.js', () => ({
   GROUPS_DIR: '/tmp/deus-test-groups',
   HOME_DIR: '/tmp/deus-test-home',
   IDLE_TIMEOUT: 1800000, // 30min
+  LLAMA_CPP_MODEL: 'llama-test-model',
+  LLAMA_CPP_PORT: '8765',
   TIMEZONE: 'America/Los_Angeles',
   TOOL_PROXY_PORT: 3003,
 }));
@@ -1223,6 +1225,75 @@ describe.skipIf(onWindows)('OAuth session-based auth', () => {
   });
 });
 
+describe.skipIf(onWindows)('llama-cpp backend container env', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    fakeProc = createFakeProcess();
+
+    const fsMocked = vi.mocked((fsMod as any).default as typeof fsMod);
+    fsMocked.existsSync.mockReset();
+    fsMocked.existsSync.mockReturnValue(false);
+    fsMocked.mkdirSync.mockReset();
+    fsMocked.writeFileSync.mockReset();
+    fsMocked.readdirSync.mockReset();
+    fsMocked.readdirSync.mockReturnValue([]);
+    fsMocked.statSync.mockReset();
+    fsMocked.statSync.mockReturnValue({
+      isDirectory: () => false,
+    } as ReturnType<typeof fsMod.statSync>);
+
+    vi.mocked(getProjectById).mockReturnValue(undefined);
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      fakeProc as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+  });
+
+  it('injects LLAMA_CPP env vars, bypasses credential proxy, no Anthropic/OpenAI env vars', async () => {
+    const group: RegisteredGroup = {
+      name: 'Main',
+      folder: 'main-group',
+      trigger: '@Deus',
+      added_at: new Date().toISOString(),
+      isControlGroup: true,
+    };
+
+    setImmediate(() => fakeProc.emit('close', 0));
+
+    await runContainerAgent(
+      group,
+      {
+        prompt: 'test',
+        backend: 'llama-cpp',
+        groupFolder: group.folder,
+        chatJid: 'x@g.us',
+        isControlGroup: true,
+      },
+      () => {},
+    );
+
+    const spawnMock = vi.mocked(childProcess.spawn);
+    const lastCall = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const args = lastCall[1] as string[];
+    const joined = args.join(' ');
+
+    // llama-cpp talks to host gateway directly on its own port — NOT the
+    // credential proxy port. Crucial security invariant: this also asserts
+    // the credential proxy is NOT in the URL (no `:3001` substring).
+    expect(joined).toMatch(
+      /LLAMA_CPP_BASE_URL=http:\/\/host\.docker\.internal:\d+\/v1/,
+    );
+    expect(joined).not.toContain(
+      'LLAMA_CPP_BASE_URL=http://host.docker.internal:3001',
+    );
+    expect(args).toContain('LLAMA_CPP_API_KEY=placeholder');
+    // No OpenAI or Anthropic env vars leak into the llama-cpp container.
+    expect(joined).not.toContain('OPENAI_BASE_URL=');
+    expect(joined).not.toContain('OPENAI_API_KEY=');
+    expect(joined).not.toContain('ANTHROPIC_BASE_URL=');
+    expect(joined).not.toContain('ANTHROPIC_API_KEY=');
+  });
+});
+
 describe.skipIf(onWindows)('OpenAI backend container env', () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -1287,6 +1358,7 @@ describe.skipIf(onWindows)('OpenAI backend container env', () => {
 describe.skipIf(onWindows)('Backend parity — system-level equivalence', () => {
   let claudeArgs: string[];
   let openaiArgs: string[];
+  let llamaCppArgs: string[];
 
   beforeAll(async () => {
     fakeProc = createFakeProcess();
@@ -1353,6 +1425,27 @@ describe.skipIf(onWindows)('Backend parity — system-level equivalence', () => 
       () => {},
     );
     openaiArgs = spawnMock.mock.calls[
+      spawnMock.mock.calls.length - 1
+    ][1] as string[];
+
+    // Capture llama-cpp backend args (third tier: local opt-in, no proxy)
+    fakeProc = createFakeProcess();
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      fakeProc as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    setImmediate(() => fakeProc.emit('close', 0));
+    await runContainerAgent(
+      group,
+      {
+        prompt: 'parity-test',
+        backend: 'llama-cpp',
+        groupFolder: group.folder,
+        chatJid: 'x@g.us',
+        isControlGroup: true,
+      },
+      () => {},
+    );
+    llamaCppArgs = spawnMock.mock.calls[
       spawnMock.mock.calls.length - 1
     ][1] as string[];
   });
@@ -1435,15 +1528,19 @@ describe.skipIf(onWindows)('Backend parity — system-level equivalence', () => 
     expect(openaiEnv.has('ANTHROPIC_API_KEY')).toBe(false);
   });
 
-  it('both use placeholder credentials (never real keys)', () => {
+  it('all backends use placeholder credentials (never real keys)', () => {
     const claudeEnv = extractEnvVars(claudeArgs);
     const openaiEnv = extractEnvVars(openaiArgs);
+    const llamaCppEnv = extractEnvVars(llamaCppArgs);
 
     expect(claudeEnv.get('ANTHROPIC_API_KEY')).toBe('placeholder');
     expect(openaiEnv.get('OPENAI_API_KEY')).toBe('placeholder');
+    expect(llamaCppEnv.get('LLAMA_CPP_API_KEY')).toBe('placeholder');
   });
 
-  it('both route through credential proxy', () => {
+  // Remote-backend tier: Claude and OpenAI MUST route through the credential
+  // proxy (the proxy injects real secrets that never live in the container).
+  it('remote backends route through credential proxy', () => {
     const claudeEnv = extractEnvVars(claudeArgs);
     const openaiEnv = extractEnvVars(openaiArgs);
 
@@ -1451,11 +1548,25 @@ describe.skipIf(onWindows)('Backend parity — system-level equivalence', () => 
     expect(openaiEnv.get('OPENAI_BASE_URL')).toContain(':3001');
   });
 
-  it('both receive DEUS_PROXY_TOKEN for proxy authentication', () => {
+  // Local-backend tier: llama-cpp MUST NOT route through the credential
+  // proxy. It talks to the host gateway directly because llama-server has
+  // no auth — the proxy is irrelevant. Asserting the absence here closes
+  // the loop with the remote-backend invariant above.
+  it('local backend (llama-cpp) bypasses credential proxy', () => {
+    const llamaCppEnv = extractEnvVars(llamaCppArgs);
+
+    const baseUrl = llamaCppEnv.get('LLAMA_CPP_BASE_URL') ?? '';
+    expect(baseUrl).not.toContain(':3001');
+    expect(baseUrl).toMatch(/host\.docker\.internal:\d+\/v1/);
+  });
+
+  it('all backends receive DEUS_PROXY_TOKEN for tool proxy authentication', () => {
     const claudeEnv = extractEnvVars(claudeArgs);
     const openaiEnv = extractEnvVars(openaiArgs);
+    const llamaCppEnv = extractEnvVars(llamaCppArgs);
 
     expect(claudeEnv.get('DEUS_PROXY_TOKEN')).toBe(TEST_PROXY_TOKEN);
     expect(openaiEnv.get('DEUS_PROXY_TOKEN')).toBe(TEST_PROXY_TOKEN);
+    expect(llamaCppEnv.get('DEUS_PROXY_TOKEN')).toBe(TEST_PROXY_TOKEN);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -21,6 +21,8 @@ import {
   DEUS_CONTEXT_FILE_MAX_CHARS,
   DEUS_OPENAI_MODEL,
   IDLE_TIMEOUT,
+  LLAMA_CPP_MODEL,
+  LLAMA_CPP_PORT,
   TIMEZONE,
   TOOL_PROXY_PORT,
 } from './config.js';
@@ -118,6 +120,20 @@ function buildContainerArgs(
     args.push('-e', 'OPENAI_API_KEY=placeholder');
     if (DEUS_OPENAI_MODEL) {
       args.push('-e', `DEUS_OPENAI_MODEL=${DEUS_OPENAI_MODEL}`);
+    }
+  } else if (backend === 'llama-cpp') {
+    // llama-server runs on the host and has no auth — no credential-proxy
+    // hop needed. The container talks to the host gateway directly. We
+    // deliberately use LLAMA_CPP_* env names (NOT OPENAI_*) so config does
+    // not co-mingle if the user has both backends configured. The container
+    // driver reads LLAMA_CPP_BASE_URL etc. directly.
+    args.push(
+      '-e',
+      `LLAMA_CPP_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${LLAMA_CPP_PORT}/v1`,
+    );
+    args.push('-e', 'LLAMA_CPP_API_KEY=placeholder');
+    if (LLAMA_CPP_MODEL) {
+      args.push('-e', `LLAMA_CPP_MODEL=${LLAMA_CPP_MODEL}`);
     }
   } else {
     // Route API traffic through the credential proxy (containers never see real secrets)

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -571,6 +571,25 @@ describe('backend-aware sessions', () => {
     });
   });
 
+  it('round-trips a llama-cpp session row without silent coercion', () => {
+    // Regression test for the binary-ternary trap fixed in src/db.ts:685.
+    // Prior to the parseAgentBackend gate, a stored backend='llama-cpp'
+    // row was silently read back as backend='claude', breaking resume.
+    setSession('llama-folder', {
+      backend: 'llama-cpp',
+      session_id: 'llama-cpp-abc',
+    });
+
+    const ref = getSession('llama-folder', 'llama-cpp');
+    expect(ref?.backend).toBe('llama-cpp');
+    expect(ref?.session_id).toBe('llama-cpp-abc');
+
+    expect(getAllBackendSessions()['llama-folder']?.['llama-cpp']).toEqual({
+      backend: 'llama-cpp',
+      session_id: 'llama-cpp-abc',
+    });
+  });
+
   it('clears only the requested backend session', () => {
     setSession('shared-folder', {
       backend: 'claude',

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,7 +5,11 @@ import path from 'path';
 import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
-import { AgentRuntimeId, defaultSession } from './agent-runtimes/types.js';
+import {
+  AgentRuntimeId,
+  defaultSession,
+  parseAgentBackend,
+} from './agent-runtimes/types.js';
 import {
   RuntimeSession,
   NewMessage,
@@ -681,8 +685,11 @@ function rowToSessionRef(row: {
   resume_cursor: string | null;
   metadata_json: string | null;
 }): RuntimeSession {
+  // Use exported parseAgentBackend as the canonical accepted-value gate.
+  // Falls back to 'claude' for null or unrecognized values (e.g., a typo or
+  // a stored backend ID from a future Deus version we don't yet recognize).
   return {
-    backend: row.backend === 'openai' ? 'openai' : 'claude',
+    backend: parseAgentBackend(row.backend) ?? 'claude',
     session_id: row.session_id,
     resume_cursor: row.resume_cursor ?? undefined,
     metadata_json: row.metadata_json ?? undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { logger } from './logger.js';
 import { initRuntimeRegistry } from './agent-runtimes/registry.js';
 import { createClaudeRuntime } from './agent-runtimes/claude-backend.js';
 import { createOpenAIRuntime } from './agent-runtimes/openai-backend.js';
+import { createLlamaCppRuntime } from './agent-runtimes/llama-cpp-backend.js';
 import { startGcalSync, stopGcalSync } from './cache/gcal-sync.js';
 
 export { getAvailableGroups } from './router-state.js';
@@ -117,6 +118,7 @@ async function main(): Promise<void> {
   };
   registry.register(createClaudeRuntime(backendDeps));
   registry.register(createOpenAIRuntime(backendDeps));
+  registry.register(createLlamaCppRuntime(backendDeps));
   logger.info({ backends: registry.list() }, 'Backend registry initialized');
 
   // Graceful shutdown handlers

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -19,7 +19,10 @@ import {
   getProjectById,
 } from './project-registry.js';
 import { RegisteredGroup } from './types.js';
-import type { AgentRuntimeId } from './agent-runtimes/types.js';
+import {
+  parseAgentBackend,
+  type AgentRuntimeId,
+} from './agent-runtimes/types.js';
 
 export interface IpcDeps {
   sendMessage: (jid: string, text: string) => Promise<void>;
@@ -37,10 +40,6 @@ export interface IpcDeps {
 }
 
 let ipcWatcherRunning = false;
-
-function parseAgentBackend(value: unknown): AgentRuntimeId | undefined {
-  return value === 'claude' || value === 'openai' ? value : undefined;
-}
 
 export function startIpcWatcher(deps: IpcDeps): void {
   if (ipcWatcherRunning) {

--- a/src/router-state.ts
+++ b/src/router-state.ts
@@ -80,6 +80,10 @@ export class RouterState {
   get sessions(): Record<string, RuntimeSession> {
     const flat: Record<string, RuntimeSession> = {};
     for (const [folder, refs] of Object.entries(this._sessions)) {
+      // llama-cpp sessions require explicit backend selection — no implicit
+      // fallback to llama-cpp from a missing-backend query. Matches Deus
+      // opt-in semantics: a caller that doesn't specify a backend should
+      // never surprise-route to an opt-in local backend.
       const ref = refs.claude ?? refs.openai;
       if (ref) flat[folder] = ref;
     }
@@ -92,6 +96,9 @@ export class RouterState {
   ): RuntimeSession | undefined {
     const refs = this._sessions[folder];
     if (!refs) return undefined;
+    // See note in `sessions` getter — no implicit fallback to llama-cpp.
+    // Callers must pass `backend: 'llama-cpp'` explicitly to retrieve a
+    // llama-cpp session from the per-folder ref map.
     return backend ? refs[backend] : (refs.claude ?? refs.openai);
   }
 

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -37,7 +37,7 @@ function makeStubRegistry(runTurnOverride?: RunTurnFn): RuntimeRegistry {
     };
   };
   const runTurn = runTurnOverride ?? defaultRunTurn;
-  const stub = (name: 'claude' | 'openai') => ({
+  const stub = (name: 'claude' | 'openai' | 'llama-cpp') => ({
     name: () => name,
     capabilities: () => ({
       shell: true,


### PR DESCRIPTION
## Summary
- Add `llama-cpp` as a third agent backend alongside Claude (default) and OpenAI/Codex. Activate via `deus backend set llama-cpp` or `DEUS_AGENT_BACKEND=llama-cpp`.
- New container-side driver `container/agent-runner/src/llama-cpp-backend.ts` (~500 LOC) that targets the OpenAI-compatible `/v1/chat/completions` endpoint. The existing OpenAI Responses-API path is **untouched** — `llama-server` does not implement `/v1/responses` so reuse there was infeasible.
- Single-source-of-truth design: host-side `parseAgentBackend` in `src/agent-runtimes/types.ts` (used by `config.ts` + `db.ts` to replace silent-coercion ternaries); container-side `VALID_BACKENDS` + `isValidAgentBackend` in `tool-broker.ts` (consumed by tool schemas, Zod enums, dispatch sites).
- Credential-proxy invariant preserved: container always gets `LLAMA_CPP_API_KEY=placeholder`; proxy hop bypassed only because `llama-server` requires no auth. Encoded in the restructured parity test suite (shared / remote-proxy / local-bypass tiers).

## Scope
**Chat-backend only.** Eval-side providers (text gen, judge, embeddings) deferred per ADR `docs/decisions/llama-cpp-optional-integration.md` — embeddings ADR-gated on full re-embed + threshold recalibration + benchmark snapshot. Foreground CLI `deus llama` also deferred (Codex CLI is Responses-API-coupled).

## Files
- 23 modified, 4 new (~1038 insertions, 79 deletions, 27 files)
- 6 host TS, 5 container TS, 2 shell (sh + ps1), 3 docs (incl. ADR parity-matrix +Llama.cpp column), `.env.example`, 6 test files

## Test plan
- [x] `tsc -p .` clean (host + container)
- [x] `npm test`: 1048/1048 host tests pass
- [x] Container tests: 80/80 pass
- [x] Prettier clean on edited files
- [x] Plan-reviewer warden SHIP (6 rounds)
- [x] Code-reviewer warden SHIP (3 rounds)
- [x] Verification-gate warden SHIP (all 16 plan items confirmed with file:line evidence)
- [ ] CI green
- [ ] Manual end-to-end smoke on a host with `/add-llama-cpp` installed: `deus backend set llama-cpp` → channel message → expect chat/completions request to llama-server

## Notes for reviewers
- Plan: `~/.claude/plans/eventual-meandering-bear.md` (6 plan-review rounds, all blockers resolved)
- Brainstorm: `Session-Logs/2026-05-16/llama-cpp-deus-integration-brainstorm.md`
- Pushed with `--no-verify` (user-authorized): pre-push hook flagged 19 **pre-existing** agent-native MCP violations in `packages/mcp-{channel-core,gmail,whatsapp,x}` — none touched by this PR. Cleanup is a separate tracked task in CLAUDE.md pending.
- Foreground `deus` REPL with llama-cpp backend now prints an actionable error pointing the user at channel messages or `deus backend set claude/codex` — no silent fallthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)