### PR TITLE
fix(rules): auto-invoke plan-reviewer after plan drafting

### DIFF
--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -13,6 +13,7 @@
 - Never execute without explicit user approval. Wait to be told.
 - Show commit message and wait for approval before committing.
 - Source edits require /plan mode + plan-reviewer SHIP for non-trivial changes. Trivial-bypass: touch marker with stated judgment.
+- After drafting a plan in /plan mode, immediately invoke plan-reviewer (`Agent(subagent_type="plan-reviewer")`) with the plan summary as the prompt — do not ask the user, do not call ExitPlanMode first. Trigger: when you would otherwise present the plan or ask to proceed. On non-Claude-Code backends, the PreToolUse gate is the backstop.
 - Never proceed while a review agent is running. Wait for its verdict.
 - REVISE from any warden means re-run after fixes until SHIP. Never touch markers, commit, or proceed on REVISE — no exceptions, no "close enough," no time-pressure rationalization.
 - Quality over speed by default. Never shortcut a warden loop, skip a review round, or rationalize lower standards because of time pressure, autonomy grants, or late-session fatigue. Only skip when the user explicitly says to prioritize speed.


### PR DESCRIPTION
## Summary
- Adds a behavioral rule to `core-behavioral-rules.md` that makes the model automatically invoke plan-reviewer after drafting a plan in /plan mode
- Addresses the gap where the model would ask "should I proceed?" instead of auto-invoking the warden — the gate hooks block without SHIP, but the model didn't know to invoke the reviewer proactively
- The new rule specifies the trigger ("when you would otherwise present the plan or ask to proceed"), the invocation syntax, and the cross-backend fallback

## Test plan
- [ ] Enter /plan mode, draft a non-trivial plan, verify the model auto-invokes plan-reviewer without asking
- [ ] Verify trivial bypass still works (model can still mark TRIVIAL with stated judgment)
- [ ] Verify the gate still blocks ExitPlanMode when no SHIP marker exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)