### PR TITLE
docs(linear): add automation setup, pipeline audit, and env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,9 @@ Use these instead of rediscovering the system:
 | Linear dispatcher | `src/linear-dispatcher.ts` | Polls Linear for "Ready for Agent" issues, runs container agents with role prompts, posts results back |
 | Linear webhook gates | `src/linear-webhook.ts` | Receives Linear webhooks, runs warden-style gates on column transitions |
 | Linear gate specs | `.claude/agents/wardens/` | Config-driven gate specs — file presence = gate enabled |
+| Linear auto-merge | `src/linear-auto-merge.ts` | Polls CI after gate SHIP, squash-merges agent PRs, moves issue to Done |
+| Linear notifications | `src/linear-notifications.ts` | Unified pipeline comment (rolling timeline) + macOS desktop notifications |
+| Pipeline CLI | `src/linear-pipeline-cli.ts` | `deus pipeline` -- event audit from the terminal |
 | Codex Warden hooks | `scripts/codex_warden_hooks.py` | Installs and runs Codex hook equivalents for Warden gates (plan-reviewer, code-reviewer, verification-gate, threat-modeler) |
 
 More detailed maps live in [docs/AGENT_DEUS_101.md](docs/AGENT_DEUS_101.md).
@@ -126,6 +129,7 @@ Commands that must remain stable across backends:
 - `deus openai`
 - `DEUS_CLI_AGENT=claude|codex`
 - `DEUS_AGENT_BACKEND=claude|openai`
+- `deus pipeline`
 - `/settings`
 - `/settings session_idle_hours=N`
 - `/settings timeout=N`

--- a/README.md
+++ b/README.md
@@ -148,6 +148,69 @@ python3 scripts/codex_warden_hooks.py check
 
 ---
 
