### PR TITLE
fix(security): harden applyPatchArtifact pipeline (LIA-103, LIA-104, LIA-105)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,8 @@ LINEAR_API_TOKEN=
 # LINEAR_AUTO_MERGE=0
 # Host project path for dispatch agents (mounted writable in container)
 # LINEAR_DISPATCH_PROJECT=~/deus
+# Comma-separated path prefixes blocked from auto-apply patches (default: .github/workflows/)
+# DEUS_PATCH_BLOCKED_PATHS=.github/workflows/
 # Max retry attempts for webhook dispatch (default: 3)
 # WEBHOOK_MAX_RETRIES=3
 # Base delay in ms for webhook retry backoff: min(base * 2^attempt + jitter, 30000) (default: 1000)

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-05-25" # LIA-94-remaining
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -3,7 +3,7 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-27"
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -5,7 +5,7 @@ governs:
   - src/startup-gate.ts
   - src/checks.ts
   - setup/
-last_verified: "2026-05-27"
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Refactor src/router.ts into smaller modules"
   - "Add a new utility function for parsing timestamps"

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -4,10 +4,12 @@ import path from 'path';
 import os from 'os';
 
 const execFileMock = vi.fn();
+const spawnMock = vi.fn();
 
 vi.mock('child_process', async (importOriginal) => {
   const orig = await importOriginal<typeof import('child_process')>();
   const { promisify } = await import('util');
+  const { EventEmitter } = await import('events');
   type ExecFileCb = (err: Error | null, stdout: string, stderr: string) => void;
   const mockFn = vi.fn((...args: unknown[]) => {
     const cb = args[args.length - 1];
@@ -28,7 +30,36 @@ vi.mock('child_process', async (importOriginal) => {
       stderr: result?.stderr ?? '',
     });
   };
-  return { ...orig, execFile: mockFn };
+  const mockSpawnFn = vi.fn((...args: unknown[]) => {
+    const child = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    });
+    const result = spawnMock(
+      args[0] as string,
+      args[1] as string[],
+      args[2] as Record<string, unknown>,
+    ) as
+      | { code?: number; stderr?: string; hang?: boolean; error?: Error }
+      | undefined;
+    if (result?.hang) {
+      // Don't emit — test controls timeout
+    } else if (result?.error) {
+      process.nextTick(() => child.emit('error', result.error));
+    } else {
+      const code = result?.code ?? 0;
+      if (result?.stderr) {
+        const stderrStr = result.stderr;
+        process.nextTick(() =>
+          child.stderr.emit('data', Buffer.from(stderrStr)),
+        );
+      }
+      process.nextTick(() => child.emit('close', code));
+    }
+    return child;
+  });
+  return { ...orig, execFile: mockFn, spawn: mockSpawnFn };
 });
 
 vi.mock('./config.js', async () => {
@@ -59,7 +90,12 @@ vi.mock('./linear-notifications.js', () => ({
 
 vi.mock('./platform.js', async (importOriginal) => {
   const orig = await importOriginal<typeof import('./platform.js')>();
-  return { ...orig, IS_MACOS: true, IS_LINUX: false };
+  return {
+    ...orig,
+    IS_MACOS: true,
+    IS_LINUX: false,
+    forceKillProcessGroup: vi.fn(),
+  };
 });
 
 const TEST_PROJECT_ROOT = path.join(os.tmpdir(), `deus-test-${process.pid}`);
@@ -487,6 +523,8 @@ describe('applyPatchArtifact', () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue({ code: 0 });
     createComment.mockClear();
     fs.mkdirSync(patchGroupDir, { recursive: true });
   });
@@ -591,7 +629,6 @@ describe('applyPatchArtifact', () => {
       if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
       if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
       if (cmd === 'git' && args[0] === 'am') return { stdout: '' };
-      if (cmd === 'npm') return { stdout: '' };
       if (cmd === 'gh')
         return { stdout: 'https://github.com/test/repo/pull/10\n' };
       return { stdout: '' };
@@ -607,9 +644,12 @@ describe('applyPatchArtifact', () => {
       prUrl: 'https://github.com/test/repo/pull/10',
       applied: true,
     });
-    // git apply should NOT have been called (am succeeded)
+    // git apply (non-stat) should NOT have been called (am succeeded)
     const applyCalls = execFileMock.mock.calls.filter(
-      (c: unknown[]) => c[0] === 'git' && (c[1] as string[])[0] === 'apply',
+      (c: unknown[]) =>
+        c[0] === 'git' &&
+        (c[1] as string[])[0] === 'apply' &&
+        !(c[1] as string[]).includes('--stat'),
     );
     expect(applyCalls).toHaveLength(0);
   });
@@ -632,7 +672,6 @@ describe('applyPatchArtifact', () => {
       if (cmd === 'git' && args[0] === 'apply') return { stdout: '' };
       if (cmd === 'git' && args[0] === 'add') return { stdout: '' };
       if (cmd === 'git' && args[0] === 'commit') return { stdout: '' };
-      if (cmd === 'npm' && args[0] === 'run') return { stdout: '' };
       if (cmd === 'git' && args[0] === 'push') return { stdout: '' };
       if (cmd === 'gh' && args[0] === 'pr')
         return { stdout: 'https://github.com/test/repo/pull/42\n' };
@@ -682,13 +721,12 @@ describe('applyPatchArtifact', () => {
   it('posts comment and cleans up on build failure', async () => {
     fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
 
+    spawnMock.mockReturnValue({ code: 1, stderr: 'tsc: error TS2345' });
     execFileMock.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
       if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
       if (cmd === 'git' && args[0] === 'am')
         return { error: new Error('not mbox') };
-      if (cmd === 'npm' && args[0] === 'run')
-        return { error: new Error('tsc: error TS2345') };
       return { stdout: '' };
     });
 
@@ -715,6 +753,10 @@ describe('applyPatchArtifact', () => {
       if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
       if (cmd === 'git' && args[0] === 'am')
         return { error: new Error('not mbox') };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat'))
+        return {
+          stdout: ' src/foo.ts | 1 +\n 1 file changed, 1 insertion(+)\n',
+        };
       if (cmd === 'git' && args[0] === 'apply')
         return { error: new Error('patch does not apply') };
       return { stdout: '' };
@@ -767,5 +809,144 @@ describe('applyPatchArtifact', () => {
       (c) => c.cmd === 'git' && c.args[0] === 'branch' && c.args[1] === '-D',
     );
     expect(branchDeletes).toHaveLength(0);
+  });
+
+  it('build env does not contain host credentials', async () => {
+    const origGH = process.env.GITHUB_TOKEN;
+    const origLK = process.env.LINEAR_API_KEY;
+    const origAK = process.env.ANTHROPIC_API_KEY;
+    process.env.GITHUB_TOKEN = 'gh-secret';
+    process.env.LINEAR_API_KEY = 'linear-secret';
+    process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+
+    try {
+      fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+      execFileMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'rev-parse')
+          return { stdout: 'main\n' };
+        if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+        if (cmd === 'git' && args[0] === 'am')
+          return { error: new Error('not mbox') };
+        if (cmd === 'gh')
+          return { stdout: 'https://github.com/test/repo/pull/1\n' };
+        return { stdout: '' };
+      });
+
+      await applyPatchArtifact(patchGroupDir, 'LIA-99', 'issue-id', patchCtx());
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'npm',
+        ['run', 'build'],
+        expect.objectContaining({
+          env: expect.not.objectContaining({
+            GITHUB_TOKEN: expect.anything(),
+            LINEAR_API_KEY: expect.anything(),
+            ANTHROPIC_API_KEY: expect.anything(),
+          }),
+        }),
+      );
+      const buildCall = spawnMock.mock.calls.find(
+        (c: unknown[]) => c[0] === 'npm' && (c[1] as string[])[0] === 'run',
+      ) as unknown[] | undefined;
+      expect(buildCall).toBeDefined();
+      const buildOpts = buildCall![2] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(buildOpts.env).toHaveProperty('PATH');
+      expect(buildOpts.env).toHaveProperty('HOME');
+    } finally {
+      process.env.GITHUB_TOKEN = origGH;
+      process.env.LINEAR_API_KEY = origLK;
+      process.env.ANTHROPIC_API_KEY = origAK;
+    }
+  });
+
+  it('patch hash appears in pipeline event on success', async () => {
+    const { notifyPipelineStep: notifyMock } =
+      await import('./linear-notifications.js');
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff content');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    await applyPatchArtifact(patchGroupDir, 'LIA-99', 'issue-id', patchCtx());
+
+    const appliedCall = (
+      notifyMock as ReturnType<typeof vi.fn>
+    ).mock.calls.find((c: unknown[]) => c[3] === 'patch_applied');
+    expect(appliedCall).toBeDefined();
+    expect(appliedCall![4]).toMatch(/^hash:[0-9a-f]{64} pr:/);
+  });
+
+  it('rejects patch touching blocked paths', async () => {
+    const { notifyPipelineStep: notifyMock } =
+      await import('./linear-notifications.js');
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return {
+          stdout:
+            ' .github/workflows/ci.yml | 5 ++---\n src/foo.ts              | 10 ++++++++++\n 2 files changed, 12 insertions(+), 3 deletions(-)\n',
+        };
+      }
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('restricted paths'),
+      }),
+    );
+    const failedCall = (notifyMock as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) =>
+        c[3] === 'patch_failed' && (c[4] as string).includes('blocked paths'),
+    );
+    expect(failedCall).toBeDefined();
+  });
+
+  it('allows patches that only touch non-blocked paths', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return {
+          stdout:
+            ' src/foo.ts | 10 ++++++++++\n 1 file changed, 10 insertions(+)\n',
+        };
+      }
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+
+    expect(result.applied).toBe(true);
   });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -1,4 +1,5 @@
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
+import { createHash } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
@@ -10,7 +11,7 @@ import { PROJECT_ROOT } from './config.js';
 import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
 import { fireAndForget } from './async/index.js';
