### PR TITLE
fix(dispatcher): expand patch allowlist with two-tier blocking

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780042927
+last_verified: "2026-05-29" # auto-bump @1780043447
 governs:
   - src/
   - setup/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780042927
+last_verified: "2026-05-29" # auto-bump @1780043447
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -647,12 +647,13 @@ describe('applyPatchArtifact', () => {
       prUrl: 'https://github.com/test/repo/pull/10',
       applied: true,
     });
-    // git apply (non-stat) should NOT have been called (am succeeded)
+    // git apply (non-stat, non-check) should NOT have been called (am succeeded)
     const applyCalls = execFileMock.mock.calls.filter(
       (c: unknown[]) =>
         c[0] === 'git' &&
         (c[1] as string[])[0] === 'apply' &&
-        !(c[1] as string[]).includes('--stat'),
+        !(c[1] as string[]).includes('--stat') &&
+        !(c[1] as string[]).includes('--check'),
     );
     expect(applyCalls).toHaveLength(0);
   });
@@ -760,6 +761,8 @@ describe('applyPatchArtifact', () => {
         return {
           stdout: ' src/foo.ts | 1 +\n 1 file changed, 1 insertion(+)\n',
         };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--check'))
+        return { stdout: '' };
       if (cmd === 'git' && args[0] === 'apply')
         return { error: new Error('patch does not apply') };
       return { stdout: '' };
@@ -1027,5 +1030,182 @@ describe('applyPatchArtifact', () => {
     expect(buildOpts.cwd).toBe(worktreeDir);
 
     fs.rmSync(worktreeDir, { recursive: true, force: true });
+  });
+
+  it('rejects patch touching hard-blocked path (.claude/)', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return {
+          stdout:
+            ' .claude/agents/foo.md | 3 +++\n src/foo.ts | 1 +\n 2 files changed\n',
+        };
+      }
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('restricted paths'),
+      }),
+    );
+  });
+
+  it('applies patch touching warn-only path and posts warning comment', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return {
+          stdout:
+            ' package.json | 2 +-\n src/foo.ts | 5 +++++\n 2 files changed\n',
+        };
+      }
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+
+    expect(result.applied).toBe(true);
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('warning'),
+      }),
+    );
+  });
+
+  it('rejects shell script outside container/', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return {
+          stdout:
+            ' scripts/deploy.sh | 10 ++++++++++\n src/foo.ts | 1 +\n 2 files changed\n',
+        };
+      }
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('restricted paths'),
+      }),
+    );
+  });
+
+  it('allows shell script inside container/', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return {
+          stdout: ' container/entrypoint.sh | 5 +++++\n 1 file changed\n',
+        };
+      }
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+
+    expect(result.applied).toBe(true);
+  });
+
+  it('rejects malformed patch when git apply --check fails', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return { stdout: ' src/foo.ts | 1 +\n 1 file changed\n' };
+      }
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--check')) {
+        return { error: new Error('patch does not apply: context mismatch') };
+      }
+      return { stdout: '' };
+    });
+
+    const ctx = patchCtx();
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      ctx,
+    );
+
+    expect(result).toEqual({ prUrl: null, applied: false });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('malformed'),
+      }),
+    );
+  });
+
+  it('applies clean patch with no blocked files normally', async () => {
+    fs.writeFileSync(path.join(patchGroupDir, 'LIA-99.patch'), 'diff');
+    execFileMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') return { stdout: 'main\n' };
+      if (cmd === 'git' && args[0] === 'status') return { stdout: '' };
+      if (cmd === 'git' && args[0] === 'apply' && args.includes('--stat')) {
+        return { stdout: ' src/bar.ts | 3 +++\n 1 file changed\n' };
+      }
+      if (cmd === 'git' && args[0] === 'am')
+        return { error: new Error('not mbox') };
+      if (cmd === 'gh')
+        return { stdout: 'https://github.com/test/repo/pull/1\n' };
+      return { stdout: '' };
+    });
+
+    const result = await applyPatchArtifact(
+      patchGroupDir,
+      'LIA-99',
+      'issue-id',
+      patchCtx(),
+    );
+
+    expect(result.applied).toBe(true);
+    expect(createComment).not.toHaveBeenCalled();
   });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -53,13 +53,7 @@ const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
 const GIT_TIMEOUT_MS = 30_000;
 const BUILD_TIMEOUT_MS = 120_000;
 const PUSH_TIMEOUT_MS = 120_000;
