### PR TITLE
feat(setup): add vault path to Claude Code sandbox allowlist

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-24"  # auto-bump
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-24"  # auto-bump
+last_verified: "2026-05-24" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-24"  # auto-bump
+last_verified: "2026-05-24" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/scripts/settings_merge.py
+++ b/scripts/settings_merge.py
@@ -182,6 +182,12 @@ if __name__ == "__main__":
              "SETTINGS_SUBST_<N>_OLD / SETTINGS_SUBST_<N>_NEW (N=0,1,...).",
     )
 
+    sp = sub.add_parser(
+        "sandbox-allow",
+        help="Add a path to sandbox.filesystem.allowWrite (dedup, flock)",
+    )
+    sp.add_argument("path_to_add", help="Path to add (e.g. ~/Desktop/vault)")
+
     args = parser.parse_args()
 
     if args.cmd == "merge" or args.cmd is None:
@@ -222,3 +228,16 @@ if __name__ == "__main__":
 
         result = rewrite_settings(args.path, _subst_transform)
         print(json.dumps(result, indent=2))
+
+    elif args.cmd == "sandbox-allow":
+        new_path = args.path_to_add
+
+        def _add_sandbox_path(settings: dict[str, Any]) -> dict[str, Any]:
+            sandbox = settings.setdefault("sandbox", {})
+            fs_cfg = sandbox.setdefault("filesystem", {})
+            existing = fs_cfg.get("allowWrite", [])
+            if new_path not in existing:
+                fs_cfg["allowWrite"] = existing + [new_path]
+            return settings
+
+        rewrite_settings(args.path, _add_sandbox_path)

--- a/setup/memory.ts
+++ b/setup/memory.ts
@@ -9,13 +9,14 @@
  *   5. Memory database initialized
  *   6. Gemini API key (suggested, not required)
  */
-import { execSync, spawnSync } from 'child_process';
+import { execFileSync, execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
 import { HOME_DIR, CONFIG_DIR } from '../src/config.js';
 import { resolvePython } from '../src/checks.js';
 import { logger } from '../src/logger.js';
+import { isUnderProtectedDir } from '../src/platform.js';
 import { emitStatus } from './status.js';
 
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
@@ -277,6 +278,30 @@ export async function run(args: string[]): Promise<void> {
 
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
   logger.info({ configPath: CONFIG_PATH }, 'Config written');
+
+  // ── 4b. Ensure Claude Code sandbox allows vault access ──────────────────
+  if (isUnderProtectedDir(vaultPath)) {
+    const vaultTilde = vaultPath.startsWith(HOME_DIR)
+      ? '~' + vaultPath.slice(HOME_DIR.length)
+      : vaultPath;
+    try {
+      execFileSync(
+        pythonCmd,
+        [
+          path.join(process.cwd(), 'scripts', 'settings_merge.py'),
+          'sandbox-allow',
+          vaultTilde,
+        ],
+        { encoding: 'utf-8', timeout: 5000 },
+      );
+      logger.info(
+        { path: vaultTilde },
+        'Added vault to Claude Code sandbox allowlist',
+      );
+    } catch (err) {
+      logger.warn({ err }, 'Could not update Claude Code sandbox settings');
+    }
+  }
 
   // ── 5. Initialize memory database ────────────────────────────────────────
   try {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -12,6 +12,7 @@
 import { execFileSync, spawn } from 'child_process';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 
 // ── Platform detection ─────────────────────────────────────────────────────
 
@@ -32,6 +33,31 @@ export const PYTHON_BIN =
 
 /** Home directory. Always use this — process.env.HOME is undefined on Windows. */
 export const homeDir = os.homedir();
+
+const MACOS_PROTECTED_DIRS = [
+  'Desktop',
+  'Documents',
+  'Downloads',
+  'Pictures',
+  'Movies',
+  'Music',
+  'Library',
+];
+
+/**
+ * Check if a path is under a macOS TCC-protected directory.
+ * Claude Code's Bash sandbox restricts access to these directories.
+ * Linux/Windows: no equivalent restriction — always returns false.
+ */
+export function isUnderProtectedDir(absPath: string): boolean {
+  if (!IS_MACOS) return false;
+  return MACOS_PROTECTED_DIRS.some((dir) => {
+    const protectedPath = path.join(homeDir, dir);
+    return (
+      absPath === protectedPath || absPath.startsWith(protectedPath + path.sep)
+    );
+  });
+}
 
 // ── Process management ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add `isUnderProtectedDir()` to `src/platform.ts` — checks if a path is under a macOS TCC-protected directory (IS_MACOS-gated)
- Add `sandbox-allow` subcommand to `scripts/settings_merge.py` — appends a path to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json` with flock + dedup
- Call from `setup/memory.ts` after vault config write when vault is under a protected dir

When the vault is under `~/Desktop`, `~/Documents`, etc., Claude Code's Bash sandbox blocks read/write access to existing files. This caused `/compress` to silently fail on vault CLAUDE.md updates.

## Test plan

- [x] `npm run build` compiles
- [x] `npm test` — 1494 tests pass
- [x] `python3 scripts/settings_merge.py sandbox-allow "~/Desktop/test"` — entry added
- [x] Run again — no duplicate
- [x] `permissions.allow` array unchanged after sandbox-allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)