### PR TITLE
feat(linear): priority-ordered dispatch with slot throttling

### DIFF
--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -78,11 +78,16 @@ sequenceDiagram
     participant DB as GroupQueue
 
     PD->>LAPI: issues(filter: state = Ready for Agent)
-    loop each issue
-        PD->>LAPI: issue.labels() -- find agent:* label
-        PD->>LAPI: updateIssue → Agent Working
+    Note over PD: sort by sortOrder ASC (column drag position)
+    Note over PD: cap dispatch to availableSlots()
+    loop each issue (up to available slots)
+        PD->>LAPI: issue.labels() -- find agent:* or Scoped label
         PD->>DB: enqueueTask(chatJid, issueId, runIssue)
     end
+    Note over ART: issue stays in "Ready for Agent" until run starts
+    ART->>LAPI: updateIssue → Agent Working (best-effort)
+    Note over ART: proceeds even if state update fails
+    ART->>ART: executeAgentRun
     ART-->>PD: output text
     alt success
         PD->>LAPI: createComment(output)

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-22T23:30:00" # auto-bump (container-github-push)
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-22" # auto-bump
+last_verified: "2026-05-22" # auto-bump — dispatch priority ADR update
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-22T23:30:00" # auto-bump (container-github-push)
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -433,6 +433,38 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
   });
 
