### PR TITLE
feat(pipeline): inject failure dossier into re-dispatched agent prompts

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25T20" # auto-bump
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25T20" # auto-bump
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -17,7 +17,9 @@ vi.mock('./config.js', async () => {
 vi.mock('./db.js', () => ({
   CIRCUIT_BREAKER_THRESHOLD: 3,
   getConsecutiveFailCount: vi.fn().mockReturnValue(0),
+  getIssuePr: vi.fn().mockReturnValue(null),
   getLastFailTime: vi.fn().mockReturnValue(null),
+  getPipelineEvents: vi.fn().mockReturnValue([]),
   logPipelineEvent: vi.fn(),
   upsertIssuePr: vi.fn(),
 }));

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -12,7 +12,9 @@ import { extractPrUrl } from './pr-url-extractor.js';
 import {
   CIRCUIT_BREAKER_THRESHOLD,
   getConsecutiveFailCount,
+  getIssuePr,
   getLastFailTime,
+  getPipelineEvents,
   logPipelineEvent,
   upsertIssuePr,
 } from './db.js';
@@ -185,6 +187,7 @@ export function buildIssuePrompt(
   issueIdentifier: string,
   issueDescription: string | undefined,
   comments: Array<{ author: string; body: string }>,
+  failureDossier?: string | null,
 ): string {
   const parts = [
     `<role>\n${role.content}\n</role>`,
@@ -196,6 +199,9 @@ export function buildIssuePrompt(
       .map((c) => `[${c.author}]: ${c.body}`)
       .join('\n\n');
     parts.push(`<comments>\n${commentBlock}\n</comments>`);
+  }
+  if (failureDossier) {
+    parts.push(failureDossier);
   }
   return parts.join('\n\n');
 }
@@ -268,11 +274,47 @@ export function extractScopeBlock(description: string): string {
   return description.slice(startIdx + startMarker.length, endIdx).trim();
 }
 
+function buildFailureDossier(issueId: string): string | null {
+  const pr = getIssuePr(issueId);
+  if (!pr || pr.auto_merge_state === 'merged') return null;
+
+  const events = getPipelineEvents({
+    issueId,
+    eventType: 'automerge_failed',
+  });
+  const lastFailure = events.at(-1);
+  if (!lastFailure) return null;
+
+  const prNumber = pr.pr_url.match(/\/pull\/(\d+)/)?.[1] ?? '?';
+  const branch = pr.branch ?? 'unknown';
+  const ciDetail = lastFailure.detail ?? 'Unknown failure';
+
+  const lines = [
+    '<failure-context>',
+    'A previous PR exists and CI failed. Fix the existing PR — do NOT create a new one.',
+    `- PR: ${pr.pr_url}`,
+    `- Branch: ${branch}`,
+    `- CI failure: ${ciDetail}`,
+  ];
+  if (prNumber !== '?') {
+    lines.push(
+      `Checkout the branch, run \`gh pr checks ${prNumber}\` to see current CI status, diagnose and fix the failure, then push to the same branch.`,
+    );
+  } else {
+    lines.push(
+      'Checkout the branch, diagnose and fix the CI failure, then push to the same branch.',
+    );
+  }
+  lines.push('</failure-context>');
+  return lines.join('\n');
+}
+
 export function buildScopedIssuePrompt(
   issueTitle: string,
   issueIdentifier: string,
   issueDescription: string,
   comments: Array<{ author: string; body: string }>,
+  failureDossier?: string | null,
 ): string {
   const scopeContent = extractScopeBlock(issueDescription);
   const parts = [
@@ -305,9 +347,14 @@ export function buildScopedIssuePrompt(
     contextBlock +=
       'A quality gate REVISE\'d a previous attempt. The gate feedback is in the comments above (look for "**Warden: ... - REVISE**"). Your FIRST priority is to fix the specific issues mentioned in the REVISE feedback. After addressing those, verify remaining acceptance criteria are met. Do not start over from scratch.\n\n';
   }
-  if (hasAgentHistory) {
+  // Dossier supersedes generic history hint — more specific instruction wins
+  if (hasAgentHistory && !failureDossier) {
     contextBlock +=
       'A previous agent attempt exists. Review the comments above — check what was already committed, pushed, or opened as a PR. Continue from where the last attempt stopped. Do not redo completed steps. If CI failed, check out the existing branch, read the CI logs, fix the failures, and push.\n\n';
+  }
+
+  if (failureDossier) {
+    parts.push(failureDossier);
   }
 
   parts.push(
@@ -565,6 +612,7 @@ async function pollLinear(): Promise<void> {
       }),
     );
 
+    const failureDossier = buildFailureDossier(issue.id);
     let prompt: string;
     if (roleSpec) {
       prompt = buildIssuePrompt(
@@ -573,6 +621,7 @@ async function pollLinear(): Promise<void> {
         issue.identifier,
         issue.description ?? undefined,
         comments,
+        failureDossier,
       );
     } else {
       prompt = buildScopedIssuePrompt(
@@ -580,6 +629,7 @@ async function pollLinear(): Promise<void> {
         issue.identifier,
         issue.description ?? '',
         comments,
+        failureDossier,
       );
     }
 


### PR DESCRIPTION
## Summary

- When CI fails and an issue returns to Ready for Agent, the re-dispatched agent now receives a structured `<failure-context>` block with the existing PR URL, branch name, and failing check names from SQLite
- This replaces the generic "check CI logs" instruction so the agent fixes the existing PR instead of creating a new one (fixes LIA-84 ping-pong loop)
- The `merged` state suppresses the dossier — no stale context on a fresh retry after a successful merge

## Test plan

- [ ] `npm run build` passes
- [ ] Seed `linear_issue_prs` + `linear_pipeline_events` with a known `automerge_failed` event, confirm dossier output contains correct PR URL, branch, and failure detail
- [ ] Confirm `buildFailureDossier` returns null for: no PR, merged state, no failure events
- [ ] (Optional) E2E: create a Linear issue, let agent open a PR with deliberate CI failure, confirm re-dispatched prompt contains `<failure-context>` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)