### PR TITLE
fix(agent-runner): exit query loop immediately for scheduled tasks (LIA-65)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1140,6 +1140,11 @@ async function main(): Promise<void> {
         newSessionId: sessionId,
       });
 
+      if (containerInput.isScheduledTask) {
+        log('Scheduled task: exiting after first result');
+        break;
+      }
+
       log('Query ended, waiting for next IPC message...');
 
       // Wait for the next message or _close sentinel

--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -522,6 +522,12 @@ export async function runLlamaCppConversation(
     }
 
     if (shouldClose()) break;
+
+    if (containerInput.isScheduledTask) {
+      log('Scheduled task: exiting after first result');
+      break;
+    }
+
     const nextMessage = await waitForIpcMessage();
     if (nextMessage === null) break;
     prompt = nextMessage;

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -595,6 +595,11 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
 
     if (shouldClose()) break;
 
+    if (containerInput.isScheduledTask) {
+      log('Scheduled task: exiting after first result');
+      break;
+    }
+
     const nextMessage = await waitForIpcMessage();
     if (nextMessage === null) break;
     prompt = nextMessage;


### PR DESCRIPTION
## Summary
- Adds `isScheduledTask` early-exit guard after `writeOutput` in all three backends
- Prevents containers from idling in `waitForIpcMessage()` when no follow-up is coming
- Patch originally produced by container agent but blocked by read-only mount

Closes LIA-65

## Test plan
- [ ] Verify `npm run build` passes in container/agent-runner
- [ ] Verify scheduled task exits after first result
- [ ] Verify interactive (non-scheduled) sessions still wait for follow-up messages

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>