### PR TITLE
feat(cli): add `deus sync` + live-command freshness nudge

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -89,6 +89,51 @@ _build_and_restart() {
   fi
 }
 
+# Warn (never block) when the live tree drifts off main or behind origin/main, so
+# `deus <cmd>` doesn't silently ship stale behavior from a feature branch.
+# darwin/Linux only (date +%s, git); Windows port pending — project_windows_support.md
+_deus_freshness_check() {
+  [[ "$OSTYPE" == darwin* || "$OSTYPE" == linux* ]] || return 0
+  # Skip for sync (does its own reporting) and help/no-arg paths.
+  case "$1" in sync|""|-h|--help|help) return 0 ;; esac
+  git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1 || return 0
+
+  local stamp_dir="$HOME/.config/deus" stamp now last
+  stamp="$stamp_dir/freshness-stamp"
+  now=$(date +%s 2>/dev/null) || return 0
+  mkdir -p "$stamp_dir" 2>/dev/null || {
+    [ -n "$DEUS_DEBUG" ] && echo "deus: freshness stamp dir unwritable, skipping" >&2
+    return 0
+  }
+  last=0
+  [ -f "$stamp" ] && last=$(cat "$stamp" 2>/dev/null || echo 0)
+  # Throttle: at most one real check (and one background fetch) per 600s.
+  [ $((now - last)) -lt 600 ] 2>/dev/null && return 0
+  echo "$now" > "$stamp" 2>/dev/null || {
+    [ -n "$DEUS_DEBUG" ] && echo "deus: freshness stamp unwritable" >&2
+  }
+
+  # Refresh the cached origin/main ref in the background — no hot-path network/hang.
+  # Stamp-race: concurrent calls at window-expiry may each spawn one harmless fetch.
+  ( git -C "$SCRIPT_DIR" fetch --quiet origin main >/dev/null 2>&1 & ) >/dev/null 2>&1
+
+  # Offline compare local state vs the cached origin/main ref.
+  local branch behind
+  branch=$(git -C "$SCRIPT_DIR" symbolic-ref --short -q HEAD 2>/dev/null)
+  # Detached HEAD (e.g. a future pinned-worktree install) — don't nag.
+  [ -z "$branch" ] && return 0
+  if [ "$branch" != "main" ]; then
+    echo "deus: live tree on '$branch', not main — run 'deus sync'" >&2
+    return 0
+  fi
+  git -C "$SCRIPT_DIR" rev-parse --verify -q origin/main >/dev/null 2>&1 || return 0
+  behind=$(git -C "$SCRIPT_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+  if [ "${behind:-0}" -gt 0 ] 2>/dev/null; then
+    echo "deus: live tree $behind commit(s) behind origin/main — run 'deus sync'" >&2
+  fi
+  return 0
+}
+
 _fcc_validate_model_name() {
   if ! printf '%s' "$1" | grep -qE '^[a-zA-Z0-9_./:@-]+$'; then
     echo "Error: invalid characters in model name."
@@ -857,6 +902,9 @@ SKILLEOF
   echo "$current_version" > "$marker"
 }
 
+# Nudge if the live tree has drifted off/behind main (warn-only, throttled).
+_deus_freshness_check "$1"
+
 case "$1" in
   auth)
     # `deus auth refresh [--dry-run]` → proactive OAuth refresh CLI
@@ -1579,6 +1627,35 @@ $STARTUP_INSTRUCTION"
     shift
     exec python3 "$SCRIPT_DIR/scripts/analyze_token_efficiency.py" "$@"
     ;;
