### PR TITLE
feat(pipeline): two-gate architecture -- enrichment + bouncer gates

### DIFF
--- a/.claude/agents/wardens/bouncer-gate.md
+++ b/.claude/agents/wardens/bouncer-gate.md
@@ -1,0 +1,64 @@
+---
+name: bouncer-gate
+gate_to: "Ready for Agent"
+allowed_from: ["Todo"]
+mode: advise
+fallback: REVISE
+cooldown_minutes: 3
+max_attempts: 3
+revert_to: "Todo"
+model: sonnet
+effort: medium
+fetch_comments: false
+---
+
+Bouncer gate that validates issue readiness before agent dispatch. Does NOT create scope -- only validates that the enrichment gate already produced complete, actionable scope.
+
+## Your job
+
+You receive an issue that was enriched by the upstream enrichment gate. The enrichment scope block is enclosed in `<!-- gate:enrichment-gate:start -->` ... `<!-- gate:enrichment-gate:end -->` HTML comments in the issue description. Validate that the scope block is complete, actionable, and ready for an autonomous agent to implement.
+
+## Validation checklist
+
+Check each section in the enrichment block:
+
+1. **Problem statement**: Is it grounded in the actual codebase (references real files/functions), not generic?
+2. **Relevant files**: Are actual file paths listed (not placeholders)?
+3. **Requirements**: Are they concrete and referencing actual code?
+4. **Acceptance criteria**: Are they verifiable (can be checked programmatically or by inspection)?
+5. **Implementation plan**: Does it reference real files and functions to modify?
+6. **Ratings**: Are Effort/Complexity/Impact all present with integer values 1-5?
+
+## Decision rules
+
+- **SHIP** if all 6 sections are present and substantive. Minor imperfections are OK -- the agent can handle ambiguity in details, but needs the structural scaffolding.
+- **REVISE** if any section is missing, empty, or contains only placeholder text (e.g., "TBD", "TODO", "...").
+- **REVISE** if the problem statement doesn't reference the actual codebase.
+- **REVISE** if acceptance criteria are aspirational rather than verifiable (e.g., "code is clean" vs "npm run build succeeds").
+
+## Output format
+
+```
+## Enrichment
+
+## Validation
+
+**Sections checked**:
+- [x/!] Problem statement: <1-line assessment>
+- [x/!] Relevant files: <1-line assessment>
+- [x/!] Requirements: <1-line assessment>
+- [x/!] Acceptance criteria: <1-line assessment>
+- [x/!] Implementation plan: <1-line assessment>
+- [x/!] Ratings: <1-line assessment>
+
+**Gaps found**: <none / list of specific gaps>
+
+## Verdict: SHIP
+```
+
+Rules:
+- Never modify the issue description. You are a validator, not a mutator.
+- Be pragmatic: a scope block that's 80% complete with real file paths is better than blocking for perfection.
+- If enrichment is missing entirely (no scope block found), REVISE with reason "bounced:unscoped".
+- If enrichment exists but is stale or doesn't match the current issue title/context, REVISE with reason "bounced:stale".
+- Verdict is exactly `## Verdict: SHIP` or `## Verdict: REVISE`.

--- a/.claude/agents/wardens/enrichment-gate.md
+++ b/.claude/agents/wardens/enrichment-gate.md
@@ -1,29 +1,30 @@
 ---
-name: agent-readiness-gate
-gate_to: "Ready for Agent"
-allowed_from: ["Todo"]
+name: enrichment-gate
+gate_to: "Todo"
+allowed_from: ["Backlog"]
 mode: advise
 fallback: REVISE
 cooldown_minutes: 5
+max_attempts: 3
 model: sonnet
 effort: high
 fetch_comments: false
 ---
 
-Gate that runs before an issue moves from **Todo** to **Ready for Agent**. Scopes the issue so an autonomous agent can act without back-and-forth.
+Gate that runs when an issue moves from **Backlog** to **Todo**. Enriches the issue with a complete, actionable scope block grounded in the actual codebase.
 
 ## Your job
 
-You receive an issue title and description (may be empty or minimal). Your job is to produce a complete, actionable scope block grounded in the actual codebase.
+You receive an issue title and description (may be empty or minimal). Your job is to produce a complete, actionable scope block so a downstream bouncer gate and autonomous agent can act without back-and-forth. Your output will be wrapped in `<!-- gate:enrichment-gate:start -->` ... `<!-- gate:enrichment-gate:end -->` HTML comments by the system -- do not emit these markers yourself.
 
 ## Step 1: Explore the codebase
 
 Before writing any scope, use the cached codebase map for efficient exploration:
 
 **Primary path (map present)**:
