### PR TITLE
docs(adr): close out Phase 4 embedding migration with measurement-backed park decision

### DIFF
--- a/docs/decisions/embedding-model-selection.md
+++ b/docs/decisions/embedding-model-selection.md
@@ -56,3 +56,49 @@ Each model at its optimal threshold configuration (abstain + gap + low):
 - Threshold defaults in `memory_tree.py` are calibrated per provider (Ollama vs Gemini)
 - The 3 remaining recall misses (phone/submissions, career goal, current courses) are at the embedding quality ceiling — they require better OOD-separable embeddings or a fundamentally different retrieval approach
 - nomic-embed-text remains installed locally for future re-evaluation if its OOD behavior improves in newer versions
+
+## Amendment — 2026-05-17: General policy "embedding model is the schema"
+
+Phase 4 of the llama.cpp migration produced a measurement that should generalize beyond memory-tree retrieval. This amendment lifts the principle to a general policy applying to all Deus embedding surfaces (memory tree, atom retrieval, evolution loop reflection retrieval, auto-memory indexing).
+
+**The embedding model is the schema.** Treat any change to it as a foundational data-format choice, not as a hyperparameter.
+
+Any proposal to change the production embedding model — whether changing `OLLAMA_EMBED_MODEL`, swapping `EMBEDDING_PROVIDER` defaults, or introducing a new provider as the default — must pass **all** of the following gates:
+
+1. **Full re-embed of stored vectors** — irreversible without pre-migration DB snapshot. Always snapshot first.
+2. **Schema migration if dimension differs** — sqlite_vec `vec0` column widths are baked in. Different dim = new table.
+3. **Threshold recalibration** — every distance / similarity / abstain / OOD threshold in production was tuned against the current model's distribution. Re-measure, don't blindly carry over.
+4. **Benchmark snapshot before promotion** — recall@k (5 + 20), MRR when ground-truth ordering exists, OOD-abstain rate on held-out queries, wrong-confident rate, per-call latency. Compare against current production on the same fixture.
+5. **Never auto-fallback across models** — `EMBEDDING_PROVIDER=auto` must only resolve to models that produced the stored vectors. Cross-model auto-fallback silently breaks retrieval.
+6. **Document the decision (with measurements) in an ADR amendment** — both promotion AND non-promotion outcomes. Future investigators must not have to re-derive the work.
+
+### When this policy applies
+
+- Any change to `OLLAMA_EMBED_MODEL` default
+- Any change to `EMBEDDING_PROVIDER` default
+- Any new embedding-provider implementation becoming the default
+- Any swap from one model family to another (gemma↔bge↔nomic↔...)
+- Any swap within a family that changes dimension
+
+### When this policy does NOT apply
+
+- **Reranker (cross-encoder) swaps** — covered by `atom-retrieval-pipeline.md`; rerankers don't store state and can be swapped via env var freely
+- **Generation / judge model swaps** — covered by `llama-cpp-optional-integration.md`; these don't store state
+- **Adding new providers without flipping the default** — PR #453's `LlamaCppEmbeddingProvider` registration is fine; this policy only fires on default promotion
+
+### Worked example: Phase 4 close-out
+
+`docs/decisions/llama-cpp-optional-integration.md` Phase 4 close-out (2026-05-17) is the canonical example of this policy applied correctly to a non-promotion outcome:
+- Candidate (`bge-m3` raw + prefix variants) measured vs baseline (`embeddinggemma`)
+- 50-query bilingual fixture in full production pipeline (bi-encoder@20 → bge-reranker-v2-m3 → top-5)
+- Result: zero pipeline recall gain
+- Decision: do not migrate; document; close until new data
+- Avoided ~5-10K re-embeds + schema migration + threshold sweep
+
+### Rejected alternatives
+
+**Allow auto-fallback across models.** Rejected. Silent data-format mismatch produces silent retrieval breakage. Better to fail loud than to be subtly wrong.
+
+**Make embedding swaps a runtime env var (like rerankers).** Rejected. The schema-breaking nature makes the env-var-flip pattern misleading — it would be a footgun. The explicit provider-registration + benchmark-gating friction is appropriate.
+
+**Skip the benchmark snapshot when swapping within a known-good family.** Rejected. Even minor model variants shift the distribution enough to invalidate calibrated thresholds. The benchmark cost is dwarfed by the cost of a silent retrieval regression.

