### PR TITLE
fix(auth): add macOS Keychain fallback for credential checks

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -815,10 +815,32 @@ case "$1" in
       shift 2
       exec node "$SCRIPT_DIR/dist/auth-refresh.js" "$@"
     fi
-    # Validate credentials file is readable before restarting
-    python3 -c 'import sys,json; d=json.load(open(sys.argv[1])); assert d.get("claudeAiOauth",{}).get("accessToken")' "$HOME/.claude/.credentials.json" 2>/dev/null
+    # Validate credentials exist (file or macOS Keychain) before restarting
+    python3 -c '
+import sys, json, subprocess, os
+# Try credentials file first
+try:
+    d = json.load(open(os.path.expanduser("~/.claude/.credentials.json")))
+    assert d.get("claudeAiOauth", {}).get("accessToken")
+    sys.exit(0)
+except Exception:
+    pass
+# Fallback: macOS Keychain
+try:
+    raw = subprocess.check_output(
+        ["security", "find-generic-password", "-s", "Claude Code-credentials",
+         "-a", os.environ.get("USER", ""), "-w"],
+        text=True, stderr=subprocess.DEVNULL).strip()
+    d = json.loads(raw)
+    assert d.get("claudeAiOauth", {}).get("accessToken")
+    sys.exit(0)
+except Exception:
+    pass
+sys.exit(1)
+' 2>/dev/null
     if [ $? -ne 0 ]; then
-      echo "Error: could not read token from ~/.claude/.credentials.json"
+      echo "Error: no OAuth token found in ~/.claude/.credentials.json or macOS Keychain"
+      echo "Run: claude auth login"
       exit 1
     fi
     # Do NOT write token to .env — the credential proxy reads credentials.json
@@ -1033,9 +1055,26 @@ case "$1" in
       export DEUS_TUI_BACKEND="$CLI_AGENT"
       exec "$tui_bin"
     }
