### PR TITLE
feat(linear): add dispatch service for ticket-driven agent runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ DEUS_VAULT_PATH=
 # Generate at: Linear Settings → API → Personal API keys
 # Accepted as LINEAR_API_KEY or LINEAR_API_TOKEN.
 LINEAR_API_TOKEN=
+# Linear dispatcher poll interval (ms, default: 30000)
+# LINEAR_POLL_INTERVAL_MS=30000
+# Optional: Linear team ID override (auto-discovered if only one team)
+# LINEAR_TEAM_ID=
 
 # === Safety ===
 # Max characters per incoming message (truncates, doesn't reject)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Use these instead of rediscovering the system:
 | Tool proxy | `src/tool-proxy.ts`, `src/tool-registry.ts` | HTTP proxy (:3003) executing allowlisted host CLIs for containers; credentials never passed to containers |
 | Mount/security boundary | `src/container-mounter.ts` | Project/group/vault visibility and isolation |
 | Memory retrieval | `scripts/memory_tree.py`, `scripts/memory_indexer.py` | Personal recall and semantic lookup |
+| Linear dispatcher | `src/linear-dispatcher.ts` | Polls Linear for "Ready for Agent" issues, runs container agents with role prompts, posts results back |
 | Codex Warden hooks | `scripts/codex_warden_hooks.py` | Installs and runs Codex hook equivalents for Warden gates (plan-reviewer, code-reviewer, verification-gate, threat-modeler) |
 
 More detailed maps live in [docs/AGENT_DEUS_101.md](docs/AGENT_DEUS_101.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "deus",
       "version": "1.14.0",
       "dependencies": {
+        "@linear/sdk": "^84.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
         "cron-parser": "^5.5.0",
@@ -1083,6 +1084,15 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@hapi/boom": {
       "version": "9.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
@@ -1680,6 +1690,18 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@linear/sdk": {
+      "version": "84.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-84.0.0.tgz",
+      "integrity": "sha512-jPtGlY06zG86ba6cL78d4JB9m61YMHo3L0luMrtVFgeOounI/GK3S3c6Ncjw7cxWzcsepoNZD10mQYoT81uKKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -4606,6 +4628,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/gtoken": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "truecourse:list-diff": "truecourse list --diff"
   },
   "dependencies": {
+    "@linear/sdk": "^84.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
     "cron-parser": "^5.5.0",

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-21" # auto-bump (linear-mcp-phase2)
+last_verified: "2026-05-21" # auto-bump (linear-dispatcher)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-21" # auto-bump
+last_verified: "2026-05-21" # auto-bump (linear-dispatcher)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,10 @@ import { createClaudeRuntime } from './agent-runtimes/claude-backend.js';
 import { createOpenAIRuntime } from './agent-runtimes/openai-backend.js';
 import { createLlamaCppRuntime } from './agent-runtimes/llama-cpp-backend.js';
 import { startGcalSync, stopGcalSync } from './cache/gcal-sync.js';
+import {
+  startLinearDispatcher,
+  stopLinearDispatcher,
+} from './linear-dispatcher.js';
 
 export { getAvailableGroups } from './router-state.js';
 
@@ -125,6 +129,7 @@ async function main(): Promise<void> {
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutdown signal received');
     stopGcalSync();
+    stopLinearDispatcher();
     proxyServer.close();
     toolProxyServer.close();
     await queue.shutdown(10000);
@@ -349,6 +354,14 @@ async function main(): Promise<void> {
       const text = formatOutbound(rawText);
       if (text) await channel.sendMessage(jid, text);
     },
+  });
+
+  // Start Linear dispatch daemon (no-op if LINEAR_API_KEY not configured)
+  startLinearDispatcher({
+    registeredGroups: () => state.registeredGroups,
+    registerGroup: (jid, group) => state.registerGroup(jid, group),
+    registry,
+    queue,
   });
 
   // Load skill IPC handlers before starting the IPC watcher

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import {
+  loadRoleSpecs,
+  buildIssuePrompt,
+  startLinearDispatcher,
+  stopLinearDispatcher,
+} from './linear-dispatcher.js';
+import type { LinearDispatcherDependencies } from './linear-dispatcher.js';
+import { RuntimeRegistry } from './agent-runtimes/registry.js';
+import type {
+  RunContext,
+  RuntimeSession,
+  RuntimeEventSink,
+  RunResult,
+} from './agent-runtimes/types.js';
+
+function makeMockDeps(
+  overrides: Partial<LinearDispatcherDependencies> = {},
+): LinearDispatcherDependencies {
+  return {
+    registeredGroups: () => ({}),
+    registerGroup: vi.fn(),
+    registry: new RuntimeRegistry(),
+    queue: {
+      enqueueTask: vi.fn(),
+      notifyIdle: vi.fn(),
+      closeStdin: vi.fn(),
+    } as unknown as LinearDispatcherDependencies['queue'],
+    ...overrides,
+  };
+}
+
+describe('loadRoleSpecs', () => {
+  const tmpDir = path.join(process.cwd(), '.test-agents-tmp');
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses frontmatter and extracts linear_label', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'test-role.md'),
+      `---
+name: test-role
+description: A test role
+model: sonnet
+linear_label: "agent:test-role"
+---
+
+You are a test role agent.`,
+    );
+
+    const specs = loadRoleSpecs(tmpDir);
+    expect(specs.size).toBe(1);
+    expect(specs.has('agent:test-role')).toBe(true);
+
+    const spec = specs.get('agent:test-role')!;
+    expect(spec.name).toBe('test-role');
+    expect(spec.model).toBe('sonnet');
+    expect(spec.content).toBe('You are a test role agent.');
+  });
+
+  it('skips files without linear_label', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'no-label.md'),
+      `---
+name: no-label
+description: No linear label
+---
+
+Some content.`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'has-label.md'),
+      `---
+name: has-label
+linear_label: "agent:has-label"
+---
+
+Content.`,
+    );
+
+    const specs = loadRoleSpecs(tmpDir);
+    expect(specs.size).toBe(1);
+    expect(specs.has('agent:has-label')).toBe(true);
+  });
+
+  it('returns empty map for nonexistent directory', () => {
+    const specs = loadRoleSpecs('/nonexistent/path');
+    expect(specs.size).toBe(0);
+  });
+});
+
+describe('buildIssuePrompt', () => {
+  const role = {
+    label: 'agent:test',
+    name: 'test',
+    content: 'You are a test agent.',
+  };
+
+  it('includes role, title, description', () => {
+    const prompt = buildIssuePrompt(
+      role,
+      'Fix the bug',
+      'LIA-42',
+      'There is a bug in the login flow.',
+      [],
+    );
+    expect(prompt).toContain('<role>');
+    expect(prompt).toContain('You are a test agent.');
+    expect(prompt).toContain('Title: Fix the bug');
+    expect(prompt).toContain('ID: LIA-42');
+    expect(prompt).toContain('There is a bug in the login flow.');
+    expect(prompt).not.toContain('<comments>');
+  });
+
+  it('includes comments when present', () => {
+    const prompt = buildIssuePrompt(role, 'Task', 'LIA-1', 'Desc', [
+      { author: 'Alice', body: 'Check the auth module' },
+    ]);
+    expect(prompt).toContain('<comments>');
+    expect(prompt).toContain('[Alice]: Check the auth module');
+  });
+
+  it('handles missing description', () => {
+    const prompt = buildIssuePrompt(role, 'Task', 'LIA-1', undefined, []);
+    expect(prompt).toContain('(no description)');
+  });
+});
+
+describe('startLinearDispatcher', () => {
+  afterEach(() => {
+    stopLinearDispatcher();
+    vi.unstubAllEnvs();
+  });
+
+  it('goes dormant when LINEAR_API_KEY is not set', () => {
+    vi.stubEnv('LINEAR_API_KEY', '');
+    vi.stubEnv('LINEAR_API_TOKEN', '');
+    const deps = makeMockDeps();
+    startLinearDispatcher(deps);
+    expect(deps.registerGroup).not.toHaveBeenCalled();
+  });
+});

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -1,0 +1,419 @@
+import fs from 'fs';
+import path from 'path';
+import { LinearClient } from '@linear/sdk';
+import { parse as parseYaml } from 'yaml';
+import { logger } from './logger.js';
+import { PROJECT_ROOT } from './config.js';
+import { FatalError, RetryableError } from './errors/index.js';
+import { fireAndForget } from './async/index.js';
+import { defaultSession } from './agent-runtimes/types.js';
+import type {
+  RunContext,
+  RuntimeEventSink,
+  RuntimeSession,
+} from './agent-runtimes/types.js';
+import type { RuntimeRegistry } from './agent-runtimes/registry.js';
+import type { GroupQueue } from './group-queue.js';
+import type { RegisteredGroup } from './types.js';
+
+const DEFAULT_POLL_MS = 30_000;
+const DISPATCH_GROUP_JID = 'linear-dispatch';
+const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
+
+export interface LinearDispatcherDependencies {
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  registerGroup: (jid: string, group: RegisteredGroup) => void;
+  registry: RuntimeRegistry;
+  queue: GroupQueue;
+}
+
+interface RoleSpec {
+  label: string;
+  name: string;
+  model?: string;
+  content: string;
+}
+
+interface WorkflowState {
+  id: string;
+  name: string;
+}
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+let _client: LinearClient | null = null;
+let _dispatchGroup: RegisteredGroup | null = null;
+let _roleSpecs: Map<string, RoleSpec> = new Map();
+let _stateMap: Map<string, WorkflowState> = new Map();
+let _inFlight: Set<string> = new Set();
+let _deps: LinearDispatcherDependencies | null = null;
+
+function extractFrontmatter(content: string): {
+  data: Record<string, unknown>;
+  body: string;
+} {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { data: {}, body: content };
+  return {
+    data: parseYaml(match[1]) as Record<string, unknown>,
+    body: match[2],
+  };
+}
+
+export function loadRoleSpecs(agentsDir: string): Map<string, RoleSpec> {
+  const specs = new Map<string, RoleSpec>();
+  if (!fs.existsSync(agentsDir)) return specs;
+
+  const files = fs.readdirSync(agentsDir).filter((f) => f.endsWith('.md'));
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(agentsDir, file), 'utf-8');
+    const { data, body } = extractFrontmatter(raw);
+    const label =
+      typeof data.linear_label === 'string' ? data.linear_label : undefined;
+    if (!label) continue;
+    specs.set(label, {
+      label,
+      name: typeof data.name === 'string' ? data.name : file.replace('.md', ''),
+      model: typeof data.model === 'string' ? data.model : undefined,
+      content: body.trim(),
+    });
+  }
+  return specs;
+}
+
+async function discoverTeamId(client: LinearClient): Promise<string> {
+  const teams = await client.teams();
+  if (teams.nodes.length === 0) {
+    throw new FatalError('No Linear teams found');
+  }
+  const override = process.env.LINEAR_TEAM_ID;
+  if (override) {
+    const match = teams.nodes.find((t) => t.id === override);
+    if (!match) {
+      throw new FatalError(
+        `LINEAR_TEAM_ID "${override}" not found among ${teams.nodes.length} teams`,
+      );
+    }
+    return match.id;
+  }
+  if (teams.nodes.length > 1) {
+    logger.warn(
+      { count: teams.nodes.length },
+      'linear-dispatcher: multiple teams found, using first. Set LINEAR_TEAM_ID to override',
+    );
+  }
+  return teams.nodes[0].id;
+}
+
+async function discoverWorkflowStates(
+  client: LinearClient,
+  teamId: string,
+): Promise<Map<string, WorkflowState>> {
+  const states = await client.workflowStates({
+    filter: { team: { id: { eq: teamId } } },
+  });
+  const map = new Map<string, WorkflowState>();
+  for (const s of states.nodes) {
+    map.set(s.name, { id: s.id, name: s.name });
+  }
+  const required = ['Ready for Agent', 'Agent Working', 'In Review', 'Backlog'];
+  for (const name of required) {
+    if (!map.has(name)) {
+      throw new FatalError(
+        `linear-dispatcher: required workflow state "${name}" not found`,
+      );
+    }
+  }
+  logger.debug(
+    { states: [...map.keys()] },
+    'linear-dispatcher: discovered workflow states',
+  );
+  return map;
+}
+
+export function buildIssuePrompt(
+  role: RoleSpec,
+  issueTitle: string,
+  issueIdentifier: string,
+  issueDescription: string | undefined,
+  comments: Array<{ author: string; body: string }>,
+): string {
+  const parts = [
+    `<role>\n${role.content}\n</role>`,
+    `<issue>\nTitle: ${issueTitle}\nID: ${issueIdentifier}\n\n${issueDescription ?? '(no description)'}\n</issue>`,
+  ];
+  if (comments.length > 0) {
+    const commentBlock = comments
+      .map((c) => `[${c.author}]: ${c.body}`)
+      .join('\n\n');
+    parts.push(`<comments>\n${commentBlock}\n</comments>`);
+  }
+  return parts.join('\n\n');
+}
+
+async function runIssue(
+  issueId: string,
+  runContext: RunContext,
+): Promise<void> {
+  if (!_client || !_dispatchGroup || !_deps || !_stateMap) return;
+
+  const resolvedBackend = _deps.registry.resolve(_dispatchGroup);
+  const backend = resolvedBackend.name();
+  const sessionRef: RuntimeSession = defaultSession('', backend);
+  let result = '';
+  let error = '';
+
+  const eventSink: RuntimeEventSink = (event) => {
+    if (event.type === 'output_text') {
+      result += event.text;
+    }
+    if (event.type === 'turn_complete') {
+      _deps!.queue.notifyIdle(runContext.chatJid);
+    }
+    if (event.type === 'error') {
+      error = event.error;
+    }
+  };
+
+  try {
+    const runResult = await resolvedBackend.runTurn(
+      runContext,
+      sessionRef,
+      eventSink,
+    );
+    if (runResult.status === 'error') {
+      error = runResult.error || 'Unknown error';
+    } else if (runResult.result && !result) {
+      result = runResult.result;
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    logger.warn({ issueId, error }, 'linear-dispatcher: agent run failed');
+  }
+
+  try {
+    if (error) {
+      await _client.createComment({
+        issueId,
+        body: `**Agent run failed**\n\n\`\`\`\n${error}\n\`\`\``,
+      });
+      const backlogState = _stateMap.get('Backlog')!;
+      await _client.updateIssue(issueId, { stateId: backlogState.id });
+      logger.warn(
+        { issueId },
+        'linear-dispatcher: moved failed issue to Backlog',
+      );
+    } else {
+      const body = result || '(no output produced)';
+      await _client.createComment({ issueId, body });
+      const reviewState = _stateMap.get('In Review')!;
+      await _client.updateIssue(issueId, { stateId: reviewState.id });
+      logger.info({ issueId }, 'linear-dispatcher: issue moved to In Review');
+    }
+  } catch (err) {
+    logger.warn(
+      { issueId, err },
+      'linear-dispatcher: failed to update Linear issue after run',
+    );
+  } finally {
+    _inFlight.delete(issueId);
+  }
+}
+
+async function pollLinear(): Promise<void> {
+  if (!_client || !_stateMap || !_deps || !_dispatchGroup) return;
+
+  const readyState = _stateMap.get('Ready for Agent')!;
+  const workingState = _stateMap.get('Agent Working')!;
+
+  const issues = await _client.issues({
+    filter: { state: { id: { eq: readyState.id } } },
+  });
+
+  for (const issue of issues.nodes) {
+    if (_inFlight.has(issue.id)) continue;
+
+    const labels = await issue.labels();
+    const agentLabel = labels.nodes.find((l) => l.name.startsWith('agent:'));
+    if (!agentLabel) {
+      logger.debug(
+        { issueId: issue.id },
+        'linear-dispatcher: issue has no agent:* label, skipping',
+      );
+      continue;
+    }
+
+    const roleSpec = _roleSpecs.get(agentLabel.name);
+    if (!roleSpec) {
+      logger.warn(
+        { issueId: issue.id, label: agentLabel.name },
+        'linear-dispatcher: no role spec found for label, skipping',
+      );
+      continue;
+    }
+
+    try {
+      await _client.updateIssue(issue.id, { stateId: workingState.id });
+    } catch (err) {
+      logger.warn(
+        { issueId: issue.id, err },
+        'linear-dispatcher: failed to move issue to Agent Working',
+      );
+      continue;
+    }
+
+    _inFlight.add(issue.id);
+
+    const issueComments = await issue.comments();
+    const comments = await Promise.all(
+      issueComments.nodes.map(async (c) => {
+        const user = await c.user;
+        return { author: user?.displayName ?? 'Unknown', body: c.body };
+      }),
+    );
+
+    const prompt = buildIssuePrompt(
+      roleSpec,
+      issue.title,
+      issue.identifier,
+      issue.description ?? undefined,
+      comments,
+    );
+
+    const chatJid = `linear-dispatch-${issue.id.slice(0, 8)}`;
+    const runContext: RunContext = {
+      prompt,
+      groupFolder: DISPATCH_GROUP_JID,
+      chatJid,
+      isControlGroup: false,
+      isScheduledTask: true,
+      effort: 'high',
+    };
+
+    _deps.queue.enqueueTask(chatJid, issue.id, () =>
+      runIssue(issue.id, runContext),
+    );
+
+    logger.info(
+      { issueId: issue.id, role: roleSpec.name, chatJid },
+      'linear-dispatcher: enqueued issue for agent run',
+    );
+  }
+}
+
+export function startLinearDispatcher(
+  deps: LinearDispatcherDependencies,
+): void {
+  if (_timer) {
+    logger.warn('linear-dispatcher: already running');
+    return;
+  }
+
+  const apiKey = process.env.LINEAR_API_KEY || process.env.LINEAR_API_TOKEN;
+  if (!apiKey) {
+    logger.warn('linear-dispatcher: LINEAR_API_KEY not set — daemon dormant');
+    return;
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(apiKey)) {
+    throw new FatalError(
+      'linear-dispatcher: LINEAR_API_KEY contains invalid characters',
+    );
+  }
+
+  _roleSpecs = loadRoleSpecs(AGENTS_DIR);
+  if (_roleSpecs.size === 0) {
+    logger.warn(
+      'linear-dispatcher: no role specs with linear_label found — daemon dormant',
+    );
+    return;
+  }
+  logger.info(
+    { labels: [..._roleSpecs.keys()] },
+    'linear-dispatcher: loaded role specs',
+  );
+
+  _client = new LinearClient({ apiKey });
+  _deps = deps;
+  _inFlight = new Set();
+
+  const parsedPollMs = parseInt(
+    process.env.LINEAR_POLL_INTERVAL_MS || String(DEFAULT_POLL_MS),
+    10,
+  );
+  const pollMs =
+    isNaN(parsedPollMs) || parsedPollMs < 1000 ? DEFAULT_POLL_MS : parsedPollMs;
+
+  fireAndForget(
+    async () => {
+      const teamId = await discoverTeamId(_client!);
+      _stateMap = await discoverWorkflowStates(_client!, teamId);
+
+      const existing = Object.values(deps.registeredGroups()).find(
+        (g) => g.folder === DISPATCH_GROUP_JID,
+      );
+      const dispatchGroup: RegisteredGroup = existing || {
+        name: 'Linear Dispatch',
+        folder: DISPATCH_GROUP_JID,
+        trigger: '',
+        added_at: new Date().toISOString(),
+        requiresTrigger: false,
+        isControlGroup: false,
+      };
+      if (!existing) {
+        deps.registerGroup(DISPATCH_GROUP_JID, dispatchGroup);
+      }
+      _dispatchGroup = dispatchGroup;
+
+      const tick = () => {
+        fireAndForget(() => pollLinear(), {
+          name: 'linear.dispatch',
+          onError: (err) => {
+            if (err instanceof RetryableError) {
+              logger.warn(
+                { err },
+                'linear-dispatcher: transient error, will retry',
+              );
+            } else {
+              logger.error(
+                { err },
+                'linear-dispatcher: unexpected error during poll',
+              );
+            }
+          },
+        });
+      };
+
+      tick();
+      _timer = setInterval(tick, pollMs);
+      _timer.unref();
+      logger.info(
+        { pollMs, teamId, roles: _roleSpecs.size },
+        'linear-dispatcher: daemon started',
+      );
+    },
+    {
+      name: 'linear.dispatch.init',
+      onError: (err) => {
+        if (err instanceof FatalError) {
+          logger.warn(
+            { err },
+            'linear-dispatcher: initialization failed — daemon dormant',
+          );
+        } else {
+          logger.error({ err }, 'linear-dispatcher: unexpected init error');
+        }
+      },
+    },
+  );
+}
+
+export function stopLinearDispatcher(): void {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+  _client = null;
+  _dispatchGroup = null;
+  _stateMap = new Map();
+  _inFlight = new Set();
+  _deps = null;
+}


### PR DESCRIPTION
## Summary
- Adds `src/linear-dispatcher.ts` — polls Linear for "Ready for Agent" issues, loads role prompts from `.claude/agents/*.md` by `linear_label` frontmatter, runs container agents via GroupQueue, posts results back as comments
- Follows gcal-sync dormant pattern — self-gates on missing `LINEAR_API_KEY`, no-op if unconfigured
- Auto-discovers Linear team and workflow states at startup (no hardcoded IDs)
- Singleton pattern chosen because only one Linear workspace is expected per Deus instance; class refactor is straightforward if multi-tenant use arises

## Architecture
- **Entry**: `startLinearDispatcher()` called from `main()` after scheduler loop, receives `{ registeredGroups, registerGroup, registry, queue }`
- **Group**: auto-creates `linear-dispatch` group folder at startup (idempotent)
- **Flow**: Ready for Agent → Agent Working → container run → In Review (success) / Backlog (failure)
- **Dedup**: in-flight `Set<string>` prevents double-dispatch; primary guard is state-based (only polls "Ready for Agent")
- **Error taxonomy**: `FatalError` for bad key/missing states (dormant), `RetryableError` for transient API errors (retry next tick)

## Test plan
- [x] `npm run build` — TypeScript compiles clean
- [x] `npm test` — 1057 tests pass (7 new for dispatcher)
- [ ] Without `LINEAR_API_KEY`: verify dormant log message
- [ ] With `LINEAR_API_KEY`: verify team/state discovery logs
- [ ] Create Linear issue with `agent:lit-scout` label in "Ready for Agent" → verify end-to-end dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)