--- a/docs/decisions/llama-cpp-optional-integration.md
+++ b/docs/decisions/llama-cpp-optional-integration.md
@@ -97,3 +97,32 @@ Following PR #452 (agent runtime), PR #453 (eval-side providers), and a Stage 1/
 - Phase 4 (embedding migration to bge-m3 or similar) — DEMOTED to LOW priority per Stage 1/2 findings; multilingual reranker (PR #459) already captures most of the gain
 - `deus llama` foreground CLI shorthand (PR #6 from earlier roadmap)
 - Per-dimension Prometheus architecture (interesting but not warranted at current scale)
+
+## Phase 4 close-out — 2026-05-17: Embedding migration parked indefinitely
+
+**Decision**: Do **NOT** migrate from `embeddinggemma` (Ollama) to `bge-m3` (or any other bi-encoder candidate). Measured zero benefit in the realistic production pipeline.
+
+**Measurement** (`Research/judge-bench-phase4-2026-05-17.json`):
+
+Head-to-head on the 50-query bilingual fixture (40 English + 20 Hebrew, 1709 atoms, full production pipeline = bi-encoder@20 → bge-reranker-v2-m3 → top-5):
+
+| Bi-encoder | Bi-recall@5 | Bi-recall@20 | Pipeline recall@5 | Hebrew | English |
+|---|---|---|---|---|---|
+| embeddinggemma (baseline) | 90.0% | 98.0% | **49/50 (98.0%)** | 19/20 | 30/30 |
+| bge-m3 raw | 92.0% | 100.0% | 49/50 (98.0%) | 19/20 | 30/30 |
+| bge-m3 +prefix | 90.0% | 100.0% | 49/50 (98.0%) | 19/20 | 30/30 |
+
+**The multilingual reranker (PR #459) absorbs all bi-encoder differences.** While bge-m3 produces better candidate pools (100% vs 98% bi-encoder recall@20), the reranker is the deciding stage and the single remaining miss trips it the same way regardless.
+
+**The single remaining pipeline miss** is `'איך לטפל ב-RTL במסמכים של פייתון'` (Hebrew "how to handle RTL in python-docx documents"). Failure mode differs by embedder:
+- embeddinggemma: "outside-top-20" (bi-encoder couldn't surface target 1371)
+- bge-m3 variants: "rerank-failed" (target IS in top-20 but reranker picks 1373 / 2240 / 1777 instead)
+
+**Cost-benefit**: zero pipeline gain vs ~5-10K re-embeds + 768d→1024d schema migration + threshold recalibration + benchmark snapshot + irreversible-without-backup. Decisively negative.
+
+**If we ever want to recover that one miss**, the lever is **not** the embedder:
+1. Query rewriting: transliterate Hebrew `"פייתון"` → English `"python"` before retrieval
+2. Expand reranker candidate pool: `DEUS_RERANKER_CANDIDATES=30` (currently 20)
+3. Try a stronger multilingual cross-encoder if one emerges
+
+**This decision supersedes the "Idea #2C" line in the 2026-05-16 brainstorm and the corresponding pending item.** Phase 4 is closed unless future measurements on different data overturn this finding.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
+last_verified: "2026-05-17T20:15:00" # auto-bump (phase 4 close-out)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary

Documents the decision NOT to migrate the production embedding model from `embeddinggemma` to `bge-m3`. Phase 4 measurement showed zero net pipeline-recall benefit on the realistic production pipeline with the new multilingual reranker (PR #459) in place.

## Measurement

Full data: vault `Research/judge-bench-phase4-*-2026-05-17.{log,json}`.

| Bi-encoder | Bi-recall@5 | Bi-recall@20 | **Pipeline recall@5** | Hebrew | English |
|---|---|---|---|---|---|
| **embeddinggemma** (baseline) | 90.0% | 98.0% | **49/50 (98.0%)** | 19/20 | 30/30 |
| bge-m3 raw | 92.0% | 100.0% | 49/50 (98.0%) | 19/20 | 30/30 |
| bge-m3 +prefix | 90.0% | 100.0% | 49/50 (98.0%) | 19/20 | 30/30 |

Full production pipeline: bi-encoder@20 → `bge-reranker-v2-m3` → top-5. Fixture: 50 queries (40 English + 20 Hebrew from PR #457). Atom pool: 1709 production atoms.

**The multilingual reranker absorbs all bi-encoder differences.** bge-m3 produces better candidate pools (100% vs 98% recall@20), but the deciding reranker stage trips the same way on the single remaining miss regardless.

## Decision

**Park Phase 4 indefinitely.** Zero pipeline gain vs ~5-10K re-embeds + 768d→1024d schema migration + threshold recalibration + benchmark snapshot. Decisively negative cost/benefit.

## What this PR ships

3 files, +76/-1, **docs-only**:

| File | Change |
|---|---|
| `docs/decisions/llama-cpp-optional-integration.md` | Append "Phase 4 close-out — 2026-05-17" section with measurement table + analysis + reopening conditions |
| `docs/decisions/embedding-model-selection.md` | Append "Amendment — 2026-05-17: General policy 'embedding model is the schema'" — lifts the principle from a memory-tree-specific note to a general gating policy across all Deus embedding surfaces |
| `patterns/documentation.md` | drift_check timestamp bump |

## Test plan

- [x] Both ADR amendments append-only (preserve existing content)
- [x] code-reviewer SHIP (zero rule matches, docs-only)
- [x] verification-gate SHIP (3 files, +76/-1, no source code touched, original 2026-04-24 ADR content preserved)
- [x] `drift_check.py` clean

## If we ever reopen

Three cheaper levers exist for the one remaining pipeline miss (`'איך לטפל ב-RTL במסמכים של פייתון'`) — none require an embedding migration:
1. Query rewriting: Hebrew `"פייתון"` → English `"python"` before retrieval
2. Expand reranker candidate pool: `DEUS_RERANKER_CANDIDATES=30`
3. Stronger multilingual cross-encoder if one emerges

🤖 Generated with [Claude Code](https://claude.com/claude-code)