-1. Read `.claude/codebase_map.md` — this gives you the file tree, key exports, and architecture summary in ~800 tokens
+1. Read `.claude/codebase_map.md` -- this gives you the file tree, key exports, and architecture summary in ~800 tokens
 2. From the map, identify the 3-5 files most relevant to this issue
-3. Use targeted `Read` or `Grep` only on those specific files — do not grep across all of `src/`
+3. Use targeted `Read` or `Grep` only on those specific files -- do not grep across all of `src/`
 4. Check `docs/decisions/` for related ADRs if the issue touches architecture
 5. Look for existing tests near the relevant files
 
@@ -38,7 +39,7 @@ Ground your scope in what you find. Reference actual file paths, function names,
 
 ## Step 2: Write the scope
 
-If the description contains `<!-- gate:agent-readiness-gate:start -->`, refine the existing scope -- do not start from scratch.
+If the description contains `<!-- gate:enrichment-gate:start -->`, refine the existing scope -- do not start from scratch.
 
 REVISE only if the title is so vague that meaningful scoping is impossible even with inference (e.g., "misc", "stuff to do").
 
@@ -83,7 +84,7 @@ Checklist:
 - [x] Implementation plan -- references real files
 - [x] No blockers
 
-Scope block populated. Ready for autonomous agent pickup.
+Scope block populated. Ready for bouncer validation.
 ```
 
 Rules:

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -29,16 +29,17 @@ Gate specs are markdown files in `.claude/agents/wardens/` with YAML frontmatter
 
 ```mermaid
 flowchart LR
-    BL[Backlog] --> TD[Todo]
-    TD -- "gate: agent-readiness-gate\n(advise)" --> RFA[Ready for Agent]
+    BL[Backlog] -- "gate: enrichment-gate\n(advise)" --> TD[Todo]
+    TD -- "gate: bouncer-gate\n(advise→strict)" --> RFA[Ready for Agent]
     RFA -- "dispatcher poll" --> AW[Agent Working]
-    AW -- "gate: output-quality-gate\n(advise)" --> IR[In Review]
-    IR -- "gate: completion-gate\n(advise)" --> DN[Done]
+    AW -- "gate: output-quality-gate\n(strict)" --> IR[In Review]
+    IR -- "gate: completion-gate\n(strict)" --> DN[Done]
 
     AW -- "agent error" --> BL
+    TD -- "BLOCK after 3 REVISE" --> MR[Manual Review Required]
 ```
 
-Gates fire on transitions into: **Ready for Agent**, **In Review**, **Done**. The transition into **Agent Working** is made by the dispatcher itself (bot actor) and is skipped by the webhook handler.
+Gates fire on transitions into: **Todo**, **Ready for Agent**, **In Review**, **Done**. The enrichment gate (Backlog->Todo) is a Mutating Admission Controller that produces the scope block. The bouncer gate (Todo->RfA) is a Validating Admission Controller that checks scope completeness, with a hash fast-path that skips LLM when enrichment is fresh. The transition into **Agent Working** is made by the dispatcher itself (bot actor) and is skipped by the webhook handler.
 
 ### End-to-End Request Flow
 
@@ -135,6 +136,7 @@ Each `.md` file in `.claude/agents/wardens/` with a `gate_to` frontmatter key is
 | `fallback` | `SHIP` \| `REVISE` | `REVISE` | Verdict used when the agent errors |
 | `revert_to` | string | fromState | Target state for strict-mode revert (overrides fromState) |
 | `cooldown_minutes` | number | 60 | Minimum minutes between gate runs per issue |
+| `max_attempts` | number | unset | BLOCK after this many REVISE rounds (moves to Manual Review Required) |
 | `effort` | `low` \| `medium` \| `high` | unset | Passed to `RunContext.effort` |
 | `fetch_comments` | boolean | `false` | Whether to include issue comments in prompt |
 
@@ -171,15 +173,32 @@ Gate agents can emit an `## Enrichment` section above `## Verdict`. The webhook 
 3. Patches the existing sentinel block in-place on re-runs, or appends if absent.
 4. Writes the updated description back to Linear.
 
