### PR TITLE
feat(hooks): add Prettier format-check gate for git commit

### DIFF
--- a/.claude/hooks/format-check.sh
+++ b/.claude/hooks/format-check.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# PreToolUse hook: blocks git commit when staged .ts files fail prettier --check.
+# Mechanical pass/fail — no warden verdict lifecycle.
+# Non-zero exit blocks the tool call (Claude Code PreToolUse hook contract).
+set -e
+
+INPUT=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+[ "$TOOL" = "Bash" ] || exit 0
+
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+[ -n "$CMD" ] || exit 0
+
+if ! printf '%s' "$CMD" | grep -qE '(^|[;&|]\s*)git(\s+(-C\s+\S+|--\S+))*\s+commit(\s|$)'; then
+  exit 0
+fi
+
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$TOPLEVEL" ] || exit 0
+
+PROJECT_ROOT="$(cd "$(dirname "$(git rev-parse --git-common-dir 2>/dev/null)")" && pwd)" 2>/dev/null || exit 0
+
+case "$TOPLEVEL" in
+  "$PROJECT_ROOT"|"$PROJECT_ROOT/.claude/worktrees/"*) ;;
+  *) exit 0 ;;
+esac
+
+STAGED_TS=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' 2>/dev/null)
+[ -n "$STAGED_TS" ] || exit 0
+
+PRETTIER="$PROJECT_ROOT/node_modules/.bin/prettier"
+if [ ! -x "$PRETTIER" ]; then
+  echo "[format-check] WARNING: prettier not found at $PRETTIER, skipping" >&2
+  exit 0
+fi
+
+cd "$TOPLEVEL"
+
+if ! printf '%s' "$STAGED_TS" | tr '\n' '\0' | xargs -0 "$PRETTIER" --check -- 2>/dev/null; then
+  echo "[format-check] BLOCKED — staged .ts files have formatting issues."
+  echo "Fix with:  $PRETTIER --write <files>"
+  echo "Then re-stage and retry the commit."
+  echo "Files with issues:"
+  echo "$STAGED_TS" | sed 's/^/  /'
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,11 @@
             "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" admin-merge-gate'",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/format-check.sh\"'",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds a `PreToolUse` hook (`.claude/hooks/format-check.sh`) that blocks `git commit` when staged `.ts` files fail `prettier --check`
- Registers the hook in `.claude/settings.json` in the existing `Bash` matcher group alongside `code-review-gate`, `verification-gate`, and `admin-merge-gate`
- Prevents CI `Format check` failures caused by background agents committing unformatted code from worktrees (evidence: CI runs 26341440250, 26341284409)

## Design

Standalone shell script (not routed through `warden-shim.sh`) — mechanical pass/fail with no verdict lifecycle needed. Uses `node_modules/.bin/prettier` directly (no npx cold-start). Handles filenames safely via `tr '\n' '\0' | xargs -0`. Scoped to this project + its worktrees via `git rev-parse --git-common-dir`.

## Smoke test evidence

Hook tested with 4 scenarios using the identical stdin JSON format Claude Code sends to PreToolUse hooks:

```
=== Test 1: unformatted file ===
Checking formatting...
[format-check] BLOCKED — staged .ts files have formatting issues.
Fix with:  /Users/liam10play/deus/node_modules/.bin/prettier --write <files>
Then re-stage and retry the commit.
Files with issues:
  src/_format-test-temp.ts
EXIT: 2

=== Test 2: after formatting ===
Checking formatting...
All matched files use Prettier code style!
EXIT: 0

=== Test 3: non-.ts file only ===
EXIT: 0

=== Test 4: non-commit git commands ===
EXIT: 0
```

Note: real-session test not possible pre-merge (hook must be registered in settings.json first — chicken-and-egg).

## Test plan

- [ ] CI passes (lint, typecheck, tests, drift check)
- [ ] After merge: stage unformatted `.ts` in a new session, verify hook blocks commit
- [ ] After merge: verify formatted files pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)