### PR TITLE
feat(dispatcher): restore stall watchdog (LIA-123)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780076902
+last_verified: "2026-05-30" # auto-bump @1780089233
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -122,11 +122,13 @@ import {
   extractScopeBlock,
   applyPatchArtifact,
   initLinearContext,
+  getDispatcherHealth,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
   LinearDispatcherDependencies,
 } from './linear-dispatcher.js';
+import { logger } from './logger.js';
 import { RuntimeRegistry } from './agent-runtimes/registry.js';
 
 function makeMockDeps(
@@ -412,6 +414,113 @@ describe('startLinearDispatcher', () => {
     const ctx = makeMockCtx();
     startLinearDispatcher(ctx);
     // No timer started because no role specs exist
+  });
+});
+
+describe('getDispatcherHealth / stall watchdog', () => {
+  const agentsDir = path.join(TEST_PROJECT_ROOT, '.claude', 'agents');
+
+  beforeEach(() => {
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, 'test-role.md'),
+      `---\nname: test-role\nlinear_label: "agent:test"\n---\nYou are a test agent.`,
+    );
+  });
+
+  afterEach(() => {
+    stopLinearDispatcher();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    fs.rmSync(TEST_PROJECT_ROOT, { recursive: true, force: true });
+  });
+
+  it('returns running:false and null health when dispatcher is stopped', () => {
+    const health = getDispatcherHealth();
+    expect(health.running).toBe(false);
+    expect(health.lastTickAt).toBeNull();
+    expect(health.stallMs).toBeNull();
+  });
+
+  it('returns running:true and recent lastTickAt after dispatcher starts', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('LINEAR_POLL_INTERVAL_MS', '5000');
+    const ctx = makeMockCtx({
+      client: {
+        issues: vi.fn().mockResolvedValue({ nodes: [] }),
+        updateIssue: vi.fn().mockResolvedValue({}),
+      } as unknown as LinearContext['client'],
+    });
+    startLinearDispatcher(ctx);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const health = getDispatcherHealth();
+    expect(health.running).toBe(true);
+    expect(health.lastTickAt).not.toBeNull();
+    expect(health.stallMs).not.toBeNull();
+    expect(health.stallMs!).toBeLessThan(5000);
+    expect(health.pollMs).toBe(5000);
+  });
+
+  it('watchdog emits logger.error when tick has stalled beyond 3x pollMs', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('LINEAR_POLL_INTERVAL_MS', '5000');
+
+    const errorSpy = vi.spyOn(logger, 'error');
+
+    // Intercept setInterval to capture the watchdog callback before delegating to fake timer
+    const capturedIntervals: Array<{ fn: () => void; ms: number }> = [];
+    const origSetInterval = global.setInterval;
+    (global as unknown as Record<string, unknown>)['setInterval'] = (
+      fn: (() => void) | string,
+      ms?: number,
+      ...args: unknown[]
+    ) => {
+      if (typeof fn === 'function' && typeof ms === 'number') {
+        capturedIntervals.push({ fn: fn as () => void, ms });
+      }
+      return (origSetInterval as typeof global.setInterval)(
+        fn as Parameters<typeof global.setInterval>[0],
+        ms,
+        ...args,
+      );
+    };
+
+    try {
+      const ctx = makeMockCtx({
+        client: {
+          issues: vi.fn().mockResolvedValue({ nodes: [] }),
+          updateIssue: vi.fn().mockResolvedValue({}),
+        } as unknown as LinearContext['client'],
+      });
+      startLinearDispatcher(ctx);
+
+      // Restore setInterval before advancing timers to avoid double-capturing
+      (global as unknown as Record<string, unknown>)['setInterval'] =
+        origSetInterval;
+
+      // Let the initial synchronous tick stamp _lastTickAt
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Find the watchdog interval (3 x 5000 = 15000 ms)
+      const watchdogEntry = capturedIntervals.find(({ ms }) => ms === 15_000);
+      expect(watchdogEntry).toBeDefined();
+
+      // Jump system time forward beyond 3x pollMs without firing any timer callbacks
+      vi.setSystemTime(new Date(Date.now() + 4 * 5000));
+
+      // Directly invoke the watchdog callback — it should detect the stall
+      watchdogEntry!.fn();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ stallMs: expect.any(Number), pollMs: 5000 }),
+        expect.stringContaining('stall'),
+      );
+    } finally {
+      (global as unknown as Record<string, unknown>)['setInterval'] =
+        origSetInterval;
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -128,6 +128,11 @@ let _roleSpecs: Map<string, RoleSpec> = new Map();
 let _ctx: LinearContext | null = null;
 // Promise-chain serializer — same pattern as commentLocks in linear-notifications.ts
 let _patchMutex: Promise<void> = Promise.resolve();
+// Stall watchdog: tracks last tick timestamp and emits logger.error when ticks stall.
+// Removed in LIA-108 and restored in LIA-123.
+let _lastTickAt: number | null = null;
+let _pollMs: number = DEFAULT_POLL_MS;
+let _watchdogTimer: ReturnType<typeof setInterval> | null = null;
 
 export function extractFrontmatter(content: string): {
   data: Record<string, unknown>;
@@ -1854,6 +1859,7 @@ export function startLinearDispatcher(ctx: LinearContext): void {
     isNaN(parsedPollMs) || parsedPollMs < 1000 ? DEFAULT_POLL_MS : parsedPollMs;
 
   _tick = () => {
+    _lastTickAt = Date.now();
     fireAndForget(() => pollLinear(), {
       name: 'linear.dispatch',
       onError: (err) => {
@@ -1872,9 +1878,11 @@ export function startLinearDispatcher(ctx: LinearContext): void {
     });
   };
 
+  _pollMs = pollMs;
   _tick();
   _timer = setInterval(_tick, pollMs);
   _timer.unref();
+  _watchdogTimer = _startWatchdog(pollMs);
   logger.info(
     { pollMs, roles: _roleSpecs.size },
     'linear-dispatcher: daemon started',
@@ -1886,19 +1894,71 @@ export function stopLinearDispatcher(): void {
     clearInterval(_timer);
     _timer = null;
   }
+  if (_watchdogTimer) {
+    clearInterval(_watchdogTimer);
+    _watchdogTimer = null;
+  }
   _tick = null;
   _ctx = null;
+  _lastTickAt = null;
 }
 
 const MIN_POLL_MS = 5_000;
 const MAX_POLL_MS = 300_000;
 
+// Internal helper: creates the stall-watchdog timer at 3× pollMs.
+// Fires logger.error when no tick has been observed within the window.
+function _startWatchdog(pollMs: number): ReturnType<typeof setInterval> {
+  const timer = setInterval(() => {
+    if (_lastTickAt !== null && Date.now() - _lastTickAt > 3 * _pollMs) {
+      logger.error(
+        {
+          lastTickAt: _lastTickAt,
+          stallMs: Date.now() - _lastTickAt,
+          pollMs: _pollMs,
+        },
+        'linear-dispatcher: tick stall detected — no tick has fired within 3× poll interval',
+      );
+    }
+  }, 3 * pollMs);
+  timer.unref();
+  return timer;
+}
+
+export interface DispatcherHealth {
+  /** Whether the dispatcher's main poll timer is currently active. */
+  running: boolean;
+  /** Unix ms timestamp of the most recent tick, or null if never ticked. */
+  lastTickAt: number | null;
+  /** Milliseconds since the last tick, or null when not running. */
+  stallMs: number | null;
+  /** Current poll interval in milliseconds. */
+  pollMs: number;
+}
+
+/**
+ * Returns a snapshot of the dispatcher's health for observability / health-check endpoints.
+ * Restored in LIA-123 after accidental removal in LIA-108.
+ */
+export function getDispatcherHealth(): DispatcherHealth {
+  const now = Date.now();
+  return {
+    running: _timer !== null,
+    lastTickAt: _lastTickAt,
+    stallMs: _lastTickAt !== null ? now - _lastTickAt : null,
+    pollMs: _pollMs,
+  };
+}
+
 export function setPollInterval(ms: number): boolean {
   if (!_tick) return false;
   const clamped = Math.max(MIN_POLL_MS, Math.min(MAX_POLL_MS, ms));
+  _pollMs = clamped;
   if (_timer) clearInterval(_timer);
   _timer = setInterval(_tick, clamped);
   _timer.unref();
+  if (_watchdogTimer) clearInterval(_watchdogTimer);
+  _watchdogTimer = _startWatchdog(clamped);
   logger.info({ pollMs: clamped }, 'linear-dispatcher: poll interval updated');
   return true;
 }


### PR DESCRIPTION
## Summary

- Restores `_lastTickAt`, `_pollMs`, `_watchdogTimer`, `getDispatcherHealth()`, and `_startWatchdog()` to `src/linear-dispatcher.ts`
- Watchdog fires every 3x pollMs and emits logger.error when no tick has been observed within that window
- `getDispatcherHealth()` + `DispatcherHealth` interface exported for health-check consumers
- `stopLinearDispatcher` clears watchdog timer and resets `_lastTickAt`
- `setPollInterval` keeps watchdog in sync when interval changes

Removed in LIA-108 as accidental collateral; restored in LIA-123.

## Test plan
- All 56 existing tests pass
- 3 new watchdog tests added

Closes LIA-123
