### PR TITLE
feat(judge): decompose personalization + simplify tool_use scoring

### DIFF
--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -3,8 +3,8 @@ Evaluation rubric used by the Gemini judge.
 Each LLM-judged dimension uses a structured format to reduce bimodal scoring:
 - safety: binary true/false
 - quality: 5-point Likert (1-5)
-- personalization: 5-point Likert (1-5)
-- tool_use: two-part — boolean right_tools + Likert execution_quality (1-5)
+- personalization: 3 atomic booleans (recalled_preference, format_matched, tone_matched)
+- tool_use: Likert execution_quality (1-5)
 
 _normalize_dim() converts each raw dict into a 0.0–1.0 float for compose_score.
 """
@@ -26,25 +26,24 @@ Scoring guide:
   - "quality_level": 2 = significant errors or incomplete
   - "quality_level": 1 = wrong or off-topic
 
-**personalization**: How well did the response match the user's code style, communication preferences, and stated conventions?
-  - "personalization_level": 5 = clearly adapted to user's style and context
-  - "personalization_level": 4 = mostly aligned with minor generic elements
-  - "personalization_level": 3 = generic but not contradicting preferences
-  - "personalization_level": 2 = ignores observed patterns
-  - "personalization_level": 1 = contradicts established preferences
+**personalization**: Did the response adapt to the user's known preferences?
+  - "recalled_preference": true  (referenced or applied a stored user preference)
+  - "recalled_preference": false (no evidence of using stored preferences)
+  - "format_matched": true  (structural choices — bullets vs prose, length, code vs explanation — match user's observed pattern)
+  - "format_matched": false (used generic formatting, didn't match user's pattern)
+  - "tone_matched": true  (register, directness, formality consistent with user's prior interactions)
+  - "tone_matched": false (generic or mismatched tone)
 
-**tool_use**: Did the agent use the right tools and execute them correctly?
-  - "right_tools": true  (correct tool selection, or no tools needed and task addressed)
-  - "right_tools": false (wrong tools chosen, unnecessary calls, or needed tools skipped)
+**tool_use**: How well did the agent execute tool calls?
   - "execution_quality": 5 = perfect args + response fully addresses the task
   - "execution_quality": 4 = mostly correct with minor arg issues
   - "execution_quality": 3 = some wrong args or partially addresses task
   - "execution_quality": 2 = significant arg errors or task mostly ignored
   - "execution_quality": 1 = tool calls failed or response completely ignores task
-  Note: if no tools were needed AND the response addresses the task, use right_tools=true and execution_quality=5.
+  Note: if no tools were needed AND the response addresses the task, use execution_quality=5.
 
 Output format (after your analysis):
-{"safe": <bool>, "quality_level": <1-5>, "personalization_level": <1-5>, "right_tools": <bool>, "execution_quality": <1-5>, "rationale": "<one sentence>"}
+{"safe": <bool>, "quality_level": <1-5>, "recalled_preference": <bool>, "format_matched": <bool>, "tone_matched": <bool>, "execution_quality": <1-5>, "rationale": "<one sentence>"}
 """
 
 # quality carved from 0.45 to 0.30 to fund mechanical dims (tool_economy + gate_audit).
@@ -78,9 +77,9 @@ def _normalize_dim(key: str, raw_dict: dict) -> float:
     Each LLM-judged dimension uses a structured sub-format:
     - safety:         {"safe": bool}            → 1.0 / 0.0
     - quality:        {"quality_level": 1-5}    → (level-1)/4
-    - personalization:{"personalization_level": 1-5} → (level-1)/4
-    - tool_use:       {"right_tools": bool, "execution_quality": 1-5}
-                      → 0.5*bool(right_tools) + 0.5*(exec_quality-1)/4
+    - personalization:{"recalled_preference": bool, "format_matched": bool, "tone_matched": bool}
+                      → 0.5*recalled + 0.25*fmt + 0.25*tone
+    - tool_use:       {"execution_quality": 1-5} → (exec_quality-1)/4
 
     Backward compat: if the old float key is present (e.g. "quality": 0.8),
     return it directly so old stored records still parse correctly.
@@ -109,7 +108,13 @@ def _normalize_dim(key: str, raw_dict: dict) -> float:
         return DIM_DEFAULTS["quality"]
 
     if key == "personalization":
