### PR TITLE
fix(auth): harden credential proxy with placeholder detection and startup validation

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-28" # auto-bump
+last_verified: "2026-05-29" # auto-bump
 governs:
   - src/
   - setup/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump
+last_verified: "2026-05-29"
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-05-27T21" # auto-bump
+last_verified: "2026-05-29" # auto-bump
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/auth-providers/anthropic.ts
+++ b/src/auth-providers/anthropic.ts
@@ -19,6 +19,7 @@ import { readFileSync, renameSync, writeFileSync } from 'fs';
 import path from 'path';
 
 import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
 import { homeDir, IS_LINUX, IS_MACOS, IS_WINDOWS } from '../platform.js';
 import type { AuthProvider } from './types.js';
 import type { AuthMode } from '../credential-proxy.js';
@@ -71,6 +72,9 @@ export function readCredentialsFile(): OAuthCredentials | undefined {
     };
     const oauth = parsed?.claudeAiOauth;
     if (!oauth?.accessToken) return undefined;
+    // Real Claude Code OAuth tokens are 40+ chars; anything shorter is a dev stub
+    if (oauth.accessToken === 'placeholder' || oauth.accessToken.length < 20)
+      return undefined;
     return {
       accessToken: oauth.accessToken,
       refreshToken: oauth.refreshToken,
@@ -301,6 +305,36 @@ export class AnthropicAuthProvider implements AuthProvider {
     this.authMode = this.secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
     this.envOauthToken =
       this.secrets.CLAUDE_CODE_OAUTH_TOKEN || this.secrets.ANTHROPIC_AUTH_TOKEN;
+
+    if (this.authMode === 'oauth') {
+      this.validateOAuthCredentials();
+    }
+  }
+
+  private validateOAuthCredentials(): void {
+    if (this.envOauthToken) {
+      logger.info(
+        'OAuth mode: using token from env (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN)',
+      );
+      return;
+    }
+    const fileCreds = readCredentialsFile();
+    if (fileCreds) {
+      logger.info(
+        { path: CREDENTIALS_PATH },
+        'OAuth mode: credentials loaded from file',
+      );
+      return;
+    }
+    const keychainCreds = readKeychainCredentials();
+    if (keychainCreds) {
+      logger.info('OAuth mode: credentials loaded from OS keychain');
+      return;
+    }
+    logger.warn(
+      { path: CREDENTIALS_PATH },
+      'OAuth mode: no valid credentials found — container requests will fail until credentials are provided',
+    );
   }
 
   /** Get the auth mode for external consumers (e.g. container-runner). */

--- a/src/auth-providers/anthropic.ts
+++ b/src/auth-providers/anthropic.ts
@@ -105,6 +105,8 @@ export function readKeychainCredentials(): OAuthCredentials | undefined {
     };
     const oauth = parsed?.claudeAiOauth;
     if (!oauth?.accessToken) return undefined;
+    if (oauth.accessToken === 'placeholder' || oauth.accessToken.length < 20)
+      return undefined;
     return {
       accessToken: oauth.accessToken,
       refreshToken: oauth.refreshToken,

--- a/src/auth-providers/auth-providers.test.ts
+++ b/src/auth-providers/auth-providers.test.ts
@@ -509,6 +509,32 @@ describe('AnthropicAuthProvider', () => {
       expect(result).toBeDefined();
       expect(result?.accessToken).toBe('valid-token-that-is-long-enough');
     });
+
+    it('rejects accessToken of exactly 19 characters', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: '1234567890123456789',
+            expiresAt: Date.now() + 3600000,
+          },
+        }),
+      );
+      expect(readCredentialsFile()).toBeUndefined();
+    });
+
+    it('accepts accessToken of exactly 20 characters', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: '12345678901234567890',
+            expiresAt: Date.now() + 3600000,
+          },
+        }),
+      );
+      const result = readCredentialsFile();
+      expect(result).toBeDefined();
+      expect(result?.accessToken).toBe('12345678901234567890');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -517,7 +543,7 @@ describe('AnthropicAuthProvider', () => {
   describe('credential store fallback', () => {
     const keychainCreds = JSON.stringify({
       claudeAiOauth: {
-        accessToken: 'keychain-tok',
+        accessToken: 'keychain-tok-valid-test-pad',
         refreshToken: 'keychain-refresh',
         expiresAt: Date.now() + 7200000,
       },
@@ -580,7 +606,7 @@ describe('AnthropicAuthProvider', () => {
       provider.isAvailable(); // triggers getDynamicOAuthToken → keychain read → write
       expect(mockWriteFileSync).toHaveBeenCalledWith(
         expect.stringContaining('.credentials.json'),
-        expect.stringContaining('keychain-tok'),
+        expect.stringContaining('keychain-tok-valid-test-pad'),
         expect.objectContaining({ mode: 0o600 }),
       );
     });
@@ -621,7 +647,9 @@ describe('AnthropicAuthProvider', () => {
         authorization: 'Bearer placeholder',
       };
       provider.injectAuth(headers);
-      expect(headers['authorization']).toBe('Bearer keychain-tok');
+      expect(headers['authorization']).toBe(
+        'Bearer keychain-tok-valid-test-pad',
+      );
     });
 
     it('handles malformed JSON from credential store gracefully', () => {

--- a/src/auth-providers/auth-providers.test.ts
+++ b/src/auth-providers/auth-providers.test.ts
@@ -53,6 +53,7 @@ import type { AuthProvider } from './types.js';
 import { ensureDefaultProviders } from './index.js';
 import {
   AnthropicAuthProvider,
+  readCredentialsFile,
   _resetCredentialsCacheForTest,
 } from './anthropic.js';
 import { OpenAIAuthProvider, _resetCodexCacheForTest } from './openai.js';
@@ -426,7 +427,7 @@ describe('AnthropicAuthProvider', () => {
     mockReadFileSync.mockReturnValue(
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: 'creds-tok',
+          accessToken: 'creds-tok-valid-test-pad',
           expiresAt: Date.now() + 3600000,
         },
       }),
@@ -465,6 +466,49 @@ describe('AnthropicAuthProvider', () => {
     const provider = new AnthropicAuthProvider();
     expect(provider.name).toBe('anthropic');
     expect(provider.priority).toBe(10);
+  });
+
+  // -------------------------------------------------------------------------
+  // Placeholder detection tests
+  // -------------------------------------------------------------------------
+  describe('readCredentialsFile placeholder detection', () => {
+    it('rejects literal "placeholder" accessToken', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'placeholder',
+            expiresAt: Date.now() + 3600000,
+          },
+        }),
+      );
+      expect(readCredentialsFile()).toBeUndefined();
+    });
+
+    it('rejects accessToken shorter than 20 characters', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'short-token',
+            expiresAt: Date.now() + 3600000,
+          },
+        }),
+      );
+      expect(readCredentialsFile()).toBeUndefined();
+    });
+
+    it('accepts accessToken with 20+ characters', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'valid-token-that-is-long-enough',
+            expiresAt: Date.now() + 3600000,
+          },
+        }),
+      );
+      const result = readCredentialsFile();
+      expect(result).toBeDefined();
+      expect(result?.accessToken).toBe('valid-token-that-is-long-enough');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -553,7 +597,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'file-tok',
+            accessToken: 'file-tok-valid-test-pad',
             expiresAt: Date.now() + 7200000,
           },
         }),
