### PR TITLE
fix(pipeline): emit moved_done + drop dead gate-event branches (LIA-134, LIA-139)

### DIFF
--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-29" # auto-bump @1780075832
+last_verified: "2026-05-30" # auto-bump @1780141984
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-29" # auto-bump
+last_verified: "2026-05-30" # auto-bump @1780141984
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-30" # auto-bump @1780100991
+last_verified: "2026-05-30" # auto-bump @1780141984
 governs:
   - src/
   - evolution/

--- a/src/linear-actions.test.ts
+++ b/src/linear-actions.test.ts
@@ -247,7 +247,7 @@ describe('triggerGateRerun', () => {
 });
 
 describe('moveIssueState', () => {
-  it('moves to a valid state', async () => {
+  it('moves to Done and emits moved_done (shipped event)', async () => {
     const ctx = makeCtx();
     const result = await moveIssueState(ctx, 'issue-1', 'LIA-1', 'Done');
     expect(result.ok).toBe(true);
@@ -255,7 +255,32 @@ describe('moveIssueState', () => {
     expect(ctx.client.updateIssue).toHaveBeenCalledWith('issue-1', {
       stateId: 's-done',
     });
-    expect(mockLogEvent).toHaveBeenCalled();
+    // Done transitions must emit `moved_done` (in SUCCESS_TYPES/TERMINAL_TYPES) so
+    // computeTodayStats counts non-automerge ships — not the generic state_changed.
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      'issue-1',
+      'LIA-1',
+      'moved_done',
+      expect.stringContaining('Done'),
+    );
+  });
+
+  it('emits state_changed for non-Done transitions', async () => {
+    const ctx = makeCtx();
+    const result = await moveIssueState(ctx, 'issue-1', 'LIA-1', 'In Review');
+    expect(result.ok).toBe(true);
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      'issue-1',
+      'LIA-1',
+      'state_changed',
+      expect.stringContaining('In Review'),
+    );
+    expect(mockLogEvent).not.toHaveBeenCalledWith(
+      'issue-1',
+      'LIA-1',
+      'moved_done',
+      expect.anything(),
+    );
   });
 
   it('returns error for unknown state', async () => {

--- a/src/linear-actions.ts
+++ b/src/linear-actions.ts
@@ -195,7 +195,11 @@ export async function moveIssueState(
 
   try {
     await ctx.client.updateIssue(issueId, { stateId: state.id });
-    logPipelineEvent(issueId, identifier, 'state_changed', `→ ${state.name}`);
+    // Done transitions emit `moved_done` (a terminal "shipped" event) so
+    // computeTodayStats counts them; automerge emits `automerge_done` on its own
+    // direct path (linear-auto-merge.ts) and never reaches here.
+    const eventType = state.name === 'Done' ? 'moved_done' : 'state_changed';
+    logPipelineEvent(issueId, identifier, eventType, `→ ${state.name}`);
     return { ok: true, message: `${identifier} → ${state.name}` };
   } catch (err) {
     return {

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -96,7 +96,6 @@ export const TERMINAL_TYPES = new Set([
   'agent_failed',
   'moved_done',
   'gate_error',
-  'bouncer_revert',
   'gate_blocked',
 ]);
 
@@ -815,16 +814,6 @@ export function formatWhyReason(issue: {
       return 'Gate pending';
     case 'state_changed':
       return 'State changed';
-    case 'gate_enrich_start':
-      return 'Enriching';
-    case 'gate_enrich_done':
-      return 'Enriched';
-    case 'gate_enrich_revise':
-      return 'Enrich revise';
-    case 'bouncer_pass':
-      return 'Bouncer pass';
-    case 'bouncer_revert':
-      return 'Bounced';
     case 'gate_blocked':
       return 'Blocked';
     default:


### PR DESCRIPTION
## What

Wave 1 of the **LIA-133 facade audit** — pipeline event vocabulary fixes.

### LIA-134 — `moved_done` metric bug (live)
`computeTodayStats` counts an issue as "shipped" when its last pipeline event is `moved_done` or `automerge_done`. But `moved_done` was **emitted nowhere**, so every issue reaching Done *without* automerge was silently undercounted.

Fix: `moveIssueState` (linear-actions.ts) now emits `moved_done` instead of `state_changed` when the target state is Done.
- **No double-count:** automerge moves to Done directly via `client.updateIssue` (linear-auto-merge.ts:222) and emits `automerge_done` — it does NOT pass through `moveIssueState`. Verified.
- Consumer side was already correct (`moved_done` in SUCCESS_TYPES/TERMINAL_TYPES). `EVENT_LABELS['moved_done']` in linear-notifications.ts was already present and is intentional — not a stale remnant.
- Known limit (out of scope): issues a human drags to Done directly in Linear (no `moveIssueState` call) still emit nothing — a separate webhook-observation concern.

### LIA-139 — dead consumer branches
Removed 5 `case` arms in `formatWhyReason` (`gate_enrich_*`, `bouncer_pass`, `bouncer_revert`) + `bouncer_revert` from `TERMINAL_TYPES`. These event types are emitted nowhere (verified by cross-language grep, zero residual).

## Verification
- `npm run build` green; `npx vitest run` on the two affected files → **98 tests pass**.
- New tests: `moveIssueState` → Done emits `moved_done`; → non-Done emits `state_changed`.

## Review
- plan-reviewer: SHIP · code-reviewer: SHIP (advisories applied).

## Note
`patterns/{channel-add,deployment,general-code}.md` carry `last_verified` date bumps — the mtime drift-gate fired in the worktree; all three are content-valid on `main` (general-code is the genuine src/ bump, the other two were fresh-checkout mtime artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)