### PR TITLE
feat(compaction): extend ContainerOutput with contextStats and compactionEvent (LIA-94)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -78,6 +78,22 @@ interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   prUrl?: string;
+  contextStats?: ContextStats;
+  compactionEvent?: CompactionEvent;
+}
+
+interface ContextStats {
+  tokens: number;
+  limit: number;
+  pct: number;
+  warn?: boolean;
+  autoCompact?: boolean;
+}
+
+interface CompactionEvent {
+  trigger: 'manual' | 'auto';
+  preTokens?: number;
+  summary?: string;
 }
 
 interface SessionEntry {
@@ -116,6 +132,29 @@ const SWARM_SIGNALS = [
   'multiple agents',
   'spawn agent',
 ];
+
+// Module-level state is safe: container runs one session per process lifecycle.
+let _lastContextStats: ContextStats | undefined;
+let _contextAlertShown = false;
+let _compactTriggered = false;
+let _pendingCompactionEvent: CompactionEvent | undefined;
+let _trackedSessionId: string | undefined;
+
+// Forwarded from host via DEUS_CONTEXT_WARN_PCT / DEUS_CONTEXT_AUTO_COMPACT_PCT.
+// Defaults match host-side src/config.ts; container trusts the forwarded values.
+const WARN_PCT = parseInt(process.env.DEUS_CONTEXT_WARN_PCT || '70', 10);
+const AUTO_COMPACT_PCT = parseInt(
+  process.env.DEUS_CONTEXT_AUTO_COMPACT_PCT || '75',
+  10,
+);
+
+function resetContextTracking(sessionId?: string): void {
+  _lastContextStats = undefined;
+  _contextAlertShown = false;
+  _compactTriggered = false;
+  _pendingCompactionEvent = undefined;
+  _trackedSessionId = sessionId;
+}
 
 /**
  * Push-based async iterable for streaming user messages to the SDK.
@@ -307,11 +346,28 @@ function createPreCompactHook(assistantName?: string): HookCallback {
 }
 
 /**
- * Append SDK-reported per-turn usage metadata to JSONL. This is the direct
- * billing signal (inputTokens, outputTokens, cache read/create, cost) and the
- * basis for before/after token-efficiency comparisons. Opt-out: DEUS_USAGE_LOG=0.
+ * Compute context utilization stats (always) and append usage metadata to JSONL.
+ * DEUS_USAGE_LOG=0 skips the JSONL write but NOT the stats -- they feed the
+ * compaction UX regardless of logging preference.
  */
 function logUsage(msg: SDKResultMessage): void {
+  const firstModel = Object.values(msg.modelUsage)[0];
+  const contextWindow = firstModel?.contextWindow ?? 0;
+  if (contextWindow > 0) {
+    const tokens = msg.usage.inputTokens + msg.usage.outputTokens;
+    const pct = Math.round((tokens / contextWindow) * 100);
+    const stats: ContextStats = { tokens, limit: contextWindow, pct };
+    if (pct >= WARN_PCT && !_contextAlertShown) {
+      stats.warn = true;
+      _contextAlertShown = true;
+    }
+    if (pct >= AUTO_COMPACT_PCT && !_compactTriggered) {
+      stats.autoCompact = true;
+      _compactTriggered = true;
+    }
+    _lastContextStats = stats;
+  }
+
   if (process.env.DEUS_USAGE_LOG === '0') return;
   try {
     const logPath = '/workspace/group/logs/usage.jsonl';
@@ -869,6 +925,9 @@ async function runQuery(
 
     if (message.type === 'system' && message.subtype === 'init') {
       newSessionId = message.session_id;
+      if (newSessionId !== _trackedSessionId) {
+        resetContextTracking(newSessionId);
+      }
       log(`Session initialized: ${newSessionId}`);
     }
 
@@ -899,7 +958,10 @@ async function runQuery(
         result: textResult || null,
         newSessionRef: defaultSession(newSessionId),
         newSessionId,
+        contextStats: _lastContextStats,
+        compactionEvent: _pendingCompactionEvent,
       });
+      _pendingCompactionEvent = undefined;
     }
   }
 

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-24"  # auto-bump
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-22T23:30:00" # auto-bump (container-github-push)
+last_verified: "2026-05-25" # auto-bump
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25" # auto-bump
+last_verified: "2026-05-25" # LIA-94
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25" # auto-bump
+last_verified: "2026-05-25" # LIA-94
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/config.ts
+++ b/src/config.ts
@@ -161,6 +161,19 @@ export const DEUS_CONTEXT_FILE_MAX_CHARS =
   envConfig.DEUS_CONTEXT_FILE_MAX_CHARS ||
   '';
 
+// ── Context compaction thresholds ────────────────────────────────────────────
+// At WARN_PCT the user sees an advisory; at AUTO_COMPACT_PCT auto-compaction fires.
+// Matches TUI defaults (context_alert_shown / auto_compact_threshold). Override for testing:
+// DEUS_CONTEXT_WARN_PCT=5 DEUS_CONTEXT_AUTO_COMPACT_PCT=10
+export const CONTEXT_WARN_PCT = parseInt(
+  process.env.DEUS_CONTEXT_WARN_PCT || '70',
+  10,
+);
+export const CONTEXT_AUTO_COMPACT_PCT = parseInt(
+  process.env.DEUS_CONTEXT_AUTO_COMPACT_PCT || '75',
+  10,
+);
+
 // Credential proxy authentication.
 // Per-group tokens generated in group-tokens.ts (process-lifetime).
 // Set DEUS_PROXY_AUTH=0 to disable enforcement (ignored in production).

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -28,6 +28,8 @@ vi.mock('./config.js', () => ({
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min
   CONFIG_DIR: '/tmp/deus-test-config',
+  CONTEXT_AUTO_COMPACT_PCT: 75,
+  CONTEXT_WARN_PCT: 70,
   CREDENTIAL_PROXY_PORT: 3001,
   DATA_DIR: '/tmp/deus-test-data',
   DEUS_CONTEXT_FILE_MAX_CHARS: '12345',

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -17,6 +17,8 @@ import {
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
+  CONTEXT_AUTO_COMPACT_PCT,
+  CONTEXT_WARN_PCT,
   CREDENTIAL_PROXY_PORT,
   DEUS_CONTEXT_FILE_MAX_CHARS,
   DEUS_OPENAI_MODEL,
@@ -82,6 +84,22 @@ export interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   prUrl?: string;
+  contextStats?: ContextStats;
+  compactionEvent?: CompactionEvent;
+}
+
+export interface ContextStats {
+  tokens: number;
+  limit: number;
+  pct: number;
+  warn?: boolean;
+  autoCompact?: boolean;
+}
+
+export interface CompactionEvent {
+  trigger: 'manual' | 'auto';
+  preTokens?: number;
+  summary?: string;
 }
 
 function buildContainerArgs(
@@ -107,6 +125,12 @@ function buildContainerArgs(
       `DEUS_CONTEXT_FILE_MAX_CHARS=${DEUS_CONTEXT_FILE_MAX_CHARS}`,
     );
   }
+  args.push(
+    '-e',
+    `DEUS_CONTEXT_WARN_PCT=${CONTEXT_WARN_PCT}`,
+    '-e',
+    `DEUS_CONTEXT_AUTO_COMPACT_PCT=${CONTEXT_AUTO_COMPACT_PCT}`,
+  );
 
   const linearKey = process.env.LINEAR_API_KEY || process.env.LINEAR_API_TOKEN;
   if (linearKey) {


### PR DESCRIPTION
## Summary
- Phase 1 foundation for channel compaction UX (LIA-94)
- Extended `ContainerOutput` IPC with `contextStats` and `compactionEvent` fields (both host + container sides, SYNC-REQUIRED)
- Container computes context utilization % from SDK `modelUsage.contextWindow` per turn, emits in `writeOutput`
- Added configurable thresholds: `DEUS_CONTEXT_WARN_PCT` (70%) and `DEUS_CONTEXT_AUTO_COMPACT_PCT` (75%), forwarded to container as env vars
- Module-level context tracking with session-aware reset on `system/init`
- No user-visible behavior change -- stats computed but not consumed by host yet

## Test plan
- [x] Host build passes (`npm run build`)
- [x] Container type-check passes (`npx tsc --noEmit`)
- [x] All 1559 tests pass (`npm test`)
- [x] Test mock updated with new config constants
- [ ] Phase 2 will add host-side consumption (notifications, warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)