### PR TITLE
feat(pipeline): circuit breaker for dispatch re-dispatch loops (LIA-65)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-24" # auto-bump (LIA-80)
+last_verified: "2026-05-24"  # auto-bump (LIA-80)
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-24" # auto-bump (LIA-80)
+last_verified: "2026-05-24"  # auto-bump (LIA-80)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -7,12 +7,15 @@ import {
   deleteTask,
   getAllChats,
   getAllRegisteredGroups,
+  getConsecutiveFailCount,
+  getLastFailTime,
   getMessagesSince,
   getNewMessages,
   getAllSessions,
   getAllBackendSessions,
   getTaskById,
   getSession,
+  logPipelineEvent,
   setSession,
   setRegisteredGroup,
   storeChatMetadata,
@@ -768,6 +771,96 @@ describe('linear_issue_cache', () => {
       upsertIssueCache(sampleIssue('stale', 'Backlog'));
       reconcileIssueCache(new Set(ids), upserts);
       expect(getIssueCacheCount()).toBe(50);
+    });
+  });
+});
+
+describe('circuit breaker', () => {
+  describe('getConsecutiveFailCount', () => {
+    it('returns 0 when no events exist', () => {
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(0);
+    });
+
+    it('counts consecutive failures', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'CI failed');
+      logPipelineEvent(
+        'issue-1',
+        'LIA-1',
+        'automerge_failed',
+        'CI failed again',
+      );
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(2);
+    });
+
+    it('resets count after agent_completed', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
+      logPipelineEvent('issue-1', 'LIA-1', 'agent_completed');
+      logPipelineEvent(
+        'issue-1',
+        'LIA-1',
+        'automerge_failed',
+        'fail after reset',
+      );
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
+    });
+
+    it('resets count after circuit_breaker_reset', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
+      logPipelineEvent('issue-1', 'LIA-1', 'circuit_breaker_reset', 'manual');
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(0);
+    });
+
+    it('counts agent failures separately from automerge failures', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'CI fail');
+      logPipelineEvent('issue-1', 'LIA-1', 'agent_failed', 'agent crash');
+      logPipelineEvent('issue-1', 'LIA-1', 'agent_failed', 'agent crash 2');
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
+      expect(getConsecutiveFailCount('issue-1', 'agent_failed')).toBe(2);
+    });
+
+    it('isolates counts between different issues', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail');
+      logPipelineEvent('issue-2', 'LIA-2', 'automerge_failed', 'fail');
+      logPipelineEvent('issue-2', 'LIA-2', 'automerge_failed', 'fail 2');
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
+      expect(getConsecutiveFailCount('issue-2', 'automerge_failed')).toBe(2);
+    });
+  });
+
+  describe('getLastFailTime', () => {
+    it('returns null when no events exist', () => {
+      expect(getLastFailTime('issue-1', 'automerge_failed')).toBeNull();
+    });
+
+    it('returns the most recent event time', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
+      const lastTime = getLastFailTime('issue-1', 'automerge_failed');
+      expect(lastTime).not.toBeNull();
+      expect(typeof lastTime).toBe('string');
+    });
+
+    it('returns time for correct event type only', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'agent_failed', 'crash');
+      expect(getLastFailTime('issue-1', 'automerge_failed')).toBeNull();
+      expect(getLastFailTime('issue-1', 'agent_failed')).not.toBeNull();
+    });
+
+    it('returns null after reset clears the window', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      logPipelineEvent('issue-1', 'LIA-1', 'circuit_breaker_reset', 'manual');
+      expect(getLastFailTime('issue-1', 'automerge_failed')).toBeNull();
+    });
+
+    it('returns time only from current failure epoch', () => {
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'old fail');
+      logPipelineEvent('issue-1', 'LIA-1', 'agent_completed');
+      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'new fail');
+      const lastTime = getLastFailTime('issue-1', 'automerge_failed');
+      expect(lastTime).not.toBeNull();
+      expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
     });
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -1402,6 +1402,45 @@ export function getReviseCount(issueId: string): number {
   return row.cnt;
 }
 
