### PR TITLE
feat(integrations): linear MCP phase 2 — container agent access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,9 @@ DEUS_VAULT_PATH=
 # DEUS_PYTHON=python3
 
 # === Integrations ===
-# Linear project management MCP (host-side Claude Code).
+# Linear project management MCP (host-side Claude Code + container agents).
 # Generate at: Linear Settings → API → Personal API keys
+# Accepted as LINEAR_API_KEY or LINEAR_API_TOKEN.
 LINEAR_API_TOKEN=
 
 # === Safety ===

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -31,7 +31,7 @@ ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Install agent-browser and claude-code globally (pinned)
-RUN npm install -g agent-browser@0.23.0 @anthropic-ai/claude-code@2.1.87
+RUN npm install -g agent-browser@0.23.0 @anthropic-ai/claude-code@2.1.87 @tacticlaunch/mcp-linear@1.1.2
 
 # Create app directory
 WORKDIR /app

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -710,6 +710,11 @@ async function runQuery(
     log('Google Calendar MCP: enabled (credentials + package found)');
   }
 
+  const hasLinearMcp = !!process.env.LINEAR_API_KEY;
+  if (hasLinearMcp) {
+    log('Linear MCP: enabled (API key found)');
+  }
+
   // CLAUDE.md probe: log fingerprint before every query() call.
   // Compare across turns in the same session — if len= appears N times for
   // N turns, the SDK re-reads the file on every resumed call (lazy loading is worth it).
@@ -758,6 +763,7 @@ async function runQuery(
         'NotebookEdit',
         'mcp__deus__*',
         ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
+        ...(hasLinearMcp ? ['mcp__linear__*'] : []),
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -784,6 +790,19 @@ async function runQuery(
                 env: {
                   DEUS_PROJECT_ROOT: '/workspace/project',
                   LOG_LEVEL: process.env.LOG_LEVEL || 'info',
+                },
+              },
+            }
+          : {}),
+        ...(hasLinearMcp
+          ? {
+              linear: {
+                command: 'node',
+                args: [
+                  '/usr/local/lib/node_modules/@tacticlaunch/mcp-linear/dist/index.js',
+                ],
+                env: {
+                  LINEAR_API_KEY: process.env.LINEAR_API_KEY ?? '',
                 },
               },
             }

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-17T19:00:00" # auto-bump (llama-cpp router mode)
+last_verified: "2026-05-21" # auto-bump (linear-mcp-phase2)
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-18" # auto-bump
+last_verified: "2026-05-21" # auto-bump (linear-mcp-phase2)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-18T13:00:00" # auto-bump (judge-LoRA step-3 bench)
+last_verified: "2026-05-21" # auto-bump (linear-mcp-phase2)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -34,7 +34,8 @@ import { logger } from './logger.js';
 function redactContainerArgs(args: string[]): string {
   return args
     .join(' ')
-    .replace(/DEUS_PROXY_TOKEN=[0-9a-f]+/g, 'DEUS_PROXY_TOKEN=[REDACTED]');
+    .replace(/DEUS_PROXY_TOKEN=[0-9a-f]+/g, 'DEUS_PROXY_TOKEN=[REDACTED]')
+    .replace(/LINEAR_API_KEY=\S+/g, 'LINEAR_API_KEY=[REDACTED]');
 }
 import {
   CONTAINER_HOST_GATEWAY,
@@ -103,6 +104,17 @@ function buildContainerArgs(
       '-e',
       `DEUS_CONTEXT_FILE_MAX_CHARS=${DEUS_CONTEXT_FILE_MAX_CHARS}`,
     );
+  }
+
+  const linearKey = process.env.LINEAR_API_KEY || process.env.LINEAR_API_TOKEN;
+  if (linearKey) {
+    if (/^[A-Za-z0-9_-]+$/.test(linearKey)) {
+      args.push('-e', `LINEAR_API_KEY=${linearKey}`);
+    } else {
+      logger.warn(
+        'LINEAR_API_KEY contains invalid characters; Linear MCP disabled for this container',
+      );
+    }
   }
 
   // Inject per-channel memory privacy allowlist if configured


### PR DESCRIPTION
## Summary
- Bundle `@tacticlaunch/mcp-linear@1.1.2` in container image for agent access to 140+ Linear tools
- Forward `LINEAR_API_KEY` env var to containers with regex validation + log redaction
- Add conditional MCP server block in agent-runner following the GCal pattern
- Claude SDK containers only; Codex/llama-cpp not supported (same limitation as GCal MCP)

## Design decisions
- **Direct env var** (not credential-proxy): Integration tokens follow the GCal precedent. Credential proxy is for LLM API keys (pay-per-token). Linear free plan, no monetary risk.
- **Package choice**: `@tacticlaunch/mcp-linear` chosen in Phase 1 (PR #473) over official Linear remote MCP (140+ tools vs 21). Source reviewed, MIT license, 1,551 stars.
- **Explicit node path**: Uses `/usr/local/lib/node_modules/...` instead of bare `mcp-linear` binary to avoid PATH differences between root install and node user.

## Security (threat-modeler SHIP R2)
- Key validated with `^[A-Za-z0-9_-]+$` before forwarding
- `LINEAR_API_KEY` redacted in debug container logs via `redactContainerArgs`
- `mcp__linear__*` wildcard consistent with `mcp__gcal__*` pattern; container already runs with `bypassPermissions` + full Bash
- Accepted risks documented: no per-group opt-in (same as GCal), no tool-level denylist (MCP SDK limitation)

## Requires container rebuild
Run `./container/build.sh` after merging to pick up the new MCP server installation.

## Test plan
- [ ] `npm run build` passes (verified: host-side + agent-runner tsc clean)
- [ ] `./container/build.sh` succeeds
- [ ] `docker run --rm deus-agent:latest node -e "require('/usr/local/lib/node_modules/@tacticlaunch/mcp-linear/dist/index.js')"` succeeds
- [ ] Container logs show `Linear MCP: enabled` when `LINEAR_API_KEY` is set
- [ ] Agent can invoke `linear_getTeams` from inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)