-This means the issue description accumulates structured context from each gate as the issue progresses. The `completion-gate` reads the `<!-- gate:agent-readiness-gate:start -->` block to verify acceptance criteria -- gates downstream depend on enrichment written by gates upstream.
+This means the issue description accumulates structured context from each gate as the issue progresses. The `completion-gate` reads the full description which includes the enrichment block. `extractScopeBlock(description, gateName)` extracts the scope content with a legacy fallback for pre-migration `agent-readiness-gate` sentinels.
+
+### Gate Meta Tracking
+
+The `linear_gate_meta` table tracks per-issue, per-gate metadata:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `issue_id` | TEXT | Linear issue ID (composite PK) |
+| `gate_name` | TEXT | Gate spec name (composite PK) |
+| `enrichment_hash` | TEXT | SHA-256 of enrichment block (for bouncer fast-path) |
+| `enrichment_snapshot` | TEXT | Full enrichment block at last SHIP |
+| `attempt_count` | INTEGER | REVISE round counter (reset on SHIP) |
+| `revise_history` | TEXT | JSON array of one-line REVISE summaries (for BLOCK guide) |
+| `shipped_at` | TEXT | ISO timestamp of last SHIP |
+
+The bouncer gate uses the enrichment hash for a fast-path: if the hash matches the current description and is less than 72 hours old, SHIP without an LLM call.
 
 ## Active Gate Specs
 
