### PR TITLE
feat(warden): escalating deny message for codegraph-first gate (LIA-129)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -418,15 +418,22 @@ def _line_is_codegraph_toolcall(obj: Any) -> bool:
 
 def _scan_transcript_for_codegraph(
     transcript_path: str,
-) -> tuple[bool, int, int] | None:
+) -> tuple[bool, int, int, int] | None:
     """Read the transcript JSONL at *transcript_path* and return
-    ``(found, assistant_turns, any_tool_uses)``, or ``None`` on IO error.
+    ``(found, assistant_turns, any_tool_uses, prior_search_attempts)``,
+    or ``None`` on IO error.
 
     * ``found``: True if any line satisfies ``_line_is_codegraph_toolcall``.
     * ``assistant_turns``: count of lines with outer ``type == "assistant"``.
     * ``any_tool_uses``: count of tool_use blocks seen across all lines
       (used to detect parse blindness: if assistant_turns is high but
       any_tool_uses is zero, the format may have changed).
+    * ``prior_search_attempts``: count of tool_use blocks whose name is
+      ``"Grep"`` or ``"Glob"``, or ``"Bash"`` with a primary code-search
+      command (per ``_bash_is_code_search``).  The current hook's search
+      attempt is NOT yet in the transcript when the hook fires, so this
+      counts only PAST attempts — exactly what the escalating-deny message
+      needs.
     * Returns ``None`` when the file cannot be opened (missing path, permission
       error).  The caller should treat ``None`` as a fail-open signal.
 
@@ -437,6 +444,7 @@ def _scan_transcript_for_codegraph(
     found = False
     assistant_turns = 0
     any_tool_uses = 0
+    prior_search_attempts = 0
     try:
         with path.open(encoding="utf-8", errors="replace") as fh:
             for raw in fh:
@@ -458,6 +466,15 @@ def _scan_transcript_for_codegraph(
                             for blk in content:
                                 if isinstance(blk, dict) and blk.get("type") == "tool_use":
                                     any_tool_uses += 1
+                                    blk_name = blk.get("name", "")
+                                    if blk_name in ("Grep", "Glob"):
+                                        prior_search_attempts += 1
+                                    elif blk_name == "Bash":
+                                        blk_input = blk.get("input")
+                                        if isinstance(blk_input, dict):
+                                            cmd = blk_input.get("command", "")
+                                            if isinstance(cmd, str) and _bash_is_code_search(cmd):
+                                                prior_search_attempts += 1
                 if _line_is_codegraph_toolcall(obj):
                     found = True
                     # Answer known; the turn/tool_use counters are only consulted
@@ -465,7 +482,7 @@ def _scan_transcript_for_codegraph(
                     break
     except OSError:
         return None
-    return found, assistant_turns, any_tool_uses
+    return found, assistant_turns, any_tool_uses, prior_search_attempts
 
 
 def _resolve_agent_transcript(event: dict[str, Any]) -> str:
@@ -961,6 +978,43 @@ def run_session_init(repo_root: Path) -> int:
     return 0
 
 
+def _codegraph_deny_message(prior_searches: int) -> str:
+    """Return an escalating deny message for the codegraph-first gate.
+
+    The message tier is based on how many search-tool attempts (Grep, Glob, or
+    Bash code-search) the agent has already made in its transcript, giving a
+    repeatedly-blocked agent increasingly explicit instructions instead of
+    cycling on the same polite hint.
+
+    * prior_searches == 0  → polite hint (tier 0, preserved wording).
+    * 1 <= prior_searches <= 2 → imperative + exact two-step sequence (tier 1).
+    * prior_searches >= 3  → tier-1 text PLUS Read fallback for when the
+      codegraph MCP server is unavailable (tier 2).
+    """
+    tier0 = (
+        "[codegraph-first-gate] Call a codegraph or code_search tool first "
+        '(ToolSearch "select:mcp__codegraph__codegraph_context"), then retry. '
+        "core-behavioral-rules.md § Code Exploration."
+    )
+    tier1 = (
+        "[codegraph-first-gate] Blocked again — stop retrying search. "
+        "Run these two calls, in order, THEN retry: "
+        '(1) ToolSearch(query="select:mcp__codegraph__codegraph_context"); '
+        "(2) codegraph_context with your question. "
+        "core-behavioral-rules.md § Code Exploration."
+    )
+    tier2 = (
+        tier1
+        + " If ToolSearch returns no codegraph tool (the MCP server is down), "
+        "use Read on the specific files you need instead — do not keep retrying grep/find."
+    )
+    if prior_searches == 0:
+        return tier0
+    if prior_searches <= 2:
+        return tier1
+    return tier2
+
+
 def run_codegraph_first_gate(event: dict[str, Any], repo_root: Path) -> int:
     """Single PreToolUse gate enforcing codegraph-first exploration for gated
     agents (``codegraph_gated: true``). LIA-121 / RETRO-2026-05-29-01.
