### PR TITLE
feat(evolution): add tool-economy mechanical judge dimension

### DIFF
--- a/evolution/cc_backfill.py
+++ b/evolution/cc_backfill.py
@@ -76,6 +76,16 @@ def _extract_user_text(entry: dict) -> Optional[str]:
     return None
 
 
+def _extract_tool_call_input(block: dict) -> dict:
+    """Extract scoring-relevant fields from a tool_use content block."""
+    inp = block.get("input", {})
+    result = {"name": block.get("name", "")}
+    for field in ("file_path", "subagent_type", "command"):
+        if field in inp:
+            result[field] = inp[field]
+    return result
+
+
 def _extract_assistant_content(entry: dict) -> Optional[dict]:
     """Extract text + tool names from a complete assistant entry."""
     msg = entry.get("message", {})
@@ -118,7 +128,17 @@ def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
     except (OSError, json.JSONDecodeError):
         return
 
-    # Collect turns in order: real user prompts and complete assistant messages
+    # Pass 1: pre-compute final content blocks per msg_id (streaming dedup)
+    msg_final_content: dict[str, list] = {}
+    for entry in lines:
+        if entry.get("type") != "assistant":
+            continue
+        msg = entry.get("message", {})
+        msg_id = msg.get("id")
+        if msg_id and msg.get("stop_reason") is not None:
+            msg_final_content[msg_id] = msg.get("content", [])
+
+    # Pass 2: walk in order, collect turns with enriched tool call data
     turns: list[tuple[str, dict]] = []
     seen_msg_ids: set[str] = set()
 
@@ -132,24 +152,38 @@ def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
 
         elif entry_type == "assistant":
             msg_id = entry.get("message", {}).get("id")
-            # Dedup streaming: keep only the last entry per message ID
-            # (entries come in order, so last seen with stop_reason wins)
             content = _extract_assistant_content(entry)
             if content and msg_id:
+                # Extract enriched tool call inputs from the final content
+                enriched_calls = []
+                final_blocks = msg_final_content.get(msg_id, [])
+                for block in final_blocks:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        enriched_calls.append(_extract_tool_call_input(block))
+
                 if msg_id in seen_msg_ids:
-                    # Replace previous entry for this msg_id
                     for i in range(len(turns) - 1, -1, -1):
                         if turns[i][0] == "assistant" and turns[i][1].get("msg_id") == msg_id:
-                            turns[i] = ("assistant", {**content, "msg_id": msg_id})
+                            turns[i] = ("assistant", {
+                                **content,
+                                "msg_id": msg_id,
+                                "tool_calls": enriched_calls,
+                            })
                             break
                 else:
                     seen_msg_ids.add(msg_id)
-                    turns.append(("assistant", {**content, "msg_id": msg_id}))
+                    turns.append(("assistant", {
+                        **content,
+                        "msg_id": msg_id,
+                        "tool_calls": enriched_calls,
+                    }))
 
-    # Pair: for each user turn, find the last assistant response before the next user turn
+    # Pair: tool_calls aggregates across all assistant msgs in a turn;
+    # tools comes from the last assistant msg only (backward compat).
     pair_index = 0
     current_user = None
     last_assistant = None
+    turn_tool_calls: list[dict] = []
 
     for role, data in turns:
         if role == "user":
@@ -160,15 +194,17 @@ def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
                         "prompt": current_user,
                         "response": response_text,
                         "tools": last_assistant.get("tools", []),
+                        "tool_calls": list(turn_tool_calls),
                         "pair_index": pair_index,
                     }
                     pair_index += 1
             current_user = data["text"]
             last_assistant = None
+            turn_tool_calls = []
         elif role == "assistant":
             last_assistant = data
+            turn_tool_calls.extend(data.get("tool_calls", []))
 
-    # Emit the final pair
     if current_user is not None and last_assistant is not None:
         response_text = last_assistant["text"]
         if len(response_text) >= _MIN_RESPONSE_LEN:
