### PR TITLE
feat(eval): judge-LoRA step-3 post-LoRA bench (Adapter vs Base)

### DIFF
--- a/evolution/training/__tests__/test_bench_judge_lora.py
+++ b/evolution/training/__tests__/test_bench_judge_lora.py
@@ -1,0 +1,549 @@
+"""Unit tests for evolution.training.bench_judge_lora (mock-only).
+
+These tests do NOT load a real mlx_lm model — that path is exercised
+manually via `bench_judge_lora.py --limit 2 --skip-base` before any push
+that touches the inference loop. The tests here cover:
+
+  - parser correctness on valid / fenced / malformed / partial / out-of-range JSON
+  - metric helpers (Pearson, Spearman, MAE) edge cases
+  - test-split loader validation
+  - adapter-path resolution
+  - mocked end-to-end `run_bench` flow (seed kwarg absent, cleanup fired)
+  - results JSON schema
+
+Total: 22 tests. Plan-reviewer R2 SHIP + code-reviewer R2 SHIP.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from evolution.training import bench_judge_lora as bj  # noqa: E402
+
+
+# ----------------------------- parsing -------------------------------------
+
+
+def test_parse_judge_response_valid():
+    raw = '{"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8, "rationale": "ok"}'
+    scores, err = bj.parse_judge_response(raw)
+    assert err is None
+    assert scores == {"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8}
+
+
+def test_parse_judge_response_fenced_json():
+    raw = '```json\n{"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8}\n```'
+    scores, err = bj.parse_judge_response(raw)
+    assert err is None
+    assert scores["quality"] == 0.9
+    assert scores["safety"] == 1.0
+
+
+def test_parse_judge_response_missing_dim():
+    # missing tool_use + personalization
+    raw = '{"quality": 0.9, "safety": 0.8}'
+    scores, err = bj.parse_judge_response(raw)
+    assert err is not None
+    assert "tool_use" in err
+    assert "personalization" in err
+    assert scores["tool_use"] == 0.5
+    assert scores["personalization"] == 0.5
+    # present dims kept
+    assert scores["quality"] == 0.9
+
+
+def test_parse_judge_response_malformed():
+    scores, err = bj.parse_judge_response("not json at all")
+    assert err is not None
+    assert all(scores[d] == 0.5 for d in bj.DIMENSIONS)
+
+
+def test_parse_judge_response_clamps_out_of_range():
+    raw = '{"quality": 1.5, "safety": -0.1, "tool_use": 0.5, "personalization": 0.5}'
+    scores, err = bj.parse_judge_response(raw)
+    assert err is None  # all dims present + parseable, clamping is silent
+    assert scores["quality"] == 1.0
+    assert scores["safety"] == 0.0
+
+
+def test_parse_judge_response_empty():
+    scores, err = bj.parse_judge_response("")
+    assert err == "empty response"
+    assert all(scores[d] == 0.5 for d in bj.DIMENSIONS)
+
+
+# ----------------------------- metrics -------------------------------------
+
+
+def test_pearson_zero_variance():
+    """Identical input → returns 0.0 (not div-zero crash). Convention from
+    evolution/benchmark_judge.py:76-87."""
+    assert bj._pearson([0.5, 0.5, 0.5, 0.5], [0.1, 0.2, 0.3, 0.4]) == 0.0
+    assert bj._pearson([0.1, 0.2, 0.3, 0.4], [0.5, 0.5, 0.5, 0.5]) == 0.0
+
+
+def test_pearson_perfect_correlation():
+    assert bj._pearson([0.1, 0.2, 0.3, 0.4], [0.1, 0.2, 0.3, 0.4]) == pytest.approx(1.0)
+    assert bj._pearson([0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]) == pytest.approx(-1.0)
+
+
+def test_spearman_perfect_correlation():
+    # Spearman of sorted-vs-sorted is 1.0; reverse is -1.0
+    assert bj._spearman([1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]) == pytest.approx(1.0)
+    assert bj._spearman([1.0, 2.0, 3.0, 4.0], [40.0, 30.0, 20.0, 10.0]) == pytest.approx(-1.0)
+
+
+def test_mae_simple():
+    # |0.1-0.0| + |0.2-0.1| + |0.3-0.5| = 0.1 + 0.1 + 0.2 = 0.4 / 3 ≈ 0.1333
+    assert bj._mae([0.1, 0.2, 0.3], [0.0, 0.1, 0.5]) == pytest.approx(0.4 / 3)
+
+
+def test_metrics_n_below_3_returns_zero():
+    assert bj._pearson([0.1, 0.2], [0.3, 0.4]) == 0.0
+    assert bj._spearman([0.1, 0.2], [0.3, 0.4]) == 0.0
+
+
+# ----------------------------- loaders -------------------------------------
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+
+def test_load_test_records_validates_shape(tmp_path: Path):
+    valid = {
+        "messages": [
+            {"role": "user", "content": "score this"},
+            {"role": "assistant", "content": '{"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8}'},
+        ]
+    }
+    invalid_role = {
+        "messages": [
+            {"role": "system", "content": "x"},
+            {"role": "assistant", "content": "x"},
+        ]
+    }
+    invalid_count = {"messages": [{"role": "user", "content": "x"}]}
+
+    valid_path = tmp_path / "valid.jsonl"
+    _write_jsonl(valid_path, [valid, valid])
+    records = bj.load_test_records(valid_path)
+    assert len(records) == 2
+    assert records[0]["user_prompt"] == "score this"
+    assert records[0]["ground_truth"]["quality"] == 0.9
+
+    bad_role_path = tmp_path / "bad_role.jsonl"
+    _write_jsonl(bad_role_path, [invalid_role])
+    with pytest.raises(ValueError, match="role mismatch"):
+        bj.load_test_records(bad_role_path)
+
+    bad_count_path = tmp_path / "bad_count.jsonl"
+    _write_jsonl(bad_count_path, [invalid_count])
+    with pytest.raises(ValueError, match="expected messages"):
+        bj.load_test_records(bad_count_path)
+
+
+def test_load_test_records_respects_limit(tmp_path: Path):
+    valid = {
+        "messages": [
+            {"role": "user", "content": "score this"},
+            {"role": "assistant", "content": '{"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8}'},
+        ]
+    }
+    path = tmp_path / "many.jsonl"
+    _write_jsonl(path, [valid] * 10)
+    records = bj.load_test_records(path, limit=3)
+    assert len(records) == 3
+
+
+# ----------------------------- adapter resolution --------------------------
+
+
+def test_resolve_default_adapter_path_picks_latest(tmp_path: Path):
+    # Three ULID-style run dirs; lexicographically-largest should be picked
+    for run_id in ["20260518T010000Z-aaa", "20260518T020000Z-bbb", "20260518T030000Z-ccc"]:
+        run_dir = tmp_path / run_id
+        run_dir.mkdir()
+        (run_dir / "adapters.safetensors").write_bytes(b"\x00")
+        (run_dir / "adapter_config.json").write_text("{}")
+    chosen = bj.resolve_default_adapter_path(tmp_path)
+    assert chosen.name == "20260518T030000Z-ccc"
+
+
+def test_resolve_default_adapter_path_missing_safetensors(tmp_path: Path):
+    run_dir = tmp_path / "20260518T010000Z-aaa"
+    run_dir.mkdir()
+    (run_dir / "adapter_config.json").write_text("{}")
+    # No adapters.safetensors
+    with pytest.raises(FileNotFoundError, match="adapters.safetensors"):
+        bj.resolve_default_adapter_path(tmp_path)
+
+
+def test_resolve_default_adapter_path_empty_dir(tmp_path: Path):
+    # Adapters root exists but has no subdirs
+    with pytest.raises(FileNotFoundError, match="no adapter directories"):
+        bj.resolve_default_adapter_path(tmp_path)
+
+
+# ----------------------------- run_bench with mocks ------------------------
+
+
+def _install_mlx_mocks(monkeypatch, generate_outputs: list[str], capture: dict):
+    """Install fake mlx + mlx_lm into sys.modules so run_bench can import them.
+
+    `capture` dict will accumulate observed call args."""
+    capture.setdefault("generate_calls", [])
+    capture.setdefault("load_calls", [])
+    capture.setdefault("seed_calls", [])
+    capture.setdefault("clear_cache_calls", 0)
+    capture.setdefault("gc_collect_calls", 0)
+
+    # ----- fake mlx.core / mlx.core.random / mlx.core.metal -----
+    fake_mlx = types.ModuleType("mlx")
+    fake_mlx_core = types.ModuleType("mlx.core")
+    fake_mlx_random = types.ModuleType("mlx.core.random")
+    fake_mlx_metal = types.ModuleType("mlx.core.metal")
+
+    def fake_seed(s):
+        capture["seed_calls"].append(s)
+
+    def fake_clear_cache():
+        capture["clear_cache_calls"] += 1
+
+    fake_mlx_random.seed = fake_seed
+    fake_mlx_metal.clear_cache = fake_clear_cache
+    fake_mlx_core.random = fake_mlx_random
+    fake_mlx_core.metal = fake_mlx_metal
+    fake_mlx.core = fake_mlx_core
+
+    # ----- fake mlx_lm.load + mlx_lm.generate + sample_utils.make_sampler -----
+    class _FakeTok:
+        def apply_chat_template(self, messages, add_generation_prompt, tokenize):
+            # Return the user prompt verbatim so we can assert on it later
+            assert add_generation_prompt is True
+            assert tokenize is False
+            return f"<<<{messages[0]['content']}>>>"
+
+    class _FakeModel:
+        pass
+
+    class _FakeSampler:
+        """Marker so we can assert the sampler kwarg was the one we built."""
+        def __init__(self, temp):
+            self.temp = temp
+
+    def fake_load(base_model, adapter_path=None):
+        capture["load_calls"].append({"base_model": base_model, "adapter_path": adapter_path})
+        return _FakeModel(), _FakeTok()
+
+    def fake_make_sampler(temp=0.0, **kw):
+        capture.setdefault("make_sampler_calls", []).append({"temp": temp, **kw})
+        return _FakeSampler(temp=temp)
+
+    output_iter = iter(generate_outputs)
+
+    def fake_generate(model, tok, prompt, **kwargs):
+        capture["generate_calls"].append({"prompt": prompt, "kwargs": dict(kwargs)})
+        try:
+            return next(output_iter)
+        except StopIteration:
+            return ""
+
+    fake_mlx_lm = types.ModuleType("mlx_lm")
+    fake_mlx_lm.load = fake_load
+    fake_mlx_lm.generate = fake_generate
+    fake_sample_utils = types.ModuleType("mlx_lm.sample_utils")
+    fake_sample_utils.make_sampler = fake_make_sampler
+
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mlx_core)
+    monkeypatch.setitem(sys.modules, "mlx.core.random", fake_mlx_random)
+    monkeypatch.setitem(sys.modules, "mlx.core.metal", fake_mlx_metal)
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.sample_utils", fake_sample_utils)
+
+    # mlx.core.metal access via `mx.metal.clear_cache()` — mx is mlx.core.
+    # Some real installs expose it as `mx.metal`; we already wired that above.
+
+    # ----- patch gc.collect to count -----
+    real_gc_collect = bj.gc.collect
+
+    def fake_gc_collect():
+        capture["gc_collect_calls"] += 1
+        return real_gc_collect()
+
+    monkeypatch.setattr(bj.gc, "collect", fake_gc_collect)
+
+
+def test_run_bench_uses_mocked_mlx_lm(monkeypatch):
+    """End-to-end run_bench with mocked mlx, asserting:
+    - mlx_lm.load called with adapter_path
+    - mx.random.seed called exactly ONCE before the loop
+    - mlx_lm.generate called with max_tokens, temp, verbose — and NO seed kwarg
+    - chat template applied to each user prompt
+    - cleanup_after=True → gc.collect + mx.metal.clear_cache both called
+    """
+    records = [
+        {
+            "user_prompt": f"prompt-{i}",
+            "ground_truth": {"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8},
+        }
+        for i in range(3)
+    ]
+    outputs = [
+        '{"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8}',
+        '{"quality": 0.5, "safety": 1.0, "tool_use": 0.5, "personalization": 0.5}',
+        "garbage not json",
+    ]
+    capture: dict = {}
+    _install_mlx_mocks(monkeypatch, outputs, capture)
+
+    result = bj.run_bench(
+        backend_name="adapter",
+        base_model="fake-base",
+        adapter_path=Path("/tmp/fake-adapter"),
+        records=records,
+        max_tokens=128,
+        temp=0.0,
+        seed=42,
+        quiet=True,
+        cleanup_after=True,
+    )
+
+    # --- assertions ---
+    # Load was called once with adapter path
+    assert len(capture["load_calls"]) == 1
+    assert capture["load_calls"][0]["adapter_path"] == "/tmp/fake-adapter"
+
+    # Seed called once before the loop
+    assert capture["seed_calls"] == [42]
+
+    # make_sampler called once with the configured temp BEFORE the loop
+    assert capture.get("make_sampler_calls") == [{"temp": 0.0}]
+
+    # All 3 records generated, each call had the right kwargs
+    assert len(capture["generate_calls"]) == 3
+    for call in capture["generate_calls"]:
+        assert "max_tokens" in call["kwargs"]
+        assert call["kwargs"]["max_tokens"] == 128
+        assert call["kwargs"]["verbose"] is False
+        # The sampler from make_sampler() is forwarded
+        assert "sampler" in call["kwargs"]
+        # CRITICAL regression guards — mlx_lm.generate_step does NOT accept
+        # `seed` or `temp` (verified empirically against mlx_lm 0.31.3).
+        # Both would raise TypeError. seed is via mx.random.seed(),
+        # temp is via make_sampler(temp=...).
+        assert "seed" not in call["kwargs"], (
+            f"seed leaked into mlx_lm.generate kwargs: {call['kwargs']}. "
+            f"Should be set via mx.random.seed() once before the loop."
+        )
+        assert "temp" not in call["kwargs"], (
+            f"temp leaked into mlx_lm.generate kwargs: {call['kwargs']}. "
+            f"Should be wrapped via make_sampler(temp=...) and passed as sampler=."
+        )
+
+    # Chat template applied (prompts wrapped in <<<...>>> by the fake tok)
+    for i, call in enumerate(capture["generate_calls"]):
+        assert call["prompt"] == f"<<<prompt-{i}>>>"
+
+    # Cleanup fired exactly once (cleanup_after=True)
+    assert capture["gc_collect_calls"] == 1
+    assert capture["clear_cache_calls"] == 1
+
+    # Records captured + parse outcomes
+    assert result.n == 3
+    assert result.records[0].parse_ok is True
+    assert result.records[1].parse_ok is True
+    assert result.records[2].parse_ok is False  # "garbage not json"
+
+
+def test_run_bench_invokes_metal_cleanup_between_backends(monkeypatch):
+    """Plan-reviewer R1 informational: a regression test that guards against
+    the cleanup-between-backends path being silently dropped. When
+    `cleanup_after=True`, both gc.collect and mx.metal.clear_cache fire;
+    when `cleanup_after=False`, neither does."""
+    records = [
+        {
+            "user_prompt": "x",
+            "ground_truth": {"quality": 0.5, "safety": 0.5, "tool_use": 0.5, "personalization": 0.5},
+        }
+    ]
+    outputs = ['{"quality": 0.5, "safety": 0.5, "tool_use": 0.5, "personalization": 0.5}']
+
+    # cleanup_after=True path
+    capture_t: dict = {}
+    _install_mlx_mocks(monkeypatch, outputs, capture_t)
+    bj.run_bench(
+        backend_name="adapter",
+        base_model="fake",
+        adapter_path=Path("/tmp/x"),
+        records=records,
+        max_tokens=16,
+        temp=0.0,
+        seed=1,
+        quiet=True,
+        cleanup_after=True,
+    )
+    assert capture_t["gc_collect_calls"] == 1
+    assert capture_t["clear_cache_calls"] == 1
+
+    # cleanup_after=False path (final backend in a sequence)
+    capture_f: dict = {}
+    _install_mlx_mocks(monkeypatch, outputs, capture_f)
+    bj.run_bench(
+        backend_name="base",
+        base_model="fake",
+        adapter_path=None,
+        records=records,
+        max_tokens=16,
+        temp=0.0,
+        seed=1,
+        quiet=True,
+        cleanup_after=False,
+    )
+    assert capture_f["gc_collect_calls"] == 0
+    assert capture_f["clear_cache_calls"] == 0
+
+
+# ----------------------------- save_results_json ---------------------------
+
+
+def test_save_results_json_atomic_and_valid_schema(tmp_path: Path):
+    """Build minimal BackendResult fixtures, write JSON, re-read and assert
+    schema-level expectations."""
+    adapter = bj.BackendResult(
+        name="adapter", base_model="b", adapter_path="/a", load_time_s=1.5
+    )
+    base = bj.BackendResult(name="base", base_model="b", adapter_path=None, load_time_s=2.0)
+    # Add 3 records each so Pearson/Spearman are computable
+    for i in range(3):
+        gt = {"quality": 0.5 + 0.1 * i, "safety": 1.0, "tool_use": 0.5, "personalization": 0.5}
+        adapter.records.append(
+            bj.BenchRecord(
+                interaction_idx=i,
+                prompt_preview="p",
+                ground_truth=gt,
+                generated_scores=gt,
+                parse_ok=True,
+                parse_error=None,
+                latency_s=0.1,
+                raw_generated="{}",
+            )
+        )
+        base.records.append(
+            bj.BenchRecord(
+                interaction_idx=i,
+                prompt_preview="p",
+                ground_truth=gt,
+                generated_scores={"quality": 0.5, "safety": 0.5, "tool_use": 0.5, "personalization": 0.5},
+                parse_ok=False,
+                parse_error="malformed",
+                latency_s=0.2,
+                raw_generated="oops",
+            )
+        )
+
+    out = tmp_path / "result.json"
+    bj.save_results_json(
+        adapter,
+        base,
+        out,
+        base_model="b",
+        test_jsonl_path=Path("/fake/test.jsonl"),
+        test_jsonl_sha256="deadbeef",
+        seed=42,
+    )
+
+    assert out.exists()
+    # Tmp file was atomically renamed away
+    assert not (tmp_path / "result.json.tmp").exists()
+
+    data = json.loads(out.read_text())
+    assert data["schema_version"] == 1
+    assert data["base_model"] == "b"
+    assert data["seed"] == 42
+    assert data["test_jsonl_sha256"] == "deadbeef"
+    assert data["dimensions"] == list(bj.DIMENSIONS)
+    assert len(data["backends"]) == 2
+    assert data["backends"][0]["name"] == "adapter"
+    assert data["backends"][1]["name"] == "base"
+    # Records preserved
+    assert len(data["backends"][0]["records"]) == 3
+    # Verdict present (two-backend payload)
+    assert "verdict" in data
+    assert "mean_pearson_delta" in data["verdict"]
+    assert "parse_error_rate_delta" in data["verdict"]
+
+
+# ----------------------------- argument validation ------------------------
+
+
+def test_main_rejects_negative_temp(tmp_path: Path):
+    """Code-reviewer R1: temp must be >= 0.0; negative values would silently
+    pass to make_sampler and produce undefined behavior."""
+    # Need a valid adapter dir so the temp check fires before any FS errors
+    adapter_dir = tmp_path / "20260518T000000Z-test"
+    adapter_dir.mkdir()
+    (adapter_dir / "adapters.safetensors").write_bytes(b"\x00")
+    (adapter_dir / "adapter_config.json").write_text("{}")
+    with pytest.raises(SystemExit, match=r"--temp must be >= 0\.0"):
+        bj.main([
+            "--dry-run",
+            "--temp", "-0.5",
+            "--adapter-path", str(adapter_dir),
+            "--test-jsonl", str(tmp_path / "fake.jsonl"),
+        ])
+
+
+def test_main_rejects_max_tokens_zero(tmp_path: Path):
+    adapter_dir = tmp_path / "20260518T000000Z-test"
+    adapter_dir.mkdir()
+    (adapter_dir / "adapters.safetensors").write_bytes(b"\x00")
+    (adapter_dir / "adapter_config.json").write_text("{}")
+    with pytest.raises(SystemExit, match=r"--max-tokens must be >= 1"):
+        bj.main([
+            "--dry-run",
+            "--max-tokens", "0",
+            "--adapter-path", str(adapter_dir),
+            "--test-jsonl", str(tmp_path / "fake.jsonl"),
+        ])
+
+
+def test_save_results_json_skip_base_omits_verdict(tmp_path: Path):
+    adapter = bj.BackendResult(name="adapter", base_model="b", adapter_path="/a")
+    for i in range(3):
+        gt = {"quality": 0.9, "safety": 1.0, "tool_use": 0.7, "personalization": 0.8}
+        adapter.records.append(
+            bj.BenchRecord(
+                interaction_idx=i,
+                prompt_preview="p",
+                ground_truth=gt,
+                generated_scores=gt,
+                parse_ok=True,
+                parse_error=None,
+                latency_s=0.1,
+                raw_generated="{}",
+            )
+        )
+    out = tmp_path / "adapter-only.json"
+    bj.save_results_json(
+        adapter,
+        None,
+        out,
+        base_model="b",
+        test_jsonl_path=Path("/fake/test.jsonl"),
+        test_jsonl_sha256="deadbeef",
+        seed=42,
+    )
+    data = json.loads(out.read_text())
+    assert len(data["backends"]) == 1
+    assert "verdict" not in data

--- a/evolution/training/bench_judge_lora.py
+++ b/evolution/training/bench_judge_lora.py
@@ -1,0 +1,905 @@
+"""Judge-LoRA post-training bench — Adapter vs Base on the held-out test split.
+
+Step 3/4 of the judge-LoRA pipeline (plan at
+~/.claude/plans/eventual-meandering-bear.md, plan-reviewer SHIP'd Round 2).
+Consumes the step-1 stratified test split + the step-2 trained adapter and
+produces (a) a per-dimension comparison table on stdout and (b) a results
+JSON artifact that feeds step-4 (the ADR `judge-lora-specialization.md`)
+and the PR #1.5 conditional rationale regeneration.
+
+The earlier n=50 stratified bench (2026-05-17) measured Gemma-3n-E4B-Q8_0
+(Ollama) vs Gemini and surfaced a 0.163 Pearson gap. The LoRA was trained
+to close that gap. This bench is the empirical answer.
+
+## Platform constraints
+
+**macOS / Apple Silicon only — requires `mlx` + Metal GPU. Not portable to
+Linux/x86.** mlx_lm and mlx.core.metal cleanup are mac-specific. The bench
+fails fast on other platforms because `mlx_lm` cannot be imported there —
+the `with_mlx=True` branch of `preflight()` (and the lazy import at the top
+of `run_bench`) surface `ImportError` → `SystemExit` immediately. There is
+no explicit `sys.platform` guard; the import failure IS the guard.
+
+## Inference design (in-process)
+
+Both backends load the same base model. The Adapter backend additionally
+applies the trained LoRA via `mlx_lm.load(..., adapter_path=...)`. Each
+backend runs ONCE, processes all 40 records sequentially, then explicit
+`del model + gc.collect() + mx.metal.clear_cache()` frees Metal before the
+next backend loads.
+
+Determinism: `mx.random.seed(seed)` is called ONCE per backend BEFORE the
+generate loop. `seed` is NOT passed to `mlx_lm.generate` — that kwarg is not
+accepted by `generate_step` and would raise TypeError. CLI canonical usage:
+`mlx_lm/generate.py:1970-1971`. For temperature: `temp` is also NOT a valid
+kwarg on `mlx_lm.generate` (verified empirically against mlx_lm 0.31.3 —
+`generate_step` signature has no `temp` parameter). Instead, build a sampler
+via `make_sampler(temp=temp, ...)` (signature at `mlx_lm/sample_utils.py`)
+and pass `sampler=...` to `generate`. `temp=0.0` ⇒ greedy argmax.
+
+## Lazy import boundary
+
+`mlx_lm` and `mlx.core` are imported INSIDE `run_bench()` and (optionally)
+`preflight()`, NEVER at module top. This lets `--dry-run` and the
+import-only path of `--pre-flight-only` run on host Python without the
+judge-lora venv installed.
+
+## Output
+
+JSON results land at `finetune/judge-lora-gemma3n/bench/<adapter-run-id>-vs-base-<UTC>.json`.
+The path is gitignored (the entire `finetune/judge-lora-gemma3n/` subtree is
+gitignored at the repo level).
+
+## Composite metric note
+
+Composite is dominated by parse_error_rate when base parse failures are
+>20% — the comparison table reports mean Pearson, mean MAE, and
+parse_error_rate as separate headline columns so the composite alone never
+drives the verdict. The verdict line uses mean Pearson delta directly.
+
+## Developer note
+
+The unit tests for this module use `monkeypatch` to stub `mlx_lm.load`,
+`mlx_lm.generate`, `mlx.core.random.seed`, `gc.collect`, and
+`mlx.core.metal.clear_cache`. They do NOT exercise real-model inference.
+Before pushing changes that touch the inference path you MUST run
+`bench_judge_lora.py --limit 2 --skip-base` locally; that is the only
+catch-net for `mlx_lm` API drift inside this module.
+"""
+from __future__ import annotations
+
+import argparse
+import functools
+import gc
+import hashlib
+import json
+import os
+import re
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ---------- Defaults --------------------------------------------------------
+
+# Default base model: 4-bit Gemma-3n-E4B text-only. Same model the adapter
+# was trained on (locked in training_manifest.json under step-2). Using a
+# different base would invalidate the comparison.
+DEFAULT_BASE_MODEL = "mlx-community/gemma-3n-E4B-it-lm-4bit"
+
+DEFAULT_DATASET_DIR = PROJECT_ROOT / "finetune/judge-lora-gemma3n"
+DEFAULT_TEST_JSONL = DEFAULT_DATASET_DIR / "data/test.jsonl"
+DEFAULT_ADAPTERS_ROOT = DEFAULT_DATASET_DIR / "adapters"
+DEFAULT_BENCH_OUT_DIR = DEFAULT_DATASET_DIR / "bench"
+
+DEFAULT_MAX_TOKENS = 256
+DEFAULT_TEMP = 0.0
+DEFAULT_SEED = 20260518
+
+# Judge rubric dimensions (same as evolution/judge/ollama_judge.py and the
+# step-1 dataset builder). Order matters: it's the canonical iteration order
+# for tables + JSON output.
+DIMENSIONS: tuple[str, ...] = (
+    "quality",
+    "safety",
+    "tool_use",
+    "personalization",
+)
+
+VENV = Path(
+    os.environ.get("JUDGE_LORA_VENV", "~/deus/.venvs/judge-lora/bin/python3")
+).expanduser()
+
+
+# ---------- Data classes ----------------------------------------------------
+
+
+@dataclass
+class BenchRecord:
+    """One scored record from one backend."""
+    interaction_idx: int
+    prompt_preview: str
+    ground_truth: dict[str, float]
+    generated_scores: dict[str, float]
+    parse_ok: bool
+    parse_error: str | None
+    latency_s: float
+    raw_generated: str  # first 400 chars for debug
+
+
+@dataclass
+class BackendResult:
+    """Aggregated results for one backend (Adapter or Base).
+
+    The metric properties below are `cached_property` so each one is computed
+    AT MOST ONCE per instance. This eliminates the recomputation chain that
+    arises when `print_comparison` and `save_results_json` both access
+    `pearson_per_dim`, `mean_pearson`, etc. several times. Safe because
+    `records` is only ever appended to inside `run_bench` and never mutated
+    after that function returns; properties are only accessed downstream.
+    """
+    name: str
+    base_model: str
+    adapter_path: str | None
+    records: list[BenchRecord] = field(default_factory=list)
+    load_time_s: float = 0.0
+
+    @property
+    def n(self) -> int:
+        return len(self.records)
+
+    @functools.cached_property
+    def parse_error_rate(self) -> float:
+        if not self.records:
+            return 0.0
+        return sum(1 for r in self.records if not r.parse_ok) / len(self.records)
+
+    @functools.cached_property
+    def avg_latency_s(self) -> float:
+        if not self.records:
+            return 0.0
+        return statistics.mean(r.latency_s for r in self.records)
+
+    @functools.cached_property
+    def pearson_per_dim(self) -> dict[str, float]:
+        return {
+            dim: _pearson(
+                [r.generated_scores.get(dim, 0.5) for r in self.records],
+                [r.ground_truth.get(dim, 0.5) for r in self.records],
+            )
+            for dim in DIMENSIONS
+        }
+
+    @functools.cached_property
+    def spearman_per_dim(self) -> dict[str, float]:
+        return {
+            dim: _spearman(
+                [r.generated_scores.get(dim, 0.5) for r in self.records],
+                [r.ground_truth.get(dim, 0.5) for r in self.records],
+            )
+            for dim in DIMENSIONS
+        }
+
+    @functools.cached_property
+    def mae_per_dim(self) -> dict[str, float]:
+        return {
+            dim: _mae(
+                [r.generated_scores.get(dim, 0.5) for r in self.records],
+                [r.ground_truth.get(dim, 0.5) for r in self.records],
+            )
+            for dim in DIMENSIONS
+        }
+
+    @functools.cached_property
+    def mean_pearson(self) -> float:
+        vals = list(self.pearson_per_dim.values())
+        return statistics.mean(vals) if vals else 0.0
+
+    @functools.cached_property
+    def mean_mae(self) -> float:
+        vals = list(self.mae_per_dim.values())
+        return statistics.mean(vals) if vals else 0.0
+
+    @functools.cached_property
+    def composite(self) -> float:
+        """0.4 * mean_pearson + 0.3 * (1 - mean_mae) + 0.3 * (1 - parse_err).
+
+        Same weighting as evolution/benchmark_judge.py:252-256. Reported for
+        ranking convenience, but the headline verdict line uses mean_pearson
+        delta directly to avoid the parse-error-domination trap.
+        """
+        corr = max(self.mean_pearson, 0.0)
+        mae_score = max(0.0, 1.0 - self.mean_mae)
+        parse_score = 1.0 - self.parse_error_rate
+        return 0.4 * corr + 0.3 * mae_score + 0.3 * parse_score
+
+
+# ---------- Pure metric helpers --------------------------------------------
+
+
+def _pearson(xs: list[float], ys: list[float]) -> float:
+    """Pearson correlation. Returns 0.0 when n < 3 or zero variance (same
+    convention as evolution/benchmark_judge.py:76-87)."""
+    n = len(xs)
+    if n < 3 or n != len(ys):
+        return 0.0
+    mean_x = statistics.mean(xs)
+    mean_y = statistics.mean(ys)
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den_x = sum((x - mean_x) ** 2 for x in xs) ** 0.5
+    den_y = sum((y - mean_y) ** 2 for y in ys) ** 0.5
+    if den_x == 0 or den_y == 0:
+        return 0.0
+    return num / (den_x * den_y)
+
+
+def _spearman(xs: list[float], ys: list[float]) -> float:
+    """Spearman rank correlation. Returns 0.0 when n < 3 (same convention as
+    evolution/benchmark_judge.py:89-105)."""
+    n = len(xs)
+    if n < 3 or n != len(ys):
+        return 0.0
+
+    def _rank(vals: list[float]) -> list[float]:
+        indexed = sorted(enumerate(vals), key=lambda kv: kv[1])
+        ranks = [0.0] * n
+        for rank, (orig_idx, _) in enumerate(indexed, 1):
+            ranks[orig_idx] = float(rank)
+        return ranks
+
+    r_x = _rank(xs)
+    r_y = _rank(ys)
+    d_sq = sum((a - b) ** 2 for a, b in zip(r_x, r_y))
+    return 1 - (6 * d_sq) / (n * (n * n - 1))
+
+
+def _mae(xs: list[float], ys: list[float]) -> float:
+    """Mean absolute error. Returns 0.0 when empty."""
+    if not xs or len(xs) != len(ys):
+        return 0.0
+    return statistics.mean(abs(x - y) for x, y in zip(xs, ys))
+
+
+# ---------- Parsing --------------------------------------------------------
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*", re.IGNORECASE)
+_JSON_BLOCK_RE = re.compile(r"\{[^{}]*\}", re.DOTALL)
+
+
+def parse_judge_response(raw: str) -> tuple[dict[str, float], str | None]:
+    """Extract the 4-dimension score dict from a model-generated string.
+
+    Mirrors evolution/judge/ollama_judge.py:_parse_result behaviour (strips
+    markdown fences, attempts json.loads of first {...} block, casts to
+    float, clamps to [0.0, 1.0], falls back to 0.5 neutral on failure).
+
+    Returns (scores_dict, error_msg). `error_msg` is None on success. On
+    partial parse (e.g. missing dim) the dict is filled with 0.5 fallback
+    and `error_msg` describes which fields were missing/invalid. On total
+    failure all dims default to 0.5 and `error_msg` carries the reason.
+    """
+    if not raw or not raw.strip():
+        return ({d: 0.5 for d in DIMENSIONS}, "empty response")
+
+    # Strip ``` / ```json fences but keep the content
+    cleaned = _FENCE_RE.sub("", raw).strip()
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3].strip()
+
+    # Try direct json.loads first, then fall back to first {...} block
+    parsed: dict | None = None
+    try:
+        candidate = json.loads(cleaned)
+        if isinstance(candidate, dict):
+            parsed = candidate
+    except json.JSONDecodeError:
+        match = _JSON_BLOCK_RE.search(cleaned)
+        if match:
+            try:
+                candidate = json.loads(match.group(0))
+                if isinstance(candidate, dict):
+                    parsed = candidate
+            except json.JSONDecodeError:
+                pass
+
+    if parsed is None:
+        return ({d: 0.5 for d in DIMENSIONS}, "no parseable JSON object found")
+
+    scores: dict[str, float] = {}
+    missing: list[str] = []
+    for dim in DIMENSIONS:
+        v = parsed.get(dim)
+        if v is None:
+            missing.append(dim)
+            scores[dim] = 0.5
+            continue
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            missing.append(f"{dim}(not-float)")
+            scores[dim] = 0.5
+            continue
+        # Clamp to [0.0, 1.0]
+        scores[dim] = max(0.0, min(1.0, f))
+
+    err = None
+    if missing:
+        err = f"missing/invalid: {', '.join(missing)}"
+    return scores, err
+
+
+# ---------- Loaders --------------------------------------------------------
+
+
+def load_test_records(path: Path, limit: int = 0) -> list[dict[str, Any]]:
+    """Read test.jsonl and validate the messages[0]=user, messages[1]=assistant
+    shape. Returns [{"user_prompt": str, "ground_truth": {q,s,t,p}}, ...].
+
+    Raises ValueError on the FIRST malformed record (fail-fast — the
+    upstream dataset builder enforces the shape so any drift is a bug).
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"test split not found: {path}")
+    records: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"{path}:{line_no} invalid JSON: {e}") from e
+            msgs = obj.get("messages")
+            if not isinstance(msgs, list) or len(msgs) != 2:
+                raise ValueError(
+                    f"{path}:{line_no} expected messages: [user, assistant], got {msgs!r}"
+                )
+            user, assistant = msgs[0], msgs[1]
+            if user.get("role") != "user" or assistant.get("role") != "assistant":
+                raise ValueError(
+                    f"{path}:{line_no} messages role mismatch (user/assistant required)"
+                )
+            user_prompt = user.get("content")
+            if not isinstance(user_prompt, str):
+                raise ValueError(f"{path}:{line_no} user content not a string")
+            gt_raw = assistant.get("content")
+            if not isinstance(gt_raw, str):
+                raise ValueError(f"{path}:{line_no} assistant content not a string")
+            gt_scores, gt_err = parse_judge_response(gt_raw)
+            if gt_err is not None:
+                raise ValueError(
+                    f"{path}:{line_no} ground-truth unparseable ({gt_err}); "
+                    f"raw={gt_raw[:200]!r}"
+                )
+            records.append({"user_prompt": user_prompt, "ground_truth": gt_scores})
+            if limit and len(records) >= limit:
+                break
+    if not records:
+        raise ValueError(f"{path} contained zero records")
+    return records
+
+
+def resolve_default_adapter_path(adapters_root: Path) -> Path:
+    """Pick the lexicographically-largest run dir under adapters_root. The
+    step-2 driver writes run IDs of the form `<UTC-compact>-<git-sha>[-dirty]`,
+    which sort correctly by recency. Validates the chosen dir contains the
+    final-iteration adapter + config."""
+    if not adapters_root.exists() or not adapters_root.is_dir():
+        raise FileNotFoundError(
+            f"adapters root missing: {adapters_root}. Run step-2 (train_judge_lora.py) first."
+        )
+    candidates = sorted(
+        (p for p in adapters_root.iterdir() if p.is_dir()),
+        key=lambda p: p.name,
+    )
+    if not candidates:
+        raise FileNotFoundError(
+            f"no adapter directories under {adapters_root}. Run step-2 first."
+        )
+    chosen = candidates[-1]
+    final_weights = chosen / "adapters.safetensors"
+    adapter_config = chosen / "adapter_config.json"
+    if not final_weights.exists():
+        raise FileNotFoundError(
+            f"adapter dir {chosen} is missing adapters.safetensors — "
+            f"training may have aborted mid-run."
+        )
+    if not adapter_config.exists():
+        raise FileNotFoundError(
+            f"adapter dir {chosen} is missing adapter_config.json — "
+            f"training may have aborted mid-run."
+        )
+    return chosen
+
+
+# ---------- Bench runner ---------------------------------------------------
+
+
+def run_bench(
+    *,
+    backend_name: str,
+    base_model: str,
+    adapter_path: Path | None,
+    records: list[dict[str, Any]],
+    max_tokens: int,
+    temp: float,
+    seed: int,
+    quiet: bool = False,
+    cleanup_after: bool = True,
+) -> BackendResult:
+    """Load model (with optional adapter) and score each record.
+
+    Lazy-imports mlx + mlx_lm — these only exist in the judge-lora venv.
+
+    `cleanup_after=True` (default) explicitly frees Metal state after the
+    inference loop so a follow-up backend can load without OOMing. Set
+    False for the LAST backend in a sequence (cleanup is a no-op at that
+    point but cheaper to skip).
+    """
+    try:
+        import mlx.core as mx
+        import mlx_lm
+        from mlx_lm.sample_utils import make_sampler
+    except ImportError as e:
+        raise SystemExit(
+            f"[bench] mlx_lm import failed ({e}). Run inside the judge-lora venv: "
+            f"{VENV} -m evolution.training.bench_judge_lora ..."
+        )
+
+    if not quiet:
+        adapter_str = str(adapter_path) if adapter_path else "(none)"
+        print(
+            f"[bench] Loading backend={backend_name} model={base_model} adapter={adapter_str}",
+            flush=True,
+        )
+    t_load_start = time.monotonic()
+    model, tok = mlx_lm.load(
+        base_model,
+        adapter_path=str(adapter_path) if adapter_path else None,
+    )
+    load_time_s = time.monotonic() - t_load_start
+    if not quiet:
+        print(f"[bench] Loaded in {load_time_s:.1f}s", flush=True)
+
+    # Set seed ONCE before the loop (NOT inside generate kwargs — that kwarg
+    # would raise TypeError per mlx_lm/generate.py:307). Canonical CLI
+    # pattern at mlx_lm/generate.py:1971.
+    mx.random.seed(seed)
+
+    # Build sampler ONCE — make_sampler(temp=0.0) returns a callable that
+    # picks argmax (greedy). Passing temp= directly to mlx_lm.generate raises
+    # TypeError; we must pass sampler= which generate_step does accept.
+    sampler = make_sampler(temp=temp)
+
+    result = BackendResult(
+        name=backend_name,
+        base_model=base_model,
+        adapter_path=str(adapter_path) if adapter_path else None,
+        load_time_s=load_time_s,
+    )
+
+    for idx, rec in enumerate(records, 1):
+        user_prompt = rec["user_prompt"]
+        ground_truth = rec["ground_truth"]
+        prompt_str = tok.apply_chat_template(
+            [{"role": "user", "content": user_prompt}],
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        t0 = time.monotonic()
+        # NB: NO seed kwarg, NO temp kwarg here — both would raise TypeError
+        # against mlx_lm 0.31.3 (`generate_step` signature has neither).
+        # Determinism is via `mx.random.seed` above; temperature is via the
+        # sampler built from `make_sampler(temp=...)`.
+        raw = mlx_lm.generate(
+            model,
+            tok,
+            prompt_str,
+            max_tokens=max_tokens,
+            sampler=sampler,
+            verbose=False,
+        )
+        latency_s = time.monotonic() - t0
+        scores, err = parse_judge_response(raw)
+        preview = user_prompt[:80].replace("\n", " ")
+        if len(user_prompt) > 80:
+            preview += "..."
+        record = BenchRecord(
+            interaction_idx=idx - 1,
+            prompt_preview=preview,
+            ground_truth=ground_truth,
+            generated_scores=scores,
+            parse_ok=(err is None),
+            parse_error=err,
+            latency_s=latency_s,
+            raw_generated=raw[:400] if isinstance(raw, str) else str(raw)[:400],
+        )
+        result.records.append(record)
+        if not quiet:
+            gen_str = " ".join(f"{d[0]}={scores[d]:.2f}" for d in DIMENSIONS)
+            gt_str = " ".join(f"{d[0]}={ground_truth[d]:.2f}" for d in DIMENSIONS)
+            err_str = "" if err is None else f" err={err[:40]!r}"
+            print(
+                f"[{idx}/{len(records)}] {backend_name} {gen_str} | gt {gt_str} | "
+                f"{latency_s:.1f}s{err_str}",
+                flush=True,
+            )
+
+    if cleanup_after:
+        del model
+        del tok
+        gc.collect()
+        try:
+            mx.metal.clear_cache()
+        except (AttributeError, RuntimeError):
+            # Non-Metal builds (shouldn't happen on this platform, but safe)
+            pass
+        if not quiet:
+            print(
+                f"[bench] Cleaned up Metal state after backend={backend_name}",
+                flush=True,
+            )
+
+    return result
+
+
+# ---------- Output ---------------------------------------------------------
+
+
+def print_comparison(
+    adapter_result: BackendResult,
+    base_result: BackendResult | None,
+) -> None:
+    """Per-dimension table + headline aggregate + verdict line driven by
+    mean Pearson delta (not composite)."""
+    print("\n" + "=" * 96)
+    print(f"BENCH RESULTS — n={adapter_result.n} records")
+    print(f"  Adapter: {adapter_result.adapter_path}")
+    if base_result is not None:
+        print(f"  Base:    {base_result.base_model}")
+    else:
+        print("  Base:    (skipped via --skip-base)")
+    print("=" * 96)
+
+    # Per-dim table
+    if base_result is not None:
+        print(
+            f"\n{'Dimension':<18} {'Adp Pearson':>12} {'Base Pearson':>13} "
+            f"{'ΔPearson':>10} {'Adp MAE':>9} {'Base MAE':>10} {'ΔMAE':>8}"
+        )
+        print("-" * 90)
+        for dim in DIMENSIONS:
+            ap = adapter_result.pearson_per_dim[dim]
+            bp = base_result.pearson_per_dim[dim]
+            am = adapter_result.mae_per_dim[dim]
+            bm = base_result.mae_per_dim[dim]
+            print(
+                f"{dim:<18} {ap:>12.3f} {bp:>13.3f} {ap-bp:>+10.3f} "
+                f"{am:>9.3f} {bm:>10.3f} {am-bm:>+8.3f}"
+            )
+    else:
+        print(f"\n{'Dimension':<18} {'Adp Pearson':>12} {'Adp Spearman':>13} {'Adp MAE':>9}")
+        print("-" * 60)
+        for dim in DIMENSIONS:
+            print(
+                f"{dim:<18} {adapter_result.pearson_per_dim[dim]:>12.3f} "
+                f"{adapter_result.spearman_per_dim[dim]:>13.3f} "
+                f"{adapter_result.mae_per_dim[dim]:>9.3f}"
+            )
+
+    # Headline row — independent metrics so composite alone can't drive the verdict
+    print("\n" + "-" * 96)
+    print(
+        f"{'Backend':<10} {'Mean Pearson':>14} {'Mean MAE':>10} {'Parse Err':>11} "
+        f"{'Composite':>11} {'Avg Latency':>13}"
+    )
+    print("-" * 96)
+    print(
+        f"{'Adapter':<10} {adapter_result.mean_pearson:>14.3f} "
+        f"{adapter_result.mean_mae:>10.3f} {adapter_result.parse_error_rate:>10.1%} "
+        f"{adapter_result.composite:>11.3f} {adapter_result.avg_latency_s:>12.1f}s"
+    )
+    if base_result is not None:
+        print(
+            f"{'Base':<10} {base_result.mean_pearson:>14.3f} "
+            f"{base_result.mean_mae:>10.3f} {base_result.parse_error_rate:>10.1%} "
+            f"{base_result.composite:>11.3f} {base_result.avg_latency_s:>12.1f}s"
+        )
+
+    # Verdict — driven by mean Pearson delta, not composite (see module docstring)
+    print()
+    if base_result is None:
+        print("No base comparison (--skip-base). Use a full run to draw a verdict.")
+    else:
+        pearson_delta = adapter_result.mean_pearson - base_result.mean_pearson
+        parse_delta = base_result.parse_error_rate - adapter_result.parse_error_rate
+        if pearson_delta > 0:
+            print(
+                f"VERDICT: Adapter improves mean Pearson by {pearson_delta:+.3f} "
+                f"(parse_error_rate {base_result.parse_error_rate:.1%} → "
+                f"{adapter_result.parse_error_rate:.1%}, Δ={parse_delta:+.1%})."
+            )
+        else:
+            print(
+                f"VERDICT: Adapter does NOT improve mean Pearson "
+                f"(Δ={pearson_delta:+.3f}). Inspect per-dim columns above. "
+                f"Parse-error rate changed from "
+                f"{base_result.parse_error_rate:.1%} → {adapter_result.parse_error_rate:.1%}."
+            )
+    print(
+        "Note: 'composite' is dominated by parse_error_rate when base parse failures >20%. "
+        "The verdict line uses mean Pearson delta to avoid that trap."
+    )
+
+
+def save_results_json(
+    adapter_result: BackendResult,
+    base_result: BackendResult | None,
+    output_path: Path,
+    *,
+    base_model: str,
+    test_jsonl_path: Path,
+    test_jsonl_sha256: str,
+    seed: int,
+) -> None:
+    """Write the bench artifact atomically (tmp + rename)."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _serialize_backend(br: BackendResult) -> dict:
+        return {
+            "name": br.name,
+            "base_model": br.base_model,
+            "adapter_path": br.adapter_path,
+            "n": br.n,
+            "load_time_s": br.load_time_s,
+            "avg_latency_s": br.avg_latency_s,
+            "parse_error_rate": br.parse_error_rate,
+            "mean_pearson": br.mean_pearson,
+            "mean_mae": br.mean_mae,
+            "composite": br.composite,
+            "pearson_per_dim": br.pearson_per_dim,
+            "spearman_per_dim": br.spearman_per_dim,
+            "mae_per_dim": br.mae_per_dim,
+            "records": [asdict(r) for r in br.records],
+        }
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "base_model": base_model,
+        "test_jsonl_path": str(test_jsonl_path),
+        "test_jsonl_sha256": test_jsonl_sha256,
+        "seed": seed,
+        "dimensions": list(DIMENSIONS),
+        "backends": [_serialize_backend(adapter_result)],
+    }
+    if base_result is not None:
+        payload["backends"].append(_serialize_backend(base_result))
+        payload["verdict"] = {
+            "mean_pearson_delta": (
+                adapter_result.mean_pearson - base_result.mean_pearson
+            ),
+            "parse_error_rate_delta": (
+                adapter_result.parse_error_rate - base_result.parse_error_rate
+            ),
+        }
+    tmp = output_path.with_suffix(output_path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=False)
+    tmp.replace(output_path)
+
+
+# ---------- Pre-flight + main ---------------------------------------------
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def preflight(test_jsonl: Path, adapter_path: Path, *, with_mlx: bool) -> None:
+    """Asserts test split + adapter dir are valid. If `with_mlx`, also confirms
+    mlx_lm is importable in the current interpreter."""
+    if not test_jsonl.exists():
+        raise SystemExit(f"[preflight] test split missing: {test_jsonl}")
+    # Validate by loading the first record
+    try:
+        load_test_records(test_jsonl, limit=1)
+    except (ValueError, FileNotFoundError) as e:
+        raise SystemExit(f"[preflight] test split invalid: {e}")
+    if not adapter_path.exists():
+        raise SystemExit(f"[preflight] adapter dir missing: {adapter_path}")
+    if not (adapter_path / "adapters.safetensors").exists():
+        raise SystemExit(
+            f"[preflight] adapter dir missing adapters.safetensors: {adapter_path}"
+        )
+    if not (adapter_path / "adapter_config.json").exists():
+        raise SystemExit(
+            f"[preflight] adapter dir missing adapter_config.json: {adapter_path}"
+        )
+    if with_mlx:
+        try:
+            import mlx_lm  # noqa: F401
+            import mlx.core  # noqa: F401
+        except ImportError as e:
+            raise SystemExit(
+                f"[preflight] mlx_lm/mlx unavailable in current interpreter "
+                f"({e}). Run via the judge-lora venv: {VENV}"
+            )
+    print("[preflight] passed.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bench the judge-LoRA adapter against the base Gemma-3n model on "
+            "the held-out test split. macOS / Apple Silicon only (requires mlx)."
+        )
+    )
+    parser.add_argument(
+        "--base-model", default=DEFAULT_BASE_MODEL,
+        help=f"Base model (default: {DEFAULT_BASE_MODEL})",
+    )
+    parser.add_argument(
+        "--adapter-path", default=None,
+        help="Adapter dir; default: latest under finetune/judge-lora-gemma3n/adapters/",
+    )
+    parser.add_argument(
+        "--test-jsonl", default=str(DEFAULT_TEST_JSONL),
+        help=f"Test split (default: {DEFAULT_TEST_JSONL})",
+    )
+    parser.add_argument(
+        "--adapters-root", default=str(DEFAULT_ADAPTERS_ROOT),
+        help="Where to look for adapter dirs when --adapter-path is omitted",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Process only first N records (0 = all)",
+    )
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    parser.add_argument(
+        "--temp", type=float, default=DEFAULT_TEMP,
+        help="Sampling temperature; 0.0 = greedy (default)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=DEFAULT_SEED,
+        help="Passed to mx.random.seed before each backend loop",
+    )
+    parser.add_argument(
+        "--output-json", default=None,
+        help="Results JSON path; default: finetune/judge-lora-gemma3n/bench/<run-id>-vs-base-<UTC>.json",
+    )
+    parser.add_argument(
+        "--skip-base", action="store_true",
+        help="Run Adapter backend only (useful for iteration)",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress per-record output",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print resolved config + adapter dir contents and exit 0 (no mlx_lm import)",
+    )
+    parser.add_argument(
+        "--pre-flight-only", action="store_true",
+        help="Run preflight checks and exit 0 (asserts mlx_lm importable)",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Validate ranges that argparse can't express tersely
+    if args.temp < 0.0:
+        raise SystemExit(
+            f"--temp must be >= 0.0 (got {args.temp}). Use 0.0 for greedy decoding."
+        )
+    if args.max_tokens < 1:
+        raise SystemExit(f"--max-tokens must be >= 1 (got {args.max_tokens}).")
+    if args.limit < 0:
+        raise SystemExit(f"--limit must be >= 0 (got {args.limit}). 0 means 'all'.")
+
+    test_jsonl = Path(args.test_jsonl).expanduser().resolve()
+    adapters_root = Path(args.adapters_root).expanduser().resolve()
+
+    # Resolve adapter
+    if args.adapter_path:
+        adapter_path = Path(args.adapter_path).expanduser().resolve()
+        if not adapter_path.exists():
+            raise SystemExit(f"--adapter-path does not exist: {adapter_path}")
+    else:
+        try:
+            adapter_path = resolve_default_adapter_path(adapters_root)
+        except FileNotFoundError as e:
+            raise SystemExit(f"[bench] {e}")
+
+    if args.dry_run:
+        print("=== bench_judge_lora.py --dry-run ===")
+        print(f"base_model:     {args.base_model}")
+        print(f"adapter_path:   {adapter_path}")
+        print(f"test_jsonl:     {test_jsonl}")
+        print(f"limit:          {args.limit or 'all'}")
+        print(f"max_tokens:     {args.max_tokens}")
+        print(f"temp:           {args.temp}")
+        print(f"seed:           {args.seed}")
+        print(f"skip_base:      {args.skip_base}")
+        print(f"venv:           {VENV}")
+        if adapter_path.exists():
+            print("adapter dir contents:")
+            for p in sorted(adapter_path.iterdir()):
+                print(f"  {p.name}  ({p.stat().st_size} bytes)")
+        return 0
+
+    if args.pre_flight_only:
+        preflight(test_jsonl, adapter_path, with_mlx=True)
+        return 0
+
+    # Real run
+    preflight(test_jsonl, adapter_path, with_mlx=True)
+
+    print(f"[bench] Loading test split from {test_jsonl}")
+    records = load_test_records(test_jsonl, limit=args.limit)
+    test_sha = sha256_file(test_jsonl)
+    print(f"[bench] Loaded {len(records)} records (sha256={test_sha[:12]}...)")
+
+    adapter_result = run_bench(
+        backend_name="adapter",
+        base_model=args.base_model,
+        adapter_path=adapter_path,
+        records=records,
+        max_tokens=args.max_tokens,
+        temp=args.temp,
+        seed=args.seed,
+        quiet=args.quiet,
+        cleanup_after=not args.skip_base,  # only clean up if base is coming next
+    )
+
+    base_result: BackendResult | None = None
+    if not args.skip_base:
+        base_result = run_bench(
+            backend_name="base",
+            base_model=args.base_model,
+            adapter_path=None,
+            records=records,
+            max_tokens=args.max_tokens,
+            temp=args.temp,
+            seed=args.seed,
+            quiet=args.quiet,
+            cleanup_after=False,  # last backend, no follow-up
+        )
+
+    # Print comparison
+    print_comparison(adapter_result, base_result)
+
+    # Save JSON
+    if args.output_json:
+        output_path = Path(args.output_json).expanduser().resolve()
+    else:
+        run_id = adapter_path.name
+        utc = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_path = DEFAULT_BENCH_OUT_DIR / f"{run_id}-vs-base-{utc}.json"
+    save_results_json(
+        adapter_result,
+        base_result,
+        output_path,
+        base_model=args.base_model,
+        test_jsonl_path=test_jsonl,
+        test_jsonl_sha256=test_sha,
+        seed=args.seed,
+    )
+    print(f"\n[bench] Results saved to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-18T09:00:00" # auto-bump (judge-LoRA step-2.1 smoke-test gate + working defaults)
+last_verified: "2026-05-18T13:00:00" # auto-bump (judge-LoRA step-3 bench)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"
@@ -64,4 +64,4 @@ The evolution layer reads from the **project root `.env`** — not from `~/.conf
 
 ## Tests
 
-Python tests in `scripts/tests/`. Run `python3 -m pytest scripts/tests/` before committing.
+Python tests in `scripts/tests/` OR `evolution/training/__tests__/` (judge-lora pipeline). Run `python3 -m pytest scripts/tests/ evolution/training/__tests__/` before committing.

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-18T09:00:00" # auto-bump (judge-LoRA step-2.1 smoke-test gate + working defaults)
+last_verified: "2026-05-18T13:00:00" # auto-bump (judge-LoRA step-3 bench)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary

Step-3 of the judge-LoRA pipeline. Adds an in-process mlx_lm bench (`evolution/training/bench_judge_lora.py`) that compares the step-2 trained adapter vs base Gemma-3n-E4B-4bit on the held-out 40-record stratified test split. Reports per-dimension Pearson/Spearman/MAE + parse-error rate + composite. Verdict line is driven by mean Pearson delta — not composite — to avoid parse-error domination.

Builds on PR #466 (steps 1+2: dataset + training driver) and PR #469 (step-2.1: smoke gate + working defaults). The trained adapter being benched is run `20260518T071842Z-1614baf-dirty`.

## Headline finding: **Adapter does NOT improve over Base on this inference stack.**

| Metric | Adapter | Base | Δ |
|--------|---------|------|----|
| Mean Pearson | 0.368 | 0.390 | **−0.022** |
| Mean MAE | 0.287 | 0.261 | +0.026 |
| Parse error rate | 0.0% | 0.0% | 0 |
| Composite | 0.661 | 0.678 | −0.017 |

Per-dim Pearson deltas: quality −0.027, tool_use −0.052, personalization −0.011, safety zero variance on both (ground truth = 1.0 across all 40 records).

### Two surprising findings

1. **Base Gemma-3n-E4B-4bit already outputs perfectly structured JSON.** The hypothesized "LoRA fixes parse errors" win doesn't exist — Base never breaks format on this prompt template.
2. **The LoRA slightly degraded scoring quality** across all measurable dimensions. Likely overshooting: LR 5e-5 × 5 epochs may have moved the model away from base judgment.

### Caveat — possible apples-to-oranges

The original 0.163 Pearson gap motivating the LoRA (2026-05-17 bench) was measured against **Ollama Q8_0**. Today's bench measures **mlx_lm Q4**. Different inference stack. We may have been chasing a gap that doesn't exist on the actual deployment target.

This is a **clean negative result with sound methodology**. Step-4 ADR (`docs/decisions/judge-lora-specialization.md`, follow-up PR) will document the decision: do NOT adopt this adapter as-is; future tuning experiments use this same bench script as the load-bearing artifact.

## Library-contract gotchas captured by tests

mlx_lm 0.31.3 verified empirically:
- `seed` is **not** a valid kwarg on `mlx_lm.generate` → use `mx.random.seed(seed)` before the loop
- `temp` is **also not** a valid kwarg → use `sampler=make_sampler(temp=temp)` instead

Both invariants enforced as regression guards in `test_run_bench_uses_mocked_mlx_lm`. A future mlx_lm bump that breaks this would fire those tests, not silently regress the bench.

## Wardens

- plan-reviewer R2 ✅ SHIP — fixed 6 R1 issues (seed kwarg, lazy import, cleanup test, eval-change.md drift fix, composite domination, .gitignore noop)
- code-reviewer R2 ✅ SHIP — fixed 2 R1 warnings (cached_property on 5 BackendResult metrics, `--temp` / `--max-tokens` / `--limit` range guards)
- verification-gate ✅ SHIP — pytest 51/51, dry-run + preflight exit 0, bench artifact valid JSON, gitignored, staged files = 4 expected

## Implementation highlights

- **Lazy mlx_lm imports** inside `run_bench()` + `preflight()` — `--dry-run` and (without-mlx) preflight work on host Python.
- **Explicit Metal cleanup** between backends (`del model; gc.collect(); mx.metal.clear_cache()`) — prevents OOM on the second load.
- **`@functools.cached_property`** on `BackendResult.{pearson,spearman,mae}_per_dim` + `mean_pearson` + `mean_mae` — single recompute per instance.
- **22 unit tests** with mocked `mlx_lm` + `mlx.core.random.seed` + `mlx.core.metal.clear_cache` — no real model loads required.

## Test plan

- [x] `python3 -m pytest evolution/training/__tests__/` — 51 passed (22 new + 29 existing)
- [x] `npm run drift-check` — ALL CHECKS PASSED
- [x] `python3 evolution/training/bench_judge_lora.py --dry-run` — exit 0 on host Python
- [x] `python3 evolution/training/bench_judge_lora.py --pre-flight-only` (judge-lora venv) — `[preflight] passed.`
- [x] `python3 evolution/training/bench_judge_lora.py --limit 2 --skip-base` (judge-lora venv) — 2 records parsed
- [x] `python3 evolution/training/bench_judge_lora.py` (full n=40, both backends) — completed in ~10 min, JSON saved
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)