### PR TITLE
feat(linear): pipeline observability layer with unified event log and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ See [AGENTS.md](AGENTS.md#commands-and-skills) for all available skills.
 | `deus gcal` | Google Calendar token management (`status`, `auth`, `ping`) |
 | `deus listen` | Record from mic, transcribe locally, copy to clipboard |
 | `deus tui` | Full-screen terminal UI for chat, wardens, services, and channels |
+| `deus pipeline` | Pipeline event audit (`LIA-123`, `--failed`, `--active`, `--since 24h`) |
 | `deus backend` | Show active agent backend (`claude`, `codex`, `llama-cpp`) |
 | `deus backend set <name>` | Switch backend for all future sessions |
 

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1508,6 +1508,10 @@ $STARTUP_INSTRUCTION"
         ;;
     esac
     ;;
+  pipeline)
+    shift
+    exec node "$SCRIPT_DIR/dist/linear-pipeline-cli.js" "$@"
+    ;;
   solution)
     # Solution atom management — structured lesson capture.
     shift
@@ -1529,7 +1533,7 @@ $STARTUP_INSTRUCTION"
     exec "$tui_bin" "$@"
     ;;
   *)
-    echo "Usage: deus [claude|codex] [home|auth|web|backend|gcal|listen|logs|solution|sweep|tui] [--agents]"
+    echo "Usage: deus [claude|codex] [home|auth|web|backend|gcal|listen|logs|pipeline|solution|sweep|tui] [--agents]"
     echo ""
     echo "  deus            Launch in current directory (external project mode if not ~/deus)"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
@@ -1541,6 +1545,7 @@ $STARTUP_INSTRUCTION"
     echo "  deus gcal       Google Calendar token management (status|auth|ping)"
     echo "  deus listen     Record from mic, transcribe, and copy to clipboard"
     echo "  deus logs       Review system health logs (rotate|review|summary|pinned)"
+    echo "  deus pipeline   Pipeline event audit (LIA-XX | --failed | --active | --all)"
     echo "  deus solution   Manage solution atoms (list|search|add)"
     echo "  deus sweep      Run threshold calibration sweep against benchmark queries"
     echo "  deus tui        Interactive terminal UI (set tui_default=true in config to use by default)"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T01:07:00" # auto-bump (pipeline-notifications) # auto-bump (auto-merge-label-cleanup) # auto-bump (retry-aware-prompt) # auto-bump (auto-merge-admin) # auto-bump (auto-merge-lazy-eval)
+last_verified: "2026-05-23T01:57:00" # auto-bump (pipeline-observability)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T01:07:00" # auto-bump (pipeline-notifications) # auto-bump (auto-merge-label-cleanup) # auto-bump (retry-aware-prompt) # auto-bump (auto-merge-admin) # auto-bump (auto-merge-lazy-eval)
+last_verified: "2026-05-23T01:57:00" # auto-bump (pipeline-observability)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/db.ts
+++ b/src/db.ts
@@ -134,8 +134,30 @@ function createSchema(database: Database.Database): void {
       issue_id TEXT PRIMARY KEY,
       pr_url TEXT NOT NULL,
       branch TEXT,
+      identifier TEXT,
       auto_merge_state TEXT DEFAULT 'none',
       created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS linear_pipeline_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      issue_id TEXT NOT NULL,
+      identifier TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      detail TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_pipeline_events_issue
+      ON linear_pipeline_events(issue_id);
+    CREATE INDEX IF NOT EXISTS idx_pipeline_events_type
+      ON linear_pipeline_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_pipeline_events_created
+      ON linear_pipeline_events(created_at);
+
+    CREATE TABLE IF NOT EXISTS linear_pipeline_comments (
+      issue_id TEXT PRIMARY KEY,
+      comment_id TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
   `);
@@ -145,6 +167,13 @@ function createSchema(database: Database.Database): void {
     database.exec(
       `ALTER TABLE scheduled_tasks ADD COLUMN context_mode TEXT DEFAULT 'isolated'`,
     );
+  } catch {
+    /* column already exists */
+  }
+
+  // Add identifier column to linear_issue_prs (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE linear_issue_prs ADD COLUMN identifier TEXT`);
   } catch {
     /* column already exists */
   }
