### PR TITLE
feat(memory): wire learned retrieval params into live tree retrieval (LIA-136)

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -110,8 +110,11 @@ COVERAGE_CONTENT_CAP = float(os.environ.get("DEUS_COVERAGE_CAP", "0.35"))
 DEFAULT_USE_COHERENCE_GATE = os.environ.get("DEUS_COHERENCE_GATE", "1") == "1"
 DEFAULT_MIN_ENTITY_OVERLAP = int(os.environ.get("DEUS_MIN_ENTITY_OVERLAP", "2"))
 
-# Optimized params: load from evolution artifact if DEUS_TREE_PARAMS=1.
-if os.environ.get("DEUS_TREE_PARAMS") == "1":
+# Optimized params: load the learned evolution artifact by default.
+# Off-switch: DEUS_TREE_PARAMS=0 (kept for debug / A-B). The producer
+# (param_optimizer.optimize_and_save) only saves an artifact when it beats
+# baseline, so consuming it by default is the self-tuning path, not a risk.
+if os.environ.get("DEUS_TREE_PARAMS", "1") != "0":
     _project_root = str(Path(__file__).resolve().parent.parent)
     _added_to_path = _project_root not in sys.path
     try:
@@ -129,8 +132,13 @@ if os.environ.get("DEUS_TREE_PARAMS") == "1":
             DEFAULT_TOP_K = int(_learned.get("top_k", DEFAULT_TOP_K))
             DEFAULT_RRF_K = int(_learned.get("rrf_k", DEFAULT_RRF_K))
             DEFAULT_MIN_ENTITY_OVERLAP = int(_learned.get("min_entity_overlap", DEFAULT_MIN_ENTITY_OVERLAP))
-    except Exception:
-        pass  # Fall back to env/hardcoded defaults
+    except Exception as e:
+        # Visible signal — a silent fallback would hide a broken optimizer
+        # wire (the exact facade class this gate exists to prevent).
+        print(
+            f"[memory_tree] optimized-param load failed; using defaults: {e}",
+            file=sys.stderr,
+        )
     finally:
         if _added_to_path and _project_root in sys.path:
             sys.path.remove(_project_root)