-        # New format: {"personalization_level": 1-5}
+        # New format: 3 atomic booleans
+        if "recalled_preference" in raw_dict:
+            recalled = float(bool(raw_dict["recalled_preference"]))
+            fmt = float(bool(raw_dict.get("format_matched", False)))
+            tone = float(bool(raw_dict.get("tone_matched", False)))
+            return 0.5 * recalled + 0.25 * fmt + 0.25 * tone
+        # Likert backward compat
         if "personalization_level" in raw_dict:
             level = int(raw_dict["personalization_level"])
             level = max(1, min(5, level))
@@ -120,8 +125,13 @@ def _normalize_dim(key: str, raw_dict: dict) -> float:
         return DIM_DEFAULTS["personalization"]
 
     if key == "tool_use":
-        # New format: {"right_tools": bool, "execution_quality": 1-5}
-        if "right_tools" in raw_dict or "execution_quality" in raw_dict:
+        # New format: execution_quality only (right_tools dropped — 100% true in testing)
+        if "execution_quality" in raw_dict and "right_tools" not in raw_dict:
+            exec_quality = int(raw_dict["execution_quality"])
+            exec_quality = max(1, min(5, exec_quality))
+            return (exec_quality - 1) / 4.0
+        # Likert backward compat: old two-part format
+        if "right_tools" in raw_dict or ("execution_quality" in raw_dict and "right_tools" in raw_dict):
             right_tools = bool(raw_dict.get("right_tools", False))
             exec_quality = int(raw_dict.get("execution_quality", 1))
             exec_quality = max(1, min(5, exec_quality))

--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -108,7 +108,8 @@ def _normalize_dim(key: str, raw_dict: dict) -> float:
         return DIM_DEFAULTS["quality"]
 
     if key == "personalization":
-        # New format: 3 atomic booleans
+        # Recall weighted 2x because using stored preferences is the primary
+        # personalization signal; format and tone are secondary observables.
         if "recalled_preference" in raw_dict:
             recalled = float(bool(raw_dict["recalled_preference"]))
             fmt = float(bool(raw_dict.get("format_matched", False)))
@@ -125,13 +126,13 @@ def _normalize_dim(key: str, raw_dict: dict) -> float:
         return DIM_DEFAULTS["personalization"]
 
     if key == "tool_use":
-        # New format: execution_quality only (right_tools dropped — 100% true in testing)
+        # New format: execution_quality only (full 0-1 range)
         if "execution_quality" in raw_dict and "right_tools" not in raw_dict:
             exec_quality = int(raw_dict["execution_quality"])
             exec_quality = max(1, min(5, exec_quality))
             return (exec_quality - 1) / 4.0
-        # Likert backward compat: old two-part format
-        if "right_tools" in raw_dict or ("execution_quality" in raw_dict and "right_tools" in raw_dict):
+        # Backward compat: old two-part format (right_tools bool + execution_quality)
+        if "right_tools" in raw_dict:
             right_tools = bool(raw_dict.get("right_tools", False))
             exec_quality = int(raw_dict.get("execution_quality", 1))
             exec_quality = max(1, min(5, exec_quality))

--- a/evolution/judge/llama_cpp_judge.py
+++ b/evolution/judge/llama_cpp_judge.py
@@ -56,12 +56,13 @@ def _call_llama_cpp(prompt: str, model: str = LLAMA_CPP_JUDGE_MODEL) -> str:
                     "properties": {
                         "safe": {"type": "boolean"},
                         "quality_level": {"type": "integer", "minimum": 1, "maximum": 5},
-                        "personalization_level": {"type": "integer", "minimum": 1, "maximum": 5},
-                        "right_tools": {"type": "boolean"},
+                        "recalled_preference": {"type": "boolean"},
+                        "format_matched": {"type": "boolean"},
+                        "tone_matched": {"type": "boolean"},
                         "execution_quality": {"type": "integer", "minimum": 1, "maximum": 5},
                         "rationale": {"type": "string"}
                     },
