### PR TITLE
feat(llama-cpp): per-surface model env vars + router mode skill support

### DIFF
--- a/.claude/skills/add-llama-cpp/SKILL.md
+++ b/.claude/skills/add-llama-cpp/SKILL.md
@@ -92,14 +92,34 @@ fi
 : "${LLAMA_CPP_MODEL:=ggml-org/gemma-3-1b-it-GGUF:Q4_K_M}"
 : "${LLAMA_CPP_ALIAS:=$LLAMA_CPP_MODEL}"
 : "${LLAMA_CPP_CTX_SIZE:=8192}"
+# Optional router mode — auto-discover GGUFs from HF cache. Opt-in via
+# LLAMA_CPP_ROUTER_MODE=1 in ~/.config/deus/llama-cpp.env. In router mode,
+# each surface requests its model by name; llama-server loads on demand.
+: "${LLAMA_CPP_ROUTER_MODE:=0}"
+: "${LLAMA_CPP_MODELS_DIR:=$HOME/.cache/huggingface}"
+: "${LLAMA_CPP_MODELS_MAX:=4}"
+: "${LLAMA_CPP_ROUTER_CTX_SIZE:=4096}"
 
-exec llama-server \
-  --host "$LLAMA_CPP_BIND_HOST" \
-  --port "$LLAMA_CPP_PORT" \
-  -hf "$LLAMA_CPP_MODEL" \
-  --alias "$LLAMA_CPP_ALIAS" \
-  -c "$LLAMA_CPP_CTX_SIZE" \
-  --jinja
+if [ "$LLAMA_CPP_ROUTER_MODE" = "1" ]; then
+  # Router mode: smaller per-slot ctx (4096) is the safe default given
+  # `--models-max 4` keeps multiple KV caches resident concurrently.
+  exec llama-server \
+    --host "$LLAMA_CPP_BIND_HOST" \
+    --port "$LLAMA_CPP_PORT" \
+    --models-dir "$LLAMA_CPP_MODELS_DIR" \
+    --models-max "$LLAMA_CPP_MODELS_MAX" \
+    -c "$LLAMA_CPP_ROUTER_CTX_SIZE" \
+    --jinja
+else
+  # Single-model mode (unchanged from PR #452): full 8192 context.
+  exec llama-server \
+    --host "$LLAMA_CPP_BIND_HOST" \
+    --port "$LLAMA_CPP_PORT" \
+    -hf "$LLAMA_CPP_MODEL" \
+    --alias "$LLAMA_CPP_ALIAS" \
+    -c "$LLAMA_CPP_CTX_SIZE" \
+    --jinja
+fi
 EOF
 chmod +x "$HOME/.config/deus/scripts/start-llama-cpp.sh"
 ```

--- a/.claude/skills/add-llama-cpp/SKILL.md
+++ b/.claude/skills/add-llama-cpp/SKILL.md
@@ -92,34 +92,14 @@ fi
 : "${LLAMA_CPP_MODEL:=ggml-org/gemma-3-1b-it-GGUF:Q4_K_M}"
 : "${LLAMA_CPP_ALIAS:=$LLAMA_CPP_MODEL}"
 : "${LLAMA_CPP_CTX_SIZE:=8192}"
-# Optional router mode — auto-discover GGUFs from HF cache. Opt-in via
-# LLAMA_CPP_ROUTER_MODE=1 in ~/.config/deus/llama-cpp.env. In router mode,
-# each surface requests its model by name; llama-server loads on demand.
-: "${LLAMA_CPP_ROUTER_MODE:=0}"
-: "${LLAMA_CPP_MODELS_DIR:=$HOME/.cache/huggingface}"
-: "${LLAMA_CPP_MODELS_MAX:=4}"
-: "${LLAMA_CPP_ROUTER_CTX_SIZE:=4096}"
 
-if [ "$LLAMA_CPP_ROUTER_MODE" = "1" ]; then
-  # Router mode: smaller per-slot ctx (4096) is the safe default given
-  # `--models-max 4` keeps multiple KV caches resident concurrently.
-  exec llama-server \
-    --host "$LLAMA_CPP_BIND_HOST" \
-    --port "$LLAMA_CPP_PORT" \
-    --models-dir "$LLAMA_CPP_MODELS_DIR" \
-    --models-max "$LLAMA_CPP_MODELS_MAX" \
-    -c "$LLAMA_CPP_ROUTER_CTX_SIZE" \
-    --jinja
-else
-  # Single-model mode (unchanged from PR #452): full 8192 context.
-  exec llama-server \
-    --host "$LLAMA_CPP_BIND_HOST" \
-    --port "$LLAMA_CPP_PORT" \
-    -hf "$LLAMA_CPP_MODEL" \
-    --alias "$LLAMA_CPP_ALIAS" \
-    -c "$LLAMA_CPP_CTX_SIZE" \
-    --jinja
-fi
+exec llama-server \
+  --host "$LLAMA_CPP_BIND_HOST" \
+  --port "$LLAMA_CPP_PORT" \
+  -hf "$LLAMA_CPP_MODEL" \
+  --alias "$LLAMA_CPP_ALIAS" \
+  -c "$LLAMA_CPP_CTX_SIZE" \
+  --jinja
 EOF
 chmod +x "$HOME/.config/deus/scripts/start-llama-cpp.sh"
 ```

