### PR TITLE
feat(resilience): retry backoff for container runtime + Docker auto-start

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
+last_verified: "2026-05-18" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-18T00:45:00" # auto-bump (judge-LoRA step 2 training driver)
+last_verified: "2026-05-18" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -141,6 +141,8 @@ function setupLaunchd(
     // launchctl list failed
   }
 
+  ensureDockerAutoStart();
+
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: 'launchd',
     NODE_PATH: nodePath,
@@ -150,6 +152,39 @@ function setupLaunchd(
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
+}
+
+function ensureDockerAutoStart(): void {
+  const runtime = process.env.CONTAINER_RUNTIME || 'docker';
+  if (runtime !== 'docker') {
+    logger.info({ runtime }, 'Skipping Docker auto-start: non-docker runtime');
+    return;
+  }
+
+  const dockerAppPath = '/Applications/Docker.app';
+  if (!fs.existsSync(dockerAppPath)) {
+    logger.info('Docker.app not found at /Applications/Docker.app — skipping');
+    return;
+  }
+
+  try {
+    const existing = execSync(
+      'osascript -e \'tell application "System Events" to get the name of every login item\'',
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 },
+    );
+    if (existing.toLowerCase().includes('docker')) {
+      logger.info('Docker already in login items');
+      return;
+    }
+
+    execSync(
+      `osascript -e 'tell application "System Events" to make login item at end with properties {path:"${dockerAppPath}", hidden:false}'`,
+      { stdio: 'ignore', timeout: 5000 },
+    );
+    logger.info('Added Docker Desktop to login items');
+  } catch (err) {
+    logger.warn({ err }, 'Could not configure Docker auto-start (non-fatal)');
+  }
 }
 
 function setupLogReviewLaunchd(projectRoot: string, homeDir: string): void {
@@ -461,6 +496,8 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     logger.error({ err }, 'systemctl start failed');
   }
 
+  ensureDockerSystemdEnabled(runningAsRoot);
+
   // Verify
   let serviceLoaded = false;
   try {
@@ -480,6 +517,36 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
+}
+
+function ensureDockerSystemdEnabled(runningAsRoot: boolean): void {
+  const runtime = process.env.CONTAINER_RUNTIME || 'docker';
+  if (runtime !== 'docker') {
+    logger.info(
+      { runtime },
+      'Skipping Docker systemd enable: non-docker runtime',
+    );
+    return;
+  }
+
+  if (!runningAsRoot) {
+    logger.info(
+      'Not root — skipping docker.service enable (system service requires root)',
+    );
+    return;
+  }
+
+  try {
+    execSync('systemctl is-enabled docker', { stdio: 'pipe', timeout: 5000 });
+    logger.info('docker.service already enabled');
+  } catch {
+    try {
+      execSync('systemctl enable docker', { stdio: 'ignore', timeout: 10_000 });
+      logger.info('Enabled docker.service for auto-start');
+    } catch (err) {
+      logger.warn({ err }, 'Could not enable docker.service (non-fatal)');
+    }
+  }
 }
 
 function setupWindows(

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -24,11 +24,14 @@ import {
   stopContainerSync,
   ensureContainerRuntimeRunning,
   cleanupOrphans,
+  _setSleepFnForTests,
 } from './container-runtime.js';
+import { FatalError } from './errors/index.js';
 import { logger } from './logger.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  _setSleepFnForTests(() => {});
 });
 
 // --- Pure functions ---
@@ -62,22 +65,72 @@ describe('ensureContainerRuntimeRunning', () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       CONTAINER_RUNTIME_BIN,
       ['info'],
-      { stdio: 'pipe', timeout: 10000 },
+      { stdio: 'pipe', timeout: 10_000 },
     );
     expect(logger.debug).toHaveBeenCalledWith(
       'Container runtime already running',
     );
   });
 
-  it('throws when docker info fails', () => {
-    mockExecFileSync.mockImplementationOnce(() => {
-      throw new Error('Cannot connect to the Docker daemon');
+  it('throws FatalError after all retries exhausted', () => {
+    const dockerErr = new Error('Cannot connect to the Docker daemon');
+    mockExecFileSync.mockImplementation(() => {
+      throw dockerErr;
     });
 
-    expect(() => ensureContainerRuntimeRunning()).toThrow(
-      'Container runtime is required but failed to start',
-    );
+    expect(() => ensureContainerRuntimeRunning()).toThrow(FatalError);
+    // 1 initial + 6 retries = 7 total calls
+    expect(mockExecFileSync).toHaveBeenCalledTimes(7);
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('succeeds after retries when runtime becomes available', () => {
+    const dockerErr = new Error('Cannot connect to the Docker daemon');
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw dockerErr;
+      })
+      .mockImplementationOnce(() => {
+        throw dockerErr;
+      })
+      .mockImplementationOnce(() => {
+        throw dockerErr;
+      })
+      .mockReturnValueOnce('');
+
+    ensureContainerRuntimeRunning();
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(4);
+    expect(logger.info).toHaveBeenCalledWith(
+      { attempt: 4 },
+      'Container runtime became available after retries',
+    );
+  });
+
+  it('logs warning on each retry attempt', () => {
+    const dockerErr = new Error('Cannot connect to the Docker daemon');
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw dockerErr;
+      })
+      .mockImplementationOnce(() => {
+        throw dockerErr;
+      })
+      .mockReturnValueOnce('');
+
+    ensureContainerRuntimeRunning();
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenNthCalledWith(
+      1,
+      { attempt: 1, maxRetries: 6, delayMs: 5_000 },
+      'Container runtime not ready, retrying...',
+    );
+    expect(logger.warn).toHaveBeenNthCalledWith(
+      2,
+      { attempt: 2, maxRetries: 6, delayMs: 10_000 },
+      'Container runtime not ready, retrying...',
+    );
   });
 });
 

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -4,6 +4,7 @@
  */
 import { execFileSync } from 'child_process';
 
