### PR TITLE
feat(pipeline): container project mount + dispatch agent context

### DIFF
--- a/.claude/codebase_map.md
+++ b/.claude/codebase_map.md
@@ -1,4 +1,4 @@
-<!-- sha: 654d2d6797ce83f3de986fd1bec4cb45612d9aec -->
+<!-- sha: 671be0813be191aa7c977b8e70aa34cdac657dfd -->
 
 # Deus Codebase Map
 

--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,8 @@ LINEAR_API_TOKEN=
 # LINEAR_BOT_USER_ID=
 # Auto-merge agent PRs after CI passes (0=off, 1=on)
 # LINEAR_AUTO_MERGE=0
+# Host project path for dispatch agents (mounted writable in container)
+# LINEAR_DISPATCH_PROJECT=~/deus
 # Max retry attempts for webhook dispatch (default: 3)
 # WEBHOOK_MAX_RETRIES=3
 # Base delay in ms for webhook retry backoff: min(base * 2^attempt + jitter, 30000) (default: 1000)

--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,13 @@ logs/
 groups/*
 !groups/main/
 !groups/global/
+!groups/linear-dispatch/
 groups/main/*
 groups/global/*
+groups/linear-dispatch/*
 !groups/main/CLAUDE.md.template
 !groups/global/CLAUDE.md.template
+!groups/linear-dispatch/CLAUDE.md.template
 
 # Generated group CLAUDE.md files (local customizations, like .env)
 groups/*/CLAUDE.md

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -332,3 +332,13 @@ Every pipeline event also fires a macOS native notification via `osascript` (bes
 - Cooldown and dedup mechanisms prevent runaway agent spend on flapping issues.
 - The SQLite event log provides a complete audit trail of every gate evaluation without external infrastructure.
 - ngrok (or equivalent tunnel) is a hard dependency for local development; production deployments need a stable public endpoint.
+
+## Revision: 2026-05-24 -- Dispatch Group Elevated to Control Group
+
+The dispatch group (`linear-dispatch`) is now registered with `isControlGroup: true`, and dispatch agent `RunContext` uses `isControlGroup: true`. This enables writable project mounts for dispatch agents that need to create branches, edit files, commit, and push.
+
+Previously `isControlGroup: false` -- the mount at `/workspace/project` was forced readonly by `container-mounter.ts:152` (`effectiveReadonly = project.readonly || !isControlGroup`). Dispatch agents could not make code changes.
+
+Gate agents (webhook handler) remain `isControlGroup: false` -- they only read and evaluate, never modify the project.
+
+Security is maintained through mount allowlist validation at project registration time, sensitive file shadowing (`.env`, credentials, `.git/config`), and container isolation. Existing installs are automatically upgraded on next startup.

--- a/groups/linear-dispatch/CLAUDE.md.template
+++ b/groups/linear-dispatch/CLAUDE.md.template
@@ -1,0 +1,44 @@
+# Linear Dispatch Agent
+
+You are an autonomous software engineer dispatched by Deus to implement a Linear issue.
+
+## Workflow
+
+1. Read the scope block in the issue description for the implementation plan and acceptance criteria.
+2. Create a feature branch from main: `git checkout -b feat/<issue-id>-<short-desc>`
+3. Implement the changes following the plan.
+4. Run all quality gates before pushing (see below).
+5. Push and create a PR using the tool proxy.
+6. Report what you did and include the PR URL in your response.
+
+## Quality Gates
+
+Before pushing, verify all of the following pass:
+
+- `npm run build` - TypeScript compiles without errors
+- `npx prettier --check src/` - formatting passes (fix with `npx prettier --write src/`)
+- `npm test` - tests pass for modified areas
+- Self-review: re-read the acceptance criteria and verify each one is met
+- Security: no hardcoded secrets, no command injection, proper input validation at boundaries
+
+## Git Push (via tool proxy)
+
+Do NOT use `git push` directly. Use the tool proxy:
+
+```bash
+curl -s -X POST "$DEUS_TOOL_PROXY_URL/tool/deus-git-push" \
+  -H "Content-Type: application/json" \
+  -H "x-deus-proxy-token: $DEUS_PROXY_TOKEN" \
+  -d '{"args": ["-u", "origin", "HEAD"]}'
+```
+
+## PR Creation (via tool proxy)
+
+```bash
+curl -s -X POST "$DEUS_TOOL_PROXY_URL/tool/gh" \
+  -H "Content-Type: application/json" \
+  -H "x-deus-proxy-token: $DEUS_PROXY_TOKEN" \
+  -d '{"args": ["pr", "create", "--fill", "--body", "Closes <ISSUE-ID>"]}'
+```
+
+Replace `<ISSUE-ID>` with the actual issue identifier (e.g., LIA-42).

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-24"  # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-24"  # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-24"  # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -21,6 +21,8 @@ import {
   buildIssuePrompt,
   startLinearDispatcher,
   stopLinearDispatcher,
+  truncateComments,
+  extractScopeBlock,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
@@ -298,5 +300,120 @@ describe('pollLinear dispatch ordering', () => {
       (call: unknown[]) => call[1] as string,
     );
     expect(callOrder).toEqual(['aaa', 'bbb']);
+  });
+});
+
+describe('truncateComments', () => {
+  it('returns empty array for empty input', () => {
+    expect(truncateComments([])).toEqual([]);
+  });
+
+  it('preserves all comments when under budget', () => {
+    const comments = [
+      { author: 'Alice', body: 'First' },
+      { author: 'Bob', body: 'Second' },
+    ];
+    expect(truncateComments(comments)).toEqual(comments);
+  });
+
+  it('always preserves gate verdict comments', () => {
+    const comments = [
+      { author: 'Bot', body: '**Warden: readiness-gate** - SHIP\nLooks good' },
+      { author: 'Alice', body: 'old comment 1' },
+      { author: 'Bob', body: 'old comment 2' },
+      { author: 'Carol', body: 'old comment 3' },
+      { author: 'Dave', body: 'recent 1' },
+      { author: 'Eve', body: 'recent 2' },
+      { author: 'Frank', body: 'recent 3' },
+    ];
+    const result = truncateComments(comments, 50);
+    const bodies = result.map((c) => c.body);
+    expect(bodies).toContain('**Warden: readiness-gate** - SHIP\nLooks good');
+  });
+
+  it('always preserves the most recent 3 regular comments', () => {
+    const comments = [
+      { author: 'A', body: 'old 1' },
+      { author: 'B', body: 'old 2' },
+      { author: 'C', body: 'recent 1' },
+      { author: 'D', body: 'recent 2' },
+      { author: 'E', body: 'recent 3' },
+    ];
+    const result = truncateComments(comments, 10);
+    const bodies = result.map((c) => c.body);
+    expect(bodies).toContain('recent 1');
+    expect(bodies).toContain('recent 2');
+    expect(bodies).toContain('recent 3');
+  });
+
+  it('drops oldest non-gate comments when over budget', () => {
+    const comments = [
+      { author: 'A', body: 'x'.repeat(20000) },
+      { author: 'B', body: 'y'.repeat(20000) },
+      { author: 'C', body: 'recent 1' },
+      { author: 'D', body: 'recent 2' },
+      { author: 'E', body: 'recent 3' },
+    ];
+    const result = truncateComments(comments, 100);
+    expect(result[0]).toEqual({
+      author: 'System',
+      body: '[2 earlier comments omitted]',
+    });
+    expect(result.length).toBe(4); // omission marker + 3 recent
+  });
+
+  it('includes omission marker when older comments are dropped', () => {
+    const comments = [
+      { author: 'A', body: 'old' },
+      { author: 'B', body: 'old' },
+      { author: 'C', body: 'r1' },
+      { author: 'D', body: 'r2' },
+      { author: 'E', body: 'r3' },
+    ];
+    const result = truncateComments(comments, 1);
+    expect(result[0].body).toMatch(/earlier comments omitted/);
+  });
+});
+
+describe('extractScopeBlock', () => {
+  it('extracts content between scope markers', () => {
+    const desc = `Some intro text
+
+<!-- gate:agent-readiness-gate:start -->
+## Scope
+- Fix the login bug
+- Add tests
+<!-- gate:agent-readiness-gate:end -->
+
+<!-- gate:output-quality-gate:start -->
+Quality feedback here
+<!-- gate:output-quality-gate:end -->`;
+
+    const result = extractScopeBlock(desc);
+    expect(result).toContain('Fix the login bug');
+    expect(result).toContain('Add tests');
+    expect(result).not.toContain('Quality feedback');
+    expect(result).not.toContain('Some intro text');
+  });
+
+  it('returns full description when no scope block exists', () => {
+    const desc = 'Just a plain description with no markers.';
+    expect(extractScopeBlock(desc)).toBe(desc);
+  });
+
+  it('returns full description with malformed markers (start only)', () => {
+    const desc = 'Text <!-- gate:agent-readiness-gate:start --> partial block';
+    expect(extractScopeBlock(desc)).toBe(desc);
+  });
+
+  it('returns full description with malformed markers (end only)', () => {
+    const desc = 'Text <!-- gate:agent-readiness-gate:end --> partial block';
+    expect(extractScopeBlock(desc)).toBe(desc);
+  });
+
+  it('returns full description when end comes before start', () => {
+    const desc =
+      '<!-- gate:agent-readiness-gate:end -->before<!-- gate:agent-readiness-gate:start -->';
+    expect(extractScopeBlock(desc)).toBe(desc);
   });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -1,10 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { LinearClient } from '@linear/sdk';
-import { DATA_DIR } from './config.js';
+import { DATA_DIR, HOME_DIR, GROUPS_DIR } from './config.js';
 import { parse as parseYaml } from 'yaml';
 import { logger } from './logger.js';
 import { PROJECT_ROOT } from './config.js';
+import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
 import { fireAndForget } from './async/index.js';
 import { extractPrUrl } from './pr-url-extractor.js';
@@ -176,13 +177,82 @@ export function buildIssuePrompt(
     `<role>\n${role.content}\n</role>`,
     `<issue>\nTitle: ${issueTitle}\nID: ${issueIdentifier}\n\n${issueDescription ?? '(no description)'}\n</issue>`,
   ];
-  if (comments.length > 0) {
-    const commentBlock = comments
+  const truncated = truncateComments(comments);
+  if (truncated.length > 0) {
+    const commentBlock = truncated
       .map((c) => `[${c.author}]: ${c.body}`)
       .join('\n\n');
     parts.push(`<comments>\n${commentBlock}\n</comments>`);
   }
   return parts.join('\n\n');
+}
+
+export function truncateComments(
+  comments: Array<{ author: string; body: string }>,
+  maxChars: number = 32000,
+): Array<{ author: string; body: string }> {
+  if (comments.length === 0) return [];
+
+  const isGateComment = (c: { body: string }) => c.body.includes('**Warden:');
+
+  const keepSet = new Set<number>();
+  let regularCount = 0;
+  for (let i = comments.length - 1; i >= 0; i--) {
+    if (isGateComment(comments[i])) {
+      keepSet.add(i);
+    } else if (regularCount < 3) {
+      keepSet.add(i);
+      regularCount++;
+    }
+  }
+
+  const preservedChars = [...keepSet].reduce(
+    (sum, i) => sum + comments[i].author.length + comments[i].body.length,
+    0,
+  );
+
+  // Determine which older regular comments fit in the remaining budget
+  let remainingBudget = maxChars - preservedChars;
+  const droppable = comments
+    .map((c, i) => ({ idx: i, chars: c.author.length + c.body.length }))
+    .filter(({ idx }) => !keepSet.has(idx));
+
+  // Fill from newest droppable toward oldest
+  const includedSet = new Set<number>();
+  for (let i = droppable.length - 1; i >= 0; i--) {
+    if (droppable[i].chars <= remainingBudget) {
+      includedSet.add(droppable[i].idx);
+      remainingBudget -= droppable[i].chars;
+    }
+  }
+
+  const omitted = droppable.length - includedSet.size;
+  const result: Array<{ author: string; body: string }> = [];
+  if (omitted > 0) {
+    result.push({
+      author: 'System',
+      body: `[${omitted} earlier comments omitted]`,
+    });
+  }
+
+  // Emit kept comments in original chronological order
+  for (let i = 0; i < comments.length; i++) {
+    if (keepSet.has(i) || includedSet.has(i)) {
+      result.push(comments[i]);
+    }
+  }
+  return result;
+}
+
+export function extractScopeBlock(description: string): string {
+  const startMarker = '<!-- gate:agent-readiness-gate:start -->';
+  const endMarker = '<!-- gate:agent-readiness-gate:end -->';
+  const startIdx = description.indexOf(startMarker);
+  const endIdx = description.indexOf(endMarker);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    return description;
+  }
+  return description.slice(startIdx + startMarker.length, endIdx).trim();
 }
 
 export function buildScopedIssuePrompt(
@@ -191,19 +261,14 @@ export function buildScopedIssuePrompt(
   issueDescription: string,
   comments: Array<{ author: string; body: string }>,
 ): string {
+  const scopeContent = extractScopeBlock(issueDescription);
   const parts = [
-    `<task>\nYou are an autonomous software engineer. Implement the following issue.\nTitle: ${issueTitle}\nID: ${issueIdentifier}\n\n${issueDescription}\n</task>`,
+    `<task>\nYou are an autonomous software engineer. Implement the following issue.\nTitle: ${issueTitle}\nID: ${issueIdentifier}\n\n${scopeContent}\n</task>`,
   ];
-  if (comments.length > 0) {
-    const commentBlock = comments
-      .map((c) => `[${c.author}]: ${c.body}`)
-      .join('\n\n');
-    parts.push(`<comments>\n${commentBlock}\n</comments>`);
-  }
+
   const hasReviseHistory = comments.some(
     (c) => c.body.includes('**Warden:') && c.body.includes('REVISE'),
   );
-
   const hasAgentHistory = comments.some(
     (c) =>
       c.body.includes('Agent run failed') ||
@@ -212,6 +277,15 @@ export function buildScopedIssuePrompt(
       c.body.includes('**Auto-merge blocked**') ||
       c.body.includes('PR URL in your response'),
   );
+
+  // Scan above runs on full array — truncation may drop older slots containing these signals
+  const truncated = truncateComments(comments);
+  if (truncated.length > 0) {
+    const commentBlock = truncated
+      .map((c) => `[${c.author}]: ${c.body}`)
+      .join('\n\n');
+    parts.push(`<comments>\n${commentBlock}\n</comments>`);
+  }
 
   let contextBlock = '';
   if (hasReviseHistory) {
@@ -224,31 +298,7 @@ export function buildScopedIssuePrompt(
   }
 
   parts.push(
-    `<instructions>
-${contextBlock}Read the scope block in the task description. Follow the implementation plan and satisfy all acceptance criteria.
-
-## Quality Gates (run before pushing)
-1. Run \`npm run build\` to verify TypeScript compiles.
-2. Run \`npx prettier --check src/\` and fix any formatting issues.
-3. Run \`npm test\` if tests exist for the modified area.
-4. Self-review: re-read the acceptance criteria and verify each one is met.
-5. Check your diff for: security issues, hardcoded values, missing error handling at system boundaries.
-
-## Git Workflow
-1. Create a feature branch: \`git checkout -b feat/${issueIdentifier.toLowerCase().replace(/[^a-z0-9-]/g, '')}-<short-desc>\`
-2. Implement the changes, run tests, commit.
-3. Push the branch using the tool proxy:
-   curl -s -X POST "$DEUS_TOOL_PROXY_URL/tool/deus-git-push" \\
-     -H "Content-Type: application/json" \\
-     -H "x-deus-proxy-token: $DEUS_PROXY_TOKEN" \\
-     -d '{"args": ["-u", "origin", "HEAD"]}'
-4. Create a PR using the tool proxy:
-   curl -s -X POST "$DEUS_TOOL_PROXY_URL/tool/gh" \\
-     -H "Content-Type: application/json" \\
-     -H "x-deus-proxy-token: $DEUS_PROXY_TOKEN" \\
-     -d '{"args": ["pr", "create", "--fill", "--body", "Closes ${issueIdentifier.replace(/[^A-Za-z0-9-]/g, '')}"]}'
-5. Report what you did and include the PR URL in your response.
-</instructions>`,
+    `<instructions>\n${contextBlock}Read the scope block in the task description. Follow the implementation plan and satisfy all acceptance criteria.\n</instructions>`,
   );
   return parts.join('\n\n');
 }
@@ -461,7 +511,7 @@ async function pollLinear(): Promise<void> {
       prompt,
       groupFolder: DISPATCH_GROUP_JID,
       chatJid,
-      isControlGroup: false,
+      isControlGroup: true,
       isScheduledTask: true,
       effort: 'high',
     };
@@ -522,16 +572,93 @@ export async function initLinearContext(
     const existing = Object.values(deps.registeredGroups()).find(
       (g) => g.folder === DISPATCH_GROUP_JID,
     );
-    const dispatchGroup: RegisteredGroup = existing || {
-      name: 'Linear Dispatch',
-      folder: DISPATCH_GROUP_JID,
-      trigger: '',
-      added_at: new Date().toISOString(),
-      requiresTrigger: false,
-      isControlGroup: false,
-    };
+    let dispatchGroup: RegisteredGroup = existing
+      ? { ...existing }
+      : {
+          name: 'Linear Dispatch',
+          folder: DISPATCH_GROUP_JID,
+          trigger: '',
+          added_at: new Date().toISOString(),
+          requiresTrigger: false,
+          isControlGroup: true,
+        };
     if (!existing) {
       deps.registerGroup(DISPATCH_GROUP_JID, dispatchGroup);
+    }
+    // Upgrade existing installs: dispatch group needs control-group privileges
+    // for writable project mounts (agents create branches, edit files, commit)
+    if (existing && !dispatchGroup.isControlGroup) {
+      dispatchGroup = { ...dispatchGroup, isControlGroup: true };
+      deps.registerGroup(DISPATCH_GROUP_JID, dispatchGroup);
+      logger.info(
+        'linear-dispatcher: upgraded dispatch group to control group',
+      );
+    }
+
+    // Auto-associate project with dispatch group (find-or-create pattern)
+    const dispatchProjectPath = process.env.LINEAR_DISPATCH_PROJECT;
+    if (dispatchProjectPath && !dispatchGroup.projectId) {
+      const resolved = path.resolve(
+        dispatchProjectPath.replace(/^~/, HOME_DIR),
+      );
+      let realPath = '';
+      try {
+        realPath = fs.realpathSync(resolved);
+      } catch {
+        logger.warn(
+          { path: resolved },
+          'linear-dispatcher: LINEAR_DISPATCH_PROJECT path does not exist',
+        );
+      }
+      if (realPath) {
+        let project = getProjectByPath(realPath);
+        if (!project) {
+          try {
+            project = registerProject(path.basename(realPath), realPath, {
+              readonly: false,
+            });
+            logger.info(
+              { projectId: project.id, path: realPath },
+              'linear-dispatcher: auto-registered project',
+            );
+          } catch (err) {
+            project = getProjectByPath(realPath);
+            if (project) {
+              logger.info(
+                { projectId: project.id, path: realPath },
+                'linear-dispatcher: project already registered (race)',
+              );
+            } else {
+              const msg = err instanceof Error ? err.message : String(err);
+              logger.warn(
+                { path: realPath, error: msg },
+                'linear-dispatcher: failed to register project',
+              );
+            }
+          }
+        }
+        if (project) {
+          dispatchGroup = { ...dispatchGroup, projectId: project.id };
+          deps.registerGroup(DISPATCH_GROUP_JID, dispatchGroup);
+          logger.info(
+            { projectId: project.id },
+            'linear-dispatcher: project associated with dispatch group',
+          );
+        }
+      }
+    }
+
+    // Bootstrap group CLAUDE.md from template if not yet initialized
+    const groupDir = path.join(GROUPS_DIR, DISPATCH_GROUP_JID);
+    const claudeMdPath = path.join(groupDir, 'CLAUDE.md');
+    const templatePath = path.join(
+      GROUPS_DIR,
+      DISPATCH_GROUP_JID,
+      'CLAUDE.md.template',
+    );
+    if (!fs.existsSync(claudeMdPath) && fs.existsSync(templatePath)) {
+      fs.copyFileSync(templatePath, claudeMdPath);
+      logger.info('linear-dispatcher: initialized CLAUDE.md from template');
     }
 
     // Discover or create gate status labels for board-level visibility


### PR DESCRIPTION
## Summary

- Wire up project mount for Linear-dispatch container agents via `LINEAR_DISPATCH_PROJECT` env var
- Elevate dispatch group to `isControlGroup: true` for writable project mounts
- Add `groups/linear-dispatch/CLAUDE.md.template` with dispatch agent instructions (Quality Gates, Git Workflow)
- Add `truncateComments()` (32k char budget, preserves gate verdicts + recent 3, chronological order)
- Add `extractScopeBlock()` (strips non-scope gate enrichment blocks from dispatch prompts)
- 7 new unit tests for truncation and extraction

Previously, dispatch agents had no project mounted — they couldn't read source, build, test, or lint. The mount infrastructure existed in `container-mounter.ts` but was never connected.

Restart required to apply `isControlGroup` upgrade and bootstrap CLAUDE.md from template on existing installs.

## Test plan

- [x] `npm run build` compiles clean
- [x] 20 tests pass (`npx vitest run src/linear-dispatcher.test.ts`)
- [x] Template file not gitignored (`git check-ignore` returns exit code 1)
- [x] Drift check passes
- [ ] E2E: Set `LINEAR_DISPATCH_PROJECT=~/deus`, restart, verify logs show auto-registration + association
- [ ] E2E: Dispatch a test issue, verify container can `npm run build` in `/workspace/project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)