@@ -1037,7 +1091,7 @@ def run_codegraph_first_gate(event: dict[str, Any], repo_root: Path) -> int:
             )
             return 0
 
-        found, assistant_turns, any_tool_uses = scan_result
+        found, assistant_turns, any_tool_uses, prior_search_attempts = scan_result
 
         if found:
             return 0
@@ -1056,11 +1110,7 @@ def run_codegraph_first_gate(event: dict[str, Any], repo_root: Path) -> int:
             )
             return 0
 
-        _block_pre_tool(
-            "[codegraph-first-gate] Call a codegraph or code_search tool first "
-            '(ToolSearch "select:mcp__codegraph__codegraph_context"), then retry. '
-            "core-behavioral-rules.md § Code Exploration."
-        )
+        _block_pre_tool(_codegraph_deny_message(prior_search_attempts))
         return 0
     except Exception:
         return 0

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -3607,7 +3607,7 @@ def test_scan_transcript_detects_mcp_call(tmp_path):
     """_scan_transcript_for_codegraph finds a direct MCP call."""
     hooks = load_hooks()
     tr = _write_transcript(tmp_path, [_MCP_CODEGRAPH_LINE])
-    found, turns, tool_uses = hooks._scan_transcript_for_codegraph(str(tr))
+    found, turns, tool_uses, prior_searches = hooks._scan_transcript_for_codegraph(str(tr))
     assert found
     assert turns >= 1
     assert tool_uses >= 1
@@ -3617,7 +3617,7 @@ def test_scan_transcript_detects_toolsearch(tmp_path):
     """_scan_transcript_for_codegraph finds a ToolSearch select call."""
     hooks = load_hooks()
     tr = _write_transcript(tmp_path, [_TOOLSEARCH_CODEGRAPH_LINE])
-    found, turns, tool_uses = hooks._scan_transcript_for_codegraph(str(tr))
+    found, turns, tool_uses, prior_searches = hooks._scan_transcript_for_codegraph(str(tr))
     assert found
     assert tool_uses >= 1
 
@@ -3626,7 +3626,7 @@ def test_scan_transcript_returns_false_for_no_call(tmp_path):
     """_scan_transcript_for_codegraph returns False when no codegraph call present."""
     hooks = load_hooks()
     tr = _write_transcript(tmp_path, [_BASH_LINE, _USER_RESULT_LINE])
-    found, turns, tool_uses = hooks._scan_transcript_for_codegraph(str(tr))
+    found, turns, tool_uses, prior_searches = hooks._scan_transcript_for_codegraph(str(tr))
     assert not found
     assert tool_uses >= 1  # Bash tool_use counts
 
@@ -3636,3 +3636,109 @@ def test_scan_transcript_missing_file():
     hooks = load_hooks()
     result = hooks._scan_transcript_for_codegraph("/nonexistent/x.jsonl")
     assert result is None, "missing file must return None (fail-open sentinel)"