-import { IS_MACOS, IS_LINUX } from './platform.js';
+import { IS_MACOS, IS_LINUX, forceKillProcessGroup } from './platform.js';
 import { extractPrUrl } from './pr-url-extractor.js';
 import { queryPrState, checkConflictingPrs } from './linear-auto-merge.js';
 import {
@@ -45,6 +46,7 @@ const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
 const GIT_TIMEOUT_MS = 30_000;
 const BUILD_TIMEOUT_MS = 120_000;
 const PUSH_TIMEOUT_MS = 120_000;
+const BLOCKED_PATHS_DEFAULT = ['.github/workflows/'];
 
 export interface LinearDispatcherDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
@@ -524,6 +526,9 @@ export async function applyPatchArtifact(
   });
   await prev;
 
+  const patchBytes = fs.readFileSync(patchFilePath);
+  const patchHash = createHash('sha256').update(patchBytes).digest('hex');
+
   // Global serialization: a slow build blocks other patches, but concurrent
   // git operations on one working tree corrupt state. Acceptable for the
   // expected throughput (1-2 patches/hour).
@@ -557,7 +562,7 @@ export async function applyPatchArtifact(
         issueId,
         identifier,
         'patch_failed',
-        'not on main',
+        `hash:${patchHash} not on main`,
       ).catch(() => {});
       releaseMutex();
       return noResult;
