### PR TITLE
feat(evolution): add session-correction mining for implicit signals

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -493,6 +493,25 @@ def cmd_dismiss_warden_finding(json_str: str) -> None:
         print(json.dumps({"id": None, "status": "duplicate", "reason": "Similar reflection already exists"}))
 
 
+def cmd_mine_corrections(dry_run: bool = False, limit: Optional[int] = None) -> None:
+    """Mine session-correction signals from existing interactions."""
+    from .mining import mine_corrections
+    result = mine_corrections(dry_run=dry_run, limit=limit)
+    prefix = "[dry-run] " if dry_run else ""
+    print(f"{prefix}Matched: {result['matched']} correction pairs")
+    if not dry_run:
+        print(f"Updated: {result['updated']} | Skipped: {result['skipped']}")
+    if result['examples']:
+        print("\nExamples:")
+        for ex in result['examples']:
+            print(f"  Target: {ex['target_prompt']}")
+            print(f"  Follow-up: {ex['followup']}")
+            print()
+    if result['matched'] < 20:
+        print("Warning: fewer than 20 matches — CORRECTION_VOCAB may need tuning")
+    # Reversal: UPDATE interactions SET user_signal = NULL WHERE correction_mined_at IS NOT NULL
+
+
 def cmd_serve() -> None:
     from .mcp_server import _run_mcp_server
     _run_mcp_server()
@@ -558,6 +577,11 @@ def main() -> None:
     # serve
     sub.add_parser("serve", help="Start MCP stdio server")
 
