### PR TITLE
feat(security): validate Linear identifier before git/worktree path construction (LIA-115)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780241514
+last_verified: "2026-05-31" # auto-bump @1780250270
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -123,6 +123,7 @@ import {
   applyPatchArtifact,
   initLinearContext,
   deriveFetchTimeout,
+  validateLinearIdentifier,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
@@ -1462,5 +1463,28 @@ describe('initLinearContext partial label failure', () => {
     expect(ctx.gateLabels.scoped).toBeDefined();
     expect(ctx.gateLabels.error).toBeDefined();
     expect(ctx.gateLabels.revise).toBeUndefined();
+  });
+});
+
+describe('validateLinearIdentifier', () => {
+  it.each(['LIA-1', 'LIA-115', 'ABC123-99', 'AB-0'])(
+    'accepts valid identifier %s',
+    (id) => {
+      expect(() => validateLinearIdentifier(id)).not.toThrow();
+    },
+  );
+
+  it.each([
+    ['lowercase prefix', 'lowerCase-1'],
+    ['path traversal slash', 'LIA-1/../../x'],
+    ['shell injection', 'LIA-1; rm -rf'],
+    ['missing number', 'LIA'],
+    ['leading digit', '1-LIA'],
+    ['empty string', ''],
+    ['path traversal to passwd', 'LIA-1/../../etc/passwd'],
+  ])('rejects invalid identifier: %s', (_label, id) => {
+    expect(() => validateLinearIdentifier(id)).toThrow(
+      `Invalid Linear identifier: "${id}"`,
+    );
   });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -67,6 +67,15 @@ const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
 const GIT_TIMEOUT_MS = 30_000;
 const BUILD_TIMEOUT_MS = 120_000;
 const PUSH_TIMEOUT_MS = 120_000;
+
+// Linear identifier format: alpha-led alphanumeric team prefix + numeric suffix (e.g. LIA-115).
+const LINEAR_ID_RE = /^[A-Z][A-Z0-9]+-[0-9]+$/;
+export function validateLinearIdentifier(id: string): void {
+  if (!LINEAR_ID_RE.test(id)) {
+    throw new Error(`Invalid Linear identifier: "${id}"`);
+  }
+}
+
 // Trailing '/' = prefix match; exact names match literally (prevents .env matching .envrc)
 function matchesPath(file: string, entry: string): boolean {
   if (entry.endsWith('/')) {
@@ -579,6 +588,8 @@ export async function applyPatchArtifact(
   const patchFileName = sorted[0].name;
   const patchFilePath = path.join(groupDir, patchFileName);
   const patchRelPath = path.relative(effectiveCwd, patchFilePath);
+  // Validate before any path/branch construction that interpolates the identifier.
+  validateLinearIdentifier(identifier);
   const commitMessage = parseCommitMessage(groupDir, identifier);
   const branchName = `feat/${identifier.toLowerCase()}-auto-patch`;
 
@@ -1089,9 +1100,16 @@ async function triageIssue(
 async function ensureIssueWorktree(
   identifier: string,
 ): Promise<{ worktreePath: string; branchName: string } | null> {
+  validateLinearIdentifier(identifier);
   if (!(IS_MACOS || IS_LINUX)) return null;
   const branchName = `feat/${identifier.toLowerCase()}-auto-patch`;
-  const worktreePath = path.join(DATA_DIR, 'worktrees', identifier);
+  const worktreePath = path.resolve(
+    path.join(DATA_DIR, 'worktrees', identifier),
+  );
+  const sandboxRoot = path.resolve(path.join(DATA_DIR, 'worktrees'));
+  if (!worktreePath.startsWith(sandboxRoot + path.sep)) {
+    throw new Error(`Worktree path escapes sandbox: ${worktreePath}`);
+  }
   if (fs.existsSync(worktreePath)) return { worktreePath, branchName };
   fs.mkdirSync(path.join(DATA_DIR, 'worktrees'), { recursive: true });
   await execFileAsync(


### PR DESCRIPTION
Closes LIA-115

## Changes

- Add `validateLinearIdentifier()` helper enforcing `^[A-Z][A-Z0-9]+-[0-9]+$`
- Guard branch name construction (SEC-001) at `applyPatchArtifact` (~line 575)
- Guard `ensureIssueWorktree()` (SEC-008) with regex + `path.resolve()` sandbox assertion
- Unit tests for valid/invalid/path-traversal identifiers (11 new tests, 64 total passing)
- Bump drifted pattern files (`deployment.md`, `general-code.md`)