### PR TITLE
fix(evolution): sanitize reflection injection with XML escaping and data envelope

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -118,7 +118,7 @@ def cmd_get_reflections(query_json: str) -> None:
         tools_planned=params.get("tools_planned"),
         top_k=params.get("top_k", 3),
     )
-    block = format_reflections_block(refs)
+    block = format_reflections_block(refs, group_folder=params.get("group_folder"))
     ref_ids = [r["id"] for r in refs]
     print(json.dumps({"reflections_block": block, "count": len(refs), "reflection_ids": ref_ids}))
 

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -98,7 +98,7 @@ def _run_mcp_server() -> None:
             tools_planned=tools_planned,
             top_k=top_k,
         )
-        return format_reflections_block(refs)
+        return format_reflections_block(refs, group_folder=group_folder)
 
     @mcp.tool()
     def get_active_prompt_tool(module: str) -> Optional[str]:

--- a/evolution/reflexion/retriever.py
+++ b/evolution/reflexion/retriever.py
@@ -70,20 +70,17 @@ MAX_REFLECTIONS_PER_REQUEST = 10
 def format_reflections_block(reflections: list[dict], group_folder: str | None = None) -> str:
     """
     Format retrieved reflections as a sanitized, enveloped prompt block.
-    Applies XML escaping to content and caps at MAX_REFLECTIONS_PER_REQUEST entries.
     Returns empty string if list is empty (no tokens added).
-
-    The data-envelope marks the source and whether the content is trusted
-    (trusted=true only when no group_folder, i.e. cross-group system reflections).
     """
     if not reflections:
         return ""
     reflections = reflections[:MAX_REFLECTIONS_PER_REQUEST]
-    trusted = "true" if group_folder is None else "false"
+    # Group-scoped content is trusted; cross-group (no folder) has wider blast radius = untrusted.
+    trusted = "true" if group_folder else "false"
     lines = [f'<data-envelope source="evolution-reflections" trusted="{trusted}">']
     lines.append("<reflections>")
     for i, r in enumerate(reflections, 1):
-        content = html.escape(r['content'].strip())[:500]
+        content = html.escape(r['content'].strip()[:500])
         lines.append(f"[{i}] ({r['category']}) {content}")
     lines.append("</reflections>")
     lines.append("</data-envelope>")

--- a/evolution/reflexion/retriever.py
+++ b/evolution/reflexion/retriever.py
@@ -2,6 +2,7 @@
 Reflection retriever: semantic top-k lookup keyed by query + planned tools.
 Returns a formatted <reflections> block ready to prepend to the agent prompt.
 """
+import html
 import math
 from typing import Optional
 
@@ -57,19 +58,33 @@ def get_reflections(
     for r in results:
         increment_retrieved(r["id"])
 
+    for r in results:
+        r['group_folder'] = group_folder
+
     return results
 
 
-def format_reflections_block(reflections: list[dict]) -> str:
+MAX_REFLECTIONS_PER_REQUEST = 10
+
+
+def format_reflections_block(reflections: list[dict], group_folder: str | None = None) -> str:
     """
-    Format retrieved reflections as a compact prompt block.
+    Format retrieved reflections as a sanitized, enveloped prompt block.
+    Applies XML escaping to content and caps at MAX_REFLECTIONS_PER_REQUEST entries.
     Returns empty string if list is empty (no tokens added).
