### PR TITLE
fix(linear): initialize database before pipeline CLI queries

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T01:57:00" # auto-bump (pipeline-observability)
+last_verified: "2026-05-23T15:05:00" # auto-bump (pipeline-cli-db-init)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T01:57:00" # auto-bump (pipeline-observability)
+last_verified: "2026-05-23T15:05:00" # auto-bump (pipeline-cli-db-init)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -8,7 +8,11 @@
  *   deus pipeline --active              Currently in-flight issues
  */
 
-import { getPipelineEvents, type PipelineEventFilter } from './db.js';
+import {
+  getPipelineEvents,
+  initDatabase,
+  type PipelineEventFilter,
+} from './db.js';
 import { EVENT_LABELS } from './linear-notifications.js';
 
 const GREEN = '\x1b[32m';
@@ -98,6 +102,8 @@ function main(): void {
     console.log('  deus pipeline --all [--since Xh]     All events');
     process.exit(0);
   }
+
+  initDatabase();
 
   const filter: PipelineEventFilter = {};
   let showFailed = false;


### PR DESCRIPTION
## Summary
- `deus pipeline --all` crashed with `Cannot read properties of undefined (reading 'prepare')` because the standalone CLI never called `initDatabase()` before querying the SQLite database
- Added `initDatabase()` call in `main()` after the `--help` early exit

## Test plan
- [x] `deus pipeline --all` now prints "No events found" instead of crashing
- [x] `deus pipeline --help` still works without DB init
- [x] All 4 existing `linear-pipeline-cli.test.ts` tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)