+export const CIRCUIT_BREAKER_THRESHOLD = 3;
+
+export function getConsecutiveFailCount(
+  issueId: string,
+  eventType: string,
+): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as cnt FROM linear_pipeline_events
+       WHERE issue_id = ? AND event_type = ?
+       AND rowid > COALESCE(
+         (SELECT MAX(rowid) FROM linear_pipeline_events
+          WHERE issue_id = ? AND event_type IN ('agent_completed', 'circuit_breaker_reset')),
+         0
+       )`,
+    )
+    .get(issueId, eventType, issueId) as { cnt: number };
+  return row.cnt;
+}
+
+export function getLastFailTime(
+  issueId: string,
+  eventType: string,
+): string | null {
+  const row = db
+    .prepare(
+      `SELECT created_at FROM linear_pipeline_events
+       WHERE issue_id = ? AND event_type = ?
+       AND rowid > COALESCE(
+         (SELECT MAX(rowid) FROM linear_pipeline_events
+          WHERE issue_id = ? AND event_type IN ('agent_completed', 'circuit_breaker_reset')),
+         0
+       )
+       ORDER BY rowid DESC LIMIT 1`,
+    )
+    .get(issueId, eventType, issueId) as { created_at: string } | undefined;
+  return row?.created_at ?? null;
+}
+
 export interface PipelineEventFilter {
   issueId?: string;
   identifier?: string;

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -10,8 +10,11 @@ import { promisify } from 'util';
 
 import { isAutoMergeEnabled } from './config.js';
 import {
+  CIRCUIT_BREAKER_THRESHOLD,
+  getConsecutiveFailCount,
   getIssuePr,
   getPendingAutoMerges,
+  logPipelineEvent,
   updatePrAutoMergeState,
   upsertIssuePr,
 } from './db.js';
@@ -23,6 +26,28 @@ import type { LinearContext } from './linear-dispatcher.js';
 const execFileAsync = promisify(execFile);
 
 const CI_POLL_INTERVAL_MS = 60_000;
+// Separate from linear-dispatcher.ts's inline version due to circular import (LinearContext)
+async function tripCircuitBreaker(
+  ctx: LinearContext,
+  issueId: string,
+  ident: string,
+  failCount: number,
+  reason: string,
+): Promise<void> {
+  const manualReviewState = ctx.stateByName.get('Manual Review Required');
+  const parkState = manualReviewState ?? ctx.stateByName.get('Backlog')!;
+  await ctx.client.updateIssue(issueId, { stateId: parkState.id });
+  await ctx.client.createComment({
+    issueId,
+    body: `**Circuit breaker tripped** — ${failCount} consecutive CI/merge failures${reason ? ` (${reason})` : ''}. Moved to ${parkState.name}.\n\nTo retry: fix the underlying issue, then move back to **Ready for Agent**.`,
+  });
+  logPipelineEvent(
+    issueId,
+    ident,
+    'circuit_breaker_tripped',
+    `${failCount} consecutive automerge failures`,
+  );
+}
 const CI_CHECK_TIMEOUT_MS = 30_000;
 const MERGE_TIMEOUT_MS = 120_000;
 const MAX_POLL_ATTEMPTS = 30;
@@ -173,6 +198,12 @@ export async function attemptAutoMerge(
       notifyPipelineStep(ctx, issueId, ident, 'automerge_done', prUrl).catch(
         () => {},
       );
+      logPipelineEvent(
+        issueId,
+        ident,
+        'circuit_breaker_reset',
+        'merge succeeded',
+      );
       logger.info({ issueId, prUrl }, 'auto-merge: merged and moved to Done');
     } else {
       logger.warn(
@@ -187,10 +218,24 @@ export async function attemptAutoMerge(
         'automerge_failed',
         result.error,
       ).catch(() => {});
-      await ctx.client.createComment({
+      const mergeFailCount = getConsecutiveFailCount(
         issueId,
-        body: `**Auto-merge failed** - ${result.error}`,
-      });
+        'automerge_failed',
+      );
+      if (mergeFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
+        await tripCircuitBreaker(
+          ctx,
+          issueId,
+          ident,
+          mergeFailCount,
+          'merge failure',
+        );
+      } else {
+        await ctx.client.createComment({
+          issueId,
+          body: `**Auto-merge failed** - ${result.error}`,
+        });
+      }
     }
     return;
   }
@@ -205,21 +250,32 @@ export async function attemptAutoMerge(
         'automerge_failed',
         'Timed out',
       ).catch(() => {});
-      await ctx.client.createComment({
+      const timeoutFailCount = getConsecutiveFailCount(
         issueId,
-        body: `**Auto-merge timed out** - CI still pending after ${MAX_POLL_ATTEMPTS} attempts. PR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
-      });
-      const readyStateTimeout = ctx.stateByName.get('Ready for Agent');
-      if (readyStateTimeout) {
-        await ctx.client.updateIssue(issueId, {
-          stateId: readyStateTimeout.id,
-          priority: 1,
-        });
-      }
-      logger.warn(
-        { issueId, prUrl },
-        'auto-merge: timed out, moved to Ready for Agent',
+        'automerge_failed',
       );
