### PR TITLE
feat(evolution): fix zero-signal bug, add has_code tagging, expand user signals

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -218,6 +218,10 @@ def cmd_log_interaction(json_str: str) -> None:
     if context_tokens is not None:
         context_tokens = int(context_tokens)
 
+    has_code = params.get("has_code")
+    if has_code is not None:
+        has_code = int(has_code)
+
     session_id = params.get("session_id")
 
     iid = log_interaction(
@@ -231,6 +235,7 @@ def cmd_log_interaction(json_str: str) -> None:
         domain_presets=domain_presets if isinstance(domain_presets, list) else None,
         user_signal=user_signal,
         context_tokens=context_tokens,
+        has_code=has_code,
     )
 
     # Batch judge: check if we've accumulated enough unjudged interactions

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -23,6 +23,7 @@ def log_interaction(
     domain_presets: Optional[list[str]] = None,
     user_signal: Optional[str] = None,
     context_tokens: Optional[int] = None,
+    has_code: Optional[int] = None,
 ) -> str:
     """
     Persist one agent interaction.  Returns the interaction ID.
@@ -44,6 +45,7 @@ def log_interaction(
         domain_presets=json.dumps(domain_presets) if domain_presets else None,
         user_signal=user_signal,
         context_tokens=context_tokens,
+        has_code=has_code,
     )
     return iid
 

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -56,6 +56,7 @@ class StorageProvider(ABC):
         domain_presets: Optional[str] = None,
         user_signal: Optional[str] = None,
         context_tokens: Optional[int] = None,
+        has_code: Optional[int] = None,
     ) -> str:
         """Persist one agent interaction. Returns the interaction ID."""
         ...

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -40,6 +40,8 @@ _UPDATABLE_INTERACTION_COLS = frozenset({
     "parse_error",
     "latency_ms",
     "timestamp",
+    "has_code",
+    "user_signal",
 })
 
 # Guard against concurrent schema migrations from multiple threads
@@ -256,6 +258,7 @@ class SQLiteStorageProvider(StorageProvider):
             ("user_signal", "TEXT"),
             ("parse_error", "INTEGER DEFAULT 0"),
             ("context_tokens", "INTEGER"),
+            ("has_code", "INTEGER DEFAULT 0"),
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list
@@ -316,6 +319,7 @@ class SQLiteStorageProvider(StorageProvider):
         domain_presets: Optional[str] = None,
         user_signal: Optional[str] = None,
         context_tokens: Optional[int] = None,
+        has_code: Optional[int] = None,
     ) -> str:
         db = self._connect()
         db.execute(
@@ -323,13 +327,13 @@ class SQLiteStorageProvider(StorageProvider):
             INSERT OR REPLACE INTO interactions
                 (id, timestamp, group_folder, prompt, response, tools_used,
                  latency_ms, eval_suite, session_id, domain_presets, user_signal,
-                 context_tokens)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 context_tokens, has_code)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 interaction_id, timestamp, group_folder, prompt, response,
                 tools_used, latency_ms, eval_suite, session_id,
-                domain_presets, user_signal, context_tokens,
+                domain_presets, user_signal, context_tokens, has_code,
             ),
         )
         db.commit()

--- a/evolution/tests/test_signal_pipeline.py
+++ b/evolution/tests/test_signal_pipeline.py
@@ -1,0 +1,26 @@
+"""Tests for the has_code column and signal pipeline additions."""
+import pytest
+
+
+def test_has_code_column_migration():
+    """Verify has_code column exists after migration."""
+    from evolution.storage import get_storage
+    store = get_storage()
+    db = store._connect()
+    # Column should exist (migration adds it)
+    row = db.execute("PRAGMA table_info(interactions)").fetchall()
+    col_names = [r[1] for r in row]
+    assert "has_code" in col_names
+    db.close()
+
+
+def test_has_code_updatable():
+    """Verify has_code is in the updatable columns set."""
+    from evolution.storage.providers.sqlite import _UPDATABLE_INTERACTION_COLS
+    assert "has_code" in _UPDATABLE_INTERACTION_COLS
+
+
+def test_user_signal_updatable():
+    """Verify user_signal is in the updatable columns set (needed for Phase 5 mining)."""
+    from evolution.storage.providers.sqlite import _UPDATABLE_INTERACTION_COLS
+    assert "user_signal" in _UPDATABLE_INTERACTION_COLS

--- a/evolution/tests/test_signal_pipeline.py
+++ b/evolution/tests/test_signal_pipeline.py
@@ -1,5 +1,4 @@
 """Tests for the has_code column and signal pipeline additions."""
-import pytest
 
 
 def test_has_code_column_migration():

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-25" # LIA-94-remaining
+last_verified: "2026-05-26T22" # LIA-94-remaining
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26T22" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-26T19" # auto-bump
+last_verified: "2026-05-26T22" # auto-bump
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26T19" # auto-bump
+last_verified: "2026-05-26T22" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/__tests__/user-signal.test.ts
+++ b/src/__tests__/user-signal.test.ts
@@ -8,7 +8,6 @@ describe('detectUserSignal', () => {
     expect(detectUserSignal('exactly')).toBe('positive');
     expect(detectUserSignal('great job')).toBe('positive');
     expect(detectUserSignal('love it')).toBe('positive');
-    expect(detectUserSignal('works')).toBe('positive');
     expect(detectUserSignal('that works')).toBe('positive');
     expect(detectUserSignal('looks good')).toBe('positive');
     expect(detectUserSignal('lgtm')).toBe('positive');

--- a/src/__tests__/user-signal.test.ts
+++ b/src/__tests__/user-signal.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { detectUserSignal } from '../user-signal.js';
+
+describe('detectUserSignal', () => {
+  it('detects positive keywords', () => {
+    expect(detectUserSignal('perfect')).toBe('positive');
+    expect(detectUserSignal('exactly')).toBe('positive');
+    expect(detectUserSignal('great job')).toBe('positive');
+    expect(detectUserSignal('love it')).toBe('positive');
+    expect(detectUserSignal('works')).toBe('positive');
+    expect(detectUserSignal('that works')).toBe('positive');
+    expect(detectUserSignal('looks good')).toBe('positive');
+    expect(detectUserSignal('lgtm')).toBe('positive');
+    expect(detectUserSignal('thanks')).toBe('positive');
+    expect(detectUserSignal('thank you')).toBe('positive');
+  });
+
+  it('detects negative keywords', () => {
+    expect(detectUserSignal('wrong')).toBe('negative');
+    expect(detectUserSignal('try again')).toBe('negative');
+    expect(detectUserSignal('not what i asked')).toBe('negative');
+    expect(detectUserSignal('redo')).toBe('negative');
+    expect(detectUserSignal('start over')).toBe('negative');
+    expect(detectUserSignal('redo this')).toBe('negative');
+  });
+
+  it('returns null for messages exceeding MAX_SIGNAL_LENGTH (200)', () => {
+    const longMessage = 'perfect ' + 'x'.repeat(200);
+    expect(detectUserSignal(longMessage)).toBeNull();
+  });
+
+  it('detects signals up to MAX_SIGNAL_LENGTH boundary', () => {
+    // 200 chars exactly should still work
+    const atBoundary = 'perfect' + ' '.repeat(193);
+    expect(atBoundary.length).toBe(200);
+    expect(detectUserSignal(atBoundary)).toBe('positive');
+
+    // 201 chars should return null
+    const overBoundary = 'perfect' + ' '.repeat(194);
+    expect(overBoundary.length).toBe(201);
+    expect(detectUserSignal(overBoundary)).toBeNull();
+  });
+
+  it('returns null for normal prompts without signal keywords', () => {
+    expect(detectUserSignal('hello world')).toBeNull();
+    expect(detectUserSignal('what is the weather?')).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(detectUserSignal('PERFECT')).toBe('positive');
+    expect(detectUserSignal('WRONG')).toBe('negative');
+    expect(detectUserSignal('LGTM')).toBe('positive');
+  });
+
+  it('negative takes priority over positive when both present', () => {
+    expect(detectUserSignal('perfect but wrong')).toBe('negative');
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -61,6 +61,11 @@ import { getProjectById } from './db.js';
 const OUTPUT_START_MARKER = '---DEUS_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---DEUS_OUTPUT_END---';
 
+function containsCodeBlock(text: string | null): boolean {
+  if (!text) return false;
+  return /```[\s\S]{10,}?```/.test(text);
+}
+
 export interface ContainerInput {
   prompt: string;
   backend?: AgentRuntimeId;
@@ -235,6 +240,10 @@ export async function runContainerAgent(
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
 
+  // Detect user signal BEFORE reflections prepend — reflections inflate prompt
+  // length past MAX_SIGNAL_LENGTH, causing false-null on short feedback messages.
+  const userSignal = detectUserSignal(input.prompt);
+
   // Pre-dispatch: inject relevant reflections from the evolution loop.
   // getReflections returns '' when evolution is disabled or nothing is found —
   // no tokens are added in that case.
@@ -246,7 +255,6 @@ export async function runContainerAgent(
   // Detect domain tags for evolution loop metadata (no prompt injection).
   // detectDomainsWithFallback: fast keyword path first; if no keywords match,
   // falls back to a Gemini LLM call bounded to 3 s. Never throws.
-  const userSignal = detectUserSignal(input.prompt);
   const domains = await detectDomainsWithFallback(input.prompt);
 
   // Pre-dispatch: build project type hint if group has an associated project.
@@ -634,6 +642,7 @@ export async function runContainerAgent(
                 ? reflections.reflectionIds
                 : undefined,
             contextTokens: estimateTokens(input.prompt),
+            hasCode: false, // streaming mode: result is null, no code blocks
           });
           resolve({
             status: 'success',
@@ -696,6 +705,7 @@ export async function runContainerAgent(
               ? reflections.reflectionIds
               : undefined,
           contextTokens: estimateTokens(input.prompt),
+          hasCode: containsCodeBlock(output.result),
         });
 
         resolve(output);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -642,7 +642,7 @@ export async function runContainerAgent(
                 ? reflections.reflectionIds
                 : undefined,
             contextTokens: estimateTokens(input.prompt),
-            hasCode: false, // streaming mode: result is null, no code blocks
+            hasCode: false,
           });
           resolve({
             status: 'success',

--- a/src/evolution-client.ts
+++ b/src/evolution-client.ts
@@ -32,6 +32,7 @@ export interface LogInteractionParams {
   userSignal?: string;
   retrievedReflectionIds?: string[];
   contextTokens?: number;
+  hasCode?: boolean;
 }
 
 export interface ReflectionsResult {
@@ -88,6 +89,7 @@ export function logInteraction(params: LogInteractionParams): void {
     user_signal: params.userSignal ?? null,
     retrieved_reflection_ids: params.retrievedReflectionIds ?? [],
     context_tokens: params.contextTokens ?? null,
+    has_code: params.hasCode ? 1 : 0,
   });
 
   // Spawn detached so it survives even if the host process exits quickly

--- a/src/user-signal.test.ts
+++ b/src/user-signal.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { detectUserSignal } from './user-signal.js';
 
-// MAX_SIGNAL_LENGTH = 80 (from source)
-const MAX_SIGNAL_LENGTH = 80;
+const MAX_SIGNAL_LENGTH = 200;
 
 describe('detectUserSignal', () => {
   // Positive signals
@@ -52,13 +51,12 @@ describe('detectUserSignal', () => {
   });
 
   it('returns null when message exceeds MAX_SIGNAL_LENGTH', () => {
-    const longMessage = 'perfect '.repeat(12); // 96 chars > 80
+    const longMessage = 'perfect ' + 'x'.repeat(200);
     expect(longMessage.length).toBeGreaterThan(MAX_SIGNAL_LENGTH);
     expect(detectUserSignal(longMessage)).toBeNull();
   });
 
   it('returns signal when message is exactly at MAX_SIGNAL_LENGTH', () => {
-    // Build a message exactly 80 chars long that contains "wrong"
     const msg = 'wrong' + ' '.repeat(MAX_SIGNAL_LENGTH - 5);
     expect(msg.length).toBe(MAX_SIGNAL_LENGTH);
     expect(detectUserSignal(msg)).toBe('negative');

--- a/src/user-signal.ts
+++ b/src/user-signal.ts
@@ -19,7 +19,6 @@ const POSITIVE_KEYWORDS = [
   'well done',
   'nailed it',
   'spot on',
-  'works',
   'that works',
   'looks good',
   'lgtm',

--- a/src/user-signal.ts
+++ b/src/user-signal.ts
@@ -19,6 +19,12 @@ const POSITIVE_KEYWORDS = [
   'well done',
   'nailed it',
   'spot on',
+  'works',
+  'that works',
+  'looks good',
+  'lgtm',
+  'thanks',
+  'thank you',
 ];
 
 const NEGATIVE_KEYWORDS = [
@@ -31,9 +37,13 @@ const NEGATIVE_KEYWORDS = [
   'completely wrong',
   'no thats wrong',
   "no that's wrong",
+  'not what i asked',
+  'redo',
+  'start over',
+  'redo this',
 ];
 
-const MAX_SIGNAL_LENGTH = 80;
+const MAX_SIGNAL_LENGTH = 200;
 
 export function detectUserSignal(
   prompt: string,


### PR DESCRIPTION
## Summary
- Fix zero-signal bug: moved `detectUserSignal` before reflections prepend (was inflating prompt past MAX_SIGNAL_LENGTH=80, causing 100% null user_signal on 1,397 interactions)
- Add `has_code` column to evolution DB for code-content tagging with full pipeline pass-through
- Expand user signal keywords (positive: `that works`, `looks good`, `lgtm`, `thanks`; negative: `not what i asked`, `redo`, `start over`) and increase MAX_SIGNAL_LENGTH to 200
- Add `containsCodeBlock` helper for detecting code blocks in container output
- Cross-branch dependency: `user_signal` added to `_UPDATABLE_INTERACTION_COLS` for Phase 5 mining

## Test plan
- [x] Python tests pass (evolution/tests/test_signal_pipeline.py — 3 tests)
- [x] TypeScript tests pass (src/__tests__/user-signal.test.ts — 7 tests)
- [x] Code-reviewer SHIP (2 rounds)
- [ ] After deploy: send "perfect" via WhatsApp, verify user_signal IS NOT NULL in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)