@@ -564,7 +608,7 @@ describe('AnthropicAuthProvider', () => {
         authorization: 'Bearer placeholder',
       };
       provider.injectAuth(headers);
-      expect(headers['authorization']).toBe('Bearer file-tok');
+      expect(headers['authorization']).toBe('Bearer file-tok-valid-test-pad');
       // Keychain should not have been called
       expect(mockExecFileSync).not.toHaveBeenCalled();
     });
@@ -607,7 +651,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'cached-tok',
+            accessToken: 'cached-tok-valid-test-pad',
             expiresAt: Date.now() + 7200000,
           },
         }),
@@ -618,13 +662,13 @@ describe('AnthropicAuthProvider', () => {
         authorization: 'Bearer x',
       };
       provider.injectAuth(h1);
-      expect(h1['authorization']).toBe('Bearer cached-tok');
+      expect(h1['authorization']).toBe('Bearer cached-tok-valid-test-pad');
 
       // Change what the file returns — should still get cached value
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'new-tok',
+            accessToken: 'new-tok-valid-test-pad-x',
             expiresAt: Date.now() + 7200000,
           },
         }),
@@ -633,7 +677,7 @@ describe('AnthropicAuthProvider', () => {
         authorization: 'Bearer x',
       };
       provider.injectAuth(h2);
-      expect(h2['authorization']).toBe('Bearer cached-tok');
+      expect(h2['authorization']).toBe('Bearer cached-tok-valid-test-pad');
     });
 
     it('invalidates cache when token is about to expire', () => {
@@ -641,7 +685,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'expiring-tok',
+            accessToken: 'expiring-tok-valid-test',
             expiresAt: Date.now() + 10 * 60 * 1000,
           },
         }),