+      if (timeoutFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
+        await tripCircuitBreaker(
+          ctx,
+          issueId,
+          ident,
+          timeoutFailCount,
+          'timeout',
+        );
+      } else {
+        await ctx.client.createComment({
+          issueId,
+          body: `**Auto-merge timed out** - CI still pending after ${MAX_POLL_ATTEMPTS} attempts. PR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
+        });
+        const readyStateTimeout = ctx.stateByName.get('Ready for Agent');
+        if (readyStateTimeout) {
+          await ctx.client.updateIssue(issueId, {
+            stateId: readyStateTimeout.id,
+            priority: 1,
+          });
+        }
+      }
+      logger.warn({ issueId, prUrl }, 'auto-merge: timed out');
       return;
     }
     setTimeout(() => {
@@ -232,7 +288,6 @@ export async function attemptAutoMerge(
     return;
   }
 
-  // CI failed — re-dispatch the agent to fix it
   updatePrAutoMergeState(issueId, 'failed');
   notifyPipelineStep(
     ctx,
@@ -241,22 +296,31 @@ export async function attemptAutoMerge(
     'automerge_failed',
     checks.summary,
   ).catch(() => {});
-  await ctx.client.createComment({
-    issueId,
-    body: `**Auto-merge blocked** - CI failed: ${checks.summary}\n\nPR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
-  });
-  const readyState = ctx.stateByName.get('Ready for Agent');
-  if (readyState) {
-    // priority 1 = urgent; ensures CI-fix re-dispatch runs before new work
-    await ctx.client.updateIssue(issueId, {
-      stateId: readyState.id,
-      priority: 1,
+
+  const ciFailCount = getConsecutiveFailCount(issueId, 'automerge_failed');
+  if (ciFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
+    await tripCircuitBreaker(ctx, issueId, ident, ciFailCount, 'CI failure');
+    logger.warn(
+      { issueId, prUrl, ciFailCount },
+      'auto-merge: circuit breaker tripped, parked issue',
+    );
+  } else {
+    await ctx.client.createComment({
+      issueId,
+      body: `**Auto-merge blocked** - CI failed: ${checks.summary}\n\nPR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
     });
+    const readyState = ctx.stateByName.get('Ready for Agent');
+    if (readyState) {
+      await ctx.client.updateIssue(issueId, {
+        stateId: readyState.id,
+        priority: 1,
+      });
+    }
+    logger.warn(
+      { issueId, prUrl },
+      'auto-merge: CI failed, moved to Ready for Agent',
+    );
   }
-  logger.warn(
-    { issueId, prUrl },
-    'auto-merge: CI failed, moved to Ready for Agent',
-  );
 }
 
 export async function sweepPendingAutoMerges(

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -14,6 +14,14 @@ vi.mock('./config.js', async () => {
   };
 });
 
+vi.mock('./db.js', () => ({
+  CIRCUIT_BREAKER_THRESHOLD: 3,
+  getConsecutiveFailCount: vi.fn().mockReturnValue(0),
+  getLastFailTime: vi.fn().mockReturnValue(null),
+  logPipelineEvent: vi.fn(),
+  upsertIssuePr: vi.fn(),
+}));
+
 const TEST_PROJECT_ROOT = path.join(os.tmpdir(), `deus-test-${process.pid}`);
 
 import {

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -9,7 +9,13 @@ import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
 import { fireAndForget } from './async/index.js';
 import { extractPrUrl } from './pr-url-extractor.js';
-import { upsertIssuePr } from './db.js';
+import {
+  CIRCUIT_BREAKER_THRESHOLD,
+  getConsecutiveFailCount,
+  getLastFailTime,
+  logPipelineEvent,
+  upsertIssuePr,
+} from './db.js';
 import { notifyPipelineStep } from './linear-notifications.js';
 import { resolveVaultPath } from './solutions/store.js';
 import { defaultSession } from './agent-runtimes/types.js';
@@ -24,6 +30,8 @@ import type { RegisteredGroup } from './types.js';
 
 const DEFAULT_POLL_MS = 30_000;
 const DISPATCH_GROUP_JID = 'linear-dispatch';
+const BACKOFF_FIRST_MS = 5 * 60_000;
+const BACKOFF_REPEAT_MS = 10 * 60_000;
 const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
 
 export interface LinearDispatcherDependencies {
@@ -150,6 +158,11 @@ export async function discoverWorkflowStates(
   if (!map.has('Done')) {
     logger.warn(
       'linear-dispatcher: workflow state "Done" not found — auto-merge will skip Done transition',
+    );
+  }
+  if (!map.has('Manual Review Required')) {
+    logger.info(
+      'linear-dispatcher: "Manual Review Required" state not found — circuit breaker will fall back to Backlog',
     );
   }
   for (const name of required) {
@@ -390,12 +403,33 @@ async function runIssue(
       notifyPipelineStep(ctx, issueId, identifier, 'agent_failed', error).catch(
         () => {},
       );
-      const backlogState = ctx.stateByName.get('Backlog')!;
-      await ctx.client.updateIssue(issueId, { stateId: backlogState.id });
-      logger.warn(
-        { issueId },
-        'linear-dispatcher: moved failed issue to Backlog',
-      );
+      const agentFailCount = getConsecutiveFailCount(issueId, 'agent_failed');
+      if (agentFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
+        const manualReviewState = ctx.stateByName.get('Manual Review Required');
+        const parkState = manualReviewState ?? ctx.stateByName.get('Backlog')!;
+        await ctx.client.updateIssue(issueId, { stateId: parkState.id });
+        await ctx.client.createComment({
+          issueId,
+          body: `**Circuit breaker tripped** — ${agentFailCount} consecutive agent failures. Moved to ${parkState.name}.\n\nTo retry: investigate the root cause, then move back to **Ready for Agent**.`,
+        });
+        logPipelineEvent(
+          issueId,
+          identifier,
+          'circuit_breaker_tripped',
+          `${agentFailCount} consecutive agent failures`,
+        );
+        logger.warn(
+          { issueId, agentFailCount },
+          'linear-dispatcher: circuit breaker tripped, parked issue',
+        );
+      } else {
+        const backlogState = ctx.stateByName.get('Backlog')!;
+        await ctx.client.updateIssue(issueId, { stateId: backlogState.id });
+        logger.warn(
+          { issueId },
+          'linear-dispatcher: moved failed issue to Backlog',
+        );
+      }
     } else {
       const body = text || '(no output produced)';
       const prUrl = extractPrUrl(body, ctx.repoSlug);
@@ -418,6 +452,12 @@ async function runIssue(
       });
       notifyPipelineStep(ctx, issueId, identifier, 'agent_completed').catch(
         () => {},
+      );
+      logPipelineEvent(
+        issueId,
+        identifier,
+        'circuit_breaker_reset',
+        'agent completed successfully',
       );
       logger.info({ issueId }, 'linear-dispatcher: issue moved to In Review');
     }
@@ -455,6 +495,43 @@ async function pollLinear(): Promise<void> {
   for (const issue of sorted) {
     if (dispatched >= slots) break;
     if (ctx.inFlightDispatch.has(issue.id)) continue;
+
+    const mergeFailCount = getConsecutiveFailCount(
+      issue.id,
+      'automerge_failed',
+    );
+    if (mergeFailCount > 0) {
+      const lastFail = getLastFailTime(issue.id, 'automerge_failed');
+      if (lastFail) {
+        const backoffMs =
+          mergeFailCount === 1 ? BACKOFF_FIRST_MS : BACKOFF_REPEAT_MS;
+        const elapsed = Date.now() - new Date(lastFail).getTime();
+        if (elapsed < backoffMs) {
+          logger.debug(
+            { issueId: issue.id, mergeFailCount, backoffMs, elapsed },
+            'linear-dispatcher: skipping issue in CI backoff window',
+          );
+          continue;
+        }
+      }
+    }
+
+    const agentFailCount = getConsecutiveFailCount(issue.id, 'agent_failed');
+    if (agentFailCount > 0) {
+      const lastAgentFail = getLastFailTime(issue.id, 'agent_failed');
+      if (lastAgentFail) {
+        const backoffMs =
+          agentFailCount === 1 ? BACKOFF_FIRST_MS : BACKOFF_REPEAT_MS;
+        const elapsed = Date.now() - new Date(lastAgentFail).getTime();
+        if (elapsed < backoffMs) {
+          logger.debug(
+            { issueId: issue.id, agentFailCount, backoffMs, elapsed },
+            'linear-dispatcher: skipping issue in agent failure backoff window',
+          );
+          continue;
+        }
+      }
+    }
 
     const labels = await issue.labels();
     const agentLabel = labels.nodes.find((l) => l.name.startsWith('agent:'));

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -52,6 +52,8 @@ export const EVENT_LABELS: Record<string, string> = {
   automerge_failed: 'Auto-merge failed',
   moved_done: 'Moved to Done',
   state_changed: 'State changed',
+  circuit_breaker_tripped: 'Circuit breaker tripped',
+  circuit_breaker_reset: 'Circuit breaker reset',
 };
 
 export function buildPipelineCommentBody(

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -10,6 +10,7 @@ import {
   insertWebhookEvent,
   updateWebhookEventStatus,
   getLastCompletedGateRun,
+  logPipelineEvent,
   upsertGateComment,
   getGateCommentId,
   upsertIssueCache,
@@ -451,6 +452,19 @@ async function handleIssueUpdate(
       'linear-webhook: skipping bot-triggered transition',
     );
     return;
+  }
+
+  if (toState.name === 'Ready for Agent') {
+    logPipelineEvent(
+      data.id,
+      data.identifier,
+      'circuit_breaker_reset',
+      'manual move to Ready for Agent',
+    );
+    logger.info(
+      { issueId: data.id },
+      'linear-webhook: circuit breaker reset (manual Ready for Agent)',
+    );
   }
 
   if (data.labels.some((l) => l.name === 'warden:skip')) {


### PR DESCRIPTION
## Summary

- Adds circuit breaker to prevent infinite CI-failure and agent-failure re-dispatch loops
- Parks stuck issues in "Manual Review Required" (fallback: Backlog) after 3 consecutive failures
- Adds 5m/10m backoff in `pollLinear()` to give CI time to settle between retries
- Counters reset on successful agent completion, successful merge, and manual user re-queue to "Ready for Agent"

## Changes

| File | Change |
|------|--------|
| `src/db.ts` | `getConsecutiveFailCount()`, `getLastFailTime()`, `CIRCUIT_BREAKER_THRESHOLD` |
| `src/linear-auto-merge.ts` | `tripCircuitBreaker()` helper; circuit breaker in CI fail, timeout, merge fail paths; reset on merge success |
| `src/linear-dispatcher.ts` | Backoff in `pollLinear()`; agent failure circuit breaker in `runIssue()`; reset on `agent_completed`; startup log for optional state |
| `src/linear-webhook.ts` | Counter reset on manual move to "Ready for Agent" |
| `src/linear-notifications.ts` | Event labels for `circuit_breaker_tripped` and `circuit_breaker_reset` |
| `src/db.test.ts` | 11 unit tests for `getConsecutiveFailCount` and `getLastFailTime` |
| `src/linear-dispatcher.test.ts` | DB mock for circuit breaker functions |

## Design decisions

- **5m/10m backoff** chosen over immediate retry: gives CI time to settle, prevents token waste
- **rowid-based ordering** in SQL (not `created_at`): monotonically increasing even within same millisecond
- **Reset-aware `getLastFailTime`**: uses same rowid anchor as `getConsecutiveFailCount` to avoid stale timestamps from prior failure epochs
- **`tripCircuitBreaker` not shared** between auto-merge and dispatcher: importing would create circular dep via `LinearContext`

## Test plan

- [x] `npm run build` compiles clean
- [x] All 1514 tests pass
- [x] `getConsecutiveFailCount` correctly resets after `agent_completed` and `circuit_breaker_reset`
- [x] `getLastFailTime` returns null after reset
- [x] Failure counts isolated between issues and event types
- [ ] Manual E2E: trigger CI failure, verify backoff timing and circuit breaker trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)