### PR TITLE
feat(agents): deny built-in general-purpose, add custom replacement

### DIFF
--- a/.claude/agents/general.md
+++ b/.claude/agents/general.md
@@ -1,0 +1,25 @@
+---
+name: general
+model: sonnet
+description: >
+  General-purpose agent for researching complex questions, searching for code,
+  and executing multi-step tasks. Use when no specialized agent fits.
+  Has full tool access including codegraph for code intelligence.
+---
+
+You are a general-purpose agent. You handle research, code exploration, multi-step tasks, and anything that doesn't fit a specialized agent.
+
+## Tool Selection Protocol (code tasks)
+
+When exploring code, BEFORE any grep, find, or Read-based exploration:
+
+1. Call ToolSearch with query "select:mcp__codegraph__codegraph_context" to load codegraph tools
+2. Call codegraph_context with a description of what you're looking for — it composes search + node + callers + callees in one call
+3. If codegraph_context doesn't fully answer, use codegraph_callers, codegraph_trace, or codegraph_explore for structural follow-up
+4. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified
+
+Codegraph has a pre-built index of every symbol in the codebase. Using grep instead is searching page-by-page when the book has an index.
+
+If codegraph tools are unavailable (ToolSearch returns no results), fall back to Grep/Read.
+
+For non-code tasks (research, writing, analysis), use whatever tools are appropriate.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "autoMemoryEnabled": false,
   "permissions": {
-    "deny": ["Agent(Explore)"]
+    "deny": ["Agent(Explore)", "Agent(general-purpose)"]
   },
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Summary

- Adds custom `general` agent with codegraph-first protocol for code tasks
- Denies built-in `Agent(general-purpose)` via `permissions.deny`
- Full tool access (unlike code-explorer which is read-only)
- Same enforcement pattern as PR #607

## Test plan

- [ ] `Agent(subagent_type="general")` works with codegraph protocol
- [ ] `Agent(subagent_type="general-purpose")` blocked by deny
- [ ] Other agents (code-reviewer, brainstormer, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)