### PR TITLE
fix(pipeline): allow pre-implemented issues to close without gate revert (LIA-85)

### DIFF
--- a/.claude/agents/wardens/completion-gate.md
+++ b/.claude/agents/wardens/completion-gate.md
@@ -12,6 +12,8 @@ fetch_comments: true
 
 Gate that runs before an issue moves from **In Review** or **In Progress** to **Done**. Ensures all acceptance criteria are met, any code change has a merged PR, and no open questions remain. Prevents premature closure that inflates Done metrics.
 
+**Bypass:** Issues with the `Done: Pre-implemented` label skip this gate entirely. Use this label when closing an issue that was already implemented outside the normal pipeline (e.g., shipped via another PR, discovered during triage).
+
 ## Your job
 
 You receive the issue title, description, agent output, PR link (if any), and review comments. Extract the acceptance criteria from the `<!-- gate:agent-readiness-gate:start -->...<!-- gate:agent-readiness-gate:end -->` block in the description. If that block is missing, REVISE — completion cannot be verified against undefined criteria.

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -189,10 +189,11 @@ This means the issue description accumulates structured context from each gate a
 
 1. **Bot actor skip** - if `payload.actor.id === ctx.botUserId`, the event is skipped. This prevents the dispatcher's own state writes from triggering gates.
 2. **`warden:skip` label** - if the issue carries this label, all gate evaluation is skipped for that event.
-3. **Dedup** - `INSERT OR IGNORE` on `linear_webhook_events` using `event_key`. Duplicate webhook deliveries are silently dropped.
-4. **`allowedFrom` check** - illegal transitions (e.g., Backlog directly to Done) are immediately reverted without running a gate agent.
-5. **Cooldown** - if a gate ran for this issue within `cooldown_minutes`, the previous verdict is reused and no agent is spawned.
-6. **`inFlightGate`** - if a gate is already running for this issue, the new event is dropped. One gate run per issue at a time.
+3. **`Done: Pre-implemented` label** - if the issue carries this label AND the target state is Done, gate evaluation is skipped. For issues that were already implemented outside the normal pipeline.
+4. **Dedup** - `INSERT OR IGNORE` on `linear_webhook_events` using `event_key`. Duplicate webhook deliveries are silently dropped.
+5. **`allowedFrom` check** - illegal transitions (e.g., Backlog directly to Done) are immediately reverted without running a gate agent.
+6. **Cooldown** - if a gate ran for this issue within `cooldown_minutes`, the previous verdict is reused and no agent is spawned.
+7. **`inFlightGate`** - if a gate is already running for this issue, the new event is dropped. One gate run per issue at a time.
 
 ## UX -- Advise vs Strict Mode
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25" # dashboard ux improvements
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-24T14:00:00" # auto-bump (rebase-fix)
+last_verified: "2026-05-24" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25" # auto-bump
+last_verified: "2026-05-25" # auto-bump (rebase)
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -955,6 +955,14 @@ export async function initLinearContext(
         gateLabels.wardenSkip = labelMap.get('warden:skip');
       }
 
+      if (!labelMap.has('Done: Pre-implemented')) {
+        await client.createIssueLabel({
+          name: 'Done: Pre-implemented',
+          color: '#6b7280',
+          teamId,
+        });
+      }
+
       for (let i = 1; i <= 5; i++) {
         const eName = `Effort: ${i}`;
         const cName = `Complexity: ${i}`;

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -488,6 +488,17 @@ async function handleIssueUpdate(
     return;
   }
 
+  if (
+    toState.name === 'Done' &&
+    data.labels.some((l) => l.name === 'Done: Pre-implemented')
+  ) {
+    logger.info(
+      { issueId: data.id },
+      'linear-webhook: Done: Pre-implemented label present, skipping gate',
+    );
+    return;
+  }
+
   const gateSpec = gateSpecs.get(toState.name);
   if (!gateSpec) return;
 


### PR DESCRIPTION
## Summary
- Add `Done: Pre-implemented` label as a targeted bypass for the completion-gate when closing issues that were already implemented outside the normal pipeline
- Auto-create the label at startup alongside other gate labels (Warden: Evaluating, Scoped, etc.)
- Update ADR loop-break mechanisms list to document the new bypass (7 items, was 6)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` -- 1535 tests pass, zero regression
- [x] Drift check passes
- [ ] Manual: add `Done: Pre-implemented` label to a test issue in Linear, move to Done, confirm no revert
- [ ] Confirm label does NOT bypass non-Done gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)