### PR TITLE
feat(hooks): Phase 1 hook-dispatch system — Enforcement Layer

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "events": {
+    "SessionStart": [
+      { "behavior": "session-init", "timeout": 5 },
+      { "script": "scripts/vault_context_hook.py", "timeout": 10 },
+      { "script": "scripts/standards_pack.py", "timeout": 10 }
+    ],
+    "UserPromptSubmit": [
+      { "behavior": "plan-mode-invalidator", "timeout": 5 },
+      { "behavior": "catchup-freshness", "timeout": 8 },
+      { "behavior": "orchestrator-preflight", "timeout": 5 },
+      { "behavior": "migration-nudge", "timeout": 5 }
+    ],
+    "Stop": [
+      { "behavior": "stop-checkpoint", "timeout": 10 }
+    ]
+  }
+}

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17"
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17"
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17"
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-17T07:25:00" # auto-bump (llama-cpp eval providers)
+last_verified: "2026-05-17" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,3 +141,9 @@ export const INJECTION_SCANNER_CONFIG: InjectionScannerConfig = {
   threshold: parseFloat(process.env.DEUS_INJECTION_SCANNER_THRESHOLD || '0.7'),
   logOnly: process.env.DEUS_INJECTION_SCANNER_LOG_ONLY !== '0', // true unless explicitly set to 0
 };
+
+// ── Hook dispatch (Phase 1: Enforcement Layer) ─────────────────────────────
+// Path to hooks.json config. No file = zero hooks fire (default-off).
+export const HOOKS_CONFIG_PATH =
+  process.env.HOOKS_CONFIG_PATH ??
+  path.join(PROJECT_ROOT, '.claude', 'hooks.json');

