### PR TITLE
fix(pipeline): add logger.warn when gate fallback verdict is applied (LIA-75)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-27" # auto-bump
+last_verified: "2026-05-27"
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-27" # auto-bump
+last_verified: "2026-05-27"
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -912,7 +912,12 @@ async function handleIssueUpdate(
     if (!parsedVerdict && error) {
       verdict = gateSpec.fallback;
       logger.warn(
-        { issueId: data.id, gate: gateSpec.name, fallback: gateSpec.fallback, error },
+        {
+          issueId: data.id,
+          gate: gateSpec.name,
+          fallback: gateSpec.fallback,
+          error,
+        },
         'linear-webhook: gate agent error, applying fallback verdict',
       );
       commentBody = formatGateComment(

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -911,6 +911,10 @@ async function handleIssueUpdate(
 
     if (!parsedVerdict && error) {
       verdict = gateSpec.fallback;
+      logger.warn(
+        { issueId: data.id, gate: gateSpec.name, fallback: gateSpec.fallback, error },
+        'linear-webhook: gate agent error, applying fallback verdict',
+      );
       commentBody = formatGateComment(
         gateSpec.name,
         verdict,


### PR DESCRIPTION
## Summary. bouncer-gate.md already has fallback: REVISE. Added logger.warn in agent-error fallback branch. Closes LIA-75