### PR TITLE
feat(pipeline): pre-dispatch triage skips issues with existing PRs

### DIFF
--- a/.claude/agents/wardens/completion-gate.md
+++ b/.claude/agents/wardens/completion-gate.md
@@ -1,7 +1,7 @@
 ---
 name: completion-gate
 gate_to: "Done"
-allowed_from: ["In Review"]
+allowed_from: ["In Review", "In Progress"]
 mode: strict
 fallback: REVISE
 cooldown_minutes: 5
@@ -10,7 +10,7 @@ effort: medium
 fetch_comments: true
 ---
 
-Gate that runs before an issue moves from **In Review** to **Done**. Ensures all acceptance criteria are met, any code change has a merged PR, and no open questions remain. Prevents premature closure that inflates Done metrics.
+Gate that runs before an issue moves from **In Review** or **In Progress** to **Done**. Ensures all acceptance criteria are met, any code change has a merged PR, and no open questions remain. Prevents premature closure that inflates Done metrics.
 
 ## Your job
 

--- a/.claude/agents/wardens/output-quality-gate.md
+++ b/.claude/agents/wardens/output-quality-gate.md
@@ -1,7 +1,7 @@
 ---
 name: output-quality-gate
 gate_to: "In Review"
-allowed_from: ["Agent Working", "In Progress"]
+allowed_from: ["Agent Working", "In Progress", "Ready for Agent"]
 mode: strict
 fallback: REVISE
 revert_to: "Ready for Agent"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25" # auto-bump (LIA-83 rebase)
+last_verified: "2026-05-25" # LIA-91 pre-dispatch triage
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25" # auto-bump (LIA-83 rebase)
+last_verified: "2026-05-25" # LIA-91 pre-dispatch triage
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -59,6 +59,32 @@ interface PrChecksResult {
   summary: string;
 }
 
