### PR TITLE
fix(LIA-126): clear stale Warden: Revise on Done/Cancelled; Warden: Error on gate failures

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-02" # auto-bump @1780409961
+last_verified: "2026-06-02" # auto-bump @1780413558
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -114,6 +114,7 @@ interface RoleSpec {
 export interface WorkflowState {
   id: string;
   name: string;
+  type?: string; // e.g. 'backlog' | 'unstarted' | 'started' | 'completed' | 'cancelled' | 'triage'
 }
 
 export interface GateLabels {
@@ -247,7 +248,7 @@ export async function discoverWorkflowStates(
   });
   const map = new Map<string, WorkflowState>();
   for (const s of states.nodes) {
-    map.set(s.name, { id: s.id, name: s.name });
+    map.set(s.name, { id: s.id, name: s.name, type: s.type });
   }
   const required = ['Ready for Agent', 'Agent Working', 'In Review', 'Backlog'];
   if (!map.has('Done')) {

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -245,7 +245,9 @@ All checks pass.`;
   });
 
   it('returns null when no Enrichment section', () => {
-    const output = `## Verdict: SHIP\n\nAll checks pass.`;
+    const output = `## Verdict: SHIP
+
+All checks pass.`;
     expect(parseEnrichment(output)).toBeNull();
   });
 
