### PR TITLE
fix(dispatcher): bound Linear poll fetch with a timeout (LIA-123)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,8 @@ DEUS_VAULT_PATH=
 LINEAR_API_TOKEN=
 # Linear dispatcher poll interval (ms, default: 30000)
 # LINEAR_POLL_INTERVAL_MS=30000
+# Ceiling for a single poll-fetch deadline (ms, default: 15000); clamped below the poll interval
+# LINEAR_FETCH_TIMEOUT_MS=15000
 # Optional: Linear team ID override (auto-discovered if only one team)
 # LINEAR_TEAM_ID=
 # Webhook secret for Linear event verification (HMAC-SHA256)

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -157,6 +157,7 @@ Group/task effort overrides:
 |----------|---------|-------------|
 | `LINEAR_API_TOKEN` | -- | Personal API key (also accepted as `LINEAR_API_KEY`). Generate at Linear Settings > API > Personal API keys |
 | `LINEAR_POLL_INTERVAL_MS` | `30000` | How often the dispatcher polls for "Ready for Agent" issues (ms) |
+| `LINEAR_FETCH_TIMEOUT_MS` | `15000` | Ceiling for a single poll-fetch deadline; effective value is clamped below the poll interval so a hung Linear API call rejects (logged transient, retried next tick) instead of leaking |
 | `LINEAR_TEAM_ID` | auto-discovered | Override if the workspace has multiple teams |
 | `LINEAR_WEBHOOK_SECRET` | -- | HMAC-SHA256 secret for webhook signature verification. Required for gates |
 | `LINEAR_WEBHOOK_PORT` | `3005` | Port the webhook server binds to |

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-29" # auto-bump @1748515200
+last_verified: "2026-05-30" # auto-bump @1780100991
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump @1780076902
+last_verified: "2026-05-30" # auto-bump @1780100991
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -122,12 +122,14 @@ import {
   extractScopeBlock,
   applyPatchArtifact,
   initLinearContext,
+  deriveFetchTimeout,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
   LinearDispatcherDependencies,
 } from './linear-dispatcher.js';
 import { RuntimeRegistry } from './agent-runtimes/registry.js';
+import { logger } from './logger.js';
 
 function makeMockDeps(
   overrides: Partial<LinearDispatcherDependencies> = {},
@@ -517,6 +519,67 @@ describe('pollLinear dispatch ordering', () => {
       (call: unknown[]) => call[1] as string,
     );
     expect(callOrder).toEqual(['aaa', 'bbb']);
+  });
+});
+
+describe('deriveFetchTimeout', () => {
+  it('uses the ceiling for the default poll interval', () => {
+    expect(deriveFetchTimeout(30_000)).toBe(15_000);
+  });
+
+  it('clamps below the poll interval', () => {
+    expect(deriveFetchTimeout(5_000)).toBe(4_500);
+  });
+
+  it('stays strictly below pollMs at the small-interval edge', () => {
+    const t = deriveFetchTimeout(1_000);
+    expect(t).toBe(900);
+    expect(t).toBeLessThan(1_000);
+  });
+});
+
+describe('pollLinear fetch timeout', () => {
+  const agentsDir = path.join(TEST_PROJECT_ROOT, '.claude', 'agents');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, 'test-role.md'),
+      `---\nname: test-role\nlinear_label: "agent:test"\n---\nYou are a test agent.`,
+    );
+  });
+
+  afterEach(() => {
+    stopLinearDispatcher();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    fs.rmSync(TEST_PROJECT_ROOT, { recursive: true, force: true });
+  });
+
+  it('logs a transient retry warning when the poll fetch hangs', async () => {
+    // pollMs=2000 -> _fetchTimeoutMs=1800 (clamped below interval).
+    vi.stubEnv('LINEAR_POLL_INTERVAL_MS', '2000');
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    const ctx = makeMockCtx({
+      client: {
+        // Never resolves — simulates a hung Linear API call.
+        issues: vi.fn(() => new Promise(() => {})),
+        updateIssue: vi.fn().mockResolvedValue({}),
+      } as unknown as LinearContext['client'],
+    });
+
+    startLinearDispatcher(ctx);
+    // Advance just past the derived fetch deadline (stays < the 2000ms next tick).
+    // Derived from deriveFetchTimeout so it tracks the constant/multiplier if they change.
+    await vi.advanceTimersByTimeAsync(deriveFetchTimeout(2_000) + 50);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.anything() }),
+      'linear-dispatcher: transient error, will retry',
+    );
   });
 });
 

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -11,7 +11,7 @@ import { logger } from './logger.js';
 import { PROJECT_ROOT } from './config.js';
 import { getProjectByPath, registerProject } from './project-registry.js';
 import { FatalError, RetryableError } from './errors/index.js';
