### PR TITLE
fix(pipeline): strip newlines from event details in TUI

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-23T22:57" # auto-bump
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-23T22:57" # auto-bump
+last_verified: "2026-05-23" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -156,8 +156,10 @@ export function formatElapsed(isoTimestamp: string): string {
 }
 
 function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + '…';
+  // DB stores raw gh stderr which embeds newlines/tabs that break TUI rows
+  const clean = str.replace(/[\r\n\t]+/g, ' ');
+  if (clean.length <= maxLen) return clean;
+  return clean.slice(0, maxLen - 1) + '…';
 }
 
 function printEvents(
@@ -174,10 +176,15 @@ function printEvents(
     return;
   }
 
+  const cols = process.stdout.columns || 80;
+  const detailWidth = Math.max(10, cols - 46);
+
   for (const e of events) {
     const time = e.created_at.slice(0, 16).replace('T', ' ');
     const color = colorFor(e.event_type);
-    const detail = e.detail ? ` ${DIM}— ${e.detail}${RESET}` : '';
+    const detail = e.detail
+      ? ` ${DIM}— ${truncate(e.detail, detailWidth)}${RESET}`
+      : '';
     console.log(
       `${DIM}${time}${RESET}  ${CYAN}${e.identifier.padEnd(8)}${RESET}  ${color}${(EVENT_LABELS[e.event_type] || e.event_type).padEnd(22)}${RESET}${detail}`,
     );
@@ -680,7 +687,10 @@ async function startWatchMode(): Promise<void> {
         const time = e.created_at.slice(0, 16).replace('T', ' ');
         const color = colorFor(e.event_type);
         const label = EVENT_LABELS[e.event_type] || e.event_type;
-        const detail = e.detail ? ` ${DIM}— ${e.detail}${RESET}` : '';
+        const detailWidth = Math.max(10, cols - 46);
+        const detail = e.detail
+          ? ` ${DIM}— ${truncate(e.detail, detailWidth)}${RESET}`
+          : '';
         lines.push(
           `  ${DIM}${time}${RESET}  ${color}${label.padEnd(22)}${RESET}${detail}`,
         );


### PR DESCRIPTION
## Summary
- Pipeline event details stored in SQLite contain raw `gh` stderr output with embedded newlines
- On wide terminals, newlines passed through `truncate()` and broke TUI rows into garbled multi-line fragments
- Fixed by stripping `\r\n\t` in `truncate()` and adding proper truncation to detail view + one-shot mode

## Test plan
- [x] All 17 existing tests pass
- [x] Verified fix handles actual DB data with embedded newlines
- [ ] Visual verification: run `deus pipeline` and confirm no garbled text

🤖 Generated with [Claude Code](https://claude.com/claude-code)