+    # mine-corrections
+    p_mine = sub.add_parser("mine-corrections", help="Mine session-correction signals from existing interactions")
+    p_mine.add_argument("--dry-run", action="store_true", help="Preview matches without updating DB")
+    p_mine.add_argument("--limit", type=int, default=None, help="Process at most N pairs")
+
     # backfill
     p_backfill = sub.add_parser("backfill", help="Backfill historical sessions into evolution loop")
     p_backfill.add_argument("--sessions-dir", type=Path,
@@ -615,6 +639,8 @@ def main() -> None:
             sys.exit(1)
     elif args.cmd == "serve":
         cmd_serve()
+    elif args.cmd == "mine-corrections":
+        cmd_mine_corrections(dry_run=args.dry_run, limit=args.limit)
     elif args.cmd == "backfill":
         from .backfill import run_backfill, print_status, SESSIONS_DIR
         if args.status:

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -509,7 +509,6 @@ def cmd_mine_corrections(dry_run: bool = False, limit: Optional[int] = None) -> 
             print()
     if result['matched'] < 20:
         print("Warning: fewer than 20 matches — CORRECTION_VOCAB may need tuning")
-    # Reversal: UPDATE interactions SET user_signal = NULL WHERE correction_mined_at IS NOT NULL
 
 
 def cmd_serve() -> None:

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -96,6 +96,17 @@ COMPACT_AFTER_DAYS = int(os.environ.get("EVOLUTION_COMPACT_AFTER_DAYS", "7"))
 JUDGE_BATCH_SIZE = int(os.environ.get("EVOLUTION_JUDGE_BATCH_SIZE", "5"))
 
 
+# ── Correction Mining ───────────────────────────────────────────────────────
+
+CORRECTION_VOCAB = [
+    "without the", "not like that", "can you redo", "shorter", "longer",
+    "different format", "try again", "no,", "wrong",
+    "that's not", "thats not", "don't include", "remove the", "change the",
+    "actually,", "i meant", "i said",
+]
+CORRECTION_MAX_PROMPT_LEN = int(os.environ.get("EVOLUTION_CORRECTION_MAX_LEN", "120"))
+
+
 def load_api_key() -> str:
     """Load GEMINI_API_KEY from .env files (in priority order) or environment."""
     for path in _ENV_SEARCH_PATHS:

--- a/evolution/mining.py
+++ b/evolution/mining.py
@@ -1,0 +1,113 @@
+"""
+Session-correction mining for the Evolution loop.
+
+Retroactively extracts implicit negative signals from existing interactions by
+detecting correction patterns in follow-up messages within the same session.
+Batch Filter/Transform pattern: stateless pure functions, no class hierarchy.
+"""
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from .config import CORRECTION_VOCAB, CORRECTION_MAX_PROMPT_LEN
+from .storage import get_storage
+
+log = logging.getLogger(__name__)
+
+# Pre-compile vocab patterns for efficiency
+_CORRECTION_PATTERNS = [re.compile(re.escape(v), re.IGNORECASE) for v in CORRECTION_VOCAB]
+
+
+def _is_correction(text: str) -> bool:
+    """Check if text matches any correction vocabulary pattern."""
+    lower = text.lower().strip()
+    for pattern in _CORRECTION_PATTERNS:
+        if pattern.search(lower):
+            return True
+    return False
+
+
+def mine_corrections(
+    *,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+) -> dict:
+    """
+    Mine session-correction signals from existing interactions.
+
+    Finds pairs (A, B) where B is a short follow-up in the same session
+    that matches correction vocabulary, indicating A was unsatisfactory.
+    Labels A with user_signal='correction'.
+
+    Safety: only updates rows where user_signal IS NULL.
+
+    Returns dict with keys: matched, updated, skipped, examples.
+    """
+    store = get_storage()
+    db = store._connect()
+
+    # Self-join: find interactions followed by short corrective messages
+    query = """
+        SELECT a.id AS target_id,
+               a.prompt AS target_prompt,
+               b.prompt AS followup_prompt,
+               a.session_id
+        FROM interactions a
+        JOIN interactions b ON b.session_id = a.session_id
+            AND b.timestamp > a.timestamp
+            AND b.id != a.id
+        WHERE a.user_signal IS NULL
+          AND a.session_id IS NOT NULL
+          AND LENGTH(b.prompt) < ?
+        ORDER BY a.session_id, a.timestamp
+    """
+    rows = db.execute(query, (CORRECTION_MAX_PROMPT_LEN,)).fetchall()
+
+    # Deduplicate: only the first follow-up per target interaction
+    seen_targets: set = set()
+    matched = []
+    for row in rows:
+        target_id = row[0]
+        if target_id in seen_targets:
+            continue
+        followup = row[2]
+        if _is_correction(followup):
+            seen_targets.add(target_id)
+            matched.append({
+                "target_id": target_id,
+                "target_prompt": row[1][:100],
+                "followup": followup[:100],
+                "session_id": row[3],
+            })
+            if limit and len(matched) >= limit:
+                break
+
+    updated = 0
+    skipped = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not dry_run and matched:
+        for m in matched:
+            try:
+                db.execute(
+                    """UPDATE interactions
+                       SET user_signal = 'correction',
+                           correction_mined_at = ?
+                       WHERE id = ? AND user_signal IS NULL""",
+                    (now, m["target_id"]),
+                )
+                updated += 1
+            except Exception as exc:
+                log.warning("Failed to update %s: %s", m["target_id"], exc)
+                skipped += 1
+        db.commit()
+
+    db.close()
+
+    return {
+        "matched": len(matched),
+        "updated": updated,
+        "skipped": skipped,
+        "examples": matched[:5],
+    }

--- a/evolution/mining.py
+++ b/evolution/mining.py
@@ -1,9 +1,8 @@
 """
 Session-correction mining for the Evolution loop.
 
-Retroactively extracts implicit negative signals from existing interactions by
-detecting correction patterns in follow-up messages within the same session.
-Batch Filter/Transform pattern: stateless pure functions, no class hierarchy.
+Retroactively extracts implicit negative signals from existing interactions
+by detecting correction patterns in follow-up messages within the same session.
 """
 import logging
 import re
@@ -15,15 +14,13 @@ from .storage import get_storage
 
 log = logging.getLogger(__name__)
 
-# Pre-compile vocab patterns for efficiency
 _CORRECTION_PATTERNS = [re.compile(re.escape(v), re.IGNORECASE) for v in CORRECTION_VOCAB]
 
 
 def _is_correction(text: str) -> bool:
     """Check if text matches any correction vocabulary pattern."""
-    lower = text.lower().strip()
     for pattern in _CORRECTION_PATTERNS:
-        if pattern.search(lower):
+        if pattern.search(text):
             return True
     return False
 
@@ -45,69 +42,36 @@ def mine_corrections(
     Returns dict with keys: matched, updated, skipped, examples.
     """
     store = get_storage()
-    db = store._connect()
+    rows = store.get_correction_candidates(max_followup_len=CORRECTION_MAX_PROMPT_LEN)
 
-    # Self-join: find interactions followed by short corrective messages
-    query = """
-        SELECT a.id AS target_id,
-               a.prompt AS target_prompt,
-               b.prompt AS followup_prompt,
-               a.session_id
-        FROM interactions a
-        JOIN interactions b ON b.session_id = a.session_id
-            AND b.timestamp > a.timestamp
-            AND b.id != a.id
-        WHERE a.user_signal IS NULL
-          AND a.session_id IS NOT NULL
-          AND LENGTH(b.prompt) < ?
-        ORDER BY a.session_id, a.timestamp
-    """
-    rows = db.execute(query, (CORRECTION_MAX_PROMPT_LEN,)).fetchall()
-
-    # Deduplicate: only the first follow-up per target interaction
     seen_targets: set = set()
     matched = []
     for row in rows:
-        target_id = row[0]
+        target_id = row["target_id"]
         if target_id in seen_targets:
             continue
-        followup = row[2]
+        followup = row["followup_prompt"]
         if _is_correction(followup):
             seen_targets.add(target_id)
             matched.append({
                 "target_id": target_id,
-                "target_prompt": row[1][:100],
+                "target_prompt": row["target_prompt"][:100],
                 "followup": followup[:100],
-                "session_id": row[3],
+                "session_id": row["session_id"],
             })
             if limit and len(matched) >= limit:
                 break
 
     updated = 0
-    skipped = 0
     now = datetime.now(timezone.utc).isoformat()
 
     if not dry_run and matched:
-        for m in matched:
-            try:
-                db.execute(
-                    """UPDATE interactions
-                       SET user_signal = 'correction',
-                           correction_mined_at = ?
-                       WHERE id = ? AND user_signal IS NULL""",
-                    (now, m["target_id"]),
-                )
-                updated += 1
-            except Exception as exc:
-                log.warning("Failed to update %s: %s", m["target_id"], exc)
-                skipped += 1
-        db.commit()
-
-    db.close()
+        ids = [m["target_id"] for m in matched]
+        updated = store.bulk_label_corrections(ids=ids, mined_at=now)
 
     return {
         "matched": len(matched),
         "updated": updated,
-        "skipped": skipped,
+        "skipped": len(matched) - updated if not dry_run else 0,
         "examples": matched[:5],
     }

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -307,6 +307,23 @@ class StorageProvider(ABC):
         ...
 
     @abstractmethod
+    def get_correction_candidates(self, max_followup_len: int) -> list[dict]:
+        """Get session pairs where a short follow-up might indicate a correction.
+
+        Returns rows with keys: target_id, target_prompt, followup_prompt, session_id.
+        Only includes rows where user_signal IS NULL on the target.
+        """
+        ...
+
+    @abstractmethod
+    def bulk_label_corrections(self, ids: list[str], mined_at: str) -> int:
+        """Label interactions as corrections. Only updates rows where user_signal IS NULL.
+
+        Returns the number of rows actually updated.
+        """
+        ...
+
+    @abstractmethod
     def score_by_reflection_count(self) -> list[dict]:
         """
         Return average judge score grouped by the number of reflections an

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -953,6 +953,48 @@ class SQLiteStorageProvider(StorageProvider):
         db.close()
         return [dict(r) for r in rows]
 
+    def get_correction_candidates(self, max_followup_len: int) -> list[dict]:
+        db = self._connect()
+        rows = db.execute(
+            """
+            SELECT a.id AS target_id,
+                   a.prompt AS target_prompt,
+                   b.prompt AS followup_prompt,
+                   a.session_id
+            FROM interactions a
+            JOIN interactions b ON b.session_id = a.session_id
+                AND b.timestamp > a.timestamp
+                AND b.id != a.id
+            WHERE a.user_signal IS NULL
+              AND a.session_id IS NOT NULL
+              AND LENGTH(b.prompt) < ?
+            ORDER BY a.session_id, a.timestamp
+            """,
+            (max_followup_len,),
+        ).fetchall()
+        db.close()
+        return [
+            {"target_id": r[0], "target_prompt": r[1], "followup_prompt": r[2], "session_id": r[3]}
+            for r in rows
+        ]
+
+    def bulk_label_corrections(self, ids: list[str], mined_at: str) -> int:
+        if not ids:
+            return 0
+        db = self._connect()
+        updated = 0
+        for iid in ids:
+            cursor = db.execute(
+                """UPDATE interactions
+                   SET user_signal = 'correction', correction_mined_at = ?
+                   WHERE id = ? AND user_signal IS NULL""",
+                (mined_at, iid),
+            )
+            updated += cursor.rowcount
+        db.commit()
+        db.close()
+        return updated
+
     def score_by_reflection_count(self) -> list[dict]:
         """
         Return avg judge score grouped by the number of reflections an interaction has.

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -42,6 +42,7 @@ _UPDATABLE_INTERACTION_COLS = frozenset({
     "timestamp",
     "has_code",
     "user_signal",
+    "correction_mined_at",
 })
 
 # Guard against concurrent schema migrations from multiple threads
@@ -258,7 +259,11 @@ class SQLiteStorageProvider(StorageProvider):
             ("user_signal", "TEXT"),
             ("parse_error", "INTEGER DEFAULT 0"),
             ("context_tokens", "INTEGER"),
+<<<<<<< HEAD
             ("has_code", "INTEGER DEFAULT 0"),
+=======
+            ("correction_mined_at", "TEXT"),
+>>>>>>> b7eb59ae (feat(evolution): add session-correction mining for implicit signals)
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -259,11 +259,8 @@ class SQLiteStorageProvider(StorageProvider):
             ("user_signal", "TEXT"),
             ("parse_error", "INTEGER DEFAULT 0"),
             ("context_tokens", "INTEGER"),
-<<<<<<< HEAD
             ("has_code", "INTEGER DEFAULT 0"),
-=======
             ("correction_mined_at", "TEXT"),
->>>>>>> b7eb59ae (feat(evolution): add session-correction mining for implicit signals)
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list

--- a/evolution/tests/test_mining.py
+++ b/evolution/tests/test_mining.py
@@ -1,0 +1,129 @@
+"""Tests for session-correction mining."""
+import sqlite3
+import pytest
+from pathlib import Path
+
+import evolution.config as config_mod
+import evolution.db as db_mod
+from evolution.storage.provider import StorageRegistry
+from evolution.storage.providers.sqlite import SQLiteStorageProvider, _migrated_paths
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Ensure each test gets a fresh registry, restored after."""
+    StorageRegistry.reset()
+    yield
+    # Re-register the built-in provider so subsequent test files aren't affected
+    StorageRegistry.reset()
+    reg = StorageRegistry.default()
+    reg.register(SQLiteStorageProvider())
+
+
+@pytest.fixture
+def test_db(tmp_path, monkeypatch):
+    """Create a temporary evolution DB with test interactions."""
+    db_path = tmp_path / "test_evolution.db"
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", db_path)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", db_path)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
+
+    db = sqlite3.connect(db_path)
+    db.execute("""
+        CREATE TABLE interactions (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            group_folder TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            response TEXT,
+            tools_used TEXT,
+            latency_ms REAL,
+            judge_score REAL,
+            judge_dims TEXT,
+            eval_suite TEXT DEFAULT 'runtime',
+            session_id TEXT,
+            domain_presets TEXT,
+            user_signal TEXT,
+            parse_error INTEGER DEFAULT 0,
+            context_tokens INTEGER,
+            has_code INTEGER DEFAULT 0,
+            correction_mined_at TEXT
+        )
+    """)
+    # Session with correction pattern
+    db.execute("INSERT INTO interactions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+               ("i1", "2026-01-01T00:00:00", "test", "Write a function to sort a list", "def sort...", "[]", 100, 0.5, "{}", "runtime", "s1", None, None, 0, None, 0, None))
+    db.execute("INSERT INTO interactions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+               ("i2", "2026-01-01T00:01:00", "test", "no, try again", None, "[]", 50, None, None, "runtime", "s1", None, None, 0, None, 0, None))
+    # Session without correction
+    db.execute("INSERT INTO interactions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+               ("i3", "2026-01-01T00:02:00", "test", "What is the weather?", "It's sunny", "[]", 100, 0.8, "{}", "runtime", "s2", None, None, 0, None, 0, None))
+    db.execute("INSERT INTO interactions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+               ("i4", "2026-01-01T00:03:00", "test", "thanks", None, "[]", 50, None, None, "runtime", "s2", None, None, 0, None, 0, None))
+    # Interaction with existing signal (should NOT be overwritten)
+    db.execute("INSERT INTO interactions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+               ("i5", "2026-01-01T00:04:00", "test", "Do something", "done", "[]", 100, 0.3, "{}", "runtime", "s3", None, 'negative', 0, None, 0, None))
+    db.execute("INSERT INTO interactions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+               ("i6", "2026-01-01T00:05:00", "test", "wrong, try again", None, "[]", 50, None, None, "runtime", "s3", None, None, 0, None, 0, None))
+    db.commit()
+    db.close()
+
+    # Register the provider so get_storage() can resolve it
+    reg = StorageRegistry.default()
+    reg.register(SQLiteStorageProvider())
+    _migrated_paths.discard(str(db_path))
+
+    return db_path
+
+
+def test_is_correction():
+    """Test correction vocabulary matching."""
+    from evolution.mining import _is_correction
+    assert _is_correction("no, try again") is True
+    assert _is_correction("actually, I meant something else") is True
+    assert _is_correction("shorter") is True
+    assert _is_correction("that's not what I wanted") is True
+    assert _is_correction("Hello, how are you?") is False
+    assert _is_correction("What is the weather?") is False
+    assert _is_correction("thanks") is False
+
+
+def test_mine_corrections_dry_run(test_db):
+    """Test dry-run doesn't modify DB."""
+    from evolution.mining import mine_corrections
+    result = mine_corrections(dry_run=True)
+    assert result["matched"] >= 1  # "no, try again" should match
+    assert result["updated"] == 0  # dry-run: no updates
+
+    # Verify DB unchanged
+    db = sqlite3.connect(test_db)
+    nulls = db.execute("SELECT COUNT(*) FROM interactions WHERE user_signal IS NULL").fetchone()[0]
+    db.close()
+    # i1, i2, i3, i4, i6 should still be NULL (i5 has 'negative')
+    assert nulls == 5
+
+
+def test_mine_corrections_updates(test_db):
+    """Test actual mining updates user_signal."""
+    from evolution.mining import mine_corrections
+    result = mine_corrections(dry_run=False)
+    assert result["matched"] >= 1
+    assert result["updated"] >= 1
+
+    # Verify i1 got labeled (its follow-up i2 says "try again")
+    db = sqlite3.connect(test_db)
+    row = db.execute("SELECT user_signal, correction_mined_at FROM interactions WHERE id = 'i1'").fetchone()
+    assert row[0] == "correction"
+    assert row[1] is not None  # correction_mined_at should be set
+    db.close()
+
+
+def test_mine_corrections_preserves_existing_signal(test_db):
+    """Test that existing user_signal values are not overwritten."""
+    from evolution.mining import mine_corrections
+    mine_corrections(dry_run=False)
+
+    db = sqlite3.connect(test_db)
+    row = db.execute("SELECT user_signal FROM interactions WHERE id = 'i5'").fetchone()
+    assert row[0] == "negative"  # Should NOT be overwritten to 'correction'
+    db.close()

--- a/evolution/tests/test_mining.py
+++ b/evolution/tests/test_mining.py
@@ -26,7 +26,6 @@ def test_db(tmp_path, monkeypatch):
     db_path = tmp_path / "test_evolution.db"
     monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", db_path)
     monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", db_path)
-    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
 
     db = sqlite3.connect(db_path)
     db.execute("""

--- a/evolution/tests/test_storage_provider.py
+++ b/evolution/tests/test_storage_provider.py
@@ -47,6 +47,8 @@ class FakeStorageProvider(StorageProvider):
     def count_interactions(self, **kw): return 0
     def score_trend(self, **kw): return []
     def token_trend(self, **kw): return []
+    def get_correction_candidates(self, *a, **kw): return []
+    def bulk_label_corrections(self, *a, **kw): return 0
     def score_by_reflection_count(self): return []
     def save_reflection(self, **kw): ...
     def get_reflections_by_embedding(self, *a, **kw): return []

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-26T22" # auto-bump
+last_verified: "2026-05-26T23" # auto-bump
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26T22" # auto-bump
+last_verified: "2026-05-26T23" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary
- New `mine-corrections` CLI command: retroactively extracts implicit negative signals from existing interactions by detecting correction patterns in follow-up messages
- Routes through public StorageProvider API with `get_correction_candidates` and `bulk_label_corrections` (no private API leaks)
- Adds `correction_mined_at` column for reversibility (no-db-deletion compliant)
- Correction vocab: 17 phrases covering common correction patterns (e.g., "try again", "actually,", "shorter")
- Expected yield: 200-400 corrections from existing 1,397 interactions

## Test plan
- [x] Python tests pass (evolution/tests/test_mining.py — 4 tests + 62 existing)
- [x] Code-reviewer SHIP (2 rounds)
- [ ] Run `python3 evolution/cli.py mine-corrections --dry-run` — verify 20+ matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)