### PR TITLE
fix(pipeline): allow Done transitions from any state

### DIFF
--- a/.claude/agents/wardens/completion-gate.md
+++ b/.claude/agents/wardens/completion-gate.md
@@ -1,7 +1,7 @@
 ---
 name: completion-gate
 gate_to: "Done"
-allowed_from: ["In Review", "In Progress"]
+allowed_from: []
 mode: strict
 fallback: REVISE
 cooldown_minutes: 5

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -198,7 +198,7 @@ The bouncer gate uses the enrichment hash for a fast-path: if the hash matches t
 | `enrichment-gate` | Todo | Backlog | advise | REVISE | 3 | - | high | no |
 | `bouncer-gate` | Ready for Agent | Todo | advise (planned: strict) | REVISE | - | Todo | medium | no |
 | `output-quality-gate` | In Review | Agent Working | strict | REVISE | - | Ready for Agent | medium | yes |
-| `completion-gate` | Done | In Review | strict | REVISE | - | fromState | medium | yes |
+| `completion-gate` | Done | (any) | strict | REVISE | - | fromState | medium | yes |
 
 ## Triggers and Loop-Break Mechanisms
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # LIA-97: agent working sweep
+last_verified: "2026-05-26" # completion-gate: allow Done from any state
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-25" # auto-bump
+last_verified: "2026-05-26" # completion-gate: allow Done from any state
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # completion-honesty dimension added
+last_verified: "2026-05-26" # completion-gate: allow Done from any state
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -210,6 +210,15 @@ Minimal gate.`,
     const spec = specs.get('Done')!;
     expect(spec.revertTo).toBeUndefined();
   });
+
+  it('completion-gate allows Done from any state (empty allowedFrom)', () => {
+    const realDir = path.join(process.cwd(), '.claude', 'agents', 'wardens');
+    const specs = loadGateSpecs(realDir);
+    const spec = specs.get('Done');
+    expect(spec).toBeDefined();
+    expect(spec!.name).toBe('completion-gate');
+    expect(spec!.allowedFrom).toEqual([]);
+  });
 });
 
 describe('parseEnrichment', () => {


### PR DESCRIPTION
## Summary

- Remove `allowed_from` restriction from completion-gate so Done is reachable from any state
- Gate agent still runs content evaluation (acceptance criteria, PR check) -- only the source-state check is removed
- Update ADR table to reflect the change

## Motivation

During batch triage, issues resolved out-of-band (via MCP API updates) got bounced back by the completion-gate's `allowed_from: ["In Review", "In Progress"]` restriction. This created revert cascades: completion-gate reverts Done->Todo, then enrichment-gate fires on the Done->Todo revert and REVISEs again.

Done is a terminal state -- the gate's content-based checks are the real quality gate, not the source state. The `Done: Pre-implemented` label bypass and `warden:skip` still work for fast triage closures.

## Test plan

- [x] New test confirms completion-gate loads with empty `allowedFrom`
- [x] `npm run build` passes
- [x] `npm test` -- all 1583 tests pass (48/48 in webhook test file)
- [x] `npm run drift-check` -- all checks pass
- [ ] Manual: move a Todo issue to Done in Linear -- should NOT get instant-reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)