@@ -652,13 +696,13 @@ describe('AnthropicAuthProvider', () => {
         authorization: 'Bearer x',
       };
       provider.injectAuth(h1);
-      expect(h1['authorization']).toBe('Bearer expiring-tok');
+      expect(h1['authorization']).toBe('Bearer expiring-tok-valid-test');
 
       // Now update the file — cache should be stale due to early-expire window
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'refreshed-tok',
+            accessToken: 'refreshed-tok-valid-test',
             expiresAt: Date.now() + 7200000,
           },
         }),
@@ -667,7 +711,7 @@ describe('AnthropicAuthProvider', () => {
         authorization: 'Bearer x',
       };
       provider.injectAuth(h2);
-      expect(h2['authorization']).toBe('Bearer refreshed-tok');
+      expect(h2['authorization']).toBe('Bearer refreshed-tok-valid-test');
     });
   });
 
@@ -701,7 +745,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'old-tok',
+            accessToken: 'old-tok-valid-test-pad-x',
             refreshToken: 'old-refresh',
             expiresAt: Date.now() + 10 * 60 * 1000,
           },
@@ -738,7 +782,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'good-tok',
+            accessToken: 'good-tok-valid-test-pad',
             refreshToken: 'refresh-tok',
             expiresAt: Date.now() + 7200000, // 2 hours
           },
@@ -755,7 +799,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'no-refresh-tok',
+            accessToken: 'no-refresh-tok-valid-test',
             expiresAt: Date.now() + 10 * 60 * 1000, // expiring soon
           },
         }),
@@ -790,7 +834,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'dup-tok',
+            accessToken: 'dup-tok-valid-test-pad-x',
             refreshToken: 'dup-refresh',
             expiresAt: Date.now() + 10 * 60 * 1000,
           },
@@ -825,7 +869,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'stale-tok',
+            accessToken: 'stale-tok-valid-test-pad',
             refreshToken: 'bad-refresh',
             expiresAt: Date.now() + 10 * 60 * 1000,
           },
