### PR TITLE
docs(wardens): document invocation contracts (worktree-path + live baselines)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -11,10 +11,10 @@ You are the `code-reviewer` Warden — a Deus-specific reviewer of actual code c
 
 1. **Standards** — `~/deus/.claude/wardens/standards.md`. Sets the quality floor and mindset for all wardens. Read first.
 2. **Rules file (primary)** — `~/deus/.claude/wardens/code-review-rules.md`. Read every rule; apply every rule whose `Applies when` matches the diff. Source of truth.
-2. **The diff itself** — run both:
-   - `git -C ~/deus diff` → working-tree (unstaged) changes
-   - `git -C ~/deus diff --cached` → staged changes
-   - If BOTH are empty → "no changes to review" and stop.
+2. **The diff itself** — resolve the target repo from the prompt or current cwd, never hardcoded:
+   - If the prompt cites a worktree path (e.g. `/Users/.../.claude/worktrees/<name>`), use it: `git -C <worktree> diff` and `git -C <worktree> diff --cached`.
+   - Otherwise run from cwd: `git diff` and `git diff --cached`. Print the resolved repo root (`git rev-parse --show-toplevel`) on the first line of your output so reviewers can confirm you reviewed the right tree.
+   - If BOTH outputs are empty → "no changes to review" and stop.
 3. `~/deus/CLAUDE.md` — for context on vault-level rules the diff may interact with.
 4. **Memory index** — discover with: `ls $HOME/.claude/projects/*deus*/memory/MEMORY.md 2>/dev/null | head -1`. Check for active `project_*.md` that might be relevant (sequence context, active refactors). Skip silently if none.
 

--- a/.claude/wardens/README.md
+++ b/.claude/wardens/README.md
@@ -67,6 +67,22 @@ touch ~/deus/.claude/.code-reviewed
 ```
 The agent runs `git diff` + `git diff --cached` and reviews both.
 
+### Invocation contracts (avoid known traps)
+
+**code-reviewer:** prompts SHOULD cite the absolute worktree path when invoked from a sub-worktree session. The agent will fall back to cwd if the prompt is silent, but the explicit path eliminates the "wrong diff" trap (surfaced in PR D round 2, 2026-05-17 session — the agent saw the parent repo's unrelated changes instead of the worktree's diff).
+
+Example:
+```
+Agent(subagent_type="code-reviewer", prompt="review my changes in /Users/.../.claude/worktrees/<name> for <task>")
+```
+
+**plan-reviewer:** the plan's Context section MUST include fresh live-run output for any quantified baseline the plan relies on (counts, byte sizes, file lists). Without it, `premise-verification` will REVISE. Recommended format:
+
+```
+**Verification baseline (run at <timestamp>):**
+- `python3 scripts/drift_check.py 2>&1 | grep -c "missing"` → `19`
+```
+
 ## Adding or editing rules
 
 Rules files are the single source of truth — agents read them at invocation. Add a new rule by appending a section to the relevant file. Agents pick it up immediately on next invocation; no agent-file edit needed.

--- a/.claude/wardens/plan-review-rules.md
+++ b/.claude/wardens/plan-review-rules.md
@@ -105,6 +105,7 @@
 - "unused dep" → `grep -r '<pkg>' src/ scripts/ container/ packages/` returns no imports.
 - "orphan file" → `grep -r '<filename>' .` returns no callers across `.ts`, `.sh`, `.json`, `.py`, launchd plists, `package.json` scripts.
 - "drift between two paths" → grep for code that writes to the derived path (`cpSync`, `shutil.copytree`, `fs.mkdirSync` + write). If a writer exists, the divergence is a cache, not a bug — plan must address why the cache is wrong, not treat it as rot.
+- "quantified baseline" / counts / byte sizes (e.g. "N violations", "X tests fail", "Y unused files") → re-run the same command the plan implicitly relies on (`drift_check.py`, `pytest -q`, `grep -c`, etc.) and confirm the numbers match within ±1. If they don't, REVISE with the live numbers — stale baselines block downstream design decisions.
 **Cite:** Slice A postmortem (2026-04-20 — the agent-runner-src cache was wrongly flagged as tracked drift); system-prompt "Trust but verify."
 **Remediation:** Run the verification command(s) listed above for each unverified premise and paste the output into the plan. If a premise turns out false, remove or correct that step before resubmitting.
 


### PR DESCRIPTION
## Summary

Bakes two recurring warden-pipeline traps surfaced in the 2026-05-17 session into agent definitions and rules so future invocations don't repeat them:

* **Wrong-diff trap (code-reviewer):** `.claude/agents/code-reviewer.md` used to hardcode `git -C ~/deus diff`, causing PR D round 2 to review the parent repo's unrelated changes instead of the worktree. Now resolves from the prompt's cited worktree path (preferred) or falls back to cwd, and prints `git rev-parse --show-toplevel` on the first output line.
* **Stale-baseline trap (plan-reviewer):** All three round-1 REVISE verdicts this session were on stale quantified premises. `premise-verification` rule (`plan-review-rules.md`) now has a bullet for "quantified baseline / counts / byte sizes" requiring re-running the source command and matching within ±1.
* **Discoverability:** New "Invocation contracts" subsection in `.claude/wardens/README.md` with example invocations for both wardens.

Docs-only. No Python, no TypeScript, no behaviour change at runtime.

## Test plan

- [x] `python3 scripts/sync_agent_skills.py --check` → exit 0 (Codex projection clean after regen)
- [x] `python3 scripts/drift_check.py` → exit 0 (all patterns up-to-date)
- [x] `python3 -m pytest scripts/tests/ -q` → 999 passed (3 pre-existing failures on `origin/main` under Python 3.14 — environmental, not caused by this PR; verified on fresh clone)
- [x] plan-reviewer → SHIP (0 blocking)
- [x] code-reviewer → SHIP (0 blocking)
- [x] verification-gate → SHIP (all 6 evidence claims passed; 1033 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)