### PR TITLE
fix(pipeline): prevent duplicate mount, fix label discovery, add proxy auth logging

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-05-27
+last_verified: "2026-05-27" # auto-bump
 governs:
   - src/
   - setup/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-05-27
+last_verified: "2026-05-27" # auto-bump
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-05-27" # auto-bump
+last_verified: "2026-05-27T21" # auto-bump
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/auth-providers/anthropic.ts
+++ b/src/auth-providers/anthropic.ts
@@ -325,16 +325,21 @@ export class AnthropicAuthProvider implements AuthProvider {
       delete headers['x-api-key'];
       headers['x-api-key'] = this.secrets.ANTHROPIC_API_KEY;
     } else {
-      // OAuth mode: replace placeholder Bearer token with the real one
-      // only when the container actually sends an Authorization header
-      // (exchange request + auth probes). Post-exchange requests use
-      // x-api-key only, so they pass through without token injection.
+      // OAuth mode: replace placeholder Bearer token with the real one.
       if (headers['authorization']) {
         delete headers['authorization'];
         const token = this.envOauthToken || getDynamicOAuthToken();
         if (token) {
           headers['authorization'] = `Bearer ${token}`;
+        } else {
+          console.error(
+            '[credential-proxy] OAuth mode: no token available to inject — request will reach Anthropic without auth',
+          );
         }
+      } else if (!headers['x-api-key']) {
+        console.error(
+          '[credential-proxy] OAuth mode: request has neither Authorization nor x-api-key header — auth will fail',
+        );
       }
     }
   }

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -77,27 +77,23 @@ export function buildVolumeMounts(
   const groupDir = resolveGroupFolderPath(group.folder);
 
   if (isControlGroup) {
-    // Main gets the project root read-only. Writable paths the agent needs
-    // (group folder, IPC, .claude/) are mounted separately below.
-    // Read-only prevents the agent from modifying host application code
-    // (src/, dist/, package.json, etc.) which would bypass the sandbox
-    // entirely on next restart.
-    mounts.push({
-      hostPath: projectRoot,
-      containerPath: '/workspace/project',
-      readonly: true,
-    });
-
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the credential proxy, never exposed to containers.
-    // os.devNull is '/dev/null' on Unix and '\\.\nul' on Windows.
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
+    // Only mount the Deus project root as a fallback when no worktree or
+    // external project will provide /workspace/project (avoids duplicate mounts).
+    const hasProjectOverride = !!(worktreePath || group.projectId);
+    if (!hasProjectOverride) {
       mounts.push({
-        hostPath: os.devNull,
-        containerPath: '/workspace/project/.env',
+        hostPath: projectRoot,
+        containerPath: '/workspace/project',
         readonly: true,
       });
+      const envFile = path.join(projectRoot, '.env');
+      if (fs.existsSync(envFile)) {
+        mounts.push({
+          hostPath: os.devNull,
+          containerPath: '/workspace/project/.env',
+          readonly: true,
+        });
+      }
     }
 
     // Main also gets its group folder as the working directory

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -1429,108 +1429,106 @@ export async function initLinearContext(
       '#2563eb',
       '#1d4ed8',
     ];
+    let labelMap = new Map<string, string>();
     try {
       const allLabels = await client.issueLabels();
-      const labelMap = new Map(allLabels.nodes.map((l) => [l.name, l.id]));
+      labelMap = new Map(allLabels.nodes.map((l) => [l.name, l.id]));
+    } catch (err) {
+      logger.error(
+        { err },
+        'linear: failed to fetch labels — gate labels will be unavailable',
+      );
+    }
 
-      for (const def of statusDefs) {
-        if (labelMap.has(def.name)) {
-          gateLabels[def.key] = labelMap.get(def.name);
-        } else {
-          const created = await client.createIssueLabel({
-            name: def.name,
-            color: def.color,
-            teamId,
-          });
-          const label = await created.issueLabel;
-          if (label) gateLabels[def.key] = label.id;
-        }
-      }
-
-      if (labelMap.has('warden:skip')) {
-        gateLabels.wardenSkip = labelMap.get('warden:skip');
-      }
-
-      const bouncedDefs: Array<{
-        key:
-          | 'blocked'
-          | 'bouncedUnscoped'
-          | 'bouncedStale'
-          | 'bouncedNoContext';
-        name: string;
-        color: string;
-      }> = [
-        { key: 'blocked', name: 'warden:blocked', color: '#dc2626' },
-        { key: 'bouncedUnscoped', name: 'bounced:unscoped', color: '#f97316' },
-        { key: 'bouncedStale', name: 'bounced:stale', color: '#f97316' },
-        {
-          key: 'bouncedNoContext',
-          name: 'bounced:no-context',
-          color: '#f97316',
-        },
-      ];
-      for (const def of bouncedDefs) {
-        if (labelMap.has(def.name)) {
-          gateLabels[def.key] = labelMap.get(def.name);
-        } else {
-          const created = await client.createIssueLabel({
-            name: def.name,
-            color: def.color,
-            teamId,
-          });
-          const label = await created.issueLabel;
-          if (label) gateLabels[def.key] = label.id;
-        }
-      }
-
-      if (labelMap.has('conflict')) {
-        gateLabels.conflict = labelMap.get('conflict');
-      } else {
+    async function ensureLabel(
+      key: string,
+      name: string,
+      color: string,
+    ): Promise<string | undefined> {
+      try {
+        if (labelMap.has(name)) return labelMap.get(name);
         const created = await client.createIssueLabel({
-          name: 'conflict',
-          color: '#b45309',
+          name,
+          color,
           teamId,
         });
         const label = await created.issueLabel;
-        if (label) gateLabels.conflict = label.id;
+        return label?.id;
+      } catch (err) {
+        logger.warn(
+          { err, label: name },
+          'linear: failed to create/discover label',
+        );
+        return undefined;
       }
+    }
 
-      if (!labelMap.has('Done: Pre-implemented')) {
-        await client.createIssueLabel({
-          name: 'Done: Pre-implemented',
-          color: '#6b7280',
-          teamId,
-        });
-      }
+    for (const def of statusDefs) {
+      const id = await ensureLabel(def.key, def.name, def.color);
+      if (id) gateLabels[def.key] = id;
+    }
 
-      for (let i = 1; i <= 5; i++) {
-        const eName = `Effort: ${i}`;
-        const cName = `Complexity: ${i}`;
-        if (labelMap.has(eName)) {
-          gateLabels.effort[i] = labelMap.get(eName)!;
-        } else {
-          const created = await client.createIssueLabel({
-            name: eName,
-            color: effortColors[i - 1],
-            teamId,
-          });
-          const label = await created.issueLabel;
-          if (label) gateLabels.effort[i] = label.id;
-        }
-        if (labelMap.has(cName)) {
-          gateLabels.complexity[i] = labelMap.get(cName)!;
-        } else {
-          const created = await client.createIssueLabel({
-            name: cName,
-            color: complexityColors[i - 1],
-            teamId,
-          });
-          const label = await created.issueLabel;
-          if (label) gateLabels.complexity[i] = label.id;
-        }
-      }
-    } catch (err) {
-      logger.warn({ err }, 'linear: failed to setup gate status labels');
+    if (labelMap.has('warden:skip')) {
+      gateLabels.wardenSkip = labelMap.get('warden:skip');
+    }
+
+    const bouncedDefs: Array<{
+      key: 'blocked' | 'bouncedUnscoped' | 'bouncedStale' | 'bouncedNoContext';
+      name: string;
+      color: string;
+    }> = [
+      { key: 'blocked', name: 'warden:blocked', color: '#dc2626' },
+      { key: 'bouncedUnscoped', name: 'bounced:unscoped', color: '#f97316' },
+      { key: 'bouncedStale', name: 'bounced:stale', color: '#f97316' },
+      {
+        key: 'bouncedNoContext',
+        name: 'bounced:no-context',
+        color: '#f97316',
+      },
+    ];
+    for (const def of bouncedDefs) {
+      const id = await ensureLabel(def.key, def.name, def.color);
+      if (id) gateLabels[def.key] = id;
+    }
+
+    const conflictId = await ensureLabel('conflict', 'conflict', '#b45309');
+    if (conflictId) gateLabels.conflict = conflictId;
+
+    await ensureLabel('done-pre', 'Done: Pre-implemented', '#6b7280');
+
+    for (let i = 1; i <= 5; i++) {
+      const eId = await ensureLabel(
+        `effort-${i}`,
+        `Effort: ${i}`,
+        effortColors[i - 1],
+      );
+      if (eId) gateLabels.effort[i] = eId;
+      const cId = await ensureLabel(
+        `complexity-${i}`,
+        `Complexity: ${i}`,
+        complexityColors[i - 1],
+      );
+      if (cId) gateLabels.complexity[i] = cId;
+    }
+
+    const populatedKeys = Object.entries(gateLabels)
+      .filter(
+        ([k, v]) => k !== 'effort' && k !== 'complexity' && v !== undefined,
+      )
+      .map(([k]) => k);
+    const missingKeys = ['evaluating', 'scoped', 'revise', 'error'].filter(
+      (k) => !(gateLabels as unknown as Record<string, unknown>)[k],
+    );
+    if (missingKeys.length > 0) {
+      logger.error(
+        { missingKeys },
+        'linear: some gate labels failed to populate — label operations will be no-ops for these',
+      );
+    } else {
+      logger.info(
+        { populated: populatedKeys.length },
+        'linear: all gate labels populated',
+      );
     }
 
     logger.info(


### PR DESCRIPTION
## Summary
Three fixes triggered by the LIA-73 investigation:

1. **Duplicate /workspace/project mount** — guard control-group default mount with `hasProjectOverride` when a `projectId` or `worktreePath` is set. Fixes Docker exit code 125.
2. **Label discovery** — replace single try/catch wrapping all label operations with per-label `ensureLabel()`. One failure no longer nukes all labels. Logs missing keys at startup with `logger.error`.
3. **Proxy auth logging** — log when OAuth token injection has no token available or when a request arrives with no auth headers. Makes 401 root cause visible instead of silent pass-through.

## Root causes
- Duplicate mount: adding `LINEAR_DISPATCH_PROJECT=~/deus` gave the dispatch group a `projectId`, causing both the control-group default mount and the project override to target `/workspace/project`
- Missing labels: all label discovery wrapped in one `try/catch` that swallows errors — any failure silently makes ALL label operations no-ops
- 401 on gates: proxy auth injection silently did nothing when OAuth token was unavailable

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 88 tests pass (dispatcher + auth-providers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)