### PR TITLE
feat(auto-merge): use GitHub auto-merge to eliminate polling loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   ci:

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780041910
+last_verified: "2026-05-29" # auto-bump @1780042453
 governs:
   - src/
   - setup/

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump
+last_verified: "2026-05-29" # auto-bump @1780041910
 governs:
   - src/
   - setup/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780041910
+last_verified: "2026-05-29" # auto-bump @1780042453
 governs:
   - src/
   - evolution/

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promisify } from 'util';
 import { _initTestDatabase } from './db.js';
 import {
@@ -455,5 +455,216 @@ describe('checkConflictingPrs', () => {
     await checkConflictingPrs(ctx);
 
     expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attemptAutoMerge — GitHub auto-merge flow
+// ---------------------------------------------------------------------------
+
+function makeAutoMergeCtx() {
+  return {
+    client: {
+      updateIssue: vi.fn().mockResolvedValue({}),
+      createComment: vi.fn().mockResolvedValue({}),
+      issue: vi.fn().mockResolvedValue({
+        labels: vi.fn().mockResolvedValue({ nodes: [] }),
+        comments: vi.fn().mockResolvedValue({ nodes: [] }),
+      }),
+    },
+    stateByName: new Map([
+      ['Done', { id: 'done-id', name: 'Done' }],
+      ['Ready for Agent', { id: 'ready-id', name: 'Ready for Agent' }],
+      ['In Review', { id: 'review-id', name: 'In Review' }],
+    ]),
+    gateLabels: {
+      wardenSkip: 'warden-skip-id',
+      revise: 'revise-id',
+      evaluating: 'eval-id',
+    },
+    repoSlug: 'sliamh11/Deus',
+  } as unknown as import('./linear-dispatcher.js').LinearContext;
+}
+
+describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
+  beforeEach(() => {
+    process.env.LINEAR_AUTO_MERGE = '1';
+  });
+  afterEach(() => {
+    delete process.env.LINEAR_AUTO_MERGE;
+  });
+
+  it('passes --auto flag when queuing GitHub auto-merge', async () => {
+    // First call: gh pr checks (preCheck inside mergePr with {auto:true}) → pending
+    // Second call: gh pr merge --auto → success (autoQueued)
+    execFileMock
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
+      })
+      .mockReturnValueOnce({ stdout: '' }); // merge --auto succeeds
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-issue-1', 'https://github.com/sliamh11/Deus/pull/99');
+    updatePrAutoMergeState('am-issue-1', 'pending');
+
+    await attemptAutoMerge(
+      ctx,
+      'am-issue-1',
+      'https://github.com/sliamh11/Deus/pull/99',
+      'LIA-99',
+    );
+
+    // Verify --auto was in the merge call args
+    const mergeCall = execFileMock.mock.calls.find(
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && (c[1] as string[]).includes('merge'),
+    );
+    expect(mergeCall).toBeDefined();
+    expect(mergeCall![1]).toContain('--auto');
+  });
+
+  it('returns immediately when GitHub auto-merge is successfully queued', async () => {
+    // preCheck → pending; merge --auto → success
+    execFileMock
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
+      })
+      .mockReturnValueOnce({ stdout: '' });
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-issue-2', 'https://github.com/sliamh11/Deus/pull/100');
+    updatePrAutoMergeState('am-issue-2', 'pending');
+
+    await attemptAutoMerge(
+      ctx,
+      'am-issue-2',
+      'https://github.com/sliamh11/Deus/pull/100',
+      'LIA-100',
+    );
+
+    // No issue state update yet — GitHub handles the merge asynchronously
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+    expect(ctx.client.createComment).not.toHaveBeenCalled();
+  });
+
+  it('falls back to direct merge when --auto fails, and merges if CI passes', async () => {
+    vi.useFakeTimers();
+
+    // Call sequence:
+    //  1. gh pr checks (preCheck for --auto) → pending
+    //  2. gh pr merge --auto → error (branch protection not set)
+    //  3. gh pr checks (fallback poll) → pass
+    //  4. gh pr checks (preCheck for direct merge) → pass
+    //  5. gh pr merge (direct) → success
+    const autoError = new Error(
+      'auto-merge not allowed: branch protection not configured',
+    );
+    execFileMock
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
+      })
+      .mockReturnValueOnce({ error: autoError })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'pass', name: 'ci' }]),
+      })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'pass', name: 'ci' }]),
+      })
+      .mockReturnValueOnce({ stdout: '' });
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-issue-3', 'https://github.com/sliamh11/Deus/pull/101');
+    updatePrAutoMergeState('am-issue-3', 'pending');
+
+    const promise = attemptAutoMerge(
+      ctx,
+      'am-issue-3',
+      'https://github.com/sliamh11/Deus/pull/101',
+      'LIA-101',
+    );
+    // Advance past the CI_POLL_INTERVAL_MS wait
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // Direct merge succeeded → issue moved to Done
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'am-issue-3',
+      expect.objectContaining({ stateId: 'done-id' }),
+    );
+    expect(ctx.client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId: 'am-issue-3' }),
+    );
+
+    vi.useRealTimers();
+  });
+
+  it('allows pending CI state for --auto preCheck (does not block on pending)', async () => {
+    // preCheck → pending; merge --auto → success (autoQueued)
+    execFileMock
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
+      })
+      .mockReturnValueOnce({ stdout: '' });
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-issue-4', 'https://github.com/sliamh11/Deus/pull/102');
+    updatePrAutoMergeState('am-issue-4', 'pending');
+
+    // Should NOT throw or fail — pending CI is allowed for --auto
+    await expect(
+      attemptAutoMerge(
+        ctx,
+        'am-issue-4',
+        'https://github.com/sliamh11/Deus/pull/102',
+        'LIA-102',
+      ),
+    ).resolves.toBeUndefined();
+
+    // No error comment, no re-queue
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('blocks --auto when CI is already failing', async () => {
+    vi.useFakeTimers();
+
+    // preCheck for --auto → fail (blocks auto-merge attempt)
+    // fallback poll → fail (CI still failing)
+    execFileMock
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'fail', name: 'ci' }]),
+      })
+      // mergePr({auto:true}) returns early, no merge call
+      // fallback: preCheck returns fail immediately in mergePr({auto:false})
+      // but we hit the "auto failed" path first — need to wait for the timer
+      // then the fallback queryPrChecks call:
+      .mockReturnValueOnce({
+        stdout: JSON.stringify([{ bucket: 'fail', name: 'ci' }]),
+      });
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-issue-5', 'https://github.com/sliamh11/Deus/pull/103');
+    updatePrAutoMergeState('am-issue-5', 'pending');
+
+    const promise = attemptAutoMerge(
+      ctx,
+      'am-issue-5',
+      'https://github.com/sliamh11/Deus/pull/103',
+      'LIA-103',
+    );
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // CI fail triggers re-queue to Ready for Agent
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'am-issue-5',
+      expect.objectContaining({ stateId: 'ready-id' }),
+    );
+
+    vi.useRealTimers();
   });
 });

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -668,3 +668,72 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
     vi.useRealTimers();
   });
 });
