### PR TITLE
feat(dispatch): per-task git worktree for isolated agent runs (LIA-106)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,4 +1,5 @@
 ---
+last_verified: 2026-05-27
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,4 +1,5 @@
 ---
+last_verified: 2026-05-27
 governs:
   - src/
   - setup/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,4 +1,5 @@
 ---
+last_verified: 2026-05-27
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-05-17" # auto-bump
+last_verified: "2026-05-27" # auto-bump
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/agent-runtimes/container-backend.ts
+++ b/src/agent-runtimes/container-backend.ts
@@ -100,6 +100,9 @@ export class ContainerRuntime implements AgentRuntime {
         ...(runContext.imageInputs?.length && {
           imageAttachments: runContext.imageInputs,
         }),
+        ...(runContext.worktreePath && {
+          worktreePath: runContext.worktreePath,
+        }),
       },
       (proc, containerName) =>
         this.deps.registerProcess(

--- a/src/agent-runtimes/types.ts
+++ b/src/agent-runtimes/types.ts
@@ -40,6 +40,7 @@ export interface RunContext {
   backendConfig?: Record<string, unknown>;
   imageInputs?: Array<{ relativePath: string; mediaType: string }>;
   toolBroker?: ToolBroker;
+  worktreePath?: string;
 }
 
 export type RuntimeEvent =

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -70,6 +70,7 @@ function resolveVaultPath(): string | null {
 export function buildVolumeMounts(
   group: RegisteredGroup,
   isControlGroup: boolean,
+  worktreePath?: string,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -125,12 +126,56 @@ export function buildVolumeMounts(
     }
   }
 
-  // External project mount: when a group has an associated project,
-  // mount it at /workspace/project so the agent works on the external codebase.
-  // Security: project path was validated against mount-allowlist at registration time.
-  // We re-validate the real path hasn't changed (symlink TOCTOU defense) and
-  // shadow sensitive files to prevent credential exfiltration.
-  if (group.projectId) {
+  // Per-task worktree override: mount the worktree instead of the project root.
+  // Worktree is always writable — the agent must commit back to its branch.
+  // Apply credential shadows defensively (same as regular project mounts).
+  if (worktreePath && fs.existsSync(worktreePath)) {
+    const realWorktree = fs.realpathSync(worktreePath);
+    if (realWorktree !== path.resolve(worktreePath)) {
+      logger.warn(
+        { worktreePath, realWorktree },
+        'Worktree path changed after creation, skipping mount',
+      );
+    } else {
+      mounts.push({
+        hostPath: realWorktree,
+        containerPath: '/workspace/project',
+        readonly: false,
+      });
+      for (const pattern of SENSITIVE_FILE_PATTERNS) {
+        const filePath = path.join(worktreePath, pattern);
+        if (fs.existsSync(filePath)) {
+          mounts.push({
+            hostPath: os.devNull,
+            containerPath: `/workspace/project/${pattern}`,
+            readonly: true,
+          });
+        }
+      }
+      for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
+        const dirPath = path.join(worktreePath, dirPattern);
+        if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+          const shadowDir = path.join(
+            DATA_DIR,
+            'worktree-shadows',
+            path.basename(worktreePath),
+            dirPattern,
+          );
+          fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
+          mounts.push({
+            hostPath: shadowDir,
+            containerPath: `/workspace/project/${dirPattern}`,
+            readonly: true,
+          });
+        }
+      }
+    }
+  } else if (group.projectId) {
+    // External project mount: when a group has an associated project,
+    // mount it at /workspace/project so the agent works on the external codebase.
+    // Security: project path was validated against mount-allowlist at registration time.
+    // We re-validate the real path hasn't changed (symlink TOCTOU defense) and
+    // shadow sensitive files to prevent credential exfiltration.
     const project = getProjectById(group.projectId);
     if (project && fs.existsSync(project.path)) {
       // TOCTOU defense: re-resolve symlinks at mount time.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -79,6 +79,7 @@ export interface ContainerInput {
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
   projectHint?: string;
   effort?: AgentEffortLevel;
+  worktreePath?: string;
 }
 
 // SYNC-REQUIRED: Duplicated in container/agent-runner/src/index.ts.
@@ -280,7 +281,11 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isControlGroup);
+  const mounts = buildVolumeMounts(
+    group,
+    input.isControlGroup,
+    input.worktreePath,
+  );
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `deus-${safeName}-${Date.now()}`;
   const containerArgs = buildContainerArgs(

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -949,4 +949,80 @@ describe('applyPatchArtifact', () => {
 
     expect(result.applied).toBe(true);
   });
+
+  it('skips main/dirty checks when worktreePath is provided', async () => {
+    const worktreeDir = path.join(TEST_PROJECT_ROOT, 'worktrees', 'LIA-99');
+    fs.mkdirSync(worktreeDir, { recursive: true });
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+
+    const gitCalls: Array<{ cmd: string; args: string[] }> = [];
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      gitCalls.push({ cmd, args: [...args] });
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+      worktreeDir,
+    );
+
+    expect(result.applied).toBe(true);
+    // Should NOT have called rev-parse (no main check)
+    const revParseCalls = gitCalls.filter(
+      (c) => c.cmd === 'git' && c.args[0] === 'rev-parse',
+    );
+    expect(revParseCalls).toHaveLength(0);
+    // Should NOT have called status (no dirty check)
+    const statusCalls = gitCalls.filter(
+      (c) => c.cmd === 'git' && c.args[0] === 'status',
+    );
+    expect(statusCalls).toHaveLength(0);
+    // Should NOT have called checkout -B (no branch creation)
+    const checkoutCalls = gitCalls.filter(
+      (c) =>
+        c.cmd === 'git' && c.args[0] === 'checkout' && c.args.includes('-B'),
+    );
+    expect(checkoutCalls).toHaveLength(0);
+
+    fs.rmSync(worktreeDir, { recursive: true, force: true });
+  });
+
+  it('uses worktreePath as cwd for git operations', async () => {
+    const worktreeDir = path.join(TEST_PROJECT_ROOT, 'worktrees', 'LIA-99');
+    fs.mkdirSync(worktreeDir, { recursive: true });
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+      worktreeDir,
+    );
+
+    // Verify spawn (build) was called with worktreeDir as cwd
+    const buildCall = spawnMock.mock.calls.find(
+      (c: unknown[]) => c[0] === 'npm' && (c[1] as string[])[0] === 'run',
+    ) as unknown[] | undefined;
+    expect(buildCall).toBeDefined();
+    const buildOpts = buildCall![2] as Record<string, unknown>;
+    expect(buildOpts.cwd).toBe(worktreeDir);
+
+    fs.rmSync(worktreeDir, { recursive: true, force: true });
+  });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -480,9 +480,11 @@ export async function applyPatchArtifact(
   identifier: string,
   issueId: string,
   ctx: LinearContext,
+  worktreePath?: string,
 ): Promise<{ prUrl: string | null; applied: boolean }> {
   const noResult = { prUrl: null, applied: false };
-  const gitOpts = { cwd: PROJECT_ROOT, timeout: GIT_TIMEOUT_MS };
+  const effectiveCwd = worktreePath ?? PROJECT_ROOT;
+  const gitOpts = { cwd: effectiveCwd, timeout: GIT_TIMEOUT_MS };
 
   if (!(IS_MACOS || IS_LINUX)) return noResult;
   if (!fs.existsSync(groupDir)) return noResult;
@@ -514,7 +516,7 @@ export async function applyPatchArtifact(
     .sort((a, b) => b.mtime - a.mtime);
   const patchFileName = sorted[0].name;
   const patchFilePath = path.join(groupDir, patchFileName);
-  const patchRelPath = path.relative(PROJECT_ROOT, patchFilePath);
+  const patchRelPath = path.relative(effectiveCwd, patchFilePath);
   const commitMessage = parseCommitMessage(groupDir, identifier);
   const branchName = `feat/${identifier.toLowerCase()}-auto-patch`;
 
@@ -533,68 +535,71 @@ export async function applyPatchArtifact(
   // git operations on one working tree corrupt state. Acceptable for the
   // expected throughput (1-2 patches/hour).
   async function cleanup(deleteBranch: boolean): Promise<void> {
-    try {
-      await execFileAsync('git', ['checkout', 'main'], gitOpts);
-      if (deleteBranch) {
-        await execFileAsync('git', ['branch', '-D', branchName], gitOpts);
+    if (!worktreePath) {
+      try {
+        await execFileAsync('git', ['checkout', 'main'], gitOpts);
+        if (deleteBranch) {
+          await execFileAsync('git', ['branch', '-D', branchName], gitOpts);
+        }
+      } catch {
+        /* best-effort */
       }
-    } catch {
-      // Checkout failure leaves HEAD on feat branch; next mutex holder re-checks branch
-      /* best-effort */
     }
     releaseMutex();
   }
 
   try {
-    // Branch safety: refuse if not on main
-    const { stdout: currentBranch } = await execFileAsync(
-      'git',
-      ['rev-parse', '--abbrev-ref', 'HEAD'],
-      gitOpts,
-    );
-    if (currentBranch.trim() !== 'main') {
-      await ctx.client.createComment({
-        issueId,
-        body: `**Patch auto-apply skipped** — working tree is on branch \`${currentBranch.trim()}\`, not \`main\`.\n\nApply manually:\n\`\`\`bash\ngit apply ${patchRelPath}\n\`\`\``,
-      });
-      notifyPipelineStep(
-        ctx,
-        issueId,
-        identifier,
-        'patch_failed',
-        `hash:${patchHash} not on main`,
-      ).catch(() => {});
-      releaseMutex();
-      return noResult;
+    if (!worktreePath) {
+      // Branch safety: refuse if not on main
+      const { stdout: currentBranch } = await execFileAsync(
+        'git',
+        ['rev-parse', '--abbrev-ref', 'HEAD'],
+        gitOpts,
+      );
+      if (currentBranch.trim() !== 'main') {
+        await ctx.client.createComment({
+          issueId,
+          body: `**Patch auto-apply skipped** — working tree is on branch \`${currentBranch.trim()}\`, not \`main\`.\n\nApply manually:\n\`\`\`bash\ngit apply ${patchRelPath}\n\`\`\``,
+        });
+        notifyPipelineStep(
+          ctx,
+          issueId,
+          identifier,
+          'patch_failed',
+          `hash:${patchHash} not on main`,
+        ).catch(() => {});
+        releaseMutex();
+        return noResult;
+      }
+
+      // Dirty tree check
+      const { stdout: status } = await execFileAsync(
+        'git',
+        ['status', '--porcelain'],
+        gitOpts,
+      );
+      if (status.trim()) {
+        await ctx.client.createComment({
+          issueId,
+          body: `**Patch auto-apply skipped** — working tree has uncommitted changes.\n\nApply manually:\n\`\`\`bash\ngit apply ${patchRelPath}\n\`\`\``,
+        });
+        notifyPipelineStep(
+          ctx,
+          issueId,
+          identifier,
+          'patch_failed',
+          `hash:${patchHash} dirty tree`,
+        ).catch(() => {});
+        releaseMutex();
+        return noResult;
+      }
+
+      // Pull latest main
+      await execFileAsync('git', ['pull', '--ff-only'], gitOpts);
+
+      // Create feature branch (-B creates or resets)
+      await execFileAsync('git', ['checkout', '-B', branchName], gitOpts);
     }
-
-    // Dirty tree check
-    const { stdout: status } = await execFileAsync(
-      'git',
-      ['status', '--porcelain'],
-      gitOpts,
-    );
-    if (status.trim()) {
-      await ctx.client.createComment({
-        issueId,
-        body: `**Patch auto-apply skipped** — working tree has uncommitted changes.\n\nApply manually:\n\`\`\`bash\ngit apply ${patchRelPath}\n\`\`\``,
-      });
-      notifyPipelineStep(
-        ctx,
-        issueId,
-        identifier,
-        'patch_failed',
-        `hash:${patchHash} dirty tree`,
-      ).catch(() => {});
-      releaseMutex();
-      return noResult;
-    }
-
-    // Pull latest main
-    await execFileAsync('git', ['pull', '--ff-only'], gitOpts);
-
-    // Create feature branch (-B creates or resets)
-    await execFileAsync('git', ['checkout', '-B', branchName], gitOpts);
 
     // Pre-flight: reject patches touching blocked paths
     const blockedPathsRaw = (process.env.DEUS_PATCH_BLOCKED_PATHS ?? '')
@@ -707,7 +712,7 @@ export async function applyPatchArtifact(
       };
       await new Promise<void>((resolve, reject) => {
         const child = spawn('npm', ['run', 'build'], {
-          cwd: PROJECT_ROOT,
+          cwd: effectiveCwd,
           env: buildEnv,
           detached: true,
           stdio: ['ignore', 'ignore', 'pipe'],
@@ -921,6 +926,46 @@ async function triageIssue(
   return 'dispatch';
 }
 
+async function ensureIssueWorktree(
+  identifier: string,
+): Promise<{ worktreePath: string; branchName: string } | null> {
+  if (!(IS_MACOS || IS_LINUX)) return null;
+  const branchName = `feat/${identifier.toLowerCase()}-auto-patch`;
+  const worktreePath = path.join(DATA_DIR, 'worktrees', identifier);
+  if (fs.existsSync(worktreePath)) return { worktreePath, branchName };
+  fs.mkdirSync(path.join(DATA_DIR, 'worktrees'), { recursive: true });
+  await execFileAsync(
+    'git',
+    ['worktree', 'add', worktreePath, '-b', branchName],
+    { cwd: PROJECT_ROOT, timeout: GIT_TIMEOUT_MS },
+  );
+  return { worktreePath, branchName };
+}
+
+async function cleanupWorktree(worktreePath: string): Promise<void> {
+  try {
+    await execFileAsync(
+      'git',
+      ['worktree', 'remove', '--force', worktreePath],
+      { cwd: PROJECT_ROOT, timeout: GIT_TIMEOUT_MS },
+    );
+  } catch {
+    try {
+      fs.rmSync(worktreePath, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+    try {
+      await execFileAsync('git', ['worktree', 'prune'], {
+        cwd: PROJECT_ROOT,
+        timeout: GIT_TIMEOUT_MS,
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
 async function runIssue(
   ctx: LinearContext,
   issueId: string,
@@ -991,6 +1036,7 @@ async function runIssue(
             identifier,
             issueId,
             ctx,
+            runContext.worktreePath,
           );
           if (patchResult.applied && patchResult.prUrl) {
             prUrl = patchResult.prUrl;
@@ -1038,6 +1084,9 @@ async function runIssue(
     );
   } finally {
     ctx.inFlightDispatch.delete(issueId);
+    if (runContext.worktreePath) {
+      await cleanupWorktree(runContext.worktreePath).catch(() => {});
+    }
   }
 }
 
@@ -1177,6 +1226,16 @@ async function pollLinear(): Promise<void> {
     }
 
     const chatJid = `linear-dispatch-${issue.id.slice(0, 8)}`;
+    let worktreePath: string | undefined;
+    try {
+      const wt = await ensureIssueWorktree(issue.identifier);
+      if (wt) worktreePath = wt.worktreePath;
+    } catch (wtErr) {
+      logger.warn(
+        { issueId: issue.id, err: wtErr },
+        'linear-dispatcher: failed to create worktree, dispatching without isolation',
+      );
+    }
     const runContext: RunContext = {
       prompt,
       groupFolder: DISPATCH_GROUP_JID,
@@ -1184,6 +1243,7 @@ async function pollLinear(): Promise<void> {
       isControlGroup: true,
       isScheduledTask: true,
       effort: 'high',
+      ...(worktreePath && { worktreePath }),
     };
 
     notifyPipelineStep(
@@ -1234,6 +1294,16 @@ export async function initLinearContext(
     const stateById = new Map<string, WorkflowState>();
     for (const state of stateByName.values()) {
       stateById.set(state.id, state);
+    }
+
+    // Prune stale worktrees from previous crashes
+    try {
+      await execFileAsync('git', ['worktree', 'prune'], {
+        cwd: PROJECT_ROOT,
+        timeout: GIT_TIMEOUT_MS,
+      });
+    } catch {
+      /* best-effort */
     }
 
     const viewer = await client.viewer;


### PR DESCRIPTION
## Summary
- Each dispatch agent now gets its own `git worktree` checkout instead of operating on the live `PROJECT_ROOT`
- Eliminates dirty-tree conflicts, enables concurrent dispatch, reduces blast radius to the worktree only
- `worktreePath` threaded through `RunContext` → `ContainerInput` → `buildVolumeMounts`
- Credential shadows (`.env`, sensitive dirs) applied defensively to worktree mounts with TOCTOU check
- `applyPatchArtifact` accepts worktree path, skips main/dirty checks, uses worktree as cwd
- Startup `git worktree prune` in `initLinearContext` cleans leaked worktrees

## Files changed
- `src/agent-runtimes/types.ts` — `worktreePath?: string` on `RunContext`
- `src/agent-runtimes/container-backend.ts` — forward to `ContainerInput`
- `src/container-runner.ts` — pass to `buildVolumeMounts`
- `src/container-mounter.ts` — worktree mount + credential shadows + TOCTOU
- `src/linear-dispatcher.ts` — `ensureIssueWorktree`, `cleanupWorktree`, `runIssue`, `applyPatchArtifact`
- `src/linear-dispatcher.test.ts` — 2 new tests (skip main check, correct cwd)

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 37/37 pass (2 new worktree tests)
- [x] Code-reviewer SHIP (TOCTOU check added per warning)

Closes LIA-106

🤖 Generated with [Claude Code](https://claude.com/claude-code)