### PR TITLE
feat(pipeline): detect and handle merge-conflicting PRs (LIA-90)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-26" # LIA-90: conflict detection sweep added
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # tool-economy dimension added
+last_verified: "2026-05-26" # LIA-90: conflict detection sweep added
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/db.ts
+++ b/src/db.ts
@@ -1506,6 +1506,27 @@ export function getPendingAutoMerges(): Array<{
   }>;
 }
 
+export function getOpenPrsForActiveIssues(): Array<{
+  issue_id: string;
+  pr_url: string;
+  identifier: string | null;
+}> {
+  return db
+    .prepare(
+      `SELECT p.issue_id, p.pr_url, p.identifier
+       FROM linear_issue_prs p
+       JOIN linear_issue_cache c ON p.issue_id = c.issue_id
+       WHERE c.state_name IN ('Agent Working', 'In Review')
+         AND c.deleted_at IS NULL
+         AND p.auto_merge_state != 'merged'`,
+    )
+    .all() as Array<{
+    issue_id: string;
+    pr_url: string;
+    identifier: string | null;
+  }>;
+}
+
 // --- Pipeline event accessors ---
 
 export function logPipelineEvent(

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -6,6 +6,8 @@ import {
   getIssuePr,
   updatePrAutoMergeState,
   getPendingAutoMerges,
+  getOpenPrsForActiveIssues,
+  upsertIssueCache,
 } from './db.js';
 
 const execFileMock = vi.fn();
@@ -126,5 +128,332 @@ describe('queryPrChecks', () => {
     const { queryPrChecks } = await import('./linear-auto-merge.js');
     const result = await queryPrChecks('https://github.com/test/repo/pull/1');
     expect(result.status).toBe('pass');
+  });
+});
+
+describe('getOpenPrsForActiveIssues', () => {
+  it('returns PRs for issues in Agent Working or In Review', () => {
+    // Seed issue cache with two active issues and one Done issue
+    upsertIssueCache({
+      issue_id: 'issue-working',
+      identifier: 'LIA-1',
+      title: 'Working issue',
+      state_name: 'Agent Working',
+      team_id: 'team-1',
+      priority: 2,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssueCache({
+      issue_id: 'issue-review',
+      identifier: 'LIA-2',
+      title: 'Review issue',
+      state_name: 'In Review',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssueCache({
+      issue_id: 'issue-done',
+      identifier: 'LIA-3',
+      title: 'Done issue',
+      state_name: 'Done',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    upsertIssuePr(
+      'issue-working',
+      'https://github.com/o/r/pull/10',
+      'feat/a',
+      'LIA-1',
+    );
+    upsertIssuePr(
+      'issue-review',
+      'https://github.com/o/r/pull/11',
+      'feat/b',
+      'LIA-2',
+    );
+    upsertIssuePr(
+      'issue-done',
+      'https://github.com/o/r/pull/12',
+      'feat/c',
+      'LIA-3',
+    );
+    // Mark done PR as merged
+    updatePrAutoMergeState('issue-done', 'merged');
+
+    const active = getOpenPrsForActiveIssues();
+    expect(active).toHaveLength(2);
+    const ids = active.map((p) => p.issue_id).sort();
+    expect(ids).toEqual(['issue-review', 'issue-working']);
+  });
+
+  it('excludes merged PRs even if issue is in active state', () => {
+    upsertIssueCache({
+      issue_id: 'issue-merged',
+      identifier: 'LIA-4',
+      title: 'Merged issue',
+      state_name: 'Agent Working',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssuePr(
+      'issue-merged',
+      'https://github.com/o/r/pull/20',
+      'feat/m',
+      'LIA-4',
+    );
+    updatePrAutoMergeState('issue-merged', 'merged');
+
+    const active = getOpenPrsForActiveIssues();
+    expect(active).toHaveLength(0);
+  });
+});
+
+describe('buildConflictRebasePrompt', () => {
+  it('includes PR URL, changed files, and base branch', async () => {
+    const { buildConflictRebasePrompt } =
+      await import('./linear-auto-merge.js');
+    const prompt = buildConflictRebasePrompt(
+      'https://github.com/o/r/pull/42',
+      5,
+      'main',
+    );
+    expect(prompt).toContain('https://github.com/o/r/pull/42');
+    expect(prompt).toContain('5');
+    expect(prompt).toContain('main');
+    expect(prompt).toContain('rebase');
+  });
+});
+
+describe('checkConflictingPrs', () => {
+  function makeCtx(
+    overrides: {
+      updateIssue?: ReturnType<typeof vi.fn>;
+      createComment?: ReturnType<typeof vi.fn>;
+      issue?: ReturnType<typeof vi.fn>;
+    } = {},
+  ) {
+    const updateIssue = overrides.updateIssue ?? vi.fn().mockResolvedValue({});
+    const createComment =
+      overrides.createComment ?? vi.fn().mockResolvedValue({});
+    const issue =
+      overrides.issue ??
+      vi.fn().mockResolvedValue({
+        labels: vi.fn().mockResolvedValue({ nodes: [] }),
+        state: Promise.resolve({ name: 'In Review' }),
+      });
+
+    return {
+      client: { updateIssue, createComment, issue },
+      stateByName: new Map([
+        ['Ready for Agent', { id: 'ready-id', name: 'Ready for Agent' }],
+        [
+          'Manual Review Required',
+          { id: 'manual-id', name: 'Manual Review Required' },
+        ],
+        ['In Review', { id: 'review-id', name: 'In Review' }],
+        ['Agent Working', { id: 'working-id', name: 'Agent Working' }],
+      ]),
+      gateLabels: { conflict: 'conflict-label-id', effort: {}, complexity: {} },
+    } as unknown as import('./linear-dispatcher.js').LinearContext;
+  }
+
+  it('skips PRs with UNKNOWN mergeability', async () => {
+    upsertIssueCache({
+      issue_id: 'issue-u',
+      identifier: 'LIA-10',
+      title: 'Unknown issue',
+      state_name: 'In Review',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssuePr(
+      'issue-u',
+      'https://github.com/o/r/pull/100',
+      'feat/u',
+      'LIA-10',
+    );
+
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'UNKNOWN',
+        changedFiles: 3,
+        headRefName: 'feat/u',
+        baseRefName: 'main',
+      }),
+    });
+
+    const ctx = makeCtx();
+    const { checkConflictingPrs } = await import('./linear-auto-merge.js');
+    await checkConflictingPrs(ctx);
+
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+    expect(ctx.client.createComment).not.toHaveBeenCalled();
+  });
+
+  it('routes small conflicting PR to Ready for Agent', async () => {
+    upsertIssueCache({
+      issue_id: 'issue-small',
+      identifier: 'LIA-11',
+      title: 'Small conflict',
+      state_name: 'In Review',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssuePr(
+      'issue-small',
+      'https://github.com/o/r/pull/101',
+      'feat/s',
+      'LIA-11',
+    );
+
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        changedFiles: 3,
+        headRefName: 'feat/s',
+        baseRefName: 'main',
+      }),
+    });
+
+    const ctx = makeCtx();
+    const { checkConflictingPrs } = await import('./linear-auto-merge.js');
+    await checkConflictingPrs(ctx);
+
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'issue-small',
+      expect.objectContaining({ stateId: 'ready-id' }),
+    );
+    expect(ctx.client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId: 'issue-small' }),
+    );
+  });
+
+  it('routes large conflicting PR to Manual Review Required', async () => {
+    upsertIssueCache({
+      issue_id: 'issue-large',
+      identifier: 'LIA-12',
+      title: 'Large conflict',
+      state_name: 'In Review',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssuePr(
+      'issue-large',
+      'https://github.com/o/r/pull/102',
+      'feat/l',
+      'LIA-12',
+    );
+
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        changedFiles: 15,
+        headRefName: 'feat/l',
+        baseRefName: 'main',
+      }),
+    });
+
+    const ctx = makeCtx();
+    const { checkConflictingPrs } = await import('./linear-auto-merge.js');
+    await checkConflictingPrs(ctx);
+
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'issue-large',
+      expect.objectContaining({ stateId: 'manual-id' }),
+    );
+  });
+
+  it('skips issues already labeled conflict', async () => {
+    upsertIssueCache({
+      issue_id: 'issue-already',
+      identifier: 'LIA-13',
+      title: 'Already labeled',
+      state_name: 'In Review',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssuePr(
+      'issue-already',
+      'https://github.com/o/r/pull/103',
+      'feat/x',
+      'LIA-13',
+    );
+
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        changedFiles: 3,
+        headRefName: 'feat/x',
+        baseRefName: 'main',
+      }),
+    });
+
+    // Issue already has conflict label
+    const issueWithLabel = {
+      labels: vi.fn().mockResolvedValue({
+        nodes: [{ id: 'conflict-label-id', name: 'conflict' }],
+      }),
+      state: Promise.resolve({ name: 'In Review' }),
+    };
+    const ctx = makeCtx({ issue: vi.fn().mockResolvedValue(issueWithLabel) });
+    const { checkConflictingPrs } = await import('./linear-auto-merge.js');
+    await checkConflictingPrs(ctx);
+
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('skips MERGEABLE PRs', async () => {
+    upsertIssueCache({
+      issue_id: 'issue-mergeable',
+      identifier: 'LIA-14',
+      title: 'Mergeable issue',
+      state_name: 'In Review',
+      team_id: 'team-1',
+      priority: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    upsertIssuePr(
+      'issue-mergeable',
+      'https://github.com/o/r/pull/104',
+      'feat/m',
+      'LIA-14',
+    );
+
+    execFileMock.mockReturnValue({
+      stdout: JSON.stringify({
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        changedFiles: 2,
+        headRefName: 'feat/m',
+        baseRefName: 'main',
+      }),
+    });
+
+    const ctx = makeCtx();
+    const { checkConflictingPrs } = await import('./linear-auto-merge.js');
+    await checkConflictingPrs(ctx);
+
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
   });
 });

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -13,6 +13,7 @@ import {
   CIRCUIT_BREAKER_THRESHOLD,
   getConsecutiveFailCount,
   getIssuePr,
+  getOpenPrsForActiveIssues,
   getPendingAutoMerges,
   logPipelineEvent,
   updatePrAutoMergeState,
@@ -449,6 +450,224 @@ export async function sweepStaleInReview(
     }
   } catch (err) {
     logger.warn({ err }, 'auto-merge: failed to sweep stale In Review issues');
+  }
+}
+
+/**
+ * Builds a rebase context prompt to inject when routing a conflicting PR back
+ * to Ready for Agent.
+ */
+export function buildConflictRebasePrompt(
+  prUrl: string,
+  changedFiles: number,
+  baseBranch: string,
+): string {
+  const lines = [
+    '<conflict-context>',
+    'The PR for this issue has a merge conflict with the base branch.',
+    `- PR: ${prUrl}`,
+    `- Changed files: ${changedFiles}`,
+    `- Base branch: ${baseBranch}`,
+    '',
+    'To resolve: check out the branch, rebase onto the latest base branch',
+    `(\`git fetch origin && git rebase origin/${baseBranch}\`), resolve any`,
+    'conflicts, then force-push the branch.',
+    '</conflict-context>',
+  ];
+  return lines.join('\n');
+}
+
+type MergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
+
+interface PrMergeabilityResult {
+  mergeable: MergeableState;
+  mergeStateStatus: string;
+  changedFiles: number;
+  headRefName: string;
+  baseRefName: string;
+}
+
+async function queryPrMergeability(
+  prUrl: string,
+): Promise<PrMergeabilityResult | null> {
+  const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
+  if (!prNumber) return null;
+  const repoMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/);
+  const repo = repoMatch?.[1];
+  if (!repo) return null;
+
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      [
+        'pr',
+        'view',
+        prNumber,
+        '--repo',
+        repo,
+        '--json',
+        'mergeable,mergeStateStatus,changedFiles,headRefName,baseRefName',
+      ],
+      { timeout: CI_CHECK_TIMEOUT_MS },
+    );
+    return JSON.parse(stdout) as PrMergeabilityResult;
+  } catch (err) {
+    logger.warn(
+      { prUrl, err },
+      'conflict-check: failed to query PR mergeability',
+    );
+    return null;
+  }
+}
+
+const LARGE_PR_FILE_THRESHOLD = 10;
+
+/**
+ * Sweeps active issues (Agent Working + In Review) for conflicting PRs.
+ * On CONFLICTING: logs event, applies Conflict label, routes to Manual Review
+ * Required (>=10 changed files) or Ready for Agent with rebase context (<10).
+ * Skips issues already labeled "conflict" or in Manual Review Required.
+ * Runs every poll cycle; lightweight because it only hits the GitHub API for
+ * PRs that exist in the DB.
+ */
+export async function checkConflictingPrs(ctx: LinearContext): Promise<void> {
+  const activePrs = getOpenPrsForActiveIssues();
+  if (activePrs.length === 0) return;
+
+  for (const { issue_id, pr_url, identifier } of activePrs) {
+    const ident = identifier ?? 'unknown';
+
+    try {
+      const mergeability = await queryPrMergeability(pr_url);
+      if (!mergeability) continue;
+
+      // UNKNOWN means GitHub is still computing — skip, check next poll
+      if (mergeability.mergeable === 'UNKNOWN') {
+        logger.debug(
+          { issueId: issue_id, prUrl: pr_url },
+          'conflict-check: mergeable=UNKNOWN, will retry next poll',
+        );
+        continue;
+      }
+
+      if (mergeability.mergeable !== 'CONFLICTING') continue;
+
+      // Fetch current labels to check skip conditions
+      let currentLabels: Array<{ id: string; name: string }> = [];
+      try {
+        const issue = await ctx.client.issue(issue_id);
+        const labelConn = await issue.labels();
+        currentLabels = labelConn.nodes.map((l) => ({
+          id: l.id,
+          name: l.name,
+        }));
+      } catch (err) {
+        logger.warn(
+          { issueId: issue_id, err },
+          'conflict-check: failed to fetch issue labels, skipping',
+        );
+        continue;
+      }
+
+      // Skip if already labeled conflict
+      if (currentLabels.some((l) => l.name === 'conflict')) {
+        logger.debug(
+          { issueId: issue_id },
+          'conflict-check: already labeled conflict, skipping',
+        );
+        continue;
+      }
+
+      // Skip if already in Manual Review Required
+      const issueObj = await ctx.client.issue(issue_id);
+      const issueState = await issueObj.state;
+      if (issueState?.name === 'Manual Review Required') {
+        logger.debug(
+          { issueId: issue_id },
+          'conflict-check: already in Manual Review Required, skipping',
+        );
+        continue;
+      }
+
+      // Log the conflict event
+      logPipelineEvent(issue_id, ident, 'merge_conflict', pr_url);
+      notifyPipelineStep(ctx, issue_id, ident, 'merge_conflict', pr_url).catch(
+        () => {},
+      );
+
+      // Apply Conflict label
+      const labelUpdates: Record<string, unknown> = {};
+      if (ctx.gateLabels.conflict) {
+        labelUpdates.addedLabelIds = [ctx.gateLabels.conflict];
+      }
+
+      const isLargePr = mergeability.changedFiles >= LARGE_PR_FILE_THRESHOLD;
+
+      if (isLargePr) {
+        // Large PR — park in Manual Review Required
+        const manualReviewState = ctx.stateByName.get('Manual Review Required');
+        if (manualReviewState) {
+          await ctx.client.updateIssue(issue_id, {
+            stateId: manualReviewState.id,
+            ...labelUpdates,
+          });
+          await ctx.client.createComment({
+            issueId: issue_id,
+            body: `**Merge conflict detected** — PR ${pr_url} has conflicts with the base branch.\n\nThis PR touches ${mergeability.changedFiles} files (≥${LARGE_PR_FILE_THRESHOLD}), so it has been moved to **Manual Review Required** for a human to resolve.\n\nTo retry after resolving: rebase the branch and move back to **Ready for Agent**.`,
+          });
+          logger.info(
+            {
+              issueId: issue_id,
+              prUrl: pr_url,
+              changedFiles: mergeability.changedFiles,
+            },
+            'conflict-check: large PR conflict, moved to Manual Review Required',
+          );
+        } else {
+          logger.warn(
+            { issueId: issue_id },
+            'conflict-check: Manual Review Required state not found, skipping routing',
+          );
+        }
+      } else {
+        // Small PR — route back to Ready for Agent with rebase context
+        const readyState = ctx.stateByName.get('Ready for Agent');
+        if (readyState) {
+          await ctx.client.updateIssue(issue_id, {
+            stateId: readyState.id,
+            priority: 1,
+            ...labelUpdates,
+          });
+          const rebasePrompt = buildConflictRebasePrompt(
+            pr_url,
+            mergeability.changedFiles,
+            mergeability.baseRefName,
+          );
+          await ctx.client.createComment({
+            issueId: issue_id,
+            body: `**Merge conflict detected** — PR ${pr_url} has conflicts with \`${mergeability.baseRefName}\`.\n\nMoved back to **Ready for Agent** with rebase instructions.\n\n\`\`\`\n${rebasePrompt}\n\`\`\``,
+          });
+          logger.info(
+            {
+              issueId: issue_id,
+              prUrl: pr_url,
+              changedFiles: mergeability.changedFiles,
+            },
+            'conflict-check: small PR conflict, moved to Ready for Agent',
+          );
+        } else {
+          logger.warn(
+            { issueId: issue_id },
+            'conflict-check: Ready for Agent state not found, skipping routing',
+          );
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { issueId: issue_id, prUrl: pr_url, err },
+        'conflict-check: error processing PR, skipping',
+      );
+    }
   }
 }
 

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -22,6 +22,7 @@ vi.mock('./db.js', () => ({
   getPipelineEvents: vi.fn().mockReturnValue([]),
   logPipelineEvent: vi.fn(),
   upsertIssuePr: vi.fn(),
+  getOpenPrsForActiveIssues: vi.fn().mockReturnValue([]),
 }));
 
 const TEST_PROJECT_ROOT = path.join(os.tmpdir(), `deus-test-${process.pid}`);

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -9,7 +9,7 @@ import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
 import { fireAndForget } from './async/index.js';
 import { extractPrUrl } from './pr-url-extractor.js';
-import { queryPrState } from './linear-auto-merge.js';
+import { queryPrState, checkConflictingPrs } from './linear-auto-merge.js';
 import {
   CIRCUIT_BREAKER_THRESHOLD,
   getConsecutiveFailCount,
@@ -67,6 +67,7 @@ export interface GateLabels {
   bouncedUnscoped?: string;
   bouncedStale?: string;
   bouncedNoContext?: string;
+  conflict?: string;
   effort: Record<number, string>;
   complexity: Record<number, string>;
 }
@@ -649,6 +650,11 @@ async function pollLinear(): Promise<void> {
   if (!_ctx) return;
   const ctx = _ctx;
 
+  // Conflict detection sweep — runs every poll alongside dispatch
+  checkConflictingPrs(ctx).catch((err) => {
+    logger.warn({ err }, 'linear-dispatcher: conflict check sweep failed');
+  });
+
   const readyState = ctx.stateByName.get('Ready for Agent')!;
 
   const issues = await ctx.client.issues({
@@ -1010,6 +1016,18 @@ export async function initLinearContext(
           const label = await created.issueLabel;
           if (label) gateLabels[def.key] = label.id;
         }
+      }
+
+      if (labelMap.has('conflict')) {
+        gateLabels.conflict = labelMap.get('conflict');
+      } else {
+        const created = await client.createIssueLabel({
+          name: 'conflict',
+          color: '#b45309',
+          teamId,
+        });
+        const label = await created.issueLabel;
+        if (label) gateLabels.conflict = label.id;
       }
 
       if (!labelMap.has('Done: Pre-implemented')) {

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -50,6 +50,7 @@ export const EVENT_LABELS: Record<string, string> = {
   automerge_pending: 'Auto-merge pending',
   automerge_done: 'Auto-merged → Done',
   automerge_failed: 'Auto-merge failed',
+  merge_conflict: 'Conflict',
   moved_done: 'Moved to Done',
   state_changed: 'State changed',
   circuit_breaker_tripped: 'Circuit breaker tripped',


### PR DESCRIPTION
## Summary

- Adds a `checkConflictingPrs()` sweep that runs every 30s alongside the existing dispatch loop
- When a PR enters `CONFLICTING` state (e.g. another PR merged to main), the sweep detects it via `gh pr view --json mergeable,mergeStateStatus,changedFiles`, logs a `merge_conflict` pipeline event, applies a `conflict` label, and routes appropriately
- PRs with <10 changed files → **Ready for Agent** with rebase context injected into the prompt
- PRs with ≥10 changed files → **Manual Review Required** (too large to auto-rebase)
- Skips issues already labeled `conflict` or already in Manual Review Required
- Skips `UNKNOWN` mergeability (GitHub still computing — retries next poll)

## Changes

- `src/db.ts`: `getOpenPrsForActiveIssues()` — joins `linear_issue_prs` + `linear_issue_cache`, returns active (Agent Working + In Review) non-merged PRs
- `src/linear-notifications.ts`: add `merge_conflict: 'Conflict'` to `EVENT_LABELS`
- `src/linear-dispatcher.ts`: add `conflict?: string` to `GateLabels`; auto-discover/create `conflict` label in `initLinearContext`; wire `checkConflictingPrs()` into `pollLinear()` (fire-and-forget, errors don't block dispatch)
- `src/linear-auto-merge.ts`: `checkConflictingPrs(ctx)`, `queryPrMergeability()` (single `gh` call for all fields), `buildConflictRebasePrompt()`
- `src/linear-auto-merge.test.ts`: 17 tests covering CONFLICTING/UNKNOWN/MERGEABLE routing, skip conditions, large vs small PR threshold
- `src/linear-dispatcher.test.ts`: add `getOpenPrsForActiveIssues` mock entry

## Test plan

- [x] `npx vitest run src/linear-auto-merge.test.ts` — 17 tests pass
- [x] `npx vitest run src/linear-dispatcher.test.ts src/linear-notifications.test.ts src/db.test.ts` — 80 tests pass (97 total across all 4 files)
- [x] `npx tsc --noEmit` — no type errors in main source
- [x] Prettier formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)