+import { FatalError } from './errors/index.js';
 import { logger } from './logger.js';
 import { detectProxyBindHost, hostGatewayArgs } from './platform.js';
 
@@ -50,24 +51,68 @@ export function stopContainerSync(name: string): void {
   });
 }
 
-/** Ensure the container runtime is running, starting it if needed. */
+const DOCKER_MAX_RETRIES = 6;
+const DOCKER_BASE_RETRY_MS = 5_000;
+const DOCKER_MAX_RETRY_MS = 30_000;
+
+// Sync sleep via Atomics.wait — blocks the event loop without busy-looping.
+let sleepFn = (ms: number): void => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+};
+
+/** Replace the sleep implementation (test-only). */
+export function _setSleepFnForTests(fn: (ms: number) => void): void {
+  sleepFn = fn;
+}
+
+/** Ensure the container runtime is running, retrying with exponential backoff. */
 export function ensureContainerRuntimeRunning(): void {
-  try {
-    execFileSync(CONTAINER_RUNTIME_BIN, ['info'], {
-      stdio: 'pipe',
-      timeout: 10000,
-    });
-    logger.debug('Container runtime already running');
-  } catch (err) {
-    logger.error({ err }, 'Failed to reach container runtime');
-    logger.error(
-      'FATAL: Container runtime failed to start. ' +
-        'Agents cannot run without a container runtime. ' +
-        'To fix: 1) Ensure Docker is installed and running, ' +
-        '2) Run: docker info, 3) Restart Deus',
-    );
-    throw new Error('Container runtime is required but failed to start');
+  let lastErr: unknown;
+
+  for (let attempt = 1; attempt <= DOCKER_MAX_RETRIES + 1; attempt++) {
+    try {
+      execFileSync(CONTAINER_RUNTIME_BIN, ['info'], {
+        stdio: 'pipe',
+        timeout: 10_000,
+      });
+      if (attempt > 1) {
+        logger.info(
+          { attempt },
+          'Container runtime became available after retries',
+        );
+      } else {
+        logger.debug('Container runtime already running');
+      }
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (attempt <= DOCKER_MAX_RETRIES) {
+        const delayMs = Math.min(
+          DOCKER_BASE_RETRY_MS * Math.pow(2, attempt - 1),
+          DOCKER_MAX_RETRY_MS,
+        );
+        logger.warn(
+          { attempt, maxRetries: DOCKER_MAX_RETRIES, delayMs },
+          'Container runtime not ready, retrying...',
+        );
+        sleepFn(delayMs);
+      }
+    }
   }
+
+  logger.error(
+    { err: lastErr, attempts: DOCKER_MAX_RETRIES + 1 },
+    'Container runtime failed to start after all retries',
+  );
+  logger.error(
+    'FATAL: Container runtime unreachable. ' +
+      'Agents cannot run without a container runtime. ' +
+      'To fix: 1) Ensure Docker is installed and running, ' +
+      '2) Run: docker info, 3) Restart Deus',
+  );
+  throw new FatalError('Container runtime is required but failed to start', {
+    cause: lastErr,
+  });
 }
 
 /** Kill orphaned Deus containers from previous runs. */


### PR DESCRIPTION
## Summary

- `ensureContainerRuntimeRunning()` now retries with exponential backoff (6 retries, 5s base, 30s cap, ~125s total) instead of crashing on a single `docker info` failure
- Throws `FatalError` after exhaustion (aligns with `error-discipline.md` taxonomy)
- Setup script enables Docker auto-start: macOS login items via osascript, Linux `systemctl enable docker` when root
- Both auto-start helpers are idempotent, guarded by `CONTAINER_RUNTIME` env, and non-fatal on failure

**Root cause:** After a PC crash, Docker Desktop didn't auto-start. Deus started via launchd `RunAtLoad`, hit the single-shot `docker info` check, crashed immediately. launchd `KeepAlive` retried but Docker was never up — crash loop got throttled — extended WhatsApp outage.

**Note:** `ensureDockerAutoStart()` uses macOS `osascript` for login-item management — flagged for future SoT migration per `project_windows_sot_plan.md`.

## Test plan

- [x] `npx vitest run src/container-runtime.test.ts` — 10/10 pass
- [x] `npx tsc --noEmit` — no type errors in changed files
- [x] `npx eslint src/container-runtime.ts` — clean
- [ ] Manual: stop Docker → start Deus → verify retry logs → start Docker → verify connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)