@@ -176,6 +212,7 @@ def _extract_pairs(jsonl_path: Path) -> Iterator[dict]:
                 "prompt": current_user,
                 "response": response_text,
                 "tools": last_assistant.get("tools", []),
+                "tool_calls": list(turn_tool_calls),
                 "pair_index": pair_index,
             }
 
@@ -231,6 +268,7 @@ def collect_pairs(
                 "prompt": pair["prompt"],
                 "response": pair["response"],
                 "tools": pair["tools"],
+                "tool_calls": pair.get("tool_calls", []),
             })
             if limit and len(pairs) >= limit:
                 return pairs
@@ -290,6 +328,8 @@ def run_cc_backfill(
 
     from .reflexion.generator import generate_reflection, generate_positive_reflection
     from .reflexion.store import save_reflection
+    from .judge.mechanical import score_tool_economy
+    from .judge.criteria import compose_score
 
     for i, pair in enumerate(pairs):
         iid = pair["interaction_id"]
@@ -333,27 +373,31 @@ def run_cc_backfill(
                 stats["processed"] += 1
                 continue
 
+            te_score, te_diag = score_tool_economy(pair.get("tool_calls", []))
+
             dims = {
                 "quality": result.quality,
                 "safety": result.safety,
                 "tool_use": result.tool_use,
                 "personalization": result.personalization,
+                "tool_economy": te_score,
             }
-            update_score(iid, result.score, dims, parse_error=result.is_parse_error)
+            composite = compose_score(dims)
+            update_score(iid, composite, dims, parse_error=result.is_parse_error)
 
             if verbose:
-                print(f"  score={result.score:.2f}  q={result.quality:.2f}  "
+                print(f"  score={composite:.2f}  q={result.quality:.2f}  "
                       f"s={result.safety:.2f}  t={result.tool_use:.2f}  "
-                      f"p={result.personalization:.2f}")
+                      f"p={result.personalization:.2f}  te={te_score:.2f}")
 
             # Generate reflections
             if not result.is_parse_error:
-                if result.score < REFLECTION_THRESHOLD:
+                if composite < REFLECTION_THRESHOLD:
                     try:
                         content, category = generate_reflection(
                             prompt=pair["prompt"],
                             response=pair["response"],
-                            score=result.score,
+                            score=composite,
                             dims=dims,
                             rationale=result.rationale,
                             tools_used=pair["tools"],
@@ -361,7 +405,7 @@ def run_cc_backfill(
                         save_reflection(
                             content=content,
                             category=category,
-                            score_at_gen=result.score,
+                            score_at_gen=composite,
                             interaction_id=iid,
                             group_folder=pair["group_folder"],
                         )
@@ -371,12 +415,12 @@ def run_cc_backfill(
                     except Exception as exc:
                         if verbose:
                             print(f"  !! reflection failed: {exc}")
-                elif result.score >= POSITIVE_THRESHOLD:
+                elif composite >= POSITIVE_THRESHOLD:
                     try:
                         content, category = generate_positive_reflection(
                             prompt=pair["prompt"],
                             response=pair["response"],
-                            score=result.score,
+                            score=composite,
                             dims=dims,
                             rationale=result.rationale,
                             tools_used=pair["tools"],
@@ -384,7 +428,7 @@ def run_cc_backfill(
                         save_reflection(
                             content=content,
                             category=category,
-                            score_at_gen=result.score,
+                            score_at_gen=composite,
                             interaction_id=iid,
                             group_folder=pair["group_folder"],
                         )

--- a/evolution/judge/base.py
+++ b/evolution/judge/base.py
@@ -18,6 +18,7 @@ class JudgeResult:
     rationale: str                        # brief explanation of scores
     raw_response: Optional[str] = None   # full judge LLM output for debugging
     is_parse_error: bool = False          # True if score is a fallback due to JSON parse failure
+    tool_economy: Optional[float] = None  # mechanical scorer, not LLM-judged
 
 
 class BaseJudge(ABC):

--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -29,17 +29,29 @@ Return JSON only:
 {"quality": <float>, "safety": <float>, "tool_use": <float>, "personalization": <float>, "rationale": "<sentence>"}
 """
 
+# quality carved from 0.45 to 0.35 to fund tool_economy at 0.10.
+# tool_economy is mechanical (not LLM-judged), so it doesn't compete for rubric attention.
 COMPOSITE_WEIGHTS = {
-    "quality": 0.45,
+    "quality": 0.35,
     "safety": 0.25,
     "tool_use": 0.15,
     "personalization": 0.15,
+    "tool_economy": 0.10,
+}
+
+# tool_economy defaults to 1.0 (neutral) so old rows without this dim aren't penalized.
+_DIM_DEFAULTS = {
+    "quality": 0.0,
+    "safety": 0.0,
+    "tool_use": 0.0,
+    "personalization": 0.0,
+    "tool_economy": 1.0,
 }
 
 
 def compose_score(dims: dict) -> float:
     """Weighted composite score from individual dimension scores."""
     return sum(
-        COMPOSITE_WEIGHTS[k] * dims.get(k, 0.0)
+        COMPOSITE_WEIGHTS[k] * dims.get(k, _DIM_DEFAULTS[k])
         for k in COMPOSITE_WEIGHTS
     )

--- a/evolution/judge/mechanical.py
+++ b/evolution/judge/mechanical.py
@@ -1,0 +1,89 @@
+"""
+Mechanical tool-economy scorer for the evolution loop.
+
+Detects wasteful tool-use patterns from the ordered sequence of tool calls
+in a single turn. No LLM call required.
+
+Rules:
+  R1  Edit-without-Read:  Edit/Write on a path not preceded by Read on same path
+  R2  Duplicate-Read:     Reading the same file_path more than once in a turn
+  R4a Explore-no-recon:   Agent(Explore) called before any direct Read or Bash grep
+
+Deferred:
+  R3  Search-after-grep:  reserved for when a semantic search tool is added
+  R4b Full unnecessary-subagent: needs LLM complexity assessment
+"""
+from __future__ import annotations
+
+
+def _looks_like_search(command: str) -> bool:
+    # Trailing space guards against lsblk, lsof, etc.
+    cmd = command.lower()
+    return any(kw in cmd for kw in ("grep ", "find ", "ls ", "rg ", "ag "))
+
+
+def score_tool_economy(tool_calls: list[dict]) -> tuple[float, dict]:
+    """
+    Score tool economy for a single turn's ordered tool call sequence.
+
+    Parameters
+    ----------
+    tool_calls : list of dicts, each with:
+        "name"         : str  -- tool name (Read, Edit, Write, Bash, Agent, etc.)
+        "file_path"    : str  (optional) -- for Read/Edit/Write
+        "subagent_type": str  (optional) -- for Agent
+        "command"      : str  (optional) -- for Bash
+
+    Returns
+    -------
+    (score, diagnostics)
+        score       : float in [0.0, 1.0]; 1.0 = no wasteful patterns
+        diagnostics : dict with per-rule violation counts
+    """
+    if not tool_calls:
+        return 1.0, {"violations": 0, "rules_fired": []}
+
+    violations = 0
+    rules_fired: list[str] = []
+    read_paths: set[str] = set()
+    has_direct_recon = False
+
+    for i, tc in enumerate(tool_calls):
+        name = tc.get("name", "")
+        path = tc.get("file_path", "")
+
+        if name == "Read":
+            if path:
+                if path in read_paths:
+                    violations += 1
+                    rules_fired.append("R2")
+                else:
+                    read_paths.add(path)
+            has_direct_recon = True
+
+        elif name in ("Edit", "Write"):
+            if path and path not in read_paths:
+                violations += 1
+                rules_fired.append("R1")
+
+        elif name == "Bash":
+            cmd = tc.get("command", "")
+            if _looks_like_search(cmd):
+                has_direct_recon = True
+
+        elif name == "Agent":
+            st = tc.get("subagent_type", "")
+            if st == "Explore" and not has_direct_recon:
+                violations += 1
+                rules_fired.append("R4a")
+
+    score = max(0.0, 1.0 - violations * 0.15)
+
+    diagnostics = {
+        "violations": violations,
+        "rules_fired": rules_fired,
+        "edit_without_read": rules_fired.count("R1"),
+        "duplicate_read": rules_fired.count("R2"),
+        "explore_no_prior_recon": rules_fired.count("R4a"),
+    }
+    return score, diagnostics

--- a/evolution/tests/test_mechanical_judge.py
+++ b/evolution/tests/test_mechanical_judge.py
@@ -1,0 +1,158 @@
+"""Tests for the mechanical tool-economy scorer."""
+import pytest
+
+from evolution.judge.mechanical import score_tool_economy
+
+
+class TestEmptyInput:
+    def test_empty_list(self):
+        score, diag = score_tool_economy([])
+        assert score == 1.0
+        assert diag["violations"] == 0
+        assert diag["rules_fired"] == []
+
+
+class TestR1EditWithoutRead:
+    def test_edit_unread_path(self):
+        calls = [{"name": "Edit", "file_path": "/a.py"}]
+        score, diag = score_tool_economy(calls)
+        assert score < 1.0
+        assert "R1" in diag["rules_fired"]
+        assert diag["edit_without_read"] == 1
+
+    def test_write_unread_path(self):
+        calls = [{"name": "Write", "file_path": "/a.py"}]
+        score, diag = score_tool_economy(calls)
+        assert "R1" in diag["rules_fired"]
+
+    def test_edit_after_read_same_path(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Edit", "file_path": "/a.py"},
+        ]
+        score, diag = score_tool_economy(calls)
+        assert score == 1.0
+        assert diag["edit_without_read"] == 0
+
+    def test_edit_after_read_different_path(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Edit", "file_path": "/b.py"},
+        ]
+        _, diag = score_tool_economy(calls)
+        assert diag["edit_without_read"] == 1
+
+    def test_write_after_read_same_path(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Write", "file_path": "/a.py"},
+        ]
+        score, diag = score_tool_economy(calls)
+        assert score == 1.0
+
+    def test_edit_no_file_path_no_violation(self):
+        calls = [{"name": "Edit"}]
+        score, diag = score_tool_economy(calls)
+        assert diag["edit_without_read"] == 0
+
+
+class TestR2DuplicateRead:
+    def test_read_same_file_twice(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Read", "file_path": "/a.py"},
+        ]
+        _, diag = score_tool_economy(calls)
+        assert diag["duplicate_read"] == 1
+
+    def test_read_same_file_three_times(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Read", "file_path": "/a.py"},
+        ]
+        _, diag = score_tool_economy(calls)
+        assert diag["duplicate_read"] == 2
+
+    def test_read_two_different_files(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Read", "file_path": "/b.py"},
+        ]
+        score, diag = score_tool_economy(calls)
+        assert score == 1.0
+        assert diag["duplicate_read"] == 0
+
+
+class TestR4aExploreNoRecon:
+    def test_explore_with_no_prior_read(self):
+        calls = [{"name": "Agent", "subagent_type": "Explore"}]
+        _, diag = score_tool_economy(calls)
+        assert diag["explore_no_prior_recon"] == 1
+
+    def test_explore_after_read(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Agent", "subagent_type": "Explore"},
+        ]
+        _, diag = score_tool_economy(calls)
+        assert diag["explore_no_prior_recon"] == 0
+
+    def test_explore_after_bash_grep(self):
+        calls = [
+            {"name": "Bash", "command": "grep -rn 'foo' src/"},
+            {"name": "Agent", "subagent_type": "Explore"},
+        ]
+        _, diag = score_tool_economy(calls)
+        assert diag["explore_no_prior_recon"] == 0
+
+    def test_non_explore_agent_no_violation(self):
+        calls = [{"name": "Agent", "subagent_type": "plan-reviewer"}]
+        _, diag = score_tool_economy(calls)
+        assert diag["explore_no_prior_recon"] == 0
+
+
+class TestScoreFormula:
+    def test_zero_violations(self):
+        score, _ = score_tool_economy([{"name": "Read", "file_path": "/a.py"}])
+        assert score == 1.0
+
+    def test_one_violation(self):
+        score, _ = score_tool_economy([{"name": "Edit", "file_path": "/a.py"}])
+        assert score == pytest.approx(0.85)
+
+    def test_six_violations_near_zero(self):
+        calls = [{"name": "Edit", "file_path": f"/{i}.py"} for i in range(6)]
+        score, _ = score_tool_economy(calls)
+        assert score == pytest.approx(0.10)
+
+    def test_seven_violations_clamped(self):
+        calls = [{"name": "Edit", "file_path": f"/{i}.py"} for i in range(7)]
+        score, _ = score_tool_economy(calls)
+        assert score == 0.0
+
+
+class TestMixedPattern:
+    def test_r1_and_r2_combined(self):
+        calls = [
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Read", "file_path": "/a.py"},
+            {"name": "Edit", "file_path": "/b.py"},
+        ]
+        _, diag = score_tool_economy(calls)
+        assert diag["violations"] == 2
+        assert diag["duplicate_read"] == 1
+        assert diag["edit_without_read"] == 1
+
+    def test_clean_workflow(self):
+        calls = [
+            {"name": "Bash", "command": "grep -rn 'pattern' src/"},
+            {"name": "Read", "file_path": "/src/foo.py"},
+            {"name": "Edit", "file_path": "/src/foo.py"},
+            {"name": "Agent", "subagent_type": "Explore"},
+            {"name": "Read", "file_path": "/src/bar.py"},
+            {"name": "Write", "file_path": "/src/bar.py"},
+        ]
+        score, diag = score_tool_economy(calls)
+        assert score == 1.0
+        assert diag["violations"] == 0

--- a/evolution/tests/test_tool_economy_extraction.py
+++ b/evolution/tests/test_tool_economy_extraction.py
@@ -1,0 +1,146 @@
+"""Tests for enriched extraction and compose_score backward compat."""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from evolution.cc_backfill import _extract_pairs
+from evolution.judge.criteria import compose_score, _DIM_DEFAULTS, COMPOSITE_WEIGHTS
+
+
+def _make_jsonl(entries: list[dict]) -> str:
+    return "\n".join(json.dumps(e) for e in entries)
+
+
+def _user_entry(text: str) -> dict:
+    return {"type": "user", "message": {"content": text}}
+
+
+def _assistant_entry(msg_id: str, tool_blocks: list[dict] = None,
+                     text: str = "", stop_reason: str = "tool_use") -> dict:
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for tb in (tool_blocks or []):
+        content.append({"type": "tool_use", **tb})
+    return {
+        "type": "assistant",
+        "message": {"id": msg_id, "stop_reason": stop_reason, "content": content},
+    }
+
+
+def _tool_result_entry() -> dict:
+    return {"type": "user", "message": {"content": [{"type": "tool_result", "content": "ok"}]}}
+
+
+class TestEnrichedExtraction:
+    def test_multi_msg_id_aggregates_tool_calls(self, tmp_path):
+        """tool_calls should include calls from ALL assistant msgs, not just the last."""
+        entries = [
+            _user_entry("Fix the bug in foo.py please, it is broken"),
+            _assistant_entry("msg_1", [
+                {"name": "Read", "input": {"file_path": "/src/foo.py"}},
+            ]),
+            _tool_result_entry(),
+            _assistant_entry("msg_2", [
+                {"name": "Edit", "input": {"file_path": "/src/foo.py", "old_string": "x", "new_string": "y"}},
+            ]),
+            _tool_result_entry(),
+            _assistant_entry("msg_3", text="Done, I fixed the bug in foo.py.", stop_reason="end_turn"),
+        ]
+        jsonl_path = tmp_path / "test.jsonl"
+        jsonl_path.write_text(_make_jsonl(entries))
+
+        pairs = list(_extract_pairs(jsonl_path))
+        assert len(pairs) == 1
+        p = pairs[0]
+        assert len(p["tool_calls"]) == 2
+        assert p["tool_calls"][0]["name"] == "Read"
+        assert p["tool_calls"][0]["file_path"] == "/src/foo.py"
+        assert p["tool_calls"][1]["name"] == "Edit"
+        assert p["tool_calls"][1]["file_path"] == "/src/foo.py"
+
+    def test_tools_key_is_last_assistant_only(self, tmp_path):
+        """The 'tools' key should only contain names from the last assistant msg."""
+        entries = [
+            _user_entry("Fix the bug in foo.py please, it is broken"),
+            _assistant_entry("msg_1", [
+                {"name": "Read", "input": {"file_path": "/src/foo.py"}},
+            ]),
+            _tool_result_entry(),
+            _assistant_entry("msg_2", text="Done, I fixed the bug in foo.py.", stop_reason="end_turn"),
+        ]
+        jsonl_path = tmp_path / "test.jsonl"
+        jsonl_path.write_text(_make_jsonl(entries))
+
+        pairs = list(_extract_pairs(jsonl_path))
+        assert len(pairs) == 1
+        assert pairs[0]["tools"] == []
+        assert len(pairs[0]["tool_calls"]) == 1
+
+    def test_pair_index_increments(self, tmp_path):
+        """Multiple pairs should have sequential pair_index values."""
+        entries = [
+            _user_entry("First question about the codebase architecture"),
+            _assistant_entry("msg_1", text="Here is the answer to the first question about architecture.", stop_reason="end_turn"),
+            _user_entry("Second question about deployment patterns"),
+            _assistant_entry("msg_2", text="Here is the answer to the second question about deployment.", stop_reason="end_turn"),
+        ]
+        jsonl_path = tmp_path / "test.jsonl"
+        jsonl_path.write_text(_make_jsonl(entries))
+
+        pairs = list(_extract_pairs(jsonl_path))
+        assert len(pairs) == 2
+        assert pairs[0]["pair_index"] == 0
+        assert pairs[1]["pair_index"] == 1
+
+    def test_subagent_type_extracted(self, tmp_path):
+        """Agent tool calls should have subagent_type in tool_calls."""
+        entries = [
+            _user_entry("Explore the evolution subsystem thoroughly please"),
+            _assistant_entry("msg_1", [
+                {"name": "Agent", "input": {"subagent_type": "Explore", "prompt": "find files"}},
+            ]),
+            _tool_result_entry(),
+            _assistant_entry("msg_2", text="I found the files in the evolution subsystem here.", stop_reason="end_turn"),
+        ]
+        jsonl_path = tmp_path / "test.jsonl"
+        jsonl_path.write_text(_make_jsonl(entries))
+
+        pairs = list(_extract_pairs(jsonl_path))
+        assert pairs[0]["tool_calls"][0]["subagent_type"] == "Explore"
+
+    def test_command_extracted_for_bash(self, tmp_path):
+        """Bash tool calls should have command in tool_calls."""
+        entries = [
+            _user_entry("Search for the function definition in the codebase"),
+            _assistant_entry("msg_1", [
+                {"name": "Bash", "input": {"command": "grep -rn 'def foo' src/"}},
+            ]),
+            _tool_result_entry(),
+            _assistant_entry("msg_2", text="Found the function definition at line 42 in src.", stop_reason="end_turn"),
+        ]
+        jsonl_path = tmp_path / "test.jsonl"
+        jsonl_path.write_text(_make_jsonl(entries))
+
+        pairs = list(_extract_pairs(jsonl_path))
+        assert pairs[0]["tool_calls"][0]["command"] == "grep -rn 'def foo' src/"
+
+
+class TestComposeScoreBackwardCompat:
+    def test_old_4dim_row_gets_neutral_tool_economy(self):
+        """Old rows missing tool_economy should default to 1.0, not 0.0."""
+        old_dims = {"quality": 1.0, "safety": 1.0, "tool_use": 1.0, "personalization": 1.0}
+        score = compose_score(old_dims)
+        expected = 0.35 + 0.25 + 0.15 + 0.15 + 0.10  # tool_economy=1.0 default
+        assert score == pytest.approx(expected)
+
+    def test_new_5dim_row(self):
+        dims = {"quality": 1.0, "safety": 1.0, "tool_use": 1.0,
+                "personalization": 1.0, "tool_economy": 0.5}
+        score = compose_score(dims)
+        expected = 0.35 + 0.25 + 0.15 + 0.15 + 0.05
+        assert score == pytest.approx(expected)
+
+    def test_dim_defaults_match_weights_keys(self):
+        assert set(COMPOSITE_WEIGHTS.keys()) == set(_DIM_DEFAULTS.keys())

--- a/evolution/training/build_judge_lora_dataset.py
+++ b/evolution/training/build_judge_lora_dataset.py
@@ -38,7 +38,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from evolution.judge.criteria import RUBRIC, COMPOSITE_WEIGHTS, compose_score
+from evolution.judge.criteria import RUBRIC, COMPOSITE_WEIGHTS, _DIM_DEFAULTS, compose_score
 from evolution.storage import get_storage
 from evolution.training._provenance import git_sha, git_dirty, sha256_file
 
@@ -222,7 +222,7 @@ def split_bucket_counts(split_records: list[dict]) -> dict:
     for rec in split_records:
         try:
             dims = json.loads(rec["messages"][1]["content"])
-            dim_subset = {k: float(dims[k]) for k in COMPOSITE_WEIGHTS}
+            dim_subset = {k: float(dims.get(k, _DIM_DEFAULTS.get(k, 1.0))) for k in COMPOSITE_WEIGHTS}
             counts[composite_bucket(compose_score(dim_subset))] += 1
         except Exception:
             counts["?"] += 1

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26" # tool-economy dimension added
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26" # tool-economy dimension added
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"


### PR DESCRIPTION
## Summary

- Adds a 5th judge dimension (`tool_economy`) that mechanically detects wasteful tool-use patterns from session transcripts -- no LLM judgment needed
- Enriches `_extract_pairs` to capture ALL tool calls across all assistant messages in a turn (previously only the last message's tool names were kept)
- New `evolution/judge/mechanical.py` with 3 rules: edit-without-read (R1), duplicate-read (R2), explore-without-recon (R4a)
- Weight shift: `quality` 0.45 -> 0.35, `tool_economy` 0.10 (new). Old rows default to 1.0 (neutral)
- Fixes `build_judge_lora_dataset.py` COMPOSITE_WEIGHTS iteration to tolerate old rows missing `tool_economy`

## Motivation

The evolution judge had no visibility into process integrity. Observed failure: the agent repeatedly self-marked warden gates as TRIVIAL to skip wardens, 3+ times in one session, and the judge scored those sessions normally because no dimension penalized the pattern.

Research: `Research/2026-05-26-evolution-judge-dimension-gaps.md`

## Weight change note

`quality` carved from 0.45 to 0.35 (intentional, minimal carve-out). Spot-checked on real session data -- old 4-dim rows get `tool_economy=1.0` default via `_DIM_DEFAULTS`, so stored composite scores are not retroactively affected. LoRA training data uses `DIM_KEYS` (4 dims) and is unaffected.

## Test plan

- [x] 28 new tests covering mechanical scorer rules, score formula, enriched extraction, and backward compat
- [x] 299 total tests pass (271 existing + 28 new)
- [x] Validated enriched extraction on real .jsonl (10 pairs, tool_calls correctly aggregated across all assistant msgs)
- [x] Verified backward compat: `compose_score({quality, safety, tool_use, personalization})` works with tool_economy defaulting to 1.0
- [x] Verified `split_bucket_counts` on old 4-dim rows does not KeyError
- [x] Confirmed RUBRIC text and all 3 LLM judge backends are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)