### PR TITLE
fix(pipeline): completion-gate before auto-merge + LIA-51 Retry-After patch

### DIFF
--- a/.claude/agents/wardens/completion-gate.md
+++ b/.claude/agents/wardens/completion-gate.md
@@ -18,6 +18,14 @@ You receive the issue title, description, agent output, PR link (if any), and re
 
 Check each acceptance criterion against the evidence in comments and the PR. Produce an enrichment block recording the completion record, then a verdict.
 
+## Invocation context
+
+If the prompt includes `<invocation-context>pre-merge</invocation-context>`, you are running **before** the PR is merged. In this mode:
+- Replace the "PR exists and merged" check with "PR exists and linked" (a PR URL in comments is sufficient).
+- Do not check whether the PR shows as merged -- only verify that acceptance criteria are met.
+- A SHIP verdict authorises the auto-merge to proceed.
+- A REVISE verdict blocks the merge and leaves the issue in In Review.
+
 ## Output format
 
 ```
@@ -37,7 +45,7 @@ Check each acceptance criterion against the evidence in comments and the PR. Pro
 
 Checklist:
 - [x] All acceptance criteria met — <n> of <n> verified
-- [x] PR exists and merged — <URL>
+- [x] PR exists and linked (pre-merge) / merged (post-merge) — <URL>
 - [x] No open review threads — all resolved
 - [x] No open questions or blockers
 
@@ -61,7 +69,7 @@ Safe to close.
 
 Checklist:
 - [ ] All acceptance criteria met — criterion "<criterion>" not met: <what is missing>
-- [ ] PR exists and merged — no PR linked; issue description implies code change
+- [ ] PR exists and linked (pre-merge) / merged (post-merge) — no PR linked; issue description implies code change
 - [x] No open review threads
 - [ ] No open questions — <describe open question>
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T23:50" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T22:58" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T22:58" # auto-bump
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T23:50" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T22:58" # auto-bump
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23" # auto-bump
+last_verified: "2026-05-23T22:58" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,14 +399,15 @@ async function main(): Promise<void> {
     if (linearCtx) {
       startLinearDispatcher(linearCtx);
 
+      const wardensDir = path.join(
+        PROJECT_ROOT,
+        '.claude',
+        'agents',
+        'wardens',
+      );
+      const gateSpecs = loadGateSpecs(wardensDir);
+
       if (process.env.LINEAR_WEBHOOK_SECRET) {
-        const wardensDir = path.join(
-          PROJECT_ROOT,
-          '.claude',
-          'agents',
-          'wardens',
-        );
-        const gateSpecs = loadGateSpecs(wardensDir);
         if (gateSpecs.size === 0) {
           logger.warn(
             'linear-webhook: no gate specs found — webhook server will pass all transitions',
@@ -429,7 +430,11 @@ async function main(): Promise<void> {
       sweepPendingAutoMerges(linearCtx).catch((err) => {
         logger.warn({ err }, 'auto-merge: startup sweep failed');
       });
-      sweepStaleInReview(linearCtx).catch((err) => {
+      const { runInlineCompletionCheck } = await import('./linear-webhook.js');
+      const ctx = linearCtx;
+      sweepStaleInReview(ctx, (issueData) =>
+        runInlineCompletionCheck(ctx, issueData, gateSpecs),
+      ).catch((err) => {
         logger.warn({ err }, 'auto-merge: stale In Review sweep failed');
       });
     }

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -279,7 +279,18 @@ export async function sweepPendingAutoMerges(
   }
 }
 
-export async function sweepStaleInReview(ctx: LinearContext): Promise<void> {
+export type CompletionChecker = (issueData: {
+  id: string;
+  identifier: string;
+  title: string;
+  description?: string | null;
+  labels: Array<{ id: string; name: string }>;
+}) => Promise<'SHIP' | 'REVISE'>;
+
+export async function sweepStaleInReview(
+  ctx: LinearContext,
+  completionCheck?: CompletionChecker,
+): Promise<void> {
   if (!isAutoMergeEnabled()) return;
 
   const inReviewState = ctx.stateByName.get('In Review');
@@ -305,12 +316,38 @@ export async function sweepStaleInReview(ctx: LinearContext): Promise<void> {
         continue;
       }
 
-      triggerAutoMerge(ctx, issue.id, issue.identifier).catch((err) => {
-        logger.error(
-          { issueId: issue.id, err },
-          'auto-merge: stale sweep failed',
-        );
-      });
+      if (completionCheck) {
+        const issueData = {
+          id: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          description: issue.description,
+          labels: labels.nodes.map((l) => ({ id: l.id, name: l.name })),
+        };
+        completionCheck(issueData)
+          .then((verdict) => {
+            if (verdict === 'SHIP') {
+              return triggerAutoMerge(ctx, issue.id, issue.identifier);
+            }
+            logger.info(
+              { issueId: issue.id },
+              'auto-merge: sweep completion-gate REVISE, auto-merge blocked',
+            );
+          })
+          .catch((err) => {
+            logger.error(
+              { issueId: issue.id, err },
+              'auto-merge: stale sweep failed',
+            );
+          });
+      } else {
+        triggerAutoMerge(ctx, issue.id, issue.identifier).catch((err) => {
+          logger.error(
+            { issueId: issue.id, err },
+            'auto-merge: stale sweep failed',
+          );
+        });
+      }
       triggered++;
     }
 

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -20,6 +20,7 @@ import {
   computeScopeLabelChanges,
   retryWithBackoff,
   _setSleepFnForTests,
+  runInlineCompletionCheck,
 } from './linear-webhook.js';
 import { RetryableError, UserError, FatalError } from './errors/index.js';
 
@@ -690,5 +691,42 @@ describe('retryWithBackoff', () => {
     // Should use computed backoff (baseDelayMs * 2^0 + jitter), not a fixed value
     expect(sleepCalls[0]).toBeGreaterThan(0);
     expect(sleepCalls[0]).toBeLessThanOrEqual(30_000);
+  });
+});
+
+// ── runInlineCompletionCheck tests ───────────────────────────────────────────
+
+describe('runInlineCompletionCheck', () => {
+  const mockIssueData = {
+    id: 'issue-123',
+    identifier: 'LIA-99',
+    title: 'Test issue',
+    description: 'Test description',
+    labels: [] as Array<{ id: string; name: string }>,
+  };
+
+  it('returns REVISE when completion gate spec is missing', async () => {
+    const emptyGateSpecs = new Map();
+    const ctx = {
+      inFlightGate: new Set<string>(),
+    } as Parameters<typeof runInlineCompletionCheck>[0];
+
+    const result = await runInlineCompletionCheck(
+      ctx,
+      mockIssueData,
+      emptyGateSpecs,
+    );
+    expect(result).toBe('REVISE');
+  });
+
+  it('cleans up inFlightGate even on error', async () => {
+    const emptyGateSpecs = new Map();
+    const inFlightGate = new Set<string>();
+    const ctx = { inFlightGate } as Parameters<
+      typeof runInlineCompletionCheck
+    >[0];
+
+    await runInlineCompletionCheck(ctx, mockIssueData, emptyGateSpecs);
+    expect(inFlightGate.has('issue-123')).toBe(false);
   });
 });

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -576,14 +576,19 @@ describe('retryWithBackoff', () => {
     loggerWarnSpy.mockRestore();
   });
 
-  it('logs webhook.failed on exhaustion', async () => {
+  it('logs webhook.failed on exhaustion with first_error and error', async () => {
     const loggerErrorSpy = vi.spyOn(
       await import('./logger.js').then((m) => m.logger),
       'error',
     );
 
-    const retryableErr = new RetryableError('always fails');
-    const handler = vi.fn().mockRejectedValue(retryableErr);
+    const firstErr = new RetryableError('initial transient');
+    const laterErr = new RetryableError('different transient');
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(firstErr)
+      .mockRejectedValueOnce(laterErr)
+      .mockRejectedValueOnce(laterErr);
 
     await expect(retryWithBackoff(handler, 3, 100)).rejects.toBeInstanceOf(
       FatalError,
@@ -593,8 +598,97 @@ describe('retryWithBackoff', () => {
       (call) => call[1] === 'webhook.failed',
     );
     expect(exhaustedCalls.length).toBeGreaterThanOrEqual(1);
-    expect(exhaustedCalls[0][0]).toMatchObject({ attempts_exhausted: 3 });
+    expect(exhaustedCalls[0][0]).toMatchObject({
+      attempts_exhausted: 3,
+      first_error: 'initial transient',
+      error: 'different transient',
+    });
 
     loggerErrorSpy.mockRestore();
+  });
+
+  it('uses Retry-After header (numeric seconds) when present on 429', async () => {
+    const sleepCalls: number[] = [];
+    _setSleepFnForTests((ms: number) => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    });
+
+    const rateLimitErr = Object.assign(new Error('Too Many Requests'), {
+      status: 429,
+      headers: { 'retry-after': '5' },
+    });
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitErr)
+      .mockResolvedValue('ok');
+
+    await retryWithBackoff(handler, 3, 100);
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBe(5000);
+  });
+
+  it('uses Retry-After header from response.headers (axios-style)', async () => {
+    const sleepCalls: number[] = [];
+    _setSleepFnForTests((ms: number) => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    });
+
+    const rateLimitErr = Object.assign(new Error('Too Many Requests'), {
+      status: 429,
+      response: { headers: { 'retry-after': '10' } },
+    });
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitErr)
+      .mockResolvedValue('ok');
+
+    await retryWithBackoff(handler, 3, 100);
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBe(10_000);
+  });
+
+  it('caps Retry-After at WEBHOOK_MAX_DELAY_MS (30s)', async () => {
+    const sleepCalls: number[] = [];
+    _setSleepFnForTests((ms: number) => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    });
+
+    const rateLimitErr = Object.assign(new Error('Too Many Requests'), {
+      status: 429,
+      headers: { 'retry-after': '120' },
+    });
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitErr)
+      .mockResolvedValue('ok');
+
+    await retryWithBackoff(handler, 3, 100);
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBe(30_000);
+  });
+
+  it('falls back to exponential backoff when no Retry-After header', async () => {
+    const sleepCalls: number[] = [];
+    _setSleepFnForTests((ms: number) => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    });
+
+    const rateLimitErr = Object.assign(new Error('Too Many Requests'), {
+      status: 429,
+    });
+    const handler = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitErr)
+      .mockResolvedValue('ok');
+
+    await retryWithBackoff(handler, 3, 100);
+    expect(sleepCalls).toHaveLength(1);
+    // Should use computed backoff (baseDelayMs * 2^0 + jitter), not a fixed value
+    expect(sleepCalls[0]).toBeGreaterThan(0);
+    expect(sleepCalls[0]).toBeLessThanOrEqual(30_000);
   });
 });

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -336,6 +336,90 @@ async function fetchIssueComments(
   }
 }
 
+export async function runInlineCompletionCheck(
+  ctx: LinearContext,
+  issueData: {
+    id: string;
+    identifier: string;
+    title: string;
+    description?: string | null;
+    labels: Array<{ id: string; name: string }>;
+  },
+  gateSpecs: Map<string, GateSpec>,
+): Promise<'SHIP' | 'REVISE'> {
+  const completionGateSpec = gateSpecs.get('Done');
+  if (!completionGateSpec) {
+    logger.warn(
+      { issueId: issueData.id },
+      'inline-completion-check: gate spec for Done not found, blocking merge',
+    );
+    return 'REVISE';
+  }
+
+  ctx.inFlightGate.add(issueData.id);
+  try {
+    let commentBlock = '';
+    const comments = await fetchIssueComments(ctx, issueData.id);
+    if (comments.length > 0) {
+      commentBlock =
+        '\n\n<comments>\n' +
+        comments.map((c) => `[${c.author}]: ${c.body}`).join('\n\n') +
+        '\n</comments>';
+    }
+
+    const prompt =
+      [
+        `<gate-spec>\n${completionGateSpec.content}\n</gate-spec>`,
+        `<invocation-context>pre-merge</invocation-context>`,
+        `<issue>\nTitle: ${issueData.title}\nID: ${issueData.identifier}\n\n${issueData.description ?? '(no description)'}\n</issue>`,
+        `<transition>\nFrom: In Review\nTo: Done (pre-merge check)\n</transition>`,
+      ].join('\n\n') + commentBlock;
+
+    const chatJid = `linear-gate-completion-pre-merge-${issueData.id.slice(0, 8)}`;
+    const runContext: RunContext = {
+      prompt,
+      groupFolder: ctx.dispatchGroup.folder,
+      chatJid,
+      isControlGroup: false,
+      isScheduledTask: true,
+      effort: completionGateSpec.effort ?? 'medium',
+    };
+
+    const { text, error } = await retryWithBackoff(
+      () => executeAgentRun(ctx, runContext),
+      WEBHOOK_MAX_RETRIES,
+      WEBHOOK_BASE_DELAY_MS,
+    );
+
+    const output = text || error || '';
+    const parsedVerdict = parseVerdict(output);
+    const verdict: 'SHIP' | 'REVISE' =
+      parsedVerdict === 'SHIP' ? 'SHIP' : 'REVISE';
+
+    const commentBody = formatGateComment(
+      completionGateSpec.name,
+      verdict,
+      parsedVerdict ? stripEnrichmentSection(output) : output,
+      'pre-merge',
+    );
+    await postOrUpdateComment(ctx, issueData.id, 'Done:pre-merge', commentBody);
+
+    logger.info(
+      { issueId: issueData.id, verdict },
+      'inline-completion-check: verdict',
+    );
+    return verdict;
+  } catch (err) {
+    logger.warn(
+      { issueId: issueData.id, err },
+      'inline-completion-check: failed, blocking merge',
+    );
+    return 'REVISE';
+  } finally {
+    ctx.inFlightGate.delete(issueData.id);
+  }
+}
+
 async function handleIssueUpdate(
   payload: EntityWebhookPayloadWithIssueData,
   ctx: LinearContext,
@@ -484,7 +568,30 @@ async function handleIssueUpdate(
                 const issue = await ctx.client.issue(issueId);
                 const currentState = await issue.state;
                 if (currentState?.name === targetStateName) {
-                  await triggerAutoMerge(ctx, issueId, identifier);
+                  const labels = await issue.labels();
+                  const issueData = {
+                    id: issue.id,
+                    identifier: issue.identifier,
+                    title: issue.title,
+                    description: issue.description,
+                    labels: labels.nodes.map((l) => ({
+                      id: l.id,
+                      name: l.name,
+                    })),
+                  };
+                  const cgVerdict = await runInlineCompletionCheck(
+                    ctx,
+                    issueData,
+                    gateSpecs,
+                  );
+                  if (cgVerdict === 'SHIP') {
+                    await triggerAutoMerge(ctx, issueId, identifier);
+                  } else {
+                    logger.info(
+                      { issueId },
+                      'linear-webhook: deferred completion-gate REVISE, auto-merge blocked',
+                    );
+                  }
                 }
               } catch (retryErr) {
                 logger.warn(
@@ -742,12 +849,28 @@ async function handleIssueUpdate(
     }
 
     if (finalVerdict === 'SHIP' && gateSpec.name === 'output-quality-gate') {
-      triggerAutoMerge(ctx, data.id, data.identifier).catch((err) => {
-        logger.warn(
-          { issueId: data.id, err },
-          'linear-webhook: auto-merge trigger failed',
-        );
-      });
+      void (async () => {
+        try {
+          const cgVerdict = await runInlineCompletionCheck(
+            ctx,
+            data,
+            gateSpecs,
+          );
+          if (cgVerdict === 'SHIP') {
+            await triggerAutoMerge(ctx, data.id, data.identifier);
+          } else {
+            logger.info(
+              { issueId: data.id },
+              'linear-webhook: inline completion-gate REVISE, auto-merge blocked',
+            );
+          }
+        } catch (err) {
+          logger.warn(
+            { issueId: data.id, err },
+            'linear-webhook: inline completion check failed, merge blocked',
+          );
+        }
+      })();
     }
   }
 }

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -79,12 +79,14 @@ export async function retryWithBackoff<T>(
   baseDelayMs: number,
 ): Promise<T> {
   let lastErr: unknown;
+  let firstErr: unknown;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       return await fn();
     } catch (err) {
       lastErr = err;
+      if (attempt === 0) firstErr = err;
 
       if (err instanceof UserError) {
         throw err;
@@ -102,11 +104,14 @@ export async function retryWithBackoff<T>(
         break;
       }
 
-      const jitter = Math.random() * baseDelayMs;
-      const delayMs = Math.min(
-        baseDelayMs * Math.pow(2, attempt) + jitter,
-        WEBHOOK_MAX_DELAY_MS,
-      );
+      const retryAfterMs = extractRetryAfterMs(err);
+      const delayMs =
+        retryAfterMs !== null
+          ? Math.min(retryAfterMs, WEBHOOK_MAX_DELAY_MS)
+          : Math.min(
+              baseDelayMs * Math.pow(2, attempt) + Math.random() * baseDelayMs,
+              WEBHOOK_MAX_DELAY_MS,
+            );
 
       const errMsg = err instanceof Error ? err.message : String(err);
       logger.warn(
@@ -115,6 +120,7 @@ export async function retryWithBackoff<T>(
           maxAttempts,
           delayMs: Math.round(delayMs),
           error: errMsg,
+          ...(retryAfterMs !== null && { retryAfterHeader: true }),
         },
         'webhook.retry',
       );
@@ -123,9 +129,15 @@ export async function retryWithBackoff<T>(
     }
   }
 
-  const errMsg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  const lastMsg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  const firstMsg =
+    firstErr instanceof Error ? firstErr.message : String(firstErr);
   logger.error(
-    { attempts_exhausted: maxAttempts, error: errMsg },
+    {
+      attempts_exhausted: maxAttempts,
+      first_error: firstMsg,
+      error: lastMsg,
+    },
     'webhook.failed',
   );
   throw new FatalError(
@@ -134,6 +146,32 @@ export async function retryWithBackoff<T>(
       cause: lastErr,
     },
   );
+}
+
+function extractRetryAfterMs(err: unknown): number | null {
+  if (!(err instanceof Error)) return null;
+  const typed = err as Error & {
+    headers?: Record<string, string>;
+    response?: {
+      headers?: Record<string, string> & { get?: (k: string) => string };
+    };
+  };
+  const raw =
+    typed.headers?.['retry-after'] ??
+    typed.response?.headers?.['retry-after'] ??
+    typed.response?.headers?.get?.('retry-after');
+  if (!raw) return null;
+
+  const seconds = Number(raw);
+  if (!Number.isNaN(seconds) && seconds > 0) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(raw);
+  if (!Number.isNaN(dateMs)) {
+    const delta = dateMs - Date.now();
+    return delta > 0 ? delta : 0;
+  }
+  return null;
 }
 
 function isNonRetryableHttpError(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- **Block auto-merge until completion-gate finishes**: Fixes race condition where 3 PRs (#509, #501, #497) merged with incomplete ACs. Adds `runInlineCompletionCheck()` that runs the completion-gate inline at all 3 auto-merge call sites (immediate, cooldown retry, startup sweep). Fail-closed on error.
- **LIA-51 patch**: Extract `Retry-After` header on 429 responses (numeric + HTTP-date, capped at 30s). Capture `first_error` in `webhook.failed` exhaustion log.
- Updates completion-gate spec with pre-merge invocation context.

## Test plan
- [x] All 1147 tests pass (45 webhook-specific)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Prettier format check passes
- [x] All drift checks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)