### PR TITLE
fix: use surrogate-safe string slicing for task prompts

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -13,6 +13,18 @@ import { CronExpressionParser } from 'cron-parser';
 
 import { VALID_BACKENDS } from './tool-broker.js';
 
+// Iterate by code point to avoid splitting UTF-16 surrogate pairs (emoji crash on Anthropic API).
+function safeSlice(str: string, maxCodePoints: number): string {
+  let result = '';
+  let count = 0;
+  for (const ch of str) {
+    if (count >= maxCodePoints) break;
+    result += ch;
+    count++;
+  }
+  return result;
+}
+
 const IPC_DIR = '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
@@ -259,7 +271,7 @@ server.tool(
             status: string;
             next_run: string;
           }) =>
-            `- [${t.id}] ${t.prompt.slice(0, 50)}... (${t.schedule_type}: ${t.schedule_value}) - ${t.status}, next: ${t.next_run || 'N/A'}`,
+            `- [${t.id}] ${safeSlice(t.prompt, 50)}... (${t.schedule_type}: ${t.schedule_value}) - ${t.status}, next: ${t.next_run || 'N/A'}`,
         )
         .join('\n');
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -4,6 +4,7 @@ import { _initTestDatabase, createTask, getTaskById } from './db.js';
 import {
   _resetSchedulerLoopForTests,
   computeNextRun,
+  safeSlice,
   startSchedulerLoop,
 } from './task-scheduler.js';
 import type {
@@ -518,5 +519,30 @@ describe('startSchedulerLoop execution path', () => {
       backend: 'claude',
       session_id: 'claude-session-next',
     });
+  });
+});
+
+describe('safeSlice', () => {
+  it('slices ASCII strings normally', () => {
+    expect(safeSlice('hello world', 5)).toBe('hello');
+  });
+
+  it('preserves emoji code points at boundary', () => {
+    expect(safeSlice('hello 🎉🎊 world', 8)).toBe('hello 🎉🎊');
+  });
+
+  it('does not split surrogate pairs', () => {
+    const emoji50 = '🎉'.repeat(50);
+    const sliced = safeSlice(emoji50, 25);
+    expect(sliced).toBe('🎉'.repeat(25));
+    expect([...sliced]).toHaveLength(25);
+  });
+
+  it('handles empty string', () => {
+    expect(safeSlice('', 10)).toBe('');
+  });
+
+  it('returns full string when shorter than limit', () => {
+    expect(safeSlice('short', 100)).toBe('short');
   });
 });

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -1,6 +1,18 @@
 import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
 
+// Iterate by code point to avoid splitting UTF-16 surrogate pairs (emoji crash on Anthropic API).
+export function safeSlice(str: string, maxCodePoints: number): string {
+  let result = '';
+  let count = 0;
+  for (const ch of str) {
+    if (count >= maxCodePoints) break;
+    result += ch;
+    count++;
+  }
+  return result;
+}
+
 import { fireAndForget } from './async/index.js';
 import {
   defaultSession,
@@ -255,7 +267,7 @@ async function runTask(
   const resultSummary = error
     ? `Error: ${error}`
     : result
-      ? result.slice(0, 200)
+      ? safeSlice(result, 200)
       : 'Completed';
   updateTaskAfterRun(task.id, nextRun, resultSummary);
 }


### PR DESCRIPTION
## Summary
- Replace `String.prototype.slice()` with `safeSlice()` that iterates by Unicode code point, preventing surrogate pair splitting
- Primary fix: `ipc-mcp-stdio.ts:262` (`list_tasks` MCP tool truncation)
- Secondary fix: `task-scheduler.ts:258` (task result summary truncation)
- 5 unit tests for `safeSlice` including emoji boundary cases

Note: `safeSlice` is duplicated across host and container packages (separate `tsconfig.json`, no cross-imports). Consolidation deferred to a future `packages/` utility.

Closes #577

## Test plan
- [x] `npx vitest run src/task-scheduler -t safeSlice` — 5/5 pass
- [x] `npx tsc --noEmit` in `container/agent-runner/` — 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)