### PR TITLE
fix(user-signal): remove false-positive signals; gitignore warden backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .claude/.plan-reviewed
 .claude/.code-reviewed
 .claude/.threat-modeled
+.claude/.warden-verdicts.json.bak-*
 
 # Warden config (user-local toggle state and custom instructions)
 .claude/wardens/config.json

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26T22" # auto-bump
+last_verified: "2026-05-26" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26T25" # auto-bump
+last_verified: "2026-05-26" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/__tests__/user-signal.test.ts
+++ b/src/__tests__/user-signal.test.ts
@@ -11,8 +11,6 @@ describe('detectUserSignal', () => {
     expect(detectUserSignal('that works')).toBe('positive');
     expect(detectUserSignal('looks good')).toBe('positive');
     expect(detectUserSignal('lgtm')).toBe('positive');
-    expect(detectUserSignal('thanks')).toBe('positive');
-    expect(detectUserSignal('thank you')).toBe('positive');
   });
 
   it('detects negative keywords', () => {

--- a/src/user-signal.ts
+++ b/src/user-signal.ts
@@ -22,8 +22,6 @@ const POSITIVE_KEYWORDS = [
   'that works',
   'looks good',
   'lgtm',
-  'thanks',
-  'thank you',
 ];
 
 const NEGATIVE_KEYWORDS = [


### PR DESCRIPTION
## Summary
- Remove `thanks`/`thank you` from `POSITIVE_KEYWORDS` in user-signal.ts -- conversational acknowledgments, not satisfaction signals (warden finding)
- Add `.claude/.warden-verdicts.json.bak-*` to `.gitignore` to suppress untracked noise

Warden swarm follow-up (Branch C of 3).

## Test plan
- [x] 7/7 user-signal tests pass (removed 2 assertions matching removed keywords)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)