@@ -300,7 +302,9 @@ After.`;
   it('creates block as entire description when empty', () => {
     const result = mergeEnrichment('', 'test-gate', 'Content');
     expect(result).toBe(
-      '<!-- gate:test-gate:start -->\nContent\n<!-- gate:test-gate:end -->',
+      '<!-- gate:test-gate:start -->
+Content
+<!-- gate:test-gate:end -->',
     );
   });
 });
@@ -344,11 +348,13 @@ describe('parseRatings', () => {
 
 describe('parseVerdict', () => {
   it('extracts SHIP verdict', () => {
-    expect(parseVerdict('## Verdict: SHIP\nDone.')).toBe('SHIP');
+    expect(parseVerdict('## Verdict: SHIP
+Done.')).toBe('SHIP');
   });
 
   it('extracts REVISE verdict', () => {
-    expect(parseVerdict('## Verdict: REVISE\nNeeds work.')).toBe('REVISE');
+    expect(parseVerdict('## Verdict: REVISE
+Needs work.')).toBe('REVISE');
   });
 
   it('returns null when no verdict', () => {
@@ -446,7 +452,9 @@ describe('computeScopeLabelChanges', () => {
     const result = computeScopeLabelChanges(
       'agent-readiness-gate',
       'SHIP',
-      '## Scope\n\n**Problem**: fix the bug',
+      '## Scope
+
+**Problem**: fix the bug',
       gateLabels,
     );
     expect(result.addIds).toEqual(['label-scoped-id']);
@@ -490,7 +498,9 @@ describe('computeScopeLabelChanges', () => {
     const result = computeScopeLabelChanges(
       'output-quality-gate',
       'SHIP',
-      '## Scope\n\nsome enrichment',
+      '## Scope
+
+some enrichment',
       gateLabels,
     );
     expect(result.addIds).toEqual([]);
@@ -885,101 +895,98 @@ describe('label update error callback', () => {
 // ── computeTerminalLabelCleanup tests (LIA-126 fix 1) ────────────────────────
 
 describe('computeTerminalLabelCleanup', () => {
-  const gateLabels = {
-    scoped: 'label-scoped-id',
-    revise: 'label-revise-id',
-    evaluating: 'label-eval-id',
-    error: 'label-error-id',
-    bouncedUnscoped: 'label-bounced-unscoped-id',
-    bouncedStale: 'label-bounced-stale-id',
-    bouncedNoContext: 'label-bounced-nocontext-id',
+  const labels = {
+    scoped: 'label-scoped',
+    revise: 'label-revise',
+    evaluating: 'label-eval',
+    error: 'label-error',
+    bouncedUnscoped: 'label-bounced-u',
+    bouncedStale: 'label-bounced-s',
+    bouncedNoContext: 'label-bounced-n',
     effort: {},
     complexity: {},
   };
 
-  it('removes Warden: Revise when the issue carries it', () => {
-    const result = computeTerminalLabelCleanup(gateLabels, ['label-revise-id', 'some-other-id']);
-    expect(result).toContain('label-revise-id');
-    expect(result).not.toContain('label-scoped-id');
-    expect(result).not.toContain('label-error-id');
-  });
-
-  it('removes Evaluating label when present', () => {
-    const result = computeTerminalLabelCleanup(gateLabels, ['label-eval-id']);
-    expect(result).toContain('label-eval-id');
-  });
-
-  it('removes all bounced labels when present', () => {
-    const result = computeTerminalLabelCleanup(gateLabels, [
-      'label-bounced-unscoped-id',
-      'label-bounced-stale-id',
-      'label-bounced-nocontext-id',
+  it('strips Warden: Revise when issue carries it (Done transition)', () => {
+    const result = computeTerminalLabelCleanup(labels, [
+      'label-revise',
+      'some-other-label',
     ]);
-    expect(result).toContain('label-bounced-unscoped-id');
-    expect(result).toContain('label-bounced-stale-id');
-    expect(result).toContain('label-bounced-nocontext-id');
+    expect(result).toContain('label-revise');
+    expect(result).not.toContain('label-scoped');
+    expect(result).not.toContain('label-error');
   });
 
-  it('returns empty array when issue has none of the transient labels', () => {
-    const result = computeTerminalLabelCleanup(gateLabels, ['some-unrelated-label']);
+  it('strips Evaluating label when present', () => {
+    const result = computeTerminalLabelCleanup(labels, ['label-eval']);
+    expect(result).toContain('label-eval');
+  });
+
+  it('strips all bounced labels when present', () => {
+    const result = computeTerminalLabelCleanup(labels, [
+      'label-bounced-u',
+      'label-bounced-s',
+      'label-bounced-n',
+    ]);
+    expect(result).toContain('label-bounced-u');
+    expect(result).toContain('label-bounced-s');
+    expect(result).toContain('label-bounced-n');
+  });
+
+  it('returns empty array when issue has no transient labels', () => {
+    const result = computeTerminalLabelCleanup(labels, [
+      'unrelated-label',
+    ]);
     expect(result).toHaveLength(0);
   });
 
-  it('does not include labels not currently on the issue', () => {
-    // issue only has revise; evaluating and bounced are NOT on the issue
-    const result = computeTerminalLabelCleanup(gateLabels, ['label-revise-id']);
-    expect(result).toEqual(['label-revise-id']);
+  it('only returns labels currently on the issue', () => {
+    // issue only has revise — evaluating and bounced are not present
+    const result = computeTerminalLabelCleanup(labels, ['label-revise']);
+    expect(result).toEqual(['label-revise']);
+  });
+
+  it('does not strip Warden: Error (not a transient label)', () => {
+    const result = computeTerminalLabelCleanup(labels, [
+      'label-revise',
+      'label-error',
+    ]);
+    expect(result).toContain('label-revise'); // revise IS stripped
+    expect(result).not.toContain('label-error'); // error is NOT stripped
   });
 
   it('handles partial gateLabels (no bounced labels configured)', () => {
-    const minimalLabels = { revise: 'label-revise-id', effort: {}, complexity: {} };
-    const result = computeTerminalLabelCleanup(minimalLabels, ['label-revise-id']);
-    expect(result).toContain('label-revise-id');
-    // no bounced labels configured — should not throw
+    const minimal = { revise: 'label-revise', effort: {}, complexity: {} };
+    const result = computeTerminalLabelCleanup(minimal, ['label-revise']);
+    expect(result).toContain('label-revise');
+    // no bounced labels defined — should not throw
   });
 });
 
-// ── gate-error label behaviour (LIA-126 fix 2) ───────────────────────────────
+// ── gate-error label guard pre-condition (LIA-126 fix 2) ─────────────────────
+//
+// computeScopeLabelChanges is skipped when gateDidError / gateAgentError is
+// true in the finally blocks of handleIssueUpdate and runGateForIssue.
+// This test documents the pre-condition: without the guard, REVISE verdict
+// adds Warden: Revise even on infrastructure failures.
 
-describe('computeScopeLabelChanges – error guard', () => {
-  // Verifies the pre-condition: computeScopeLabelChanges with REVISE DOES add revise label.
-  // This is what the handleIssueUpdate finally block produced before the LIA-126 fix
-  // when gateDidError was true.
-  it('REVISE verdict adds Warden: Revise (pre-condition for guard test)', () => {
-    const gateLabels = {
-      revise: 'label-revise-id',
-      error: 'label-error-id',
-      evaluating: 'label-eval-id',
-      effort: {},
-      complexity: {},
-    };
+describe('computeScopeLabelChanges – gate-error guard', () => {
+  const gateLabels = {
+    revise: 'label-revise',
+    error: 'label-error',
+    evaluating: 'label-eval',
+    effort: {},
+    complexity: {},
+  };
+
+  it('REVISE verdict adds revise label (pre-condition for guard)', () => {
+    // Without !gateDidError guard this would fire on agent/infra errors too.
     const result = computeScopeLabelChanges(
       'agent-readiness-gate',
       'REVISE',
       undefined,
       gateLabels,
     );
-    // Without the guard, this would be added even on infrastructure errors
-    expect(result.addIds).toContain('label-revise-id');
-  });
-
-  // The LIA-126 fix guards the computeScopeLabelChanges call with !gateDidError /
-  // !gateAgentError, so the above path is never taken on errors. We verify that
-  // computeTerminalLabelCleanup (the terminal-strip path) correctly excludes
-  // the error label — error should persist, not be cleaned up on Done.
-  it('does not remove Warden: Error label on terminal cleanup (error label is not transient)', () => {
-    const gateLabels = {
-      revise: 'label-revise-id',
-      error: 'label-error-id',
-      evaluating: 'label-eval-id',
-      effort: {},
-      complexity: {},
-    };
-    const result = computeTerminalLabelCleanup(gateLabels, [
-      'label-revise-id',
-      'label-error-id',
-    ]);
-    expect(result).toContain('label-revise-id');    // revise IS stripped on terminal
-    expect(result).not.toContain('label-error-id'); // error is NOT stripped (not a transient label)
+    expect(result.addIds).toContain('label-revise');
   });
 });

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -302,9 +302,9 @@ After.`;
   it('creates block as entire description when empty', () => {
     const result = mergeEnrichment('', 'test-gate', 'Content');
     expect(result).toBe(
-      '<!-- gate:test-gate:start -->
+      `<!-- gate:test-gate:start -->
 Content
-<!-- gate:test-gate:end -->',
+<!-- gate:test-gate:end -->`,
     );
   });
 });
