### PR TITLE
test(fixtures): add Hebrew regression queries + redact trading specifics

### DIFF
--- a/scripts/tests/fixtures/atom_queries.jsonl
+++ b/scripts/tests/fixtures/atom_queries.jsonl
@@ -1,6 +1,6 @@
 {"query": "where is the deus project located", "expected_atoms": ["project directory is located at ~/deus", "project at ~/deus", "project 'deus' at the path ~/deus"], "tag": "fact"}
 {"query": "what is the default embedding provider", "expected_atoms": ["Ollama is the default provider for memory embeddings"], "tag": "entity"}
-{"query": "what are the trading risk limits", "expected_atoms": ["maximum 2% risk per trade", "3% daily drawdown limit", "bracket limit orders"], "tag": "constraint"}
+{"query": "what are the trading risk limits", "expected_atoms": ["trading risk management requires"], "tag": "constraint"}
 {"query": "database deletion policy", "expected_atoms": ["no-DB-deletion policy", "orphaned_at and expired_at flags"], "tag": "constraint"}
 {"query": "how does the code review process work", "expected_atoms": [".code-reviewed marker", "SHIP verdict from a code reviewer"], "tag": "methodology"}
 {"query": "documentation style preference", "expected_atoms": ["caveman", "extreme brevity", "removing articles"], "tag": "preference"}
@@ -38,3 +38,23 @@
 {"query": "what gym do I go to", "expected_atoms": [], "tag": "abstain-near"}
 {"query": "my shoe size", "expected_atoms": [], "tag": "abstain-near"}
 {"query": "what brand laptop do I use", "expected_atoms": [], "tag": "abstain-near"}
+{"query": "איפה הקבצים של לינארית 1", "expected_atoms": ["linear algebra course materials are located", "permanent study tools"], "tag": "hebrew"}
+{"query": "מתי המבחן בלינארית 1", "expected_atoms": ["preparing for a linear algebra 1 exam", "studying for a linear algebra 1 exam"], "tag": "hebrew"}
+{"query": "איך לטפל ב-RTL במסמכים של פייתון", "expected_atoms": ["whitespace-normalization (handling tabs"], "tag": "hebrew"}
+{"query": "באיזה מודל אני משתמש ל-OCR בעברית", "expected_atoms": ["primary ocr model for hebrew cursive", "gemini api for hebrew ocr"], "tag": "hebrew"}
+{"query": "סדר אלמנטים של w:pPr ב-OOXML", "expected_atoms": ["manually construct w:ppr elements"], "tag": "hebrew"}
+{"query": "מה ההעדפה שלי ל-OCR בכתב יד", "expected_atoms": ["primary ocr model for hebrew cursive"], "tag": "hebrew"}
+{"query": "מודל ה-OCR העדיף לעברית", "expected_atoms": ["primary ocr model for hebrew cursive", "gemini api for hebrew ocr"], "tag": "hebrew"}
+{"query": "תיקיית הלימודים של לינארית 1", "expected_atoms": ["linear algebra course materials are located"], "tag": "hebrew"}
+{"query": "איך אני מציג עברית ב-CLI", "expected_atoms": ["hebrew text in cli output to be rendered"], "tag": "hebrew"}
+{"query": "למה ויתרתי על BiDi בטרמינל", "expected_atoms": ["abandoned attempts to use terminal-based bidi"], "tag": "hebrew"}
+{"query": "איזה קוד שפה ל-YouTube בעברית", "expected_atoms": ["'iw' language code for hebrew youtube"], "tag": "hebrew"}
+{"query": "איפה הגדרות Ghostty", "expected_atoms": ["ghostty configuration file is located"], "tag": "hebrew"}
+{"query": "איך להציג KaTeX בעמוד עברי", "expected_atoms": ["katex ltr isolation rule"], "tag": "hebrew"}
+{"query": "איך אני מטפל ב-RTL בטרמינל", "expected_atoms": ["unicode-bidi crate"], "tag": "hebrew"}
+{"query": "איך להמיר מסמך מ-RTL ל-LTR", "expected_atoms": ["rtl-to-ltr conversion for hebrew documents"], "tag": "hebrew"}
+{"query": "מה אני משתמש לאוטומציה של clipboard", "expected_atoms": ["hammerspoon for clipboard processing"], "tag": "hebrew"}
+{"query": "מבנה של Feynman Check", "expected_atoms": ["feynman study checks as 1-by-1 question formats"], "tag": "hebrew"}
+{"query": "באיזו שפה אני עונה", "expected_atoms": ["respond in english only"], "tag": "hebrew"}
+{"query": "איזה כרכים של לינארית 1 אני לומד", "expected_atoms": ["volume c (chapters 9-12)"], "tag": "hebrew"}
+{"query": "מה הלולאה השבועית של הלימוד שלי", "expected_atoms": ["weekly study loop consisting of setup"], "tag": "hebrew"}


### PR DESCRIPTION
## Summary

Two coupled changes to `scripts/tests/fixtures/atom_queries.jsonl`:

1. **20 Hebrew queries added** (tag=`hebrew`) covering cross-lingual + native Hebrew retrieval against existing English-flattened atoms. Mapped to 14 verified atoms in `~/.deus/memory.db` — Linear Algebra course materials/exams, RTL/BiDi tooling (python-docx, OOXML, KaTeX, Ghostty, terminal), Hebrew OCR preferences, study methodology, CLI language policy. All substrings verified to uniquely match the intended atom.

2. **Pre-existing trading-limits entry redacted.** Replaces specific `2% risk per trade` / `3% daily drawdown` / `bracket limit orders` with generic substring `"trading risk management requires"` (still validates retrieval, no longer exposes specific risk parameters in the public repo).

## Context

Phase 0.5 of the llama.cpp embedding migration investigation (per `Session-Logs/2026-05-17/`). The fixture previously had zero Hebrew queries, making Hebrew retrieval quality invisible to the embedding shootout harness.

## Measurement results

Two new shootout runs with this fixture, archived to vault `Research/`:

**Small-distractor (50 distractors, recall@5):**
| Model | Recall@5 |
|---|---|
| bge-m3 +prefix | 50/50 |
| embeddinggemma | 49/50 |

**Production-scale (1528 distractors, recall@5):**
| Model | Recall@5 | English misses | Hebrew misses |
|---|---|---|---|
| bge-m3 raw | 46/50 | 0 | 4 |
| embeddinggemma | 45/50 | 1 | 4 |
| bge-m3 +prefix | 45/50 | 1 | 4 |

**Structural insight from per-query analysis**: ~80% of misses have the correct target at rank #6–#13. Expanding bi-encoder top-K from 5 to 10 would likely recover most failures **without any embedding-model migration**. This shifts the next phase from "swap embeddings" to "tune retrieval K."

## Verification

- All 20 Hebrew substrings verified to uniquely match the intended atom (no spurious matches across the 1671-atom corpus)
- Trading-entry redaction verified: `grep -E '2%|3%|bracket limit'` against the new fixture returns zero matches
- `python3 scripts/embedding_shootout.py --models embeddinggemma 2>&1 | head -3` → loads cleanly, reports `50 queries`
- All JSONL lines parse as valid JSON

## Test plan

- [x] Substring uniqueness verified
- [x] Trading redaction does not break the existing test (still uniquely matches atom 1017)
- [x] All JSONL parses
- [x] Shootout loads + runs end-to-end on extended fixture
- [x] code-reviewer SHIP (round 2)
- [x] verification-gate SHIP (round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)