### PR TITLE
fix(session): break stale session retry storm on dead conversations

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1306,12 +1306,15 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
+    // Claude SDK throws "No conversation found" when session ID no longer exists server-side.
+    // Mirrored in src/message-orchestrator.ts — update both if the SDK message changes.
+    const isStaleSession = errorMessage.includes('No conversation found');
     log(`Agent error: ${errorMessage}`);
     writeOutput({
       status: 'error',
       result: null,
-      newSessionRef: defaultSession(sessionId),
-      newSessionId: sessionId,
+      newSessionRef: isStaleSession ? undefined : defaultSession(sessionId),
+      newSessionId: isStaleSession ? undefined : sessionId,
       error: errorMessage,
     });
     throw err instanceof Error ? err : new Error(errorMessage);

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -2,7 +2,7 @@
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-26T22" # LIA-94-remaining
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-26" # auto-bump
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/agent-runtimes/container-backend.ts
+++ b/src/agent-runtimes/container-backend.ts
@@ -65,7 +65,7 @@ export class ContainerRuntime implements AgentRuntime {
       if (output.result) {
         await eventSink({ type: 'output_text', text: output.result });
       }
-      if (output.newSessionRef || output.newSessionId) {
+      if ((output.newSessionRef || output.newSessionId) && output.status !== 'error') {
         const ref =
           output.newSessionRef ??
           defaultSession(output.newSessionId!, this.backendName);

--- a/src/agent-runtimes/container-backend.ts
+++ b/src/agent-runtimes/container-backend.ts
@@ -65,7 +65,10 @@ export class ContainerRuntime implements AgentRuntime {
       if (output.result) {
         await eventSink({ type: 'output_text', text: output.result });
       }
-      if ((output.newSessionRef || output.newSessionId) && output.status !== 'error') {
+      if (
+        (output.newSessionRef || output.newSessionId) &&
+        output.status !== 'error'
+      ) {
         const ref =
           output.newSessionRef ??
           defaultSession(output.newSessionId!, this.backendName);

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -145,7 +145,7 @@ vi.mock('fs', async () => {
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
 import { createMessageOrchestrator } from './message-orchestrator.js';
-import { getMessagesSince, getNewMessages } from './db.js';
+import { getMessagesSince, getNewMessages, clearSession, setSession } from './db.js';
 import { findChannel } from './router.js';
 import {
   handleSessionCommand,
@@ -381,6 +381,41 @@ describe('processGroupMessages', () => {
       'group@g.us',
       'ts-prev',
     );
+  });
+
+  it('clears stale session on "No conversation found" error instead of persisting it', async () => {
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+
+    const mockClearSession = vi.mocked(clearSession);
+    const mockSetSession = vi.mocked(setSession);
+    mockClearSession.mockClear();
+    mockSetSession.mockClear();
+    state.clearSession.mockClear();
+    state.setSession.mockClear();
+
+    activeRunTurn = async () => ({
+      status: 'error',
+      result: null,
+      error: 'No conversation found with session ID: abc123',
+      sessionRef: { backend: 'claude' as const, session_id: 'abc123' },
+    });
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(false);
+    expect(mockClearSession).toHaveBeenCalledWith('whatsapp_main', 'claude');
+    expect(state.clearSession).toHaveBeenCalledWith('whatsapp_main', 'claude');
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(state.setSession).not.toHaveBeenCalled();
   });
 
   it('does NOT roll back cursor when output was already sent to the user', async () => {

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -145,7 +145,12 @@ vi.mock('fs', async () => {
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
 import { createMessageOrchestrator } from './message-orchestrator.js';
-import { getMessagesSince, getNewMessages, clearSession, setSession } from './db.js';
+import {
+  getMessagesSince,
+  getNewMessages,
+  clearSession,
+  setSession,
+} from './db.js';
 import { findChannel } from './router.js';
 import {
   handleSessionCommand,

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -213,17 +213,22 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
         eventSink,
       );
 
-      if (runResult.sessionRef) {
-        state.setSession(group.folder, runResult.sessionRef);
-        setSession(group.folder, runResult.sessionRef);
-      }
-
       if (runResult.status === 'error') {
+        // Claude SDK error for dead sessions. Mirrored in container/agent-runner/src/index.ts.
+        if (runResult.error?.includes('No conversation found')) {
+          clearSession(group.folder, backend);
+          state.clearSession(group.folder, backend);
+        }
         logger.error(
           { group: group.name, error: runResult.error },
           'Container agent error',
         );
         return 'error';
+      }
+
+      if (runResult.sessionRef) {
+        state.setSession(group.folder, runResult.sessionRef);
+        setSession(group.folder, runResult.sessionRef);
       }
 
       return 'success';


### PR DESCRIPTION
## Summary
- **Layer 1** (agent-runner): Detect "No conversation found" in catch block, omit stale session ID from error output
- **Layer 2** (container-backend): Don't emit session events from error outputs — general behavioral fix
- **Layer 3** (orchestrator): Reorder error check before session write; clear session on stale-session errors

Root cause: when Claude SDK throws for a dead session, the stale ID was echoed back and re-persisted, causing 5x exponential backoff retry storms per message indefinitely.

Requires container rebuild: `./container/build.sh`

Closes #581

## Test plan
- [x] New test: "clears stale session on 'No conversation found' error" — asserts clearSession called, setSession NOT called
- [x] `npx vitest run src/message-orchestrator` — 20/20 pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)