### PR TITLE
feat(pipeline): auto-apply container agent patches on the host

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # completion-gate: allow Done from any state
+last_verified: "2026-05-26" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # completion-gate: allow Done from any state
+last_verified: "2026-05-26" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -3,6 +3,34 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
+const execFileMock = vi.fn();
+
+vi.mock('child_process', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('child_process')>();
+  const { promisify } = await import('util');
+  type ExecFileCb = (err: Error | null, stdout: string, stderr: string) => void;
+  const mockFn = vi.fn((...args: unknown[]) => {
+    const cb = args[args.length - 1];
+    if (typeof cb === 'function') {
+      const result = execFileMock(args[0], args[1]);
+      if (result?.error) (cb as ExecFileCb)(result.error, '', '');
+      else (cb as ExecFileCb)(null, result?.stdout ?? '', result?.stderr ?? '');
+    }
+  });
+  // promisify(execFile) uses a custom symbol to return { stdout, stderr }
+  (mockFn as unknown as Record<symbol, unknown>)[promisify.custom] = (
+    ...args: unknown[]
+  ) => {
+    const result = execFileMock(args[0], args[1]);
+    if (result?.error) return Promise.reject(result.error);
+    return Promise.resolve({
+      stdout: result?.stdout ?? '',
+      stderr: result?.stderr ?? '',
+    });
+  };
+  return { ...orig, execFile: mockFn };
+});
+
 vi.mock('./config.js', async () => {
   const actual =
     await vi.importActual<typeof import('./config.js')>('./config.js');
@@ -25,6 +53,10 @@ vi.mock('./db.js', () => ({
   getOpenPrsForActiveIssues: vi.fn().mockReturnValue([]),
 }));
 
+vi.mock('./linear-notifications.js', () => ({
+  notifyPipelineStep: vi.fn().mockResolvedValue(undefined),
+}));
+
 const TEST_PROJECT_ROOT = path.join(os.tmpdir(), `deus-test-${process.pid}`);
 
 import {
@@ -34,6 +66,7 @@ import {
   stopLinearDispatcher,
   truncateComments,
   extractScopeBlock,
+  applyPatchArtifact,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
@@ -426,5 +459,308 @@ Quality feedback here
     const desc =
       '<!-- gate:agent-readiness-gate:end -->before<!-- gate:agent-readiness-gate:start -->';
     expect(extractScopeBlock(desc)).toBe(desc);
+  });
+});
+
+describe('applyPatchArtifact', () => {
+  const patchGroupDir = path.join(
+    TEST_PROJECT_ROOT,
+    'groups',
+    'linear-dispatch',
+  );
+  const createComment = vi.fn().mockResolvedValue({});
+
+  function patchCtx(): LinearContext {
+    return makeMockCtx({
+      client: {
+        createComment,
+        updateIssue: vi.fn().mockResolvedValue({}),
+      } as unknown as LinearContext['client'],
+      repoSlug: 'test/repo',
+    });
+  }
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    createComment.mockClear();
+    fs.mkdirSync(patchGroupDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(patchGroupDir, { recursive: true, force: true });
+  });
+
+  it('returns no-op when no patch files exist', async () => {
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no-op when group dir does not exist', async () => {
+    const result = await applyPatchArtifact(
+      '/nonexistent/dir',
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+  });
+
+  it('skips .applied patch files', async () => {
+    fs.writeFileSync(
+      path.join(patchGroupDir, 'LIA-99.patch.applied'),
+      'old patch',
+    );
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+  });
+
+  it('refuses when not on main branch', async () => {
+    fs.writeFileSync(
+      path.join(patchGroupDir, 'LIA-99.patch'),
+      'diff --git ...',
+    );
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse')
+        return { stdout: 'feat/other\n' };
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('not `main`'),
+      }),
+    );
+  });
+
+  it('refuses when working tree is dirty', async () => {
+    fs.writeFileSync(
+      path.join(patchGroupDir, 'LIA-99.patch'),
+      'diff --git ...',
+    );
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status')
+        return { stdout: 'M src/foo.ts\n' };
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('uncommitted changes'),
+      }),
+    );
+  });
+
+  it('succeeds via git am when patch is mbox format', async () => {
+    const patchPath = path.join(patchGroupDir, 'LIA-99.patch');
+    fs.writeFileSync(patchPath, 'From abc123\nSubject: fix\n\ndiff --git ...');
+
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am') return { stdout: '' };
+      if (cmd === 'npm') return { stdout: '' };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/10\n' };
+      return { stdout: '' };
+    });
+
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+    expect(result).toEqual({
+      prUrl: 'https://github.com/test/repo/pull/10',
+      applied: true,
+    });
+    // git apply should NOT have been called (am succeeded)
+    const applyCalls = execFileMock.mock.calls.filter(
+      (c: unknown[]) => c[0] === 'git' && (c[1] as string[])[0] === 'apply',
+    );
+    expect(applyCalls).toHaveLength(0);
+  });
+
+  it('applies patch, builds, pushes, creates PR on success', async () => {
+    const patchPath = path.join(patchGroupDir, 'LIA-99.patch');
+    fs.writeFileSync(patchPath, 'diff --git a/foo b/foo');
+    fs.writeFileSync(
+      path.join(patchGroupDir, 'LIA-99-status.md'),
+      '```bash\ngit commit -m "fix: resolve scheduled task exit"\n```',
+    );
+
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'pull') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'checkout') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'git' && args[0] === 'apply') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'add') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'commit') return { stdout: '' };
+      if (cmd === 'npm' && args[0] === 'run') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'push') return { stdout: '' };
+      if (cmd === 'gh' && args[0] === 'pr')
+        return { stdout: 'https://github.com/test/repo/pull/42\n' };
+      return { stdout: '' };
+    });
+
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+    expect(result).toEqual({
+      prUrl: 'https://github.com/test/repo/pull/42',
+      applied: true,
+    });
+    expect(fs.existsSync(patchPath)).toBe(false);
+    expect(fs.existsSync(patchPath + '.applied')).toBe(true);
+  });
+
+  it('parses commit message from status file', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    fs.writeFileSync(
+      path.join(patchGroupDir, 'LIA-99-status.md'),
+      'some text\ngit commit -m "my custom message"\nmore text',
+    );
+
+    const commitArgs: string[][] = [];
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'git' && args[0] === 'commit') {
+        commitArgs.push([...args]);
+        return { stdout: '' };
+      }
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    await applyPatchArtifact(patchGroupDir, 'LIA-99', 'issue-id', patchCtx());
+    expect(commitArgs[0]).toContain('my custom message');
+  });
+
+  it('posts comment and cleans up on build failure', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'npm' && args[0] === 'run')
+        return { error: new Error('tsc: error TS2345') };
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('build failed'),
+      }),
+    );
+  });
+
+  it('posts comment and cleans up on git apply failure', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'git' && args[0] === 'apply')
+        return { error: new Error('patch does not apply') };
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('git apply'),
+      }),
+    );
+  });
+
+  it('leaves branch on gh pr create failure', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+
+    const gitCalls: Array<{ cmd: string; args: string[] }> = [];
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      gitCalls.push({ cmd, args: [...args] });
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh') return { error: new Error('auth required') };
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('create PR manually'),
+      }),
+    );
+    // Should NOT delete branch (push succeeded)
+    const branchDeletes = gitCalls.filter(
+      (c) => c.cmd === 'git' && c.args[0] === 'branch' && c.args[1] === '-D',
+    );
+    expect(branchDeletes).toHaveLength(0);
   });
 });

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -57,6 +57,11 @@ vi.mock('./linear-notifications.js', () => ({
   notifyPipelineStep: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('./platform.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('./platform.js')>();
+  return { ...orig, IS_MACOS: true, IS_LINUX: false };
+});
+
 const TEST_PROJECT_ROOT = path.join(os.tmpdir(), `deus-test-${process.pid}`);
 
 import {

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -1,5 +1,7 @@
+import { execFile } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { promisify } from 'util';
 import { LinearClient } from '@linear/sdk';
 import { DATA_DIR, HOME_DIR, GROUPS_DIR } from './config.js';
 import { parse as parseYaml } from 'yaml';
@@ -8,6 +10,7 @@ import { PROJECT_ROOT } from './config.js';
 import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
 import { fireAndForget } from './async/index.js';
+import { IS_MACOS, IS_LINUX } from './platform.js';
 import { extractPrUrl } from './pr-url-extractor.js';
 import { queryPrState, checkConflictingPrs } from './linear-auto-merge.js';
 import {
@@ -32,11 +35,16 @@ import type { RuntimeRegistry } from './agent-runtimes/registry.js';
 import type { GroupQueue } from './group-queue.js';
 import type { RegisteredGroup } from './types.js';
 
+const execFileAsync = promisify(execFile);
+
 const DEFAULT_POLL_MS = 30_000;
 const DISPATCH_GROUP_JID = 'linear-dispatch';
 const BACKOFF_FIRST_MS = 5 * 60_000;
 const BACKOFF_REPEAT_MS = 10 * 60_000;
 const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
+const GIT_TIMEOUT_MS = 30_000;
+const BUILD_TIMEOUT_MS = 120_000;
+const PUSH_TIMEOUT_MS = 120_000;
 
 export interface LinearDispatcherDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
@@ -92,6 +100,8 @@ let _timer: ReturnType<typeof setInterval> | null = null;
 let _tick: (() => void) | null = null;
 let _roleSpecs: Map<string, RoleSpec> = new Map();
 let _ctx: LinearContext | null = null;
+// Promise-chain serializer — same pattern as commentLocks in linear-notifications.ts
+let _patchMutex: Promise<void> = Promise.resolve();
 
 export function extractFrontmatter(content: string): {
   data: Record<string, unknown>;
@@ -449,6 +459,276 @@ export async function executeAgentRun(
   return { text: result, error };
 }
 
+function parseCommitMessage(groupDir: string, identifier: string): string {
+  const statusFile = path.join(groupDir, `${identifier}-status.md`);
+  try {
+    if (fs.existsSync(statusFile)) {
+      const content = fs.readFileSync(statusFile, 'utf-8');
+      const match = content.match(/git commit -m "([^"]+)"/);
+      if (match) return match[1];
+    }
+  } catch {
+    /* best-effort */
+  }
+  return `${identifier}: auto-apply patch artifact`;
+}
+
+export async function applyPatchArtifact(
+  groupDir: string,
+  identifier: string,
+  issueId: string,
+  ctx: LinearContext,
+): Promise<{ prUrl: string | null; applied: boolean }> {
+  const noResult = { prUrl: null, applied: false };
+  const gitOpts = { cwd: PROJECT_ROOT, timeout: GIT_TIMEOUT_MS };
+
+  if (!(IS_MACOS || IS_LINUX)) return noResult;
+  if (!fs.existsSync(groupDir)) return noResult;
+
+  const patchFiles = fs
+    .readdirSync(groupDir)
+    .filter(
+      (f) =>
+        f.startsWith(identifier) &&
+        f.endsWith('.patch') &&
+        !f.endsWith('.applied') &&
+        path.basename(f) === f,
+    );
+
+  if (patchFiles.length === 0) return noResult;
+
+  if (patchFiles.length > 1) {
+    logger.info(
+      { identifier, count: patchFiles.length },
+      'patch-applicator: multiple patches found, using newest',
+    );
+  }
+
+  const sorted = patchFiles
+    .map((f) => ({
+      name: f,
+      mtime: fs.statSync(path.join(groupDir, f)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime);
+  const patchFileName = sorted[0].name;
+  const patchFilePath = path.join(groupDir, patchFileName);
+  const patchRelPath = path.relative(PROJECT_ROOT, patchFilePath);
+  const commitMessage = parseCommitMessage(groupDir, identifier);
+  const branchName = `feat/${identifier.toLowerCase()}-auto-patch`;
+
+  // Acquire mutex
+  const prev = _patchMutex;
+  let releaseMutex!: () => void;
+  _patchMutex = new Promise<void>((r) => {
+    releaseMutex = r;
+  });
+  await prev;
+
+  // Global serialization: a slow build blocks other patches, but concurrent
+  // git operations on one working tree corrupt state. Acceptable for the
+  // expected throughput (1-2 patches/hour).
+  async function cleanup(deleteBranch: boolean): Promise<void> {
+    try {
+      await execFileAsync('git', ['checkout', 'main'], gitOpts);
+      if (deleteBranch) {
+        await execFileAsync('git', ['branch', '-D', branchName], gitOpts);
+      }
+    } catch {
+      // Checkout failure leaves HEAD on feat branch; next mutex holder re-checks branch
+      /* best-effort */
+    }
+    releaseMutex();
+  }
+
+  try {
+    // Branch safety: refuse if not on main
+    const { stdout: currentBranch } = await execFileAsync(
+      'git',
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      gitOpts,
+    );
+    if (currentBranch.trim() !== 'main') {
+      await ctx.client.createComment({
+        issueId,
+        body: `**Patch auto-apply skipped** — working tree is on branch \`${currentBranch.trim()}\`, not \`main\`.\n\nApply manually:\n\`\`\`bash\ngit apply ${patchRelPath}\n\`\`\``,
+      });
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        identifier,
+        'patch_failed',
+        'not on main',
+      ).catch(() => {});
+      releaseMutex();
+      return noResult;
+    }
+
+    // Dirty tree check
+    const { stdout: status } = await execFileAsync(
+      'git',
+      ['status', '--porcelain'],
+      gitOpts,
+    );
+    if (status.trim()) {
+      await ctx.client.createComment({
+        issueId,
+        body: `**Patch auto-apply skipped** — working tree has uncommitted changes.\n\nApply manually:\n\`\`\`bash\ngit apply ${patchRelPath}\n\`\`\``,
+      });
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        identifier,
+        'patch_failed',
+        'dirty tree',
+      ).catch(() => {});
+      releaseMutex();
+      return noResult;
+    }
+
+    // Pull latest main
+    await execFileAsync('git', ['pull', '--ff-only'], gitOpts);
+
+    // Create feature branch (-B creates or resets)
+    await execFileAsync('git', ['checkout', '-B', branchName], gitOpts);
+
+    // Try git am first (for format-patch output), fall back to git apply
+    let applied = false;
+    try {
+      await execFileAsync('git', ['am', patchFilePath], {
+        ...gitOpts,
+        timeout: 60_000,
+      });
+      applied = true;
+    } catch {
+      try {
+        await execFileAsync('git', ['am', '--abort'], gitOpts);
+      } catch {
+        /* may not be in am state */
+      }
+
+      try {
+        await execFileAsync('git', ['apply', patchFilePath], {
+          ...gitOpts,
+          timeout: 60_000,
+        });
+        await execFileAsync('git', ['add', '-A'], gitOpts);
+        await execFileAsync('git', ['commit', '-m', commitMessage], gitOpts);
+        applied = true;
+      } catch (applyErr) {
+        const stderr =
+          applyErr instanceof Error ? applyErr.message : String(applyErr);
+        await ctx.client.createComment({
+          issueId,
+          body: `**Patch auto-apply failed** — \`git apply\` returned an error:\n\n\`\`\`\n${stderr.slice(0, 2000)}\n\`\`\`\n\nApply manually: \`git apply ${patchRelPath}\``,
+        });
+        notifyPipelineStep(
+          ctx,
+          issueId,
+          identifier,
+          'patch_failed',
+          'git apply failed',
+        ).catch(() => {});
+        await cleanup(true);
+        return noResult;
+      }
+    }
+
+    if (!applied) {
+      await cleanup(true);
+      return noResult;
+    }
+
+    // Build verification
+    try {
+      await execFileAsync('npm', ['run', 'build'], {
+        cwd: PROJECT_ROOT,
+        timeout: BUILD_TIMEOUT_MS,
+      });
+    } catch (buildErr) {
+      const stderr =
+        buildErr instanceof Error ? buildErr.message : String(buildErr);
+      await ctx.client.createComment({
+        issueId,
+        body: `**Patch applied but build failed** — \`npm run build\` exited with error:\n\n\`\`\`\n${stderr.slice(0, 2000)}\n\`\`\`\n\nBranch \`${branchName}\` has been deleted. Fix build errors and reapply.`,
+      });
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        identifier,
+        'patch_failed',
+        'build failed',
+      ).catch(() => {});
+      await cleanup(true);
+      return noResult;
+    }
+
+    // Push
+    await execFileAsync('git', ['push', '-u', 'origin', 'HEAD'], {
+      ...gitOpts,
+      timeout: PUSH_TIMEOUT_MS,
+    });
+
+    // Create PR
+    let prUrl: string | null = null;
+    try {
+      const { stdout: prOutput } = await execFileAsync(
+        'gh',
+        [
+          'pr',
+          'create',
+          '--title',
+          `feat(${identifier}): auto-apply patch`,
+          '--body',
+          `Auto-applied from ${patchFileName}\n\nRef: ${identifier}`,
+        ],
+        { ...gitOpts, timeout: 60_000 },
+      );
+      prUrl = extractPrUrl(prOutput, ctx.repoSlug) ?? prOutput.trim();
+    } catch (prErr) {
+      // Push succeeded — leave branch for manual PR creation
+      const stderr = prErr instanceof Error ? prErr.message : String(prErr);
+      await ctx.client.createComment({
+        issueId,
+        body: `**Patch applied and pushed** but \`gh pr create\` failed:\n\n\`\`\`\n${stderr.slice(0, 1000)}\n\`\`\`\n\nBranch \`${branchName}\` is pushed — create PR manually.`,
+      });
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        identifier,
+        'patch_failed',
+        'gh pr create failed',
+      ).catch(() => {});
+      await cleanup(false);
+      return noResult;
+    }
+
+    // Success — rename patch, notify, return
+    try {
+      fs.renameSync(patchFilePath, patchFilePath + '.applied');
+    } catch {
+      /* best-effort */
+    }
+
+    notifyPipelineStep(ctx, issueId, identifier, 'patch_applied', prUrl).catch(
+      () => {},
+    );
+    logger.info(
+      { issueId, prUrl, patchFileName },
+      'patch-applicator: PR created from patch artifact',
+    );
+
+    await cleanup(false);
+    return { prUrl, applied: true };
+  } catch (err) {
+    logger.warn(
+      { issueId, err },
+      'patch-applicator: unexpected error during patch application',
+    );
+    await cleanup(true);
+    return noResult;
+  }
+}
+
 // Checks live PR state via gh CLI and routes the issue accordingly.
 // DB-first in triageIssue avoids the API call when we already know the answer;
 // this function only runs when the DB record is stale or absent.
@@ -607,7 +887,28 @@ async function runIssue(
       }
     } else {
       const body = text || '(no output produced)';
-      const prUrl = extractPrUrl(body, ctx.repoSlug);
+      let prUrl = extractPrUrl(body, ctx.repoSlug);
+
+      if (!prUrl) {
+        try {
+          const groupDir = path.join(GROUPS_DIR, DISPATCH_GROUP_JID);
+          const patchResult = await applyPatchArtifact(
+            groupDir,
+            identifier,
+            issueId,
+            ctx,
+          );
+          if (patchResult.applied && patchResult.prUrl) {
+            prUrl = patchResult.prUrl;
+          }
+        } catch (patchErr) {
+          logger.warn(
+            { issueId, patchErr },
+            'linear-dispatcher: patch application failed',
+          );
+        }
+      }
+
       if (prUrl) {
         upsertIssuePr(issueId, prUrl, undefined, identifier);
         logger.info({ issueId, prUrl }, 'linear-dispatcher: persisted PR URL');

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -55,6 +55,8 @@ export const EVENT_LABELS: Record<string, string> = {
   state_changed: 'State changed',
   circuit_breaker_tripped: 'Circuit breaker tripped',
   circuit_breaker_reset: 'Circuit breaker reset',
+  patch_applied: 'Patch applied',
+  patch_failed: 'Patch apply failed',
 };
 
 export function buildPipelineCommentBody(


### PR DESCRIPTION
## Summary

- Adds `applyPatchArtifact()` to `src/linear-dispatcher.ts` — scans the group directory for `.patch` files after a container agent completes and auto-creates a PR
- Integrates into `runIssue()` success path: if the agent didn't produce a PR URL, checks for patch artifacts
- Supports both `git format-patch` (via `git am`) and raw `git diff` (via `git apply` fallback)
- Build verification (`npm run build`) runs before pushing — broken patches don't become PRs
- All failure paths post descriptive Linear comments with manual recovery instructions
- Promise-chain mutex serializes concurrent patch applications on the shared working tree
- Platform guard (macOS/Linux only), path traversal prevention, branch safety check (must be on main)

## Test plan

- [x] `npm run build` passes
- [x] 31/31 tests pass (`npx vitest run src/linear-dispatcher.test.ts`)
- [x] Prettier clean on all 3 changed files
- [x] Tests cover: no patch (no-op), git am success, git apply fallback success, build failure, apply failure, not-on-main, dirty tree, gh pr create failure, .applied skip

Closes LIA-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)