+  // --- Available slots ---
+
+  it('returns correct availableSlots count', async () => {
+    const completionCallbacks: Array<() => void> = [];
+
+    const processMessages = vi.fn(async () => {
+      await new Promise<void>((resolve) => completionCallbacks.push(resolve));
+      return true;
+    });
+
+    queue.setProcessMessagesFn(processMessages);
+
+    expect(queue.availableSlots()).toBe(2); // MAX_CONCURRENT_CONTAINERS = 2
+
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    expect(queue.availableSlots()).toBe(1);
+
+    queue.enqueueMessageCheck('group2@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    expect(queue.availableSlots()).toBe(0);
+
+    // Free a slot
+    completionCallbacks[0]();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(queue.availableSlots()).toBe(1);
+
+    completionCallbacks[1]();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(queue.availableSlots()).toBe(2);
+  });
+
   it('preempts when idle arrives with pending tasks', async () => {
     const fs = await import('fs');
     let resolveProcess: () => void;

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -283,6 +283,10 @@ export class GroupQueue {
     }, delayMs);
   }
 
+  availableSlots(): number {
+    return Math.max(0, MAX_CONCURRENT_CONTAINERS - this.activeCount);
+  }
+
   private drainGroup(groupJid: string): void {
     if (this.shuttingDown) return;
 

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -1,6 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
+
+vi.mock('./config.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('./config.js')>('./config.js');
+  const { join } = await import('path');
+  const { tmpdir } = await import('os');
+  return {
+    ...actual,
+    PROJECT_ROOT: join(tmpdir(), `deus-test-${process.pid}`),
+  };
+});
+
+const TEST_PROJECT_ROOT = path.join(os.tmpdir(), `deus-test-${process.pid}`);
+
 import {
   loadRoleSpecs,
   buildIssuePrompt,
@@ -24,6 +39,7 @@ function makeMockDeps(
       enqueueTask: vi.fn(),
       notifyIdle: vi.fn(),
       closeStdin: vi.fn(),
+      availableSlots: vi.fn().mockReturnValue(5),
     } as unknown as LinearDispatcherDependencies['queue'],
     ...overrides,
   };
@@ -175,5 +191,110 @@ describe('startLinearDispatcher', () => {
     const ctx = makeMockCtx();
     startLinearDispatcher(ctx);
     // No timer started because no role specs exist
+  });
+});
+
+describe('pollLinear dispatch ordering', () => {
+  const agentsDir = path.join(TEST_PROJECT_ROOT, '.claude', 'agents');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, 'test-role.md'),
+      `---\nname: test-role\nlinear_label: "agent:test"\n---\nYou are a test agent.`,
+    );
+  });
+
+  afterEach(() => {
+    stopLinearDispatcher();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    fs.rmSync(TEST_PROJECT_ROOT, { recursive: true, force: true });
+  });
+
+  function makeIssue(id: string, sortOrder: number, labelName = 'agent:test') {
+    return {
+      id,
+      title: `Issue ${id}`,
+      identifier: `LIA-${id}`,
+      description: 'test',
+      sortOrder,
+      labels: vi.fn().mockResolvedValue({
+        nodes: [{ name: labelName }],
+      }),
+      comments: vi.fn().mockResolvedValue({ nodes: [] }),
+    };
+  }
+
+  it('dispatches issues in sortOrder ASC', async () => {
+    const enqueueTask = vi.fn();
+    const deps = makeMockDeps({
+      queue: {
+        enqueueTask,
+        notifyIdle: vi.fn(),
+        closeStdin: vi.fn(),
+        availableSlots: vi.fn().mockReturnValue(5),
+      } as unknown as LinearDispatcherDependencies['queue'],
+    });
+
+    const issues = [
+      makeIssue('ccc', 3.0),
+      makeIssue('aaa', 1.0),
+      makeIssue('bbb', 2.0),
+    ];
+
+    const ctx = makeMockCtx({
+      deps,
+      client: {
+        issues: vi.fn().mockResolvedValue({ nodes: issues }),
+        updateIssue: vi.fn().mockResolvedValue({}),
+      } as unknown as LinearContext['client'],
+    });
+
+    startLinearDispatcher(ctx);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(enqueueTask).toHaveBeenCalledTimes(3);
+    const callOrder = enqueueTask.mock.calls.map(
+      (call: unknown[]) => call[1] as string,
+    );
+    expect(callOrder).toEqual(['aaa', 'bbb', 'ccc']);
+  });
+
+  it('throttles dispatch to available slots', async () => {
+    const enqueueTask = vi.fn();
+    const deps = makeMockDeps({
+      queue: {
+        enqueueTask,
+        notifyIdle: vi.fn(),
+        closeStdin: vi.fn(),
+        availableSlots: vi.fn().mockReturnValue(2),
+      } as unknown as LinearDispatcherDependencies['queue'],
+    });
+
+    const issues = [
+      makeIssue('aaa', 1.0),
+      makeIssue('bbb', 2.0),
+      makeIssue('ccc', 3.0),
+      makeIssue('ddd', 4.0),
+    ];
+
+    const ctx = makeMockCtx({
+      deps,
+      client: {
+        issues: vi.fn().mockResolvedValue({ nodes: issues }),
+        updateIssue: vi.fn().mockResolvedValue({}),
+      } as unknown as LinearContext['client'],
+    });
+
+    startLinearDispatcher(ctx);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(enqueueTask).toHaveBeenCalledTimes(2);
+    const callOrder = enqueueTask.mock.calls.map(
+      (call: unknown[]) => call[1] as string,
+    );
+    expect(callOrder).toEqual(['aaa', 'bbb']);
   });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -279,6 +279,16 @@ async function runIssue(
   issueId: string,
   runContext: RunContext,
 ): Promise<void> {
+  const workingState = ctx.stateByName.get('Agent Working')!;
+  try {
+    await ctx.client.updateIssue(issueId, { stateId: workingState.id });
+  } catch (err) {
+    logger.warn(
+      { issueId, err },
+      'linear-dispatcher: failed to move issue to Agent Working',
+    );
+  }
+
   const { text, error } = await executeAgentRun(ctx, runContext);
 
   ctx.deps.queue.notifyIdle(runContext.chatJid);
@@ -322,13 +332,18 @@ async function pollLinear(): Promise<void> {
   const ctx = _ctx;
 
   const readyState = ctx.stateByName.get('Ready for Agent')!;
-  const workingState = ctx.stateByName.get('Agent Working')!;
 
   const issues = await ctx.client.issues({
     filter: { state: { id: { eq: readyState.id } } },
   });
 
-  for (const issue of issues.nodes) {
+  const sorted = [...issues.nodes].sort((a, b) => a.sortOrder - b.sortOrder);
+
+  let dispatched = 0;
+  const slots = ctx.deps.queue.availableSlots();
+
+  for (const issue of sorted) {
+    if (dispatched >= slots) break;
     if (ctx.inFlightDispatch.has(issue.id)) continue;
 
     const labels = await issue.labels();
@@ -349,16 +364,6 @@ async function pollLinear(): Promise<void> {
       logger.debug(
         { issueId: issue.id },
         'linear-dispatcher: issue has no agent:* label and is not scoped, skipping',
-      );
-      continue;
-    }
-
-    try {
-      await ctx.client.updateIssue(issue.id, { stateId: workingState.id });
-    } catch (err) {
-      logger.warn(
-        { issueId: issue.id, err },
-        'linear-dispatcher: failed to move issue to Agent Working',
       );
       continue;
     }
@@ -405,13 +410,22 @@ async function pollLinear(): Promise<void> {
       runIssue(ctx, issue.id, runContext),
     );
 
+    dispatched++;
     logger.info(
       {
         issueId: issue.id,
         role: roleSpec?.name ?? 'scoped',
         chatJid,
+        sortOrder: issue.sortOrder,
       },
       'linear-dispatcher: enqueued issue for agent run',
+    );
+  }
+
+  if (sorted.length > dispatched) {
+    logger.debug(
+      { total: sorted.length, dispatched, slots },
+      'linear-dispatcher: issues waiting in Ready for Agent (no slots)',
     );
   }
 }


### PR DESCRIPTION
## Summary
- Issues in "Ready for Agent" are now sorted by `sortOrder` (column drag position) and dispatched only when container slots are available
- Eager "Agent Working" state transition moves from poll time to run time, so issues stay reorderable in the Linear board until they actually start
- Added `GroupQueue.availableSlots()` getter for slot-aware throttling

## How it works
The Linear column IS the queue. Drag issues up/down in the "Ready for Agent" column to control dispatch order. The dispatcher polls every 30s, sorts by column position, and only picks up as many issues as there are free container slots (`MAX_CONCURRENT_CONTAINERS`, default 5). Remaining issues stay in the column for the next poll.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npx vitest run src/group-queue.test.ts` — 14 tests pass (including new `availableSlots` test)
- [x] `npx vitest run src/linear-dispatcher.test.ts` — 9 tests pass (including new sort-order and slot-throttle tests)
- [x] ADR Mermaid diagram updated to reflect new dispatch flow
- [ ] E2E: drag issues in Linear board, verify dispatch respects column order

🤖 Generated with [Claude Code](https://claude.com/claude-code)