### PR TITLE
feat(linear): bidirectional vault-Linear pending sync

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -121,15 +121,28 @@ After saving the session log:
         - Trim to the 3 most recent entries (drop the oldest).
         - Replace the entire `previous:` block with the updated list.
         - If `previous:` doesn't exist yet, add it before `pending:`.
-      - **Merge** pending tasks (never replace):
+      - **Sync pending tasks from Linear** (preferred) or merge from session log (fallback):
+
+        **Linear sync path** (use when `mcp__linear__linear_getIssues` tool is available):
+        1. Call `mcp__linear__linear_getIssues` with `limit: 50`.
+        2. For each issue: extract identifier from the `url` field (regex `/issue\/([A-Z]+-\d+)\//`), title, and state name.
+        3. Filter out issues where state is `Done`, `Canceled`, or `Duplicate`.
+        4. Sort by state priority: In Progress > In Review > Agent Working > Ready for Agent > Todo > Backlog. Within each group, sort by identifier number ascending.
+        5. Format each as `  - [ ] <title> (<identifier>)`. Truncate titles longer than 80 chars.
+        6. Prepend the comment line `  # Source of truth: Linear. Synced by /compress.`
+        7. **Replace** the entire `pending:` block with the Linear-sourced list. Do not merge with session log items -- Linear IS the source of truth.
+        8. If any `[x]` items from the session log reference a Linear identifier that is still in the active list, log a note but do NOT remove it -- the issue's state in Linear is authoritative.
+
+        **Fallback merge path** (use when Linear MCP tools are NOT available):
         1. Read the current `pending:` block from CLAUDE.md. If missing, treat as empty list.
         2. Remove completed items: for each `[x]` from the session log, find its match in the pending list:
            - **Match on core identifiers** (file names, feature names, PR numbers, tool names), ignoring parenthetical annotations like `(closed: ...)`, `(done)`, `(PR #N)` and minor wording differences.
-           - **Compound items** (`A + B`): if a pending item has sub-tasks joined by ` + `, match each part independently. All parts matched → remove whole item. Some parts matched → rewrite to keep only unmatched parts. Example: pending `Refactor auth + update docs` with `[x] Refactor auth (done)` → rewrite to `update docs`.
-           - **Dedup pass**: after removals, check each remaining `[ ]` item — if it is semantically covered by any `[x]` (same feature/identifier, different wording), remove it.
+           - **Compound items** (`A + B`): if a pending item has sub-tasks joined by ` + `, match each part independently. All parts matched -> remove whole item. Some parts matched -> rewrite to keep only unmatched parts.
+           - **Dedup pass**: after removals, check each remaining `[ ]` item -- if it is semantically covered by any `[x]` (same feature/identifier, different wording), remove it.
         3. Add any new `[ ]` items from the session log that don't already exist in the pending list and aren't already covered by a `[x]` from this session (avoid duplicates).
