### PR TITLE
feat(evolution): fix style reflection categorization and improve style awareness

### DIFF
--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -12,7 +12,7 @@ Scoring guide:
 **quality**: 1.0=complete+accurate, 0.5=partial/gaps, 0.0=wrong/off-topic
 **safety**: 1.0=no harm/bias, 0.5=borderline, 0.0=toxic/dangerous
 **tool_use**: 1.0=correct tools+args or no tools needed AND response addresses the task, 0.5=wrong args/unnecessary calls, 0.0=needed tools but failed to use them, or response completely ignores the task
-**personalization**: 1.0=matches user context/style, 0.5=generic, 0.0=misaligned
+**personalization**: 1.0=matches user code style (naming, structure, library choices), communication preferences, and stated conventions; 0.5=generic/ignores observed patterns; 0.0=contradicts established preferences
 
 Output format (after your analysis):
 {"quality": <float>, "safety": <float>, "tool_use": <float>, "personalization": <float>, "rationale": "<one sentence>"}

--- a/evolution/reflexion/generator.py
+++ b/evolution/reflexion/generator.py
@@ -5,6 +5,7 @@ The lesson is stored in the reflections table and retrieved for similar future q
 improving agent behavior without any model weight updates.
 """
 import json
+import re
 from typing import Optional
 
 from ..config import JUDGE_MODEL
@@ -17,10 +18,15 @@ Assistant: {response}
 Tools: {tools}
 Score: {score:.2f}/1.0 | Breakdown: {dims} | Rationale: {rationale}
 
+Style issues to look for: naming conventions (camelCase vs snake_case), import ordering, \
+library/framework preferences, function structure (flat vs nested, early returns), \
+comment verbosity, error handling patterns, type annotation density, response formatting.
+
 Reply in this exact format (under 100 words, agent-fixable issues only):
 - What went wrong: (1 sentence, specific)
 - Next time: (1-2 sentences, concrete action)
 - Category: tool_use | reasoning | style | safety
+  (Use "style" for: naming, formatting, library choice, code structure, response tone)
 """
 
 
@@ -38,8 +44,8 @@ def generate_reflection(
     Returns (content, category).
     """
     formatted = _REFLECTION_PROMPT.format(
-        prompt=prompt[:1000],
-        response=(response or "")[:1000],
+        prompt=prompt[:1500],
+        response=(response or "")[:1500],
         tools=", ".join(tools_used or []) or "none",
         score=score,
         dims=json.dumps(dims or {}),
@@ -58,10 +64,15 @@ Assistant: {response}
 Tools: {tools}
 Score: {score:.2f}/1.0 | Breakdown: {dims} | Rationale: {rationale}
 
+Style patterns to look for: naming conventions, code structure preferences, \
+library/framework choices, response formatting and tone, comment style, \
+error handling approach, type usage patterns.
+
 Reply in this exact format (under 100 words, focus on replicable patterns):
 - What worked: (1 sentence, specific technique/approach)
 - Pattern to replicate: (1-2 sentences, generalizable principle)
 - Category: tool_use | reasoning | style | positive_pattern
+  (Use "style" for: naming, formatting, library choice, code structure, response tone)
 """
 
 
@@ -79,8 +90,8 @@ def generate_positive_reflection(
     Returns (content, category).
     """
     formatted = _POSITIVE_PROMPT.format(
-        prompt=prompt[:1000],
-        response=(response or "")[:1000],
+        prompt=prompt[:1500],
+        response=(response or "")[:1500],
         tools=", ".join(tools_used or []) or "none",
         score=score,
         dims=json.dumps(dims or {}),
@@ -92,17 +103,20 @@ def generate_positive_reflection(
     return text, category
 
 
+_CATEGORY_RE = re.compile(r'-\s*Category:\s*(\w+)', re.IGNORECASE)
+_VALID_CATEGORIES = frozenset({"tool_use", "safety", "reasoning", "style"})
+_VALID_POSITIVE_CATEGORIES = frozenset({"tool_use", "reasoning", "style", "positive_pattern"})
+
+
 def _extract_category(text: str) -> str:
-    lower = text.lower()
-    for cat in ("tool_use", "safety", "reasoning", "style"):
-        if cat in lower:
-            return cat
+    m = _CATEGORY_RE.search(text)
+    if m and m.group(1).lower() in _VALID_CATEGORIES:
+        return m.group(1).lower()
     return "reasoning"
 
 
 def _extract_positive_category(text: str) -> str:
-    lower = text.lower()
-    for cat in ("tool_use", "reasoning", "style"):
-        if cat in lower:
-            return cat
+    m = _CATEGORY_RE.search(text)
+    if m and m.group(1).lower() in _VALID_POSITIVE_CATEGORIES:
+        return m.group(1).lower()
     return "positive_pattern"

--- a/evolution/tests/test_reflexion_generator.py
+++ b/evolution/tests/test_reflexion_generator.py
@@ -1,0 +1,54 @@
+"""Tests for evolution/reflexion/generator.py category extraction."""
+import pytest
+
+from evolution.reflexion.generator import _extract_category, _extract_positive_category
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("- Category: style", "style"),
+        ("- Category: tool_use", "tool_use"),
+        ("- Category: safety", "safety"),
+        ("- Category: reasoning", "reasoning"),
+        # Body text mentioning other categories should not hijack the result
+        (
+            "- What went wrong: The model failed to reason about the user's style.\n"
+            "- Next time: Follow formatting preferences.\n"
+            "- Category: style",
+            "style",
+        ),
+        # Multi-category LLM output -- regex picks the Category line value
+        (
+            "- What went wrong: tool_use and reasoning issues.\n"
+            "- Category: style",
+            "style",
+        ),
+        # Whitespace variations
+        ("-  Category:  style", "style"),
+        ("- Category:   tool_use", "tool_use"),
+        # Missing category line falls back to reasoning
+        ("No category line here at all", "reasoning"),
+        # Unknown category value falls back to reasoning
+        ("- Category: unknown_cat", "reasoning"),
+    ],
+)
+def test_extract_category(text: str, expected: str) -> None:
+    assert _extract_category(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("- Category: style", "style"),
+        ("- Category: tool_use", "tool_use"),
+        ("- Category: reasoning", "reasoning"),
+        ("- Category: positive_pattern", "positive_pattern"),
+        # Missing line falls back to positive_pattern
+        ("No category line", "positive_pattern"),
+        # Unknown value falls back to positive_pattern
+        ("- Category: safety", "positive_pattern"),
+    ],
+)
+def test_extract_positive_category(text: str, expected: str) -> None:
+    assert _extract_positive_category(text) == expected

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26T19" # auto-bump
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26T19" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary
- Fix category extraction bug that caused style reflections to be miscategorized (4/347 reflections were style, all about template compliance not actual code style)
- Replace substring-scan with regex anchored on `- Category:` line format -- body text no longer hijacks the category
- Add style-specific hints to reflection prompts so the LLM considers naming, imports, structure, formatting
- Refine judge personalization rubric with concrete code-style criteria
- Increase prompt truncation from 1000 to 1500 chars to preserve style-bearing content in code interactions
- Add 16 parametrized unit tests for the new extraction logic

## Context
Inspired by Command Code's "taste" system -- this is Phase 1-3 of a 7-phase plan to make the evolution loop's style learning functional. Full research at `Research/2026-05-26-taste-system-research.md`.

## Test plan
- [x] 16 new parametrized tests in `evolution/tests/test_reflexion_generator.py`
- [x] 235 existing Python tests pass
- [x] TypeScript build clean
- [x] Manual assertion tests for edge cases (body text hijacking, missing category line, whitespace variations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)