-    TOKEN=$(python3 -c 'import sys,json; print(json.load(open(sys.argv[1]))["claudeAiOauth"]["accessToken"])' "$HOME/.claude/.credentials.json" 2>/dev/null)
+    TOKEN=$(python3 -c '
+import json, os, subprocess, sys
+# Try file first
+try:
+    d = json.load(open(os.path.expanduser("~/.claude/.credentials.json")))
+    print(d["claudeAiOauth"]["accessToken"]); sys.exit(0)
+except Exception: pass
+# Fallback: macOS Keychain
+try:
+    raw = subprocess.check_output(
+        ["security", "find-generic-password", "-s", "Claude Code-credentials",
+         "-a", os.environ.get("USER", ""), "-w"],
+        text=True, stderr=subprocess.DEVNULL).strip()
+    print(json.loads(raw)["claudeAiOauth"]["accessToken"]); sys.exit(0)
+except Exception: pass
+sys.exit(1)
+' 2>/dev/null)
     if [ -z "$TOKEN" ]; then
-      echo "Error: could not read token from ~/.claude/.credentials.json"
+      echo "Error: no OAuth token found in ~/.claude/.credentials.json or macOS Keychain"
+      echo "Run: claude auth login"
       exit 1
     fi
     # Do NOT export CLAUDE_CODE_OAUTH_TOKEN — the Claude CLI reads
@@ -1495,7 +1534,7 @@ $STARTUP_INSTRUCTION"
     echo "  deus            Launch in current directory (external project mode if not ~/deus)"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
     echo "  deus home       Launch in home mode (~/deus) regardless of current directory"
-    echo "  deus auth       Restart background services (credential proxy auto-reads ~/.claude/.credentials.json)"
+    echo "  deus auth       Restart background services (credential proxy reads Keychain or ~/.claude/.credentials.json)"
     echo "  deus auth refresh [--dry-run]  Proactive OAuth token refresh (scheduled every 30 min by launchd)"
     echo "  deus web        Same as 'deus' but launches claude with --chrome (Claude-in-Chrome integration)"
     echo "  deus backend    Manage default AI backend and model (show|set|model|list)"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-22" # auto-bump (linear-webhook-gates)
+last_verified: "2026-05-22" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-22" # auto-bump (linear-webhook-gates)
+last_verified: "2026-05-22" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/auth-providers/anthropic.ts
+++ b/src/auth-providers/anthropic.ts
@@ -88,7 +88,7 @@ export function readCredentialsFile(): OAuthCredentials | undefined {
  *   Linux:   libsecret / GNOME Keyring (secret-tool CLI)
  *   Windows: Credential Manager (PowerShell)
  */
-function readKeychainCredentials(): OAuthCredentials | undefined {
+export function readKeychainCredentials(): OAuthCredentials | undefined {
   const raw = readRawFromCredentialStore();
   if (!raw) return undefined;
   try {

--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -35,9 +35,15 @@ vi.mock('child_process', async () => {
   };
 });
 
+vi.mock('./auth-providers/anthropic.js', () => ({
+  readCredentialsFile: vi.fn(() => undefined),
+  readKeychainCredentials: vi.fn(() => undefined),
+}));
+
 import fs from 'fs';
 import { execFileSync } from 'child_process';
 import { readEnvFile } from './env.js';
+import { readCredentialsFile } from './auth-providers/anthropic.js';
 import {
   hasApiCredentials,
   hasGeminiApiKey,
@@ -53,6 +59,7 @@ const mockReadEnvFile = vi.mocked(readEnvFile);
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReadFileSync = vi.mocked(fs.readFileSync);
 const mockExecFileSync = vi.mocked(execFileSync);
+const mockReadCredentialsFile = vi.mocked(readCredentialsFile);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -100,10 +107,11 @@ describe('hasApiCredentials', () => {
     expect(hasApiCredentials()).toBe(false);
   });
 
-  it('returns true when ~/.claude/.credentials.json has a valid OAuth token', () => {
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-from-file' } }),
-    );
+  it('returns true when credentials file has a valid OAuth token', () => {
+    mockReadCredentialsFile.mockReturnValue({
+      accessToken: 'oauth-from-file',
+      expiresAt: Infinity,
+    });
     expect(hasApiCredentials()).toBe(true);
   });
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -13,6 +13,10 @@ import path from 'path';
 
 import { HOME_DIR, CONFIG_DIR, STORE_DIR } from './config.js';
 import { readEnvFile } from './env.js';
+import {
+  readCredentialsFile,
+  readKeychainCredentials,
+} from './auth-providers/anthropic.js';
 import { CODEX_AUTH_PATH } from './auth-providers/openai.js';
 
 const DEUS_CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
@@ -23,17 +27,10 @@ const CLAUDE_CREDENTIALS_PATH = path.join(
   '.credentials.json',
 );
 
-/** Check if ~/.claude/.credentials.json has a valid OAuth access token. */
-function hasClaudeCredentialsFile(): boolean {
-  try {
-    const raw = fs.readFileSync(CLAUDE_CREDENTIALS_PATH, 'utf-8');
-    const parsed = JSON.parse(raw) as {
-      claudeAiOauth?: { accessToken?: string };
-    };
-    return !!parsed?.claudeAiOauth?.accessToken;
-  } catch {
-    return false;
-  }
+/** Check if Claude OAuth credentials exist (file or OS keychain). */
+function hasClaudeCredentials(): boolean {
+  const creds = readCredentialsFile() ?? readKeychainCredentials();
+  return !!creds?.accessToken;
 }
 
 /** Check if ~/.codex/auth.json has a valid OAuth access token. */
@@ -76,7 +73,7 @@ export function hasApiCredentials(): boolean {
     process.env.ANTHROPIC_API_KEY ||
     process.env.CLAUDE_CODE_OAUTH_TOKEN ||
     process.env.ANTHROPIC_AUTH_TOKEN ||
-    hasClaudeCredentialsFile()
+    hasClaudeCredentials()
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { getAllTasks } from './db.js';
 import { writeGroupsSnapshot, writeTasksSnapshot } from './container-runner.js';
 import { Channel, NewMessage, NewReaction } from './types.js';
 import { logReactionSignal } from './evolution-client.js';
+import { readEnvFile } from './env.js';
 import { resolveGroupFolderPath } from './group-folder.js';
 import { processImage } from './image.js';
 import { logger } from './logger.js';
@@ -366,6 +367,18 @@ async function main(): Promise<void> {
   });
 
   // Start Linear subsystems (no-op if LINEAR_API_KEY not configured)
+  const linearEnv = readEnvFile([
+    'LINEAR_API_KEY',
+    'LINEAR_API_TOKEN',
+    'LINEAR_WEBHOOK_SECRET',
+    'LINEAR_WEBHOOK_PORT',
+    'LINEAR_BOT_USER_ID',
+    'LINEAR_POLL_INTERVAL_MS',
+    'LINEAR_TEAM_ID',
+  ]);
+  for (const [k, v] of Object.entries(linearEnv)) {
+    if (v && !process.env[k]) process.env[k] = v;
+  }
   const linearApiKey =
     process.env.LINEAR_API_KEY || process.env.LINEAR_API_TOKEN;
   let linearCtx: LinearContext | null = null;


### PR DESCRIPTION
## Summary

- Startup gate (`hasApiCredentials`) and CLI (`deus auth`, `deus show`) now check macOS Keychain when `~/.claude/.credentials.json` is missing
- Claude Code v4.6+ stores OAuth tokens in the macOS Keychain (`Claude Code-credentials`) instead of the file — this broke `deus auth` and the startup gate
- Also loads `LINEAR_*` env vars from `.env` into `process.env` so Linear subsystems work under launchd

## Test plan

- [x] `deus auth` succeeds with Keychain-only auth (no credentials.json)
- [x] All 1368 tests pass
- [x] Deus starts without fatal credential error

🤖 Generated with [Claude Code](https://claude.com/claude-code)