### PR TITLE
fix(setup): exit after step completion to prevent CI hang

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Docker build context: only container/ is needed.
+# build.sh stages skill-agents into container/skill-agents/ before building.
+*
+!container/

--- a/.github/workflows/setup-test.yml
+++ b/.github/workflows/setup-test.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   setup-smoke:
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -63,6 +63,8 @@ async function main(): Promise<void> {
   try {
     const mod = await loader();
     await mod.run(stepArgs);
+    // pino-pretty transport worker thread keeps the event loop alive on Linux
+    process.exit(0);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error({ err, step: stepName }, 'Setup step failed');


### PR DESCRIPTION
## Summary

- Add `process.exit(0)` after successful setup step completion — pino-pretty's transport worker thread keeps the Node.js event loop alive on Linux CI, preventing the process from exiting
- Add `.dockerignore` excluding everything except `container/` from Docker build context (locally, `.claude/worktrees/` is 3.3GB)
- Add `timeout-minutes: 10` to `setup-smoke` CI job as a defensive guard against future hangs

Root cause: `setup/index.ts` uses `bootstrap()` which only calls `process.exit()` on error, never on success. After `main()` returns, the pino-pretty worker thread (spawned via `pino.transport()`) holds the event loop open indefinitely. Alternatives considered: `logger.flush()` + transport teardown — `process.exit(0)` is the standard CLI pattern and matches how other Deus entry points handle this.

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm test` — 1535 tests pass
- [x] `npx tsx setup/index.ts --step environment` exits within 1 second
- [ ] CI: `setup-smoke (ubuntu-latest)` completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)