### PR TITLE
chore(judge): use asyncio.get_running_loop() in async judge wrappers

### DIFF
--- a/evolution/judge/llama_cpp_judge.py
+++ b/evolution/judge/llama_cpp_judge.py
@@ -70,7 +70,7 @@ def _call_llama_cpp(prompt: str, model: str = LLAMA_CPP_MODEL) -> str:
 
 async def _call_llama_cpp_async(prompt: str, model: str = LLAMA_CPP_MODEL) -> str:
     """Async llama-server call — runs sync in thread pool to avoid blocking the event loop."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, lambda: _call_llama_cpp(prompt, model))
 
 

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -76,7 +76,7 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
 
 async def _call_ollama_async(prompt: str, model: str = OLLAMA_MODEL) -> str:
     """Async Ollama call — runs sync in thread pool to avoid blocking."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, lambda: _call_ollama(prompt, model))
 
 

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-17T11:15:00" # auto-bump (multilingual reranker)
+last_verified: "2026-05-17T16:30:00" # auto-bump (asyncio cleanup)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-17T07:25:00" # auto-bump (llama-cpp eval providers)
+last_verified: "2026-05-17T16:30:00" # auto-bump (asyncio cleanup)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary

Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in two judge runtime classes that both call it from inside `async def` methods.

| File | Line | Change |
|---|---|---|
| `evolution/judge/ollama_judge.py` | 79 | inside `_call_ollama_async` |
| `evolution/judge/llama_cpp_judge.py` | 73 | inside `_call_llama_cpp_async` |

## Why

`asyncio.get_event_loop()` is deprecated in Python 3.10+ when called outside a running loop and emits `DeprecationWarning`. Both call sites are inside `async def` functions invoked via `await`, so there is always a running loop. `asyncio.get_running_loop()` is the idiomatic replacement. **Semantics are identical** in an async context.

Surfaced as an informational recommendation by the PR #459 code-reviewer.

## Test plan

- [x] 225/225 evolution tests pass
- [x] Existing `test_a_evaluate_runs_in_executor` still passes
- [x] code-reviewer SHIP
- [x] verification-gate SHIP

Pure idiom cleanup. +2/-2 across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)