### PR TITLE
feat(pipeline): footer throughput band (LIA-81)

### DIFF
--- a/.claude/codebase_map.md
+++ b/.claude/codebase_map.md
@@ -1,4 +1,4 @@
-<!-- sha: 671be0813be191aa7c977b8e70aa34cdac657dfd -->
+<!-- sha: e565b95ad9c8783d8ea040cac07837c488411591 -->
 
 # Deus Codebase Map
 
@@ -57,10 +57,6 @@ multi-agent/
   orchestrator.ts
   prompt-templates.ts
   types.ts
-private/
-  orchestrator/
-  scripts/
-  trading/
 skills/
   index.ts
   registry.ts
@@ -120,7 +116,6 @@ tool-registry.ts
 transcription.ts
 types.ts
 user-signal.ts
-x-integration.ts
 ```
 
 ### scripts/
@@ -168,7 +163,6 @@ migrate.mjs
 migrate_atom_tiers.py
 mine_implicit_feedback.py
 redact_session.py
-rename-repo.sh
 review_benchmark.py
 session_concepts.py
 settings_merge.py
@@ -277,7 +271,7 @@ _Format: `path/to/file` → exported symbols_
 - `src/linear-dispatcher.ts` → `LinearDispatcherDependencies`, `WorkflowState`, `GateLabels`, `LinearContext`, `extractFrontmatter`, ...
 - `src/linear-gate-specs.ts` → `GateSpec`, `loadGateSpecs`
 - `src/linear-notifications.ts` → `macosNotify`, `EVENT_LABELS`, `buildPipelineCommentBody`, `updateUnifiedComment`, `notifyPipelineStep`
-- `src/linear-pipeline-cli.ts` → `elapsedMs`, `computeColumnWidths`, `parseDuration`, `formatElapsed`
+- `src/linear-pipeline-cli.ts` → `TodayStats`, `GateRevisionCounts`, `elapsedMs`, `computeColumnWidths`, `parseDuration`, ...
 - `src/linear-vault-sync.ts` → `fetchActiveIssues`, `syncVaultPending`
 - `src/linear-webhook.ts` → `_setSleepFnForTests`, `retryWithBackoff`, `parseVerdict`, `parseEnrichment`, `parseRatings`, ...
 - `src/logger.ts` → `logger`
@@ -289,64 +283,6 @@ _Format: `path/to/file` → exported symbols_
 - `src/multi-agent/types.ts` → `SubagentStatus`, `SubagentResult`, `OrchestratorResult`, `SubagentTask`
 - `src/platform.ts` → `IS_WINDOWS`, `IS_MACOS`, `IS_LINUX`, `IS_WSL`, `PYTHON_BIN`, ...
 - `src/pr-url-extractor.ts` → `extractPrUrl`
-- `src/private/orchestrator/classifier.ts` → `ClassificationContext`, `classifyByLabel`, `classifyByDescriptionLength`, `classifyByFileCount`, `classifyByDependencyDepth`, ...
-- `src/private/orchestrator/cli.ts` → `runApproveMode`, `findArg`, `createTracker`, `createStore`
-- `src/private/orchestrator/config.ts` → `loadConfig`
-- `src/private/orchestrator/context-builder.ts` → `ContextPackage`, `AgentRole`, `buildContextPackage`, `flattenContext`
-- `src/private/orchestrator/cost-tracker.ts` → `IssueCost`, `CostSummary`, `CostTracker`
-- `src/private/orchestrator/dispatcher.ts` → `DispatcherDeps`, `Dispatcher`
-- `src/private/orchestrator/event-bus.ts` → `EventListener`, `EventBus`, `consoleLogger`
-- `src/private/orchestrator/git-merger.ts` → `GitMerger`, `parseDiffNameStatus`
-- `src/private/orchestrator/github-adapter.ts` → `GitHubAdapterConfig`, `GitHubIssueTracker`
-- `src/private/orchestrator/index.ts` → `Dispatcher`, `MockIssueTracker`, `SandcastleRunner`, `InMemoryStore`, `EventBus`, ...
-- `src/private/orchestrator/instrumented-runner.ts` → `RunMetrics`, `MetricsCallback`, `InstrumentedRunner`
-- `src/private/orchestrator/issue-adapter.ts` → `MockIssueTracker`
-- `src/private/orchestrator/json-logger.ts` → `JsonLoggerOptions`, `generateSpanId`, `jsonLogger`
-- `src/private/orchestrator/label-map.ts` → `LABEL_PREFIX`, `labelToState`, `stateToLabel`, `extractStateLabels`, `extractState`
-- `src/private/orchestrator/langfuse-observer.ts` → `LangfuseConfig`, `LangfuseClient`, `LangfuseTrace`, `LangfuseObserver`
-- `src/private/orchestrator/loop-detector.ts` → `RunOutcome`, `LoopVerdict`, `LoopDetectorConfig`, `LoopDetector`
-- `src/private/orchestrator/merge-parser.ts` → `MergeResult`, `parseMergeOutput`
-- `src/private/orchestrator/model-router.ts` → `ModelTier`, `ModelSelection`, `routeModel`, `getReviewModel`, `getModelId`
-- `src/private/orchestrator/otel-tracer.ts` → `OtelExporter`, `ConsoleOtelExporter`, `OtelTracer`
-- `src/private/orchestrator/prompt-builder.ts` → `buildImplementPrompt`, `buildReviewPrompt`, `buildFixPrompt`
-- `src/private/orchestrator/retry-policy.ts` → `RetryTiming`, `computeRetryDelay`, `shouldRetry`
-- `src/private/orchestrator/review-gate.ts` → `ReviewTier`, `ChangeStats`, `ReviewGateConfig`, `ReviewGate`, `parseDiffStat`
-- `src/private/orchestrator/run-history.ts` → `RunHistoryEntry`, `RunHistoryStore`, `SqliteRunHistory`
-- `src/private/orchestrator/sandcastle-runner.ts` → `SandcastleDeps`, `SandcastleRunner`
-- `src/private/orchestrator/sqlite-store.ts` → `SqliteStore`
-- `src/private/orchestrator/state-machine.ts` → `dispatchTransition`, `reviewTransition`
-- `src/private/orchestrator/store.ts` → `InMemoryStore`
-- `src/private/orchestrator/token-budget.ts` → `BudgetVerdict`, `TokenBudgetConfig`, `TokenBudget`, `extractTokenUsage`, `extractTokenUsageDetails`
-- `src/private/orchestrator/types.ts` → `Issue`, `BlockerRef`, `IssueTracker`, `DispatchState`, `ReleaseReason`, ...
-- `src/private/orchestrator/verdict-parser.ts` → `parseTag`, `parseReviewVerdict`, `formatFindings`
-- `src/private/scripts/gemini_ocr.py` → `main`
-- `src/private/trading/analysis.ts` → `AnalysisInput`, `runAnalysis`
-- `src/private/trading/approval.ts` → `formatApprovalMessage`, `createApprovalRequest`, `isApprovalExpired`, `parseApprovalResponse`, `buildBracketOrder`, ...
-- `src/private/trading/bars-to-studies.ts` → `barsToStudies`
-- `src/private/trading/chat-trigger.ts` → `TriggerMatch`, `parseTriggerMessage`, `TriggerHandlerOptions`, `TriggerHandlerResult`, `handleTriggerMatch`, ...
-- `src/private/trading/config.ts` → `TRADING_ENABLED`, `loadSafetyConfig`
-- `src/private/trading/driver.ts` → `OHLCVBar`, `TvCapture`, `PortfolioCapture`, `TvSource`, `IbkrSource`, ...
-- `src/private/trading/earnings.ts` → `EarningsResult`, `clearEarningsCache`, `checkEarnings`, `checkEarningsBatch`
-- `src/private/trading/gateway-client.ts` → `GatewayClientOptions`, `RawGatewayPosition`, `RawGatewayAccountSummary`, `RawGatewayAuthStatus`, `RawGatewayContract`, ...
-- `src/private/trading/gateway-tv-source.ts` → `Timeframe`, `GatewayTvSourceOptions`, `createGatewayTvSource`
-- `src/private/trading/ibkr-data.ts` → `IBKRPositionsResponse`, `IBKRPosition`, `IBKRAccountSummary`, `IBKROrder`, `getSector`, ...
-- `src/private/trading/ibkr-gateway-source.ts` → `GatewaySourceOptions`, `createGatewayIbkrSource`
-- `src/private/trading/index.ts` → `TRADING_ENABLED`, `loadSafetyConfig`, `detectRegime`, `regimeAllowsTrading`, `getRegimeParams`, ...
-- `src/private/trading/indicators.ts` → `OHLCVBar`, `sma`, `ema`, `emaSeries`, `stdev`, ...
-- `src/private/trading/llm-chain.ts` → `extractJSON`, `parseMultiTFResponse`, `parseSetupResponse`, `QualitativeRisk`, `parseRiskResponse`, ...
-- `src/private/trading/logger.ts` → `logger`
-- `src/private/trading/order-submission.ts` → `SubmitOptions`, `SubmitResult`, `buildOrdersPayload`, `submitBracketOrder`
-- `src/private/trading/pipeline.ts` → `PipelineInput`, `PipelineResult`, `runPipeline`
-- `src/private/trading/prompts.ts` → `buildRegimePrompt`, `buildMultiTFPrompt`, `buildSetupPrompt`, `buildRiskPrompt`, `buildDecisionPrompt`, ...
-- `src/private/trading/regime.ts` → `RegimeInput`, `detectRegime`, `regimeAllowsTrading`, `getRegimeParams`
-- `src/private/trading/safety.ts` → `checkSafetyRails`, `calculatePositionSize`, `estimateCorrelation`, `calculatePortfolioHeat`, `checkMarketHoursBuffer`, ...
-- `src/private/trading/scheduler.ts` → `ScheduleOptions`, `scheduleAnalysis`
-- `src/private/trading/symbol-lock.ts` → `LockMode`, `SymbolLock`, `globalSymbolLock`
-- `src/private/trading/tv-data.ts` → `TVQuote`, `TVStudyEntry`, `TVOHLCVSummary`, `TVPriceLine`, `TVPriceLabel`, ...
-- `src/private/trading/tv-fixture-source.ts` → `loadTvFixture`, `createTvFixtureSource`, `createTvFixtureSourceFromFile`
-- `src/private/trading/types.ts` → `MarketRegime`, `RegimeSignal`, `TimeframeBias`, `TimeframeReading`, `MultiTFResult`, ...
-- `src/private/trading/vix-yahoo.ts` → `YahooVixOptions`, `fetchYahooVix`, `fetchYahooVixStrict`
-- `src/private/trading/vix.ts` → `VixFetchResult`, `IbkrVixProvider`, `TvVixProvider`, `fetchVix`, `isPlausibleVix`
 - `src/project-registry.ts` → `detectProjectType`, `SENSITIVE_FILE_PATTERNS`, `SENSITIVE_DIR_PATTERNS`, `registerProject`, `associateProject`, ...
 - `src/reaction-signal.ts` → `emojiToSignal`
 - `src/remote-control.ts` → `restoreRemoteControl`, `getActiveSession`, `_resetForTesting`, `_getStateFilePath`, `startRemoteControl`, ...
@@ -368,4 +304,3 @@ _Format: `path/to/file` → exported symbols_
 - `src/transcription.ts` → `TranscribeOptions`, `TranscriptionError`, `resolveDefaultModelPath`, `ensureWhisperModel`, `transcribeFile`, ...
 - `src/types.ts` → `AdditionalMount`, `MountAllowlist`, `AllowedRoot`, `AgentEffortLevel`, `VALID_EFFORT_LEVELS`, ...
 - `src/user-signal.ts` → `detectUserSignal`
-- `src/x-integration.ts` → `handleXIpc`

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-16" # auto-bump (channels-agent-native)
+last_verified: "2026-05-24" # auto-bump
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-24"  # auto-bump
+last_verified: "2026-05-24" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-24"  # auto-bump
+last_verified: "2026-05-24" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-pipeline-cli.test.ts
+++ b/src/linear-pipeline-cli.test.ts
@@ -4,7 +4,14 @@ import {
   formatElapsed,
   elapsedMs,
   computeColumnWidths,
+  renderThroughputFooter,
+  type TodayStats,
+  type GateRevisionCounts,
 } from './linear-pipeline-cli.js';
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string) => s.replace(ANSI_RE, '');
 
 describe('parseDuration', () => {
   it('parses minutes', () => {
@@ -110,5 +117,104 @@ describe('computeColumnWidths', () => {
     const narrow = computeColumnWidths(40);
     const min = computeColumnWidths(80);
     expect(narrow.titleWidth).toBe(min.titleWidth);
+  });
+});
+
+// ── renderThroughputFooter ────────────────────────────────────────────────────
+
+const baseStats: TodayStats = {
+  shipped: 3,
+  failed: 1,
+  medianAgentMs: 14 * 60_000, // 14m
+  automergeFailRate: 33,
+};
+
+describe('renderThroughputFooter', () => {
+  it('renders line 1 with shipped / failed / median / automerge-fail', () => {
+    const lines = renderThroughputFooter(baseStats, {}, 120);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const plain = lines[0].replace(ANSI_RE, '');
+    expect(plain).toContain('3 shipped');
+    expect(plain).toContain('1 failed');
+    expect(plain).toContain('Median agent 14m');
+    expect(plain).toContain('Automerge fail 33%');
+  });
+
+  it('renders em-dash when median and automerge-fail are null', () => {
+    const stats: TodayStats = {
+      shipped: 0,
+      failed: 0,
+      medianAgentMs: null,
+      automergeFailRate: null,
+    };
+    const lines = renderThroughputFooter(stats, {}, 120);
+    const plain = lines[0].replace(ANSI_RE, '');
+    expect(plain).toContain('Median agent —');
+    expect(plain).toContain('Automerge fail —');
+  });
+
+  it('renders gate revision bars on line 2', () => {
+    const gates: GateRevisionCounts = {
+      'completion-gate': 5,
+      'readiness-gate': 2,
+      'quality-gate': 1,
+    };
+    const lines = renderThroughputFooter(baseStats, gates, 120);
+    expect(lines.length).toBe(2);
+    const plain = lines[1].replace(ANSI_RE, '');
+    expect(plain).toContain('Gate revisions');
+    expect(plain).toContain('completion-gate');
+    expect(plain).toContain('readiness-gate');
+    expect(plain).toContain('quality-gate');
+  });
+
+  it('highest-count gate gets solid bar (▓), others get light bar (░)', () => {
+    const gates: GateRevisionCounts = { top: 10, mid: 5 };
+    const lines = renderThroughputFooter(baseStats, gates, 120);
+    expect(lines[1]).toContain('▓'); // top gate
+    expect(lines[1]).toContain('░'); // mid gate
+  });
+
+  it('bar length is proportional to revision count', () => {
+    const gates: GateRevisionCounts = { big: 10, small: 2 };
+    const lines = renderThroughputFooter(baseStats, gates, 120);
+    const plain = lines[1].replace(ANSI_RE, '');
+    // big should have more bar chars than small
+    const bigMatch = plain.match(/big\s+(▓+)/);
+    const smallMatch = plain.match(/small\s+(░+)/);
+    expect(bigMatch).not.toBeNull();
+    expect(smallMatch).not.toBeNull();
+    expect(bigMatch![1].length).toBeGreaterThan(smallMatch![1].length);
+  });
+
+  it('omits gate line when no revisions recorded', () => {
+    const lines = renderThroughputFooter(baseStats, {}, 120);
+    expect(lines.length).toBe(1);
+  });
+
+  it('truncates gates that would overflow terminal width', () => {
+    // Very narrow terminal — only the first gate should fit
+    const gates: GateRevisionCounts = { alpha: 5, beta: 4, gamma: 3, delta: 2 };
+    const lines = renderThroughputFooter(baseStats, gates, 30);
+    const plain = lines[1].replace(ANSI_RE, '');
+    // Should contain "Gate revisions" prefix and at least alpha
+    expect(plain).toContain('Gate revisions');
+    // beta/gamma/delta may be clipped; no assertion on their presence
+    expect(plain.length).toBeLessThanOrEqual(30);
+  });
+
+  it('formats median hours correctly', () => {
+    const stats: TodayStats = { ...baseStats, medianAgentMs: 90 * 60_000 }; // 90m = 1h30m
+    const lines = renderThroughputFooter(stats, {}, 120);
+    const plain = lines[0].replace(ANSI_RE, '');
+    expect(plain).toContain('Median agent 1h30m');
+  });
+
+  it('formats exact hours without remainder', () => {
+    const stats: TodayStats = { ...baseStats, medianAgentMs: 2 * 3_600_000 }; // exactly 2h
+    const lines = renderThroughputFooter(stats, {}, 120);
+    const plain = lines[0].replace(ANSI_RE, '');
+    expect(plain).toContain('Median agent 2h');
+    expect(plain).not.toContain('2h0m');
   });
 });

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -29,6 +29,17 @@ import {
   type ActionContext,
 } from './linear-actions.js';
 
+// ── Footer throughput types ──────────────────────────────────────────────────
+
+export interface TodayStats {
+  shipped: number;
+  failed: number;
+  medianAgentMs: number | null;
+  automergeFailRate: number | null; // 0-100 percent, null if no automerge events
+}
+
+export type GateRevisionCounts = Record<string, number>;
+
 const GREEN = '\x1b[32m';
 const RED = '\x1b[31m';
 const YELLOW = '\x1b[33m';
@@ -160,6 +171,163 @@ function truncate(str: string, maxLen: number): string {
   const clean = str.replace(/[\r\n\t]+/g, ' ');
   if (clean.length <= maxLen) return clean;
   return clean.slice(0, maxLen - 1) + '…';
+}
+
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function formatMedianMs(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining > 0 ? `${hours}h${remaining}m` : `${hours}h`;
+}
+
+// ── Footer throughput computations ───────────────────────────────────────────
+
+export function computeTodayStats(): TodayStats {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0); // local midnight
+  const since = todayStart.toISOString();
+
+  const todayEvents = getPipelineEvents({ since });
+
+  const shipped = todayEvents.filter(
+    (e) => e.event_type === 'moved_done' || e.event_type === 'automerge_done',
+  ).length;
+
+  const failed = todayEvents.filter(
+    (e) =>
+      e.event_type === 'automerge_failed' || e.event_type === 'agent_failed',
+  ).length;
+
+  const automergeTerminal = todayEvents.filter(
+    (e) =>
+      e.event_type === 'automerge_done' || e.event_type === 'automerge_failed',
+  ).length;
+  const automergeFailed = todayEvents.filter(
+    (e) => e.event_type === 'automerge_failed',
+  ).length;
+  const automergeFailRate =
+    automergeTerminal > 0
+      ? Math.round((automergeFailed / automergeTerminal) * 100)
+      : null;
+
+  // Median agent duration: time from agent_started → agent_completed / pr_created.
+  // Look for starts in all history so we capture cycles that began before today.
+  const allEvents = getPipelineEvents();
+  const issueAgentStart = new Map<string, number>(); // issue_id → latest start ms
+  for (const e of allEvents) {
+    if (e.event_type === 'agent_started') {
+      issueAgentStart.set(e.issue_id, new Date(e.created_at).getTime());
+    }
+  }
+
+  const durations: number[] = [];
+  for (const e of todayEvents) {
+    if (e.event_type === 'agent_completed' || e.event_type === 'pr_created') {
+      const startMs = issueAgentStart.get(e.issue_id);
+      if (startMs !== undefined) {
+        const dur = new Date(e.created_at).getTime() - startMs;
+        if (dur > 0) durations.push(dur);
+      }
+    }
+  }
+
+  let medianAgentMs: number | null = null;
+  if (durations.length > 0) {
+    durations.sort((a, b) => a - b);
+    const mid = Math.floor(durations.length / 2);
+    medianAgentMs =
+      durations.length % 2 === 0
+        ? (durations[mid - 1] + durations[mid]) / 2
+        : durations[mid];
+  }
+
+  return { shipped, failed, medianAgentMs, automergeFailRate };
+}
+
+export function computeGateRevisions(): GateRevisionCounts {
+  const events = getPipelineEvents({ eventType: 'gate_revise' });
+  const counts: GateRevisionCounts = {};
+
+  for (const e of events) {
+    if (e.detail) {
+      // detail format: "{gate-name}: REVISE"  e.g. "completion-gate: REVISE"
+      const match = e.detail.match(/^(.+?):\s*REVISE\b/i);
+      if (match) {
+        const name = match[1].trim();
+        counts[name] = (counts[name] ?? 0) + 1;
+      }
+    }
+  }
+
+  return counts;
+}
+
+// ── Footer throughput renderer ───────────────────────────────────────────────
+
+export function renderThroughputFooter(
+  stats: TodayStats,
+  gateRevisions: GateRevisionCounts,
+  cols: number,
+): string[] {
+  const lines: string[] = [];
+
+  // Line 1 — daily throughput stats
+  const dot = `${DIM}·${RESET}`;
+  const shippedStr = `${GREEN}${stats.shipped} shipped${RESET}`;
+  const failedStr =
+    stats.failed > 0
+      ? `${RED}${stats.failed} failed${RESET}`
+      : `${DIM}${stats.failed} failed${RESET}`;
+  const medianStr =
+    stats.medianAgentMs !== null
+      ? `Median agent ${CYAN}${formatMedianMs(stats.medianAgentMs)}${RESET}`
+      : `${DIM}Median agent —${RESET}`;
+  const failRateStr =
+    stats.automergeFailRate !== null
+      ? `Automerge fail ${stats.automergeFailRate > 50 ? RED : DIM}${stats.automergeFailRate}%${RESET}`
+      : `${DIM}Automerge fail —${RESET}`;
+
+  lines.push(
+    ` ${DIM}Today${RESET} ${shippedStr} ${dot} ${failedStr} ${dot} ${medianStr} ${dot} ${failRateStr}`,
+  );
+
+  // Line 2 — per-gate revision bars, sorted descending by count (worst first)
+  const gates = Object.entries(gateRevisions).sort((a, b) => b[1] - a[1]);
+
+  if (gates.length > 0) {
+    const maxCount = gates[0][1];
+    const MAX_BAR = 5;
+
+    const prefix = ` ${DIM}Gate revisions${RESET}  `;
+    let line2 = prefix;
+    let visibleLen = stripAnsi(prefix).length;
+
+    for (let i = 0; i < gates.length; i++) {
+      const [name, count] = gates[i];
+      const barLen = Math.max(1, Math.round((count / maxCount) * MAX_BAR));
+      // Highest-count gate gets solid block; others get lighter shade
+      const barChar = count === maxCount ? '▓' : '░';
+      const bar = barChar.repeat(barLen);
+      const sep = i > 0 ? '  ' : '';
+      const segment = `${DIM}${name}${RESET} ${CYAN}${bar}${RESET}`;
+      const segVisible = sep + name + ' ' + bar;
+
+      if (visibleLen + segVisible.length > cols - 1) break;
+
+      line2 += sep + segment;
+      visibleLen += segVisible.length;
+    }
+
+    lines.push(line2);
+  }
+
+  return lines;
 }
 
 function printEvents(
@@ -415,6 +583,8 @@ interface RenderOptions {
   confirmPrompt?: string;
   cmdLine?: string;
   lastResult?: { message: string; ok: boolean };
+  todayStats?: TodayStats;
+  gateRevisions?: GateRevisionCounts;
 }
 
 function renderDashboardOutput(
@@ -541,6 +711,16 @@ function renderDashboardOutput(
     lines.push(`${rc} ${icon} ${opts.lastResult.message}${RESET}`);
   }
 
+  if (opts.todayStats) {
+    lines.push('');
+    const footerLines = renderThroughputFooter(
+      opts.todayStats,
+      opts.gateRevisions ?? {},
+      cols,
+    );
+    for (const l of footerLines) lines.push(l);
+  }
+
   lines.push('');
   if (opts.confirmPrompt) {
     lines.push(`${YELLOW} ${opts.confirmPrompt} [y/N]${RESET}`);
@@ -633,6 +813,8 @@ async function startWatchMode(): Promise<void> {
   let cachedQueued: QueuedIssue[] = [];
   let cachedRecent: RecentIssue[] = [];
   let lastWarning: string | undefined;
+  let cachedTodayStats: TodayStats | undefined;
+  let cachedGateRevisions: GateRevisionCounts | undefined;
 
   try {
     actionCtx = await initActionContext(client, teamId);
@@ -742,6 +924,8 @@ async function startWatchMode(): Promise<void> {
         lastResult: lastActionResult
           ? { message: lastActionResult, ok: lastActionOk }
           : undefined,
+        todayStats: cachedTodayStats,
+        gateRevisions: cachedGateRevisions,
       });
     }
     process.stdout.write(CURSOR_HOME + output + '\n' + CLEAR_TO_END);
@@ -750,6 +934,12 @@ async function startWatchMode(): Promise<void> {
   async function tick(): Promise<void> {
     if (rendering) return;
     rendering = true;
+
+    // Footer stats are DB-only — compute before the API call so they're
+    // available in both the success and error render paths.
+    cachedTodayStats = computeTodayStats();
+    cachedGateRevisions = computeGateRevisions();
+
     try {
       const { active, queued, fromCache } = await fetchActiveAndQueued(
         client,


### PR DESCRIPTION
## Summary

- Adds 2-line footer below RECENT in the live pipeline dashboard
- Line 1: Today N shipped · N failed · Median agent Xm · Automerge fail N%
- Line 2: Gate revisions bar chart proportional to REVISE counts, width-adaptive
- Zero API calls — all data from linear_pipeline_events SQLite

## Test plan

- 9 new unit tests for renderThroughputFooter
- 1131 total tests, 0 failures
- ESLint + Prettier clean

Closes LIA-81

Generated with Claude Code
