### PR TITLE
fix(hooks): widen plan-review-gate scope to non-git and vault paths (LIA-77)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -781,6 +781,11 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     # otherwise `(worktree, paths_after_filtering)`. Empty `paths` after
     # filtering must NOT bypass the gate (the pre-fix `not paths` short-
     # circuit was the ExitPlanMode enforcement gap, PR #430).
+    #
+    # Scope note (LIA-77): this Python gate is intentionally scoped to deus
+    # worktrees. Edits in non-git directories (vault, scratch, config files)
+    # are covered by the user-level bash hook at ~/.claude/hooks/plan-review-gate.sh,
+    # which falls back to the deus marker when not in a wardens-enabled repo.
     worktree, paths = _managed_paths(event, repo_root)
     if worktree is None:
         return 0

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -203,10 +203,15 @@ def test_plan_review_gate_blocks_worktree_excluded_target_without_marker(tmp_pat
 
 
 def test_plan_review_gate_returns_zero_outside_worktree(tmp_path, capsys):
-    """Event from cwd outside any git worktree → gate passes silently.
+    """Event from cwd outside any git worktree → Python gate passes silently.
 
     Pins the non-worktree early-exit. Without this, the empty-paths fix
     could regress in the other direction (firing the gate everywhere).
+
+    LIA-77 scope note: this Python gate is intentionally scoped to deus
+    worktrees. The user-level bash hook (~/.claude/hooks/plan-review-gate.sh)
+    handles non-git and non-wardens-repo directories by falling back to the
+    deus marker. This test pins the Python gate boundary; it is not a gap.
     """
     hooks = load_hooks()
     outside = tmp_path / "outside"


### PR DESCRIPTION
## Summary

- The user-level bash hook (`~/.claude/hooks/plan-review-gate.sh`) previously exited silently when CWD was not inside a git repo with `.claude/wardens/`, letting vault and scratch-file edits bypass the plan-review discipline
- The hook now falls back to the deus marker (`${DEUS_HOME:-$HOME/deus}/.claude/.plan-reviewed`) in all non-wardens-repo cases
- `~/.claude/hooks/warden-mark.sh` receives the same fallback logic so the gate remains clearable when working outside a wardens-enabled repo
- The Python gate (`run_plan_review_gate`) is intentionally scoped to deus worktrees — a comment and updated test docstring make this architectural split explicit

## Hook changes (user-level, applied out-of-band)

These files live at `~/.claude/hooks/` and are not versioned in the repo per the "never bundle personal ~/.claude/ tooling into public PRs" rule.

**`~/.claude/hooks/plan-review-gate.sh`** — marker resolution now follows:
1. If CWD is in a git repo with `.claude/wardens/`: use that project's marker (existing behavior)
2. If in a git repo without `.claude/wardens/`, or not in any git repo: use `${DEUS_HOME:-$HOME/deus}/.claude/.plan-reviewed`

The scope filter is widened in the fallback case: any file not in the standard exclusion list (tmp, node_modules, dist, Atoms, Session-Logs, etc.) is gated.

**`~/.claude/hooks/warden-mark.sh`** — project root resolution uses the same two-step logic, falling back to `$DEUS_ROOT` so marks can be placed from non-repo contexts.

## Tracked changes (this PR)

- `scripts/codex_warden_hooks.py`: added a scope note comment explaining why `worktree is None → return 0` is intentional, not a gap
- `scripts/tests/test_codex_warden_hooks.py`: updated `test_plan_review_gate_returns_zero_outside_worktree` docstring to document the LIA-77 architectural split

## Test plan

- [x] 7 manual bash tests covering all three resolution paths (non-git/no-marker → exit 2, non-git/marker-present → exit 0, in-deus-repo/no-marker → exit 2, in-deus-repo/marker-present → exit 0, /tmp excluded, worktrees excluded, vault-path/no-marker → exit 2)
- [x] All 9 `plan_review_gate` pytest cases pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)