+  sync)
+    # Make the live install current with origin/main, non-destructively.
+    # See ADR: docs/decisions/live-command-freshness.md
+    sync_repo="$SCRIPT_DIR"
+    if ! git -C "$sync_repo" rev-parse --git-dir >/dev/null 2>&1; then
+      echo "deus sync: $sync_repo is not a git repository." >&2; exit 1
+    fi
+    sync_branch=$(git -C "$sync_repo" symbolic-ref --short -q HEAD 2>/dev/null || echo "DETACHED")
+    if [ "$sync_branch" != "main" ]; then
+      echo "deus sync: live tree is on '$sync_branch', not main." >&2
+      echo "  Feature work belongs in a worktree. Switch the live tree to main first:" >&2
+      echo "    git -C \"$sync_repo\" checkout main && deus sync" >&2
+      exit 1
+    fi
+    if ! git -C "$sync_repo" diff --quiet || ! git -C "$sync_repo" diff --cached --quiet; then
+      echo "deus sync: live tree has uncommitted changes — commit or stash first." >&2
+      exit 1
+    fi
+    echo "Fetching origin/main..."
+    if ! git -C "$sync_repo" fetch origin main; then
+      echo "deus sync: fetch failed." >&2; exit 1
+    fi
+    if ! git -C "$sync_repo" merge --ff-only origin/main; then
+      echo "deus sync: cannot fast-forward (live tree has diverged from origin/main)." >&2
+      exit 1
+    fi
+    _build_and_restart
+    echo "deus: synced to origin/main."
+    ;;
   pipeline)
     shift
     # cd required: config.ts evaluates PROJECT_ROOT from process.cwd() at import time
@@ -1818,6 +1895,7 @@ $STARTUP_INSTRUCTION"
     echo "  deus model      Switch proxy model or open dashboard (model-name|dashboard)"
     echo "  deus logs       Review system health logs (rotate|review|summary|pinned)"
     echo "  deus usage      Token-efficiency + cost report (--since|--project|--pricing|--json)"
+    echo "  deus sync       Update the live install to origin/main (fetch + ff + rebuild)"
     echo "  deus pipeline   Pipeline event audit (LIA-XX | --failed | --active | --all)"
     echo "  deus solution   Manage solution atoms (list|search|add)"
     echo "  deus sweep      Run threshold calibration sweep against benchmark queries"

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -36,6 +36,7 @@ One line per decision. Load the full file only when the topic is directly releva
 | [judge-lora-specialization.md](judge-lora-specialization.md) | eval / judge / LoRA | Negative result on Gemma-3n-E4B Q4 (Adapter mean Pearson 0.368 vs Base 0.390) — do NOT adopt run `20260518T071842Z-1614baf-dirty`; keep base Q4 as local judge. **Future judge-quality work begins with cross-stack truth bench + replace-base / logit-mean / frozen-head alternatives BEFORE any retune; retune requires regression bar mean Pearson ≥ Base + 0.05** |
 | [linear-webhook-pipeline.md](linear-webhook-pipeline.md) | linear / dispatch / webhooks / gates | Polling dispatcher + webhook warden gates for Linear Kanban. Enrichment gates write structured scope into issue descriptions via sentinel markers. Config-driven gate specs in `.claude/agents/wardens/` |
 | [ADR-001-hook-dispatch-service.md](ADR-001-hook-dispatch-service.md) | hooks / dispatch / observers | HookDispatchService on :3002 with PreToolUse blocking hook and fire-and-forget PostToolUse observer; gated by `HOOK_DISPATCH_ENABLED` |
+| [live-command-freshness.md](live-command-freshness.md) | cli / install / git / freshness | The `deus` CLI runs from the primary checkout's working tree, so it ships stale when `~/deus` drifts off-main/behind `origin/main`. A throttled warn-only nudge flags drift; `deus sync` makes the install current (fetch + ff + rebuild). Pinned-detached-worktree decoupling (Option 2) **deferred** until drift recurs |
 
 ## Related documentation
 