@@ -348,13 +348,17 @@ describe('parseRatings', () => {
 
 describe('parseVerdict', () => {
   it('extracts SHIP verdict', () => {
-    expect(parseVerdict('## Verdict: SHIP
-Done.')).toBe('SHIP');
+    expect(
+      parseVerdict(`## Verdict: SHIP
+Done.`),
+    ).toBe('SHIP');
   });
 
   it('extracts REVISE verdict', () => {
-    expect(parseVerdict('## Verdict: REVISE
-Needs work.')).toBe('REVISE');
+    expect(
+      parseVerdict(`## Verdict: REVISE
+Needs work.`),
+    ).toBe('REVISE');
   });
 
   it('returns null when no verdict', () => {
@@ -452,9 +456,9 @@ describe('computeScopeLabelChanges', () => {
     const result = computeScopeLabelChanges(
       'agent-readiness-gate',
       'SHIP',
-      '## Scope
+      `## Scope
 
-**Problem**: fix the bug',
+**Problem**: fix the bug`,
       gateLabels,
     );
     expect(result.addIds).toEqual(['label-scoped-id']);
@@ -498,9 +502,9 @@ describe('computeScopeLabelChanges', () => {
     const result = computeScopeLabelChanges(
       'output-quality-gate',
       'SHIP',
-      '## Scope
+      `## Scope
 
-some enrichment',
+some enrichment`,
       gateLabels,
     );
     expect(result.addIds).toEqual([]);
@@ -934,9 +938,7 @@ describe('computeTerminalLabelCleanup', () => {
   });
 
   it('returns empty array when issue has no transient labels', () => {
-    const result = computeTerminalLabelCleanup(labels, [
-      'unrelated-label',
-    ]);
+    const result = computeTerminalLabelCleanup(labels, ['unrelated-label']);
     expect(result).toHaveLength(0);
   });
 

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -19,6 +19,7 @@ import {
   stripEnrichmentSection,
   computeScopeLabelChanges,
   extractScopeBlockFromDescription,
+  computeTerminalLabelCleanup,
   retryWithBackoff,
   _setSleepFnForTests,
   runInlineCompletionCheck,
@@ -878,5 +879,107 @@ describe('label update error callback', () => {
 
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+// ── computeTerminalLabelCleanup tests (LIA-126 fix 1) ────────────────────────
+
+describe('computeTerminalLabelCleanup', () => {
+  const gateLabels = {
+    scoped: 'label-scoped-id',
+    revise: 'label-revise-id',
+    evaluating: 'label-eval-id',
+    error: 'label-error-id',
+    bouncedUnscoped: 'label-bounced-unscoped-id',
+    bouncedStale: 'label-bounced-stale-id',
+    bouncedNoContext: 'label-bounced-nocontext-id',
+    effort: {},
+    complexity: {},
+  };
+
+  it('removes Warden: Revise when the issue carries it', () => {
+    const result = computeTerminalLabelCleanup(gateLabels, ['label-revise-id', 'some-other-id']);
+    expect(result).toContain('label-revise-id');
+    expect(result).not.toContain('label-scoped-id');
+    expect(result).not.toContain('label-error-id');
+  });
+
+  it('removes Evaluating label when present', () => {
+    const result = computeTerminalLabelCleanup(gateLabels, ['label-eval-id']);
+    expect(result).toContain('label-eval-id');
+  });
+
+  it('removes all bounced labels when present', () => {
+    const result = computeTerminalLabelCleanup(gateLabels, [
+      'label-bounced-unscoped-id',
+      'label-bounced-stale-id',
+      'label-bounced-nocontext-id',
+    ]);
+    expect(result).toContain('label-bounced-unscoped-id');
+    expect(result).toContain('label-bounced-stale-id');
+    expect(result).toContain('label-bounced-nocontext-id');
+  });
+
+  it('returns empty array when issue has none of the transient labels', () => {
+    const result = computeTerminalLabelCleanup(gateLabels, ['some-unrelated-label']);
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not include labels not currently on the issue', () => {
+    // issue only has revise; evaluating and bounced are NOT on the issue
+    const result = computeTerminalLabelCleanup(gateLabels, ['label-revise-id']);
+    expect(result).toEqual(['label-revise-id']);
+  });
+
+  it('handles partial gateLabels (no bounced labels configured)', () => {
+    const minimalLabels = { revise: 'label-revise-id', effort: {}, complexity: {} };
+    const result = computeTerminalLabelCleanup(minimalLabels, ['label-revise-id']);
+    expect(result).toContain('label-revise-id');
+    // no bounced labels configured — should not throw
+  });
+});
+
+// ── gate-error label behaviour (LIA-126 fix 2) ───────────────────────────────
+
+describe('computeScopeLabelChanges – error guard', () => {
+  // Verifies the pre-condition: computeScopeLabelChanges with REVISE DOES add revise label.
+  // This is what the handleIssueUpdate finally block produced before the LIA-126 fix
+  // when gateDidError was true.
+  it('REVISE verdict adds Warden: Revise (pre-condition for guard test)', () => {
+    const gateLabels = {
+      revise: 'label-revise-id',
+      error: 'label-error-id',
+      evaluating: 'label-eval-id',
+      effort: {},
+      complexity: {},
+    };
+    const result = computeScopeLabelChanges(
+      'agent-readiness-gate',
+      'REVISE',
+      undefined,
+      gateLabels,
+    );
+    // Without the guard, this would be added even on infrastructure errors
+    expect(result.addIds).toContain('label-revise-id');
+  });
+
+  // The LIA-126 fix guards the computeScopeLabelChanges call with !gateDidError /
+  // !gateAgentError, so the above path is never taken on errors. We verify that
+  // computeTerminalLabelCleanup (the terminal-strip path) correctly excludes
+  // the error label — error should persist, not be cleaned up on Done.
+  it('does not remove Warden: Error label on terminal cleanup (error label is not transient)', () => {
+    const gateLabels = {
+      revise: 'label-revise-id',
+      error: 'label-error-id',
+      evaluating: 'label-eval-id',
+      effort: {},
+      complexity: {},
+    };
+    const result = computeTerminalLabelCleanup(gateLabels, [
+      'label-revise-id',
+      'label-error-id',
+    ]);
+    expect(result).toContain('label-revise-id');    // revise IS stripped on terminal
+    expect(result).not.toContain('label-error-id'); // error is NOT stripped (not a transient label)
   });
 });

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -1612,7 +1612,8 @@ async function runGateForIssue(
     const removeIds: string[] = [];
     const addIds: string[] = [];
     if (ctx.gateLabels.evaluating) removeIds.push(ctx.gateLabels.evaluating);
-    if (gateAgentError && ctx.gateLabels.error) addIds.push(ctx.gateLabels.error);
+    if (gateAgentError && ctx.gateLabels.error)
+      addIds.push(ctx.gateLabels.error);
     if (!gateAgentError) {
       const scopeLabels = computeScopeLabelChanges(
         gateSpec.name,

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -302,6 +302,24 @@ export function computeScopeLabelChanges(
   return { addIds, removeIds };
 }
 
+/**
+ * Returns label IDs to remove when an issue enters a terminal state (Done / Cancelled).
+ * Strips all transient Warden labels regardless of whether a gate ran.
+ */
+export function computeTerminalLabelCleanup(
+  gateLabels: GateLabels,
+  issueLabelIds: string[],
+): string[] {
+  const labelSet = new Set(issueLabelIds);
+  return [
+    gateLabels.revise,
+    gateLabels.evaluating,
+    gateLabels.bouncedUnscoped,
+    gateLabels.bouncedStale,
+    gateLabels.bouncedNoContext,
+  ].filter((id): id is string => !!id && labelSet.has(id));
+}
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -649,14 +667,25 @@ async function handleIssueUpdate(
     return;
   }
 
-  if (
-    toState.name === 'Done' &&
-    data.labels.some((l) => l.name === 'Done: Pre-implemented')
-  ) {
-    logger.info(
-      { issueId: data.id },
-      'linear-webhook: Done: Pre-implemented label present, skipping gate',
+  // Terminal state: strip transient Warden labels and bail out — no gate fires on Done/Cancelled
+  if (toState.type === 'completed' || toState.type === 'cancelled') {
+    if (data.labels.some((l) => l.name === 'Done: Pre-implemented')) {
+      logger.info(
+        { issueId: data.id },
+        'linear-webhook: Done: Pre-implemented label present, skipping gate',
+      );
+    }
+    const removeIds = computeTerminalLabelCleanup(
+      ctx.gateLabels,
+      data.labels.map((l) => l.id),
     );
+    if (removeIds.length > 0) {
+      retryLabelUpdate(ctx.client, data.id, { removedLabelIds: removeIds });
+      logger.info(
+        { issueId: data.id, toState: toState.name, count: removeIds.length },
+        'linear-webhook: stripped transient labels on terminal state entry',
+      );
+    }
     return;
   }
 
@@ -1002,20 +1031,20 @@ async function handleIssueUpdate(
     let verdictText = '';
 
     if (!parsedVerdict && error) {
+      gateDidError = true;
       verdict = gateSpec.fallback;
       logger.warn(
         {
           issueId: data.id,
           gate: gateSpec.name,
-          fallback: gateSpec.fallback,
           error,
         },
-        'linear-webhook: gate agent error, applying fallback verdict',
+        'linear-webhook: gate agent error, applying Warden: Error label',
       );
       commentBody = formatGateComment(
         gateSpec.name,
-        verdict,
-        `Gate agent error (fallback: ${gateSpec.fallback}):\n\`\`\`\n${error}\n\`\`\``,
+        'ERROR',
+        `Gate agent error:\n\`\`\`\n${error}\n\`\`\``,
         gateSpec.mode,
       );
     } else {
@@ -1221,14 +1250,17 @@ async function handleIssueUpdate(
     const addIds: string[] = [];
     if (ctx.gateLabels.evaluating) removeIds.push(ctx.gateLabels.evaluating);
     if (gateDidError && ctx.gateLabels.error) addIds.push(ctx.gateLabels.error);
-    const scopeLabels = computeScopeLabelChanges(
-      gateSpec.name,
-      finalVerdict,
-      finalEnrichment,
-      ctx.gateLabels,
-    );
-    addIds.push(...scopeLabels.addIds);
-    removeIds.push(...scopeLabels.removeIds);
+    // Only apply scope label changes when the gate ran cleanly (no infrastructure error or agent crash)
+    if (!gateDidError) {
+      const scopeLabels = computeScopeLabelChanges(
+        gateSpec.name,
+        finalVerdict,
+        finalEnrichment,
+        ctx.gateLabels,
+      );
+      addIds.push(...scopeLabels.addIds);
+      removeIds.push(...scopeLabels.removeIds);
+    }
 
     // Bouncer: apply bounced:<reason> label on REVISE, strip on SHIP
     if (gateSpec.name === 'bouncer-gate') {
@@ -1337,6 +1369,7 @@ async function runGateForIssue(
   ctx.inFlightGate.add(issue.id);
   let finalVerdict: string | undefined;
   let finalEnrichment: string | undefined;
+  let gateAgentError = false;
 
   try {
     if (ctx.gateLabels.evaluating) {
@@ -1411,6 +1444,7 @@ async function runGateForIssue(
 
     if (!parsedVerdict && error) {
       verdict = 'REVISE';
+      gateAgentError = true;
       commentBody = formatGateComment(
         gateSpec.name,
         'ERROR',
@@ -1569,6 +1603,7 @@ async function runGateForIssue(
       'startup-sweep: gate evaluation failed',
     );
     // Never fallback-SHIP on infrastructure errors — gate didn't actually run
+    gateAgentError = true;
     finalVerdict = 'REVISE';
     finalEnrichment = `Gate infrastructure error (startup sweep): ${errorMsg}`;
   } finally {
@@ -1577,14 +1612,17 @@ async function runGateForIssue(
     const removeIds: string[] = [];
     const addIds: string[] = [];
     if (ctx.gateLabels.evaluating) removeIds.push(ctx.gateLabels.evaluating);
-    const scopeLabels = computeScopeLabelChanges(
-      gateSpec.name,
-      finalVerdict,
-      finalEnrichment,
-      ctx.gateLabels,
-    );
-    addIds.push(...scopeLabels.addIds);
-    removeIds.push(...scopeLabels.removeIds);
+    if (gateAgentError && ctx.gateLabels.error) addIds.push(ctx.gateLabels.error);
+    if (!gateAgentError) {
+      const scopeLabels = computeScopeLabelChanges(
+        gateSpec.name,
+        finalVerdict,
+        finalEnrichment,
+        ctx.gateLabels,
+      );
+      addIds.push(...scopeLabels.addIds);
+      removeIds.push(...scopeLabels.removeIds);
+    }
     if (finalEnrichment) {
       const ratings = parseRatings(finalEnrichment);
       if (ratings.effort || ratings.complexity) {


### PR DESCRIPTION
## Summary

- **Fix 1 (clear-on-terminal)**: Added `computeTerminalLabelCleanup()` and a new early-return branch in `handleIssueUpdate` that strips `Warden: Revise`, `Evaluating`, and all `Bounced` labels when an issue transitions to a `completed` or `cancelled` state. Added `type?: string` to `WorkflowState` and captured it in `discoverWorkflowStates`.
- **Fix 2 (error-fallback)**: Set `gateDidError = true` in the agent-crash path (not just the infrastructure catch block), and guarded `computeScopeLabelChanges()` with `if (!gateDidError)` in the finally block. Same pattern for `runGateForIssue` via `gateAgentError`. Both error paths now apply `Warden: Error` and skip `Warden: Revise`.

## Root causes closed

| # | Root cause | Fix |
|---|-----------|-----|
| 1 | `computeScopeLabelChanges` only clears revise on SHIP; Done/Cancelled skip it entirely | `computeTerminalLabelCleanup` called before `gateSpec` lookup on terminal states |
| 2 | Agent-crash path kept `gateDidError=false`; infra-catch added both Error AND Revise | `gateDidError=true` in crash path; `computeScopeLabelChanges` guarded by `!gateDidError` |

## Test plan

- [x] `computeTerminalLabelCleanup` — 7 unit tests: strips Revise/Evaluating/Bounced, empty when no transient labels, does not strip `Warden: Error`
- [x] `computeScopeLabelChanges – gate-error guard` — pre-condition test documents what the guard prevents

Closes LIA-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