+## Linear Automation
+
+Use [Linear](https://linear.app) as a Kanban command center for autonomous agent work. Move an issue to **Ready for Agent** and Deus picks it up, implements it in a container, opens a PR, and optionally merges it -- without waiting for you.
+
+### How it works
+
+Issues move through five stages: **Todo → Ready for Agent → Agent Working → In Review → Done**. Three quality checks fire automatically as issues move through the board:
+
+| Check | Fires on | What it does |
+|-------|----------|--------------|
+| **agent-readiness-gate** | Todo → Ready for Agent | Scopes the issue: implementation plan, acceptance criteria, effort/complexity ratings |
+| **output-quality-gate** | Agent Working → In Review | Verifies the agent produced a real deliverable (PR, document, etc.) |
+| **completion-gate** | In Review → Done | Checks all acceptance criteria are met and PR is merged |
+
+When `LINEAR_AUTO_MERGE=1`, Deus automatically merges the agent's PR once CI passes.
+
+Each issue gets a single rolling **Pipeline Log** comment that tracks every event (gate verdicts, agent dispatch, PR creation, merge) -- no comment spam.
+
+### Setup
+
+```
+/add-linear    # Gives Deus read/write access to your Linear workspace
+```
+
+Then configure the automation layer in `.env`:
+
+```bash
+LINEAR_API_TOKEN=lin_api_...    # Linear personal API key
+LINEAR_WEBHOOK_SECRET=...       # For webhook signature verification
+# LINEAR_AUTO_MERGE=1           # Optional: auto-merge agent PRs after CI
+```
+
+Quality checks require a public URL to receive Linear webhook events. For local dev, use [ngrok](https://ngrok.com) (`ngrok http 3005`). Register the URL in Linear Settings → API → Webhooks. Dispatch (polling) works without a webhook URL.
+
+See [Linear automation architecture](docs/decisions/linear-webhook-pipeline.md) for the full setup, gate spec format, and configuration reference.
+
+### Pipeline audit
+
+Check the status of any issue's pipeline from the terminal:
+
+```bash
+deus pipeline PROJ-123               # Full timeline for an issue
+deus pipeline --failed --since 24h   # Failures in the last 24 hours
+deus pipeline --active               # Currently in-flight issues
+```
+
+### Adding or customizing gates
+
+Gates are plain markdown files in `.claude/agents/wardens/`. Adding a gate is one file with YAML frontmatter -- no code change:
+
+```yaml
+---
+name: my-custom-gate
+gate_to: "In Review"
+allowed_from: ["Agent Working"]
+mode: advise          # or strict (reverts on non-SHIP)
+cooldown_minutes: 60
+---
+Your gate prompt here...
+```
+
+---
+
 ## Comparison
 
 |  | **Deus** | **[OpenClaw](https://github.com/openclaw/openclaw)** | **[NemoClaw](https://github.com/NVIDIA/NemoClaw)** | **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** | **Plain Claude** |
@@ -180,6 +243,7 @@ Deus goes deep on understanding you and adapting over time. Hermes goes wide on 
 | Development setup | [Development](docs/DEVELOPMENT.md) |
 | Contributing | [Contributing](CONTRIBUTING.md) |
 | Known limitations | [Limitations](docs/KNOWN_LIMITATIONS.md) |
+| Linear automation | [Setup, gates, and pipeline](docs/decisions/linear-webhook-pipeline.md) |
 | Hook dispatch architecture | [Hook Dispatch System](docs/decisions/hook-dispatch-system.md) |
 
 ---

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -149,6 +149,25 @@ Group/task effort overrides:
 - Resolution order is: task override, group override, `DEUS_AGENT_EFFORT`, then `low`.
 - Effort currently applies to the Claude backend only. OpenAI backend logs and ignores the value.
 
+## Linear Automation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LINEAR_API_TOKEN` | -- | Personal API key (also accepted as `LINEAR_API_KEY`). Generate at Linear Settings > API > Personal API keys |
+| `LINEAR_POLL_INTERVAL_MS` | `30000` | How often the dispatcher polls for "Ready for Agent" issues (ms) |
+| `LINEAR_TEAM_ID` | auto-discovered | Override if the workspace has multiple teams |
+| `LINEAR_WEBHOOK_SECRET` | -- | HMAC-SHA256 secret for webhook signature verification. Required for gates |
+| `LINEAR_WEBHOOK_PORT` | `3005` | Port the webhook server binds to |
+| `LINEAR_BOT_USER_ID` | auto-discovered | Override the bot user ID used to filter out self-triggered webhook events |
+| `LINEAR_AUTO_MERGE` | `0` | Auto-merge agent PRs after CI passes: `0` (off) or `1` (on) |
+
+## GitHub
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GITHUB_TOKEN` | -- | Personal access token for `gh` CLI (tool proxy injects into container agent calls) |
+| `GITHUB_REPO` | auto-derived | Repository slug (`owner/repo`). Auto-derived from `git remote` if not set |
+
 ## Safety
 
 | Variable | Default | Description |

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -262,6 +262,66 @@ Linear webhooks must be configured in the workspace settings (Settings > API > W
 
 Gate agents and dispatch agents run through the same agent runtime as all other Deus agents. They use the `linear-dispatch` group folder, which is a virtual group registered at startup. The agent runtime's credential proxy is required to be running -- Linear-sourced agent runs are not exempt from the proxy dependency.
 
+## Pipeline Observability
+
+Every significant pipeline event is logged to the `linear_pipeline_events` table and surfaced in two ways:
+
+### Unified pipeline comment
+
+Each issue gets a single rolling **Pipeline Log** comment that updates as events occur. The comment body is rebuilt (materialized view pattern) from the event log on each update. A per-issue promise-chain mutex prevents duplicate comment creation under concurrent events. The comment caps at 50 events with a truncation notice for older entries.
+
+Example comment body:
+
+```
+**Pipeline Log**
+
+00:18 -- Gate: agent-readiness-gate -> SHIP
+00:19 -- Agent dispatched
+00:19 -- Agent started working
+00:24 -- PR created -- #488
+00:24 -- -> In Review
+00:28 -- Gate: output-quality-gate -> SHIP
+00:31 -- Auto-merged -> Done
+```
+
+Tracked in `linear_pipeline_comments` (issue_id PK, comment_id). Coexists with per-gate verdict comments (different DB table, different content).
+
+### Pipeline CLI
+
+`deus pipeline` queries the event log from the terminal:
+
+```bash
+deus pipeline PROJ-123             # Full timeline for an issue
+deus pipeline --failed --since 24h # Failures in the last 24 hours
+deus pipeline --active             # In-flight issues (no terminal event yet)
+deus pipeline --all --since 7d     # All events in the last week
+deus pipeline --type gate_revise   # Filter by event type
+```
+
+Color-coded output: green (SHIP/merged/completed), red (REVISE/error/failed), yellow (cooldown/pending), cyan (dispatched/started/PR).
+
+### Event types
+
+| Type | Emitted by | Description |
+|------|-----------|-------------|
+| `gate_ship` | webhook | Gate returned SHIP |
+| `gate_revise` | webhook | Gate returned REVISE |
+| `gate_cooldown` | webhook | Gate skipped (cooldown active) |
+| `gate_error` | webhook | Gate agent errored |
+| `agent_dispatched` | dispatcher | Issue enqueued for agent run |
+| `agent_started` | dispatcher | Agent container started |
+| `agent_completed` | dispatcher | Agent finished successfully |
+| `agent_failed` | dispatcher | Agent errored |
+| `pr_created` | dispatcher | PR URL extracted from agent output |
+| `automerge_pending` | auto-merge | CI poll started |
+| `automerge_done` | auto-merge | PR squash-merged |
+| `automerge_failed` | auto-merge | CI failed or merge blocked |
+| `state_changed` | various | Generic state transition |
+
+### macOS notifications
+
+Every pipeline event also fires a macOS native notification via `osascript` (best-effort, no-op on Linux/Windows). Shows the issue identifier and event label.
+
 ## Consequences
 
 - Linear becomes a first-class command interface for autonomous agent work without custom tooling beyond Deus itself.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-22" # auto-bump — dispatch priority ADR update
+last_verified: "2026-05-23" # auto-bump — Linear automation docs
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary
- Add a user-facing **Linear Automation** section to README covering the Kanban flow, quality gates, setup steps, `deus pipeline` CLI, and custom gate creation
- Document all Linear and GitHub environment variables in `docs/ENVIRONMENT.md` (were entirely missing)
- Extend the Linear ADR with the pipeline observability layer (unified comment, CLI, event types table)
- Update `AGENTS.md` core entrypoints table with auto-merge, notifications, and pipeline CLI entries

## Test plan
- [ ] Verify all links in the new README section resolve correctly
- [ ] Confirm `deus pipeline --help` output matches documented usage
- [ ] Spot-check env var names against `.env.example` and `src/config.ts`
- [ ] Verify gate spec YAML example matches the real frontmatter schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)