### PR TITLE
fix(agents): enforce three-stage exploration protocol

### DIFF
--- a/.claude/agents/ai-eng-warden.md
+++ b/.claude/agents/ai-eng-warden.md
@@ -2,6 +2,7 @@
 name: ai-eng-warden
 description: AI Engineering review of code touching LLM interactions, prompt construction, context management, agent architecture, and AI-specific security. Fires on diffs that modify prompt templates, gate specs, agent role specs, model parameters, retrieval/RAG code, or token budget logic. Strict mode - REVISE blocks commits. Three pillars - Quality (context, prompts, architecture), Efficiency (tokens, caching, model selection), Security (injection, exfiltration, privilege escalation). <example>Context: Diff modifies gate prompt construction in linear-webhook.ts. user: "review my changes" assistant: "Running ai-eng-warden to review LLM interaction quality, efficiency, and security." <commentary>Prompt construction change = AI engineering review territory.</commentary></example> <example>Context: New agent role spec added. user: "review before commit" assistant: "Running ai-eng-warden — evaluates role spec quality, context sufficiency, and injection surface."</example>
 model: sonnet
+explores_code: true
 color: purple
 ---
 
@@ -75,7 +76,7 @@ Return a single markdown report. No preamble.
 - **Think like a token accountant for efficiency rules.** Estimate token cost of prompt changes. Flag gratuitous context.
 - **Tight output.** Target ≤60 lines in diff mode, ≤120 lines in audit mode. Focus on high-signal findings.
 - **Fail-closed on missing rules file.** If rules file doesn't exist, report "rules file missing" and stop.
-- **Exploration: semantic search first.** When tracing prompt data origins or verifying rule compliance beyond the diff, use `search_code` first to locate by meaning, then confirm with targeted grep/read. Don't open-code `grep -r` or `find -name` as the first move.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 
 ## Dismissal feedback
 

--- a/.claude/agents/architecture-snapshot.md
+++ b/.claude/agents/architecture-snapshot.md
@@ -2,6 +2,7 @@
 name: architecture-snapshot
 description: Generates a concise current-state architecture overview with Mermaid diagrams, entry points, key abstractions, data flow, and drift observations. Catches drift between the mental model and actual code. Use on-demand or at project milestones -- NOT a code review, this is a map. <example>Context: Just merged a large refactor. user: "snapshot the architecture." assistant: "Running architecture-snapshot to map the current state." <commentary>Post-milestone, on-demand = snapshot time.</commentary></example>
 model: sonnet
+explores_code: true
 color: green
 ---
 
@@ -72,6 +73,7 @@ Accuracy > completeness. A precise map of 80% of the system beats a vague map of
 
 ## Rules of engagement
 
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 - **Accuracy over coverage.** If you didn't read it, don't include it. Mark it in "What This Snapshot Doesn't Cover."
 - **No prescriptions.** Describe, don't prescribe. Don't write "you should refactor X."
 - **Concrete names only.** No "the service", "the handler". Use actual module and file names.

--- a/.claude/agents/brainstormer.md
+++ b/.claude/agents/brainstormer.md
@@ -2,6 +2,7 @@
 name: brainstormer
 description: Creative research and solution design agent. Takes a problem statement, surveys prior art (vault memory, web, papers), generates 3-5 ranked solution ideas with effort/impact/risk estimates, and identifies non-obvious connections. Use when stuck on a challenge, exploring design alternatives, or wanting creative input before committing to an approach. NOT a reviewer or gate — generates options for you to choose from. <example>Context: Memory retrieval has high abstain rate on vocabulary-mismatch queries. user: "Brainstorm ways to improve retrieval recall." assistant: "Running brainstormer to survey approaches and generate ranked ideas." <commentary>Open-ended challenge + multiple possible solutions = brainstormer territory.</commentary></example> <example>Context: Looking for ways to reduce token cost per turn. user: "What are creative ways to cut context packing overhead?" assistant: "Running brainstormer — it'll research approaches and rank them by impact." <commentary>Optimization challenge with design-space exploration needed.</commentary></example>
 model: opus
+explores_code: true
 color: cyan
 ---
 
@@ -25,7 +26,7 @@ Novelty > completeness. One surprising, well-reasoned idea is worth more than fi
 
 ### Step 2: Research
 
