### PR TITLE
ci(facade): add flag-lint for net-new DEUS_* gates

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -28,3 +28,20 @@ jobs:
           subjectPatternError: |
             PR title subject must start with a lowercase letter.
             Example: "feat(skills): add Gmail skill template"
+
+  flag-lint:
+    name: Facade flag-lint (net-new DEUS_* gates)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install pytest
+        run: python3 -m pip install pytest
+      - name: Unit tests
+        run: python3 -m pytest scripts/tests/test_flag_lint.py -v
+      - name: Lint net-new DEUS_* flag gates
+        run: python3 scripts/ci/flag_lint.py --base origin/${{ github.base_ref }}

--- a/scripts/ci/flag_lint.py
+++ b/scripts/ci/flag_lint.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Layer 2 of the LIA-143 facade-prevention mechanism: net-new DEUS_* flag-gate lint.
+
+Scans a PR diff for newly introduced ``DEUS_*`` feature-flag gates and requires
+each to cite a tracking issue (``LIA-NNN`` / ``#NNN``) or carry a ``dev-only``
+escape in an adjacent comment. A flag is *net-new* only if its name does not
+already appear anywhere in the base ref — re-reading one of the ~40 existing
+flags never fires.
+
+Why: every facade in the LIA-133 audit was merged behind a flag that was never
+turned on. Forcing a citation at merge time ties each new flag to its intent and
+makes an untracked dark-ship visible. This is the deterministic, hard-failing
+companion to the advisory ``connectivity-wiring`` warden rule (Layer 1).
+
+Scope: this catches flags that are *read* as an env gate (``process.env.DEUS_*``,
+``os.environ.get`` / ``getenv`` / ``os.environ[...]``, shell ``$DEUS_*``). A flag
+that is only *mentioned* in a comment/TODO and never actually read gates nothing,
+so it is out of scope here by design — that module-level "documented but unwired"
+form is covered by the Layer 1 connectivity rule and the Layer 3 orphan-sweep.
+
+The 3-line citation window covers lines visible in the diff (added + context);
+a citation in unchanged code outside the hunk is not seen.
+
+See docs/decisions/facade-prevention-mechanism.md.
+
+Exit codes: 0 = clean, 1 = uncited net-new flag(s), 2 = usage/git error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+# Never scanned — the lint's own source/fixtures would trip on their DEUS_* examples.
+EXCLUDED_PREFIXES = (
+    "scripts/ci/",
+    "scripts/tests/",
+    "tests/",
+    "evolution/tests/",
+)
+
+CODE_EXTS = (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".sh", ".bash", ".zsh")
+SHELL_EXTS = (".sh", ".bash", ".zsh")
+
+# Ops/framework DEUS_* vars that gate nothing and need no citation; extend as needed.
+ALLOWLIST: frozenset[str] = frozenset()
+
+# Env-gate forms across TS/JS and Python. The flag name is the capture group.
+_GENERAL_GATE_PATTERNS = (
+    r"process\.env\.(DEUS_[A-Z0-9_]+)",
+    r"""process\.env\[\s*['"](DEUS_[A-Z0-9_]+)['"]\s*\]""",
+    r"""os\.environ\.get\(\s*['"](DEUS_[A-Z0-9_]+)['"]""",
+    r"""os\.environ\[\s*['"](DEUS_[A-Z0-9_]+)['"]\s*\]""",
+    r"""os\.getenv\(\s*['"](DEUS_[A-Z0-9_]+)['"]""",
+)
+# Shell env read: $DEUS_X or ${DEUS_X}. Only applied to shell files.
+_SHELL_GATE_PATTERN = r"(?<![\w$])\$\{?(DEUS_[A-Z0-9_]+)\}?"
+
+_GENERAL_RE = [re.compile(p) for p in _GENERAL_GATE_PATTERNS]
+_SHELL_RE = re.compile(_SHELL_GATE_PATTERN)
+
+_CITATION_RE = re.compile(r"(LIA-\d+|#\d+)")
+_DEV_ONLY_RE = re.compile(r"dev-only", re.IGNORECASE)
+
+# How far (in new-file lines) a citation/escape may sit from the flag gate.
+_CITE_WINDOW = 3
+
+
+@dataclass(frozen=True)
+class DiffLine:
+    """One line from a unified diff, with its new-file line number."""
+
+    lineno: int
+    added: bool  # True for '+' lines, False for ' ' context lines
+    text: str
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    lineno: int
+    flag: str
+
+
+def parse_diff(diff_text: str) -> dict[str, list[DiffLine]]:
+    """Parse a unified diff into per-file lines with new-file line numbers.
+
+    Context lines are retained (not just '+' lines) so a citation comment already
+    present next to a newly added gate still counts toward the window.
+    """
+    files: dict[str, list[DiffLine]] = {}
+    cur_path: str | None = None
+    new_lineno = 0
+    for raw in diff_text.splitlines():
+        if raw.startswith("+++ "):
+            target = raw[4:].strip()
+            # "+++ b/path" or "+++ /dev/null"
+            cur_path = None if target == "/dev/null" else target[2:] if target.startswith("b/") else target
+            if cur_path is not None:
+                files.setdefault(cur_path, [])
+            continue
+        if raw.startswith("@@"):
+            m = re.search(r"\+(\d+)", raw)
+            new_lineno = int(m.group(1)) if m else 0
+            continue
+        if cur_path is None:
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            files[cur_path].append(DiffLine(new_lineno, True, raw[1:]))
+            new_lineno += 1
+        elif raw.startswith(" "):
+            files[cur_path].append(DiffLine(new_lineno, False, raw[1:]))
+            new_lineno += 1
+        # '-' and '\' (no-newline) lines do not advance the new-file counter.
+    return files
+
+
+def _is_scannable(path: str) -> bool:
+    if path.startswith(EXCLUDED_PREFIXES):
+        return False
+    if not path.endswith(CODE_EXTS):
+        return False
+    fname = path.rsplit("/", 1)[-1]
+    if ".test." in fname or ".spec." in fname or "/__tests__/" in f"/{path}":
+        return False
+    return True
+
+
+def _flags_in_line(text: str, is_shell: bool) -> set[str]:
+    flags: set[str] = set()
+    for rx in _GENERAL_RE:
+        flags.update(rx.findall(text))
+    if is_shell:
+        flags.update(_SHELL_RE.findall(text))
+    return flags
+
+
+def _has_citation_near(lines: list[DiffLine], lineno: int) -> bool:
+    for ln in lines:
+        if abs(ln.lineno - lineno) <= _CITE_WINDOW:
+            if _CITATION_RE.search(ln.text) or _DEV_ONLY_RE.search(ln.text):
+                return True
+    return False
+
+
+def flag_exists_in_base(flag: str, base_ref: str, repo_dir: str) -> bool:
+    """True if ``flag`` appears anywhere in ``base_ref`` (so it is not net-new).
+
+    Conservative bias: any error or match is treated as "exists" so the lint
+    never hard-fails on a flag that is actually pre-existing.
+    """
+    try:
+        rc = subprocess.run(
+            ["git", "-C", repo_dir, "grep", "-q", "-F", "-e", flag, base_ref],
+            capture_output=True,
+        ).returncode
+    except OSError:
+        return True
+    # 0 = match; 1 = absent; >1 = git error (e.g. unknown ref) → treat as exists, never false-block.
+    return rc != 1
+
+
+def scan(
+    files: dict[str, list[DiffLine]],
+    base_ref: str,
+    repo_dir: str,
+    allowlist: frozenset[str] = ALLOWLIST,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    base_cache: dict[str, bool] = {}
+    for path, lines in files.items():
+        if not _is_scannable(path):
+            continue
+        is_shell = path.endswith(SHELL_EXTS)
+        for ln in lines:
+            if not ln.added:
+                continue
+            for flag in _flags_in_line(ln.text, is_shell):
+                if flag in allowlist:
+                    continue
+                if flag not in base_cache:
+                    base_cache[flag] = flag_exists_in_base(flag, base_ref, repo_dir)
+                if base_cache[flag]:
+                    continue  # pre-existing flag, just read again
+                if _has_citation_near(lines, ln.lineno):
+                    continue
+                violations.append(Violation(path, ln.lineno, flag))
+    return violations
+
+
+def _get_diff(base_ref: str, repo_dir: str) -> str:
+    return subprocess.run(
+        ["git", "-C", repo_dir, "diff", f"{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="origin/main", help="base ref to diff against")
+    ap.add_argument("--repo", default=".", help="repo root")
+    args = ap.parse_args(argv)
+
+    try:
+        diff_text = _get_diff(args.base, args.repo)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"flag-lint: git diff failed: {exc}", file=sys.stderr)
+        return 2
+
+    violations = scan(parse_diff(diff_text), args.base, args.repo)
+    if not violations:
+        print("flag-lint: no uncited net-new DEUS_* flag gates.")
+        return 0
+
+    print("flag-lint: net-new DEUS_* flag gate(s) without a tracking citation:\n", file=sys.stderr)
+    for v in violations:
+        print(f"  {v.path}:{v.lineno}  {v.flag}", file=sys.stderr)
+    print(
+        "\nEach new DEUS_* flag must cite a tracking issue (LIA-NNN or #NNN) or carry a\n"
+        "`dev-only` comment within 3 lines, so it cannot become a built-but-not-wired\n"
+        "facade. See docs/decisions/facade-prevention-mechanism.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_flag_lint.py
+++ b/scripts/tests/test_flag_lint.py
@@ -1,0 +1,242 @@
+"""Tests for the LIA-143 Layer 2 net-new DEUS_* flag-gate lint (scripts/ci/flag_lint.py).
+
+Each test builds a fully isolated temp git repo with its own base commit and HEAD
+commit, then runs the lint against that repo's real diff + base ref. Isolation
+matters: the net-new check shells out to `git grep <flag> <base>`, so the harness
+must not leak into the real repo's history.
+
+The load-bearing assertions: a net-new uncited DEUS_* gate FAILS (exit 1); a
+re-read of a flag that already exists in the base ref stays SILENT (exit 0) —
+that pair is the whole point of the "net-new only" design.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+_MOD_PATH = _ROOT / "scripts" / "ci" / "flag_lint.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("flag_lint", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["flag_lint"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+flag_lint = _load()
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _make_repo(tmp_path: Path, base_files: dict[str, str], head_files: dict[str, str]) -> tuple[Path, str]:
+    """Init a repo, commit base_files, then commit head_files on a branch.
+
+    Returns (repo_dir, base_sha). head_files are written on top of base.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@t.test")
+    _git(repo, "config", "user.name", "t")
+    for path, content in base_files.items():
+        f = repo / path
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base_sha = _git(repo, "rev-parse", "HEAD").strip()
+
+    _git(repo, "checkout", "-q", "-b", "feat")
+    for path, content in head_files.items():
+        f = repo / path
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat")
+    return repo, base_sha
+
+
+def _run(repo: Path, base_sha: str, allowlist=None):
+    diff = flag_lint._get_diff(base_sha, str(repo))
+    kwargs = {} if allowlist is None else {"allowlist": allowlist}
+    return flag_lint.scan(flag_lint.parse_diff(diff), base_sha, str(repo), **kwargs)
+
+
+# --- core red/green pair --------------------------------------------------
+
+
+def test_net_new_uncited_flag_fires(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "export const x = 1;\n"},
+        {"src/a.ts": "export const x = 1;\nif (process.env.DEUS_TEST_UNUSED_GATE) doThing();\n"},
+    )
+    violations = _run(repo, base)
+    assert len(violations) == 1
+    assert violations[0].flag == "DEUS_TEST_UNUSED_GATE"
+
+
+def test_existing_flag_reread_is_silent(tmp_path):
+    # Flag already present in base → reading it again in a new location must not fire.
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "const a = process.env.DEUS_EXISTING_FLAG;\n"},
+        {
+            "src/a.ts": "const a = process.env.DEUS_EXISTING_FLAG;\n",
+            "src/b.ts": "const b = process.env.DEUS_EXISTING_FLAG ?? 'x';\n",
+        },
+    )
+    assert _run(repo, base) == []
+
+
+# --- citation + escape paths ---------------------------------------------
+
+
+def test_net_new_with_linear_citation_passes(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "export const x = 1;\n"},
+        {"src/a.ts": "// LIA-999: gated until orchestrator lands\nif (process.env.DEUS_TEST_NEW_GATE) go();\n"},
+    )
+    assert _run(repo, base) == []
+
+
+def test_net_new_with_pr_citation_passes(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "export const x = 1;\n"},
+        {"src/a.ts": "if (process.env.DEUS_TEST_NEW_GATE) go(); // tracked in #1234\n"},
+    )
+    assert _run(repo, base) == []
+
+
+def test_net_new_with_dev_only_escape_passes(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "export const x = 1;\n"},
+        {"src/a.ts": "if (process.env.DEUS_TEST_NEW_GATE) go(); // dev-only\n"},
+    )
+    assert _run(repo, base) == []
+
+
+# --- comment syntax across languages -------------------------------------
+
+
+def test_python_hash_comment_citation_passes(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"scripts/x.py": "x = 1\n"},
+        {"scripts/x.py": "# LIA-777: experimental path\nif os.environ.get('DEUS_TEST_NEW_GATE'):\n    go()\n"},
+    )
+    assert _run(repo, base) == []
+
+
+def test_python_net_new_uncited_fires(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"scripts/x.py": "x = 1\n"},
+        {"scripts/x.py": "if os.getenv('DEUS_TEST_UNUSED_GATE'):\n    go()\n"},
+    )
+    violations = _run(repo, base)
+    assert len(violations) == 1
+    assert violations[0].flag == "DEUS_TEST_UNUSED_GATE"
+
+
+def test_shell_net_new_uncited_fires(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"deus.sh": "echo hi\n"},
+        {"deus.sh": 'if [ -n "$DEUS_TEST_UNUSED_GATE" ]; then run; fi\n'},
+    )
+    violations = _run(repo, base)
+    assert len(violations) == 1
+    assert violations[0].flag == "DEUS_TEST_UNUSED_GATE"
+
+
+# --- self-exclusion + allowlist ------------------------------------------
+
+
+def test_flag_in_excluded_path_is_ignored(tmp_path):
+    # The lint's own dir / test dirs must not trip it on example flag strings.
+    repo, base = _make_repo(
+        tmp_path,
+        {"scripts/ci/other.py": "x = 1\n"},
+        {
+            "scripts/ci/other.py": "if os.getenv('DEUS_TEST_UNUSED_GATE'): go()\n",
+            "scripts/tests/test_z.py": "v = process.env.DEUS_TEST_UNUSED_GATE\n",
+        },
+    )
+    assert _run(repo, base) == []
+
+
+def test_allowlisted_flag_passes(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "export const x = 1;\n"},
+        {"src/a.ts": "const lvl = process.env.DEUS_OPS_ONLY;\n"},
+    )
+    assert _run(repo, base, allowlist=frozenset({"DEUS_OPS_ONLY"})) == []
+    # Without the allowlist it should fire (proves the allowlist is what passed it).
+    assert len(_run(repo, base)) == 1
+
+
+# --- non-code files + end-to-end exit code -------------------------------
+
+
+def test_flag_in_markdown_is_ignored(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"docs/x.md": "hello\n"},
+        {"docs/x.md": "Set `process.env.DEUS_TEST_UNUSED_GATE` to enable.\n"},
+    )
+    assert _run(repo, base) == []
+
+
+def test_main_exit_code_on_violation(tmp_path, capsys):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "export const x = 1;\n"},
+        {"src/a.ts": "if (process.env.DEUS_TEST_UNUSED_GATE) go();\n"},
+    )
+    rc = flag_lint.main(["--base", base, "--repo", str(repo)])
+    assert rc == 1
+    assert "DEUS_TEST_UNUSED_GATE" in capsys.readouterr().err
+
+
+def test_citation_window_boundary(tmp_path):
+    # Citation exactly 3 lines above the gate (== _CITE_WINDOW) passes;
+    # 4 lines above (just outside the window) fires. Guards the constant.
+    within = "// LIA-1: tracked\nconst p = 0;\nconst q = 0;\nif (process.env.DEUS_TEST_NEW_GATE) go();\n"
+    outside = "// LIA-1: tracked\nconst p = 0;\nconst q = 0;\nconst r = 0;\nif (process.env.DEUS_TEST_NEW_GATE) go();\n"
+    repo_in, base_in = _make_repo(tmp_path / "a", {"src/a.ts": "x;\n"}, {"src/a.ts": within})
+    assert _run(repo_in, base_in) == []
+    repo_out, base_out = _make_repo(tmp_path / "b", {"src/a.ts": "x;\n"}, {"src/a.ts": outside})
+    assert len(_run(repo_out, base_out)) == 1
+
+
+def test_parse_diff_tracks_new_line_numbers(tmp_path):
+    repo, base = _make_repo(
+        tmp_path,
+        {"src/a.ts": "line1\nline2\nline3\n"},
+        {"src/a.ts": "line1\nline2\nINSERTED\nline3\n"},
+    )
+    files = flag_lint.parse_diff(flag_lint._get_diff(base, str(repo)))
+    added = [dl for dl in files["src/a.ts"] if dl.added]
+    assert len(added) == 1
+    assert added[0].text == "INSERTED"
+    assert added[0].lineno == 3