+
+// ---------------------------------------------------------------------------
+// sweepPendingAutoMerges — MERGED detection
+// ---------------------------------------------------------------------------
+
+describe('sweepPendingAutoMerges — detects PR already merged by GitHub', () => {
+  beforeEach(() => {
+    process.env.LINEAR_AUTO_MERGE = '1';
+  });
+  afterEach(() => {
+    delete process.env.LINEAR_AUTO_MERGE;
+  });
+
+  it('syncs to Done when GitHub auto-merge already completed the PR', async () => {
+    // Seed a pending auto-merge record
+    upsertIssuePr(
+      'sweep-issue-1',
+      'https://github.com/sliamh11/Deus/pull/200',
+      'feat/sweep',
+      'LIA-200',
+    );
+    updatePrAutoMergeState('sweep-issue-1', 'pending');
+
+    // gh pr view → MERGED
+    execFileMock.mockReturnValueOnce({
+      stdout: JSON.stringify({ state: 'MERGED' }),
+    });
+
+    const ctx = {
+      client: {
+        updateIssue: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        issue: vi.fn().mockResolvedValue({
+          labels: vi.fn().mockResolvedValue({ nodes: [] }),
+          comments: vi.fn().mockResolvedValue({ nodes: [] }),
+        }),
+      },
+      stateByName: new Map([
+        ['Done', { id: 'done-id', name: 'Done' }],
+        ['Ready for Agent', { id: 'ready-id', name: 'Ready for Agent' }],
+      ]),
+      gateLabels: {
+        wardenSkip: 'warden-skip-id',
+        revise: 'revise-id',
+        evaluating: 'eval-id',
+      },
+      repoSlug: 'sliamh11/Deus',
+    } as unknown as import('./linear-dispatcher.js').LinearContext;
+
+    const { sweepPendingAutoMerges } = await import('./linear-auto-merge.js');
+    await sweepPendingAutoMerges(ctx);
+
+    // Wait for the async fire-and-forget chain to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should have moved issue to Done
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'sweep-issue-1',
+      expect.objectContaining({ stateId: 'done-id' }),
+    );
+    expect(ctx.client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId: 'sweep-issue-1' }),
+    );
+
+    // DB state should be 'merged'
+    const { getIssuePr: getPr } = await import('./db.js');
+    expect(getPr('sweep-issue-1')?.auto_merge_state).toBe('merged');
+  });
+});

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -462,6 +462,8 @@ describe('checkConflictingPrs', () => {
 // attemptAutoMerge — GitHub auto-merge flow
 // ---------------------------------------------------------------------------
 
+const TEST_REPO = 'test-owner/test-repo';
+
 function makeAutoMergeCtx() {
   return {
     client: {
@@ -482,7 +484,7 @@ function makeAutoMergeCtx() {
       revise: 'revise-id',
       evaluating: 'eval-id',
     },
-    repoSlug: 'sliamh11/Deus',
+    repoSlug: TEST_REPO,
   } as unknown as import('./linear-dispatcher.js').LinearContext;
 }
 
@@ -505,13 +507,16 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr('am-issue-1', 'https://github.com/sliamh11/Deus/pull/99');
+    upsertIssuePr(
+      'am-issue-1',
+      'https://github.com/test-owner/test-repo/pull/99',
+    );
     updatePrAutoMergeState('am-issue-1', 'pending');
 
     await attemptAutoMerge(
       ctx,
       'am-issue-1',
-      'https://github.com/sliamh11/Deus/pull/99',
+      'https://github.com/test-owner/test-repo/pull/99',
       'LIA-99',
     );
 
@@ -534,13 +539,16 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr('am-issue-2', 'https://github.com/sliamh11/Deus/pull/100');
+    upsertIssuePr(
+      'am-issue-2',
+      'https://github.com/test-owner/test-repo/pull/100',
+    );
     updatePrAutoMergeState('am-issue-2', 'pending');
 
     await attemptAutoMerge(
       ctx,
       'am-issue-2',
-      'https://github.com/sliamh11/Deus/pull/100',
+      'https://github.com/test-owner/test-repo/pull/100',
       'LIA-100',
     );
 
@@ -576,13 +584,16 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr('am-issue-3', 'https://github.com/sliamh11/Deus/pull/101');
+    upsertIssuePr(
+      'am-issue-3',
+      'https://github.com/test-owner/test-repo/pull/101',
+    );
     updatePrAutoMergeState('am-issue-3', 'pending');
 
     const promise = attemptAutoMerge(
       ctx,
       'am-issue-3',
-      'https://github.com/sliamh11/Deus/pull/101',
+      'https://github.com/test-owner/test-repo/pull/101',
       'LIA-101',
     );
     // Advance past the CI_POLL_INTERVAL_MS wait
@@ -611,7 +622,10 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr('am-issue-4', 'https://github.com/sliamh11/Deus/pull/102');
+    upsertIssuePr(
+      'am-issue-4',
+      'https://github.com/test-owner/test-repo/pull/102',
+    );
     updatePrAutoMergeState('am-issue-4', 'pending');
 
     // Should NOT throw or fail — pending CI is allowed for --auto
@@ -619,7 +633,7 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
       attemptAutoMerge(
         ctx,
         'am-issue-4',
-        'https://github.com/sliamh11/Deus/pull/102',
+        'https://github.com/test-owner/test-repo/pull/102',
         'LIA-102',
       ),
     ).resolves.toBeUndefined();
@@ -647,13 +661,16 @@ describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr('am-issue-5', 'https://github.com/sliamh11/Deus/pull/103');
+    upsertIssuePr(
+      'am-issue-5',
+      'https://github.com/test-owner/test-repo/pull/103',
+    );
     updatePrAutoMergeState('am-issue-5', 'pending');
 
     const promise = attemptAutoMerge(
       ctx,
       'am-issue-5',
-      'https://github.com/sliamh11/Deus/pull/103',
+      'https://github.com/test-owner/test-repo/pull/103',
       'LIA-103',
     );
     await vi.runAllTimersAsync();
@@ -685,7 +702,7 @@ describe('sweepPendingAutoMerges — detects PR already merged by GitHub', () =>
     // Seed a pending auto-merge record
     upsertIssuePr(
       'sweep-issue-1',
-      'https://github.com/sliamh11/Deus/pull/200',
+      'https://github.com/test-owner/test-repo/pull/200',
       'feat/sweep',
       'LIA-200',
     );
@@ -714,7 +731,7 @@ describe('sweepPendingAutoMerges — detects PR already merged by GitHub', () =>
         revise: 'revise-id',
         evaluating: 'eval-id',
       },
-      repoSlug: 'sliamh11/Deus',
+      repoSlug: TEST_REPO,
     } as unknown as import('./linear-dispatcher.js').LinearContext;
 
     const { sweepPendingAutoMerges } = await import('./linear-auto-merge.js');

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -200,10 +200,6 @@ async function mergePr(
   }
 }
 
-/**
- * Handles a successful merge (direct or after --auto queuing completes via
- * the sweep).  Moves the issue to Done, updates labels, and logs events.
- */
 async function handleMergeSuccess(
   ctx: LinearContext,
   issueId: string,
@@ -236,10 +232,6 @@ async function handleMergeSuccess(
   logger.info({ issueId, prUrl }, 'auto-merge: merged and moved to Done');
 }
 
-/**
- * Handles a merge failure: updates DB state, fires notifications, and either
- * trips the circuit breaker or comments and re-queues the issue.
- */
 async function handleMergeFailure(
   ctx: LinearContext,
   issueId: string,

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -51,7 +51,6 @@ async function tripCircuitBreaker(
 }
 const CI_CHECK_TIMEOUT_MS = 30_000;
 const MERGE_TIMEOUT_MS = 120_000;
-const MAX_POLL_ATTEMPTS = 30;
 
 type CiStatus = 'pass' | 'fail' | 'pending';
 
@@ -143,7 +142,8 @@ export async function queryPrChecks(prUrl: string): Promise<PrChecksResult> {
 
 async function mergePr(
   prUrl: string,
-): Promise<{ merged: boolean; error?: string }> {
+  options: { auto: boolean } = { auto: false },
+): Promise<{ merged: boolean; autoQueued?: boolean; error?: string }> {
   const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
   const repoMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/);
   const repo = repoMatch?.[1];
@@ -152,27 +152,44 @@ async function mergePr(
     return { merged: false, error: 'Invalid PR URL' };
   }
 
+  // For direct merge (no --auto), CI must already be passing.
+  // For --auto, we only need CI to have started (pending or pass) — GitHub
+  // will wait for the required checks before completing the merge.
   const preCheck = await queryPrChecks(prUrl);
-  if (preCheck.status !== 'pass') {
-    return { merged: false, error: `CI not passing: ${preCheck.summary}` };
+  if (options.auto) {
+    if (preCheck.status === 'fail') {
+      return {
+        merged: false,
+        error: `CI already failing, not queuing auto-merge: ${preCheck.summary}`,
+      };
+    }
+  } else {
+    if (preCheck.status !== 'pass') {
+      return { merged: false, error: `CI not passing: ${preCheck.summary}` };
+    }
+  }
+
+  const args = [
+    'pr',
+    'merge',
+    prNumber,
+    '--repo',
+    repo,
+    '--squash',
+    '--delete-branch',
+    '--admin',
+  ];
+  if (options.auto) {
+    args.push('--auto');
   }
 
   try {
-    await execFileAsync(
-      'gh',
-      [
-        'pr',
-        'merge',
-        prNumber,
-        '--repo',
-        repo,
-        '--squash',
-        '--delete-branch',
-        '--admin',
-      ],
-      { timeout: MERGE_TIMEOUT_MS },
-    );
-    return { merged: true };
+    await execFileAsync('gh', args, { timeout: MERGE_TIMEOUT_MS });
+    // With --auto, gh exits 0 meaning auto-merge was successfully *queued*;
+    // GitHub will complete the merge when CI passes.
+    return options.auto
+      ? { merged: false, autoQueued: true }
+      : { merged: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('already been merged') || msg.includes('MERGED')) {
@@ -183,158 +200,69 @@ async function mergePr(
   }
 }
 
-export async function attemptAutoMerge(
+/**
+ * Handles a successful merge (direct or after --auto queuing completes via
+ * the sweep).  Moves the issue to Done, updates labels, and logs events.
+ */
+async function handleMergeSuccess(
   ctx: LinearContext,
   issueId: string,
   prUrl: string,
-  identifier?: string,
-  attempt = 0,
+  ident: string,
 ): Promise<void> {
-  if (!isAutoMergeEnabled()) return;
-  const ident = identifier ?? 'unknown';
-
-  const checks = await queryPrChecks(prUrl);
-  logger.info(
-    { issueId, prUrl, status: checks.status, attempt },
-    'auto-merge: CI status',
-  );
-
-  if (checks.status === 'pass') {
-    const result = await mergePr(prUrl);
-    if (result.merged) {
-      updatePrAutoMergeState(issueId, 'merged');
-      const doneState = ctx.stateByName.get('Done');
-      if (doneState) {
-        const labelUpdate: Record<string, unknown> = {
-          stateId: doneState.id,
-        };
-        const addIds: string[] = [];
-        const removeIds: string[] = [];
-        if (ctx.gateLabels.wardenSkip) addIds.push(ctx.gateLabels.wardenSkip);
-        if (ctx.gateLabels.revise) removeIds.push(ctx.gateLabels.revise);
-        if (ctx.gateLabels.evaluating)
-          removeIds.push(ctx.gateLabels.evaluating);
-        if (addIds.length > 0) labelUpdate.addedLabelIds = addIds;
-        if (removeIds.length > 0) labelUpdate.removedLabelIds = removeIds;
-        await ctx.client.updateIssue(issueId, labelUpdate);
-        await ctx.client.createComment({
-          issueId,
-          body: `**Auto-merged** - PR ${prUrl} merged after CI passed.`,
-        });
-      }
-      notifyPipelineStep(ctx, issueId, ident, 'automerge_done', prUrl).catch(
-        () => {},
-      );
-      logPipelineEvent(
-        issueId,
-        ident,
-        'circuit_breaker_reset',
-        'merge succeeded',
-      );
-      logger.info({ issueId, prUrl }, 'auto-merge: merged and moved to Done');
-    } else {
-      logger.warn(
-        { issueId, prUrl, error: result.error },
-        'auto-merge: merge failed despite passing CI',
-      );
-      updatePrAutoMergeState(issueId, 'failed');
-      notifyPipelineStep(
-        ctx,
-        issueId,
-        ident,
-        'automerge_failed',
-        result.error,
-      ).catch(() => {});
-      const mergeFailCount = getConsecutiveFailCount(
-        issueId,
-        'automerge_failed',
-      );
-      if (mergeFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
-        await tripCircuitBreaker(
-          ctx,
-          issueId,
-          ident,
-          mergeFailCount,
-          'merge failure',
-        );
-      } else {
-        await ctx.client.createComment({
-          issueId,
-          body: `**Auto-merge failed** - ${result.error}`,
-        });
-      }
-    }
-    return;
-  }
-
-  if (checks.status === 'pending') {
-    if (attempt >= MAX_POLL_ATTEMPTS) {
-      updatePrAutoMergeState(issueId, 'failed');
-      notifyPipelineStep(
-        ctx,
-        issueId,
-        ident,
-        'automerge_failed',
-        'Timed out',
-      ).catch(() => {});
-      const timeoutFailCount = getConsecutiveFailCount(
-        issueId,
-        'automerge_failed',
-      );
-      if (timeoutFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
-        await tripCircuitBreaker(
-          ctx,
-          issueId,
-          ident,
-          timeoutFailCount,
-          'timeout',
-        );
-      } else {
-        await ctx.client.createComment({
-          issueId,
-          body: `**Auto-merge timed out** - CI still pending after ${MAX_POLL_ATTEMPTS} attempts. PR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
-        });
-        const readyStateTimeout = ctx.stateByName.get('Ready for Agent');
-        if (readyStateTimeout) {
-          await ctx.client.updateIssue(issueId, {
-            stateId: readyStateTimeout.id,
-            priority: 1,
-          });
-        }
-      }
-      logger.warn({ issueId, prUrl }, 'auto-merge: timed out');
-      return;
-    }
-    setTimeout(() => {
-      attemptAutoMerge(ctx, issueId, prUrl, identifier, attempt + 1).catch(
-        (err) => {
-          logger.error({ issueId, err }, 'auto-merge: re-check failed');
-        },
-      );
-    }, CI_POLL_INTERVAL_MS);
-    return;
-  }
-
-  updatePrAutoMergeState(issueId, 'failed');
-  notifyPipelineStep(
-    ctx,
-    issueId,
-    ident,
-    'automerge_failed',
-    checks.summary,
-  ).catch(() => {});
-
-  const ciFailCount = getConsecutiveFailCount(issueId, 'automerge_failed');
-  if (ciFailCount >= CIRCUIT_BREAKER_THRESHOLD) {
-    await tripCircuitBreaker(ctx, issueId, ident, ciFailCount, 'CI failure');
-    logger.warn(
-      { issueId, prUrl, ciFailCount },
-      'auto-merge: circuit breaker tripped, parked issue',
-    );
-  } else {
+  updatePrAutoMergeState(issueId, 'merged');
+  const doneState = ctx.stateByName.get('Done');
+  if (doneState) {
+    const labelUpdate: Record<string, unknown> = {
+      stateId: doneState.id,
+    };
+    const addIds: string[] = [];
+    const removeIds: string[] = [];
+    if (ctx.gateLabels.wardenSkip) addIds.push(ctx.gateLabels.wardenSkip);
+    if (ctx.gateLabels.revise) removeIds.push(ctx.gateLabels.revise);
+    if (ctx.gateLabels.evaluating) removeIds.push(ctx.gateLabels.evaluating);
+    if (addIds.length > 0) labelUpdate.addedLabelIds = addIds;
+    if (removeIds.length > 0) labelUpdate.removedLabelIds = removeIds;
+    await ctx.client.updateIssue(issueId, labelUpdate);
     await ctx.client.createComment({
       issueId,
-      body: `**Auto-merge blocked** - CI failed: ${checks.summary}\n\nPR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
+      body: `**Auto-merged** - PR ${prUrl} merged after CI passed.`,
+    });
+  }
+  notifyPipelineStep(ctx, issueId, ident, 'automerge_done', prUrl).catch(
+    () => {},
+  );
+  logPipelineEvent(issueId, ident, 'circuit_breaker_reset', 'merge succeeded');
+  logger.info({ issueId, prUrl }, 'auto-merge: merged and moved to Done');
+}
+
+/**
+ * Handles a merge failure: updates DB state, fires notifications, and either
+ * trips the circuit breaker or comments and re-queues the issue.
+ */
+async function handleMergeFailure(
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  ident: string,
+  reason: string,
+  failEvent: 'automerge_failed',
+  requeue: boolean,
+): Promise<void> {
+  updatePrAutoMergeState(issueId, 'failed');
+  notifyPipelineStep(ctx, issueId, ident, failEvent, reason).catch(() => {});
+
+  const failCount = getConsecutiveFailCount(issueId, failEvent);
+  if (failCount >= CIRCUIT_BREAKER_THRESHOLD) {
+    await tripCircuitBreaker(ctx, issueId, ident, failCount, reason);
+    logger.warn(
+      { issueId, prUrl, failCount },
+      'auto-merge: circuit breaker tripped, parked issue',
+    );
+  } else if (requeue) {
+    await ctx.client.createComment({
+      issueId,
+      body: `**Auto-merge blocked** - ${reason}\n\nPR: ${prUrl}\n\nMoving to Ready for Agent for re-dispatch.`,
     });
     const readyState = ctx.stateByName.get('Ready for Agent');
     if (readyState) {
@@ -345,7 +273,101 @@ export async function attemptAutoMerge(
     }
     logger.warn(
       { issueId, prUrl },
-      'auto-merge: CI failed, moved to Ready for Agent',
+      'auto-merge: failed, moved to Ready for Agent',
+    );
+  } else {
+    await ctx.client.createComment({
+      issueId,
+      body: `**Auto-merge failed** - ${reason}`,
+    });
+  }
+}
+
+export async function attemptAutoMerge(
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  identifier?: string,
+): Promise<void> {
+  if (!isAutoMergeEnabled()) return;
+  const ident = identifier ?? 'unknown';
+
+  // Step 1: Try to enable GitHub's native auto-merge.  --auto makes GitHub
+  // wait for all required status checks before completing the merge itself, so
+  // we don't need to poll here.
+  const autoResult = await mergePr(prUrl, { auto: true });
+  logger.info(
+    {
+      issueId,
+      prUrl,
+      autoQueued: autoResult.autoQueued,
+      error: autoResult.error,
+    },
+    'auto-merge: auto-merge attempt',
+  );
+
+  if (autoResult.merged) {
+    // Already merged (edge case: --auto succeeded immediately)
+    await handleMergeSuccess(ctx, issueId, prUrl, ident);
+    return;
+  }
+
+  if (autoResult.autoQueued) {
+    // GitHub accepted the auto-merge request — it will merge when CI passes.
+    // The sweepPendingAutoMerges cycle will detect the MERGED state later.
+    logger.info(
+      { issueId, prUrl },
+      'auto-merge: GitHub auto-merge queued, waiting for CI',
+    );
+    return;
+  }
+
+  // Step 2: --auto failed (branch protection not configured, or CI already
+  // failing).  Fall back to a single direct-merge attempt after one poll cycle.
+  logger.warn(
+    { issueId, prUrl, error: autoResult.error },
+    'auto-merge: --auto unavailable, falling back to direct merge after CI poll',
+  );
+
+  await new Promise<void>((resolve) =>
+    setTimeout(resolve, CI_POLL_INTERVAL_MS),
+  );
+
+  const checks = await queryPrChecks(prUrl);
+  logger.info(
+    { issueId, prUrl, status: checks.status },
+    'auto-merge: CI status (fallback)',
+  );
+
+  if (checks.status !== 'pass') {
+    const reason =
+      checks.status === 'pending'
+        ? `CI still pending after fallback wait: ${checks.summary}`
+        : `CI failed: ${checks.summary}`;
+    await handleMergeFailure(
+      ctx,
+      issueId,
+      prUrl,
+      ident,
+      reason,
+      'automerge_failed',
+      true,
+    );
+    return;
+  }
+
+  const directResult = await mergePr(prUrl, { auto: false });
+  if (directResult.merged) {
+    await handleMergeSuccess(ctx, issueId, prUrl, ident);
+  } else {
+    await handleMergeFailure(
+      ctx,
+      issueId,
+      prUrl,
+      ident,
+      directResult.error ?? 'unknown merge error',
+      'automerge_failed',
+      false,
     );
   }
 }
@@ -364,9 +386,24 @@ export async function sweepPendingAutoMerges(
   );
 
   for (const { issue_id, pr_url, identifier: ident } of pending) {
-    attemptAutoMerge(ctx, issue_id, pr_url, ident || 'unknown').catch((err) => {
-      logger.error({ issueId: issue_id, err }, 'auto-merge: sweep failed');
-    });
+    // Check whether GitHub's auto-merge already completed while we were down.
+    queryPrState(pr_url)
+      .then(async (state) => {
+        if (state?.state === 'MERGED') {
+          logger.info(
+            { issueId: issue_id, prUrl: pr_url },
+            'auto-merge: PR already merged by GitHub auto-merge, syncing state',
+          );
+          await handleMergeSuccess(ctx, issue_id, pr_url, ident || 'unknown');
+        } else {
+          // Not yet merged — re-run the full attempt (will queue --auto again or
+          // fall through to the direct-merge fallback).
+          await attemptAutoMerge(ctx, issue_id, pr_url, ident || 'unknown');
+        }
+      })
+      .catch((err) => {
+        logger.error({ issueId: issue_id, err }, 'auto-merge: sweep failed');
+      });
   }
 }
 


### PR DESCRIPTION
## Summary
- `mergePr()` now uses `--auto` flag — GitHub handles CI polling and merges when ready
- `attemptAutoMerge()` simplified: queue auto-merge once, single fallback poll after timeout
- Extracted `handleMergeSuccess()`/`handleMergeFailure()` helpers to eliminate duplication
- `sweepPendingAutoMerges()` detects already-merged PRs and syncs Linear state
- Added `merge_group:` trigger to CI workflow (future-proofs for merge queue)
- Enabled `allow_auto_merge` on the GitHub repo

## Insights Swarm Tier 1 — Item 5

## Test plan
- [x] 5 new tests: auto flag, immediate return, fallback merge, pending CI, sweep MERGED detection
- [x] 23/23 tests passing
- [x] No personal identifiers in test fixtures (uses test-owner/test-repo)
- [ ] Manual: merge a PR and verify auto-merge queues correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>