### PR TITLE
fix(pipeline): auto-strip warden:skip on Ready for Agent entry

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25" # LIA-91 pre-dispatch triage
+last_verified: "2026-05-25" # warden-skip strip
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25" # LIA-91 pre-dispatch triage
+last_verified: "2026-05-25" # warden-skip strip
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -461,6 +461,19 @@ async function handleIssueUpdate(
       'circuit_breaker_reset',
       'manual move to Ready for Agent',
     );
+    // Auto-strip warden:skip on RfA entry so gates work normally on the next cycle
+    if (
+      ctx.gateLabels.wardenSkip &&
+      data.labels.some((l) => l.name === 'warden:skip')
+    ) {
+      retryLabelUpdate(ctx.client, data.id, {
+        removedLabelIds: [ctx.gateLabels.wardenSkip],
+      });
+      logger.info(
+        { issueId: data.id },
+        'linear-webhook: stripped warden:skip label on Ready for Agent entry',
+      );
+    }
     logger.info(
       { issueId: data.id },
       'linear-webhook: circuit breaker reset (manual Ready for Agent)',


### PR DESCRIPTION
## Summary
- Auto-removes the `warden:skip` label when an issue transitions to Ready for Agent
- The label is an escape hatch for gate loops, not permanent -- stripping it on RfA entry ensures gates work normally on the next transition cycle
- Uses existing `retryLabelUpdate` fire-and-forget pattern

## Context
During today's board audit, 5 issues had `warden:skip` applied to break infinite gate loops. Moving them back to RfA for testing left the label in place, which caused the webhook handler to skip all gate processing. This fix ensures the escape hatch is self-cleaning.

## Test plan
- [x] `npm run build` compiles clean
- [x] `npm test` -- 1544/1544 tests pass
- [ ] Manual: move an issue with `warden:skip` to RfA, confirm label is stripped within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)