### PR TITLE
feat: enforce semantic-search-first workflow (LIA-60)

### DIFF
--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -13,6 +13,7 @@
 - Never execute without explicit user approval. Wait to be told.
 - Show commit message and wait for approval before committing.
 - Source edits require /plan mode + plan-reviewer SHIP for non-trivial changes. Trivial-bypass: touch marker with stated judgment.
+- After drafting a plan in /plan mode, immediately invoke plan-reviewer (`Agent(subagent_type="plan-reviewer")`) with the plan summary as the prompt — do not ask the user, do not call ExitPlanMode first. Trigger: when you would otherwise present the plan or ask to proceed. On non-Claude-Code backends, the PreToolUse gate is the backstop.
 - Never proceed while a review agent is running. Wait for its verdict.
 - REVISE from any warden means re-run after fixes until SHIP. Never touch markers, commit, or proceed on REVISE — no exceptions, no "close enough," no time-pressure rationalization.
 - Quality over speed by default. Never shortcut a warden loop, skip a review round, or rationalize lower standards because of time pressure, autonomy grants, or late-session fatigue. Only skip when the user explicitly says to prioritize speed.

--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -35,6 +35,9 @@
 - Default to cross-platform. Flag OS-specific code loudly in PRs.
 - Chat responses always in English. Hebrew only inside artifacts.
 
+## Code Exploration
+- When exploring unfamiliar code, run `search_code` first to locate relevant areas by meaning, then drill in with grep/read. Semantic search identifies the landscape; grep/read confirms specifics. Never open-code grep -r or find -name as the first move.
+
 ## Memory & Context
 - Before implementing a feature, search memory (`memory_tree.py query "<topic>"`) for prior decisions and research. Cite the retrieved path.
 - Never duplicate content across files. When a rule or config applies in multiple places, write it once and reference it. Duplication is drift waiting to happen.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,11 @@
             "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" admin-merge-gate'",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" semantic-search-nudge'",
+            "timeout": 3
           }
         ]
       }
@@ -128,6 +133,16 @@
             "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" warden-verdict-tracker'",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "search_code",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" semantic-search-tracker'",
+            "timeout": 3
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,6 +84,11 @@
           },
           {
             "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/format-check.sh\"'",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" semantic-search-nudge'",
             "timeout": 3
           }

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -657,6 +657,7 @@ def run_session_init(repo_root: Path) -> int:
         ".verified",
         ".admin-merge-approved",
         ".migration-nudged",
+        ".semantic-search-used",
     ):
         _marker(repo_root, name).unlink(missing_ok=True)
     _PATTERN_ROUTES_CACHE = None
@@ -1694,6 +1695,40 @@ def run_migration_nudge(event: dict[str, Any], repo_root: Path) -> int:
     return 0
 
 
+# Matches broad filesystem searches that bypass semantic search:
+# - grep -r / grep --recursive (with optional flags between grep and pattern)
+# - find <path> -name
+_BROAD_SEARCH_RE = re.compile(
+    r"\bgrep\b[^|;&\n]*?(?:-\w*r\w*|--recursive)\b"
+    r"|\bfind\b[^|;&\n]*?-name\b"
+)
+
+
+def run_semantic_search_nudge(event: dict[str, Any], repo_root: Path) -> int:
+    """Nudge toward search_code when grep -r / find -name is used without prior semantic search."""
+    tool_input = event.get("tool_input")
+    command = tool_input.get("command") if isinstance(tool_input, dict) else ""
+    if not isinstance(command, str) or not _BROAD_SEARCH_RE.search(command):
+        return 0
+    if _marker(repo_root, ".semantic-search-used").exists():
+        return 0
+    _warn_post_tool(
+        "[semantic-search-nudge] You're about to run a broad filesystem search. "
+        "Consider calling search_code first - describe what you're looking for in "
+        "plain language and let semantic search narrow the field. Then use grep/read "
+        "to confirm specifics. (Nudge only - the command will still run.)"
+    )
+    return 0
+
+
+def run_semantic_search_tracker(event: dict[str, Any], repo_root: Path) -> int:
+    """Record that search_code was called this session so the nudge stays quiet."""
+    marker = _marker(repo_root, ".semantic-search-used")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.touch()
+    return 0
+
+
 RUNNERS = {
     "session-init": lambda event, repo: run_session_init(repo),
     "plan-review-gate": run_plan_review_gate,
@@ -1715,6 +1750,8 @@ RUNNERS = {
     "migration-nudge": run_migration_nudge,
     "orchestrator-preflight": run_orchestrator_preflight,
     "warden-verdict-tracker": run_verdict_tracker,
+    "semantic-search-nudge": run_semantic_search_nudge,
+    "semantic-search-tracker": run_semantic_search_tracker,
 }
 
 


### PR DESCRIPTION
Closes LIA-60

## Summary

- **Rule** (`core-behavioral-rules.md`): new `## Code Exploration` section mandating `search_code` before `grep -r` / `find -name`
- **Nudge hook** (PreToolUse/Bash): detects broad searches; emits a `systemMessage` nudge without blocking when `search_code` has not been called yet
- **Tracker hook** (PostToolUse/`search_code`): sets `.semantic-search-used` marker so nudge goes quiet after first semantic search
- **Session reset**: `.semantic-search-used` cleared by `session-init` at each new session
- **Settings**: both hooks wired in `.claude/settings.json`

## Test plan
- [ ] Fresh session + `grep -r foo src/` -> nudge system message appears
- [ ] `search_code` call then `grep -r` -> nudge is silent
- [ ] New session -> marker cleared, nudge active again

 Generated with Claude Code