### PR TITLE
fix(hooks): block ExitPlanMode without plan-reviewer SHIP

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -739,7 +739,7 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     tool_name = str(event.get("tool_name") or "")
     if tool_name and not _warden_has_tool(
         config, "plan-reviewer", tool_name,
-        ["Edit", "Write", "MultiEdit", "apply_patch"],
+        ["Edit", "Write", "MultiEdit", "apply_patch", "ExitPlanMode"],
     ):
         return 0
 

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -748,6 +748,31 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     if _marker(repo_root, ".plan-reviewed").exists():
         return 0
 
+    # ExitPlanMode has no file paths — skip _managed_paths (which would
+    # escape via the empty-paths short-circuit) and block on marker alone.
+    if tool_name == "ExitPlanMode":
+        mark_cmd = (
+            f"  python3 {shlex.quote(str(_active_script_path(repo_root)))} "
+            f"mark plan-reviewed SHIP \"reason\""
+        )
+        if _last_verdict_is_blocking(repo_root, "plan-reviewer"):
+            last = _last_verdict(repo_root, "plan-reviewer")
+            reason = (
+                f"[plan-review-gate] BLOCKED: last plan-reviewer verdict was {last}.\n\n"
+                "Re-run the plan-reviewer after fixing the issues. Trivial bypass is "
+                f"not permitted after {last} — no exceptions.\n\n"
+                f"After SHIP:\n{mark_cmd}"
+            )
+        else:
+            reason = (
+                "[plan-review-gate] BLOCKED: no plan-reviewer approval marker.\n\n"
+                "Run the plan-reviewer Warden and wait for VERDICT: SHIP before "
+                "exiting plan mode. Then run:\n\n"
+                f"{mark_cmd}"
+            )
+        _block_pre_tool(reason)
+        return 0
+
     # `_managed_paths` returns `(None, [])` outside every worktree;
     # otherwise `(worktree, paths_after_filtering)`. Empty `paths` after
     # filtering must NOT bypass the gate (the pre-fix `not paths` short-


### PR DESCRIPTION
## Summary
- Adds `ExitPlanMode` to the checked tools list in `run_plan_review_gate`
- Adds early-exit block for ExitPlanMode after the marker check — ExitPlanMode has no file paths, so the existing `_managed_paths` file-path logic would escape via the empty-paths short-circuit
- Now ExitPlanMode is blocked unless `.plan-reviewed` marker exists (set only after SHIP verdict)

## Smoke Test Evidence

```
# 1. No marker, no verdict → BLOCKED
$ rm -f .claude/.plan-reviewed
$ echo '{"tool_name":"ExitPlanMode","tool_input":{},...}' | python3 scripts/codex_warden_hooks.py run plan-review-gate --repo-root .
{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"[plan-review-gate] BLOCKED: no plan-reviewer approval marker..."}}

# 2. Marker exists → ALLOWED (empty output = no block)
$ touch .claude/.plan-reviewed
$ echo '{"tool_name":"ExitPlanMode","tool_input":{},...}' | python3 scripts/codex_warden_hooks.py run plan-review-gate --repo-root .
(empty)

# 3. Last verdict REVISE → BLOCKED with REVISE-specific message
$ rm -f .claude/.plan-reviewed
$ echo '{"plan-reviewer":{"verdict":"REVISE",...}}' > .claude/.warden-verdicts.json
$ echo '{"tool_name":"ExitPlanMode","tool_input":{},...}' | python3 scripts/codex_warden_hooks.py run plan-review-gate --repo-root .
{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"[plan-review-gate] BLOCKED: last plan-reviewer verdict was REVISE..."}}

# 4. Regression: Edit still blocked without marker
$ echo '{"tool_name":"Edit","tool_input":{"file_path":"src/index.ts"},...}' | python3 scripts/codex_warden_hooks.py run plan-review-gate --repo-root .
{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"[plan-review-gate] BLOCKED: no plan-reviewer approval marker..."}}
```

## Test plan
- [x] ExitPlanMode blocked when marker absent (no verdict)
- [x] ExitPlanMode allowed when marker present
- [x] ExitPlanMode blocked with REVISE-specific message after REVISE verdict
- [x] Edit still blocked without marker (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)