### PR TITLE
fix(code-search): auto-reindex on pull + auto-calibrate on first index

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,13 +1,11 @@
 node scripts/migrate.mjs --quiet
 
-# Mark stale only -- reindex is on-demand via index_codebase
-mkdir -p "$HOME/.deus"
-touch "$HOME/.deus/index_stale.flag"
-
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Incremental code search reindex: re-index files changed since pre-merge HEAD.
+python3 "$REPO_ROOT/scripts/code_search.py" reindex "$REPO_ROOT" --diff ORIG_HEAD >> "$HOME/.deus/code_search_reindex.log" 2>&1 &
 
 # Rebuild and restart if source files changed
 if git diff-tree --name-only ORIG_HEAD HEAD 2>/dev/null | grep -qE '^(src/|container/)'; then
   "$REPO_ROOT/deus-cmd.sh" build --quiet >> "$HOME/.deus/build.log" 2>&1 &
-  disown
 fi

--- a/scripts/code_search.py
+++ b/scripts/code_search.py
@@ -622,6 +622,55 @@ def reindex(directory: str, diff_ref: str | None = None) -> dict[str, Any]:
         "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)",
         ("indexed_directory", str(base)),
     )
+
+    # Auto-populate calibration distribution if missing (needed for retrieval_confidence)
+    cal_row = db.execute(
+        "SELECT value FROM index_meta WHERE key = 'calibration_distances'"
+    ).fetchone()
+    calibrated = bool(cal_row)
+    if not cal_row and embed and sqlite_vec is not None:
+        chunk_count = db.execute(
+            "SELECT COUNT(*) FROM chunks WHERE orphaned_at IS NULL AND embedded_at IS NOT NULL"
+        ).fetchone()[0]
+        if chunk_count >= 20:
+            sample_rows = db.execute(
+                "SELECT chunk_name FROM chunks "
+                "WHERE orphaned_at IS NULL AND embedded_at IS NOT NULL "
+                "AND chunk_name IS NOT NULL AND length(chunk_name) > 3 "
+                "AND chunk_type IN ('function', 'method', 'class') "
+                "ORDER BY RANDOM() LIMIT 150"
+            ).fetchall()
+            cal_distances: list[float] = []
+            for (chunk_name,) in sample_rows:
+                query = chunk_name.replace("_", " ")
+                if len(query) < 4:
+                    continue
+                try:
+                    emb = _embed_text(query)
+                    vec_row = db.execute(
+                        "SELECT rowid FROM chunks_vec WHERE embedding MATCH ? ORDER BY distance LIMIT 1",
+                        (_serialize(emb),),
+                    ).fetchall()
+                    if vec_row:
+                        cos = db.execute(
+                            "SELECT vec_distance_cosine(embedding, ?) FROM chunks_vec WHERE rowid = ?",
+                            (_serialize(emb), vec_row[0][0]),
+                        ).fetchone()
+                        if cos:
+                            cal_distances.append(cos[0])
+                except Exception:
+                    pass
+            if cal_distances:
+                cal_distances.sort()
+                db.execute(
+                    "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('calibration_distances', ?)",
+                    [json.dumps(cal_distances)],
+                )
+                calibrated = True
+                global _cal_cache
+                _cal_cache = None
+                print(f"Auto-calibrated: stored {len(cal_distances)} distances", file=sys.stderr)
+
     db.commit()
     db.close()
 
@@ -630,6 +679,7 @@ def reindex(directory: str, diff_ref: str | None = None) -> dict[str, Any]:
         "chunks_added": total_added,
         "chunks_unchanged": total_skipped,
         "embeddings": "yes" if embed else "no (Ollama unavailable)",
+        "calibrated": calibrated,
     }
 
 


### PR DESCRIPTION
## Summary
- Post-merge hook runs incremental code_search reindex against ORIG_HEAD so pulled code is immediately searchable
- Reindex auto-populates calibration distribution from chunk names when none exists, giving fresh installs meaningful retrieval_confidence without manual generate-fixture
- Removes stale index_stale.flag approach (replaced by direct reindex)

## Test plan
- [x] Auto-calibration produces 150 distances from chunk names
- [x] In-domain confidence 0.313 vs OOD 0.01 (rough but functional separation)
- [x] Full generate-fixture calibration still produces better results (0.609 vs 0.037)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)