### PR TITLE
docs: add missing environment variables to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ X_API_KEY=
 X_API_SECRET=
 X_ACCESS_TOKEN=
 X_ACCESS_TOKEN_SECRET=
+DISCORD_BOT_TOKEN=
+SLACK_APP_TOKEN=
+SLACK_BOT_TOKEN=
+# GMAIL_CREDENTIALS_DIR=
 ASSISTANT_NAME=Deus
 ASSISTANT_HAS_OWN_NUMBER=false
 
@@ -23,6 +27,10 @@ DEUS_CONTEXT_FILE_MAX_CHARS=20000
 OPENAI_API_KEY=
 OPENAI_BASE_URL=
 GEMINI_API_KEY=
+# ANTHROPIC_API_KEY=
+# Ollama (used for embeddings and judge by default)
+# OLLAMA_URL=http://localhost:11434
+# OLLAMA_MODEL=
 
 # llama.cpp local backend (set DEUS_AGENT_BACKEND=llama-cpp to use).
 # Install + run llama-server on the host via /add-llama-cpp skill first.
@@ -32,6 +40,19 @@ GEMINI_API_KEY=
 LLAMA_CPP_BASE_URL=
 LLAMA_CPP_PORT=8080
 LLAMA_CPP_MODEL=
+# Per-surface llama.cpp model overrides (fall back to LLAMA_CPP_MODEL)
+# LLAMA_CPP_AGENT_MODEL=
+# LLAMA_CPP_GEN_MODEL=
+# LLAMA_CPP_JUDGE_MODEL=
+# LLAMA_CPP_EMBED_MODEL=
+# LLAMA_CPP_CONTEXT_WINDOW=32768
+# LLAMA_CPP_API_KEY=
+# Agent effort level (low/medium/high)
+# DEUS_AGENT_EFFORT=
+# Auth provider override (default: auto)
+# DEUS_AUTH_PROVIDER=
+# Evolution Python binary (default: python3)
+# EVOLUTION_PYTHON=python3
 
 # === Voice Transcription ===
 WHISPER_LANG=en
@@ -94,6 +115,11 @@ LINEAR_API_TOKEN=
 # WEBHOOK_MAX_RETRIES=3
 # Base delay in ms for webhook retry backoff: min(base * 2^attempt + jitter, 30000) (default: 1000)
 # WEBHOOK_BASE_DELAY_MS=1000
+# Hook dispatch (Linear webhook pipeline)
+# HOOK_DISPATCH_ENABLED=0
+# HOOK_DISPATCH_PORT=3005
+# Tool proxy port (credential proxy for container agents)
+# TOOL_PROXY_PORT=3001
 
 # === GitHub ===
 # Personal access token for gh CLI (tool proxy injects into container agent calls)
@@ -105,5 +131,18 @@ LINEAR_API_TOKEN=
 # Max characters per incoming message (truncates, doesn't reject)
 MAX_MESSAGE_LENGTH=50000
 
+# === Injection Scanner ===
+# DEUS_INJECTION_SCANNER=0
+# DEUS_INJECTION_SCANNER_THRESHOLD=0.7
+# DEUS_INJECTION_SCANNER_LOG_ONLY=1
+
+# === Session ===
+# Hours of idle before resetting agent session (0=disabled)
+# SESSION_IDLE_RESET_HOURS=8
+
 # === Logging ===
 LOG_LEVEL=info
+# DEUS_TOOL_AUDIT_LOG=0
+# DEUS_TOOL_SIZE_LOG=0
+# DEUS_USAGE_LOG=0
+# DEUS_LISTEN_NO_CLIPBOARD=0


### PR DESCRIPTION
## Summary
- Add ~30 missing user-configurable env vars across 6 categories
- Channels: Discord, Slack, Gmail tokens
- AI: Anthropic, Ollama, llama.cpp per-surface overrides, agent effort
- Safety: injection scanner config
- Session: idle reset hours
- Integrations: hook dispatch, tool proxy
- Logging: audit/size/usage logs

Closes #50

## Test plan
- [x] No code changes — documentation only
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)