--- a/scripts/tests/test_memory_tree_params.py
+++ b/scripts/tests/test_memory_tree_params.py
@@ -1,0 +1,128 @@
+"""Tests for the DEUS_TREE_PARAMS learned-artifact gate in memory_tree (LIA-136).
+
+The wire: optimized retrieval params load *by default*, with an off-switch
+(DEUS_TREE_PARAMS=0) and a *visible* fallback on load failure (a silent
+swallow would hide a broken optimizer wire — the facade class this gate
+exists to prevent).
+
+Each test loads a fresh, uniquely-named copy of memory_tree so the
+module-level param-load block re-executes under the test's env + a stubbed
+`evolution.optimizer.artifacts.get_active`. memory_tree does no DB work at
+import time, so fresh loads are side-effect free.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+_MT_PATH = _ROOT / "scripts" / "memory_tree.py"
+
+# Distinct synthetic values, all different from the hardcoded defaults, so a
+# successful override is unambiguous.
+_ARTIFACT = {
+    "low_threshold": 0.111,
+    "abstain_threshold": 0.222,
+    "gap_threshold": 0.333,
+    "top_k": 17,
+    "rrf_k": 19,
+    "min_entity_overlap": 5,
+}
+
+_EVO_KEYS = ("evolution", "evolution.optimizer", "evolution.optimizer.artifacts")
+
+
+def _install_fake_artifacts(get_active_fn):
+    """Stub evolution.optimizer.artifacts so memory_tree's
+    `from evolution.optimizer.artifacts import get_active` resolves to our fn."""
+    evo = types.ModuleType("evolution")
+    opt = types.ModuleType("evolution.optimizer")
+    art = types.ModuleType("evolution.optimizer.artifacts")
+    art.get_active = get_active_fn
+    evo.optimizer = opt
+    opt.artifacts = art
+    sys.modules["evolution"] = evo
+    sys.modules["evolution.optimizer"] = opt
+    sys.modules["evolution.optimizer.artifacts"] = art
+
+
+def _load_fresh(name):
+    """Load a fresh copy of memory_tree under a unique name (not 'memory_tree',
+    which conftest owns) so the param-load block re-runs."""
+    spec = importlib.util.spec_from_file_location(name, _MT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.modules.pop(name, None)
+    return mod
+
+
+@pytest.fixture
+def restore_artifacts():
+    """Snapshot/restore the evolution.* sys.modules entries around a test."""
+    saved = {k: sys.modules.get(k) for k in _EVO_KEYS}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+
+
+def test_artifact_overrides_defaults_when_gate_default_on(monkeypatch, restore_artifacts):
+    """Env unset => default-on: a present artifact overrides all six DEFAULT_* constants."""
+    monkeypatch.delenv("DEUS_TREE_PARAMS", raising=False)
+    _install_fake_artifacts(lambda module: {"content": json.dumps(_ARTIFACT)})
+
+    mod = _load_fresh("memory_tree_lia136_on")
+
+    assert mod.DEFAULT_LOW_THRESHOLD == pytest.approx(0.111)
+    assert mod.DEFAULT_ABSTAIN_THRESHOLD == pytest.approx(0.222)
+    assert mod.DEFAULT_SCORE_GAP_THRESHOLD == pytest.approx(0.333)
+    assert mod.DEFAULT_TOP_K == 17
+    assert mod.DEFAULT_RRF_K == 19
+    assert mod.DEFAULT_MIN_ENTITY_OVERLAP == 5
+
+
+def test_load_failure_is_visible_and_falls_back(monkeypatch, capsys, restore_artifacts):
+    """A raising get_active emits a stderr signal AND defaults survive (no silent swallow)."""
+    monkeypatch.delenv("DEUS_TREE_PARAMS", raising=False)
+
+    def _boom(module):
+        raise RuntimeError("artifact store unavailable")
+
+    _install_fake_artifacts(_boom)
+
+    mod = _load_fresh("memory_tree_lia136_boom")
+
+    # Defaults must survive the failure (module didn't crash, constants intact).
+    assert isinstance(mod.DEFAULT_TOP_K, int)
+    assert mod.DEFAULT_LOW_THRESHOLD != pytest.approx(0.111)  # artifact NOT applied
+    # The fallback must be observable, not silent.
+    assert "optimized-param load failed" in capsys.readouterr().err
+
+
+def test_off_switch_suppresses_load(monkeypatch, restore_artifacts):
+    """DEUS_TREE_PARAMS=0 must NOT consult the artifact store even when one exists."""
+    monkeypatch.setenv("DEUS_TREE_PARAMS", "0")
+    called = {"hit": False}
+
+    def _track(module):
+        called["hit"] = True
+        return {"content": json.dumps(_ARTIFACT)}
+
+    _install_fake_artifacts(_track)
+
+    mod = _load_fresh("memory_tree_lia136_off")
+
+    assert called["hit"] is False
+    # The synthetic override must not have been applied.
+    assert mod.DEFAULT_LOW_THRESHOLD != pytest.approx(0.111)


### PR DESCRIPTION
## What

Closes the param-optimizer arm of the evolution loop. The optimizer saves learned `memory_retrieval_{provider}` threshold artifacts, but `memory_tree.py` only consumed them behind `DEUS_TREE_PARAMS` — a flag set **nowhere**. Confirmed facade from the LIA-133 audit.

## Changes

- **Gate flip (opt-in → opt-out)** at `memory_tree.py`: learned artifacts load by default; off-switch `DEUS_TREE_PARAMS=0` retained for debug / A-B.
- **Visible fallback**: replaced the silent `except: pass` with a stderr signal. A silent swallow would hide a broken wire — the exact facade class this gate exists to prevent.
- **Tests** (`test_memory_tree_params.py`): default-on artifact override, visible-fallback-on-failure, `DEUS_TREE_PARAMS=0` suppression.

## Why default-on (alternative considered)

The alternative — keep opt-in until a real artifact exists — was considered. Default-on is preferred because the path is **inert when no artifact is present** (same behavior as opt-in today), but future-ready without a second opt-in step. Safety rests on the producer's **ship-if-better gate** (`param_optimizer.optimize_and_save` refuses to save when `delta < 0`) plus the reader's fallback and the off-switch.

## Verification (sweep evidence)

Ran `optimize-params --trials 200 --provider ollama` against the 136-query labeled fixture:

```
Baseline: recall=0.743 abstain=0.5 score=0.7238
Best trial: 0.4334 (recall 0.441, abstain 0.818)
Done: baseline 0.7238 -> best 0.4334 (delta -0.2904)
No improvement found. Not saving artifact.
```

The hand-tuned defaults decisively beat the search; the optimizer **declined to save** (ship-if-better gate working). So the gate is **wired + exercised end-to-end**, **no artifact is active**, and **live retrieval is unchanged** — the documented "defaults stand" outcome. Consume path is independently covered by the new unit test (synthetic artifact → thresholds change).

- 3 new tests pass · 233 memory_tree tests pass

Part of facade-audit umbrella **LIA-133**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)