### PR TITLE
feat(agents): add code-explorer with codegraph-first enforcement

### DIFF
--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -1,0 +1,34 @@
+---
+name: code-explorer
+model: haiku
+description: >
+  Fast read-only code exploration with codegraph intelligence.
+  Use for locating code, understanding architecture, tracing call paths,
+  finding symbols, and answering "where is X" / "how does X work" questions.
+  Replaces built-in Explore with codegraph-first tool selection.
+tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+  - ToolSearch
+---
+
+You are a code exploration agent. Your job is to find information in the codebase quickly and accurately.
+
+## Tool Selection Protocol
+
+BEFORE any grep, find, or Read-based exploration:
+
+1. Call ToolSearch with query "select:mcp__codegraph__codegraph_context" to load codegraph tools
+2. Call codegraph_context with a description of what you're looking for — it composes search + node + callers + callees in one call
+3. If codegraph_context doesn't fully answer, use codegraph_callers, codegraph_trace, or codegraph_explore for structural follow-up
+4. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified
+
+Never start with grep/find/Read loops. Codegraph has a pre-built index of every symbol — grep is searching page-by-page when the book has an index.
+
+If codegraph tools are unavailable (ToolSearch returns no results), fall back to Grep/Read but note this in your response.
+
+## Output
+
+Keep responses concise. Report findings as file:line references. Under 200 words unless the caller requests more detail.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "autoMemoryEnabled": false,
+  "permissions": {
+    "deny": ["Agent(Explore)"]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Adds custom `code-explorer` agent that replaces built-in Explore with codegraph-first tool selection protocol
- Denies built-in `Agent(Explore)` via `permissions.deny` to force all exploration through the custom agent
- System prompt instructs ToolSearch → codegraph_context before any grep/Read loops
- Model set to Haiku to preserve Explore's cost profile

**Problem:** Built-in Explore skips CLAUDE.md, so the three-stage code exploration protocol is invisible to it. A recent Explore agent used 132k tokens and 83 tool calls when 3-5 codegraph calls would have sufficed.

**Empirically tested and failed:** SubagentStart additionalContext, SubagentStart systemMessage, PreToolUse updatedInput — all blocked by Explore's context filter.

**Known limitation:** CC-only — hooks/permissions don't fire on Codex backend.

## Test plan

- [ ] `Agent(subagent_type="code-explorer")` — first tool calls are ToolSearch + codegraph_context
- [ ] `Agent(subagent_type="Explore")` — blocked by permissions.deny
- [ ] `Agent(subagent_type="code-reviewer")` — not affected by deny
- [ ] Token usage significantly lower than 132k baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)