+
+
+# ---------------------------------------------------------------------------
+# Escalating deny message tests (LIA-129)
+# ---------------------------------------------------------------------------
+
+def _grep_tool_use_line(n: int = 1) -> list[str]:
+    """Return *n* JSONL lines each containing a Grep tool_use block."""
+    lines = []
+    for i in range(n):
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": f"g{i}", "name": "Grep", "input": {"pattern": "foo", "path": "."}}]},
+        }))
+    return lines
+
+
+def _bash_search_line(n: int = 1) -> list[str]:
+    """Return *n* JSONL lines each containing a Bash grep code-search tool_use."""
+    lines = []
+    for i in range(n):
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": f"b{i}", "name": "Bash", "input": {"command": "grep -r foo src/"}}]},
+        }))
+    return lines
+
+
+def test_escalating_deny_tier0_no_prior_searches(tmp_path, capsys):
+    """Tier-0: transcript has no prior search attempts → polite hint."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    # Transcript has a non-search Bash line only (ls), so prior_search_attempts == 0.
+    tr = _write_transcript(tmp_path, [_BASH_LINE])
+    hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo)
+    out = json.loads(capsys.readouterr().out)["hookSpecificOutput"]
+    reason = out["permissionDecisionReason"]
+    assert out["permissionDecision"] == "deny"
+    # Tier-0 wording: polite hint, no "Blocked again"
+    assert "Call a codegraph or code_search tool first" in reason
+    assert "Blocked again" not in reason
+
+
+def test_escalating_deny_tier1_two_prior_searches(tmp_path, capsys):
+    """Tier-1: transcript has 2 prior search-tool uses → imperative two-step."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    # Two prior Grep tool_use blocks in the transcript.
+    tr = _write_transcript(tmp_path, _grep_tool_use_line(2))
+    hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo)
+    out = json.loads(capsys.readouterr().out)["hookSpecificOutput"]
+    reason = out["permissionDecisionReason"]
+    assert out["permissionDecision"] == "deny"
+    assert "Blocked again" in reason
+    assert 'ToolSearch(query="select:mcp__codegraph__codegraph_context")' in reason
+    assert "codegraph_context" in reason
+    # Tier-1 should NOT yet include the Read fallback
+    assert "If ToolSearch returns no codegraph tool" not in reason
+
+
+def test_escalating_deny_tier2_three_plus_prior_searches(tmp_path, capsys):
+    """Tier-2: transcript has >= 3 prior search-tool uses → Read fallback added."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    # Three prior Grep tool_use blocks in the transcript.
+    tr = _write_transcript(tmp_path, _grep_tool_use_line(3))
+    hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo)
+    out = json.loads(capsys.readouterr().out)["hookSpecificOutput"]
+    reason = out["permissionDecisionReason"]
+    assert out["permissionDecision"] == "deny"
+    assert "Blocked again" in reason
+    assert "If ToolSearch returns no codegraph tool" in reason
+    assert "use Read on the specific files you need instead" in reason
+
+
+def test_scan_prior_search_attempts_counts_correctly(tmp_path):
+    """_scan_transcript_for_codegraph counts prior_search_attempts accurately.
+
+    Transcript contains:
+    - 1 Grep tool_use          (counts)
+    - 1 Bash 'grep -r x' line  (counts — primary token is grep)
+    - 1 Bash 'npm test' line   (does NOT count — not a code search)
+    - 1 Bash 'ls | grep' line  (does NOT count — grep is after a pipe)
+    """
+    hooks = load_hooks()
+    grep_line = json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "a", "name": "Grep", "input": {"pattern": "foo"}}]},
+    })
+    bash_grep_line = json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "b", "name": "Bash", "input": {"command": "grep -r x src/"}}]},
+    })
+    bash_npm_line = json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "c", "name": "Bash", "input": {"command": "npm test"}}]},
+    })
+    bash_piped_grep_line = json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "tool_use", "id": "d", "name": "Bash", "input": {"command": "ls | grep foo"}}]},
+    })
+    tr = _write_transcript(tmp_path, [grep_line, bash_grep_line, bash_npm_line, bash_piped_grep_line])
+    found, turns, tool_uses, prior_searches = hooks._scan_transcript_for_codegraph(str(tr))
+    assert not found
+    assert tool_uses == 4           # all 4 tool_use blocks counted
+    assert prior_searches == 2      # only Grep + Bash-grep, not npm test or piped grep


### PR DESCRIPTION
## What

Follow-up to LIA-121 (#639). The codegraph-first gate's deny message was constant — a blocked agent could cycle through its other tools before deciding to call codegraph. The gate already scans the agent's transcript, so it now also **counts prior search-tool attempts** (Grep/Glob/Bash-code-search) and **escalates** the message:

| Prior search attempts | Message |
|----------------------|---------|
| 0 | polite hint (unchanged wording) |
| 1–2 | imperative + the exact `ToolSearch` + `codegraph_context` steps |
| 3+ | the above + a **Read fallback** for when the codegraph MCP server is down |

Only the deny **message text** changes — the allow/deny decision, blindness canary, and fail-open behavior are untouched. Scope: code-explorer only.

## Why

Answers the "don't let it continue blindly" concern: the deny `permissionDecisionReason` is fed back into the agent's context each block, so escalating it gives a repeatedly-blocked agent increasingly explicit, copy-pasteable instructions instead of the same hint. The tier-3 Read fallback also gives an escape when the MCP server is unavailable (the headless cold-start case seen during LIA-121 dev).

## Smoke test (real data, this session)
- **Deterministic escalation on a REAL subagent transcript** (`agent-a0e800caa…`): it already had `prior_search_attempts=2`, so the gate returned the **tier-1** message (`Blocked again — stop retrying search. Run these two calls…`) rather than the polite tier-0 — anti-flail behavior confirmed on real data.
- The base gate's **deny-path was proven fully live in #639**; this change is text-only in that same deny path.

## Tests
198 pass (+5: tier 0/1/2 selection + a `prior_search_attempts` counting test that asserts `npm test` and piped `ls | grep` do **not** count). `drift_check.py --codegraph-format` green (all 4 layers).

## Deferred (code-reviewer recommendations, non-blocking)
- Trim the `_codegraph_deny_message` docstring; add `prior_search_attempts` to the break-comment; consider named constants for the tier thresholds. Cosmetic — left for a future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)