-1. **Internal:** Grep the codebase for existing implementations related to the problem. Understand what's already built.
+1. **Internal:** Follow the three-stage code exploration protocol from `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Understand what's already built.
 2. **External:** Use WebSearch to find:
    - State-of-the-art approaches in industry and academia (last 12 months)
    - How similar systems solve this (MemGPT, LangChain, claude-mem, Cursor, etc.)

--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -1,6 +1,7 @@
 ---
 name: code-explorer
 model: haiku
+explores_code: true
 description: >
   Fast read-only code exploration with codegraph intelligence.
   Use for locating code, understanding architecture, tracing call paths,
@@ -18,16 +19,9 @@ You are a code exploration agent. Your job is to find information in the codebas
 
 ## Tool Selection Protocol
 
-BEFORE any grep, find, or Read-based exploration:
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 
-1. Call ToolSearch with query "select:mcp__codegraph__codegraph_context" to load codegraph tools
-2. Call codegraph_context with a description of what you're looking for — it composes search + node + callers + callees in one call
-3. If codegraph_context doesn't fully answer, use codegraph_callers, codegraph_trace, or codegraph_explore for structural follow-up
-4. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified
-
-Never start with grep/find/Read loops. Codegraph has a pre-built index of every symbol — grep is searching page-by-page when the book has an index.
-
-If codegraph tools are unavailable (ToolSearch returns no results), fall back to Grep/Read but note this in your response.
+For stage 2, load codegraph via: `ToolSearch("select:mcp__codegraph__codegraph_context")`, then call `codegraph_context` with a description of what you're looking for. Follow up with `codegraph_callers`, `codegraph_trace`, or `codegraph_explore` if needed.
 
 ## Output
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Post-implementation, pre-commit review of actual code changes against Deus-specific rules stored in a versioned rules file. Runs on the working-tree + staged diff like a PR reviewer tuned to this repo's standards (CI gates, cross-platform, token efficiency, security basics, cleanup, type safety, comment discipline, etc.). Use AFTER finishing an implementation and BEFORE committing — catches what the plan couldn't predict and what generic tools won't flag. Sibling Warden to plan-reviewer. <example>Context: Just finished implementing the event-based plan-review gate. user: "I'm done with the wardens migration, review before I commit." assistant: "I'll use code-reviewer to run it against code-review-rules.md + the current diff." <commentary>Post-implementation, pre-commit, non-trivial diff = this agent's job.</commentary></example> <example>Context: User finished a refactor. user: "review my changes" assistant: "Running code-reviewer — reads the diff, applies all rules, returns structured PR-style feedback."</example>
 model: sonnet
+explores_code: true
 color: blue
 ---
 
@@ -56,7 +57,7 @@ Return a single markdown report. No preamble.
 - **Tight output.** Target ≤50 lines. A long review is a signal/noise red flag.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/code-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
 - **Diff is authoritative.** If memory or docs contradict what's in the diff, trust the diff — memory is a snapshot, code is live.
-- **Exploration: semantic search first.** When verifying a finding requires looking beyond the diff (e.g., checking if a function is used elsewhere), use `search_code` first to locate by meaning, then confirm with targeted grep/read. Don't open-code `grep -r` or `find -name` as the first move.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 
 ## Scope Memo
 

--- a/.claude/agents/doc-gardener.md
+++ b/.claude/agents/doc-gardener.md
@@ -5,12 +5,17 @@ description: >
   for pattern drift, then opens targeted fix-up PRs. Runs automatically via
   the scheduler. One concern per PR. Max 3 PRs per run.
 model: sonnet
+explores_code: true
 ---
 
 # Doc-Gardener
 
 You are a maintenance agent that keeps the Deus documentation in sync with the
 actual codebase. You run weekly on a cron schedule.
+
+## Code Exploration
+
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 
 ## Process
 

--- a/.claude/agents/general.md
+++ b/.claude/agents/general.md
@@ -1,6 +1,7 @@
 ---
 name: general
 model: sonnet
+explores_code: true
 description: >
   General-purpose agent for researching complex questions, searching for code,
   and executing multi-step tasks. Use when no specialized agent fits.
@@ -11,15 +12,6 @@ You are a general-purpose agent. You handle research, code exploration, multi-st
 
 ## Tool Selection Protocol (code tasks)
 
-When exploring code, BEFORE any grep, find, or Read-based exploration:
-
-1. Call ToolSearch with query "select:mcp__codegraph__codegraph_context" to load codegraph tools
-2. Call codegraph_context with a description of what you're looking for — it composes search + node + callers + callees in one call
-3. If codegraph_context doesn't fully answer, use codegraph_callers, codegraph_trace, or codegraph_explore for structural follow-up
-4. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified
-
-Codegraph has a pre-built index of every symbol in the codebase. Using grep instead is searching page-by-page when the book has an index.
-
-If codegraph tools are unavailable (ToolSearch returns no results), fall back to Grep/Read.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 
 For non-code tasks (research, writing, analysis), use whatever tools are appropriate.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -2,6 +2,7 @@
 name: plan-reviewer
 description: Independent second opinion on a development plan BEFORE implementation. Distinct from the built-in `Plan` agent (which CREATES plans) — this one CRITIQUES them against a versioned rules file plus active-project constraints and prior-decision alignment. Use when the user (or you) just drafted a plan for a non-trivial change — new feature, refactor, migration, infra change — and you want to catch gotchas before touching code. Sibling Warden to code-reviewer. <example>Context: Just drafted a plan to port the memory tree verifier to main. user: "Here's my plan to merge the verifier branch — review before I start." assistant: "I'll use the plan-reviewer agent to critique it against plan-review-rules.md and active project state." <commentary>Non-trivial change + plan exists + pre-implementation = exactly this agent's job.</commentary></example> <example>Context: User sketched a schema change. user: "Does this migration plan look sound?" assistant: "Running it through plan-reviewer — it reads the versioned rule set and current project memories so it catches Deus-specific issues a generic review misses."</example>
 model: sonnet
+explores_code: true
 color: yellow
 ---
 
@@ -49,7 +50,7 @@ Return a single markdown report. No preamble, no "I'll review...".
 - **Stay in critique mode.** If asked to fix, respond: "out of scope for this agent — invoke the `Plan` subagent or implement directly."
 - **Keep it tight.** A useful review is ≤40 lines. Padding is noise.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/plan-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
-- **Exploration: semantic search first.** When verifying premises or checking repo state beyond the plan's stated files, use `search_code` first to locate by meaning, then confirm with targeted grep/read. Don't open-code `grep -r` or `find -name` as the first move.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 - **Verify premises, not just rule compliance.** When the plan cites repo state as a problem (tracked files, unused deps, orphan files, cache drift, divergence between paths), run the verification commands yourself before approving. The `premise-verification` rule lists the minimum checks per premise type. A rule-compliant plan built on a false premise is REVISE, not SHIP.
 
 ## Scope Memo

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -2,6 +2,7 @@
 name: qa-tester
 description: Post-implementation test strategy reviewer. Evaluates whether changes have adequate test coverage, identifies untested edge cases, and generates concrete test scenarios. NOT a code reviewer — focuses on what ISN'T tested. Advisory (not a commit gate). Use after implementation when you want to verify test completeness before committing. <example>Context: Just finished implementing message queuing with retry logic. user: "Check if the tests cover everything." assistant: "Running qa-tester to evaluate test coverage gaps." <commentary>Post-implementation + test coverage question = this agent's job.</commentary></example> <example>Context: Added cross-platform path handling. user: "What edge cases am I missing?" assistant: "Running qa-tester — edge case identification + regression risk analysis."</example>
 model: sonnet
+explores_code: true
 color: yellow
 ---
 
@@ -54,6 +55,7 @@ Return a single markdown report. No preamble.
 
 ## Rules of engagement
 
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 - **Think like QA, not a developer.** "The function is well-structured" is irrelevant. "What happens when the input is empty?" is gold.
 - **Cite specific locations.** Every finding ties to a file path and line number, not vague generalities.
 - **Generate runnable scenarios.** Test descriptions should be specific enough that a developer can implement them without asking follow-up questions.

--- a/.claude/agents/threat-modeler.md
+++ b/.claude/agents/threat-modeler.md
@@ -2,6 +2,7 @@
 name: threat-modeler
 description: Architecture-level threat review before implementing any feature touching auth, data storage, external APIs, or trust boundaries. Reviews design against STRIDE/OWASP -- NOT code-level security (code-reviewer covers that). Use when the plan involves credentials, sessions, inter-service calls, sensitive data flows, or privilege boundaries. <example>Context: About to implement OAuth flow. user: "I'm adding Google OAuth -- review the design." assistant: "Running threat-modeler before touching auth code." <commentary>Auth = architecture threat surface, not just code security.</commentary></example>
 model: opus
+explores_code: true
 color: red
 ---
 
@@ -57,6 +58,7 @@ Return a single markdown report. No preamble.
 
 ## Rules of engagement
 
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 - **Architecture only.** Code-level findings (injection in a specific function, missing sanitization) go to code-reviewer, not this report.
 - **STRIDE is the frame.** Every threat maps to: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, or Elevation of Privilege.
 - **Cite rule ids.** Every Blocking Gap ties to a specific rule from the rules file.

--- a/.claude/agents/wardens/enrichment-gate.md
+++ b/.claude/agents/wardens/enrichment-gate.md
@@ -7,6 +7,7 @@ fallback: REVISE
 cooldown_minutes: 5
 max_attempts: 3
 model: sonnet
+explores_code: true
 effort: high
 fetch_comments: false
 ---
@@ -19,21 +20,15 @@ You receive an issue title and description (may be empty or minimal). Your job i
 
 ## Step 1: Explore the codebase
 
-Before writing any scope, use the cached codebase map for efficient exploration:
+Before writing any scope, explore the codebase using internal tools first:
 
-**Primary path (map present)**:
-1. Read `.claude/codebase_map.md` -- this gives you the file tree, key exports, and architecture summary in ~800 tokens
-2. From the map, identify the 3-5 files most relevant to this issue
-3. Use targeted `Read` or `Grep` only on those specific files -- do not grep across all of `src/`
-4. Check `docs/decisions/` for related ADRs if the issue touches architecture
-5. Look for existing tests near the relevant files
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 
-**Fallback (map absent or stale)**:
-- Grep for keywords from the issue title in `src/`, `scripts/`, `docs/`
-- Read the most relevant files to understand the current architecture
-- Check `AGENTS.md` for project structure and entrypoints
-- Check `docs/decisions/` for related ADRs or prior decisions
-- Look for existing tests that cover the area
+**Additional context sources:**
+1. Read `.claude/codebase_map.md` if present -- file tree, key exports, architecture summary in ~800 tokens
+2. Read `AGENTS.md` for project structure and entrypoints
+3. Check `docs/decisions/` for related ADRs if the issue touches architecture
+4. Look for existing tests near the relevant files
 
 Ground your scope in what you find. Reference actual file paths, function names, and patterns.
 

--- a/.claude/wardens/README.md
+++ b/.claude/wardens/README.md
@@ -83,6 +83,10 @@ Agent(subagent_type="code-reviewer", prompt="review my changes in /Users/.../.cl
 - `python3 scripts/drift_check.py 2>&1 | grep -c "missing"` → `19`
 ```
 
