### PR TITLE
test: add unit tests for router.ts pure functions

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-27" # auto-bump
+last_verified: "2026-05-27"
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-27" # auto-bump
+last_verified: "2026-05-27"
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -90,7 +90,8 @@ describe('stripInternalTags', () => {
   });
 
   it('strips multiple and multiline internal blocks', () => {
-    const input = 'start<internal>\nline1\nline2\n</internal>middle<internal>x</internal>end';
+    const input =
+      'start<internal>\nline1\nline2\n</internal>middle<internal>x</internal>end';
     expect(stripInternalTags(input)).toBe('startmiddleend');
   });
 });

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  escapeXml,
+  formatMessages,
+  formatOutbound,
+  stripInternalTags,
+} from './router.js';
+
+describe('escapeXml', () => {
+  it('returns empty string for falsy input', () => {
+    expect(escapeXml('')).toBe('');
+  });
+
+  it('escapes XML special characters', () => {
+    expect(escapeXml('&')).toBe('&amp;');
+    expect(escapeXml('<')).toBe('&lt;');
+    expect(escapeXml('>')).toBe('&gt;');
+    expect(escapeXml('"')).toBe('&quot;');
+  });
+
+  it('escapes multiple special chars in one string', () => {
+    expect(escapeXml('<b>"Tom & Jerry"</b>')).toBe(
+      '&lt;b&gt;&quot;Tom &amp; Jerry&quot;&lt;/b&gt;',
+    );
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeXml('hello world')).toBe('hello world');
+  });
+});
+
+describe('formatMessages', () => {
+  it('produces header and empty messages block for empty array', () => {
+    const result = formatMessages([], 'UTC');
+    expect(result).toContain('<context timezone="UTC" />');
+    expect(result).toContain('<messages>');
+    expect(result).toContain('</messages>');
+  });
+
+  it('formats a single message with correct XML structure', () => {
+    const result = formatMessages(
+      [
+        {
+          id: '1',
+          chat_jid: 'g@g.us',
+          sender: 'alice@s.whatsapp.net',
+          sender_name: 'Alice',
+          content: 'hello',
+          timestamp: '2026-01-15T12:00:00.000Z',
+          is_from_me: false,
+          is_bot_message: false,
+        },
+      ],
+      'UTC',
+    );
+    expect(result).toContain('sender="Alice"');
+    expect(result).toContain('>hello</message>');
+  });
+
+  it('escapes XML special chars in sender name', () => {
+    const result = formatMessages(
+      [
+        {
+          id: '1',
+          chat_jid: 'g@g.us',
+          sender: 'bob@s.whatsapp.net',
+          sender_name: 'Tom & Jerry',
+          content: 'hi',
+          timestamp: '2026-01-15T12:00:00.000Z',
+          is_from_me: false,
+          is_bot_message: false,
+        },
+      ],
+      'UTC',
+    );
+    expect(result).toContain('sender="Tom &amp; Jerry"');
+  });
+});
+
+describe('stripInternalTags', () => {
+  it('returns trimmed original when no tags present', () => {
+    expect(stripInternalTags('  hello world  ')).toBe('hello world');
+  });
+
+  it('strips single internal block', () => {
+    expect(stripInternalTags('before<internal>secret</internal>after')).toBe(
+      'beforeafter',
+    );
+  });
+
+  it('strips multiple and multiline internal blocks', () => {
+    const input = 'start<internal>\nline1\nline2\n</internal>middle<internal>x</internal>end';
+    expect(stripInternalTags(input)).toBe('startmiddleend');
+  });
+});
+
+describe('formatOutbound', () => {
+  it('strips internal tags from output', () => {
+    expect(formatOutbound('visible<internal>hidden</internal> text')).toBe(
+      'visible text',
+    );
+  });
+
+  it('returns empty string when only internal content', () => {
+    expect(formatOutbound('<internal>all hidden</internal>')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- 12 tests for 4 pure functions: escapeXml, formatMessages, stripInternalTags, formatOutbound
- routeOutbound/findChannel already covered in router-outbound.test.ts
- No mocks needed — all pure string transforms

Closes #51

## Test plan
- [x] `npx vitest run src/router.test.ts` — 12/12 pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)