### PR TITLE
feat(pipeline): eliminate SHIP from gate fallback type union

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-25" # LIA-94-remaining
+last_verified: "2026-05-26" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-25" # LIA-94-remaining
+last_verified: "2026-05-26" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-gate-specs.ts
+++ b/src/linear-gate-specs.ts
@@ -8,7 +8,7 @@ export interface GateSpec {
   gateTo: string;
   allowedFrom: string[];
   mode: 'advise' | 'strict';
-  fallback: 'SHIP' | 'REVISE';
+  fallback: 'REVISE';
   cooldownMinutes: number;
   content: string;
   model?: string;
@@ -41,7 +41,13 @@ export function loadGateSpecs(wardensDir: string): Map<string, GateSpec> {
 
     const mode = data.mode === 'strict' ? 'strict' : 'advise';
 
-    const fallback = data.fallback === 'SHIP' ? 'SHIP' : 'REVISE';
+    if (data.fallback === 'SHIP') {
+      logger.warn(
+        { file, gate: gateTo },
+        'gate spec declares fallback: SHIP (deprecated, overriding to REVISE)',
+      );
+    }
+    const fallback = 'REVISE' as const;
 
     const rawCooldown =
       typeof data.cooldown_minutes === 'number' ? data.cooldown_minutes : 60;

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -140,7 +140,7 @@ Check the issue.`,
     expect(spec.name).toBe('test-gate');
     expect(spec.allowedFrom).toEqual(['Todo']);
     expect(spec.mode).toBe('advise');
-    expect(spec.fallback).toBe('SHIP');
+    expect(spec.fallback).toBe('REVISE');
     expect(spec.cooldownMinutes).toBe(30);
     expect(spec.content).toBe('Check the issue.');
   });


### PR DESCRIPTION
## Summary
- Narrows `GateSpec.fallback` from `'SHIP' | 'REVISE'` to literal `'REVISE'`
- Failed gates now always fail-closed (REVISE) instead of silently approving
- Deprecation warning emitted when a spec still declares `fallback: SHIP`
- Addresses 4-retrospective-window persistent bug (LIA-88)

## Test plan
- [ ] `npm run build` passes (type narrowing catches any downstream SHIP references)
- [ ] Existing gate tests pass
- [ ] Verify deprecation warning appears in logs for SHIP-declaring specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)