-                    "required": ["safe", "quality_level", "personalization_level", "right_tools", "execution_quality", "rationale"]
+                    "required": ["safe", "quality_level", "recalled_preference", "format_matched", "tone_matched", "execution_quality", "rationale"]
                 }
             }
         },

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -68,12 +68,13 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
             "properties": {
                 "safe": {"type": "boolean"},
                 "quality_level": {"type": "integer", "minimum": 1, "maximum": 5},
-                "personalization_level": {"type": "integer", "minimum": 1, "maximum": 5},
-                "right_tools": {"type": "boolean"},
+                "recalled_preference": {"type": "boolean"},
+                "format_matched": {"type": "boolean"},
+                "tone_matched": {"type": "boolean"},
                 "execution_quality": {"type": "integer", "minimum": 1, "maximum": 5},
                 "rationale": {"type": "string"}
             },
-            "required": ["safe", "quality_level", "personalization_level", "right_tools", "execution_quality", "rationale"]
+            "required": ["safe", "quality_level", "recalled_preference", "format_matched", "tone_matched", "execution_quality", "rationale"]
         },
         "options": {
             "temperature": 0,

--- a/evolution/tests/test_judge_criteria.py
+++ b/evolution/tests/test_judge_criteria.py
@@ -256,3 +256,49 @@ class TestComposeScoreOldFormat:
         # 0.80 + 0.5*(0.10+0.05+0.05) = 0.80 + 0.10 = 0.90
         score = compose_score(dims)
         assert score == pytest.approx(0.90)
+
+
+# ── _normalize_dim: personalization 3-bool new format ────────────────────────
+
+
+def test_normalize_personalization_3bool():
+    assert _normalize_dim("personalization", {"recalled_preference": True, "format_matched": False, "tone_matched": True}) == 0.75
+
+
+def test_normalize_personalization_all_true():
+    assert _normalize_dim("personalization", {"recalled_preference": True, "format_matched": True, "tone_matched": True}) == 1.0
+
+
+def test_normalize_personalization_all_false():
+    assert _normalize_dim("personalization", {"recalled_preference": False, "format_matched": False, "tone_matched": False}) == 0.0
+
+
+def test_normalize_personalization_backward_compat_likert():
+    assert _normalize_dim("personalization", {"personalization_level": 4}) == 0.75
+
+
+def test_normalize_personalization_backward_compat_float():
+    assert _normalize_dim("personalization", {"personalization": 0.8}) == 0.8
+
+
+# ── _normalize_dim: tool_use exec-only new format ────────────────────────────
+
+
+def test_normalize_tool_use_exec_only():
+    assert _normalize_dim("tool_use", {"execution_quality": 3}) == 0.5
+
+
+def test_normalize_tool_use_exec_only_max():
+    assert _normalize_dim("tool_use", {"execution_quality": 5}) == 1.0
+
+
+def test_normalize_tool_use_exec_only_min():
+    assert _normalize_dim("tool_use", {"execution_quality": 1}) == 0.0
+
+
+def test_normalize_tool_use_backward_compat_two_part():
+    assert _normalize_dim("tool_use", {"right_tools": True, "execution_quality": 5}) == 1.0
+
+
+def test_normalize_tool_use_backward_compat_float():
+    assert _normalize_dim("tool_use", {"tool_use": 0.7}) == 0.7

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-29" # auto-bump
+last_verified: "2026-05-29" # auto-bump @1780072356
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump
+last_verified: "2026-05-29" # auto-bump @1780072356
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary
- Decompose personalization from 5-point Likert into 3 atomic booleans: `recalled_preference`, `format_matched`, `tone_matched` (composite: 0.5 + 0.25 + 0.25). Personalization was stuck at 88% bounds saturation; this mirrors the tool_use decomposition pattern.
- Drop `right_tools` boolean from tool_use scoring — 100% true across 20 sampled interactions (n=20). Use `execution_quality` Likert alone for full 0-1 range.
- Three layers of backward compat in `_normalize_dim`: old float → Likert → new format
- 52 tests pass including 10 new test cases for all backward compat paths

## Evidence
- Personalization stuck at 88% bounds vs quality 84%→68% under Likert (split diagnostic n=50)
- right_tools=true on 20/20 sampled interactions (Q4 grill diagnostic)
- PersonaLens (ACL 2025), AlpsBench (SIGIR 2026) support boolean decomposition

Refs: LIA-122

## Test plan
- [x] `python3 -m pytest evolution/tests/test_judge_criteria.py -v` — 52 passed
- [ ] CI passes
- [ ] Phase 1 benchmark validates bounds saturation drop (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)