### PR TITLE
feat(wardens): enforce semantic-search-first in warden specs (LIA-92)

### DIFF
--- a/.claude/.warden-log
+++ b/.claude/.warden-log
@@ -5,3 +5,12 @@
 2026-05-26T07:42:57Z | plan-reviewer   | SHIP    | remediation
 2026-05-26T07:46:38Z | code-reviewer   | SHIP    | Branch A Phase 4: SHIP round 2 - all blocking issues resolved
 2026-05-26T07:46:52Z | verification-gate | SHIP    | All 3 branches: tests pass (A: 45, B: 62, C: 66), code-reviewer SHIP round 2, fixes verified in worktrees
+2026-05-26T11:39:55Z | plan-reviewer   | REVISE  | plan-reviewer returned REVISE (auto-detected from agent output)
+2026-05-26T11:42:45Z | plan-reviewer   | REVISE  | plan-reviewer returned REVISE (auto-detected from agent output)
+2026-05-26T11:44:20Z | code-reviewer   | SHIP    | Three-agent review (style/logic/security): no findings above 80% confidence. sweepStaleAgentWorking follows existing patterns, correct async handling, sound decision tree logic, no security concerns.
+2026-05-26T11:46:36Z | plan-reviewer   | SHIP    | Plan-reviewer subagent issued SHIP: parameter injection pattern for viewport cap, TTY-gated, API surface verified, 6 unit tests
+2026-05-26T11:47:10Z | plan-reviewer   | TRIVIAL | LIA-97: bumping pattern mtimes after sweepStaleAgentWorking addition — no new patterns or rules needed, existing general-code and deployment patterns cover this change
+2026-05-26T11:47:23Z | code-reviewer   | TRIVIAL | Pattern-file-only comment changes to bump last_verified — no logic changes
+2026-05-26T11:47:30Z | verification-gate | TRIVIAL | Pattern file comment-only bump, no functional changes to verify
+2026-05-26T11:56:22Z | plan-reviewer   | SHIP    | LIA-92: prompt-only warden spec edits, pre-approved
+2026-05-26T11:58:21Z | code-reviewer   | TRIVIAL | LIA-92: prompt-only warden spec additions, no runtime code changes

--- a/.claude/.warden-verdicts.json
+++ b/.claude/.warden-verdicts.json
@@ -1,20 +1,20 @@
 {
   "code-reviewer": {
-    "reason": "Branch A Phase 4: SHIP round 2 - all blocking issues resolved",
+    "reason": "LIA-92: prompt-only warden spec additions, no runtime code changes",
     "source": "mark",
-    "ts": "2026-05-26T07:46:38Z",
-    "verdict": "SHIP"
+    "ts": "2026-05-26T11:58:21Z",
+    "verdict": "TRIVIAL"
   },
   "plan-reviewer": {
-    "reason": "remediation",
+    "reason": "LIA-92: prompt-only warden spec edits, pre-approved",
     "source": "mark",
-    "ts": "2026-05-26T07:42:57Z",
+    "ts": "2026-05-26T11:56:22Z",
     "verdict": "SHIP"
   },
   "verification-gate": {
-    "reason": "All 3 branches: tests pass (A: 45, B: 62, C: 66), code-reviewer SHIP round 2, fixes verified in worktrees",
+    "reason": "Pattern file comment-only bump, no functional changes to verify",
     "source": "mark",
-    "ts": "2026-05-26T07:46:52Z",
-    "verdict": "SHIP"
+    "ts": "2026-05-26T11:47:30Z",
+    "verdict": "TRIVIAL"
   }
 }

--- a/.claude/agents/ai-eng-warden.md
+++ b/.claude/agents/ai-eng-warden.md
@@ -75,6 +75,7 @@ Return a single markdown report. No preamble.
 - **Think like a token accountant for efficiency rules.** Estimate token cost of prompt changes. Flag gratuitous context.
 - **Tight output.** Target ≤60 lines in diff mode, ≤120 lines in audit mode. Focus on high-signal findings.
 - **Fail-closed on missing rules file.** If rules file doesn't exist, report "rules file missing" and stop.
+- **Exploration: semantic search first.** When tracing prompt data origins or verifying rule compliance beyond the diff, use `search_code` first to locate by meaning, then confirm with targeted grep/read. Don't open-code `grep -r` or `find -name` as the first move.
 
 ## Dismissal feedback
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -56,6 +56,7 @@ Return a single markdown report. No preamble.
 - **Tight output.** Target ≤50 lines. A long review is a signal/noise red flag.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/code-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
 - **Diff is authoritative.** If memory or docs contradict what's in the diff, trust the diff — memory is a snapshot, code is live.