@@ -579,7 +584,7 @@ export async function applyPatchArtifact(
         issueId,
         identifier,
         'patch_failed',
-        'dirty tree',
+        `hash:${patchHash} dirty tree`,
       ).catch(() => {});
       releaseMutex();
       return noResult;
@@ -590,6 +595,58 @@ export async function applyPatchArtifact(
 
     // Create feature branch (-B creates or resets)
     await execFileAsync('git', ['checkout', '-B', branchName], gitOpts);
+
+    // Pre-flight: reject patches touching blocked paths
+    const blockedPathsRaw = (process.env.DEUS_PATCH_BLOCKED_PATHS ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const effectiveBlockedPaths =
+      blockedPathsRaw.length > 0 ? blockedPathsRaw : BLOCKED_PATHS_DEFAULT;
+    try {
+      const { stdout: statOut } = await execFileAsync(
+        'git',
+        ['apply', '--stat', patchFilePath],
+        { ...gitOpts, timeout: 30_000 },
+      );
+      const touchedFiles = statOut
+        .split('\n')
+        .filter((line) => line.includes(' | '))
+        .map((line) => line.split(' | ')[0].trim())
+        .filter(Boolean);
+      const blockedFiles = touchedFiles.filter((f) =>
+        effectiveBlockedPaths.some((prefix) => f.startsWith(prefix)),
+      );
+      if (blockedFiles.length > 0) {
+        await ctx.client.createComment({
+          issueId,
+          body: `**Patch auto-apply blocked** — patch touches restricted paths: ${blockedFiles.map((f) => `\`${f}\``).join(', ')}.\n\nApply manually after review.`,
+        });
+        notifyPipelineStep(
+          ctx,
+          issueId,
+          identifier,
+          'patch_failed',
+          `hash:${patchHash} blocked paths: ${blockedFiles.join(',')}`,
+        ).catch(() => {});
+        await cleanup(true);
+        return noResult;
+      }
+    } catch (statErr) {
+      logger.warn(
+        { issueId, err: statErr },
+        'patch-applicator: git apply --stat failed, rejecting patch',
+      );
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        identifier,
+        'patch_failed',
+        `hash:${patchHash} stat pre-flight failed`,
+      ).catch(() => {});
+      await cleanup(true);
+      return noResult;
+    }
 
     // Try git am first (for format-patch output), fall back to git apply
     let applied = false;
@@ -626,7 +683,7 @@ export async function applyPatchArtifact(
           issueId,
           identifier,
           'patch_failed',
-          'git apply failed',
+          `hash:${patchHash} git apply failed`,
         ).catch(() => {});
         await cleanup(true);
         return noResult;
@@ -638,11 +695,44 @@ export async function applyPatchArtifact(
       return noResult;
     }
 
-    // Build verification
+    // Build verification (sanitized env, process-group kill on timeout)
     try {
-      await execFileAsync('npm', ['run', 'build'], {
-        cwd: PROJECT_ROOT,
-        timeout: BUILD_TIMEOUT_MS,
+      const buildEnv: Record<string, string | undefined> = {
+        PATH: process.env.PATH,
+        HOME: HOME_DIR,
+        NODE_ENV: process.env.NODE_ENV ?? 'production',
+        LANG: process.env.LANG,
+        TZ: process.env.TZ,
+        TERM: process.env.TERM,
+      };
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn('npm', ['run', 'build'], {
+          cwd: PROJECT_ROOT,
+          env: buildEnv,
+          detached: true,
+          stdio: ['ignore', 'ignore', 'pipe'],
+        });
+        const stderrChunks: Buffer[] = [];
+        child.stderr?.on('data', (d: Buffer) => stderrChunks.push(d));
+
+        const killTimer = setTimeout(() => {
+          if (child.pid) forceKillProcessGroup(child.pid);
+          reject(new Error(`Build timed out after ${BUILD_TIMEOUT_MS}ms`));
+        }, BUILD_TIMEOUT_MS);
+        killTimer.unref();
+
+        child.on('close', (code) => {
+          clearTimeout(killTimer);
+          if (code !== 0)
+            reject(
+              new Error(Buffer.concat(stderrChunks).toString().slice(0, 2000)),
+            );
+          else resolve();
+        });
+        child.on('error', (err) => {
+          clearTimeout(killTimer);
+          reject(err);
+        });
       });
     } catch (buildErr) {
       const stderr =
@@ -656,7 +746,7 @@ export async function applyPatchArtifact(
         issueId,
         identifier,
         'patch_failed',
-        'build failed',
+        `hash:${patchHash} build failed`,
       ).catch(() => {});
       await cleanup(true);
       return noResult;
@@ -696,7 +786,7 @@ export async function applyPatchArtifact(
         issueId,
         identifier,
         'patch_failed',
-        'gh pr create failed',
+        `hash:${patchHash} gh pr create failed`,
       ).catch(() => {});
       await cleanup(false);
       return noResult;
@@ -709,9 +799,13 @@ export async function applyPatchArtifact(
       /* best-effort */
     }
 
-    notifyPipelineStep(ctx, issueId, identifier, 'patch_applied', prUrl).catch(
-      () => {},
-    );
+    notifyPipelineStep(
+      ctx,
+      issueId,
+      identifier,
+      'patch_applied',
+      `hash:${patchHash} pr:${prUrl}`,
+    ).catch(() => {});
     logger.info(
       { issueId, prUrl, patchFileName },
       'patch-applicator: PR created from patch artifact',

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -111,6 +111,33 @@ export function forceKillProcess(pid: number): void {
   }
 }
 
+/**
+ * Force-kill a process group cross-platform.
+ * - Unix: SIGKILL to process group (-pid), falls back to individual PID.
+ * - Windows: `taskkill /F /T /PID` kills the entire tree.
+ */
+export function forceKillProcessGroup(pid: number): void {
+  if (IS_WINDOWS) {
+    try {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], {
+        stdio: 'pipe',
+      });
+    } catch {
+      // already dead
+    }
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // already dead
+    }
+  }
+}
+
 /** Check if a process is still alive (signal 0 probe). */
 export function processExists(pid: number): boolean {
   try {


### PR DESCRIPTION
## Summary
- **LIA-103**: Strip host credentials from `npm run build` env — only `PATH`, `HOME`, `NODE_ENV`, `LANG`, `TZ`, `TERM` inherited (allowlist pattern)
- **LIA-104**: Kill full process group on build timeout — `spawn({ detached: true })` + `forceKillProcessGroup` in `platform.ts` (cross-platform)
- **LIA-105**: SHA-256 audit hash per patch in pipeline events + `git apply --stat` dry-run to reject patches touching `.github/workflows/` (fail-closed on stat error)

## Motivation
Threat-modeler issued BLOCK verdict on `applyPatchArtifact`: build subprocess inherits full host credentials, no integrity hash ties patch content to pipeline events, and no pre-apply validation rejects patches touching sensitive paths. These are Phase 2a of the container write-back security hardening.

## Test plan
- [x] `npm run build` — TypeScript compiles clean
- [x] `npm test` — all 35 tests pass (4 new: env-strip, hash-in-event, blocked-path-reject, non-blocked-pass)
- [x] Code-reviewer SHIP (warnings fixed: fail-closed stat, killTimer.unref, stdout=ignore)

Closes LIA-103, LIA-104, LIA-105

🤖 Generated with [Claude Code](https://claude.com/claude-code)