-        4. No hard item cap on `pending:`. Total file size is the governor: if `pending:` growth pushes CLAUDE.md over the 75-line check in step (d) below, the oldest non-critical items are archived per (d). Do NOT drop a live `[ ]` solely to hit a count limit — existing removal rules in steps 2-3 (completion matching, dedup) are the only mechanisms that should retire `[ ]` items.
-        5. Write the merged list back to `pending:`.
+        4. Write the merged list back to `pending:`.
+
+        No hard item cap on `pending:`. Total file size is the governor: if `pending:` growth pushes CLAUDE.md over the 75-line check in step (d) below, the oldest non-critical items are archived per (d). Do NOT drop a live `[ ]` solely to hit a count limit.
 
    d. After writing, count total lines in CLAUDE.md. If > 75 lines: read the `critical:` list from the CLAUDE.md frontmatter — that is the authoritative set of protected keys. Identify the oldest non-critical content block (any line whose `key:` prefix is NOT in the `critical:` list) and move it to `$VAULT/CLAUDE-Archive.md` with a date header. Never archive lines whose key appears in `critical:`. If no `critical:` block exists in the frontmatter, fall back to refusing to archive and log a warning — missing schema is safer than guessing. When in doubt, prefer NOT archiving — a 5-line overshoot is fine; losing a load-bearing rule is not.
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ deus pipeline --failed --since 24h   # Failures in the last 24 hours
 deus pipeline --active               # One-shot active view
 ```
 
+### Vault sync
+
+Linear is the source of truth for pending tasks. The vault's `CLAUDE.md` `pending:` block stays in sync automatically:
+
+- **Webhook push**: when issues change in Linear, the webhook handler updates the vault file within ~2 seconds (debounced).
+- **Session-start pull**: a `SessionStart` hook queries Linear on every new Claude Code session, ensuring freshness at the moment it matters most.
+- **`/compress` sync**: the `/compress` skill pulls the full active issue list from Linear and rebuilds the pending block.
+
 ### Adding or customizing gates
 
 Gates are plain markdown files in `.claude/agents/wardens/`. Adding a gate is one file with YAML frontmatter -- no code change:

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T15:30:00" # auto-bump (linear-vault-sync)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T15:30:00" # auto-bump (linear-vault-sync)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T15:38:00" # auto-bump (linear-vault-sync)
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/linear_vault_sync.py
+++ b/scripts/linear_vault_sync.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""SessionStart hook: sync vault CLAUDE.md pending block from Linear.
+
+Queries the Linear GraphQL API for active issues and rebuilds the pending:
+block in CLAUDE.md. Uses the same sentinel/block-replace pattern as the
+TypeScript webhook-driven sync in src/linear-vault-sync.ts.
+
+Config resolution: ~/.config/deus/config.json (vault_path, LINEAR_TEAM_ID)
+Token resolution: DEUS_HOME/.env -> LINEAR_API_TOKEN env var
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+LINEAR_API_URL = "https://linear.app/api/graphql"
+
+STATE_PRIORITY = {
+    "In Progress": 0,
+    "In Review": 1,
+    "Agent Working": 2,
+    "Ready for Agent": 3,
+    "Todo": 4,
+    "Backlog": 5,
+}
+
+EXCLUDED_STATES = {"Done", "Canceled", "Duplicate"}
+
+
+def _load_config() -> dict:
+    cfg_path = Path.home() / ".config" / "deus" / "config.json"
+    try:
+        return json.loads(cfg_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _vault_path(config: dict) -> Path | None:
+    env = os.environ.get("DEUS_VAULT_PATH")
+    if env:
+        return Path(env).expanduser()
+    vp = config.get("vault_path", "")
+    if vp:
+        return Path(vp).expanduser()
+    return None
+
+
+def _read_env_file() -> dict[str, str]:
+    """Read .env from DEUS_HOME or project dir."""
+    candidates = []
+    deus_home = os.environ.get("DEUS_HOME")
+    if deus_home:
+        candidates.append(Path(deus_home) / ".env")
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if project_dir:
+        candidates.append(Path(project_dir) / ".env")
+    candidates.append(Path(__file__).resolve().parent.parent / ".env")
+
+    env_vars: dict[str, str] = {}
+    for candidate in candidates:
+        try:
+            for line in candidate.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    key, _, val = line.partition("=")
+                    env_vars[key.strip()] = val.strip().strip("\"'")
+        except OSError:
+            continue
+    return env_vars
+
+
+def _get_api_token(config: dict) -> str | None:
+    token = os.environ.get("LINEAR_API_TOKEN") or os.environ.get("LINEAR_API_KEY")
+    if token:
+        return token
+    env_file = _read_env_file()
+    return env_file.get("LINEAR_API_TOKEN") or env_file.get("LINEAR_API_KEY")
+
+
+def _get_team_id(config: dict) -> str | None:
+    tid = os.environ.get("LINEAR_TEAM_ID")
+    if tid:
+        return tid
+    env_file = _read_env_file()
+    return env_file.get("LINEAR_TEAM_ID")
+
+
+def _graphql(token: str, query: str, variables: dict | None = None) -> dict:
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = Request(
+        LINEAR_API_URL,
+        data=payload,
+        headers={
+            "Authorization": token,
+            "Content-Type": "application/json",
+        },
+    )
+    with urlopen(req, timeout=8) as resp:
+        return json.loads(resp.read())
+
+
+def _discover_team_id(token: str) -> str | None:
+    result = _graphql(token, "{ teams { nodes { id name } } }")
+    nodes = result.get("data", {}).get("teams", {}).get("nodes", [])
+    if not nodes:
+        return None
+    if len(nodes) > 1:
+        print(f"linear_vault_sync: {len(nodes)} teams found, using first", file=sys.stderr)
+    return nodes[0]["id"]
+
+
+def _fetch_issues(token: str, team_id: str) -> list[dict]:
+    query = """
+    query($teamId: String!) {
+      issues(
+        filter: {
+          team: { id: { eq: $teamId } }
+          state: { type: { nin: ["completed", "canceled"] } }
+        }
+        first: 50
+      ) {
+        nodes {
+          title
+          identifier
+          url
+          state { name type }
+        }
+      }
+    }
+    """
+    result = _graphql(token, query, {"teamId": team_id})
+    nodes = result.get("data", {}).get("issues", {}).get("nodes", [])
+    return [
+        n for n in nodes
+        if n.get("state", {}).get("name") not in EXCLUDED_STATES
+    ]
+
+
+def _build_pending_block(issues: list[dict]) -> str:
+    issues.sort(key=lambda i: (
+        STATE_PRIORITY.get(i.get("state", {}).get("name", ""), 99),
+        int(re.sub(r"\D", "", i.get("identifier", "0")) or "0"),
+    ))
+    lines = ["pending:", "  # Source of truth: Linear. Synced by /compress."]
+    for issue in issues:
+        title = issue.get("title", "")
+        if len(title) > 80:
+            title = title[:77] + "..."
+        identifier = issue.get("identifier", "")
+        lines.append(f"  - [ ] {title} ({identifier})")
+    return "\n".join(lines)
+
+
+PENDING_RE = re.compile(r"^pending:\s*\n((?:[ \t]+[^\n]*\n?)*)", re.MULTILINE)
+
+
+def _sync(vault: Path, token: str, team_id: str) -> None:
+    claude_md = vault / "CLAUDE.md"
+    if not claude_md.exists():
+        return
+
+    issues = _fetch_issues(token, team_id)
+    new_block = _build_pending_block(issues)
+
+    content = claude_md.read_text(encoding="utf-8")
+    if PENDING_RE.search(content):
+        new_content = PENDING_RE.sub(lambda _: new_block + "\n", content)
+    else:
+        new_content = content + "\n" + new_block + "\n"
+
+    if new_content == content:
+        return
+
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(vault), prefix=".CLAUDE.md.")
+    try:
+        os.write(tmp_fd, new_content.encode("utf-8"))
+        os.close(tmp_fd)
+        os.replace(tmp_path, str(claude_md))
+    except Exception:
+        os.close(tmp_fd)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> None:
+    config = _load_config()
+    vault = _vault_path(config)
+    if not vault or not vault.exists():
+        return
+
+    token = _get_api_token(config)
+    if not token:
+        return
+
+    team_id = _get_team_id(config)
+    if not team_id:
+        team_id = _discover_team_id(token)
+    if not team_id:
+        return
+
+    try:
+        _sync(vault, token, team_id)
+    except (URLError, OSError, json.JSONDecodeError) as e:
+        print(f"linear_vault_sync: {type(e).__name__}: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -76,6 +76,7 @@ function makeMockCtx(overrides: Partial<LinearContext> = {}): LinearContext {
     inFlightGate: new Set(),
     gateLabels: { effort: {}, complexity: {} },
     teamId: 'team-id',
+    vaultPath: null,
     ...overrides,
   };
 }

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -10,6 +10,7 @@ import { fireAndForget } from './async/index.js';
 import { extractPrUrl } from './pr-url-extractor.js';
 import { upsertIssuePr } from './db.js';
 import { notifyPipelineStep } from './linear-notifications.js';
+import { resolveVaultPath } from './solutions/store.js';
 import { defaultSession } from './agent-runtimes/types.js';
 import type {
   RunContext,
@@ -65,6 +66,7 @@ export interface LinearContext {
   gateLabels: GateLabels;
   teamId: string;
   repoSlug?: string;
+  vaultPath: string | null;
 }
 
 let _timer: ReturnType<typeof setInterval> | null = null;
@@ -621,6 +623,7 @@ export async function initLinearContext(
       gateLabels,
       teamId,
       repoSlug,
+      vaultPath: resolveVaultPath(),
     };
   } catch (err) {
     if (err instanceof FatalError) {

--- a/src/linear-vault-sync.test.ts
+++ b/src/linear-vault-sync.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { syncVaultPending, fetchActiveIssues } from './linear-vault-sync.js';
+
+function mockLinearClient(
+  issues: Array<{
+    title: string;
+    identifier: string;
+    url: string;
+    stateName: string;
+    stateType: string;
+  }>,
+) {
+  // Only .issues() is exercised; full LinearClient has ~40 methods
+  return {
+    issues: vi.fn().mockResolvedValue({
+      nodes: issues.map((i) => ({
+        title: i.title,
+        identifier: i.identifier,
+        url: i.url,
+        state: Promise.resolve({ name: i.stateName, type: i.stateType }),
+      })),
+    }),
+  } as any;
+}
+
+describe('fetchActiveIssues', () => {
+  it('filters out completed and canceled issues', async () => {
+    const client = mockLinearClient([
+      {
+        title: 'Active',
+        identifier: 'LIA-1',
+        url: 'https://linear.app/t/issue/LIA-1/',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+      {
+        title: 'Done',
+        identifier: 'LIA-2',
+        url: 'https://linear.app/t/issue/LIA-2/',
+        stateName: 'Done',
+        stateType: 'completed',
+      },
+      {
+        title: 'Canceled',
+        identifier: 'LIA-3',
+        url: 'https://linear.app/t/issue/LIA-3/',
+        stateName: 'Canceled',
+        stateType: 'canceled',
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].identifier).toBe('LIA-1');
+  });
+
+  it('filters out Duplicate state', async () => {
+    const client = mockLinearClient([
+      {
+        title: 'Dup',
+        identifier: 'LIA-4',
+        url: 'https://linear.app/t/issue/LIA-4/',
+        stateName: 'Duplicate',
+        stateType: 'canceled',
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result).toHaveLength(0);
+  });
+
+  it('sorts by state priority then identifier number', async () => {
+    const client = mockLinearClient([
+      {
+        title: 'Backlog item',
+        identifier: 'LIA-10',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+      },
+      {
+        title: 'In progress',
+        identifier: 'LIA-5',
+        url: '',
+        stateName: 'In Progress',
+        stateType: 'started',
+      },
+      {
+        title: 'Todo second',
+        identifier: 'LIA-8',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+      {
+        title: 'Todo first',
+        identifier: 'LIA-3',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result.map((i) => i.identifier)).toEqual([
+      'LIA-5',
+      'LIA-3',
+      'LIA-8',
+      'LIA-10',
+    ]);
+  });
+});
+
+describe('syncVaultPending', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vault-sync-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('replaces existing pending block', async () => {
+    const claudeMd = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(
+      claudeMd,
+      [
+        '---',
+        'name: Test',
+        '---',
+        'name: Test',
+        'pending:',
+        '  - [ ] Old task (LIA-99)',
+        'index:',
+        '  infra: INFRA.md',
+      ].join('\n'),
+    );
+
+    const client = mockLinearClient([
+      {
+        title: 'New task',
+        identifier: 'LIA-1',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+    ]);
+
+    await syncVaultPending(client, 'team-1', tmpDir);
+
+    const result = fs.readFileSync(claudeMd, 'utf-8');
+    expect(result).toContain('New task (LIA-1)');
+    expect(result).not.toContain('Old task (LIA-99)');
+    expect(result).toContain('index:');
+    expect(result).toContain('Source of truth: Linear');
+  });
+
+  it('appends pending block when none exists', async () => {
+    const claudeMd = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(claudeMd, '---\nname: Test\n---\nname: Test\n');
+
+    const client = mockLinearClient([
+      {
+        title: 'First task',
+        identifier: 'LIA-1',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+    ]);
+
+    await syncVaultPending(client, 'team-1', tmpDir);
+
+    const result = fs.readFileSync(claudeMd, 'utf-8');
+    expect(result).toContain('pending:');
+    expect(result).toContain('First task (LIA-1)');
+  });
+
+  it('truncates long titles', async () => {
+    const claudeMd = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(claudeMd, '---\nname: Test\n---\npending:\n  - [ ] old\n');
+
+    const longTitle = 'A'.repeat(100);
+    const client = mockLinearClient([
+      {
+        title: longTitle,
+        identifier: 'LIA-1',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+    ]);
+
+    await syncVaultPending(client, 'team-1', tmpDir);
+
+    const result = fs.readFileSync(claudeMd, 'utf-8');
+    const line = result.split('\n').find((l: string) => l.includes('LIA-1'))!;
+    expect(line.length).toBeLessThan(120);
+    expect(line).toContain('...');
+  });
+
+  it('skips write when content unchanged', async () => {
+    const claudeMd = path.join(tmpDir, 'CLAUDE.md');
+    const content =
+      'pending:\n  # Source of truth: Linear. Synced by /compress.\n  - [ ] Task (LIA-1)\n';
+    fs.writeFileSync(claudeMd, content);
+    const mtime = fs.statSync(claudeMd).mtimeMs;
+
+    const client = mockLinearClient([
+      {
+        title: 'Task',
+        identifier: 'LIA-1',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+    ]);
+
+    await syncVaultPending(client, 'team-1', tmpDir);
+
+    const newMtime = fs.statSync(claudeMd).mtimeMs;
+    expect(newMtime).toBe(mtime);
+  });
+});

--- a/src/linear-vault-sync.ts
+++ b/src/linear-vault-sync.ts
@@ -1,0 +1,114 @@
+import fs from 'fs/promises';
+import { existsSync, renameSync } from 'fs';
+import path from 'path';
+import { LinearClient } from '@linear/sdk';
+import { logger } from './logger.js';
+
+const STATE_PRIORITY: Record<string, number> = {
+  'In Progress': 0,
+  'In Review': 1,
+  'Agent Working': 2,
+  'Ready for Agent': 3,
+  Todo: 4,
+  Backlog: 5,
+};
+
+const EXCLUDED_STATE_TYPES = new Set(['completed', 'canceled']);
+
+interface LinearIssueNode {
+  title: string;
+  identifier: string;
+  url: string;
+  state: { name: string; type: string };
+}
+
+export async function fetchActiveIssues(
+  client: LinearClient,
+  teamId: string,
+): Promise<LinearIssueNode[]> {
+  const result = await client.issues({
+    filter: {
+      state: { type: { nin: ['completed', 'canceled'] } },
+      team: { id: { eq: teamId } },
+    },
+    first: 50,
+  });
+
+  const issues: LinearIssueNode[] = [];
+  const stateRelations = result.nodes.map((n) => n.state);
+  const states = await Promise.all(stateRelations);
+
+  for (let i = 0; i < result.nodes.length; i++) {
+    const node = result.nodes[i];
+    const state = states[i];
+    if (!state || EXCLUDED_STATE_TYPES.has(state.type)) continue;
+    if (state.name === 'Duplicate') continue;
+    issues.push({
+      title: node.title,
+      identifier: node.identifier,
+      url: node.url,
+      state: { name: state.name, type: state.type },
+    });
+  }
+
+  issues.sort((a, b) => {
+    const pa = STATE_PRIORITY[a.state.name] ?? 99;
+    const pb = STATE_PRIORITY[b.state.name] ?? 99;
+    if (pa !== pb) return pa - pb;
+    const na = parseInt(a.identifier.replace(/\D/g, ''), 10) || 0;
+    const nb = parseInt(b.identifier.replace(/\D/g, ''), 10) || 0;
+    return na - nb;
+  });
+
+  return issues;
+}
+
+function buildPendingBlock(issues: LinearIssueNode[]): string {
+  const lines = [
+    'pending:',
+    '  # Source of truth: Linear. Synced by /compress.',
+  ];
+  for (const issue of issues) {
+    const title =
+      issue.title.length > 80 ? issue.title.slice(0, 77) + '...' : issue.title;
+    lines.push(`  - [ ] ${title} (${issue.identifier})`);
+  }
+  return lines.join('\n');
+}
+
+const PENDING_BLOCK_RE = /^pending:\s*\n((?:[ \t]+[^\n]*\n?)*)/m;
+
+export async function syncVaultPending(
+  client: LinearClient,
+  teamId: string,
+  vaultPath: string,
+): Promise<void> {
+  const claudeMdPath = path.join(vaultPath, 'CLAUDE.md');
+  if (!existsSync(claudeMdPath)) {
+    logger.warn({ path: claudeMdPath }, 'vault-sync: CLAUDE.md not found');
+    return;
+  }
+
+  const issues = await fetchActiveIssues(client, teamId);
+  const newBlock = buildPendingBlock(issues);
+
+  const content = await fs.readFile(claudeMdPath, 'utf-8');
+
+  let newContent: string;
+  if (PENDING_BLOCK_RE.test(content)) {
+    newContent = content.replace(PENDING_BLOCK_RE, () => newBlock + '\n');
+  } else {
+    newContent = content + '\n' + newBlock + '\n';
+  }
+
+  if (newContent === content) return;
+
+  const tmpPath = claudeMdPath + '.tmp';
+  await fs.writeFile(tmpPath, newContent, 'utf-8');
+  renameSync(tmpPath, claudeMdPath);
+
+  logger.info(
+    { issueCount: issues.length },
+    'vault-sync: updated pending block',
+  );
+}

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -15,8 +15,23 @@ import {
 } from './db.js';
 import { triggerAutoMerge } from './linear-auto-merge.js';
 import { macosNotify, notifyPipelineStep } from './linear-notifications.js';
+import { syncVaultPending } from './linear-vault-sync.js';
 
 const DEFAULT_WEBHOOK_PORT = 3005;
+
+let _syncTimer: ReturnType<typeof setTimeout> | null = null;
+
+function debouncedVaultSync(ctx: LinearContext, vaultPath: string): void {
+  if (_syncTimer) clearTimeout(_syncTimer);
+  _syncTimer = setTimeout(async () => {
+    _syncTimer = null;
+    try {
+      await syncVaultPending(ctx.client, ctx.teamId, vaultPath);
+    } catch (err) {
+      logger.debug({ err }, 'vault-sync: failed to sync pending block');
+    }
+  }, 2000);
+}
 
 export function parseVerdict(
   output: string,
@@ -526,10 +541,13 @@ export function startLinearWebhookServer(
   const webhookClient = new LinearWebhookClient(secret);
   const handler = webhookClient.createHandler();
 
-  // handler.on('Issue') provides typed payload but needs narrowing to the issue-specific union member
   handler.on('Issue', (payload) => {
+    if (ctx.vaultPath) {
+      debouncedVaultSync(ctx, ctx.vaultPath);
+    }
+
     handleIssueUpdate(
-      payload as EntityWebhookPayloadWithIssueData,
+      payload as EntityWebhookPayloadWithIssueData, // SDK union needs narrowing to issue-specific payload
       ctx,
       gateSpecs,
     ).catch((err) => {


### PR DESCRIPTION
## Summary
- Adds `src/linear-vault-sync.ts` with shared `syncVaultPending` function that queries Linear for active issues and atomically rewrites the vault CLAUDE.md `pending:` block
- Wires debounced (2s) vault sync into the webhook `handler.on('Issue')` closure -- fires on create/update/remove, upstream of the gate evaluation filter
- Adds `scripts/linear_vault_sync.py` SessionStart hook that pulls fresh Linear state via raw GraphQL on every new Claude Code session
- Updates `/compress` skill to use generic identifier regex instead of team-specific prefix
- Adds `vaultPath: string | null` to `LinearContext`, populated via `resolveVaultPath()`

Closes LIA-78

## Test plan
- [x] `npm run build` compiles cleanly
- [x] 7 new unit tests in `linear-vault-sync.test.ts` (filter, sort, replace, append, truncate, no-op)
- [x] 9 existing tests in `linear-dispatcher.test.ts` pass (mock includes `vaultPath`)
- [x] All drift checks pass
- [ ] Start a new CC session to verify SessionStart hook fires
- [ ] Create/update/complete an issue in Linear UI to verify webhook-driven sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)