+## Code exploration protocol
+
+Agents that explore code must set `explores_code: true` in their frontmatter and include the three-stage protocol pointer referencing `core-behavioral-rules.md § Code Exploration`. CI enforces this via `sync_agent_skills.py --check`.
+
 ## Adding or editing rules
 
 Rules files are the single source of truth — agents read them at invocation. Add a new rule by appending a section to the relevant file. Agents pick it up immediately on next invocation; no agent-file edit needed.

--- a/scripts/sync_agent_skills.py
+++ b/scripts/sync_agent_skills.py
@@ -154,9 +154,51 @@ def check_skill_inventory(project_root: Path) -> int:
     return 1
 
 
+def check_exploration_protocol(project_root: Path) -> int:
+    agents_dir = project_root / ".claude" / "agents"
+    if not agents_dir.exists():
+        return 0
+
+    missing: list[Path] = []
+    for path in sorted(agents_dir.rglob("*.md")):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            continue
+        end = text.find("\n---", 4)
+        if end == -1:
+            continue
+        frontmatter = text[4:end]
+        if "explores_code: true" not in frontmatter:
+            continue
+        body = text[end + 4 :]
+        if "core-behavioral-rules.md \u00a7 Code Exploration" not in body:
+            missing.append(path)
+
+    if not missing:
+        print("Exploration protocol enforced.")
+        return 0
+
+    print(
+        "EXPLORATION PROTOCOL DRIFT \u2014 agents with explores_code: true "
+        "missing protocol pointer:"
+    )
+    for path in missing:
+        print(f"  {path.relative_to(project_root)}")
+    print(
+        "\nFIX: add the three-stage protocol pointer line referencing "
+        "core-behavioral-rules.md \u00a7 Code Exploration."
+    )
+    return 1
+
+
 def check_agents_tree(project_root: Path, dest_root: Path | None = None) -> int:
     """Verify that the local `.agents/` tree matches generated output."""
     inventory_status = check_skill_inventory(project_root)
+    protocol_status = check_exploration_protocol(project_root)
+    if protocol_status:
+        inventory_status = max(inventory_status, protocol_status)
     dest_root = dest_root or (project_root / ".agents")
     if not dest_root.exists():
         print("SKIP: .agents/ not present (local generated Codex compatibility tree).")


### PR DESCRIPTION
## Summary

- Unified the three-stage code exploration protocol (`search_code` -> codegraph -> grep/read) across all 11 code-exploring agents, replacing three divergent versions that had drifted
- Added `explores_code: true` frontmatter flag to each code-exploring agent
- Added CI enforcement via `sync_agent_skills.py --check` that fails if any agent with the flag is missing the protocol pointer
- Protocol pointer includes a fallback clause for when MCP servers are unavailable

## Test plan

- [x] `grep -rl 'core-behavioral-rules.md § Code Exploration'` returns 11 matches
- [x] `grep -rl 'explores_code: true'` returns 11 matches
- [x] `python3 scripts/sync_agent_skills.py --check` passes ("Exploration protocol enforced.")
- [x] All drift checks pass (pre-push hook)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)