### PR TITLE
docs(readme): surface llama.cpp, multilingual recall, backend CLI, and reliability features

### DIFF
--- a/.claude/skills/add-llama-cpp/SKILL.md
+++ b/.claude/skills/add-llama-cpp/SKILL.md
@@ -185,6 +185,14 @@ Run this phase only if:
 - `evolution/generative/providers/llama_cpp.py` exists in the current checkout, and
 - `setup/llama-cpp.ts` exists in the current checkout.
 
+### Rebuild the agent container
+
+If upgrading from a build predating llama.cpp support, rebuild the container so the new backend module is available:
+
+```bash
+./container/build.sh
+```
+
 ### Configure repo env vars
 
 Write or update the repo env:
@@ -204,6 +212,12 @@ fi
 
 mkdir -p data/env && cp .env data/env/env
 ```
+
+> **Activate the backend:** Deus wiring is complete but the active backend is unchanged. To switch all future sessions to llama.cpp, run:
+> ```bash
+> deus backend set llama-cpp
+> ```
+> Ollama remains the default for embeddings and judge scoring regardless of this setting.
 
 ### Verify setup surface
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A personal AI that understands you - not just recalls things you've said. It lea
 
 ## What it does
 
-1. **Understands you** - It doesn't just store memories - it breaks conversations into facts, indexes by meaning, and builds a model of what you care about. Ask about something from three weeks ago and it recalls the details, even if you don't remember what you called it. (95% recall on the [LongMemEval](https://arxiv.org/abs/2410.10813) benchmark.)
+1. **Understands you** - It doesn't just store memories - it breaks conversations into facts, indexes by meaning, and builds a model of what you care about. Ask about something from three weeks ago and it recalls the details, even if you don't remember what you called it. Works in any language — Hebrew, Arabic, and other non-Latin scripts included. (95% recall on the [LongMemEval](https://arxiv.org/abs/2410.10813) benchmark; multilingual reranker active.)
 
 2. **Adapts to how you think** - Scores its own responses, generates self-critiques, and rewrites its system prompt based on what worked. Tone, judgment, the kind of suggestions it surfaces - all of it improves at the personality level.
 
@@ -34,6 +34,8 @@ A personal AI that understands you - not just recalls things you've said. It lea
 - **Calendar** - Reads and manages your Google Calendar. Ask what's coming up, or tell it to book something.
 - **Scheduled tasks** - Daily summaries, weekly recaps, reminders - set it and forget it.
 - **Web & video** - Summarize YouTube videos, fetch web pages, or research a topic, all from a chat message.
+- **Self-maintaining docs** - A weekly background agent scans for stale documentation and opens fix PRs automatically.
+- **Reliable long sessions** - Detects infinite tool-call loops and auto-summarizes large tool outputs so long sessions stay coherent.
 
 </details>
 
@@ -50,6 +52,7 @@ A personal AI that understands you - not just recalls things you've said. It lea
 - Node.js 20+, Python 3.11+
 - A [Gemini API key](https://aistudio.google.com/apikey) (free tier is enough)
 - [Ollama](https://ollama.ai/download) for local embeddings and scoring (not an agent backend) - `/setup` pulls the right models automatically based on your hardware
+- **Optional:** [llama.cpp](https://github.com/ggerganov/llama.cpp) for a fully local, API-free agent backend — no per-turn cost, works offline. Run `/add-llama-cpp` to install.
 
 ### Install
 
@@ -114,6 +117,8 @@ See [AGENTS.md](AGENTS.md#commands-and-skills) for all available skills.
 | `deus gcal` | Google Calendar token management (`status`, `auth`, `ping`) |
 | `deus listen` | Record from mic, transcribe locally, copy to clipboard |
 | `deus tui` | Full-screen terminal UI for chat, wardens, services, and channels |
+| `deus backend` | Show active agent backend (`claude`, `codex`, `llama-cpp`) |
+| `deus backend set <name>` | Switch backend for all future sessions |
 
 For direct Codex CLI sessions outside the `deus` launcher, register Deus memory
 recall as an MCP tool through the repo launcher:
@@ -169,6 +174,7 @@ Deus goes deep on understanding you and adapting over time. Hermes goes wide on 
 | Benchmarks & token costs | [Benchmarks](docs/benchmarks.md) |
 | Environment variables | [Environment](docs/ENVIRONMENT.md) |
 | Using different AI backends | [Multi-backend](docs/MULTI_BACKEND.md) |
+| Local backend (llama.cpp) | [Multi-backend — llama.cpp](docs/MULTI_BACKEND.md#llamacpp-local-backend) |
 | Backend quality benchmark | [Claude vs Codex parity report](docs/research/backend-quality-benchmark-2026-04-26.md) |
 | Development setup | [Development](docs/DEVELOPMENT.md) |
 | Contributing | [Contributing](CONTRIBUTING.md) |

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T14:30:00" # bumped after add-llama-cpp skill gap fixes
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary

README and skill update reflecting features shipped in the past 2-3 weeks. No source code changed.

**README.md**
- "Understands you": added multilingual recall note — Hebrew, Arabic, non-Latin scripts (bge-reranker-v2-m3, PR #459)
- "What you need": added optional llama.cpp prerequisite with `/add-llama-cpp` install pointer (PR #452)
- "And more": added Self-maintaining docs (doc-gardener cron agent, PR #447) and Reliable long sessions (doom-loop detection PR #442 + smart summarization PR #441)
- CLI table: added `deus backend` and `deus backend set <name>` commands
- Docs table: added Local backend (llama.cpp) link to MULTI_BACKEND.md

**`.claude/skills/add-llama-cpp/SKILL.md`**
- Phase 6: added `./container/build.sh` step for users upgrading from pre-llama.cpp builds (mirrors MULTI_BACKEND.md line 188)
- Phase 6: added informational note to run `deus backend set llama-cpp` after wiring — not auto-executed per ADR `llama-cpp-optional-integration.md` §Required Guardrails

## Test plan

- [x] plan-reviewer SHIP (v2, after REVISE on ADR violation)
- [x] code-reviewer SHIP
- [x] verification-gate SHIP (8/8 requirements verified against file content)
- [x] Pre-push drift check: all 11 patterns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)