### PR TITLE
fix(linear): guard Scoped label to agent-readiness-gate

### DIFF
--- a/.claude/agents/wardens/agent-readiness-gate.md
+++ b/.claude/agents/wardens/agent-readiness-gate.md
@@ -3,7 +3,7 @@ name: agent-readiness-gate
 gate_to: "Ready for Agent"
 allowed_from: ["Todo"]
 mode: advise
-fallback: SHIP
+fallback: REVISE
 cooldown_minutes: 60
 model: sonnet
 effort: high

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T15:05:00" # auto-bump (pipeline-cli-db-init)
+last_verified: "2026-05-23T16:45:00" # auto-bump (scoped-label-guard)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T15:05:00" # auto-bump (pipeline-cli-db-init)
+last_verified: "2026-05-23T16:45:00" # auto-bump (scoped-label-guard)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -17,6 +17,7 @@ import {
   parseRatings,
   mergeEnrichment,
   stripEnrichmentSection,
+  computeScopeLabelChanges,
 } from './linear-webhook.js';
 
 beforeEach(() => {
@@ -380,5 +381,69 @@ bad: yaml: content: here
 
 Body.`);
     expect(result.data).toEqual({});
+  });
+});
+
+describe('computeScopeLabelChanges', () => {
+  const gateLabels = {
+    scoped: 'label-scoped-id',
+    revise: 'label-revise-id',
+    effort: {},
+    complexity: {},
+  };
+
+  it('adds scoped label on agent-readiness-gate SHIP with enrichment', () => {
+    const result = computeScopeLabelChanges(
+      'agent-readiness-gate',
+      'SHIP',
+      '## Scope\n\n**Problem**: fix the bug',
+      gateLabels,
+    );
+    expect(result.addIds).toEqual(['label-scoped-id']);
+    expect(result.removeIds).toEqual(['label-revise-id']);
+  });
+
+  it('no labels on agent-readiness-gate SHIP without enrichment', () => {
+    const result = computeScopeLabelChanges(
+      'agent-readiness-gate',
+      'SHIP',
+      undefined,
+      gateLabels,
+    );
+    expect(result.addIds).toEqual([]);
+    expect(result.removeIds).toEqual([]);
+  });
+
+  it('adds revise label on agent-readiness-gate REVISE', () => {
+    const result = computeScopeLabelChanges(
+      'agent-readiness-gate',
+      'REVISE',
+      undefined,
+      gateLabels,
+    );
+    expect(result.addIds).toEqual(['label-revise-id']);
+    expect(result.removeIds).toEqual(['label-scoped-id']);
+  });
+
+  it('no labels when verdict is undefined (crash path)', () => {
+    const result = computeScopeLabelChanges(
+      'agent-readiness-gate',
+      undefined,
+      undefined,
+      gateLabels,
+    );
+    expect(result.addIds).toEqual([]);
+    expect(result.removeIds).toEqual([]);
+  });
+
+  it('no labels for non-readiness gates even on SHIP with enrichment', () => {
+    const result = computeScopeLabelChanges(
+      'output-quality-gate',
+      'SHIP',
+      '## Scope\n\nsome enrichment',
+      gateLabels,
+    );
+    expect(result.addIds).toEqual([]);
+    expect(result.removeIds).toEqual([]);
   });
 });

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -3,7 +3,7 @@ import { LinearWebhookClient } from '@linear/sdk/webhooks';
 import type { EntityWebhookPayloadWithIssueData } from '@linear/sdk/webhooks';
 import { logger } from './logger.js';
 import { executeAgentRun } from './linear-dispatcher.js';
-import type { LinearContext } from './linear-dispatcher.js';
+import type { LinearContext, GateLabels } from './linear-dispatcher.js';
 import type { GateSpec } from './linear-gate-specs.js';
 import type { RunContext } from './agent-runtimes/types.js';
 import {
@@ -61,6 +61,25 @@ export function mergeEnrichment(
 
 export function stripEnrichmentSection(text: string): string {
   return text.replace(/^## Enrichment\s*\n[\s\S]*?(?=^## Verdict)/m, '').trim();
+}
+
+export function computeScopeLabelChanges(
+  gateName: string,
+  finalVerdict: string | undefined,
+  finalEnrichment: string | undefined,
+  gateLabels: GateLabels,
+): { addIds: string[]; removeIds: string[] } {
+  const addIds: string[] = [];
+  const removeIds: string[] = [];
+  if (gateName !== 'agent-readiness-gate') return { addIds, removeIds };
+  if (finalVerdict === 'SHIP' && finalEnrichment && gateLabels.scoped) {
+    addIds.push(gateLabels.scoped);
+    if (gateLabels.revise) removeIds.push(gateLabels.revise);
+  } else if (finalVerdict === 'REVISE' && gateLabels.revise) {
+    addIds.push(gateLabels.revise);
+    if (gateLabels.scoped) removeIds.push(gateLabels.scoped);
+  }
+  return { addIds, removeIds };
 }
 
 function escapeRegex(s: string): string {
@@ -436,13 +455,14 @@ async function handleIssueUpdate(
     const removeIds: string[] = [];
     const addIds: string[] = [];
     if (ctx.gateLabels.evaluating) removeIds.push(ctx.gateLabels.evaluating);
-    if (finalVerdict === 'SHIP' && ctx.gateLabels.scoped) {
-      addIds.push(ctx.gateLabels.scoped);
-      if (ctx.gateLabels.revise) removeIds.push(ctx.gateLabels.revise);
-    } else if (finalVerdict === 'REVISE' && ctx.gateLabels.revise) {
-      addIds.push(ctx.gateLabels.revise);
-      if (ctx.gateLabels.scoped) removeIds.push(ctx.gateLabels.scoped);
-    }
+    const scopeLabels = computeScopeLabelChanges(
+      gateSpec.name,
+      finalVerdict,
+      finalEnrichment,
+      ctx.gateLabels,
+    );
+    addIds.push(...scopeLabels.addIds);
+    removeIds.push(...scopeLabels.removeIds);
     // Apply effort/complexity labels only when ratings are actually present
     if (finalEnrichment) {
       const ratings = parseRatings(finalEnrichment);


### PR DESCRIPTION
## Summary
- **Bug**: "Scoped" label was applied on any gate SHIP verdict (including `output-quality-gate`, `completion-gate`, and fallback-SHIP from agent errors like 401 auth failures), causing unscoped issues to be dispatched to agents
- **Fix**: Extract `computeScopeLabelChanges()` pure function that only applies "Scoped" when `gateSpec.name === 'agent-readiness-gate'` AND `finalEnrichment` is present (real scope produced)
- **Fallback**: Change `agent-readiness-gate` fallback from SHIP to REVISE so errors don't silently promote issues

## Test plan
- [x] 5 new unit tests for `computeScopeLabelChanges` covering: SHIP+enrichment, SHIP without enrichment, REVISE, undefined verdict (crash), non-readiness gate
- [x] All 1109 existing tests pass
- [x] TypeScript compiles clean
- [ ] Manual: trigger gate error, verify "Scoped" is NOT applied
- [ ] Manual: trigger successful agent-readiness-gate, verify "Scoped" IS applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)