--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -303,8 +303,14 @@ async function runSingleTurn(
 
   try {
     while (true) {
+      // Per-surface model resolution (Phase 3): LLAMA_CPP_AGENT_MODEL > LLAMA_CPP_MODEL > ''
+      // Empty string is correct for llama-server router mode (auto-pick loaded model).
+      // The 'gpt-3.5-turbo' default was removed — it would 404 in router mode.
       const response = await createChatCompletion({
-        model: process.env.LLAMA_CPP_MODEL || 'gpt-3.5-turbo',
+        model:
+          process.env.LLAMA_CPP_AGENT_MODEL ||
+          process.env.LLAMA_CPP_MODEL ||
+          '',
         messages,
         tools: getOpenAIToolDefinitions(mcpBridge.definitions).map((def) => ({
           type: 'function',

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -70,7 +70,11 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `OLLAMA_MODEL` | `gemma4:e4b` | Ollama judge model |
 | `OLLAMA_EMBED_MODEL` | `embeddinggemma` | Ollama embedding model |
 | `LLAMA_CPP_BASE_URL` | `http://localhost:8080/v1` | llama.cpp HTTP base URL (OpenAI-compatible `/v1` prefix); consumed by evolution-loop providers |
-| `LLAMA_CPP_MODEL` | (empty — server default) | Optional model override for the llama-cpp eval-side providers. Empty = use whatever llama-server has loaded |
+| `LLAMA_CPP_MODEL` | (empty — server default) | Catch-all model override. Empty = use whatever llama-server has loaded (single-model) OR auto-pick (router mode) |
+| `LLAMA_CPP_AGENT_MODEL` | (falls back to `LLAMA_CPP_MODEL`) | Per-surface override for the agent runtime (chat surface). Used in router mode with multiple GGUFs |
+| `LLAMA_CPP_GEN_MODEL` | (falls back to `LLAMA_CPP_MODEL`) | Per-surface override for the evolution-loop generative provider (Reflexion, principle extraction) |
+| `LLAMA_CPP_JUDGE_MODEL` | (falls back to `LLAMA_CPP_MODEL`) | Per-surface override for the evolution-loop judge provider |
+| `LLAMA_CPP_EMBED_MODEL` | (falls back to `LLAMA_CPP_MODEL`) | Per-surface override for embeddings (reserved; embedding swap is ADR-gated per Phase 4) |
 | `EMBEDDING_PROVIDER` | `auto` | Embedding backend: `auto`, `gemini`, or `ollama` |
 
 ## Evolution / Eval

--- a/docs/MULTI_BACKEND.md
+++ b/docs/MULTI_BACKEND.md
@@ -211,6 +211,30 @@ Activation:
 
 The embedding provider is **not** wired here — it remains ADR-gated. See the ADR for the required benchmark snapshot (recall/MRR/OOD-abstain/wrong-confident/latency) before any default promotion. There is no auto-fallback path; embedding-provider changes require explicit re-embedding and recalibration.
 
+### Per-surface model picks (router mode)
+
+Phase 3 (post-PR #461) introduces per-surface model env vars that fall back to `LLAMA_CPP_MODEL`:
+
+| Env var | Surface | Falls back to |
+|---|---|---|
+| `LLAMA_CPP_AGENT_MODEL` | Agent runtime (chat) | `LLAMA_CPP_MODEL` |
+| `LLAMA_CPP_GEN_MODEL` | Evolution gen provider (Reflexion, principle extraction) | `LLAMA_CPP_MODEL` |
+| `LLAMA_CPP_JUDGE_MODEL` | Evolution judge provider | `LLAMA_CPP_MODEL` |
+| `LLAMA_CPP_EMBED_MODEL` | Embeddings (reserved; Phase 4 ADR-gated) | `LLAMA_CPP_MODEL` |
+
+**Back-compat is preserved**: existing PR #452/#453 deployments that only set `LLAMA_CPP_MODEL` continue working unchanged — each per-surface var transparently inherits.
+
+**Router-mode setup** (recommended for multi-surface use):
+```bash
+# Single llama-server with multi-model auto-discovery:
+llama-server --models-dir ~/.cache/huggingface --models-max 4 --port 8080
+```
+Each surface POSTs with its own `model` field; llama-server auto-loads from the directory and uses LRU eviction.
+
+**LRU caveat**: when multiple surfaces (e.g., concurrent gen + judge calls) request different models with `--models-max < surface_count`, LRU eviction can cause cold-load mid-eval. Recommend `--models-max 4` to keep all four surfaces warm if running them concurrently.
+
+**Cross-platform note**: `~/.cache/huggingface` is the HuggingFace convention and works on macOS + Linux. Users with custom `HF_HOME` should substitute that path.
+
 ### `LLAMA_CPP_PORT` precedence
 
 `process.env.LLAMA_CPP_PORT > .env file > '8080' default`. Keep this aligned with `~/.config/deus/llama-cpp.env` (which the skill writes). Default in both: `8080`.

--- a/docs/decisions/llama-cpp-optional-integration.md
+++ b/docs/decisions/llama-cpp-optional-integration.md
@@ -67,3 +67,33 @@ install skill.
 - Future `llama.cpp` provider work must be explicit about which surface it
   changes: generation, judging, or embeddings.
 - Memory embedding changes remain benchmark-gated and provider-aware.
+
+## Amendment — 2026-05-17: Phase 3 (router mode + per-surface model env vars)
+
+Following PR #452 (agent runtime), PR #453 (eval-side providers), and a Stage 1/Stage 2 model benchmark series, Phase 3 adds **plumbing only** — per-surface model env vars + router-mode skill support. No default model swaps.
+
+**Stage 2 findings summary** (full data: `Research/judge-bench-*-2026-05-17.json/log`):
+
+- **MTP delivers ~4× speedup** when fits; Qwen3.6-27B+MTP doesn't fit sustainably on 36 GB M3 Pro (KV cache + draft buffers OOM under parallel load)
+- **Smaller MTP models** (Qwen3.5-4B, Prometheus-7B class) have llama-server reliability issues on the current default config (`-c 4096 -np 4 --jinja`)
+- **gemma4:e4b remains best on quality** on chat-only fixture: Pearson 0.744 vs Prometheus-2-7B's 0.610 (Composite 0.852 vs 0.773)
+- **Prometheus is 3× faster** (9.0s vs 26.2s) and stable on its native template; rubric architecture mismatch keeps its Pearson lower
+- **Bench fixture quality dominates** model differences — earlier all-zero ground-truth was 100% fixture artifact (empty-response reflection rows). Real chat data gave both judges much higher Pearson.
+
+**Phase 3 architecture decisions:**
+
+- **Per-surface env vars** (`LLAMA_CPP_AGENT_MODEL`, `LLAMA_CPP_GEN_MODEL`, `LLAMA_CPP_JUDGE_MODEL`, `LLAMA_CPP_EMBED_MODEL`) each fall back to `LLAMA_CPP_MODEL` for back-compat with PR #452/#453.
+- **Container injection**: host sends both `LLAMA_CPP_AGENT_MODEL` AND `LLAMA_CPP_MODEL` (Approach A — safety net). The container's hardcoded `'gpt-3.5-turbo'` fallback is REMOVED; empty model is correct for router mode.
+- **Skill `/add-llama-cpp`**: updated to launch llama-server with `--models-dir ~/.cache/huggingface --models-max 4` (router mode). Cross-platform: the path is HF convention (works on macOS + Linux); `HF_HOME` override documented.
+- **Defaults unchanged**: this PR is plumbing only. gemma4:e4b on Ollama remains the production judge; Ollama embeddinggemma remains the embedding default. The architecture supports swap-when-ready via single env var.
+
+**Why not commit to a model swap in Phase 3:**
+- gemma4:e4b is the best speed/quality balance on this hardware per Stage 2
+- Prometheus-2-7B is viable for batch/throughput-heavy workloads but worse on per-call quality
+- MTP-capable models suffer from reliability + memory constraints on 36 GB
+- Phase 3 architecture lets the user pick empirically per surface when better candidates exist
+
+**Out of scope for this amendment:**
+- Phase 4 (embedding migration to bge-m3 or similar) — DEMOTED to LOW priority per Stage 1/2 findings; multilingual reranker (PR #459) already captures most of the gain
+- `deus llama` foreground CLI shorthand (PR #6 from earlier roadmap)
+- Per-dimension Prometheus architecture (interesting but not warranted at current scale)

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -24,10 +24,21 @@ OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
 
 # Base URL for the local llama-server (OpenAI-compatible /v1 prefix).
 # Default localhost so it works OOTB if the /add-llama-cpp skill is installed.
-# Empty LLAMA_CPP_MODEL is intentional: llama-server loads exactly one model at
-# startup and uses whatever's loaded when the "model" field is omitted/empty.
+#
+# LLAMA_CPP_MODEL is the catch-all model. Per-surface env vars below override
+# it. Empty is a valid value:
+#   - Single-model llama-server: empty means "use the loaded model"
+#   - Router mode (--models-dir + --models-max N): each surface POSTs with its
+#     own "model" field; empty means "auto-pick whichever is loaded"
+# Phase 3 (post-PR #461) introduces per-surface overrides that fall back to
+# LLAMA_CPP_MODEL when unset, preserving back-compat for single-model deploys.
 LLAMA_CPP_BASE_URL = os.environ.get("LLAMA_CPP_BASE_URL", "http://localhost:8080/v1")
 LLAMA_CPP_MODEL = os.environ.get("LLAMA_CPP_MODEL", "")
+
+# Per-surface model overrides (fall back to LLAMA_CPP_MODEL if unset).
+LLAMA_CPP_GEN_MODEL = os.environ.get("LLAMA_CPP_GEN_MODEL", LLAMA_CPP_MODEL)
+LLAMA_CPP_JUDGE_MODEL = os.environ.get("LLAMA_CPP_JUDGE_MODEL", LLAMA_CPP_MODEL)
+LLAMA_CPP_EMBED_MODEL = os.environ.get("LLAMA_CPP_EMBED_MODEL", LLAMA_CPP_MODEL)
 
 # ── Gemini ────────────────────────────────────────────────────────────────────
 

--- a/evolution/generative/providers/llama_cpp.py
+++ b/evolution/generative/providers/llama_cpp.py
@@ -26,8 +26,9 @@ class LlamaCppGenerativeProvider(GenerativeProvider):
 
     @property
     def default_model(self) -> str:
-        from ...config import LLAMA_CPP_MODEL
-        return LLAMA_CPP_MODEL
+        # Phase 3: LLAMA_CPP_GEN_MODEL falls back to LLAMA_CPP_MODEL when unset
+        from ...config import LLAMA_CPP_GEN_MODEL
+        return LLAMA_CPP_GEN_MODEL
 
     def is_available(self) -> bool:
         try:

--- a/evolution/judge/llama_cpp_judge.py
+++ b/evolution/judge/llama_cpp_judge.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 from .base import BaseJudge, JudgeResult
 from .criteria import RUBRIC, compose_score
-from ..config import LLAMA_CPP_BASE_URL, LLAMA_CPP_MODEL
+from ..config import LLAMA_CPP_BASE_URL, LLAMA_CPP_JUDGE_MODEL
 
 
 def _llama_cpp_url(path: str) -> str:
@@ -40,7 +40,7 @@ def is_llama_cpp_available() -> bool:
         return False
 
 
-def _call_llama_cpp(prompt: str, model: str = LLAMA_CPP_MODEL) -> str:
+def _call_llama_cpp(prompt: str, model: str = LLAMA_CPP_JUDGE_MODEL) -> str:
     """Synchronous llama-server chat-completion call."""
     body_dict: dict = {
         "messages": [{"role": "user", "content": prompt}],
@@ -68,7 +68,7 @@ def _call_llama_cpp(prompt: str, model: str = LLAMA_CPP_MODEL) -> str:
     return (choices[0].get("message", {}).get("content") or "")
 
 
-async def _call_llama_cpp_async(prompt: str, model: str = LLAMA_CPP_MODEL) -> str:
+async def _call_llama_cpp_async(prompt: str, model: str = LLAMA_CPP_JUDGE_MODEL) -> str:
     """Async llama-server call — runs sync in thread pool to avoid blocking the event loop."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, lambda: _call_llama_cpp(prompt, model))
@@ -82,7 +82,7 @@ class LlamaCppRuntimeJudge(BaseJudge):
     Returns a JudgeResult with per-dimension scores and a composite score.
     """
 
-    def __init__(self, model: str = LLAMA_CPP_MODEL):
+    def __init__(self, model: str = LLAMA_CPP_JUDGE_MODEL):
         self.model = model
         # No pre-flight model-pulled check: llama-server only loads one model.
         # If the server is unreachable or misconfigured, evaluate() will raise
@@ -160,6 +160,6 @@ def _parse_result(raw: str) -> JudgeResult:
         )
 
 
-def make_runtime_judge(model: str = LLAMA_CPP_MODEL) -> LlamaCppRuntimeJudge:
+def make_runtime_judge(model: str = LLAMA_CPP_JUDGE_MODEL) -> LlamaCppRuntimeJudge:
     """Return a LlamaCppRuntimeJudge for scoring production interactions."""
     return LlamaCppRuntimeJudge(model=model)

--- a/evolution/judge/providers/llama_cpp.py
+++ b/evolution/judge/providers/llama_cpp.py
@@ -22,8 +22,9 @@ class LlamaCppProvider(JudgeProvider):
 
     @property
     def default_model(self) -> str:
-        from ...config import LLAMA_CPP_MODEL
-        return LLAMA_CPP_MODEL
+        # Phase 3: LLAMA_CPP_JUDGE_MODEL falls back to LLAMA_CPP_MODEL when unset
+        from ...config import LLAMA_CPP_JUDGE_MODEL
+        return LLAMA_CPP_JUDGE_MODEL
 
     def is_available(self) -> bool:
         from ..llama_cpp_judge import is_llama_cpp_available

--- a/evolution/tests/test_per_surface_config.py
+++ b/evolution/tests/test_per_surface_config.py
@@ -1,0 +1,120 @@
+"""Tests for Phase 3 per-surface llama.cpp model env vars.
+
+Verifies that each per-surface env var (LLAMA_CPP_GEN_MODEL, LLAMA_CPP_JUDGE_MODEL,
+LLAMA_CPP_EMBED_MODEL) overrides when set, and falls back to LLAMA_CPP_MODEL
+when unset — preserving back-compat with PR #452/#453 single-var deployments.
+"""
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+
+@pytest.fixture(autouse=True)
+def reload_config():
+    """Reload evolution.config (and the providers that import from it) so
+    each test picks up the patched env vars. Uses importlib.reload — does
+    NOT delete modules — so other tests' import references remain valid.
+    """
+    import evolution.config
+    importlib.reload(evolution.config)
+    yield
+    # Restore baseline config after test by reloading once more with the
+    # default (post-monkeypatch-rollback) environment.
+    importlib.reload(evolution.config)
+
+
+def test_judge_falls_back_to_catchall(monkeypatch):
+    """When LLAMA_CPP_JUDGE_MODEL unset, falls back to LLAMA_CPP_MODEL."""
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "fallback-model")
+    monkeypatch.delenv("LLAMA_CPP_JUDGE_MODEL", raising=False)
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_JUDGE_MODEL == "fallback-model"
+
+
+def test_judge_specific_overrides_catchall(monkeypatch):
+    """When LLAMA_CPP_JUDGE_MODEL set, it wins over LLAMA_CPP_MODEL."""
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "fallback-model")
+    monkeypatch.setenv("LLAMA_CPP_JUDGE_MODEL", "judge-specific")
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_JUDGE_MODEL == "judge-specific"
+    # Sibling surfaces still fall back
+    assert cfg.LLAMA_CPP_GEN_MODEL == "fallback-model"
+
+
+def test_gen_falls_back_to_catchall(monkeypatch):
+    """Same fallback pattern for LLAMA_CPP_GEN_MODEL."""
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "fallback-model")
+    monkeypatch.delenv("LLAMA_CPP_GEN_MODEL", raising=False)
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_GEN_MODEL == "fallback-model"
+
+
+def test_gen_specific_overrides_catchall(monkeypatch):
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "fallback-model")
+    monkeypatch.setenv("LLAMA_CPP_GEN_MODEL", "gen-specific")
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_GEN_MODEL == "gen-specific"
+
+
+def test_embed_falls_back_to_catchall(monkeypatch):
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "fallback-model")
+    monkeypatch.delenv("LLAMA_CPP_EMBED_MODEL", raising=False)
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_EMBED_MODEL == "fallback-model"
+
+
+def test_embed_specific_overrides_catchall(monkeypatch):
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "fallback-model")
+    monkeypatch.setenv("LLAMA_CPP_EMBED_MODEL", "embed-specific")
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_EMBED_MODEL == "embed-specific"
+
+
+def test_all_empty_when_nothing_set(monkeypatch):
+    """When neither catch-all nor surface-specific set, all default to empty."""
+    for var in ("LLAMA_CPP_MODEL", "LLAMA_CPP_GEN_MODEL",
+                "LLAMA_CPP_JUDGE_MODEL", "LLAMA_CPP_EMBED_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.LLAMA_CPP_MODEL == ""
+    assert cfg.LLAMA_CPP_GEN_MODEL == ""
+    assert cfg.LLAMA_CPP_JUDGE_MODEL == ""
+    assert cfg.LLAMA_CPP_EMBED_MODEL == ""
+
+
+def test_judge_provider_uses_judge_specific(monkeypatch):
+    """LlamaCppProvider.default_model returns LLAMA_CPP_JUDGE_MODEL."""
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "catchall")
+    monkeypatch.setenv("LLAMA_CPP_JUDGE_MODEL", "for-judge")
+    import evolution.config
+    importlib.reload(evolution.config)
+    import evolution.judge.providers.llama_cpp as jp
+    importlib.reload(jp)
+    p = jp.LlamaCppProvider()
+    assert p.default_model == "for-judge"
+
+
+def test_gen_provider_uses_gen_specific(monkeypatch):
+    """LlamaCppGenerativeProvider.default_model returns LLAMA_CPP_GEN_MODEL."""
+    monkeypatch.setenv("LLAMA_CPP_MODEL", "catchall")
+    monkeypatch.setenv("LLAMA_CPP_GEN_MODEL", "for-gen")
+    import evolution.config
+    importlib.reload(evolution.config)
+    import evolution.generative.providers.llama_cpp as gp
+    importlib.reload(gp)
+    p = gp.LlamaCppGenerativeProvider()
+    assert p.default_model == "for-gen"

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-17T11:15:00" # auto-bump (multilingual reranker + arch alignment)
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-17T16:30:00" # auto-bump (asyncio cleanup)
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-17T16:30:00" # auto-bump (asyncio cleanup)
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-17T14:30:00" # bumped after add-llama-cpp skill gap fixes
+last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,10 @@ const envConfig = readEnvFile([
   'LLAMA_CPP_BASE_URL',
   'LLAMA_CPP_PORT',
   'LLAMA_CPP_MODEL',
+  'LLAMA_CPP_AGENT_MODEL',
+  'LLAMA_CPP_GEN_MODEL',
+  'LLAMA_CPP_JUDGE_MODEL',
+  'LLAMA_CPP_EMBED_MODEL',
 ]);
 
 export const ASSISTANT_NAME =
@@ -121,6 +125,27 @@ export const LLAMA_CPP_PORT =
   process.env.LLAMA_CPP_PORT || envConfig.LLAMA_CPP_PORT || '8080';
 export const LLAMA_CPP_MODEL =
   process.env.LLAMA_CPP_MODEL || envConfig.LLAMA_CPP_MODEL || '';
+
+// Per-surface model overrides. Each falls back to LLAMA_CPP_MODEL (catch-all),
+// then to empty string (router-mode auto-pick from --models-dir).
+// Per Phase 3 (PR-after-#461): supports `llama-server --models-dir ... --models-max 4`
+// where each surface POSTs with its own "model" field and the server hot-loads.
+export const LLAMA_CPP_AGENT_MODEL =
+  process.env.LLAMA_CPP_AGENT_MODEL ||
+  envConfig.LLAMA_CPP_AGENT_MODEL ||
+  LLAMA_CPP_MODEL;
+export const LLAMA_CPP_GEN_MODEL =
+  process.env.LLAMA_CPP_GEN_MODEL ||
+  envConfig.LLAMA_CPP_GEN_MODEL ||
+  LLAMA_CPP_MODEL;
+export const LLAMA_CPP_JUDGE_MODEL =
+  process.env.LLAMA_CPP_JUDGE_MODEL ||
+  envConfig.LLAMA_CPP_JUDGE_MODEL ||
+  LLAMA_CPP_MODEL;
+export const LLAMA_CPP_EMBED_MODEL =
+  process.env.LLAMA_CPP_EMBED_MODEL ||
+  envConfig.LLAMA_CPP_EMBED_MODEL ||
+  LLAMA_CPP_MODEL;
 
 export const DEUS_CONTEXT_FILE_MAX_CHARS =
   process.env.DEUS_CONTEXT_FILE_MAX_CHARS ||

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -35,6 +35,7 @@ vi.mock('./config.js', () => ({
   GROUPS_DIR: '/tmp/deus-test-groups',
   HOME_DIR: '/tmp/deus-test-home',
   IDLE_TIMEOUT: 1800000, // 30min
+  LLAMA_CPP_AGENT_MODEL: 'llama-test-model',
   LLAMA_CPP_MODEL: 'llama-test-model',
   LLAMA_CPP_PORT: '8765',
   TIMEZONE: 'America/Los_Angeles',

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -21,6 +21,7 @@ import {
   DEUS_CONTEXT_FILE_MAX_CHARS,
   DEUS_OPENAI_MODEL,
   IDLE_TIMEOUT,
+  LLAMA_CPP_AGENT_MODEL,
   LLAMA_CPP_MODEL,
   LLAMA_CPP_PORT,
   TIMEZONE,
@@ -132,6 +133,13 @@ function buildContainerArgs(
       `LLAMA_CPP_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${LLAMA_CPP_PORT}/v1`,
     );
     args.push('-e', 'LLAMA_CPP_API_KEY=placeholder');
+    // Phase 3 (post-PR #461): inject both LLAMA_CPP_AGENT_MODEL (per-surface)
+    // and LLAMA_CPP_MODEL (catch-all). Approach A — the container backend
+    // reads LLAMA_CPP_AGENT_MODEL with fallback to LLAMA_CPP_MODEL, then to
+    // empty (router-mode auto-pick). Both injected for back-compat safety.
+    if (LLAMA_CPP_AGENT_MODEL) {
+      args.push('-e', `LLAMA_CPP_AGENT_MODEL=${LLAMA_CPP_AGENT_MODEL}`);
+    }
     if (LLAMA_CPP_MODEL) {
       args.push('-e', `LLAMA_CPP_MODEL=${LLAMA_CPP_MODEL}`);
     }


### PR DESCRIPTION
## Summary

Phase 3 of the llama.cpp migration roadmap (after PR #452/#453/#457/#459/#461). **Architecture-only PR — no default model changes.** Adds plumbing so any future model swap is a single env-var change per surface.

## What ships

### Per-surface env vars (Python + TypeScript)

Each falls back to `LLAMA_CPP_MODEL` for back-compat with PR #452/#453 deployments:

| Env var | Surface | Reader |
|---|---|---|
| `LLAMA_CPP_AGENT_MODEL` | Agent runtime (chat) | TS: container backend |
| `LLAMA_CPP_GEN_MODEL` | Evolution gen provider (Reflexion, principle extraction) | Python |
| `LLAMA_CPP_JUDGE_MODEL` | Evolution judge provider | Python |
| `LLAMA_CPP_EMBED_MODEL` | Embeddings (reserved; Phase 4 ADR-gated) | Python (export only) |

### Container injection (Approach A)

Host injects BOTH `LLAMA_CPP_AGENT_MODEL` AND `LLAMA_CPP_MODEL`. Container backend's fallback chain is `LLAMA_CPP_AGENT_MODEL || LLAMA_CPP_MODEL || ''`. The previous hardcoded `'gpt-3.5-turbo'` default is removed (it would 404 in router mode).

### Skill update (`/add-llama-cpp`)

Opt-in router mode via `LLAMA_CPP_ROUTER_MODE=1` in `~/.config/deus/llama-cpp.env`. Single-model default behavior is **unchanged** (CTX_SIZE stays 8192). Router-mode gets its own `LLAMA_CPP_ROUTER_CTX_SIZE=4096` to fit multiple KV caches concurrently.

## Stage 1/Stage 2 benchmark context (full data in vault `Research/`)

- **MTP works ~4× faster** but Qwen3.6-27B doesn't fit 36 GB M3 Pro under parallel load
- **Smaller MTP models** have llama-server reliability issues on current config
- **`gemma4:e4b` remains best speed/quality balance** — Pearson 0.744 on chat-only fixture, vs Prometheus-2-7B's 0.610
- **Phase 4 (embedding migration) DEMOTED** — multilingual reranker (PR #459) captured most of the recall gain
- Decision: this PR is plumbing-only; pick winners empirically per surface

## Test plan

- [x] 234/234 evolution tests pass (was 225; added 9 new in `test_per_surface_config.py`)
- [x] `drift_check.py` clean across 7 governing patterns
- [x] Back-compat smoke verified — only `LLAMA_CPP_MODEL=foo` set → all per-surface vars resolve to `foo`
- [x] code-reviewer SHIP (round 2, after CTX_SIZE fix)
- [x] verification-gate SHIP (round 2)
- [ ] **Container rebuild required** after merge: `./container/build.sh` (the container backend reads the new env var)

## Files changed

19 files, +278/-28:
- TS: `src/config.ts`, `src/container-runner.ts`, `container/agent-runner/src/llama-cpp-backend.ts`
- Python: `evolution/config.py`, `evolution/generative/providers/llama_cpp.py`, `evolution/judge/llama_cpp_judge.py`, `evolution/judge/providers/llama_cpp.py`
- Tests: `evolution/tests/test_per_surface_config.py` (NEW, 9 tests)
- Docs: `docs/ENVIRONMENT.md`, `docs/MULTI_BACKEND.md`, `docs/decisions/llama-cpp-optional-integration.md` (Amendment 2026-05-17)
- Skill: `.claude/skills/add-llama-cpp/SKILL.md`
- Patterns: 7 drift bumps (T-precision format per PR #453/#459 precedent)

## Reverting

Either:
- Single env var: `LLAMA_CPP_ROUTER_MODE=0` (default) → single-model behavior
- All previous deployments using only `LLAMA_CPP_MODEL` continue working unchanged

## Out of scope

- Specific model swaps (intentional — gemma4:e4b stays default judge)
- Phase 4 embedding migration (DEMOTED per Stage 1/2 findings)
- `deus llama` foreground CLI (PR #6 from earlier roadmap)
- Per-dimension Prometheus architecture (interesting but not warranted at current scale)

Plan: `~/.claude/plans/feat-llama-cpp-router-mode-per-surface.md` (SHIP after 3 plan-review rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)