-// Two-tier path blocking for the patch applicator.
-// HARD_BLOCKED_PATHS_DEFAULT: patch is rejected entirely.
-// WARN_ONLY_PATHS: patch is applied but a warning comment is posted on Linear.
-// Shell scripts outside container/ are always hard-blocked (separate check).
-//
-// matchesPath distinguishes directory entries (trailing '/') from exact-file
-// entries to prevent false matches like '.env' matching '.envrc'.
+// Trailing '/' = prefix match; exact names match literally (prevents .env matching .envrc)
 function matchesPath(file: string, entry: string): boolean {
   if (entry.endsWith('/')) {
     return file.startsWith(entry);
@@ -75,6 +69,7 @@ const HARD_BLOCKED_PATHS_DEFAULT = [
   '.mex/',
   '.github/workflows/',
 ];
+// Intentionally not env-configurable — warn-only paths rarely change and misconfiguration risks silent bypass
 const WARN_ONLY_PATHS = ['package.json', 'tsconfig.json'];
 
 export interface LinearDispatcherDependencies {
@@ -730,9 +725,8 @@ export async function applyPatchArtifact(
         ...gitOpts,
         timeout: 30_000,
       });
-    } catch (checkErr) {
-      const checkMsg =
-        checkErr instanceof Error ? checkErr.message : String(checkErr);
+    } catch (checkErr: any) {
+      const checkMsg = checkErr?.stderr || checkErr?.message || 'Unknown error';
       await ctx.client.createComment({
         issueId,
         body: `**Patch auto-apply blocked** — patch is malformed or does not apply cleanly:\n\n\`\`\`\n${checkMsg.slice(0, 2000)}\n\`\`\`\n\nApply manually after review.`,

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -53,7 +53,29 @@ const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
 const GIT_TIMEOUT_MS = 30_000;
 const BUILD_TIMEOUT_MS = 120_000;
 const PUSH_TIMEOUT_MS = 120_000;
-const BLOCKED_PATHS_DEFAULT = ['.github/workflows/'];
+// Two-tier path blocking for the patch applicator.
+// HARD_BLOCKED_PATHS_DEFAULT: patch is rejected entirely.
+// WARN_ONLY_PATHS: patch is applied but a warning comment is posted on Linear.
+// Shell scripts outside container/ are always hard-blocked (separate check).
+//
+// matchesPath distinguishes directory entries (trailing '/') from exact-file
+// entries to prevent false matches like '.env' matching '.envrc'.
+function matchesPath(file: string, entry: string): boolean {
+  if (entry.endsWith('/')) {
+    return file.startsWith(entry);
+  }
+  return file === entry;
+}
+
+const HARD_BLOCKED_PATHS_DEFAULT = [
+  '.claude/',
+  'CLAUDE.md',
+  'AGENTS.md',
+  '.env',
+  '.mex/',
+  '.github/workflows/',
+];
+const WARN_ONLY_PATHS = ['package.json', 'tsconfig.json'];
 
 export interface LinearDispatcherDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
@@ -628,13 +650,14 @@ export async function applyPatchArtifact(
       await execFileAsync('git', ['checkout', '-B', branchName], gitOpts);
     }
 
-    // Pre-flight: reject patches touching blocked paths
+    // Pre-flight: reject or warn on patches touching restricted paths.
+    // DEUS_PATCH_BLOCKED_PATHS overrides HARD_BLOCKED_PATHS_DEFAULT only.
     const blockedPathsRaw = (process.env.DEUS_PATCH_BLOCKED_PATHS ?? '')
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
-    const effectiveBlockedPaths =
-      blockedPathsRaw.length > 0 ? blockedPathsRaw : BLOCKED_PATHS_DEFAULT;
+    const effectiveHardBlockedPaths =
+      blockedPathsRaw.length > 0 ? blockedPathsRaw : HARD_BLOCKED_PATHS_DEFAULT;
     try {
       const { stdout: statOut } = await execFileAsync(
         'git',
@@ -646,23 +669,44 @@ export async function applyPatchArtifact(
         .filter((line) => line.includes(' | '))
         .map((line) => line.split(' | ')[0].trim())
         .filter(Boolean);
-      const blockedFiles = touchedFiles.filter((f) =>
-        effectiveBlockedPaths.some((prefix) => f.startsWith(prefix)),
+
+      // Hard-blocked: exact-file or directory-prefix matches
+      const hardBlockedFiles = touchedFiles.filter((f) =>
+        effectiveHardBlockedPaths.some((entry) => matchesPath(f, entry)),
       );
-      if (blockedFiles.length > 0) {
+      // Shell scripts outside container/ are always hard-blocked
+      const shellViolations = touchedFiles.filter(
+        (f) => f.endsWith('.sh') && !f.startsWith('container/'),
+      );
+      // Warn-only: patch applied but warning comment posted
+      const warnOnlyFiles = touchedFiles.filter((f) =>
+        WARN_ONLY_PATHS.some((entry) => matchesPath(f, entry)),
+      );
+
+      const allHardBlocked = [
+        ...new Set([...hardBlockedFiles, ...shellViolations]),
+      ];
+      if (allHardBlocked.length > 0) {
         await ctx.client.createComment({
           issueId,
-          body: `**Patch auto-apply blocked** — patch touches restricted paths: ${blockedFiles.map((f) => `\`${f}\``).join(', ')}.\n\nApply manually after review.`,
+          body: `**Patch auto-apply blocked** — patch touches restricted paths: ${allHardBlocked.map((f) => `\`${f}\``).join(', ')}.\n\nApply manually after review.`,
         });
         notifyPipelineStep(
           ctx,
           issueId,
           identifier,
           'patch_failed',
-          `hash:${patchHash} blocked paths: ${blockedFiles.join(',')}`,
+          `hash:${patchHash} blocked paths: ${allHardBlocked.join(',')}`,
         ).catch(() => {});
         await cleanup(true);
         return noResult;
+      }
+
+      if (warnOnlyFiles.length > 0) {
+        await ctx.client.createComment({
+          issueId,
+          body: `**Patch auto-apply warning** — patch touches sensitive paths: ${warnOnlyFiles.map((f) => `\`${f}\``).join(', ')}. Applying anyway — please review carefully.`,
+        });
       }
     } catch (statErr) {
       logger.warn(
@@ -675,6 +719,30 @@ export async function applyPatchArtifact(
         identifier,
         'patch_failed',
         `hash:${patchHash} stat pre-flight failed`,
+      ).catch(() => {});
+      await cleanup(true);
+      return noResult;
+    }
+
+    // Pre-flight: verify patch applies cleanly before attempting git am/apply
+    try {
+      await execFileAsync('git', ['apply', '--check', patchFilePath], {
+        ...gitOpts,
+        timeout: 30_000,
+      });
+    } catch (checkErr) {
+      const checkMsg =
+        checkErr instanceof Error ? checkErr.message : String(checkErr);
+      await ctx.client.createComment({
+        issueId,
+        body: `**Patch auto-apply blocked** — patch is malformed or does not apply cleanly:\n\n\`\`\`\n${checkMsg.slice(0, 2000)}\n\`\`\`\n\nApply manually after review.`,
+      });
+      notifyPipelineStep(
+        ctx,
+        issueId,
+        identifier,
+        'patch_failed',
+        `hash:${patchHash} malformed patch`,
       ).catch(() => {});
       await cleanup(true);
       return noResult;


### PR DESCRIPTION
## Summary
- Two-tier patch blocking: hard-block (`.claude/`, `CLAUDE.md`, `.env`, `.mex/`, `.github/workflows/`) and warn-only (`package.json`, `tsconfig.json`)
- Shell scripts outside `container/` are hard-blocked
- `git apply --check` pre-flight validates patches before applying (captures stderr for diagnostics)
- `matchesPath()` helper prevents `.env` matching `.envrc` (prefix vs exact match)
- Warn-only patches are applied but get a warning comment on Linear

## Insights Swarm Tier 1 — Item 1

## Test plan
- [x] 6 new tests: hard-block, warn-only, shell script block/allow, malformed patch, clean patch
- [x] 43/43 tests passing
- [x] Warn-only paths intentionally not env-configurable (documented)
- [ ] Manual: submit a patch touching `.claude/` via Linear, verify rejection comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>