+
+    The data-envelope marks the source and whether the content is trusted
+    (trusted=true only when no group_folder, i.e. cross-group system reflections).
     """
     if not reflections:
         return ""
-
-    lines = ["<reflections>"]
+    reflections = reflections[:MAX_REFLECTIONS_PER_REQUEST]
+    trusted = "true" if group_folder is None else "false"
+    lines = [f'<data-envelope source="evolution-reflections" trusted="{trusted}">']
+    lines.append("<reflections>")
     for i, r in enumerate(reflections, 1):
-        lines.append(f"[{i}] ({r['category']}) {r['content'].strip()}")
+        content = html.escape(r['content'].strip())[:500]
+        lines.append(f"[{i}] ({r['category']}) {content}")
     lines.append("</reflections>")
+    lines.append("</data-envelope>")
     return "\n".join(lines)

--- a/evolution/tests/test_retriever.py
+++ b/evolution/tests/test_retriever.py
@@ -1,0 +1,41 @@
+import pytest
+from evolution.reflexion.retriever import format_reflections_block
+
+
+def test_xml_escaping():
+    refs = [{"category": "style", "content": "<script>alert('xss')</script>", "group_folder": None}]
+    result = format_reflections_block(refs)
+    assert "&lt;script&gt;" in result
+    assert "<script>" not in result
+
+
+def test_trusted_true_when_no_group():
+    refs = [{"category": "style", "content": "test", "group_folder": None}]
+    result = format_reflections_block(refs, group_folder=None)
+    assert 'trusted="true"' in result
+
+
+def test_trusted_false_when_group():
+    refs = [{"category": "style", "content": "test", "group_folder": "whatsapp_123"}]
+    result = format_reflections_block(refs, group_folder="whatsapp_123")
+    assert 'trusted="false"' in result
+
+
+def test_content_capped_at_500():
+    refs = [{"category": "style", "content": "x" * 600, "group_folder": None}]
+    result = format_reflections_block(refs)
+    # Each line has prefix like "[1] (style) " so content portion should be 500 chars
+    for line in result.split("\n"):
+        if line.startswith("[1]"):
+            content_part = line.split(") ", 1)[1]
+            assert len(content_part) <= 500
+
+
+def test_max_10_reflections():
+    refs = [{"category": "style", "content": f"ref {i}", "group_folder": None} for i in range(15)]
+    result = format_reflections_block(refs)
+    assert result.count("[") == 10  # only 10 numbered entries
+
+
+def test_empty_list_returns_empty():
+    assert format_reflections_block([]) == ""

--- a/evolution/tests/test_retriever.py
+++ b/evolution/tests/test_retriever.py
@@ -9,16 +9,18 @@ def test_xml_escaping():
     assert "<script>" not in result
 
 
-def test_trusted_true_when_no_group():
+def test_trusted_false_when_no_group():
+    # Cross-group (no folder) has widest blast radius — untrusted.
     refs = [{"category": "style", "content": "test", "group_folder": None}]
     result = format_reflections_block(refs, group_folder=None)
-    assert 'trusted="true"' in result
+    assert 'trusted="false"' in result
 
 
-def test_trusted_false_when_group():
+def test_trusted_true_when_group():
+    # Group-scoped content is more constrained — trusted.
     refs = [{"category": "style", "content": "test", "group_folder": "whatsapp_123"}]
     result = format_reflections_block(refs, group_folder="whatsapp_123")
-    assert 'trusted="false"' in result
+    assert 'trusted="true"' in result
 
 
 def test_content_capped_at_500():

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-29" # auto-bump @1780040023
+last_verified: "2026-05-29" # auto-bump @1780041387
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780039900 (LIA-73)
+last_verified: "2026-05-29" # auto-bump @1780041387
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary
- XML-escape reflection content before prompt injection (`html.escape()`) to prevent prompt injection via crafted reflections
- Add `<data-envelope>` wrapper with trust levels: group-scoped=trusted, cross-group=untrusted
- Cap individual reflections at 500 chars, max 10 per request
- Thread `group_folder` through result dicts for trust-level determination

## Insights Swarm Tier 1 — Item 8

## Test plan
- [x] 6 unit tests covering escaping, envelope wrapping, trust levels, content cap, max reflections
- [x] Escape order verified: strip → cap → escape (prevents entity bisection)
- [x] Trust model verified: group-scoped=trusted, cross-group=untrusted
- [ ] Manual: trigger reflection retrieval in a live session, verify envelope appears in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>