### PR DESCRIPTION
## Summary

Layer 2 of the LIA-143 facade-prevention mechanism (umbrella **LIA-133**). The deterministic, merge-time companion to PR #647's advisory `connectivity-wiring` warden rule. Every facade in the LIA-133 audit shipped behind an **uncited** flag that was never turned on; this fails CI when a new `DEUS_*` gate lands without a tracking citation.

## What it does

`scripts/ci/flag_lint.py` scans the PR diff for **net-new** `DEUS_*` env-flag gates — a flag name absent from the base ref — and requires each to either:
- cite a tracking issue (`LIA-NNN` or `#NNN`) in a comment within 3 diff-visible lines, or
- carry a `dev-only` escape comment.

Otherwise CI fails (exit 1).

**Net-new only** is the whole design: the ~40 existing `DEUS_*` flags and mere re-reads never fire — only newly introduced flag names. Detects `process.env.DEUS_*`, `os.environ.get`/`[]`/`getenv`, and shell `$DEUS_*`; accepts `#`, `//`, `/* */` comment forms (≈60 flags live in `.py`/`.sh`). Excludes the lint's own source + test dirs so it never trips on its own examples.

| File | Change |
|------|--------|
| `scripts/ci/flag_lint.py` | The lint (stdlib only). |
| `scripts/tests/test_flag_lint.py` | 14 hermetic tests — isolated temp git repos with their own history. |
| `.github/workflows/validate-pr.yml` | New `flag-lint` job (checkout `fetch-depth:0`, setup-python, pytest + lint). |

## Verification

- `pytest scripts/tests/test_flag_lint.py` → **14 passed**, exit 0.
- **Real-history red-green:** ran `flag_lint.py --base <parent>` against commit `a55593cb` (#281), which introduced `os.environ.get("DEUS_TREE_PARAMS")` with no adjacent citation. The lint **fires (exit 1)** — that flag's optimizer then sat unwired for months until LIA-136 wired it this week. The gate would have demanded a tracking citation at merge.
- **Self-consistency:** scanning this PR's own diff yields no violations (the gate excludes its own source/tests).
- code-reviewer SHIP (2 rounds); verification-gate SHIP.

## Follow-up (user action)

To make Layer 2 truly unbypassable, add the `flag-lint` job to **branch-protection required checks** (one-time repo-admin action). Until then it runs and reports but a merge could be forced past it.

Closes LIA-143 (Layer 2 portion). Layer 1 = #647. Layer 3 (local orphan-sweep) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