-import { fireAndForget } from './async/index.js';
+import { fireAndForget, withTimeout } from './async/index.js';
 import {
   IS_MACOS,
   IS_LINUX,
@@ -45,6 +45,19 @@ import type { RegisteredGroup } from './types.js';
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_POLL_MS = 30_000;
+// Deadline ceiling for a single Linear poll fetch (env-overridable). The effective
+// per-poll timeout (_fetchTimeoutMs) is derived from the active poll interval so it
+// is always < the interval — a hung fetch can never overlap the next tick.
+const LINEAR_FETCH_TIMEOUT_MS =
+  Number(process.env.LINEAR_FETCH_TIMEOUT_MS) || 15_000;
+// Effective per-poll fetch deadline. Recomputed by startLinearDispatcher and
+// setPollInterval (which co-manage _timer) so it tracks the live poll interval.
+let _fetchTimeoutMs = LINEAR_FETCH_TIMEOUT_MS;
+// Effective per-poll deadline. Callers (startLinearDispatcher, setPollInterval) only
+// pass pollMs >= 1000ms, so the 500ms floor is never reached and the result is always
+// strictly < pollMs — a hung fetch settles before the next tick fires.
+export const deriveFetchTimeout = (pollMs: number): number =>
+  Math.max(500, Math.min(LINEAR_FETCH_TIMEOUT_MS, Math.floor(pollMs * 0.9)));
 const DISPATCH_GROUP_JID = 'linear-dispatch';
 const BACKOFF_FIRST_MS = 5 * 60_000;
 const BACKOFF_REPEAT_MS = 10 * 60_000;
@@ -1335,9 +1348,20 @@ async function pollLinear(): Promise<void> {
 
   const readyState = ctx.stateByName.get('Ready for Agent')!;
 
-  const issues = await ctx.client.issues({
-    filter: { state: { id: { eq: readyState.id } } },
-  });
+  // Bound the only per-tick network call. On timeout withTimeout throws
+  // RetryableError, which _tick's onError logs as transient and the next interval
+  // retries. If this times out the dispatch loop below is never entered, so the
+  // in-loop SDK reads (labels/comments) need no wrapping. Note: this bounds the
+  // await, not the underlying socket — the @linear/sdk high-level client methods
+  // expose no per-call AbortSignal. Acceptable for a low-impact latent gap; upgrade
+  // path is a per-poll client built with AbortSignal.timeout.
+  const issues = await withTimeout(
+    ctx.client.issues({
+      filter: { state: { id: { eq: readyState.id } } },
+    }),
+    _fetchTimeoutMs,
+    { name: 'linear.poll.issues' },
+  );
 
   const sorted = [...issues.nodes].sort((a, b) => {
     // Priority first (1=urgent > 2=high > 3=medium > 4=low > 0=none)
@@ -1852,6 +1876,7 @@ export function startLinearDispatcher(ctx: LinearContext): void {
   );
   const pollMs =
     isNaN(parsedPollMs) || parsedPollMs < 1000 ? DEFAULT_POLL_MS : parsedPollMs;
+  _fetchTimeoutMs = deriveFetchTimeout(pollMs);
 
   _tick = () => {
     fireAndForget(() => pollLinear(), {
@@ -1896,6 +1921,7 @@ const MAX_POLL_MS = 300_000;
 export function setPollInterval(ms: number): boolean {
   if (!_tick) return false;
   const clamped = Math.max(MIN_POLL_MS, Math.min(MAX_POLL_MS, ms));
+  _fetchTimeoutMs = deriveFetchTimeout(clamped);
   if (_timer) clearInterval(_timer);
   _timer = setInterval(_tick, clamped);
   _timer.unref();


### PR DESCRIPTION
## Summary

Resolves **LIA-123**. The dispatcher's per-tick `ctx.client.issues()` Linear API fetch had **no request timeout**, so a hung call leaked a detached promise every poll tick under a sustained Linear outage — silently (the fire-and-forget tick keeps polling, but the hung promise never settles or logs).

Wraps that one call in the existing `withTimeout` helper (`src/async/index.ts`). On timeout it throws `RetryableError`, which `_tick`'s `onError` **already** logs as transient + the next interval retries — so no new error-handling or retry code.

## Why this, not the stall watchdog (#637)

LIA-123 asked: restore the stall watchdog removed in #612, or confirm intentional. Investigation showed the watchdog **measured the wrong thing** — it stamped `_lastTickAt` at *tick start*, and `setInterval(_tick)` refreshes that every interval regardless of hangs, so it never fired for a real hang (and couldn't catch an event-loop block — its own timer would be frozen too). Because `_tick` is fire-and-forget, a hung poll never stops the dispatcher anyway. So the removal created **no operational gap**; #637 was closed. The *real* latent gap was the missing fetch timeout — this PR.

## Design notes

- **Effective timeout derived from the poll interval** (`deriveFetchTimeout`) so it's always `< pollMs` — a hung fetch can never overlap the next tick. Env-overridable via `LINEAR_FETCH_TIMEOUT_MS` (default 15000), clamped below the interval. Set in both `startLinearDispatcher` and `setPollInterval`.
- **Scope: only the `issues()` call.** In-loop SDK reads (`labels`/`comments`) are intentionally not wrapped — they run after `inFlightDispatch.add()` whose cleanup is scattered, so wrapping them risks leaking `inFlightDispatch` entries. Under a real outage `issues()` times out first and the loop is never entered.
- **Known caveat (documented in-code):** bounds the JS await, not the underlying TCP socket — `@linear/sdk` high-level methods expose no per-call `AbortSignal`. Acceptable for a low-impact latent gap; upgrade path is a per-poll client built with `AbortSignal.timeout`.

## Tests
- 3 unit tests for `deriveFetchTimeout` (ceiling / clamp-below-interval / strict small-interval edge).
- 1 integration test: a hung `issues()` mock under fake timers asserts the transient-retry `logger.warn` fires (proves `RetryableError` reaches `_tick`'s `onError`).

## Verification
- `npx vitest run src/linear-dispatcher.test.ts src/async/index.test.ts` → 75 passed (4 new)
- `npm run build` → exit 0
- prettier clean on touched `.ts`; drift check clean (`--base`)

Wardens: plan-reviewer SHIP (×2), code-reviewer SHIP (×2), ai-eng-warden SHIP, verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)