--- a/src/hooks/dispatcher.test.ts
+++ b/src/hooks/dispatcher.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import path from 'path';
+import os from 'os';
+import { createHookDispatcher } from './dispatcher.js';
+import type { HookContext, HooksConfig } from './types.js';
+
+const ctx: HookContext = {
+  groupFolder: '/tmp/test-group',
+  chatJid: 'test@jid',
+  backend: 'openai',
+  prompt: 'test message',
+  sessionId: 'sess-1',
+};
+
+describe('createHookDispatcher', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `hooks-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns continue=true when no config file exists', async () => {
+    const pipeline = createHookDispatcher({
+      configPath: path.join(tmpDir, 'nonexistent.json'),
+      repoRoot: tmpDir,
+    });
+    const result = await pipeline.enforce('SessionStart', ctx, {});
+    expect(result.continue).toBe(true);
+    expect(result.additionalContext).toBeUndefined();
+  });
+
+  it('returns continue=true when config has no hooks for the event', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    const config: HooksConfig = { version: 1, events: {} };
+    writeFileSync(configPath, JSON.stringify(config));
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('UserPromptSubmit', ctx, {});
+    expect(result.continue).toBe(true);
+  });
+
+  it('returns continue=true on malformed JSON', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    writeFileSync(configPath, 'not valid json{');
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('SessionStart', ctx, {});
+    expect(result.continue).toBe(true);
+  });
+
+  it('observe() always returns empty (Phase 2 stub)', async () => {
+    const pipeline = createHookDispatcher({
+      configPath: path.join(tmpDir, 'nonexistent.json'),
+      repoRoot: tmpDir,
+    });
+    const result = await pipeline.observe('PreToolUse', ctx, {});
+    expect(result).toEqual({});
+  });
+
+  it('runs hooks sequentially and concatenates additionalContext', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    const script1 = path.join(tmpDir, 'hook1.sh');
+    const script2 = path.join(tmpDir, 'hook2.sh');
+
+    writeFileSync(
+      script1,
+      '#!/bin/bash\necho \'{"hookSpecificOutput":{"additionalContext":"context-one"}}\'',
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      script2,
+      '#!/bin/bash\necho \'{"hookSpecificOutput":{"additionalContext":"context-two"}}\'',
+      { mode: 0o755 },
+    );
+
+    const config: HooksConfig = {
+      version: 1,
+      events: {
+        SessionStart: [
+          { script: script1, timeout: 5 },
+          { script: script2, timeout: 5 },
+        ],
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(config));
+
+    // Override PYTHON_BIN for shell scripts — use bash directly
+    const { runHookEntry } = await import('./shell-adapter.js');
+    const spy = vi.spyOn(await import('./shell-adapter.js'), 'runHookEntry');
+    spy.mockResolvedValueOnce({
+      continue: true,
+      additionalContext: 'context-one',
+    });
+    spy.mockResolvedValueOnce({
+      continue: true,
+      additionalContext: 'context-two',
+    });
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('SessionStart', ctx, {});
+
+    expect(result.continue).toBe(true);
+    expect(result.additionalContext).toBe('context-one\n\ncontext-two');
+
+    spy.mockRestore();
+  });
+
+  it('short-circuits on first continue=false', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    const config: HooksConfig = {
+      version: 1,
+      events: {
+        UserPromptSubmit: [
+          { script: 'hook1.sh', timeout: 5 },
+          { script: 'hook2.sh', timeout: 5 },
+        ],
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(config));
+
+    const spy = vi.spyOn(await import('./shell-adapter.js'), 'runHookEntry');
+    spy.mockResolvedValueOnce({
+      continue: false,
+      stopReason: 'blocked by gate',
+    });
+    // second hook should NOT be called
+    spy.mockResolvedValueOnce({
+      continue: true,
+      additionalContext: 'should not appear',
+    });
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('UserPromptSubmit', ctx, {});
+
+    expect(result.continue).toBe(false);
+    expect(result.stopReason).toBe('blocked by gate');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+});
+
+describe('hooks.json validation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `hooks-validate-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects entry with neither behavior nor script', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        version: 1,
+        events: { SessionStart: [{ timeout: 5 }] },
+      }),
+    );
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('SessionStart', ctx, {});
+    expect(result.continue).toBe(true);
+  });
+
+  it('rejects entry with empty behavior string', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        version: 1,
+        events: { SessionStart: [{ behavior: '' }] },
+      }),
+    );
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('SessionStart', ctx, {});
+    expect(result.continue).toBe(true);
+  });
+
+  it('rejects unsupported version', async () => {
+    const configPath = path.join(tmpDir, 'hooks.json');
+    writeFileSync(configPath, JSON.stringify({ version: 99, events: {} }));
+
+    const pipeline = createHookDispatcher({ configPath, repoRoot: tmpDir });
+    const result = await pipeline.enforce('SessionStart', ctx, {});
+    expect(result.continue).toBe(true);
+  });
+});