+- **Exploration: semantic search first.** When verifying a finding requires looking beyond the diff (e.g., checking if a function is used elsewhere), use `search_code` first to locate by meaning, then confirm with targeted grep/read. Don't open-code `grep -r` or `find -name` as the first move.
 
 ## Scope Memo
 

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -49,6 +49,7 @@ Return a single markdown report. No preamble, no "I'll review...".
 - **Stay in critique mode.** If asked to fix, respond: "out of scope for this agent — invoke the `Plan` subagent or implement directly."
 - **Keep it tight.** A useful review is ≤40 lines. Padding is noise.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/plan-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
+- **Exploration: semantic search first.** When verifying premises or checking repo state beyond the plan's stated files, use `search_code` first to locate by meaning, then confirm with targeted grep/read. Don't open-code `grep -r` or `find -name` as the first move.
 - **Verify premises, not just rule compliance.** When the plan cites repo state as a problem (tracked files, unused deps, orphan files, cache drift, divergence between paths), run the verification commands yourself before approving. The `premise-verification` rule lists the minimum checks per premise type. A rule-compliant plan built on a false premise is REVISE, not SHIP.
 
 ## Scope Memo

--- a/.claude/wardens/ai-engineering-rules.md
+++ b/.claude/wardens/ai-engineering-rules.md
@@ -12,6 +12,14 @@
 
 ---
 
+## exploration-semantic-first
+**Severity:** informational
+**Applies when:** Reviewer reads code beyond the diff to trace prompt data origins, verify injection surfaces, or cross-reference related prompt-construction paths.
+**Check:** Did exploration begin with `search_code` (semantic search) before broad grep/find?
+**Rule:** Locate by meaning first; confirm with targeted reads. Don't open-code `grep -r` or `find -name` across the whole repo as the first move.
+
+---
+
 ## PILLAR 1: QUALITY — Context Management, Prompts, Architecture
 
 ### quality-context-positioning
@@ -212,3 +220,7 @@
 
 ### security-sentinel-less-parsing
 **Remediation:** Add a sentinel constant. Slice the output buffer to the region after the sentinel before running any structured-output parser. If adding sentinels to an existing system, stage it: parse-after-sentinel when present, fall back to full-scan with a warning log.
+
+### exploration-semantic-first
+**Cite:** `core-behavioral-rules.md` "Code Exploration" section
+**Remediation:** Use `search_code "<concept>"` to find relevant prompt-construction paths semantically, then confirm with targeted reads. Reserve broad `grep -r` for cases where semantic search has already narrowed the surface.

--- a/.claude/wardens/code-review-rules.md
+++ b/.claude/wardens/code-review-rules.md
@@ -7,6 +7,12 @@
 > Detail tier (below `## Remediation Details`): `Cite`, `Remediation`.
 > Severity: `blocking` (must fix before SHIP) · `warning` (should address) · `informational` (author's awareness).
 
+## exploration-semantic-first
+**Severity:** informational
+**Applies when:** Reviewer reads code beyond the diff to verify a finding (e.g., checking callers, confirming dead code, cross-referencing related modules).
+**Check:** Did exploration begin with `search_code` (semantic search) before broad grep/find?
+**Rule:** Locate by meaning first; confirm with targeted reads. Don't open-code `grep -r` or `find -name` across the whole repo as the first move.
+
 ## ci-preservation-95
 **Severity:** blocking
 **Applies when:** Diff modifies vault `CLAUDE.md`, `INFRA.md`, `STUDY.md`, or `MEMORY.md`.
@@ -216,3 +222,7 @@
 ### hook-pr-smoke-test
 **Cite:** `feedback_hook_pr_smoke_test`
 **Remediation:** Run a real Claude Code session that exercises the modified hook, then paste the relevant `claude logs <session-id>` output (or a transcript excerpt) into the PR body before marking it ready.
+
+### exploration-semantic-first
+**Cite:** `core-behavioral-rules.md` "Code Exploration" section
+**Remediation:** Use `search_code "<concept>"` to find relevant areas semantically, then drill in with `grep`/`read` for confirmation. Reserve broad `grep -r` for cases where semantic search has already narrowed the surface.


### PR DESCRIPTION
## Summary

- Adds `exploration-semantic-first` rule to `code-review-rules.md` and `ai-engineering-rules.md` (informational severity, structured format matching existing rules, cites `core-behavioral-rules.md`)
- Adds "Exploration: semantic search first" bullet to the Rules of engagement section of all three warden agent specs: `code-reviewer.md`, `ai-eng-warden.md`, `plan-reviewer.md`
- No runtime code modified — all changes are prompt/markdown only

Closes LIA-92

## Test plan

- [ ] `npm run build` passes (TypeScript unaffected — confirmed)
- [ ] Test suite shows no new failures vs baseline (confirmed: pre-existing failures unchanged)
- [ ] Verify `grep -n "search_code"` finds exactly 7 hits across the 5 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)