### PR TITLE
feat(pipeline): add liveness monitoring, health endpoints, and watchdog timers

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -4,7 +4,6 @@ governs:
   - src/
   - setup/
   - packages/
-last_verified: "2026-05-28" # auto-bump
 test_tasks:
   - "Deploy a hotfix to a running service and restart it after rebuilding dist/"
   - "Rebuild the WhatsApp MCP package and pick up the change live"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-28" # auto-bump
+last_verified: "2026-05-29" # auto-bump
 governs:
   - src/
   - evolution/

--- a/src/db.ts
+++ b/src/db.ts
@@ -158,6 +158,13 @@ function createSchema(database: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_pipeline_events_created
       ON linear_pipeline_events(created_at);
 
+    CREATE TABLE IF NOT EXISTS pipeline_liveness (
+      subsystem TEXT PRIMARY KEY,
+      last_seen_at TEXT NOT NULL,
+      detail TEXT,
+      cleared_at TEXT DEFAULT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS linear_pipeline_comments (
       issue_id TEXT PRIMARY KEY,
       comment_id TEXT NOT NULL,
@@ -1552,6 +1559,50 @@ export function logPipelineEvent(
   } catch (err) {
     logger.debug({ issueId, eventType, err }, 'pipeline-event: insert failed');
     return undefined;
+  }
+}
+
+// --- Pipeline liveness ---
+
+export function stampLiveness(
+  subsystem: string,
+  detail?: Record<string, unknown>,
+): void {
+  try {
+    db.prepare(
+      `INSERT OR REPLACE INTO pipeline_liveness (subsystem, last_seen_at, detail, cleared_at)
+       VALUES (?, ?, ?, NULL)`,
+    ).run(
+      subsystem,
+      new Date().toISOString(),
+      detail ? JSON.stringify(detail) : null,
+    );
+  } catch (err) {
+    logger.debug({ subsystem, err }, 'pipeline-liveness: stamp failed');
+  }
+}
+
+export interface LivenessRow {
+  subsystem: string;
+  last_seen_at: string;
+  detail: string | null;
+  cleared_at: string | null;
+}
+
+export function getLiveness(activeOnly = true): LivenessRow[] {
+  const sql = activeOnly
+    ? `SELECT * FROM pipeline_liveness WHERE cleared_at IS NULL`
+    : `SELECT * FROM pipeline_liveness`;
+  return db.prepare(sql).all() as LivenessRow[];
+}
+
+export function clearLiveness(subsystem: string): void {
+  try {
+    db.prepare(
+      `UPDATE pipeline_liveness SET cleared_at = ? WHERE subsystem = ? AND cleared_at IS NULL`,
+    ).run(new Date().toISOString(), subsystem);
+  } catch (err) {
+    logger.debug({ subsystem, err }, 'pipeline-liveness: clear failed');
   }
 }
 

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -75,11 +75,14 @@ vi.mock('./config.js', async () => {
 
 vi.mock('./db.js', () => ({
   CIRCUIT_BREAKER_THRESHOLD: 3,
+  clearLiveness: vi.fn(),
   getConsecutiveFailCount: vi.fn().mockReturnValue(0),
   getIssuePr: vi.fn().mockReturnValue(null),
   getLastFailTime: vi.fn().mockReturnValue(null),
   getPipelineEvents: vi.fn().mockReturnValue([]),
   logPipelineEvent: vi.fn(),
+  stampLiveness: vi.fn(),
+  updatePrAutoMergeState: vi.fn(),
   upsertIssuePr: vi.fn(),
   getOpenPrsForActiveIssues: vi.fn().mockReturnValue([]),
 }));

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -16,11 +16,13 @@ import { extractPrUrl } from './pr-url-extractor.js';
 import { queryPrState, checkConflictingPrs } from './linear-auto-merge.js';
 import {
   CIRCUIT_BREAKER_THRESHOLD,
+  clearLiveness,
   getConsecutiveFailCount,
   getIssuePr,
   getLastFailTime,
   getPipelineEvents,
   logPipelineEvent,
+  stampLiveness,
   updatePrAutoMergeState,
   upsertIssuePr,
 } from './db.js';
@@ -102,8 +104,28 @@ let _timer: ReturnType<typeof setInterval> | null = null;
 let _tick: (() => void) | null = null;
 let _roleSpecs: Map<string, RoleSpec> = new Map();
 let _ctx: LinearContext | null = null;
+let _lastTickAt: number = Date.now();
+let _pollMs: number = DEFAULT_POLL_MS;
 // Promise-chain serializer — same pattern as commentLocks in linear-notifications.ts
 let _patchMutex: Promise<void> = Promise.resolve();
+
+export function getDispatcherHealth(): {
+  lastTickAt: number;
+  pollMs: number;
+} | null {
+  return _ctx ? { lastTickAt: _lastTickAt, pollMs: _pollMs } : null;
+}
+
+export function withWatchdog<T>(
+  label: string,
+  promise: Promise<T>,
+  thresholdMs: number,
+  onStall: () => void,
+): Promise<T> {
+  const timer = setTimeout(() => onStall(), thresholdMs);
+  timer.unref();
+  return promise.finally(() => clearTimeout(timer));
+}
 
 export function extractFrontmatter(content: string): {
   data: Record<string, unknown>;
@@ -984,7 +1006,33 @@ async function runIssue(
 
   notifyPipelineStep(ctx, issueId, identifier, 'agent_started').catch(() => {});
 
-  const { text, error } = await executeAgentRun(ctx, runContext);
+  const DEFAULT_DISPATCH_WATCHDOG_MS = 90 * 60 * 1000;
+  const _parsedDispatchWatchdog = parseInt(
+    process.env.DISPATCH_WATCHDOG_MS || '',
+    10,
+  );
+  const dispatchWatchdogMs =
+    isNaN(_parsedDispatchWatchdog) || _parsedDispatchWatchdog < 1000
+      ? DEFAULT_DISPATCH_WATCHDOG_MS
+      : _parsedDispatchWatchdog;
+  const { text, error } = await withWatchdog(
+    `dispatch:${identifier}`,
+    executeAgentRun(ctx, runContext),
+    dispatchWatchdogMs,
+    () => {
+      logPipelineEvent(
+        issueId,
+        identifier,
+        'dispatch_stalled',
+        `threshold=${dispatchWatchdogMs}ms`,
+      );
+      stampLiveness(`dispatch_stalled:${issueId}`, {
+        identifier,
+        thresholdMs: dispatchWatchdogMs,
+      });
+    },
+  );
+  clearLiveness(`dispatch_stalled:${issueId}`);
 
   ctx.deps.queue.notifyIdle(runContext.chatJid);
 
@@ -1084,6 +1132,7 @@ async function runIssue(
     );
   } finally {
     ctx.inFlightDispatch.delete(issueId);
+    clearLiveness(`dispatch_in_flight:${issueId}`);
     if (runContext.worktreePath) {
       await cleanupWorktree(runContext.worktreePath).catch(() => {});
     }
@@ -1093,6 +1142,12 @@ async function runIssue(
 async function pollLinear(): Promise<void> {
   if (!_ctx) return;
   const ctx = _ctx;
+
+  _lastTickAt = Date.now();
+  stampLiveness('dispatcher_poll', {
+    pollMs: _pollMs,
+    inFlightCount: ctx.inFlightDispatch.size,
+  });
 
   // Conflict detection sweep — runs every poll alongside dispatch
   checkConflictingPrs(ctx).catch((err) => {
@@ -1181,6 +1236,10 @@ async function pollLinear(): Promise<void> {
 
     // Add before triage to prevent concurrent polls from double-processing the same issue
     ctx.inFlightDispatch.add(issue.id);
+    stampLiveness(`dispatch_in_flight:${issue.id}`, {
+      identifier: issue.identifier,
+      startedAt: new Date().toISOString(),
+    });
 
     const issueComments = await issue.comments();
     const comments = await Promise.all(
@@ -1201,6 +1260,7 @@ async function pollLinear(): Promise<void> {
     );
     if (triageResult === 'skip') {
       ctx.inFlightDispatch.delete(issue.id);
+      clearLiveness(`dispatch_in_flight:${issue.id}`);
       continue;
     }
 
@@ -1606,6 +1666,7 @@ export function startLinearDispatcher(ctx: LinearContext): void {
   );
   const pollMs =
     isNaN(parsedPollMs) || parsedPollMs < 1000 ? DEFAULT_POLL_MS : parsedPollMs;
+  _pollMs = pollMs;
 
   _tick = () => {
     fireAndForget(() => pollLinear(), {

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -1736,6 +1736,71 @@ async function startWatchMode(): Promise<void> {
   await tick();
 }
 
+// ── Health check ─────────────────────────────────────────────────────────────
+
+interface HealthReadyResponse {
+  status: 'ok' | 'degraded' | 'stalled';
+  dispatcher: {
+    lastTickAt: number | null;
+    lagMs: number | null;
+    pollMs: number;
+    inFlightCount: number;
+  };
+  webhook: { lastIngestAt: string | null; recentLagMs: number | null };
+  inFlight: Array<{
+    subsystem: string;
+    startedAt: string;
+    elapsedMs: number;
+  }>;
+  gates: string[];
+  reasons: string[];
+}
+
+function prettyPrintHealth(data: HealthReadyResponse): void {
+  const statusColor =
+    data.status === 'ok'
+      ? '\x1b[32m'
+      : data.status === 'degraded'
+        ? '\x1b[33m'
+        : '\x1b[31m';
+  const reset = '\x1b[0m';
+
+  console.log(`${statusColor}Pipeline: ${data.status.toUpperCase()}${reset}`);
+  console.log();
+
+  const lagStr =
+    data.dispatcher.lagMs != null
+      ? `${Math.round(data.dispatcher.lagMs / 1000)}s`
+      : 'n/a';
+  console.log(
+    `  Dispatcher   lag=${lagStr}  poll=${data.dispatcher.pollMs / 1000}s  in-flight=${data.dispatcher.inFlightCount}`,
+  );
+
+  const webhookLag =
+    data.webhook.recentLagMs != null
+      ? `${Math.round(data.webhook.recentLagMs)}ms`
+      : 'n/a';
+  console.log(`  Webhook      lag=${webhookLag}`);
+
+  if (data.inFlight.length > 0) {
+    console.log(`  In-flight:`);
+    for (const f of data.inFlight) {
+      const mins = Math.round(f.elapsedMs / 60_000);
+      console.log(`    ${f.subsystem}  ${mins}min`);
+    }
+  }
+
+  console.log(`  Gates:       ${data.gates.join(', ')}`);
+
+  if (data.reasons.length > 0) {
+    console.log();
+    console.log(`  ${statusColor}Reasons:${reset}`);
+    for (const r of data.reasons) {
+      console.log(`    - ${r}`);
+    }
+  }
+}
+
 // ── One-shot mode (existing behavior) ───────────────────────────────────────
 
 function main(): void {
@@ -1762,7 +1827,27 @@ function main(): void {
     );
     console.log('  deus pipeline --active               In-flight issues');
     console.log('  deus pipeline --all [--since Xh]     All events');
+    console.log('  deus pipeline --health [--json]      Pipeline health check');
     process.exit(0);
+  }
+
+  if (args[0] === '--health') {
+    const port = process.env.LINEAR_WEBHOOK_PORT || '3005';
+    fetch(`http://localhost:${port}/health/ready`)
+      .then(async (res) => {
+        const data = await res.json();
+        if (args.includes('--json')) {
+          console.log(JSON.stringify(data, null, 2));
+        } else {
+          prettyPrintHealth(data as HealthReadyResponse);
+        }
+        process.exit(res.status === 200 ? 0 : 1);
+      })
+      .catch(() => {
+        console.error(`Could not reach webhook server at localhost:${port}`);
+        process.exit(1);
+      });
+    return;
   }
 
   initDatabase();

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -2,7 +2,12 @@ import { createServer, Server } from 'http';
 import { LinearWebhookClient } from '@linear/sdk/webhooks';
 import type { EntityWebhookPayloadWithIssueData } from '@linear/sdk/webhooks';
 import { logger } from './logger.js';
-import { executeAgentRun, extractScopeBlock } from './linear-dispatcher.js';
+import {
+  executeAgentRun,
+  extractScopeBlock,
+  getDispatcherHealth,
+  withWatchdog,
+} from './linear-dispatcher.js';
 import type { LinearContext, GateLabels } from './linear-dispatcher.js';
 import type { GateSpec } from './linear-gate-specs.js';
 import type { RunContext } from './agent-runtimes/types.js';
@@ -20,7 +25,10 @@ import {
   getGateMeta,
   incrementAttemptCount,
   appendReviseHistory,
+  clearLiveness,
   computeEnrichmentHash,
+  getLiveness,
+  stampLiveness,
 } from './db.js';
 import { triggerAutoMerge } from './linear-auto-merge.js';
 import { notifyPipelineStep } from './linear-notifications.js';
@@ -29,8 +37,39 @@ import { RetryableError, UserError, FatalError } from './errors/index.js';
 import { WEBHOOK_MAX_RETRIES, WEBHOOK_BASE_DELAY_MS } from './config.js';
 
 const DEFAULT_WEBHOOK_PORT = 3005;
+const DEFAULT_GATE_WATCHDOG_MS = 30 * 60 * 1000;
+const _parsedGateWatchdog = parseInt(process.env.GATE_WATCHDOG_MS || '', 10);
+const GATE_WATCHDOG_MS =
+  isNaN(_parsedGateWatchdog) || _parsedGateWatchdog < 1000
+    ? DEFAULT_GATE_WATCHDOG_MS
+    : _parsedGateWatchdog;
 const LABEL_RETRY_MAX = 3;
 const LABEL_RETRY_BASE_MS = 5_000;
+
+function withGateWatchdog<T>(
+  label: string,
+  promise: Promise<T>,
+  issueId: string,
+  identifier: string,
+): Promise<T> {
+  return withWatchdog(
+    `gate:${label}:${identifier}`,
+    promise,
+    GATE_WATCHDOG_MS,
+    () => {
+      logPipelineEvent(
+        issueId,
+        identifier,
+        'gate_stalled',
+        `gate=${label} threshold=${GATE_WATCHDOG_MS}ms`,
+      );
+      stampLiveness(`gate_stalled:${issueId}`, {
+        gate: label,
+        thresholdMs: GATE_WATCHDOG_MS,
+      });
+    },
+  ).finally(() => clearLiveness(`gate_stalled:${issueId}`));
+}
 const WEBHOOK_MAX_DELAY_MS = 30_000;
 
 // Map<issueId, timeout> for deferred auto-merge after genuine cooldowns.
@@ -364,6 +403,10 @@ export async function runInlineCompletionCheck(
   }
 
   ctx.inFlightGate.add(issueData.id);
+  stampLiveness(`gate_in_flight:${issueData.id}`, {
+    gate: 'completion-check',
+    startedAt: new Date().toISOString(),
+  });
   try {
     let commentBlock = '';
     const comments = await fetchIssueComments(ctx, issueData.id);
@@ -392,10 +435,15 @@ export async function runInlineCompletionCheck(
       effort: completionGateSpec.effort ?? 'medium',
     };
 
-    const { text, error } = await retryWithBackoff(
-      () => executeAgentRun(ctx, runContext),
-      WEBHOOK_MAX_RETRIES,
-      WEBHOOK_BASE_DELAY_MS,
+    const { text, error } = await withGateWatchdog(
+      'completion-check',
+      retryWithBackoff(
+        () => executeAgentRun(ctx, runContext),
+        WEBHOOK_MAX_RETRIES,
+        WEBHOOK_BASE_DELAY_MS,
+      ),
+      issueData.id,
+      issueData.identifier,
     );
 
     const output = text || error || '';
@@ -424,6 +472,7 @@ export async function runInlineCompletionCheck(
     return 'REVISE';
   } finally {
     ctx.inFlightGate.delete(issueData.id);
+    clearLiveness(`gate_in_flight:${issueData.id}`);
   }
 }
 
@@ -532,8 +581,12 @@ async function handleIssueUpdate(
 
   if (action !== 'update') return;
 
+  const webhookLagMs =
+    Date.now() - new Date(payload.webhookTimestamp).getTime();
+  stampLiveness('webhook_ingest', { lagMs: webhookLagMs });
+
   logger.info(
-    { issueId: data.id, action, identifier: data.identifier },
+    { issueId: data.id, action, identifier: data.identifier, webhookLagMs },
     'linear-webhook: received event',
   );
 
@@ -761,6 +814,10 @@ async function handleIssueUpdate(
     return;
   }
   ctx.inFlightGate.add(data.id);
+  stampLiveness(`gate_in_flight:${data.id}`, {
+    gate: gateSpec.name,
+    startedAt: new Date().toISOString(),
+  });
 
   // --- Bouncer entry-path router: short-circuit on fresh enrichment hash ---
   if (gateSpec.name === 'bouncer-gate') {
@@ -801,6 +858,7 @@ async function handleIssueUpdate(
             'linear-webhook: bouncer fast-path SHIP (hash match)',
           );
           ctx.inFlightGate.delete(data.id);
+          clearLiveness(`gate_in_flight:${data.id}`);
           return;
         }
       }
@@ -896,10 +954,15 @@ async function handleIssueUpdate(
       effort: gateSpec.effort ?? 'medium',
     };
 
-    const { text, error } = await retryWithBackoff(
-      () => executeAgentRun(ctx, runContext),
-      WEBHOOK_MAX_RETRIES,
-      WEBHOOK_BASE_DELAY_MS,
+    const { text, error } = await withGateWatchdog(
+      gateSpec.name,
+      retryWithBackoff(
+        () => executeAgentRun(ctx, runContext),
+        WEBHOOK_MAX_RETRIES,
+        WEBHOOK_BASE_DELAY_MS,
+      ),
+      data.id,
+      data.identifier,
     );
 
     // Container may exit non-zero (e.g., docker kill) but still have output in either field
@@ -1071,6 +1134,7 @@ async function handleIssueUpdate(
     );
   } finally {
     ctx.inFlightGate.delete(data.id);
+    clearLiveness(`gate_in_flight:${data.id}`);
     const removeIds: string[] = [];
     const addIds: string[] = [];
     if (ctx.gateLabels.evaluating) removeIds.push(ctx.gateLabels.evaluating);
@@ -1189,6 +1253,10 @@ async function runGateForIssue(
   stateName: string,
 ): Promise<void> {
   ctx.inFlightGate.add(issue.id);
+  stampLiveness(`gate_in_flight:${issue.id}`, {
+    gate: gateSpec.name,
+    startedAt: new Date().toISOString(),
+  });
   let finalVerdict: string | undefined;
   let finalEnrichment: string | undefined;
 
@@ -1236,10 +1304,15 @@ async function runGateForIssue(
       effort: gateSpec.effort ?? 'medium',
     };
 
-    const { text, error } = await retryWithBackoff(
-      () => executeAgentRun(ctx, runContext),
-      WEBHOOK_MAX_RETRIES,
-      WEBHOOK_BASE_DELAY_MS,
+    const { text, error } = await withGateWatchdog(
+      gateSpec.name,
+      retryWithBackoff(
+        () => executeAgentRun(ctx, runContext),
+        WEBHOOK_MAX_RETRIES,
+        WEBHOOK_BASE_DELAY_MS,
+      ),
+      issue.id,
+      issue.identifier,
     );
 
     const output = text || error || '';
@@ -1353,6 +1426,7 @@ async function runGateForIssue(
     finalVerdict = 'REVISE';
   } finally {
     ctx.inFlightGate.delete(issue.id);
+    clearLiveness(`gate_in_flight:${issue.id}`);
 
     const removeIds: string[] = [];
     const addIds: string[] = [];
@@ -1535,6 +1609,108 @@ export function startLinearWebhookServer(
       if (req.method === 'GET' && req.url === '/health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ status: 'ok', gates: [...gateSpecs.keys()] }));
+        return;
+      }
+
+      if (req.method === 'GET' && req.url === '/health/live') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ alive: true }));
+        return;
+      }
+
+      if (req.method === 'GET' && req.url === '/health/ready') {
+        const dispatcherHealth = getDispatcherHealth();
+        const liveness = getLiveness();
+        const now = Date.now();
+
+        const dispatcherLag = dispatcherHealth
+          ? now - dispatcherHealth.lastTickAt
+          : Infinity;
+        const effectivePollMs = dispatcherHealth?.pollMs ?? 30_000;
+
+        const safeParseDetail = (
+          raw: string | null,
+        ): Record<string, unknown> => {
+          if (!raw) return {};
+          try {
+            return JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            return {};
+          }
+        };
+
+        const inFlight = liveness
+          .filter((r) => r.subsystem.includes('_in_flight:'))
+          .map((r) => {
+            const detail = safeParseDetail(r.detail);
+            const startedAt = (detail.startedAt as string) ?? r.last_seen_at;
+            return {
+              subsystem: r.subsystem,
+              startedAt,
+              elapsedMs: now - new Date(startedAt).getTime(),
+            };
+          });
+
+        const webhookRow = liveness.find(
+          (r) => r.subsystem === 'webhook_ingest',
+        );
+        const webhookDetail = safeParseDetail(webhookRow?.detail ?? null);
+
+        const reasons: string[] = [];
+        const maxInFlightMs = inFlight.reduce(
+          (max, f) => Math.max(max, f.elapsedMs),
+          0,
+        );
+
+        let status: 'ok' | 'degraded' | 'stalled' = 'ok';
+        if (
+          dispatcherLag > 5 * effectivePollMs ||
+          maxInFlightMs > 120 * 60_000
+        ) {
+          status = 'stalled';
+          if (dispatcherLag > 5 * effectivePollMs)
+            reasons.push(
+              `dispatcher lag ${Math.round(dispatcherLag / 1000)}s > 5× poll`,
+            );
+          if (maxInFlightMs > 120 * 60_000)
+            reasons.push(
+              `in-flight entry stalled ${Math.round(maxInFlightMs / 60_000)}min`,
+            );
+        } else if (
+          dispatcherLag > 2 * effectivePollMs ||
+          maxInFlightMs > 60 * 60_000
+        ) {
+          status = 'degraded';
+          if (dispatcherLag > 2 * effectivePollMs)
+            reasons.push(
+              `dispatcher lag ${Math.round(dispatcherLag / 1000)}s > 2× poll`,
+            );
+          if (maxInFlightMs > 60 * 60_000)
+            reasons.push(
+              `in-flight entry ${Math.round(maxInFlightMs / 60_000)}min`,
+            );
+        }
+
+        const body = {
+          status,
+          dispatcher: {
+            lastTickAt: dispatcherHealth?.lastTickAt ?? null,
+            lagMs: dispatcherHealth ? Math.round(dispatcherLag) : null,
+            pollMs: effectivePollMs,
+            inFlightCount: ctx.inFlightDispatch.size,
+          },
+          webhook: {
+            lastIngestAt: webhookRow?.last_seen_at ?? null,
+            recentLagMs: webhookDetail?.lagMs ?? null,
+          },
+          inFlight,
+          gates: [...gateSpecs.keys()],
+          reasons,
+        };
+
+        const statusCode = status === 'ok' ? 200 : 503;
+        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(body));
         return;
       }
 


### PR DESCRIPTION
## Summary

- Adds `pipeline_liveness` SQLite table for timestamped subsystem health tracking
- Enriches `/health` endpoint with `/health/live` (liveness probe) and `/health/ready` (structured JSON, 503 on degraded/stalled)
- Dispatcher stamps heartbeat every poll tick; in-flight dispatch/gate operations tracked as persistent DB rows
- `withWatchdog` decorator wraps gate (30min) and dispatch (90min) agent runs with deadline timers that log `gate_stalled`/`dispatch_stalled` events
- `deus pipeline --health [--json]` CLI command for programmatic health checks (exit 0=ok, 1=degraded)
- Webhook delivery lag measured from Linear's payload timestamp
- Soft-delete via `cleared_at` column per no-db-deletion ADR

Closes four identified monitoring gaps: no dispatcher heartbeat, no webhook lag detection, no machine-readable health output, no in-flight stall detection.

## Test plan

- [ ] `npm run build` passes
- [ ] `curl localhost:3005/health` returns backward-compatible response
- [ ] `curl localhost:3005/health/live` returns `{ alive: true }`
- [ ] `curl localhost:3005/health/ready` returns structured JSON with status field
- [ ] `deus pipeline --health` pretty-prints health status
- [ ] `deus pipeline --health --json` outputs JSON, exit code 0 or 1
- [ ] Move issue to Ready for Agent, verify in-flight liveness rows in DB
- [ ] Watchdog thresholds env-overridable (GATE_WATCHDOG_MS, DISPATCH_WATCHDOG_MS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)