### PR TITLE
feat(pipeline): dashboard overhaul — adaptive width, glyphs, AI status, SLA coloring

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T16:45:00" # auto-bump (scoped-label-guard)
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T16:23:00" # auto-bump (pipeline-live-monitor)
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T16:45:00" # auto-bump (scoped-label-guard)
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T16:23:00" # auto-bump (pipeline-live-monitor)
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/db.ts
+++ b/src/db.ts
@@ -146,7 +146,8 @@ function createSchema(database: Database.Database): void {
       identifier TEXT NOT NULL,
       event_type TEXT NOT NULL,
       detail TEXT,
-      created_at TEXT NOT NULL
+      created_at TEXT NOT NULL,
+      status_summary TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_pipeline_events_issue
       ON linear_pipeline_events(issue_id);
@@ -166,6 +167,15 @@ function createSchema(database: Database.Database): void {
   try {
     database.exec(
       `ALTER TABLE scheduled_tasks ADD COLUMN context_mode TEXT DEFAULT 'isolated'`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Add status_summary column to pipeline events (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE linear_pipeline_events ADD COLUMN status_summary TEXT`,
     );
   } catch {
     /* column already exists */
@@ -1317,21 +1327,62 @@ export function logPipelineEvent(
   identifier: string,
   eventType: string,
   detail?: string,
+): number | undefined {
+  try {
+    const result = db
+      .prepare(
+        `INSERT INTO linear_pipeline_events (issue_id, identifier, event_type, detail, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        issueId,
+        identifier,
+        eventType,
+        detail ?? null,
+        new Date().toISOString(),
+      );
+    return Number(result.lastInsertRowid);
+  } catch (err) {
+    logger.debug({ issueId, eventType, err }, 'pipeline-event: insert failed');
+    return undefined;
+  }
+}
+
+export function updatePipelineEventStatusSummary(
+  rowId: number,
+  summary: string,
 ): void {
   try {
     db.prepare(
-      `INSERT INTO linear_pipeline_events (issue_id, identifier, event_type, detail, created_at)
-       VALUES (?, ?, ?, ?, ?)`,
-    ).run(
-      issueId,
-      identifier,
-      eventType,
-      detail ?? null,
-      new Date().toISOString(),
-    );
+      `UPDATE linear_pipeline_events SET status_summary = ? WHERE id = ?`,
+    ).run(summary, rowId);
   } catch (err) {
-    logger.debug({ issueId, eventType, err }, 'pipeline-event: insert failed');
+    logger.debug(
+      { rowId, err },
+      'pipeline-event: status summary update failed',
+    );
   }
+}
+
+export function getLatestStatusSummary(issueId: string): string | null {
+  const row = db
+    .prepare(
+      `SELECT status_summary FROM linear_pipeline_events
+       WHERE issue_id = ? AND status_summary IS NOT NULL
+       ORDER BY id DESC LIMIT 1`,
+    )
+    .get(issueId) as { status_summary: string } | undefined;
+  return row?.status_summary ?? null;
+}
+
+export function getReviseCount(issueId: string): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as cnt FROM linear_pipeline_events
+       WHERE issue_id = ? AND event_type = 'gate_revise'`,
+    )
+    .get(issueId) as { cnt: number };
+  return row.cnt;
 }
 
 export interface PipelineEventFilter {

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -9,11 +9,13 @@
 
 import { execFile } from 'child_process';
 import { logger } from './logger.js';
+import { fireAndForget } from './async/index.js';
 import {
   logPipelineEvent,
   getPipelineEvents,
   upsertPipelineComment,
   getPipelineCommentId,
+  updatePipelineEventStatusSummary,
 } from './db.js';
 import type { LinearContext } from './linear-dispatcher.js';
 
@@ -123,6 +125,51 @@ async function doUpdateUnifiedComment(
   }
 }
 
+const OLLAMA_URL =
+  process.env.OLLAMA_URL || 'http://localhost:11434/api/generate';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'gemma4:e4b';
+const STATUS_SUMMARY_TIMEOUT_MS = 5_000;
+const SKIP_SUMMARY_EVENTS = new Set(['gate_cooldown']);
+
+async function generateStatusSummary(
+  eventType: string,
+  identifier: string,
+  detail?: string,
+): Promise<string | null> {
+  if (SKIP_SUMMARY_EVENTS.has(eventType)) return null;
+
+  const label = EVENT_LABELS[eventType] || eventType;
+  const prompt = `Summarize in 10 words or fewer what is happening. Event: ${label}. Issue: ${identifier}. Detail: ${detail ?? 'none'}. Reply with ONLY the summary, no quotes.`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), STATUS_SUMMARY_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(OLLAMA_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: OLLAMA_MODEL,
+        prompt,
+        stream: false,
+        options: { temperature: 0.2, num_ctx: 512 },
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { response?: string };
+    return data.response?.trim() || null;
+  } catch (err) {
+    logger.debug(
+      { err, eventType },
+      'pipeline: status summary generation failed',
+    );
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function notifyPipelineStep(
   ctx: LinearContext,
   issueId: string,
@@ -130,10 +177,24 @@ export async function notifyPipelineStep(
   eventType: string,
   detail?: string,
 ): Promise<void> {
-  logPipelineEvent(issueId, identifier, eventType, detail);
+  const rowId = logPipelineEvent(issueId, identifier, eventType, detail);
 
   const label = EVENT_LABELS[eventType] || eventType;
   macosNotify('Deus', `${identifier}: ${label}`);
+
+  if (rowId !== undefined) {
+    fireAndForget(
+      async () => {
+        const summary = await generateStatusSummary(
+          eventType,
+          identifier,
+          detail,
+        );
+        if (summary) updatePipelineEventStatusSummary(rowId, summary);
+      },
+      { name: 'pipeline.status-summary' },
+    );
+  }
 
   await updateUnifiedComment(ctx, issueId);
 }

--- a/src/linear-pipeline-cli.test.ts
+++ b/src/linear-pipeline-cli.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseDuration, formatElapsed } from './linear-pipeline-cli.js';
+import {
+  parseDuration,
+  formatElapsed,
+  elapsedMs,
+  computeColumnWidths,
+} from './linear-pipeline-cli.js';
 
 describe('parseDuration', () => {
   it('parses minutes', () => {
@@ -58,5 +63,52 @@ describe('formatElapsed', () => {
   it('returns 0s for future timestamps', () => {
     const ts = new Date(Date.now() + 10_000).toISOString();
     expect(formatElapsed(ts)).toBe('0s');
+  });
+});
+
+describe('elapsedMs', () => {
+  it('returns positive ms for past timestamps', () => {
+    const ts = new Date(Date.now() - 5000).toISOString();
+    const ms = elapsedMs(ts);
+    expect(ms).toBeGreaterThanOrEqual(4900);
+    expect(ms).toBeLessThan(6000);
+  });
+
+  it('returns 0 for future timestamps', () => {
+    const ts = new Date(Date.now() + 10_000).toISOString();
+    expect(elapsedMs(ts)).toBe(0);
+  });
+
+  it('crosses 30m threshold', () => {
+    const ts = new Date(Date.now() - 31 * 60_000).toISOString();
+    expect(elapsedMs(ts)).toBeGreaterThan(1_800_000);
+  });
+
+  it('crosses 2h threshold', () => {
+    const ts = new Date(Date.now() - 121 * 60_000).toISOString();
+    expect(elapsedMs(ts)).toBeGreaterThan(7_200_000);
+  });
+});
+
+describe('computeColumnWidths', () => {
+  it('returns minimum title width for narrow terminals', () => {
+    const { titleWidth } = computeColumnWidths(60);
+    expect(titleWidth).toBe(24);
+  });
+
+  it('scales title width for wide terminals', () => {
+    const { titleWidth } = computeColumnWidths(120);
+    expect(titleWidth).toBe(64);
+  });
+
+  it('calculates separator width as cols - 2', () => {
+    const { separatorWidth } = computeColumnWidths(100);
+    expect(separatorWidth).toBe(98);
+  });
+
+  it('clamps to min 80 cols', () => {
+    const narrow = computeColumnWidths(40);
+    const min = computeColumnWidths(80);
+    expect(narrow.titleWidth).toBe(min.titleWidth);
   });
 });

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -9,6 +9,9 @@
 import { LinearClient } from '@linear/sdk';
 import {
   getPipelineEvents,
+  getIssuePr,
+  getLatestStatusSummary,
+  getReviseCount,
   initDatabase,
   type PipelineEventFilter,
 } from './db.js';
@@ -60,7 +63,12 @@ const TERMINAL_TYPES = new Set([
   'moved_done',
 ]);
 
-const PIPELINE_STATES = ['Ready for Agent', 'Agent Working', 'In Review'];
+const ACTIVE_STATES = ['Ready for Agent', 'Agent Working', 'In Review'];
+const QUEUED_STATES = ['Backlog', 'Todo'];
+const ALL_VISIBLE_STATES = [...QUEUED_STATES, ...ACTIVE_STATES];
+
+const STUCK_THRESHOLD_MS = 7_200_000; // 2h
+const WARN_THRESHOLD_MS = 1_800_000; // 30m
 
 function colorFor(eventType: string): string {
   if (SUCCESS_TYPES.has(eventType)) return GREEN;
@@ -70,11 +78,37 @@ function colorFor(eventType: string): string {
   return DIM;
 }
 
-function stateColor(stateName: string): string {
-  if (stateName === 'Ready for Agent') return YELLOW;
-  if (stateName === 'Agent Working') return CYAN;
-  if (stateName === 'In Review') return GREEN;
-  return DIM;
+function stateGlyph(stateName: string): { glyph: string; color: string } {
+  switch (stateName) {
+    case 'Backlog':
+      return { glyph: '·', color: DIM };
+    case 'Todo':
+      return { glyph: '○', color: DIM };
+    case 'Ready for Agent':
+      return { glyph: '◇', color: YELLOW };
+    case 'In Progress':
+      return { glyph: '●', color: YELLOW };
+    case 'Agent Working':
+      return { glyph: '▶', color: CYAN };
+    case 'In Review':
+      return { glyph: '◆', color: CYAN };
+    default:
+      return { glyph: '?', color: DIM };
+  }
+}
+
+export function elapsedMs(isoTimestamp: string): number {
+  return Math.max(0, Date.now() - new Date(isoTimestamp).getTime());
+}
+
+export function computeColumnWidths(cols: number): {
+  titleWidth: number;
+  separatorWidth: number;
+} {
+  const clamped = Math.max(80, cols);
+  // ID(8) + glyph(2) + PR(6) + status(24) + elapsed(6) + revise(4) + separators(6) = 56
+  const titleWidth = Math.max(20, clamped - 56);
+  return { titleWidth, separatorWidth: clamped - 2 };
 }
 
 export function parseDuration(input: string): string | null {
@@ -92,8 +126,7 @@ export function parseDuration(input: string): string | null {
 }
 
 export function formatElapsed(isoTimestamp: string): string {
-  const ms = Date.now() - new Date(isoTimestamp).getTime();
-  if (ms < 0) return '0s';
+  const ms = elapsedMs(isoTimestamp);
   const seconds = Math.floor(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
@@ -141,6 +174,16 @@ interface ActiveIssue {
   stateName: string;
   lastEvent: string;
   lastEventTime: string;
+  prNumber: string | null;
+  statusSummary: string | null;
+  reviseCount: number;
+}
+
+interface QueuedIssue {
+  identifier: string;
+  title: string;
+  stateName: string;
+  createdAt: string;
 }
 
 interface RecentIssue {
@@ -169,13 +212,18 @@ async function discoverTeamId(client: LinearClient): Promise<string> {
   return teams.nodes[0].id;
 }
 
-async function fetchActiveIssues(
+function extractPrNumber(prUrl: string): string | null {
+  const match = prUrl.match(/\/pull\/(\d+)/);
+  return match ? `#${match[1]}` : null;
+}
+
+async function fetchActiveAndQueued(
   client: LinearClient,
   teamId: string,
-): Promise<ActiveIssue[]> {
+): Promise<{ active: ActiveIssue[]; queued: QueuedIssue[] }> {
   const issues = await client.issues({
     filter: {
-      state: { name: { in: PIPELINE_STATES } },
+      state: { name: { in: ALL_VISIBLE_STATES } },
       team: { id: { eq: teamId } },
     },
   });
@@ -186,43 +234,58 @@ async function fetchActiveIssues(
     stateByIssueId.set(issue.id, states[i]?.name ?? 'Unknown');
   });
 
-  const lastEventByIssue = new Map<
-    string,
-    { event_type: string; created_at: string }
-  >();
-  for (const issue of issues.nodes) {
-    const events = getPipelineEvents({ issueId: issue.id });
-    if (events.length > 0) {
-      const last = events[events.length - 1];
-      lastEventByIssue.set(issue.id, {
-        event_type: last.event_type,
-        created_at: last.created_at,
-      });
-    }
-  }
+  const active: ActiveIssue[] = [];
+  const queued: QueuedIssue[] = [];
 
-  const result: ActiveIssue[] = issues.nodes.map((issue) => {
-    const lastEvent = lastEventByIssue.get(issue.id);
-    return {
+  for (const issue of issues.nodes) {
+    const stateName = stateByIssueId.get(issue.id) ?? 'Unknown';
+
+    if (QUEUED_STATES.includes(stateName)) {
+      queued.push({
+        identifier: issue.identifier,
+        title: issue.title,
+        stateName,
+        createdAt: issue.createdAt.toISOString(),
+      });
+      continue;
+    }
+
+    const events = getPipelineEvents({ issueId: issue.id });
+    const last = events.length > 0 ? events[events.length - 1] : null;
+    const revCount = events.filter(
+      (e) => e.event_type === 'gate_revise',
+    ).length;
+
+    const pr = getIssuePr(issue.id);
+    const prNumber = pr ? extractPrNumber(pr.pr_url) : null;
+    const statusSummary = getLatestStatusSummary(issue.id);
+
+    active.push({
       identifier: issue.identifier,
       title: issue.title,
-      stateName: stateByIssueId.get(issue.id) ?? 'Unknown',
-      lastEvent: lastEvent
-        ? EVENT_LABELS[lastEvent.event_type] || lastEvent.event_type
-        : '—',
-      lastEventTime: lastEvent?.created_at ?? issue.updatedAt.toISOString(),
-    };
-  });
+      stateName,
+      lastEvent: last ? EVENT_LABELS[last.event_type] || last.event_type : '—',
+      lastEventTime: last?.created_at ?? issue.updatedAt.toISOString(),
+      prNumber,
+      statusSummary,
+      reviseCount: revCount,
+    });
+  }
 
-  return result.sort((a, b) => {
+  active.sort((a, b) => {
     const stateOrder =
-      PIPELINE_STATES.indexOf(a.stateName) -
-      PIPELINE_STATES.indexOf(b.stateName);
+      ACTIVE_STATES.indexOf(a.stateName) - ACTIVE_STATES.indexOf(b.stateName);
     if (stateOrder !== 0) return stateOrder;
     return (
       new Date(b.lastEventTime).getTime() - new Date(a.lastEventTime).getTime()
     );
   });
+
+  queued.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return { active, queued };
 }
 
 function fetchRecentIssues(): RecentIssue[] {
@@ -268,16 +331,32 @@ function fetchRecentIssues(): RecentIssue[] {
 
 function renderDashboardOutput(
   active: ActiveIssue[],
+  queued: QueuedIssue[],
   recent: RecentIssue[],
   error?: string,
 ): string {
   const now = new Date().toLocaleTimeString('en-GB', { hour12: false });
+  const cols = process.stdout.columns || 100;
+  const { titleWidth, separatorWidth } = computeColumnWidths(cols);
   const lines: string[] = [];
 
+  const stuckCount = active.filter(
+    (i) => elapsedMs(i.lastEventTime) > STUCK_THRESHOLD_MS,
+  ).length;
+  const failCount = recent.filter((i) => FAILED_TYPES.has(i.eventType)).length;
+
+  const stuckLabel =
+    stuckCount > 0
+      ? `${YELLOW}STUCK ${stuckCount}${RESET}`
+      : `${DIM}STUCK 0${RESET}`;
+  const failLabel =
+    failCount > 0 ? `${RED}FAIL ${failCount}${RESET}` : `${DIM}FAIL 0${RESET}`;
+  const statsBar = `ACTIVE ${active.length} ${DIM}·${RESET} ${stuckLabel} ${DIM}·${RESET} ${failLabel}`;
+
   lines.push(
-    `${BOLD} Deus Pipeline${RESET}${DIM}${' '.repeat(40)}${now}  [every ${REFRESH_MS / 1000}s]${RESET}`,
+    `${BOLD} Deus Pipeline${RESET}    ${statsBar}${DIM}${' '.repeat(Math.max(1, cols - 70))}${now}  [every ${REFRESH_MS / 1000}s]${RESET}`,
   );
-  lines.push(`${DIM} ${'─'.repeat(74)}${RESET}`);
+  lines.push(`${DIM} ${'─'.repeat(separatorWidth)}${RESET}`);
 
   if (error) {
     lines.push(`${RED} ⚠ ${error}${RESET}`);
@@ -285,20 +364,52 @@ function renderDashboardOutput(
   }
 
   lines.push('');
-  lines.push(`${BOLD} ACTIVE${RESET} ${DIM}(${active.length})${RESET}`);
 
   if (active.length === 0) {
     lines.push(`${DIM}  No issues in pipeline.${RESET}`);
   } else {
     for (const issue of active) {
-      const id = issue.identifier.padEnd(10);
-      const title = truncate(issue.title, 34).padEnd(34);
-      const sc = stateColor(issue.stateName);
-      const state = issue.stateName.padEnd(16);
-      const evt = truncate(issue.lastEvent, 20).padEnd(20);
-      const elapsed = formatElapsed(issue.lastEventTime).padStart(4);
+      const id = issue.identifier.padEnd(8);
+      const sg = stateGlyph(issue.stateName);
+      const glyph = `${sg.color}${sg.glyph}${RESET}`;
+      const title = truncate(issue.title, titleWidth).padEnd(titleWidth);
+      const pr = issue.prNumber
+        ? `${DIM}${issue.prNumber.padStart(5)}${RESET}`
+        : `${DIM}${'—'.padStart(5)}${RESET}`;
+      const statusText = issue.statusSummary ?? issue.lastEvent;
+      const status = truncate(statusText, 22).padEnd(22);
+
+      const ms = elapsedMs(issue.lastEventTime);
+      const elapsedStr = formatElapsed(issue.lastEventTime).padStart(4);
+      let elapsedColored: string;
+      if (ms > STUCK_THRESHOLD_MS) {
+        elapsedColored = `${RED}${elapsedStr} !!${RESET}`;
+      } else if (ms > WARN_THRESHOLD_MS) {
+        elapsedColored = `${YELLOW}${elapsedStr}${RESET}`;
+      } else {
+        elapsedColored = `${DIM}${elapsedStr}${RESET}`;
+      }
+
+      const revise =
+        issue.reviseCount > 0 ? ` ${RED}×${issue.reviseCount}${RESET}` : '';
+
       lines.push(
-        `  ${CYAN}${id}${RESET} ${title} ${sc}${state}${RESET} ${DIM}${evt}${RESET} ${DIM}${elapsed}${RESET}`,
+        `  ${CYAN}${id}${RESET}${glyph} ${title} ${pr} ${DIM}${status}${RESET} ${elapsedColored}${revise}`,
+      );
+    }
+  }
+
+  if (queued.length > 0) {
+    lines.push('');
+    lines.push(`${DIM} QUEUED (${queued.length})${RESET}`);
+    for (const issue of queued) {
+      const id = issue.identifier.padEnd(8);
+      const sg = stateGlyph(issue.stateName);
+      const glyph = `${sg.color}${sg.glyph}${RESET}`;
+      const title = truncate(issue.title, titleWidth).padEnd(titleWidth);
+      const elapsed = formatElapsed(issue.createdAt).padStart(4);
+      lines.push(
+        `${DIM}  ${id}${RESET}${glyph} ${DIM}${title} ${' '.repeat(28)} ${elapsed}${RESET}`,
       );
     }
   }
@@ -307,13 +418,13 @@ function renderDashboardOutput(
     lines.push('');
     lines.push(`${DIM} RECENT (${recent.length})${RESET}`);
     for (const issue of recent) {
-      const id = issue.identifier.padEnd(10);
+      const id = issue.identifier.padEnd(8);
       const evtColor = FAILED_TYPES.has(issue.eventType) ? RED : GREEN;
-      const evt = truncate(issue.lastEvent, 20).padEnd(20);
-      const detail = issue.detail ? truncate(issue.detail, 28) : '';
+      const evt = truncate(issue.lastEvent, 22).padEnd(22);
+      const detail = issue.detail ? truncate(issue.detail, titleWidth) : '';
       const elapsed = formatElapsed(issue.lastEventTime).padStart(4);
       lines.push(
-        `${DIM}  ${id} ${' '.repeat(34)} ${evtColor}${evt}${DIM} ${detail.padEnd(28)} ${elapsed}${RESET}`,
+        `${DIM}  ${id} ${' '.repeat(2)}${evtColor}${evt}${DIM} ${detail.padEnd(titleWidth)} ${elapsed}${RESET}`,
       );
     }
   }
@@ -376,15 +487,15 @@ async function startWatchMode(): Promise<void> {
     if (rendering) return;
     rendering = true;
     try {
-      const active = await fetchActiveIssues(client, teamId);
+      const { active, queued } = await fetchActiveAndQueued(client, teamId);
       const recent = fetchRecentIssues();
       lastError = undefined;
-      const output = renderDashboardOutput(active, recent);
+      const output = renderDashboardOutput(active, queued, recent);
       process.stdout.write(CLEAR_SCREEN + output + '\n');
     } catch (err) {
       lastError = err instanceof Error ? err.message : 'Unknown error';
       const recent = fetchRecentIssues();
-      const output = renderDashboardOutput([], recent, lastError);
+      const output = renderDashboardOutput([], [], recent, lastError);
       process.stdout.write(CLEAR_SCREEN + output + '\n');
     } finally {
       rendering = false;


### PR DESCRIPTION
## Summary

- **Adaptive title width**: titles now fill available terminal width instead of hard-capped 34 chars
- **Unicode state glyphs**: `○` `◇` `▶` `◆` replace 16-char state names, freeing horizontal space
- **PR number column**: shows `#501` from `linear_issue_prs` table for each active issue
- **AI-generated status summaries**: Ollama generates ~10-word status on each pipeline event via `fireAndForget`, cached in SQLite `status_summary` column; falls back to EVENT_LABELS if Ollama unavailable
- **Stuck-issue SLA coloring**: elapsed turns yellow >30m, red with `!!` marker >2h
- **Revise loop counter**: `×N` badge when an issue has multiple gate_revise events
- **Header aggregate stats**: `ACTIVE N · STUCK N · FAIL N` at a glance
- **QUEUED section**: Todo/Backlog issues now visible (single API call, split in code)
- **Color fix**: "In Review" changed from green (success) to cyan (in-flight)

## Files Changed

| File | Change |
|------|--------|
| `src/db.ts` | `status_summary` column, migration, `logPipelineEvent` returns rowId, 3 new accessors |
| `src/linear-notifications.ts` | `generateStatusSummary()` + `fireAndForget` hook in `notifyPipelineStep` |
| `src/linear-pipeline-cli.ts` | Full rendering overhaul: `fetchActiveAndQueued`, `stateGlyph`, `computeColumnWidths`, `elapsedMs`, new `renderDashboardOutput` |
| `src/linear-pipeline-cli.test.ts` | 8 new tests for `elapsedMs` and `computeColumnWidths` |

## Test plan

- [x] `npx vitest run src/linear-pipeline-cli.test.ts` — 17/17 pass
- [x] `npx vitest run src/linear-notifications.test.ts` — 3/3 pass
- [x] `tsc --noEmit` — no new errors in changed files
- [ ] `deus pipeline` — verify live dashboard renders with new layout
- [ ] Resize terminal — title column adapts via SIGWINCH
- [ ] Verify Ollama-down graceful degradation (shows EVENT_LABELS fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)