### PR TITLE
feat(pipeline): reconcile stale Agent Working issues (LIA-97)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26" # LIA-97: verified deployment pattern covers startup sweep additions
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # tool-economy dimension added
+last_verified: "2026-05-26" # LIA-97: sweepStaleAgentWorking added to startup sweep
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,8 +425,11 @@ async function main(): Promise<void> {
       }
 
       // Sweep pending auto-merges and stale In Review issues from previous runs
-      const { sweepPendingAutoMerges, sweepStaleInReview } =
-        await import('./linear-auto-merge.js');
+      const {
+        sweepPendingAutoMerges,
+        sweepStaleInReview,
+        sweepStaleAgentWorking,
+      } = await import('./linear-auto-merge.js');
       sweepPendingAutoMerges(linearCtx).catch((err) => {
         logger.warn({ err }, 'auto-merge: startup sweep failed');
       });
@@ -436,6 +439,9 @@ async function main(): Promise<void> {
         runInlineCompletionCheck(ctx, issueData, gateSpecs),
       ).catch((err) => {
         logger.warn({ err }, 'auto-merge: stale In Review sweep failed');
+      });
+      sweepStaleAgentWorking(ctx).catch((err) => {
+        logger.warn({ err }, 'auto-merge: stale Agent Working sweep failed');
       });
 
       const { sweepStaleGatedIssues } = await import('./linear-webhook.js');

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { promisify } from 'util';
 import { _initTestDatabase } from './db.js';
 import {
@@ -6,7 +6,9 @@ import {
   getIssuePr,
   updatePrAutoMergeState,
   getPendingAutoMerges,
+  logPipelineEvent,
 } from './db.js';
+import type { LinearContext } from './linear-dispatcher.js';
 
 const execFileMock = vi.fn();
 
@@ -126,5 +128,261 @@ describe('queryPrChecks', () => {
     const { queryPrChecks } = await import('./linear-auto-merge.js');
     const result = await queryPrChecks('https://github.com/test/repo/pull/1');
     expect(result.status).toBe('pass');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sweepStaleAgentWorking
+// ---------------------------------------------------------------------------
+
+/** Returns a stub LinearContext with the states and client methods needed for sweep tests. */
+function makeAgentWorkingCtx(
+  overrides: Partial<LinearContext> = {},
+): LinearContext {
+  const updateIssue = vi.fn().mockResolvedValue({});
+  const createComment = vi.fn().mockResolvedValue({});
+
+  return {
+    client: {
+      updateIssue,
+      createComment,
+      issues: vi.fn().mockResolvedValue({ nodes: [] }),
+      issue: vi.fn(),
+    } as unknown as LinearContext['client'],
+    stateByName: new Map([
+      ['Ready for Agent', { id: 'ready-id', name: 'Ready for Agent' }],
+      ['Agent Working', { id: 'working-id', name: 'Agent Working' }],
+      ['In Review', { id: 'review-id', name: 'In Review' }],
+      ['Done', { id: 'done-id', name: 'Done' }],
+      ['Backlog', { id: 'backlog-id', name: 'Backlog' }],
+      [
+        'Manual Review Required',
+        { id: 'manual-id', name: 'Manual Review Required' },
+      ],
+    ]),
+    stateById: new Map(),
+    botUserId: 'bot-id',
+    viewerId: 'viewer-id',
+    inFlightDispatch: new Set(),
+    inFlightGate: new Set(),
+    gateLabels: {
+      effort: {},
+      complexity: {},
+      wardenSkip: 'label-warden-skip',
+      revise: 'label-revise',
+      evaluating: 'label-evaluating',
+    },
+    teamId: 'team-id',
+    vaultPath: null,
+    repoSlug: 'test/repo',
+    deps: {
+      registeredGroups: () => ({}),
+      registerGroup: vi.fn(),
+      registry: {} as LinearContext['deps']['registry'],
+      queue: {} as LinearContext['deps']['queue'],
+    },
+    dispatchGroup: {
+      name: 'Linear Dispatch',
+      folder: 'linear-dispatch',
+      trigger: '',
+      added_at: new Date().toISOString(),
+      requiresTrigger: false,
+      isControlGroup: false,
+    },
+    ...overrides,
+  } as unknown as LinearContext;
+}
+
+/** Builds a fake issue node that would be returned by ctx.client.issues() */
+function makeIssueNode(
+  id: string,
+  identifier: string,
+  labelNames: string[] = [],
+  updatedAt?: string,
+) {
+  return {
+    id,
+    identifier,
+    title: `Issue ${identifier}`,
+    description: null,
+    // updatedAt more than 2 hours ago by default
+    updatedAt:
+      updatedAt ?? new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    labels: vi.fn().mockResolvedValue({
+      nodes: labelNames.map((name) => ({ id: `label-${name}`, name })),
+    }),
+  };
+}
+
+describe('sweepStaleAgentWorking', () => {
+  const ORIGINAL_AUTO_MERGE = process.env.LINEAR_AUTO_MERGE;
+
+  beforeEach(() => {
+    process.env.LINEAR_AUTO_MERGE = '1';
+    _initTestDatabase();
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.LINEAR_AUTO_MERGE = ORIGINAL_AUTO_MERGE;
+  });
+
+  it('moves issue to Done when the PR is already merged', async () => {
+    const issueId = 'issue-merged-pr';
+    const prUrl = 'https://github.com/test/repo/pull/42';
+
+    logPipelineEvent(issueId, 'LIA-1', 'agent_started');
+    upsertIssuePr(issueId, prUrl);
+
+    // gh pr view returns MERGED
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({ state: 'MERGED' }),
+    });
+
+    const issueNode = makeIssueNode(issueId, 'LIA-1');
+    const ctx = makeAgentWorkingCtx({
+      client: {
+        updateIssue: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        issues: vi.fn().mockResolvedValue({ nodes: [issueNode] }),
+        issue: vi.fn(),
+      } as unknown as LinearContext['client'],
+    });
+
+    const { sweepStaleAgentWorking } = await import('./linear-auto-merge.js');
+    // Pass thresholdMs=0 so recently-added DB events are still treated as stale
+    await sweepStaleAgentWorking(ctx, 0);
+
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ stateId: 'done-id' }),
+    );
+    expect(ctx.client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId,
+        body: expect.stringContaining('already merged'),
+      }),
+    );
+  });
+
+  it('moves issue to In Review when PR exists but is not merged', async () => {
+    const issueId = 'issue-open-pr';
+    const prUrl = 'https://github.com/test/repo/pull/99';
+    upsertIssuePr(issueId, prUrl);
+
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({ state: 'OPEN' }),
+    });
+
+    const issueNode = makeIssueNode(issueId, 'LIA-2');
+    const ctx = makeAgentWorkingCtx({
+      client: {
+        updateIssue: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        issues: vi.fn().mockResolvedValue({ nodes: [issueNode] }),
+        issue: vi.fn(),
+      } as unknown as LinearContext['client'],
+    });
+
+    const { sweepStaleAgentWorking } = await import('./linear-auto-merge.js');
+    await sweepStaleAgentWorking(ctx, 0);
+
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ stateId: 'review-id' }),
+    );
+  });
+
+  it('moves issue to In Review when agent_completed event exists but no PR', async () => {
+    const issueId = 'issue-completed-no-pr';
+    logPipelineEvent(issueId, 'LIA-3', 'agent_started');
+    logPipelineEvent(issueId, 'LIA-3', 'agent_completed');
+
+    const issueNode = makeIssueNode(issueId, 'LIA-3');
+    const ctx = makeAgentWorkingCtx({
+      client: {
+        updateIssue: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        issues: vi.fn().mockResolvedValue({ nodes: [issueNode] }),
+        issue: vi.fn(),
+      } as unknown as LinearContext['client'],
+    });
+
+    const { sweepStaleAgentWorking } = await import('./linear-auto-merge.js');
+    await sweepStaleAgentWorking(ctx, 0);
+
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ stateId: 'review-id' }),
+    );
+  });
+
+  it('moves issue to Manual Review Required when stale with no progress signal', async () => {
+    const issueId = 'issue-no-signal';
+    // No pipeline events, no PR — genuinely stuck with no info
+
+    const issueNode = makeIssueNode(issueId, 'LIA-4');
+    const ctx = makeAgentWorkingCtx({
+      client: {
+        updateIssue: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        issues: vi.fn().mockResolvedValue({ nodes: [issueNode] }),
+        issue: vi.fn(),
+      } as unknown as LinearContext['client'],
+    });
+
+    const { sweepStaleAgentWorking } = await import('./linear-auto-merge.js');
+    await sweepStaleAgentWorking(ctx, 0);
+
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ stateId: 'manual-id' }),
+    );
+  });
+
+  it('does not transition an issue that is currently in-flight', async () => {
+    const issueId = 'issue-inflight';
+
+    const issueNode = makeIssueNode(issueId, 'LIA-5');
+    const updateIssue = vi.fn().mockResolvedValue({});
+    const ctx = makeAgentWorkingCtx({
+      client: {
+        updateIssue,
+        createComment: vi.fn().mockResolvedValue({}),
+        issues: vi.fn().mockResolvedValue({ nodes: [issueNode] }),
+        issue: vi.fn(),
+      } as unknown as LinearContext['client'],
+      inFlightDispatch: new Set([issueId]),
+    });
+
+    const { sweepStaleAgentWorking } = await import('./linear-auto-merge.js');
+    // Even with threshold=0, in-flight issues must be skipped
+    await sweepStaleAgentWorking(ctx, 0);
+
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('does not transition an issue that entered Agent Working recently (under threshold)', async () => {
+    const issueId = 'issue-fresh';
+    // Seed an agent_started event with current timestamp (well under 60 min threshold)
+    logPipelineEvent(issueId, 'LIA-6', 'agent_started');
+
+    const recentUpdatedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+    const issueNode = makeIssueNode(issueId, 'LIA-6', [], recentUpdatedAt);
+    const updateIssue = vi.fn().mockResolvedValue({});
+    const ctx = makeAgentWorkingCtx({
+      client: {
+        updateIssue,
+        createComment: vi.fn().mockResolvedValue({}),
+        issues: vi.fn().mockResolvedValue({ nodes: [issueNode] }),
+        issue: vi.fn(),
+      } as unknown as LinearContext['client'],
+    });
+
+    const { sweepStaleAgentWorking } = await import('./linear-auto-merge.js');
+    // Use the default 60-minute threshold — the 5-minute-old event should not be swept
+    await sweepStaleAgentWorking(ctx);
+
+    expect(updateIssue).not.toHaveBeenCalled();
   });
 });

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -14,6 +14,8 @@ import {
   getConsecutiveFailCount,
   getIssuePr,
   getPendingAutoMerges,
+  getPipelineEvents,
+  getStageEntryTime,
   logPipelineEvent,
   updatePrAutoMergeState,
   upsertIssuePr,
@@ -449,6 +451,246 @@ export async function sweepStaleInReview(
     }
   } catch (err) {
     logger.warn({ err }, 'auto-merge: failed to sweep stale In Review issues');
+  }
+}
+
+/** Issues stuck in Agent Working for longer than this are considered stale. */
+const AGENT_WORKING_STALE_THRESHOLD_MS = 60 * 60_000; // 60 minutes
+
+/**
+ * Sweeps issues that are stuck in "Agent Working" and reconciles their state.
+ *
+ * Decision tree for an issue past the stale threshold:
+ *   1. Has a merged PR           → move to Done
+ *   2. Has an open/closed PR     → move to In Review (existing merge path handles it)
+ *   3. No PR, agent_completed    → move to In Review (let completion gate decide)
+ *   4. Most recent event is agent_failed → move to Ready for Agent (circuit-breaker aware)
+ *   5. No signal at all          → move to Manual Review Required
+ *
+ * Issues that are actively in-flight or under the threshold are left alone.
+ */
+export async function sweepStaleAgentWorking(
+  ctx: LinearContext,
+  thresholdMs = AGENT_WORKING_STALE_THRESHOLD_MS,
+): Promise<void> {
+  if (!isAutoMergeEnabled()) return;
+
+  const agentWorkingState = ctx.stateByName.get('Agent Working');
+  if (!agentWorkingState) return;
+
+  let issues;
+  try {
+    issues = await ctx.client.issues({
+      filter: { state: { id: { eq: agentWorkingState.id } } },
+    });
+  } catch (err) {
+    logger.warn({ err }, 'auto-merge: failed to query Agent Working issues');
+    return;
+  }
+
+  const now = Date.now();
+  let reconciled = 0;
+
+  for (const issue of issues.nodes) {
+    // Skip in-flight agents — they are actively running in this process
+    if (ctx.inFlightDispatch.has(issue.id)) continue;
+
+    const labels = await issue.labels();
+    if (labels.nodes.some((l) => l.name === 'warden:skip')) continue;
+
+    // Skip issues that haven't exceeded the stale threshold
+    const entryTime = getStageEntryTime(issue.id, 'Agent Working');
+    if (entryTime) {
+      const ageMs = now - new Date(entryTime).getTime();
+      if (ageMs < thresholdMs) continue;
+    }
+    // If no entry time in DB, use the issue's own updatedAt as a conservative fallback
+    else {
+      const updatedAt = issue.updatedAt as Date | string | undefined;
+      if (updatedAt) {
+        const ageMs =
+          now -
+          (updatedAt instanceof Date
+            ? updatedAt.getTime()
+            : new Date(updatedAt as string).getTime());
+        if (ageMs < thresholdMs) continue;
+      }
+      // If we have no timestamp at all, fall through to reconcile
+    }
+
+    const ident = issue.identifier;
+
+    // Check for a known PR
+    const pr = getIssuePr(issue.id);
+    if (pr) {
+      if (pr.auto_merge_state === 'pending') continue; // merge already in progress
+
+      const prState = await queryPrState(pr.pr_url);
+      if (prState?.state === 'MERGED') {
+        // PR is already merged — move straight to Done
+        const doneState = ctx.stateByName.get('Done');
+        if (doneState) {
+          const labelUpdate: Record<string, unknown> = {
+            stateId: doneState.id,
+          };
+          const addIds: string[] = [];
+          const removeIds: string[] = [];
+          if (ctx.gateLabels.wardenSkip) addIds.push(ctx.gateLabels.wardenSkip);
+          if (ctx.gateLabels.revise) removeIds.push(ctx.gateLabels.revise);
+          if (ctx.gateLabels.evaluating)
+            removeIds.push(ctx.gateLabels.evaluating);
+          if (addIds.length > 0) labelUpdate.addedLabelIds = addIds;
+          if (removeIds.length > 0) labelUpdate.removedLabelIds = removeIds;
+          await ctx.client.updateIssue(issue.id, labelUpdate);
+          await ctx.client.createComment({
+            issueId: issue.id,
+            body: `**State reconciled** — PR ${pr.pr_url} was already merged. Moved to Done.`,
+          });
+          updatePrAutoMergeState(issue.id, 'merged');
+          logPipelineEvent(
+            issue.id,
+            ident,
+            'circuit_breaker_reset',
+            'sweep: pr already merged',
+          );
+          logger.info(
+            { issueId: issue.id, prUrl: pr.pr_url },
+            'auto-merge: Agent Working sweep → Done (PR already merged)',
+          );
+          reconciled++;
+        }
+        continue;
+      }
+
+      // PR exists but isn't merged — move to In Review so the normal path handles it
+      const reviewState = ctx.stateByName.get('In Review');
+      if (reviewState) {
+        await ctx.client.updateIssue(issue.id, { stateId: reviewState.id });
+        await ctx.client.createComment({
+          issueId: issue.id,
+          body: `**State reconciled** — issue was stuck in Agent Working with an open PR. Moved to In Review for auto-merge processing.\n\nPR: ${pr.pr_url}`,
+        });
+        logPipelineEvent(
+          issue.id,
+          ident,
+          'agent_completed',
+          'sweep: moved to In Review (open PR found)',
+        );
+        logger.info(
+          { issueId: issue.id, prUrl: pr.pr_url },
+          'auto-merge: Agent Working sweep → In Review (open PR)',
+        );
+        reconciled++;
+      }
+      continue;
+    }
+
+    // No PR recorded — inspect pipeline events to distinguish completed vs. failed vs. no-signal
+    const events = getPipelineEvents({ issueId: issue.id });
+    const relevantEvents = events.filter(
+      (e) =>
+        e.event_type === 'agent_completed' ||
+        e.event_type === 'agent_failed' ||
+        e.event_type === 'agent_started',
+    );
+
+    // Find the most recent terminal event
+    const lastRelevant = relevantEvents.at(-1);
+
+    if (lastRelevant?.event_type === 'agent_completed') {
+      // Agent finished cleanly but somehow state wasn't updated — move to In Review
+      const reviewState = ctx.stateByName.get('In Review');
+      if (reviewState) {
+        await ctx.client.updateIssue(issue.id, {
+          stateId: reviewState.id,
+          assigneeId: ctx.viewerId,
+        });
+        await ctx.client.createComment({
+          issueId: issue.id,
+          body: `**State reconciled** — agent completed but issue was still in Agent Working. Moved to In Review.`,
+        });
+        logPipelineEvent(
+          issue.id,
+          ident,
+          'circuit_breaker_reset',
+          'sweep: agent_completed but stuck in Agent Working',
+        );
+        logger.info(
+          { issueId: issue.id },
+          'auto-merge: Agent Working sweep → In Review (agent_completed found)',
+        );
+        reconciled++;
+      }
+      continue;
+    }
+
+    if (lastRelevant?.event_type === 'agent_failed') {
+      // Agent failed — check circuit breaker then route to Ready for Agent or Manual Review
+      const failCount = getConsecutiveFailCount(issue.id, 'agent_failed');
+      if (failCount >= CIRCUIT_BREAKER_THRESHOLD) {
+        await tripCircuitBreaker(
+          ctx,
+          issue.id,
+          ident,
+          failCount,
+          'stale sweep',
+        );
+        logger.warn(
+          { issueId: issue.id, failCount },
+          'auto-merge: Agent Working sweep → circuit breaker tripped',
+        );
+      } else {
+        const readyState = ctx.stateByName.get('Ready for Agent');
+        if (readyState) {
+          await ctx.client.updateIssue(issue.id, {
+            stateId: readyState.id,
+          });
+          await ctx.client.createComment({
+            issueId: issue.id,
+            body: `**State reconciled** — agent run failed and issue was stuck in Agent Working. Moved back to Ready for Agent for re-dispatch.`,
+          });
+          logPipelineEvent(
+            issue.id,
+            ident,
+            'circuit_breaker_reset',
+            'sweep: moved to Ready for Agent after agent_failed',
+          );
+          logger.info(
+            { issueId: issue.id },
+            'auto-merge: Agent Working sweep → Ready for Agent (agent_failed)',
+          );
+        }
+      }
+      reconciled++;
+      continue;
+    }
+
+    // No recognisable terminal event — the issue is truly stuck with no progress signal
+    const manualReviewState = ctx.stateByName.get('Manual Review Required');
+    const parkState = manualReviewState ?? ctx.stateByName.get('Backlog')!;
+    await ctx.client.updateIssue(issue.id, { stateId: parkState.id });
+    await ctx.client.createComment({
+      issueId: issue.id,
+      body: `**State reconciled** — issue has been stuck in Agent Working with no progress signal for over an hour. Moved to ${parkState.name} for manual review.\n\nTo retry: investigate, then move back to **Ready for Agent**.`,
+    });
+    logPipelineEvent(
+      issue.id,
+      ident,
+      'circuit_breaker_tripped',
+      'sweep: no progress signal, moved to manual review',
+    );
+    logger.warn(
+      { issueId: issue.id },
+      'auto-merge: Agent Working sweep → Manual Review Required (no signal)',
+    );
+    reconciled++;
+  }
+
+  if (reconciled > 0) {
+    logger.info(
+      { count: reconciled },
+      'auto-merge: swept stale Agent Working issues',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `sweepStaleAgentWorking` to post-merge state reconciliation in `src/linear-auto-merge.ts`
- Decision tree: merged PR → Done, open/closed PR → In Review, `agent_completed` event (no PR) → In Review, `agent_failed` → Ready for Agent (circuit-breaker aware), no signal → Manual Review Required
- Wires the new sweep into the startup sweep loop in `src/index.ts` alongside `sweepStaleInReview` and `sweepPendingAutoMerges`

## Note on sweep timing

`sweepStaleAgentWorking` runs only on startup (same pattern as `sweepStaleInReview`). Long-running processes won't sweep until restart — this is the existing pattern's known behavior, not a regression.

## Build note

`npm run build` exits non-zero due to 126 pre-existing type errors in `packages/mcp-*/` and `packages/tui/` (missing third-party type declarations). These are unrelated to this change — confirmed by stashing changes and observing the same 126 errors on HEAD.

## Test plan

- [x] `sweepStaleAgentWorking` with merged PR → moves to Done
- [x] `sweepStaleAgentWorking` with open/closed PR → moves to In Review
- [x] `sweepStaleAgentWorking` with `agent_completed` event, no PR → moves to In Review
- [x] `sweepStaleAgentWorking` with no signal (stale) → moves to Manual Review Required
- [x] `sweepStaleAgentWorking` with in-flight issue → no-op (skipped)
- [x] `sweepStaleAgentWorking` with recently-entered issue (under threshold) → no-op
- [x] All 1272 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)