--- a/docs/decisions/live-command-freshness.md
+++ b/docs/decisions/live-command-freshness.md
@@ -1,0 +1,93 @@
+# Live-Command Freshness
+
+**Status:** Accepted
+**Date:** 2026-05-30
+**Scope:** The `deus` CLI launcher (`deus-cmd.sh`) and how the live install stays current with `main`
+
+## Context
+
+The `deus` command is a symlink to `~/deus/deus-cmd.sh`. Its subcommands either
+`exec` compiled `dist/*.js` (TypeScript, needs a build) or run `scripts/*.py`
+straight from the working tree. So **shell and Python features go live the moment
+the primary checkout's working tree contains them** — there is no separate install
+step for them.
+
+This couples the live command to whatever branch `~/deus` happens to be on. When
+the primary checkout drifts off `main`, or sits behind `origin/main`, the live
+command silently ships stale behavior. This bit us concretely: `deus usage` was
+implemented in a worktree, reviewed, and merged to `main` via PR — but it wasn't
+live in the terminal, because `~/deus` was parked on an old feature branch
+(`feat/linear-scoring-impact`) left over from a prior session.
+
+A brainstorm reframed the issue as **two distinct problems**:
+
+- **Problem A — work location** (worktree hygiene). "Feature work happens in a
+  worktree; `~/deus` stays clean." This is what the rule in
+  `core-behavioral-rules.md` already states.
+- **Problem B — live-command freshness** (correctness). "When I type `deus <cmd>`,
+  do I get merged-`main` behavior?"
+
+The symptom we hit is **Problem B, not A**. Two facts pin this down:
+
+1. The TypeScript service already runs from `dist/` (decoupled — only stale after a
+   missed build/restart). The entire live-drift surface is `deus-cmd.sh` plus the
+   `scripts/*.py` calls, which run from the mutable working tree.
+2. **There is no auto-pull anywhere.** Even with perfect worktree discipline,
+   `~/deus` is stale-on-`main` after every merge until a human pulls. Worktree
+   discipline cannot fix B.
+
+Framed correctly, this is a **release-freshness problem** (the live command runs
+whatever is in the mutable working tree), not a branch-discipline problem.
+
+## Decisions
+
+1. **Ship a freshness nudge + `deus sync` (chosen).**
+   - `_deus_freshness_check` runs once on every `deus` invocation (before the main
+     dispatch). It is warn-only, never blocks, always returns 0, and is throttled
+     to one real check per 600s via `~/.config/deus/freshness-stamp`. It refreshes
+     the cached `origin/main` ref with a detached background `git fetch` (no
+     hot-path network), then does an **offline** comparison: if the live tree is
+     off `main` or behind `origin/main`, it prints one stderr nudge to run
+     `deus sync`. darwin/Linux only (Windows port of `deus-cmd.sh` is pending).
+   - `deus sync` makes the live install current in one command: `git fetch` +
+     `git merge --ff-only origin/main` + rebuild/restart (reusing
+     `_build_and_restart`). It is **non-destructive** — it refuses to run on a
+     feature branch or a dirty tree, and never auto-switches branches.
+
+2. **Defer decoupling the install (Option 2) — documented, not built.**
+   The root-cause fix is to stop the live command from reading the mutable dev
+   checkout at all, by making the install a **pinned detached worktree**:
+   - `git worktree add --detach ~/deus-live origin/main` (the `--detach` is
+     load-bearing — git refuses to check out the `main` *branch* in two worktrees,
+     but a detached HEAD at `origin/main` is allowed).
+   - Repoint `/usr/local/bin/deus` and `com.deus.plist` (`WorkingDirectory` +
+     `dist/index.js` path) at `~/deus-live`. `deus sync` becomes
+     `git reset --hard origin/main` (the live tree is never hand-edited, so a hard
+     reset is always safe). `~/deus` then demotes to just-another-dev-worktree and
+     its branch drift stops mattering.
+
+   This is a blue-green / symlink-swap deploy pattern applied to a local CLI. It is
+   **deferred** because the drift has only bitten once; building it now would be
+   solving a problem we have not yet repeatedly encountered.
+
+   **Footguns to resolve before ever building Option 2:**
+   - `~/.local/bin` is first on `$PATH` but `~/.local/bin/deus` does not exist
+     today, so `/usr/local/bin/deus` wins. `_build_and_restart` *creates*
+     `~/.local/bin/deus` on its next run, which would then **shadow** a
+     `/usr/local/bin` swap. Both symlinks (or `_build_and_restart`'s `LINK_DIR`)
+     must move together.
+   - `container-mounter` and `com.deus.plist` hardcode `~/deus` paths — audit
+     before relocating the live tree.
+   - GitHub merges fire no local hook, so the natural push-refresh trigger is a
+     `gh pr merge` wrapper that runs `deus sync` on success.
+
+3. **Trigger to revisit Option 2:** recurrent off-`main`/behind drift despite the
+   nudge. If the nudge proves insufficient in practice, escalate to the pinned
+   detached worktree.
+
+## Migration note
+
+`deus-cmd.sh` is the last Windows hard-blocker (`project_windows_sot_plan.md`,
+Phase 2 → `src/deus-cmd.ts`). The shell added here (`_deus_freshness_check`, the
+`sync` arm) is darwin/Linux-guarded and will need a straight translation to
+TypeScript when that migration lands.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-05-30" # auto-bump @1780147886
+last_verified: "2026-05-30" # auto-bump @1780153769
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## What

The `deus` CLI runs `deus-cmd.sh` + `scripts/*.py` directly from the primary checkout's working tree, so when `~/deus` drifts off `main` or behind `origin/main`, the live command silently ships stale behavior. This bit us when a merged `deus usage` wasn't live because `~/deus` sat on an old feature branch.

A brainstorm reframed this as two problems: **(A)** work-location/worktree hygiene and **(B)** live-command freshness. The symptom is B, and worktree discipline can't fix B (no auto-pull exists). This PR ships the right-sized fix for B and documents the deeper structural fix as a deferred ADR.

## Changes

- **`_deus_freshness_check`** — runs once per `deus` invocation before dispatch. Warn-only, never blocks, always returns 0. OS-guarded (darwin/Linux; Windows no-op). Throttled to one check per 600s via `~/.config/deus/freshness-stamp`; refreshes `origin/main` with a detached background `git fetch` (no hot-path network), then **offline**-compares and nudges to run `deus sync` if the live tree is off-main or behind. Stderr only — never pollutes piped stdout.
- **`deus sync`** — makes the live install current in one command: `git fetch` + `git merge --ff-only origin/main` + rebuild/restart (reuses `_build_and_restart`). **Non-destructive**: refuses on a feature branch or a dirty tree, never auto-switches.
- **ADR `docs/decisions/live-command-freshness.md`** — records the A-vs-B reframe, the chosen nudge approach, and the **deferred** Option 2 (pinned detached-worktree install) with its footguns (`.local/bin` PATH shadow, `container-mounter`/plist hardcoded paths, `gh pr merge` refresh trigger) and a trigger-to-revisit.

## Why defer Option 2

The structural fix (decouple the install from the mutable checkout via a pinned detached worktree) is real but drift has only bitten once — building it now would be speculative. The ADR captures the full design so it's one planning session away if drift recurs.

## Verification

- `zsh -n` + `bash -n` clean.
- Off-main nudge fires; behind-count (`rev-list --count origin/main~1..origin/main` = 1) triggers the behind nudge; immediate re-run silent (throttle); nudge skipped for `sync`/`--help`.
- `deus sync` exits 1 on a feature branch and on a dirty tree (dirty predicate confirmed in isolation), with **no git mutation**.
- Hot-path: a throttled call spawns **no** `git fetch` (cost = one stat).
- Help shows the new line; existing subcommands still dispatch.

Plan-reviewer SHIP + code-reviewer SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)