### PR TITLE
feat(retrieval): swap reranker to multilingual bge-reranker-v2-m3

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -64,7 +64,7 @@ On top of that, Deus breaks conversations into individual facts - "we chose libr
 | **Hermes Agent** | Database with full-text search | Full-text search + preference profiling | Yes - session context, full-text search, user profiling |
 | **Plain Claude** | Conversation window | None | No |
 
-Atom retrieval uses a multi-stage pipeline: embedding search (Ollama embeddinggemma) retrieves initial candidates, approach angles bridge vocabulary mismatch (HyPE pattern), BM25 keyword search rescues literal matches, and a cross-encoder reranker (ms-marco-MiniLM-L-6-v2) re-scores the final pool for precision. All local, no API calls.
+Atom retrieval uses a multi-stage pipeline: embedding search (Ollama embeddinggemma) retrieves initial candidates, approach angles bridge vocabulary mismatch (HyPE pattern), BM25 keyword search rescues literal matches, and a multilingual cross-encoder reranker (BAAI/bge-reranker-v2-m3) re-scores the final pool for precision. All local, no API calls.
 
 Deus never deletes memory data - old facts are soft-deleted, never dropped ([why](decisions/no-db-deletion.md)). For the full technical architecture (vector dimensions, recency decay formulas, embedding models), see [Architecture - Memory](ARCHITECTURE.md#memory-system), the [memory tree ADR](decisions/memory-tree.md), and the [atom retrieval pipeline ADR](decisions/atom-retrieval-pipeline.md).
 

--- a/docs/decisions/atom-retrieval-pipeline.md
+++ b/docs/decisions/atom-retrieval-pipeline.md
@@ -66,7 +66,7 @@ Tested embeddinggemma, snowflake-arctic-embed2, nomic-embed-text, bge-m3, mxbai-
 | `DEUS_ATOM_ANGLE_MIN` | `1.1` | Max L2 distance for angle rescue |
 | `DEUS_ATOM_ANGLE_ALPHA` | `0.0` | Blending weight (0 = pure angle score) |
 | `DEUS_RERANKER` | `1` | Enable cross-encoder reranking |
-| `DEUS_RERANKER_MODEL` | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Cross-encoder model |
+| `DEUS_RERANKER_MODEL` | `BAAI/bge-reranker-v2-m3` | Cross-encoder model (multilingual; see amendment 2026-05-17) |
 | `DEUS_RERANKER_CANDIDATES` | `20` | First-stage candidate pool size |
 | `DEUS_SIBLING_DISCOUNT` | `0.15` | Distance penalty for sibling atoms |
 | `DEUS_SIBLING_MAX` | `5` | Max sibling atoms to add |
@@ -88,3 +88,31 @@ This generates approach angles for all atoms (~45 min via Ollama). The cross-enc
 | Expanding cross-encoder candidate pool beyond 10 | No improvement | Plateau at 10 candidates; misses are first-stage recall failures |
 | snowflake-arctic-embed2 model swap | recall 0.933 (vs 1.000 embeddinggemma) | Worse on short personal knowledge descriptions |
 | mxbai-embed-large model swap | recall 0.967 (vs 1.000) | Lower discrimination despite higher MTEB score |
+
+## Amendment — 2026-05-17: Reranker swap to bge-reranker-v2-m3
+
+**Trigger**: Hebrew query support (PR #457 added 20 Hebrew regression queries to `atom_queries.jsonl`). Re-running the production-pipeline simulation revealed that the original English-only `ms-marco-MiniLM-L-6-v2` cross-encoder was the Hebrew bottleneck — not the embeddinggemma bi-encoder.
+
+**Measurement** (50 queries: 30 English + 20 Hebrew; 1684 atoms; bi-encoder top-20 → reranker → top-5):
+
+| Reranker | Pipeline recall@5 | Misses | Per-query latency (M3 Pro) |
+|---|---|---|---|
+| `ms-marco-MiniLM-L-6-v2` (original, 22M, English) | 92% (46/50) | 4 | 18 ms |
+| `mmarco-mMiniLMv2-L12-H384-v1` (107M, multilingual) | 96% (48/50) | 2 | 28 ms |
+| **`BAAI/bge-reranker-v2-m3`** (340M, multilingual) | **98% (49/50)** | 1 | 166 ms |
+
+The one remaining miss (`"איך לטפל ב-RTL במסמכים של פייתון"`) is a bi-encoder failure — target ranks at #42, outside the top-20 candidate window. No reranker can rescue it; either expand `DEUS_RERANKER_CANDIDATES` or address via query rewriting.
+
+**Latency stacking**: the reranker is only hit by `memory_indexer.py --query` (interactive CLI) and `--rebuild` (rare batch). The per-prompt UserPromptSubmit hook uses `memory_tree.py` which has no reranker stage, so the 148 ms latency increase has zero impact on per-turn chat UX. Rebuild adds ~4 min (1700 atoms × 150 ms) — acceptable for an operation that already takes ~20 min.
+
+**Why not stay with the smaller multilingual option (+4%)**: bge-reranker-v2-m3 also rescues an English query (`"warden portability philosophy"`) that the smaller multilingual reranker still missed — turns out the broader-trained model is just better in general, not only on Hebrew. Since latency doesn't gate UX, take the strict-best.
+
+**Updated baseline note for §2**: the "42x discrimination" finding from the original ADR was on the English-only reranker. The new reranker has not been re-measured for raw separation; pipeline recall is the primary measure.
+
+**No re-embed required**: only the cross-encoder model changes. Embeddings, schema, thresholds untouched.
+
+**Considered but not measured**: quantized variants of bge-reranker-v2-m3 (e.g., FlagEmbedding ONNX/INT8 paths, advertised ~60ms on M-series). Skipped because (a) latency is acceptable on the only surfaces that hit the reranker and (b) sticking to the HuggingFace `CrossEncoder` API keeps the swap a one-line config change. Worth revisiting if reranker latency ever stacks (e.g., if a future feature invokes it per chat turn).
+
+**Reverting**: set `DEUS_RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2` to restore original behavior.
+
+**Primary-source data**: `Second Brain/Deus/Research/shootout-hebrew-20q-2026-05-17.json`, `Research/shootout-1528distractors-2026-05-17.json`. Pipeline simulation script preserved in conversation transcript / session log.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T11:15:00" # auto-bump (multilingual reranker)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T11:15:00" # auto-bump (multilingual reranker)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -132,7 +132,7 @@ SIBLING_DISCOUNT = float(os.environ.get("DEUS_SIBLING_DISCOUNT", "0.15"))
 SIBLING_MAX = int(os.environ.get("DEUS_SIBLING_MAX", "5"))
 ENTITY_BOOST = float(os.environ.get("DEUS_ENTITY_BOOST", "0.1"))
 RERANKER_ENABLED = os.environ.get("DEUS_RERANKER", "1") == "1"
-RERANKER_MODEL = os.environ.get("DEUS_RERANKER_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+RERANKER_MODEL = os.environ.get("DEUS_RERANKER_MODEL", "BAAI/bge-reranker-v2-m3")
 RERANKER_TOP_K = int(os.environ.get("DEUS_RERANKER_CANDIDATES", "20"))
 
 _cross_encoder = None

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -88,6 +88,34 @@ def test_db_path_honors_deus_db_env(tmp_path, fresh_vault, monkeypatch):
     assert mod.DB_PATH == custom_db
 
 
+# ── Reranker configuration defaults ──────────────────────────────────────
+
+
+def test_reranker_default_is_bge_v2_m3(monkeypatch):
+    """Default RERANKER_MODEL when DEUS_RERANKER_MODEL is unset.
+
+    See docs/decisions/atom-retrieval-pipeline.md amendment (2026-05-17) for rationale.
+    """
+    monkeypatch.delenv("DEUS_RERANKER_MODEL", raising=False)
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+
+    mod = importlib.import_module("memory_indexer")
+
+    assert mod.RERANKER_MODEL == "BAAI/bge-reranker-v2-m3"
+
+
+def test_reranker_env_var_override(monkeypatch):
+    """User can revert to the legacy cross-encoder via DEUS_RERANKER_MODEL."""
+    monkeypatch.setenv("DEUS_RERANKER_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+
+    mod = importlib.import_module("memory_indexer")
+
+    assert mod.RERANKER_MODEL == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
 # ── extract_frontmatter ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Single env-var default change: cross-encoder reranker becomes `BAAI/bge-reranker-v2-m3` (multilingual, 340M) instead of `cross-encoder/ms-marco-MiniLM-L-6-v2` (English-only, 22M).

**Pipeline recall@5 on the 50-query bilingual fixture (PR #457): 92% → 98%.** +6% recall, including +1 English query the smaller English-only model still missed.

## Why not an embedding migration

Phase 0.5 investigation (production-pipeline simulation: bi-encoder top-20 → reranker → top-5) revealed the reranker was the Hebrew bottleneck, not the bi-encoder. 3 of 4 misses were "reranker failed to rescue" cases — target IS in top-20 but English reranker couldn't disambiguate similar Hebrew candidates. Multilingual reranker recovers them. **No re-embed needed.**

## Cost

| Surface | Reranker invocations | Latency hit |
|---|---|---|
| Per chat message / per tool use | 0 (uses memory_tree.py, no reranker) | 0 |
| `memory_indexer.py --query` (CLI) | 1 per call | +148 ms (invisible) |
| `memory_indexer.py --rebuild` | ~1700 | +4 min on a 20-min op |

Net per-prompt UX impact: zero.

## Reverting

`DEUS_RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2`

## Files

| File | Change |
|---|---|
| `scripts/memory_indexer.py:135` | Default string |
| `docs/decisions/atom-retrieval-pipeline.md` | Env var row + amendment section |
| `docs/benchmarks.md:67` | Reference update |
| `scripts/tests/test_memory_indexer.py` | 2 new tests |
| `patterns/{eval-change,documentation}.md` | drift_check timestamp bumps |

6 files, +61/-5.

## Test plan

- [x] 2 new tests pass
- [x] code-reviewer SHIP (round 1, 2 non-blocking warnings addressed in cleanup)
- [x] verification-gate SHIP (round 2 after precedent check on timestamp format)

## Out of scope

The 1 remaining miss (`"איך לטפל ב-RTL במסמכים של פייתון"` — target at rank #42, outside top-20) is a bi-encoder failure. Future levers: expand `DEUS_RERANKER_CANDIDATES` or add query rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)