@@ -839,7 +883,7 @@ describe('AnthropicAuthProvider', () => {
       provider.injectAuth(headers);
 
       // Should still return the stale token
-      expect(headers['authorization']).toBe('Bearer stale-tok');
+      expect(headers['authorization']).toBe('Bearer stale-tok-valid-test-pad');
 
       // Wait for the failed refresh to complete
       await vi.waitFor(() => {
@@ -856,7 +900,7 @@ describe('AnthropicAuthProvider', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
           claudeAiOauth: {
-            accessToken: 'net-err-tok',
+            accessToken: 'net-err-tok-valid-test-x',
             refreshToken: 'net-refresh',
             expiresAt: Date.now() + 10 * 60 * 1000,
           },

--- a/src/auth-providers/index.ts
+++ b/src/auth-providers/index.ts
@@ -13,6 +13,7 @@ export {
 } from './types.js';
 export {
   AnthropicAuthProvider,
+  CREDENTIALS_PATH,
   _resetCredentialsCacheForTest,
 } from './anthropic.js';
 export { OpenAIAuthProvider } from './openai.js';

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -289,7 +289,7 @@ describe('credential-proxy', () => {
     mockReadFileSync.mockReturnValue(
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: 'creds-file-token',
+          accessToken: 'creds-file-token-valid-test',
           expiresAt: Date.now() + 60 * 60 * 1000,
         },
       }),
@@ -311,7 +311,7 @@ describe('credential-proxy', () => {
     );
 
     expect(lastUpstreamHeaders['authorization']).toBe(
-      'Bearer creds-file-token',
+      'Bearer creds-file-token-valid-test',
     );
   });
 
@@ -319,7 +319,7 @@ describe('credential-proxy', () => {
     mockReadFileSync.mockReturnValue(
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: 'creds-file-token',
+          accessToken: 'creds-file-token-valid-test',
           expiresAt: Date.now() + 60 * 60 * 1000,
         },
       }),
@@ -344,20 +344,29 @@ describe('credential-proxy', () => {
   });
 
   it('OAuth mode: re-reads credentials file when cached token is about to expire', async () => {
-    // First call: token expiring in 2 min (within 5-min early-expire window)
+    // Constructor validation read (consumed during AnthropicAuthProvider init)
     mockReadFileSync.mockReturnValueOnce(
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: 'expiring-token',
+          accessToken: 'expiring-token-valid-test',
           expiresAt: Date.now() + 2 * 60 * 1000,
         },
       }),
     );
-    // Second call: refreshed token
+    // First request: token expiring in 2 min (within 30-min early-expire window)
     mockReadFileSync.mockReturnValueOnce(
       JSON.stringify({
         claudeAiOauth: {
-          accessToken: 'refreshed-token',
+          accessToken: 'expiring-token-valid-test',
+          expiresAt: Date.now() + 2 * 60 * 1000,
+        },
+      }),
+    );
+    // Second request: refreshed token
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'refreshed-token-valid-test',
           expiresAt: Date.now() + 60 * 60 * 1000,
         },
       }),
@@ -377,7 +386,9 @@ describe('credential-proxy', () => {
       }),
       '{}',
     );
-    expect(lastUpstreamHeaders['authorization']).toBe('Bearer expiring-token');
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      'Bearer expiring-token-valid-test',
+    );
 
     // Cache is stale (token about to expire) — re-read on next request
     await makeRequest(
@@ -392,7 +403,9 @@ describe('credential-proxy', () => {
       }),
       '{}',
     );
-    expect(lastUpstreamHeaders['authorization']).toBe('Bearer refreshed-token');
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      'Bearer refreshed-token-valid-test',
+    );
   });
 
   it('OAuth mode replaces Bearer token on session endpoints', async () => {

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -27,6 +27,7 @@ import { logger } from './logger.js';
 import {
   AuthProviderRegistry,
   AnthropicAuthProvider,
+  CREDENTIALS_PATH,
   _resetCredentialsCacheForTest as _resetAnthropicCache,
   ensureDefaultProviders,
 } from './auth-providers/index.js';
@@ -344,7 +345,10 @@ export function startCredentialProxy(
 
     const tryListen = () => {
       server.listen(port, host, () => {
-        logger.info({ port, host, authMode }, 'Credential proxy started');
+        logger.info(
+          { port, host, authMode, credentialsPath: CREDENTIALS_PATH },
+          'Credential proxy started',
+        );
         resolve(server);
       });
     };


### PR DESCRIPTION
## Summary
- Adds placeholder/stub token detection in `readCredentialsFile()` — rejects tokens < 20 chars (real OAuth tokens are 40+ chars)
- Logs credential source at startup (env/file/keychain) with structured logger
- Includes resolved credentials path in proxy startup log
- Re-exports `CREDENTIALS_PATH` from auth-providers barrel

Closes GitHub #605 / Linear LIA-117

## Test plan
- [x] 69/69 existing tests pass (auth-providers + credential-proxy)
- [x] 3 new tests for placeholder detection (literal "placeholder", short token, valid token)
- [x] TypeScript compiles clean
- [x] Mock tokens updated to >= 20 chars to match new validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)