--- a/src/hooks/dispatcher.ts
+++ b/src/hooks/dispatcher.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'fs';
+
+import { HOOKS_CONFIG_PATH, PROJECT_ROOT } from '../config.js';
+import { logger } from '../logger.js';
+import { runHookEntry } from './shell-adapter.js';
+import type {
+  EnforcementEvent,
+  EnforcementHookResult,
+  HookContext,
+  HookEntryConfig,
+  HooksConfig,
+  HookPipeline,
+  ObserverEvent,
+  ObserverHookResult,
+} from './types.js';
+
+export interface HookDispatcherDeps {
+  configPath?: string;
+  repoRoot?: string;
+}
+
+const MAX_CONTEXT_BYTES = 24_000;
+
+function isValidEntry(entry: unknown): entry is HookEntryConfig {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const obj = entry as Record<string, unknown>;
+  const hasBehavior =
+    'behavior' in obj &&
+    typeof obj['behavior'] === 'string' &&
+    obj['behavior'] !== '';
+  const hasScript =
+    'script' in obj &&
+    typeof obj['script'] === 'string' &&
+    obj['script'] !== '';
+  return (hasBehavior || hasScript) && !(hasBehavior && hasScript);
+}
+
+function loadHooksConfig(configPath: string): HooksConfig | null {
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  if ((parsed as { version?: unknown }).version !== 1) {
+    throw new Error(
+      `Unsupported hooks.json version: ${(parsed as { version?: unknown }).version}`,
+    );
+  }
+
+  const events = (parsed as { events?: unknown }).events;
+  if (typeof events !== 'object' || events === null) {
+    throw new Error('hooks.json: missing or invalid "events" field');
+  }
+
+  const eventsObj = events as Record<string, unknown>;
+  for (const [eventName, entries] of Object.entries(eventsObj)) {
+    if (!Array.isArray(entries)) {
+      throw new Error(`hooks.json: events.${eventName} must be an array`);
+    }
+    for (let i = 0; i < entries.length; i++) {
+      if (!isValidEntry(entries[i])) {
+        throw new Error(
+          `hooks.json: events.${eventName}[${i}] must have exactly one of "behavior" or "script" (non-empty string)`,
+        );
+      }
+    }
+  }
+
+  return parsed as unknown as HooksConfig;
+}
+
+async function runSequential(
+  hooks: HookEntryConfig[],
+  event: EnforcementEvent,
+  context: HookContext,
+  payload: Record<string, unknown>,
+  repoRoot: string,
+): Promise<EnforcementHookResult> {
+  const contextParts: string[] = [];
+  let contextBytes = 0;
+
+  for (const entry of hooks) {
+    const result = await runHookEntry(entry, event, context, payload, repoRoot);
+
+    if (result.additionalContext) {
+      const chunk = result.additionalContext;
+      if (contextBytes + chunk.length <= MAX_CONTEXT_BYTES) {
+        contextParts.push(chunk);
+        contextBytes += chunk.length;
+      } else {
+        logger.warn(
+          { event, bytes: contextBytes + chunk.length, max: MAX_CONTEXT_BYTES },
+          'Hook additionalContext exceeds budget — truncating',
+        );
+      }
+    }
+
+    if (!result.continue) {
+      return {
+        continue: false,
+        stopReason: result.stopReason,
+        additionalContext: contextParts.join('\n\n') || undefined,
+      };
+    }
+  }
+
+  return {
+    continue: true,
+    additionalContext: contextParts.join('\n\n') || undefined,
+  };
+}
+
+// Config is read once at startup — restart required to pick up changes.
+export function createHookDispatcher(
+  deps: HookDispatcherDeps = {},
+): HookPipeline {
+  const configPath = deps.configPath ?? HOOKS_CONFIG_PATH;
+  const repoRoot = deps.repoRoot ?? PROJECT_ROOT;
+
+  let config: HooksConfig | null = null;
+  try {
+    config = loadHooksConfig(configPath);
+  } catch (err) {
+    logger.error(
+      { err, configPath },
+      'hooks.json parse error — hooks disabled',
+    );
+    config = null;
+  }
+
+  if (config) {
+    const hookCount =
+      (config.events.SessionStart?.length ?? 0) +
+      (config.events.UserPromptSubmit?.length ?? 0) +
+      (config.events.Stop?.length ?? 0);
+    logger.info({ configPath, hookCount }, 'HookDispatcher loaded');
+  } else {
+    logger.debug('HookDispatcher: no hooks.json — zero hooks will fire');
+  }
+
+  return {
+    async enforce(
+      event: EnforcementEvent,
+      context: HookContext,
+      payload: Record<string, unknown>,
+    ): Promise<EnforcementHookResult> {
+      if (!config) return { continue: true };
+
+      const hooks = config.events[event] ?? [];
+      if (hooks.length === 0) return { continue: true };
+
+      return runSequential(hooks, event, context, payload, repoRoot);
+    },
+
+    // Phase 2: Observer Layer (PreToolUse/PostToolUse via container HTTP bridge)
+    async observe(
+      _event: ObserverEvent,
+      _context: HookContext,
+      _payload: Record<string, unknown>,
+    ): Promise<ObserverHookResult> {
+      return {};
+    },
+  };
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,8 @@
+export { createHookDispatcher } from './dispatcher.js';
+export type {
+  HookPipeline,
+  EnforcementHookResult,
+  ObserverHookResult,
+  HookContext,
+  HooksConfig,
+} from './types.js';

--- a/src/hooks/shell-adapter.test.ts
+++ b/src/hooks/shell-adapter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { buildEventPayload, parseHookOutput } from './shell-adapter.js';
+import type { HookContext } from './types.js';
+
+const ctx: HookContext = {
+  groupFolder: '/tmp/test-group',
+  chatJid: 'test@jid',
+  backend: 'openai',
+  prompt: 'hello world',
+  sessionId: 'sess-123',
+};
+
+describe('parseHookOutput', () => {
+  it('returns continue=true for empty output', () => {
+    expect(parseHookOutput('')).toEqual({ continue: true });
+    expect(parseHookOutput('  \n  ')).toEqual({ continue: true });
+  });
+
+  it('returns continue=true for non-JSON output', () => {
+    expect(parseHookOutput('not json')).toEqual({ continue: true });
+  });
+
+  it('parses permissionDecision deny → continue=false', () => {
+    const raw = JSON.stringify({
+      hookSpecificOutput: {
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'marker absent',
+      },
+    });
+    const result = parseHookOutput(raw);
+    expect(result.continue).toBe(false);
+    expect(result.stopReason).toBe('marker absent');
+  });
+
+  it('parses additionalContext from hookSpecificOutput', () => {
+    const raw = JSON.stringify({
+      hookSpecificOutput: {
+        additionalContext: 'vault context here',
+      },
+    });
+    const result = parseHookOutput(raw);
+    expect(result.continue).toBe(true);
+    expect(result.additionalContext).toBe('vault context here');
+  });
+
+  it('parses systemMessage as additionalContext', () => {
+    const raw = JSON.stringify({
+      systemMessage: 'warning about something',
+    });
+    const result = parseHookOutput(raw);
+    expect(result.continue).toBe(true);
+    expect(result.additionalContext).toBe('warning about something');
+  });
+
+  it('returns continue=true for unrecognized JSON shape', () => {
+    const raw = JSON.stringify({ unknown: 'field' });
+    expect(parseHookOutput(raw)).toEqual({ continue: true });
+  });
+
+  it('uses default stopReason when permissionDecisionReason is absent', () => {
+    const raw = JSON.stringify({
+      hookSpecificOutput: {
+        permissionDecision: 'deny',
+      },
+    });
+    const result = parseHookOutput(raw);
+    expect(result.continue).toBe(false);
+    expect(result.stopReason).toBe('Hook denied operation');
+  });
+});
+
+describe('buildEventPayload', () => {
+  it('builds SessionStart payload', () => {
+    const payload = buildEventPayload('SessionStart', ctx);
+    expect(payload).toEqual({
+      hook_event_name: 'SessionStart',
+      cwd: '/tmp/test-group',
+      session_id: 'sess-123',
+    });
+  });
+
+  it('builds UserPromptSubmit payload with prompt', () => {
+    const payload = buildEventPayload('UserPromptSubmit', ctx);
+    expect(payload).toEqual({
+      hook_event_name: 'UserPromptSubmit',
+      cwd: '/tmp/test-group',
+      session_id: 'sess-123',
+      prompt: 'hello world',
+    });
+  });
+
+  it('builds Stop payload', () => {
+    const payload = buildEventPayload('Stop', ctx);
+    expect(payload).toEqual({
+      hook_event_name: 'Stop',
+      cwd: '/tmp/test-group',
+      session_id: 'sess-123',
+    });
+  });
+
+  it('uses empty string for missing sessionId', () => {
+    const noSession = { ...ctx, sessionId: undefined };
+    const payload = buildEventPayload('SessionStart', noSession);
+    expect(payload.session_id).toBe('');
+  });
+
+  it('uses empty string for missing prompt on UserPromptSubmit', () => {
+    const noPrompt = { ...ctx, prompt: undefined };
+    const payload = buildEventPayload('UserPromptSubmit', noPrompt);
+    expect(payload.prompt).toBe('');
+  });
+});

--- a/src/hooks/shell-adapter.ts
+++ b/src/hooks/shell-adapter.ts
@@ -1,0 +1,163 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+import { killProcess, PYTHON_BIN } from '../platform.js';
+import { logger } from '../logger.js';
+import type {
+  EnforcementEvent,
+  EnforcementHookResult,
+  HookContext,
+  HookEntryConfig,
+} from './types.js';
+
+const DEFAULT_HOOK_TIMEOUT_MS = 10_000;
+
+export function buildEventPayload(
+  event: EnforcementEvent,
+  context: HookContext,
+): Record<string, unknown> {
+  const base = {
+    hook_event_name: event,
+    cwd: context.groupFolder,
+    session_id: context.sessionId ?? '',
+  };
+
+  if (event === 'UserPromptSubmit') {
+    return { ...base, prompt: context.prompt ?? '' };
+  }
+
+  return base;
+}
+
+export function parseHookOutput(raw: string): EnforcementHookResult {
+  const trimmed = raw.trim();
+  if (!trimmed) return { continue: true };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { continue: true };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return { continue: true };
+  const obj = parsed as Record<string, unknown>;
+
+  const hso = obj['hookSpecificOutput'];
+  if (typeof hso === 'object' && hso !== null) {
+    const hsoObj = hso as Record<string, unknown>;
+    if (hsoObj['permissionDecision'] === 'deny') {
+      return {
+        continue: false,
+        stopReason: String(
+          hsoObj['permissionDecisionReason'] ?? 'Hook denied operation',
+        ),
+      };
+    }
+    if (typeof hsoObj['additionalContext'] === 'string') {
+      return { continue: true, additionalContext: hsoObj['additionalContext'] };
+    }
+  }
+
+  if (typeof obj['systemMessage'] === 'string') {
+    return { continue: true, additionalContext: obj['systemMessage'] };
+  }
+
+  return { continue: true };
+}
+
+function runProcess(
+  args: string[],
+  stdinJson: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((resolve) => {
+    let stdout = '';
+    let settled = false;
+
+    const proc = spawn(args[0], args.slice(1), {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.stderr.on('data', (chunk: Buffer) => {
+      const msg = chunk.toString().trim();
+      if (msg) logger.debug({ hook: args.join(' ') }, msg);
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        if (proc.pid) killProcess(proc.pid);
+        logger.warn({ hook: args.join(' '), timeoutMs }, 'Hook timed out');
+        resolve('');
+      }
+    }, timeoutMs);
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      if (code !== 0 && code !== null) {
+        logger.warn({ hook: args.join(' '), code }, 'Hook exited non-zero');
+      }
+      resolve(stdout);
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      logger.error({ hook: args.join(' '), err }, 'Hook spawn error');
+      resolve('');
+    });
+
+    try {
+      proc.stdin.write(JSON.stringify(stdinJson));
+      proc.stdin.end();
+    } catch {
+      // stdin may already be closed
+    }
+  });
+}
+
+export async function runHookEntry(
+  entry: HookEntryConfig,
+  event: EnforcementEvent,
+  context: HookContext,
+  payload: Record<string, unknown>,
+  repoRoot: string,
+): Promise<EnforcementHookResult> {
+  const timeoutMs = (entry.timeout ?? 10) * 1000 || DEFAULT_HOOK_TIMEOUT_MS;
+  const stdinJson = buildEventPayload(event, context);
+
+  let args: string[];
+  if ('behavior' in entry) {
+    const scriptPath = path.join(repoRoot, 'scripts', 'codex_warden_hooks.py');
+    args = [
+      PYTHON_BIN,
+      scriptPath,
+      'run',
+      entry.behavior,
+      '--repo-root',
+      repoRoot,
+    ];
+  } else {
+    const scriptPath = path.isAbsolute(entry.script)
+      ? entry.script
+      : path.join(repoRoot, entry.script);
+    args = [PYTHON_BIN, scriptPath];
+  }
+
+  try {
+    const raw = await runProcess(args, stdinJson, timeoutMs);
+    return parseHookOutput(raw);
+  } catch (err) {
+    logger.error({ err, hook: args.join(' ') }, 'Hook execution error');
+    return { continue: true };
+  }
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,0 +1,49 @@
+export type EnforcementEvent = 'SessionStart' | 'UserPromptSubmit' | 'Stop';
+
+export type ObserverEvent = 'PreToolUse' | 'PostToolUse';
+
+export interface HookContext {
+  groupFolder: string;
+  chatJid: string;
+  backend: string;
+  prompt?: string;
+  sessionId?: string;
+}
+
+export interface EnforcementHookResult {
+  continue: boolean;
+  stopReason?: string;
+  additionalContext?: string;
+}
+
+export interface ObserverHookResult {
+  additionalContext?: string;
+  updatedInput?: Record<string, unknown>;
+}
+
+export interface HookPipeline {
+  enforce(
+    event: EnforcementEvent,
+    context: HookContext,
+    payload: Record<string, unknown>,
+  ): Promise<EnforcementHookResult>;
+
+  observe(
+    event: ObserverEvent,
+    context: HookContext,
+    payload: Record<string, unknown>,
+  ): Promise<ObserverHookResult>;
+}
+
+export type HookEntryConfig =
+  | { behavior: string; timeout?: number }
+  | { script: string; timeout?: number };
+
+export interface HooksConfig {
+  version: 1;
+  events: {
+    SessionStart?: HookEntryConfig[];
+    UserPromptSubmit?: HookEntryConfig[];
+    Stop?: HookEntryConfig[];
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { GroupQueue } from './group-queue.js';
 import { startIpcWatcher } from './ipc.js';
 import { loadSkillIpcHandlers } from './skills/index.js';
+import { createHookDispatcher } from './hooks/index.js';
 import { createMessageOrchestrator } from './message-orchestrator.js';
 import { findChannel, formatOutbound } from './router.js';
 import {
@@ -321,11 +322,14 @@ async function main(): Promise<void> {
     );
   }
 
+  const hookDispatcher = createHookDispatcher();
+
   const orchestrator = createMessageOrchestrator({
     state,
     queue,
     registry,
     channels,
+    hooks: hookDispatcher,
   });
 
   // Start subsystems (independently of connection handler)

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -55,6 +55,11 @@ import {
   isSessionCommandAllowed,
 } from './session-commands.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import type {
+  EnforcementHookResult,
+  HookContext,
+  HookPipeline,
+} from './hooks/index.js';
 
 export interface OrchestratorDeps {
   state: RouterState;
@@ -63,10 +68,15 @@ export interface OrchestratorDeps {
   /** Mutable array — channels are pushed into it during startup before the
    *  orchestrator starts processing, so this reference stays valid. */
   channels: Channel[];
+  hooks?: HookPipeline;
+}
+
+function injectHookContext(prompt: string, context: string): string {
+  return `<hook-context>\n${context}\n</hook-context>\n\n${prompt}`;
 }
 
 export function createMessageOrchestrator(deps: OrchestratorDeps) {
-  const { state, queue, registry, channels } = deps;
+  const { state, queue, registry, channels, hooks } = deps;
   let messageLoopRunning = false;
 
   async function runAgent(
@@ -134,7 +144,7 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       new Set(Object.keys(state.registeredGroups)),
     );
 
-    const runContext: RunContext = {
+    let runContext: RunContext = {
       prompt,
       groupFolder: group.folder,
       chatJid,
@@ -143,6 +153,39 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
     };
 
     const currentSessionRef = sessionRef ?? defaultSession('', backend);
+
+    // ── Enforcement Layer: SessionStart ─────────────────────────────────
+    const isNewSession = !sessionRef || sessionRef.session_id === '';
+    if (isNewSession && hooks) {
+      const hookCtx: HookContext = {
+        groupFolder: group.folder,
+        chatJid,
+        backend,
+        sessionId: currentSessionRef.session_id || undefined,
+      };
+      let sessionStartResult: EnforcementHookResult | undefined;
+      try {
+        sessionStartResult = await hooks.enforce('SessionStart', hookCtx, {});
+      } catch (err) {
+        logger.error({ err }, 'SessionStart hook error — failing open');
+      }
+      if (sessionStartResult && !sessionStartResult.continue) {
+        logger.warn(
+          { group: group.name, reason: sessionStartResult.stopReason },
+          'SessionStart hook blocked — aborting agent run',
+        );
+        return 'success';
+      }
+      if (sessionStartResult?.additionalContext) {
+        runContext = {
+          ...runContext,
+          prompt: injectHookContext(
+            runContext.prompt,
+            sessionStartResult.additionalContext,
+          ),
+        };
+      }
+    }
 
     const eventSink: RuntimeEventSink = async (event) => {
       if (event.type === 'session') {
@@ -201,12 +244,61 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       );
     }
 
+    // ── Enforcement Layer: UserPromptSubmit ──────────────────────────────
+    if (hooks) {
+      const hookCtx: HookContext = {
+        groupFolder: group.folder,
+        chatJid,
+        backend,
+        prompt: runContext.prompt,
+        sessionId: currentSessionRef.session_id || undefined,
+      };
+      let promptResult: EnforcementHookResult | undefined;
+      try {
+        promptResult = await hooks.enforce('UserPromptSubmit', hookCtx, {});
+      } catch (err) {
+        logger.error({ err }, 'UserPromptSubmit hook error — failing open');
+      }
+      if (promptResult && !promptResult.continue) {
+        logger.warn(
+          { group: group.name, reason: promptResult.stopReason },
+          'UserPromptSubmit hook blocked — message will not reach the agent',
+        );
+        return 'success';
+      }
+      if (promptResult?.additionalContext) {
+        runContext = {
+          ...runContext,
+          prompt: injectHookContext(
+            runContext.prompt,
+            promptResult.additionalContext,
+          ),
+        };
+      }
+    }
+
     try {
       const runResult = await resolvedBackend.runTurn(
         runContext,
         currentSessionRef,
         eventSink,
       );
+
+      // ── Enforcement Layer: Stop ─────────────────────────────────────
+      if (hooks) {
+        const hookCtx: HookContext = {
+          groupFolder: group.folder,
+          chatJid,
+          backend,
+          sessionId:
+            (runResult.sessionRef ?? currentSessionRef).session_id || undefined,
+        };
+        try {
+          await hooks.enforce('Stop', hookCtx, {});
+        } catch (err) {
+          logger.error({ err }, 'Stop hook error — failing open');
+        }
+      }
 
       if (runResult.sessionRef) {
         state.setSession(group.folder, runResult.sessionRef);


### PR DESCRIPTION
## Summary

- Wire 8 message-level Enforcement hooks into `message-orchestrator.ts` so they fire model-agnostically for all container backends (Claude, OpenAI, llama-cpp)
- New `src/hooks/` module: HookPipeline interface, ShellHookAdapter (spawns hook processes), HookDispatcher (loads config, routes events, aggregates results)
- Hooks fire at 3 orchestrator events: SessionStart (3 hooks), UserPromptSubmit (4 hooks), Stop (1 hook)

Per ADR `docs/decisions/hook-dispatch-system.md` (Phase 1: Interface + Enforcement Layer).

**ADR deviation (intentional):** HookPipeline is on `OrchestratorDeps`, not on `AgentRuntime` — enforce() calls happen in the orchestrator before the runtime runs. Phase 2 may reconcile.

**4 per-tool gates stay CC-only:** `plan-review-gate`, `code-review-gate`, `verification-gate`, `admin-merge-gate` require `tool_input` from PreToolUse events unavailable at orchestrator level. Empirically verified they silently no-op without it. Phase 2's Observer Layer will enable them.

**Schema note:** `parseHookOutput` field names (`hookSpecificOutput`, `permissionDecision`, `systemMessage`) are Deus-native, designed for interop with existing `codex_warden_hooks.py` output shapes. Coincidentally named the same as Claude Code's wire format.

## Test plan

- [x] 21 unit tests pass (vitest): parseHookOutput (7 shapes), buildEventPayload (5 events), dispatcher config loading/validation/short-circuit/aggregation (9 cases)
- [x] Full suite: 1069/1069 tests pass, zero regressions
- [x] TypeScript compiles clean for `src/` (pre-existing errors only in `packages/tui` and `packages/mcp-*`)
- [x] Empirical hook verification: `echo '<payload>' | python3 scripts/codex_warden_hooks.py run <behavior>` produces correct output for all 8 hooks
- [x] Default-off: dispatcher returns `{continue: true}` when no `hooks.json` exists
- [x] Plan-reviewer SHIP (3 rounds: round 1 platform + API-surface fixes, round 2 per-tool gate premise catch, round 3 clean)
- [x] Code-reviewer SHIP (type-safety validation, token budget guard, cleanup fixes applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)