### PR TITLE
fix(ci): skip personal-ID check for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${PATTERN:-}" ]; then
-            if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
-              echo "::warning::PERSONAL_ID_PATTERN unavailable in fork PR; skipping"
+            if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ] || [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+              echo "::warning::PERSONAL_ID_PATTERN unavailable in fork/dependabot PR; skipping"
               exit 0
             fi
             echo "::error::PERSONAL_ID_PATTERN secret not set; required for non-fork PRs"


### PR DESCRIPTION
## Summary
- Dependabot PRs don't have access to repo secrets, same as fork PRs
- The `PERSONAL_ID_PATTERN` check was failing all 5 dependabot dep bump PRs (#367-#371)
- Added `github.actor == 'dependabot[bot]'` alongside the existing fork check

## Test plan
- [ ] This PR's own CI passes (the personal-ID step should succeed since it's not a dependabot PR)
- [ ] After merge, re-run CI on one of the dep bump PRs to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)