### PR TITLE
fix(linear): re-dispatch agent on CI failure instead of Backlog

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T15:30:00" # auto-bump (linear-vault-sync)
+last_verified: "2026-05-23T15:50:00" # auto-bump (ci-fail-redispatch)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T15:30:00" # auto-bump (linear-vault-sync)
+last_verified: "2026-05-23T15:50:00" # auto-bump (ci-fail-redispatch)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -235,7 +235,11 @@ export async function attemptAutoMerge(
   });
   const readyState = ctx.stateByName.get('Ready for Agent');
   if (readyState) {
-    await ctx.client.updateIssue(issueId, { stateId: readyState.id });
+    // priority 1 = urgent; ensures CI-fix re-dispatch runs before new work
+    await ctx.client.updateIssue(issueId, {
+      stateId: readyState.id,
+      priority: 1,
+    });
   }
   logger.warn(
     { issueId, prUrl },

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -220,7 +220,7 @@ export async function attemptAutoMerge(
     return;
   }
 
-  // CI failed
+  // CI failed — re-dispatch the agent to fix it
   updatePrAutoMergeState(issueId, 'failed');
   notifyPipelineStep(
     ctx,
@@ -231,13 +231,16 @@ export async function attemptAutoMerge(
   ).catch(() => {});
   await ctx.client.createComment({
     issueId,
-    body: `**Auto-merge blocked** - CI failed: ${checks.summary}\n\nPR: ${prUrl}`,
+    body: `**Auto-merge blocked** - CI failed: ${checks.summary}\n\nPR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
   });
-  const backlogState = ctx.stateByName.get('Backlog');
-  if (backlogState) {
-    await ctx.client.updateIssue(issueId, { stateId: backlogState.id });
+  const readyState = ctx.stateByName.get('Ready for Agent');
+  if (readyState) {
+    await ctx.client.updateIssue(issueId, { stateId: readyState.id });
   }
-  logger.warn({ issueId, prUrl }, 'auto-merge: CI failed, moved to Backlog');
+  logger.warn(
+    { issueId, prUrl },
+    'auto-merge: CI failed, moved to Ready for Agent',
+  );
 }
 
 export async function sweepPendingAutoMerges(

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -370,7 +370,13 @@ async function pollLinear(): Promise<void> {
     filter: { state: { id: { eq: readyState.id } } },
   });
 
-  const sorted = [...issues.nodes].sort((a, b) => a.sortOrder - b.sortOrder);
+  const sorted = [...issues.nodes].sort((a, b) => {
+    // Priority first (1=urgent > 2=high > 3=medium > 4=low > 0=none)
+    const pa = a.priority === 0 ? 99 : a.priority;
+    const pb = b.priority === 0 ? 99 : b.priority;
+    if (pa !== pb) return pa - pb;
+    return a.sortOrder - b.sortOrder;
+  });
 
   let dispatched = 0;
   const slots = ctx.deps.queue.availableSlots();

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -205,12 +205,13 @@ export function buildScopedIssuePrompt(
       c.body.includes('Agent run failed') ||
       c.body.includes('**Auto-merged**') ||
       c.body.includes('**Auto-merge failed**') ||
+      c.body.includes('**Auto-merge blocked**') ||
       c.body.includes('PR URL in your response'),
   );
 
   parts.push(
     `<instructions>
-${hasAgentHistory ? 'A previous agent attempt exists. Review the comments above — check what was already committed, pushed, or opened as a PR. Continue from where the last attempt stopped. Do not redo completed steps.\n\n' : ''}Read the scope block in the task description. Follow the implementation plan and satisfy all acceptance criteria.
+${hasAgentHistory ? 'A previous agent attempt exists. Review the comments above — check what was already committed, pushed, or opened as a PR. Continue from where the last attempt stopped. Do not redo completed steps. If CI failed, check out the existing branch, read the CI logs, fix the failures, and push.\n\n' : ''}Read the scope block in the task description. Follow the implementation plan and satisfy all acceptance criteria.
 
 ## Git Workflow
 1. Create a feature branch: \`git checkout -b feat/${issueIdentifier.toLowerCase().replace(/[^a-z0-9-]/g, '')}-<short-desc>\`


### PR DESCRIPTION
## Summary
- On CI failure, move issue to **Ready for Agent** (not Backlog) so the pipeline re-dispatches the agent to fix the CI issue
- Set priority to **urgent** (1) on the re-dispatched issue so it runs before any new work
- Update dispatcher sort to prioritize by Linear priority before sortOrder
- Add `**Auto-merge blocked**` to `hasAgentHistory` detection so re-dispatched agents get the continuation prompt
- Add CI-specific instruction to the continuation prompt: "If CI failed, check out the existing branch, read the CI logs, fix the failures, and push"

## Test plan
- [x] `npm run build` compiles
- [x] 9 existing tests in `linear-dispatcher.test.ts` pass
- [ ] Trigger CI failure on an agent PR, verify issue moves to Ready for Agent with urgent priority
- [ ] Verify re-dispatched agent sees CI failure context and continues (doesn't start over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)