### PR TITLE
fix(pipeline): track gate infrastructure errors toward escalation

### DIFF
--- a/.claude/.warden-log
+++ b/.claude/.warden-log
@@ -15,3 +15,8 @@
 2026-05-26T11:56:22Z | plan-reviewer   | SHIP    | LIA-92: prompt-only warden spec edits, pre-approved
 2026-05-26T11:58:21Z | code-reviewer   | TRIVIAL | LIA-92: prompt-only warden spec additions, no runtime code changes
 2026-05-27T12:02:02Z | plan-reviewer   | SHIP    | LIA-102 content was plan-reviewed and approved (SHIP verdict) by container agent; this is a markdown-only append to a warden spec file with no runtime code changes
+2026-05-28T22:56:01Z | plan-reviewer   | SHIP    | Gate error escalation plan SHIP'd by plan-reviewer round 2 - both blocking issues from round 1 resolved
+2026-05-28T22:58:54Z | code-reviewer   | SHIP    | code-reviewer returned SHIP (auto-detected from agent output)
+2026-05-28T22:59:04Z | code-reviewer   | SHIP    | Gate error escalation fix SHIP'd by code-reviewer - no blocking issues, 3-line fix
+2026-05-28T23:00:46Z | ai-eng-warden   | TRIVIAL | Pipeline error tracking fix - sets a variable and removes a guard condition. No LLM prompts, context management, or AI-specific code changed.
+2026-05-28T23:00:58Z | verification-gate | SHIP    | Verification gate already ran and SHIP'd - build clean, 1623 tests pass, diff verified, gateDidError guard removal confirmed

--- a/.claude/.warden-verdicts.json
+++ b/.claude/.warden-verdicts.json
@@ -1,20 +1,26 @@
 {
-  "code-reviewer": {
-    "reason": "LIA-92: prompt-only warden spec additions, no runtime code changes",
+  "ai-eng-warden": {
+    "reason": "Pipeline error tracking fix - sets a variable and removes a guard condition. No LLM prompts, context management, or AI-specific code changed.",
     "source": "mark",
-    "ts": "2026-05-26T11:58:21Z",
+    "ts": "2026-05-28T23:00:46Z",
     "verdict": "TRIVIAL"
   },
-  "plan-reviewer": {
-    "reason": "LIA-102 content was plan-reviewed and approved (SHIP verdict) by container agent; this is a markdown-only append to a warden spec file with no runtime code changes",
+  "code-reviewer": {
+    "reason": "Gate error escalation fix SHIP'd by code-reviewer - no blocking issues, 3-line fix",
     "source": "mark",
-    "ts": "2026-05-27T12:02:02Z",
+    "ts": "2026-05-28T22:59:04Z",
+    "verdict": "SHIP"
+  },
+  "plan-reviewer": {
+    "reason": "Gate error escalation plan SHIP'd by plan-reviewer round 2 - both blocking issues from round 1 resolved",
+    "source": "mark",
+    "ts": "2026-05-28T22:56:01Z",
     "verdict": "SHIP"
   },
   "verification-gate": {
-    "reason": "Pattern file comment-only bump, no functional changes to verify",
+    "reason": "Verification gate already ran and SHIP'd - build clean, 1623 tests pass, diff verified, gateDidError guard removal confirmed",
     "source": "mark",
-    "ts": "2026-05-26T11:47:30Z",
-    "verdict": "TRIVIAL"
+    "ts": "2026-05-28T23:00:58Z",
+    "verdict": "SHIP"
   }
 }

--- a/.claude/rules/orchestration-rules.md
+++ b/.claude/rules/orchestration-rules.md
@@ -19,6 +19,7 @@
 - Gate fallbacks are errors, not approvals. If a gate agent fails, the verdict must be ERROR with a visible error label — never SHIP. Fallback-SHIP silently bypasses quality gates and produces false labels on unreviewed work.
 - Never auto-advance an issue past a gate that didn't actually run. Silence is not consent.
 - REVISE handling follows core-behavioral-rules.md: re-run after fixes until SHIP, no exceptions.
+- When a pipeline loop is detected, stabilize first: move the issue to a safe state (Manual Review Required or Backlog) before investigating. Never debug a live loop.
 
 ## Agent Dispatch
 - Dispatched agents must work against the current issue state. If the issue was modified after dispatch, the agent's output is suspect — re-evaluate before accepting.

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # verified: gcal-sync + mcp-gcal changes
+last_verified: "2026-05-29" # auto-bump
 governs:
   - src/
   - setup/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # verified: gcal-sync auth alerting changes
+last_verified: "2026-05-29" # auto-bump
 governs:
   - src/
   - evolution/

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -1123,6 +1123,7 @@ async function handleIssueUpdate(
 
     // Apply fallback verdict on infrastructure errors (matching agent-error path)
     finalVerdict = gateSpec.fallback;
+    finalEnrichment = `Gate infrastructure error: ${errorMsg}`;
     const errorComment = formatGateComment(
       gateSpec.name,
       finalVerdict,
@@ -1194,7 +1195,7 @@ async function handleIssueUpdate(
       retryLabelUpdate(ctx.client, data.id, update);
     }
 
-    if (finalVerdict && finalEnrichment && !gateDidError) {
+    if (finalVerdict && finalEnrichment) {
       try {
         await trackGateMetaAndEscalate(
           ctx,
@@ -1424,6 +1425,7 @@ async function runGateForIssue(
     );
     // Never fallback-SHIP on infrastructure errors — gate didn't actually run
     finalVerdict = 'REVISE';
+    finalEnrichment = `Gate infrastructure error (startup sweep): ${errorMsg}`;
   } finally {
     ctx.inFlightGate.delete(issue.id);
     clearLiveness(`gate_in_flight:${issue.id}`);


### PR DESCRIPTION
## Summary
- Gate infrastructure errors (401 auth, timeouts) were silently excluded from attempt tracking, causing infinite revise loops
- Set `finalEnrichment` in both catch blocks (handleIssueUpdate + startup sweep) so errors are defined for tracking
- Remove `!gateDidError` guard from `trackGateMetaAndEscalate` call so errors count toward `maxAttempts` escalation
- After 3 gate errors, issues now escalate to "Manual Review Required" instead of cycling forever
- Add "stabilize first" rule to orchestration-rules.md

## Root Cause
`finalEnrichment` was never set in catch blocks, and line 1197 had `!gateDidError` guard — both prevented `trackGateMetaAndEscalate` from being called on infrastructure errors. The attempt counter never incremented, so the max-attempts escalation to Manual Review Required never triggered.

## Test plan
- [x] `npm run build` compiles clean
- [x] `npm test` — 1623 tests pass
- [x] Verified `parseRatings` and `computeScopeLabelChanges` safe with error strings (no unintended label mutations)
- [x] Confirmed `gateDidError` guard removed from tracking path (3 remaining refs are declaration, set, error-label)
- [ ] Observe next gate error in production — should escalate after 3 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)