-| Gate | Triggers On | Allowed From | Mode | Fallback | Revert To | Effort | Fetch Comments |
-|---|---|---|---|---|---|---|---|
-| `agent-readiness-gate` | Ready for Agent | Todo | advise | REVISE | fromState | high | no |
-| `output-quality-gate` | In Review | Agent Working | strict | REVISE | Ready for Agent | medium | yes |
-| `completion-gate` | Done | In Review | strict | REVISE | fromState | medium | yes |
+| Gate | Triggers On | Allowed From | Mode | Fallback | Max Attempts | Revert To | Effort | Fetch Comments |
+|---|---|---|---|---|---|---|---|---|
+| `enrichment-gate` | Todo | Backlog | advise | REVISE | 3 | - | high | no |
+| `bouncer-gate` | Ready for Agent | Todo | advise (planned: strict) | REVISE | - | Todo | medium | no |
+| `output-quality-gate` | In Review | Agent Working | strict | REVISE | - | Ready for Agent | medium | yes |
+| `completion-gate` | Done | In Review | strict | REVISE | - | fromState | medium | yes |
 
 ## Triggers and Loop-Break Mechanisms
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25" # auto-bump (rebase)
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-24" # auto-bump
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25"
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { createHash } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -160,6 +161,17 @@ function createSchema(database: Database.Database): void {
       issue_id TEXT PRIMARY KEY,
       comment_id TEXT NOT NULL,
       updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS linear_gate_meta (
+      issue_id TEXT NOT NULL,
+      gate_name TEXT NOT NULL,
+      enrichment_hash TEXT,
+      enrichment_snapshot TEXT,
+      attempt_count INTEGER DEFAULT 0,
+      revise_history TEXT,
+      shipped_at TEXT,
+      PRIMARY KEY (issue_id, gate_name)
     );
 
     CREATE TABLE IF NOT EXISTS linear_issue_cache (
@@ -1274,6 +1286,125 @@ export function getGateCommentId(
     )
     .get(issueId, gateTo) as { comment_id: string } | undefined;
   return row?.comment_id;
+}
+
+// --- Linear gate meta accessors ---
+
+export interface GateMeta {
+  issueId: string;
+  gateName: string;
+  enrichmentHash: string | null;
+  enrichmentSnapshot: string | null;
+  attemptCount: number;
+  reviseHistory: string[];
+  shippedAt: string | null;
+}
+
+export function upsertGateMeta(
+  issueId: string,
+  gateName: string,
+  fields: {
+    enrichmentHash?: string;
+    enrichmentSnapshot?: string;
+    shippedAt?: string;
+    resetReviseHistory?: boolean;
+  },
+): void {
+  const reviseHistory = fields.resetReviseHistory ? '[]' : null;
+  db.prepare(
+    `INSERT INTO linear_gate_meta (issue_id, gate_name, enrichment_hash, enrichment_snapshot, shipped_at, revise_history, attempt_count)
+     VALUES (?, ?, ?, ?, ?, ?, 0)
+     ON CONFLICT(issue_id, gate_name) DO UPDATE SET
+       enrichment_hash = COALESCE(excluded.enrichment_hash, linear_gate_meta.enrichment_hash),
+       enrichment_snapshot = COALESCE(excluded.enrichment_snapshot, linear_gate_meta.enrichment_snapshot),
+       shipped_at = COALESCE(excluded.shipped_at, linear_gate_meta.shipped_at),
+       revise_history = COALESCE(excluded.revise_history, linear_gate_meta.revise_history),
+       attempt_count = CASE WHEN excluded.shipped_at IS NOT NULL THEN 0 ELSE linear_gate_meta.attempt_count END`,
+  ).run(
+    issueId,
+    gateName,
+    fields.enrichmentHash ?? null,
+    fields.enrichmentSnapshot ?? null,
+    fields.shippedAt ?? null,
+    reviseHistory,
+  );
+}
+
+export function getGateMeta(
+  issueId: string,
+  gateName: string,
+): GateMeta | null {
+  const row = db
+    .prepare(
+      `SELECT issue_id, gate_name, enrichment_hash, enrichment_snapshot, attempt_count, revise_history, shipped_at
+       FROM linear_gate_meta WHERE issue_id = ? AND gate_name = ?`,
+    )
+    .get(issueId, gateName) as
+    | {
+        issue_id: string;
+        gate_name: string;
+        enrichment_hash: string | null;
+        enrichment_snapshot: string | null;
+        attempt_count: number;
+        revise_history: string | null;
+        shipped_at: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  let history: string[];
+  try {
+    history = row.revise_history ? JSON.parse(row.revise_history) : [];
+  } catch {
+    history = [];
+  }
+  return {
+    issueId: row.issue_id,
+    gateName: row.gate_name,
+    enrichmentHash: row.enrichment_hash,
+    enrichmentSnapshot: row.enrichment_snapshot,
+    attemptCount: row.attempt_count,
+    reviseHistory: history,
+    shippedAt: row.shipped_at,
+  };
+}
+
+export function incrementAttemptCount(
+  issueId: string,
+  gateName: string,
+): number {
+  db.prepare(
+    `INSERT INTO linear_gate_meta (issue_id, gate_name, attempt_count)
+     VALUES (?, ?, 1)
+     ON CONFLICT(issue_id, gate_name) DO UPDATE SET
+       attempt_count = linear_gate_meta.attempt_count + 1`,
+  ).run(issueId, gateName);
+  const row = db
+    .prepare(
+      `SELECT attempt_count FROM linear_gate_meta WHERE issue_id = ? AND gate_name = ?`,
+    )
+    .get(issueId, gateName) as { attempt_count: number } | undefined;
+  return row?.attempt_count ?? 1;
+}
+
+export function appendReviseHistory(
+  issueId: string,
+  gateName: string,
+  summary: string,
+): void {
+  const meta = getGateMeta(issueId, gateName);
+  const history = meta?.reviseHistory ?? [];
+  history.push(summary);
+  db.prepare(
+    `INSERT INTO linear_gate_meta (issue_id, gate_name, revise_history)
+     VALUES (?, ?, ?)
+     ON CONFLICT(issue_id, gate_name) DO UPDATE SET
+       revise_history = excluded.revise_history`,
+  ).run(issueId, gateName, JSON.stringify(history));
+}
+
+export function computeEnrichmentHash(content: string): string {
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  return createHash('sha256').update(normalized).digest('hex');
 }
 
 // --- Linear issue PR accessors ---

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -63,6 +63,10 @@ export interface GateLabels {
   revise?: string;
   error?: string;
   wardenSkip?: string;
+  blocked?: string;
+  bouncedUnscoped?: string;
+  bouncedStale?: string;
+  bouncedNoContext?: string;
   effort: Record<number, string>;
   complexity: Record<number, string>;
 }
@@ -166,6 +170,11 @@ export async function discoverWorkflowStates(
       'linear-dispatcher: workflow state "Done" not found — auto-merge will skip Done transition',
     );
   }
+  if (!map.has('Todo')) {
+    logger.warn(
+      'linear-dispatcher: "Todo" state not found — enrichment gate will not fire',
+    );
+  }
   if (!map.has('Manual Review Required')) {
     logger.info(
       'linear-dispatcher: "Manual Review Required" state not found — circuit breaker will fall back to Backlog',
@@ -267,11 +276,27 @@ export function truncateComments(
   return result;
 }
 
-export function extractScopeBlock(description: string): string {
-  const startMarker = '<!-- gate:agent-readiness-gate:start -->';
-  const endMarker = '<!-- gate:agent-readiness-gate:end -->';
+export function extractScopeBlock(
+  description: string,
+  gateName = 'enrichment-gate',
+): string {
+  const startMarker = `<!-- gate:${gateName}:start -->`;
+  const endMarker = `<!-- gate:${gateName}:end -->`;
   const startIdx = description.indexOf(startMarker);
   const endIdx = description.indexOf(endMarker);
+  // Legacy fallback: remove once all issues migrated off agent-readiness-gate sentinels
+  if (
+    (startIdx === -1 || endIdx === -1) &&
+    gateName !== 'agent-readiness-gate'
+  ) {
+    const legacyStart = '<!-- gate:agent-readiness-gate:start -->';
+    const legacyEnd = '<!-- gate:agent-readiness-gate:end -->';
+    const ls = description.indexOf(legacyStart);
+    const le = description.indexOf(legacyEnd);
+    if (ls !== -1 && le !== -1 && le > ls) {
+      return description.slice(ls + legacyStart.length, le).trim();
+    }
+  }
   if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
     return description;
   }
@@ -953,6 +978,38 @@ export async function initLinearContext(
 
       if (labelMap.has('warden:skip')) {
         gateLabels.wardenSkip = labelMap.get('warden:skip');
+      }
+
+      const bouncedDefs: Array<{
+        key:
+          | 'blocked'
+          | 'bouncedUnscoped'
+          | 'bouncedStale'
+          | 'bouncedNoContext';
+        name: string;
+        color: string;
+      }> = [
+        { key: 'blocked', name: 'warden:blocked', color: '#dc2626' },
+        { key: 'bouncedUnscoped', name: 'bounced:unscoped', color: '#f97316' },
+        { key: 'bouncedStale', name: 'bounced:stale', color: '#f97316' },
+        {
+          key: 'bouncedNoContext',
+          name: 'bounced:no-context',
+          color: '#f97316',
+        },
+      ];
+      for (const def of bouncedDefs) {
+        if (labelMap.has(def.name)) {
+          gateLabels[def.key] = labelMap.get(def.name);
+        } else {
+          const created = await client.createIssueLabel({
+            name: def.name,
+            color: def.color,
+            teamId,
+          });
+          const label = await created.issueLabel;
+          if (label) gateLabels[def.key] = label.id;
+        }
       }
 
       if (!labelMap.has('Done: Pre-implemented')) {

--- a/src/linear-gate-specs.ts
+++ b/src/linear-gate-specs.ts
@@ -15,6 +15,7 @@ export interface GateSpec {
   effort?: 'low' | 'medium' | 'high';
   fetchComments?: boolean;
   revertTo?: string;
+  maxAttempts?: number;
 }
 
 export function loadGateSpecs(wardensDir: string): Map<string, GateSpec> {
@@ -59,6 +60,8 @@ export function loadGateSpecs(wardensDir: string): Map<string, GateSpec> {
         : undefined,
       fetchComments: data.fetch_comments === true,
       revertTo: typeof data.revert_to === 'string' ? data.revert_to : undefined,
+      maxAttempts:
+        typeof data.max_attempts === 'number' ? data.max_attempts : undefined,
     });
   }
 

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -96,6 +96,8 @@ export const TERMINAL_TYPES = new Set([
   'agent_failed',
   'moved_done',
   'gate_error',
+  'bouncer_revert',
+  'gate_blocked',
 ]);
 
 const ACTIVE_STATES = ['Ready for Agent', 'Agent Working', 'In Review'];
@@ -813,6 +815,18 @@ export function formatWhyReason(issue: {
       return 'Gate pending';
     case 'state_changed':
       return 'State changed';
+    case 'gate_enrich_start':
+      return 'Enriching';
+    case 'gate_enrich_done':
+      return 'Enriched';
+    case 'gate_enrich_revise':
+      return 'Enrich revise';
+    case 'bouncer_pass':
+      return 'Bouncer pass';
+    case 'bouncer_revert':
+      return 'Bounced';
+    case 'gate_blocked':
+      return 'Blocked';
     default:
       break;
   }

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -2,7 +2,7 @@ import { createServer, Server } from 'http';
 import { LinearWebhookClient } from '@linear/sdk/webhooks';
 import type { EntityWebhookPayloadWithIssueData } from '@linear/sdk/webhooks';
 import { logger } from './logger.js';
-import { executeAgentRun } from './linear-dispatcher.js';
+import { executeAgentRun, extractScopeBlock } from './linear-dispatcher.js';
 import type { LinearContext, GateLabels } from './linear-dispatcher.js';
 import type { GateSpec } from './linear-gate-specs.js';
 import type { RunContext } from './agent-runtimes/types.js';
@@ -16,6 +16,11 @@ import {
   upsertIssueCache,
   softDeleteIssueCache,
   getPipelineEvents,
+  upsertGateMeta,
+  getGateMeta,
+  incrementAttemptCount,
+  appendReviseHistory,
+  computeEnrichmentHash,
 } from './db.js';
 import { triggerAutoMerge } from './linear-auto-merge.js';
 import { notifyPipelineStep } from './linear-notifications.js';
@@ -258,7 +263,8 @@ export function computeScopeLabelChanges(
 ): { addIds: string[]; removeIds: string[] } {
   const addIds: string[] = [];
   const removeIds: string[] = [];
-  if (gateName !== 'agent-readiness-gate') return { addIds, removeIds };
+  if (gateName !== 'agent-readiness-gate' && gateName !== 'enrichment-gate')
+    return { addIds, removeIds };
   if (finalVerdict === 'SHIP' && finalEnrichment && gateLabels.scoped) {
     addIds.push(gateLabels.scoped);
     if (gateLabels.revise) removeIds.push(gateLabels.revise);
@@ -418,6 +424,102 @@ export async function runInlineCompletionCheck(
     return 'REVISE';
   } finally {
     ctx.inFlightGate.delete(issueData.id);
+  }
+}
+
+async function trackGateMetaAndEscalate(
+  ctx: LinearContext,
+  issueId: string,
+  issueIdentifier: string,
+  gateSpec: GateSpec,
+  toStateName: string,
+  finalVerdict: string,
+  finalEnrichment: string,
+): Promise<void> {
+  if (finalVerdict === 'SHIP') {
+    // Strip sentinel markers before hashing so it matches extractScopeBlock output
+    const startMarker = `<!-- gate:${gateSpec.name}:start -->`;
+    const endMarker = `<!-- gate:${gateSpec.name}:end -->`;
+    const cleanedForHash = finalEnrichment
+      .replace(new RegExp(escapeRegex(startMarker), 'g'), '')
+      .replace(new RegExp(escapeRegex(endMarker), 'g'), '')
+      .trim();
+    const hash = computeEnrichmentHash(cleanedForHash);
+    upsertGateMeta(issueId, gateSpec.name, {
+      enrichmentHash: hash,
+      enrichmentSnapshot: cleanedForHash,
+      shippedAt: new Date().toISOString(),
+      resetReviseHistory: true,
+    });
+    logger.info(
+      { issueId, gate: gateSpec.name },
+      'linear-webhook: stored enrichment hash + snapshot',
+    );
+  } else if (finalVerdict === 'REVISE') {
+    const count = incrementAttemptCount(issueId, gateSpec.name);
+    // Extract actionable gaps section; fall back to truncated enrichment
+    const gapsMatch = finalEnrichment.match(
+      /\*\*Gaps found\*\*:\s*([\s\S]*?)(?=\n##|\n\*\*|$)/,
+    );
+    const summary = gapsMatch
+      ? gapsMatch[1].trim().slice(0, 300)
+      : finalEnrichment.slice(0, 200) +
+        (finalEnrichment.length > 200 ? '...' : '');
+    appendReviseHistory(issueId, gateSpec.name, summary);
+    logger.info(
+      { issueId, gate: gateSpec.name, attemptCount: count },
+      'linear-webhook: incremented attempt count + appended revise history',
+    );
+
+    if (gateSpec.maxAttempts && count >= gateSpec.maxAttempts) {
+      const manualState = ctx.stateByName.get('Manual Review Required');
+      if (manualState) {
+        const meta = getGateMeta(issueId, gateSpec.name);
+        const historyLines = (meta?.reviseHistory ?? [])
+          .map((r, i) => `${i + 1}. ${r}`)
+          .join('\n');
+        const guideBody = [
+          `**Warden: ${gateSpec.name}** - BLOCKED`,
+          '',
+          `This issue has been revised ${count} times without passing the ${gateSpec.name} gate. Moving to manual review.`,
+          '',
+          '### REVISE history',
+          historyLines || '(no history recorded)',
+          '',
+          '### How to unblock',
+          '1. Review the REVISE history above to understand what gaps remain',
+          '2. Fix the issue description to address the specific gaps',
+          '3. Remove the `warden:blocked` label',
+          '4. Drag the issue back to **Todo** to re-enter enrichment',
+          '',
+          '---',
+          `*Gate: ${gateSpec.name} | BLOCKED after ${count} attempts | ${new Date().toISOString()}*`,
+        ].join('\n');
+        await postOrUpdateComment(ctx, issueId, toStateName, guideBody);
+        try {
+          const blockLabelIds = ctx.gateLabels.blocked
+            ? [ctx.gateLabels.blocked]
+            : [];
+          await ctx.client.updateIssue(issueId, {
+            stateId: manualState.id,
+            ...(blockLabelIds.length > 0
+              ? { addedLabelIds: blockLabelIds }
+              : {}),
+          });
+          logPipelineEvent(
+            issueId,
+            issueIdentifier,
+            'gate_blocked',
+            `${gateSpec.name}: BLOCKED after ${count} attempts`,
+          );
+        } catch (blockErr) {
+          logger.warn(
+            { issueId, err: blockErr },
+            'linear-webhook: failed to move issue to Manual Review Required',
+          );
+        }
+      }
+    }
   }
 }
 
@@ -660,6 +762,70 @@ async function handleIssueUpdate(
   }
   ctx.inFlightGate.add(data.id);
 
+  // --- Bouncer entry-path router: short-circuit on fresh enrichment hash ---
+  if (gateSpec.name === 'bouncer-gate') {
+    const enrichmentMeta = getGateMeta(data.id, 'enrichment-gate');
+    if (enrichmentMeta?.enrichmentHash && enrichmentMeta.shippedAt) {
+      const ageHours =
+        (Date.now() - new Date(enrichmentMeta.shippedAt).getTime()) / 3_600_000;
+      // 72h: beyond a typical sprint's scope-change window
+      if (ageHours < 72) {
+        const currentScope = extractScopeBlock(
+          data.description ?? '',
+          'enrichment-gate',
+        );
+        const currentHash = computeEnrichmentHash(currentScope);
+        if (currentHash === enrichmentMeta.enrichmentHash) {
+          // Path A: hash matches, enrichment is fresh -- SHIP without LLM
+          const body = formatGateComment(
+            gateSpec.name,
+            'SHIP',
+            'Enrichment hash valid and fresh -- fast-path approval.',
+            gateSpec.mode,
+          );
+          await postOrUpdateComment(ctx, data.id, toState.name, body);
+          updateWebhookEventStatus(eventKey, 'done', { verdict: 'SHIP' });
+          notifyPipelineStep(
+            ctx,
+            data.id,
+            data.identifier,
+            'gate_ship',
+            `${gateSpec.name}: SHIP (hash fast-path)`,
+          ).catch(() => {});
+          logger.info(
+            {
+              issueId: data.id,
+              gate: gateSpec.name,
+              ageHours: Math.round(ageHours),
+            },
+            'linear-webhook: bouncer fast-path SHIP (hash match)',
+          );
+          ctx.inFlightGate.delete(data.id);
+          return;
+        }
+      }
+    }
+  }
+
+  // Strip bounced labels on RfA entry so they don't persist after re-validation
+  if (toState.name === 'Ready for Agent') {
+    const bouncedLabelIds = [
+      ctx.gateLabels.bouncedUnscoped,
+      ctx.gateLabels.bouncedStale,
+      ctx.gateLabels.bouncedNoContext,
+    ].filter((id): id is string => !!id);
+    if (bouncedLabelIds.length > 0) {
+      const issueBouncedIds = bouncedLabelIds.filter((id) =>
+        data.labels.some((l) => l.id === id),
+      );
+      if (issueBouncedIds.length > 0) {
+        retryLabelUpdate(ctx.client, data.id, {
+          removedLabelIds: issueBouncedIds,
+        });
+      }
+    }
+  }
+
   updateWebhookEventStatus(eventKey, 'running');
 
   // Visual feedback: add evaluating label, remove any prior error label
@@ -700,12 +866,26 @@ async function handleIssueUpdate(
       }
     }
 
+    // Path C: inject prior feedback for post-REVISE re-entry
+    let priorFeedbackBlock = '';
+    if (gateSpec.name === 'bouncer-gate') {
+      const meta = getGateMeta(data.id, 'bouncer-gate');
+      if (meta && meta.attemptCount > 0 && meta.reviseHistory.length > 0) {
+        priorFeedbackBlock =
+          '\n\n<prior-feedback>\nThis issue was previously bounced. Prior REVISE reasons:\n' +
+          meta.reviseHistory.map((r, i) => `${i + 1}. ${r}`).join('\n') +
+          '\n\nVerify these gaps have been addressed.\n</prior-feedback>';
+      }
+    }
+
     const prompt =
       [
         `<gate-spec>\n${gateSpec.content}\n</gate-spec>`,
         `<issue>\nTitle: ${data.title}\nID: ${data.identifier}\n\n${data.description ?? '(no description)'}\n</issue>`,
         `<transition>\nFrom: ${fromState.name}\nTo: ${toState.name}\n</transition>`,
-      ].join('\n\n') + commentBlock;
+      ].join('\n\n') +
+      commentBlock +
+      priorFeedbackBlock;
 
     const runContext: RunContext = {
       prompt,
@@ -893,6 +1073,24 @@ async function handleIssueUpdate(
     );
     addIds.push(...scopeLabels.addIds);
     removeIds.push(...scopeLabels.removeIds);
+
+    // Bouncer: apply bounced:<reason> label on REVISE, strip on SHIP
+    if (gateSpec.name === 'bouncer-gate') {
+      const allBouncedIds = [
+        ctx.gateLabels.bouncedUnscoped,
+        ctx.gateLabels.bouncedStale,
+        ctx.gateLabels.bouncedNoContext,
+      ].filter((id): id is string => !!id);
+      if (finalVerdict === 'REVISE') {
+        // Always 'unscoped' until bouncer output parsing is wired
+        const bouncedId = ctx.gateLabels.bouncedUnscoped;
+        if (bouncedId) addIds.push(bouncedId);
+      } else if (finalVerdict === 'SHIP') {
+        // Strip all bounced labels on SHIP
+        removeIds.push(...allBouncedIds);
+      }
+    }
+
     // Apply effort/complexity labels only when ratings are actually present
     if (finalEnrichment) {
       const ratings = parseRatings(finalEnrichment);
@@ -920,6 +1118,25 @@ async function handleIssueUpdate(
       if (safeRemoveIds.length > 0) update.removedLabelIds = safeRemoveIds;
       if (addIds.length > 0) update.addedLabelIds = addIds;
       retryLabelUpdate(ctx.client, data.id, update);
+    }
+
+    if (finalVerdict && finalEnrichment && !gateDidError) {
+      try {
+        await trackGateMetaAndEscalate(
+          ctx,
+          data.id,
+          data.identifier,
+          gateSpec,
+          toState.name,
+          finalVerdict,
+          finalEnrichment,
+        );
+      } catch (metaErr) {
+        logger.warn(
+          { issueId: data.id, gate: gateSpec.name, err: metaErr },
+          'linear-webhook: failed to update gate meta',
+        );
+      }
     }
 
     if (finalVerdict === 'SHIP' && gateSpec.name === 'output-quality-gate') {
@@ -1166,6 +1383,25 @@ async function runGateForIssue(
       if (addIds.length > 0) update.addedLabelIds = addIds;
       retryLabelUpdate(ctx.client, issue.id, update);
     }
+
+    if (finalVerdict && finalEnrichment) {
+      try {
+        await trackGateMetaAndEscalate(
+          ctx,
+          issue.id,
+          issue.identifier,
+          gateSpec,
+          stateName,
+          finalVerdict,
+          finalEnrichment,
+        );
+      } catch (metaErr) {
+        logger.warn(
+          { issueId: issue.id, gate: gateSpec.name, err: metaErr },
+          'startup-sweep: failed to update gate meta',
+        );
+      }
+    }
   }
 }
 
@@ -1173,7 +1409,7 @@ export async function sweepStaleGatedIssues(
   ctx: LinearContext,
   gateSpecs: Map<string, GateSpec>,
 ): Promise<void> {
-  const sweepableStates = ['Ready for Agent'];
+  const sweepableStates = ['Todo', 'Ready for Agent'];
 
   for (const stateName of sweepableStates) {
     const gateSpec = gateSpecs.get(stateName);


### PR DESCRIPTION
## Summary

- Replace single `agent-readiness-gate` with a two-gate pipeline: **enrichment gate** (Backlog->Todo, mutating admission controller) produces scope blocks; **bouncer gate** (Todo->RfA, validating admission controller) checks completeness with a hash fast-path that skips LLM when enrichment is fresh
- Add `linear_gate_meta` table for per-issue, per-gate tracking: enrichment hash + snapshot for fast-path, attempt counter + revise history for BLOCK escalation
- BLOCK verdict after 3 REVISE rounds moves issue to "Manual Review Required" with actionable step-by-step guide
- Entry-path router: Path A (hash fast-path), Path C (diff injection for post-REVISE re-entry)
- TUI: new event types (`gate_enrich_*`, `bouncer_*`, `gate_blocked`) in `formatWhyReason` and `TERMINAL_TYPES`
- ADR updated with two-gate architecture, gate meta table, and new gate specs table

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` -- 1559/1559 pass
- [x] Code reviewer SHIP (2 rounds)
- [x] AI engineering warden SHIP (2 rounds)
- [x] Verification gate SHIP
- [ ] Manual E2E: drag issue Backlog->Todo, verify enrichment fires
- [ ] Manual E2E: drag enriched issue Todo->RfA, verify bouncer fast-path
- [ ] Manual E2E: drag un-enriched issue Todo->RfA, verify bouncer REVISE

🤖 Generated with [Claude Code](https://claude.com/claude-code)