@@ -1226,16 +1255,18 @@ export function upsertIssuePr(
   issueId: string,
   prUrl: string,
   branch?: string,
+  identifier?: string,
 ): void {
   const now = new Date().toISOString();
   db.prepare(
-    `INSERT INTO linear_issue_prs (issue_id, pr_url, branch, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?)
+    `INSERT INTO linear_issue_prs (issue_id, pr_url, branch, identifier, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
      ON CONFLICT(issue_id) DO UPDATE SET
        pr_url = excluded.pr_url,
        branch = COALESCE(excluded.branch, linear_issue_prs.branch),
+       identifier = COALESCE(excluded.identifier, linear_issue_prs.identifier),
        updated_at = excluded.updated_at`,
-  ).run(issueId, prUrl, branch ?? null, now, now);
+  ).run(issueId, prUrl, branch ?? null, identifier ?? null, now, now);
 }
 
 export function getIssuePr(
@@ -1265,16 +1296,115 @@ export function getPendingAutoMerges(): Array<{
   issue_id: string;
   pr_url: string;
   branch: string | null;
+  identifier: string | null;
 }> {
   return db
     .prepare(
-      `SELECT issue_id, pr_url, branch FROM linear_issue_prs WHERE auto_merge_state = 'pending'`,
+      `SELECT issue_id, pr_url, branch, identifier FROM linear_issue_prs WHERE auto_merge_state = 'pending'`,
     )
     .all() as Array<{
     issue_id: string;
     pr_url: string;
     branch: string | null;
+    identifier: string | null;
   }>;
+}
+
+// --- Pipeline event accessors ---
+
+export function logPipelineEvent(
+  issueId: string,
+  identifier: string,
+  eventType: string,
+  detail?: string,
+): void {
+  try {
+    db.prepare(
+      `INSERT INTO linear_pipeline_events (issue_id, identifier, event_type, detail, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      issueId,
+      identifier,
+      eventType,
+      detail ?? null,
+      new Date().toISOString(),
+    );
+  } catch (err) {
+    logger.debug({ issueId, eventType, err }, 'pipeline-event: insert failed');
+  }
+}
+
+export interface PipelineEventFilter {
+  issueId?: string;
+  identifier?: string;
+  eventType?: string;
+  since?: string;
+}
+
+export function getPipelineEvents(filters?: PipelineEventFilter): Array<{
+  id: number;
+  issue_id: string;
+  identifier: string;
+  event_type: string;
+  detail: string | null;
+  created_at: string;
+}> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (filters?.issueId) {
+    conditions.push('issue_id = ?');
+    params.push(filters.issueId);
+  }
+  if (filters?.identifier) {
+    conditions.push('identifier = ?');
+    params.push(filters.identifier);
+  }
+  if (filters?.eventType) {
+    conditions.push('event_type = ?');
+    params.push(filters.eventType);
+  }
+  if (filters?.since) {
+    conditions.push('created_at >= ?');
+    params.push(filters.since);
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  return db
+    .prepare(
+      `SELECT id, issue_id, identifier, event_type, detail, created_at FROM linear_pipeline_events ${where} ORDER BY id ASC`,
+    )
+    .all(...params) as Array<{
+    id: number;
+    issue_id: string;
+    identifier: string;
+    event_type: string;
+    detail: string | null;
+    created_at: string;
+  }>;
+}
+
+export function upsertPipelineComment(
+  issueId: string,
+  commentId: string,
+): void {
+  db.prepare(
+    `INSERT INTO linear_pipeline_comments (issue_id, comment_id, updated_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(issue_id) DO UPDATE SET
+       comment_id = excluded.comment_id,
+       updated_at = excluded.updated_at`,
+  ).run(issueId, commentId, new Date().toISOString());
+}
+
+export function getPipelineCommentId(issueId: string): string | undefined {
+  const row = db
+    .prepare(
+      `SELECT comment_id FROM linear_pipeline_comments WHERE issue_id = ?`,
+    )
+    .get(issueId) as { comment_id: string } | undefined;
+  return row?.comment_id;
 }
 
 // --- JSON migration ---

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -17,7 +17,7 @@ import {
 } from './db.js';
 import { logger } from './logger.js';
 import { extractPrUrl } from './pr-url-extractor.js';
-import { macosNotify } from './linear-notifications.js';
+import { macosNotify, notifyPipelineStep } from './linear-notifications.js';
 import type { LinearContext } from './linear-dispatcher.js';
 
 const execFileAsync = promisify(execFile);
@@ -133,9 +133,11 @@ export async function attemptAutoMerge(
   ctx: LinearContext,
   issueId: string,
   prUrl: string,
+  identifier?: string,
   attempt = 0,
 ): Promise<void> {
   if (!isAutoMergeEnabled()) return;
+  const ident = identifier ?? 'unknown';
 
   const checks = await queryPrChecks(prUrl);
   logger.info(
@@ -166,7 +168,9 @@ export async function attemptAutoMerge(
           body: `**Auto-merged** - PR ${prUrl} merged after CI passed.`,
         });
       }
-      macosNotify('Deus', `Auto-merged → Done (${prUrl.split('/').pop()})`);
+      notifyPipelineStep(ctx, issueId, ident, 'automerge_done', prUrl).catch(
+        () => {},
+      );
       logger.info({ issueId, prUrl }, 'auto-merge: merged and moved to Done');
     } else {
       logger.warn(
@@ -174,6 +178,13 @@ export async function attemptAutoMerge(
         'auto-merge: merge failed despite passing CI',
       );
       updatePrAutoMergeState(issueId, 'failed');
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        ident,
+        'automerge_failed',
+        result.error,
+      ).catch(() => {});
       await ctx.client.createComment({
         issueId,
         body: `**Auto-merge failed** - ${result.error}`,
@@ -185,6 +196,13 @@ export async function attemptAutoMerge(
   if (checks.status === 'pending') {
     if (attempt >= MAX_POLL_ATTEMPTS) {
       updatePrAutoMergeState(issueId, 'failed');
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        ident,
+        'automerge_failed',
+        'Timed out',
+      ).catch(() => {});
       await ctx.client.createComment({
         issueId,
         body: `**Auto-merge timed out** - CI still pending after ${MAX_POLL_ATTEMPTS} attempts. PR: ${prUrl}`,
@@ -193,15 +211,24 @@ export async function attemptAutoMerge(
       return;
     }
     setTimeout(() => {
-      attemptAutoMerge(ctx, issueId, prUrl, attempt + 1).catch((err) => {
-        logger.error({ issueId, err }, 'auto-merge: re-check failed');
-      });
+      attemptAutoMerge(ctx, issueId, prUrl, identifier, attempt + 1).catch(
+        (err) => {
+          logger.error({ issueId, err }, 'auto-merge: re-check failed');
+        },
+      );
     }, CI_POLL_INTERVAL_MS);
     return;
   }
 
   // CI failed
   updatePrAutoMergeState(issueId, 'failed');
+  notifyPipelineStep(
+    ctx,
+    issueId,
+    ident,
+    'automerge_failed',
+    checks.summary,
+  ).catch(() => {});
   await ctx.client.createComment({
     issueId,
     body: `**Auto-merge blocked** - CI failed: ${checks.summary}\n\nPR: ${prUrl}`,
@@ -226,8 +253,8 @@ export async function sweepPendingAutoMerges(
     'auto-merge: sweeping pending merges on startup',
   );
 
-  for (const { issue_id, pr_url } of pending) {
-    attemptAutoMerge(ctx, issue_id, pr_url).catch((err) => {
+  for (const { issue_id, pr_url, identifier: ident } of pending) {
+    attemptAutoMerge(ctx, issue_id, pr_url, ident || 'unknown').catch((err) => {
       logger.error({ issueId: issue_id, err }, 'auto-merge: sweep failed');
     });
   }
@@ -236,6 +263,7 @@ export async function sweepPendingAutoMerges(
 export async function triggerAutoMerge(
   ctx: LinearContext,
   issueId: string,
+  identifier?: string,
 ): Promise<void> {
   if (!isAutoMergeEnabled()) return;
 
@@ -271,6 +299,10 @@ export async function triggerAutoMerge(
     return;
   }
 
+  const ident = identifier || 'unknown';
   updatePrAutoMergeState(issueId, 'pending');
-  await attemptAutoMerge(ctx, issueId, pr.pr_url);
+  notifyPipelineStep(ctx, issueId, ident, 'automerge_pending', pr.pr_url).catch(
+    () => {},
+  );
+  await attemptAutoMerge(ctx, issueId, pr.pr_url, ident);
 }

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -62,6 +62,7 @@ function makeMockCtx(overrides: Partial<LinearContext> = {}): LinearContext {
       ['backlog-id', { id: 'backlog-id', name: 'Backlog' }],
     ]),
     botUserId: 'bot-user-id',
+    viewerId: 'viewer-user-id',
     deps,
     dispatchGroup: {
       name: 'Linear Dispatch',

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -57,6 +57,7 @@ export interface LinearContext {
   stateByName: Map<string, WorkflowState>;
   stateById: Map<string, WorkflowState>;
   botUserId: string;
+  viewerId: string; // human operator ID, used to assign issues on In Review
   deps: LinearDispatcherDependencies;
   dispatchGroup: RegisteredGroup;
   inFlightDispatch: Set<string>;
@@ -300,9 +301,7 @@ async function runIssue(
     );
   }
 
-  notifyPipelineStep(ctx, issueId, identifier, 'Agent started working').catch(
-    () => {},
-  );
+  notifyPipelineStep(ctx, issueId, identifier, 'agent_started').catch(() => {});
 
   const { text, error } = await executeAgentRun(ctx, runContext);
 
@@ -312,8 +311,11 @@ async function runIssue(
     if (error) {
       await ctx.client.createComment({
         issueId,
-        body: `**Agent run failed**\n\n\`\`\`\n${error}\n\`\`\``,
+        body: `**Agent run failed**\n\n\`\`\`\n${error}\n\`\`\`\n\n---\n*To retry: move to **Todo**, then to **Ready for Agent**.*`,
       });
+      notifyPipelineStep(ctx, issueId, identifier, 'agent_failed', error).catch(
+        () => {},
+      );
       const backlogState = ctx.stateByName.get('Backlog')!;
       await ctx.client.updateIssue(issueId, { stateId: backlogState.id });
       logger.warn(
@@ -324,19 +326,25 @@ async function runIssue(
       const body = text || '(no output produced)';
       const prUrl = extractPrUrl(body, ctx.repoSlug);
       if (prUrl) {
-        upsertIssuePr(issueId, prUrl);
+        upsertIssuePr(issueId, prUrl, undefined, identifier);
         logger.info({ issueId, prUrl }, 'linear-dispatcher: persisted PR URL');
       }
       await ctx.client.createComment({ issueId, body });
+
+      if (prUrl) {
+        notifyPipelineStep(ctx, issueId, identifier, 'pr_created', prUrl).catch(
+          () => {},
+        );
+      }
+
       const reviewState = ctx.stateByName.get('In Review')!;
-      await ctx.client.updateIssue(issueId, { stateId: reviewState.id });
-      notifyPipelineStep(
-        ctx,
-        issueId,
-        identifier,
-        prUrl ? `PR created → In Review` : 'Agent done → In Review',
-        prUrl ?? undefined,
-      ).catch(() => {});
+      await ctx.client.updateIssue(issueId, {
+        stateId: reviewState.id,
+        assigneeId: ctx.viewerId,
+      });
+      notifyPipelineStep(ctx, issueId, identifier, 'agent_completed').catch(
+        () => {},
+      );
       logger.info({ issueId }, 'linear-dispatcher: issue moved to In Review');
     }
   } catch (err) {
@@ -427,6 +435,13 @@ async function pollLinear(): Promise<void> {
       isScheduledTask: true,
       effort: 'high',
     };
+
+    notifyPipelineStep(
+      ctx,
+      issue.id,
+      issue.identifier,
+      'agent_dispatched',
+    ).catch(() => {});
 
     ctx.deps.queue.enqueueTask(chatJid, issue.id, () =>
       runIssue(ctx, issue.id, issue.identifier, runContext),
@@ -598,6 +613,7 @@ export async function initLinearContext(
       stateByName,
       stateById,
       botUserId,
+      viewerId: viewer.id,
       deps,
       dispatchGroup,
       inFlightDispatch: new Set(),

--- a/src/linear-notifications.test.ts
+++ b/src/linear-notifications.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildPipelineCommentBody } from './linear-notifications.js';
+
+describe('buildPipelineCommentBody', () => {
+  it('renders empty state', () => {
+    const body = buildPipelineCommentBody([]);
+    expect(body).toContain('No events yet');
+  });
+
+  it('renders timeline from events', () => {
+    const events = [
+      {
+        event_type: 'gate_ship',
+        detail: 'agent-readiness-gate: SHIP',
+        created_at: '2026-05-23T00:18:00.000Z',
+      },
+      {
+        event_type: 'agent_dispatched',
+        detail: null,
+        created_at: '2026-05-23T00:19:00.000Z',
+      },
+      {
+        event_type: 'pr_created',
+        detail: '#488',
+        created_at: '2026-05-23T00:24:00.000Z',
+      },
+    ];
+    const body = buildPipelineCommentBody(events);
+    expect(body).toContain('**Pipeline Log**');
+    expect(body).toContain('00:18');
+    expect(body).toContain('Gate → SHIP');
+    expect(body).toContain('Agent dispatched');
+    expect(body).toContain('PR created');
+    expect(body).toContain('#488');
+  });
+
+  it('uses event_type as label for unknown types', () => {
+    const events = [
+      {
+        event_type: 'custom_event',
+        detail: null,
+        created_at: '2026-05-23T01:00:00.000Z',
+      },
+    ];
+    const body = buildPipelineCommentBody(events);
+    expect(body).toContain('custom_event');
+  });
+});

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -1,13 +1,20 @@
 /**
  * Pipeline notifications for Linear automation.
  *
- * Emits both macOS native notifications (osascript) and Linear issue
- * comments so the operator sees progress in both the OS notification
- * center and Linear's inbox.
+ * Orchestrates three outputs per pipeline step:
+ * 1. DB event log (append-only audit trail)
+ * 2. macOS native notification (operator desktop)
+ * 3. Unified Linear comment (single rolling timeline per issue)
  */
 
 import { execFile } from 'child_process';
 import { logger } from './logger.js';
+import {
+  logPipelineEvent,
+  getPipelineEvents,
+  upsertPipelineComment,
+  getPipelineCommentId,
+} from './db.js';
 import type { LinearContext } from './linear-dispatcher.js';
 
 export function macosNotify(title: string, message: string): void {
@@ -28,27 +35,105 @@ export function macosNotify(title: string, message: string): void {
   }
 }
 
+export const EVENT_LABELS: Record<string, string> = {
+  gate_ship: 'Gate → SHIP',
+  gate_revise: 'Gate → REVISE',
+  gate_cooldown: 'Gate cooldown',
+  gate_error: 'Gate error',
+  agent_dispatched: 'Agent dispatched',
+  agent_started: 'Agent started working',
+  agent_completed: 'Agent completed',
+  agent_failed: 'Agent failed',
+  pr_created: 'PR created',
+  automerge_pending: 'Auto-merge pending',
+  automerge_done: 'Auto-merged → Done',
+  automerge_failed: 'Auto-merge failed',
+  moved_done: 'Moved to Done',
+  state_changed: 'State changed',
+};
+
+export function buildPipelineCommentBody(
+  events: Array<{
+    event_type: string;
+    detail: string | null;
+    created_at: string;
+  }>,
+): string {
+  if (events.length === 0) return '**Pipeline Log**\n\n_No events yet._';
+
+  const MAX_COMMENT_EVENTS = 50;
+  const truncated = events.length > MAX_COMMENT_EVENTS;
+  const visible = truncated ? events.slice(-MAX_COMMENT_EVENTS) : events;
+
+  const lines: string[] = [];
+  if (truncated) {
+    lines.push(
+      `_...${events.length - MAX_COMMENT_EVENTS} earlier events omitted_`,
+    );
+  }
+  for (const e of visible) {
+    const time = e.created_at.slice(11, 16); // HH:MM
+    const label = EVENT_LABELS[e.event_type] || e.event_type;
+    const detail = e.detail ? ` — ${e.detail}` : '';
+    lines.push(`${time} — ${label}${detail}`);
+  }
+
+  return `**Pipeline Log**\n\n${lines.join('\n')}`;
+}
+
+const commentLocks = new Map<string, Promise<void>>();
+
+export async function updateUnifiedComment(
+  ctx: LinearContext,
+  issueId: string,
+): Promise<void> {
+  const prev = commentLocks.get(issueId) ?? Promise.resolve();
+  const current = prev.then(() => doUpdateUnifiedComment(ctx, issueId));
+  const tracked = current.catch(() => {});
+  commentLocks.set(issueId, tracked);
+  tracked.then(() => {
+    if (commentLocks.get(issueId) === tracked) commentLocks.delete(issueId);
+  });
+  return current;
+}
+
+async function doUpdateUnifiedComment(
+  ctx: LinearContext,
+  issueId: string,
+): Promise<void> {
+  try {
+    const events = getPipelineEvents({ issueId });
+    const body = buildPipelineCommentBody(events);
+    const existingCommentId = getPipelineCommentId(issueId);
+
+    if (existingCommentId) {
+      await ctx.client.updateComment(existingCommentId, { body });
+      upsertPipelineComment(issueId, existingCommentId);
+    } else {
+      const payload = await ctx.client.createComment({ issueId, body });
+      if (payload?.commentId) {
+        upsertPipelineComment(issueId, payload.commentId);
+      }
+    }
+  } catch (err) {
+    logger.debug(
+      { issueId, err },
+      'notification: failed to update unified comment',
+    );
+  }
+}
+
 export async function notifyPipelineStep(
   ctx: LinearContext,
   issueId: string,
   identifier: string,
-  step: string,
-  details?: string,
+  eventType: string,
+  detail?: string,
 ): Promise<void> {
-  const short = `${identifier}: ${step}`;
-  const full = details ? `${step}\n\n${details}` : step;
+  logPipelineEvent(issueId, identifier, eventType, detail);
 
-  macosNotify('Deus', short);
+  const label = EVENT_LABELS[eventType] || eventType;
+  macosNotify('Deus', `${identifier}: ${label}`);
 
-  try {
-    await ctx.client.createComment({
-      issueId,
-      body: `**Pipeline** — ${full}`,
-    });
-  } catch (err) {
-    logger.debug(
-      { issueId, err },
-      'notification: failed to post Linear comment',
-    );
-  }
+  await updateUnifiedComment(ctx, issueId);
 }

--- a/src/linear-pipeline-cli.test.ts
+++ b/src/linear-pipeline-cli.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { parseDuration } from './linear-pipeline-cli.js';
+
+describe('parseDuration', () => {
+  it('parses minutes', () => {
+    const result = parseDuration('30m');
+    expect(result).toBeTruthy();
+    const diff = Date.now() - new Date(result!).getTime();
+    expect(diff).toBeGreaterThan(29 * 60_000);
+    expect(diff).toBeLessThan(31 * 60_000);
+  });
+
+  it('parses hours', () => {
+    const result = parseDuration('24h');
+    expect(result).toBeTruthy();
+    const diff = Date.now() - new Date(result!).getTime();
+    expect(diff).toBeGreaterThan(23.9 * 3_600_000);
+    expect(diff).toBeLessThan(24.1 * 3_600_000);
+  });
+
+  it('parses days', () => {
+    const result = parseDuration('7d');
+    expect(result).toBeTruthy();
+    const diff = Date.now() - new Date(result!).getTime();
+    expect(diff).toBeGreaterThan(6.9 * 86_400_000);
+    expect(diff).toBeLessThan(7.1 * 86_400_000);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseDuration('abc')).toBeNull();
+    expect(parseDuration('24')).toBeNull();
+    expect(parseDuration('h')).toBeNull();
+    expect(parseDuration('')).toBeNull();
+  });
+});

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * CLI for pipeline event audit.
+ *
+ * Usage:
+ *   deus pipeline LIA-123               Full timeline for an issue
+ *   deus pipeline --failed --since 24h  All failures in last 24h
+ *   deus pipeline --active              Currently in-flight issues
+ */
+
+import { getPipelineEvents, type PipelineEventFilter } from './db.js';
+import { EVENT_LABELS } from './linear-notifications.js';
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+const FAILED_TYPES = new Set([
+  'gate_revise',
+  'gate_error',
+  'agent_failed',
+  'automerge_failed',
+]);
+
+const SUCCESS_TYPES = new Set([
+  'gate_ship',
+  'automerge_done',
+  'agent_completed',
+  'moved_done',
+]);
+
+const PENDING_TYPES = new Set(['gate_cooldown', 'automerge_pending']);
+
+const INFO_TYPES = new Set([
+  'agent_dispatched',
+  'agent_started',
+  'pr_created',
+  'state_changed',
+]);
+
+function colorFor(eventType: string): string {
+  if (SUCCESS_TYPES.has(eventType)) return GREEN;
+  if (FAILED_TYPES.has(eventType)) return RED;
+  if (PENDING_TYPES.has(eventType)) return YELLOW;
+  if (INFO_TYPES.has(eventType)) return CYAN;
+  return DIM;
+}
+
+export function parseDuration(input: string): string | null {
+  const match = input.match(/^(\d+)(m|h|d)$/);
+  if (!match) return null;
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const ms =
+    unit === 'm'
+      ? value * 60_000
+      : unit === 'h'
+        ? value * 3_600_000
+        : value * 86_400_000;
+  return new Date(Date.now() - ms).toISOString();
+}
+
+function printEvents(
+  events: Array<{
+    issue_id: string;
+    identifier: string;
+    event_type: string;
+    detail: string | null;
+    created_at: string;
+  }>,
+): void {
+  if (events.length === 0) {
+    console.log(`${DIM}No events found.${RESET}`);
+    return;
+  }
+
+  for (const e of events) {
+    const time = e.created_at.slice(0, 16).replace('T', ' ');
+    const color = colorFor(e.event_type);
+    const detail = e.detail ? ` ${DIM}— ${e.detail}${RESET}` : '';
+    console.log(
+      `${DIM}${time}${RESET}  ${CYAN}${e.identifier.padEnd(8)}${RESET}  ${color}${(EVENT_LABELS[e.event_type] || e.event_type).padEnd(22)}${RESET}${detail}`,
+    );
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help') {
+    console.log('Usage:');
+    console.log('  deus pipeline <IDENTIFIER>          Timeline for an issue');
+    console.log('  deus pipeline --failed [--since Xh]  Failed events');
+    console.log('  deus pipeline --active               In-flight issues');
+    console.log('  deus pipeline --all [--since Xh]     All events');
+    process.exit(0);
+  }
+
+  const filter: PipelineEventFilter = {};
+  let showFailed = false;
+  let showActive = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === '--failed') {
+      showFailed = true;
+    } else if (arg === '--active') {
+      showActive = true;
+    } else if (arg === '--since' && args[i + 1]) {
+      const since = parseDuration(args[i + 1]);
+      if (!since) {
+        console.error(
+          `Invalid duration: ${args[i + 1]} (use e.g. 24h, 30m, 7d)`,
+        );
+        process.exit(1);
+      }
+      filter.since = since;
+      i++;
+    } else if (arg === '--type' && args[i + 1]) {
+      filter.eventType = args[i + 1];
+      i++;
+    } else if (arg === '--all') {
+      // no filter
+    } else if (!arg.startsWith('--')) {
+      filter.identifier = arg;
+    }
+    i++;
+  }
+
+  let events = getPipelineEvents(filter);
+
+  if (showFailed) {
+    events = events.filter((e) => FAILED_TYPES.has(e.event_type));
+  }
+
+  if (showActive) {
+    const issueLatest = new Map<string, string>();
+    for (const e of events) {
+      issueLatest.set(e.issue_id, e.event_type);
+    }
+    const terminalTypes = new Set([
+      'automerge_done',
+      'moved_done',
+      'automerge_failed',
+      'agent_failed',
+    ]);
+    const activeIds = new Set<string>();
+    for (const [id, lastType] of issueLatest) {
+      if (!terminalTypes.has(lastType)) activeIds.add(id);
+    }
+    events = events.filter((e) => activeIds.has(e.issue_id));
+  }
+
+  printEvents(events);
+}
+
+const isDirectRun =
+  process.argv[1]?.endsWith('linear-pipeline-cli.js') ||
+  process.argv[1]?.endsWith('linear-pipeline-cli.ts');
+if (isDirectRun) main();

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -14,7 +14,7 @@ import {
   getGateCommentId,
 } from './db.js';
 import { triggerAutoMerge } from './linear-auto-merge.js';
-import { macosNotify } from './linear-notifications.js';
+import { macosNotify, notifyPipelineStep } from './linear-notifications.js';
 
 const DEFAULT_WEBHOOK_PORT = 3005;
 
@@ -224,6 +224,19 @@ async function handleIssueUpdate(
       const elapsed =
         (Date.now() - new Date(lastRun.finished_at).getTime()) / 60_000;
       if (elapsed < gateSpec.cooldownMinutes) {
+        const remainMin = Math.ceil(gateSpec.cooldownMinutes - elapsed);
+        const resetAt = new Date(
+          new Date(lastRun.finished_at).getTime() +
+            gateSpec.cooldownMinutes * 60_000,
+        );
+        const resetTime = resetAt.toISOString().slice(11, 16);
+        notifyPipelineStep(
+          ctx,
+          data.id,
+          data.identifier,
+          'gate_cooldown',
+          `${gateSpec.name}: ${remainMin}min remaining, resets at ${resetTime}`,
+        ).catch(() => {});
         logger.info(
           {
             issueId: data.id,
@@ -392,7 +405,14 @@ async function handleIssueUpdate(
 
     finalVerdict = verdict;
     updateWebhookEventStatus(eventKey, 'done', { verdict });
-    macosNotify('Deus', `${data.identifier}: ${gateSpec.name} ${verdict}`);
+    const eventType = verdict === 'SHIP' ? 'gate_ship' : 'gate_revise';
+    notifyPipelineStep(
+      ctx,
+      data.id,
+      data.identifier,
+      eventType,
+      `${gateSpec.name}: ${verdict}`,
+    ).catch(() => {});
     logger.info(
       { issueId: data.id, gate: gateSpec.name, verdict, mode: effectiveMode },
       'linear-webhook: gate evaluation complete',
@@ -400,6 +420,13 @@ async function handleIssueUpdate(
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     updateWebhookEventStatus(eventKey, 'error', { error: errorMsg });
+    notifyPipelineStep(
+      ctx,
+      data.id,
+      data.identifier,
+      'gate_error',
+      `${gateSpec.name}: ${errorMsg}`,
+    ).catch(() => {});
     logger.error(
       { issueId: data.id, gate: gateSpec.name, err },
       'linear-webhook: gate evaluation failed',
@@ -451,7 +478,7 @@ async function handleIssueUpdate(
     }
 
     if (finalVerdict === 'SHIP' && gateSpec.name === 'output-quality-gate') {
-      triggerAutoMerge(ctx, data.id).catch((err) => {
+      triggerAutoMerge(ctx, data.id, data.identifier).catch((err) => {
         logger.warn(
           { issueId: data.id, err },
           'linear-webhook: auto-merge trigger failed',


### PR DESCRIPTION
## Summary
- Adds unified audit trail: `linear_pipeline_events` DB table with append-only event logging and 4 accessors
- Replaces 5-6 separate pipeline comments per issue with a single rolling comment rebuilt from event history (materialized view pattern)
- Adds `deus pipeline` CLI for terminal-based event audit with color-coded output and `--failed`/`--active`/`--since` filters
- Wires 12 event emission points across dispatcher, webhook, and auto-merge modules
- UX improvements: recovery footer on agent failure, cooldown transparency with reset time, assignee management (human operator auto-assigned on In Review)
- Adds `viewerId` to `LinearContext` for assignee management, separate from `botUserId`
- Per-issue promise-chain mutex prevents duplicate comment creation on concurrent events
- Comment body capped at 50 events with truncation notice

## macOS-only
`macosNotify` uses `osascript` (pre-existing, not new in this PR). Cross-platform notification abstraction deferred to platform parity track.

## Test plan
- [x] TypeScript compiles clean
- [x] 1104 tests pass (73 files), 7 new tests added
- [x] `buildPipelineCommentBody` renders timeline from events array
- [x] `parseDuration` parses `30m`, `24h`, `7d`, rejects invalid input
- [x] Code reviewer SHIP (2 rounds: REVISE → fixes → SHIP)
- [x] All drift checks pass
- [ ] Manual E2E: trigger a gate, verify events in DB + unified comment
- [ ] Manual E2E: `deus pipeline LIA-XX` output matches DB events

🤖 Generated with [Claude Code](https://claude.com/claude-code)