+export async function queryPrState(
+  prUrl: string,
+): Promise<{ state: 'OPEN' | 'CLOSED' | 'MERGED' } | null> {
+  const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
+  if (!prNumber) return null;
+
+  const repoMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/);
+  const repo = repoMatch?.[1];
+  if (!repo) return null;
+
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'view', prNumber, '--repo', repo, '--json', 'state'],
+      { timeout: CI_CHECK_TIMEOUT_MS },
+    );
+    const data = JSON.parse(stdout) as { state: string };
+    const VALID_STATES = new Set(['OPEN', 'CLOSED', 'MERGED']);
+    if (!VALID_STATES.has(data.state)) return null;
+    return { state: data.state as 'OPEN' | 'CLOSED' | 'MERGED' };
+  } catch (err) {
+    logger.warn({ prUrl, err }, 'auto-merge: failed to query PR state');
+    return null;
+  }
+}
+
 export async function queryPrChecks(prUrl: string): Promise<PrChecksResult> {
   const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
   if (!prNumber) {

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -9,6 +9,7 @@ import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
 import { fireAndForget } from './async/index.js';
 import { extractPrUrl } from './pr-url-extractor.js';
+import { queryPrState } from './linear-auto-merge.js';
 import {
   CIRCUIT_BREAKER_THRESHOLD,
   getConsecutiveFailCount,
@@ -16,6 +17,7 @@ import {
   getLastFailTime,
   getPipelineEvents,
   logPipelineEvent,
+  updatePrAutoMergeState,
   upsertIssuePr,
 } from './db.js';
 import { notifyPipelineStep } from './linear-notifications.js';
@@ -420,6 +422,104 @@ export async function executeAgentRun(
   return { text: result, error };
 }
 
+// Checks live PR state via gh CLI and routes the issue accordingly.
+// DB-first in triageIssue avoids the API call when we already know the answer;
+// this function only runs when the DB record is stale or absent.
+async function handlePrState(
+  ctx: LinearContext,
+  issueId: string,
+  identifier: string,
+  prUrl: string,
+): Promise<'skip' | 'dispatch'> {
+  const prState = await queryPrState(prUrl);
+  if (!prState) return 'dispatch';
+
+  if (prState.state === 'MERGED') {
+    updatePrAutoMergeState(issueId, 'merged');
+    const doneState = ctx.stateByName.get('Done');
+    if (!doneState) {
+      logger.warn(
+        { issueId },
+        'triage: "Done" state not found, falling back to dispatch',
+      );
+      return 'dispatch';
+    }
+    await ctx.client.updateIssue(issueId, { stateId: doneState.id });
+    logPipelineEvent(issueId, identifier, 'triage_skip_merged', prUrl);
+    logger.info({ issueId, prUrl }, 'triage: PR merged, moved to Done');
+    return 'skip';
+  }
+
+  if (prState.state === 'OPEN') {
+    const reviewState = ctx.stateByName.get('In Review');
+    if (!reviewState) {
+      logger.warn(
+        { issueId },
+        'triage: "In Review" state not found, falling back to dispatch',
+      );
+      return 'dispatch';
+    }
+    await ctx.client.updateIssue(issueId, { stateId: reviewState.id });
+    logPipelineEvent(issueId, identifier, 'triage_skip_open_pr', prUrl);
+    logger.info({ issueId, prUrl }, 'triage: PR open, moved to In Review');
+    return 'skip';
+  }
+
+  // CLOSED: PR was abandoned/superseded. Dispatch a fresh agent to redo the work.
+  logger.info({ issueId, prUrl }, 'triage: PR closed, dispatching fresh agent');
+  return 'dispatch';
+}
+
+// Pre-dispatch triage: checks DB then live GH state then comment text scan.
+// Returns 'skip' when the issue already has a merged/open PR (no agent needed).
+async function triageIssue(
+  ctx: LinearContext,
+  issue: { id: string; identifier: string; description: string | null },
+  comments: Array<{ author: string; body: string }>,
+): Promise<'dispatch' | 'skip'> {
+  const dbRecord = getIssuePr(issue.id);
+
+  if (dbRecord?.auto_merge_state === 'merged') {
+    const doneState = ctx.stateByName.get('Done');
+    if (!doneState) {
+      logger.warn(
+        { issueId: issue.id },
+        'triage: "Done" state not found, falling back to dispatch',
+      );
+      return 'dispatch';
+    }
+    await ctx.client.updateIssue(issue.id, { stateId: doneState.id });
+    logPipelineEvent(
+      issue.id,
+      issue.identifier,
+      'triage_skip_merged',
+      dbRecord.pr_url,
+    );
+    logger.info(
+      { issueId: issue.id },
+      'triage: DB shows merged, moved to Done',
+    );
+    return 'skip';
+  }
+
+  if (dbRecord?.pr_url) {
+    return handlePrState(ctx, issue.id, issue.identifier, dbRecord.pr_url);
+  }
+
+  // Fallback: scan issue text for PR URLs not yet recorded in DB
+  const textToScan = [
+    issue.description ?? '',
+    ...comments.map((c) => c.body),
+  ].join('\n');
+  const foundUrl = extractPrUrl(textToScan, ctx.repoSlug);
+  if (foundUrl) {
+    upsertIssuePr(issue.id, foundUrl, undefined, issue.identifier);
+    return handlePrState(ctx, issue.id, issue.identifier, foundUrl);
+  }
+
+  return 'dispatch';
+}
+
 async function runIssue(
   ctx: LinearContext,
   issueId: string,
@@ -603,6 +703,7 @@ async function pollLinear(): Promise<void> {
       continue;
     }
 
+    // Add before triage to prevent concurrent polls from double-processing the same issue
     ctx.inFlightDispatch.add(issue.id);
 
     const issueComments = await issue.comments();
@@ -612,6 +713,20 @@ async function pollLinear(): Promise<void> {
         return { author: user?.displayName ?? 'Unknown', body: c.body };
       }),
     );
+
+    const triageResult = await triageIssue(
+      ctx,
+      {
+        id: issue.id,
+        identifier: issue.identifier,
+        description: issue.description ?? null,
+      },
+      comments,
+    );
+    if (triageResult === 'skip') {
+      ctx.inFlightDispatch.delete(issue.id);
+      continue;
+    }
 
     const failureDossier = buildFailureDossier(issue.id);
     let prompt: string;


### PR DESCRIPTION
## Summary
- Adds `triageIssue()` to the dispatch loop that checks DB → live GH state → comment text scan before launching an agent. Issues with merged PRs go straight to Done; open PRs go to In Review; closed/unknown PRs dispatch normally.
- Adds `queryPrState()` helper in `linear-auto-merge.ts` (mirrors `queryPrChecks` pattern, with try/catch degradation).
- Fixes infinite gate loops: completion-gate now allows "In Progress" → Done; output-quality-gate now allows "Ready for Agent" → In Review (for triage fast-forward).

## Context
Board audit found 5 issues stuck in gate loops after re-entering Ready for Agent with already-merged PRs. Each triggered a container agent run that produced duplicate work. This triage check prevents all of those scenarios.

**Gate spec rationale:**
- `completion-gate` + "In Progress": issues cleaned up manually (In Progress → Done) were rejected as illegal transitions, reverting to RfA and triggering infinite loops.
- `output-quality-gate` + "Ready for Agent": triage's open-PR fast-forward moves RfA → In Review directly. Without this, the gate rejects the transition and reverts, creating another loop.

## Test plan
- [x] `npm run build` compiles clean
- [x] `npm test` — 1535/1535 tests pass
- [ ] Manual: move a Done issue with merged PR back to RfA → verify triage routes to Done within 30s
- [ ] Manual: issue with PR URL only in comments → verify comment-scan path finds and routes correctly

Closes LIA-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)