### PR TITLE
fix(evolution): exclude noisy tool_selection module from DSPy optimization (LIA-151)

### DIFF
--- a/evolution/optimizer/dspy_optimizer.py
+++ b/evolution/optimizer/dspy_optimizer.py
@@ -108,6 +108,20 @@ _MODULE_IO = {
 }
 
 
+# Modules excluded from GEPA optimization because their judge objective is
+# ill-defined (LIA-151); the value is the reason, logged on skip. Re-enable
+# tool_selection only after tool usage is logged with a per-interaction available
+# tool set (LIA-154), then score it with a tools_used ground-truth metric.
+_JUDGE_OPTIMIZATION_EXCLUDED = {
+    "tool_selection": (
+        "no usable ground truth: live tools_used unlogged + available_tools "
+        "hardcoded, so the judge objective is undefined (LIA-151)"
+    ),
+}
+# A typo in an exclusion key would silently exclude nothing — catch it at import.
+assert all(m in MODULE_REGISTRY for m in _JUDGE_OPTIMIZATION_EXCLUDED)
+
+
 def _make_judge_metric(judge, module: str):
     """Build a GEPA-protocol metric that scores a prediction with the real
     runtime judge instead of the old length heuristic.
@@ -191,6 +205,13 @@ def optimize(
     plus secondary pool (top cross-domain interactions) for generalization.
     Returns the artifact ID on success, None if insufficient samples.
     """
+    # Excluded modules (LIA-151) skip FIRST, before _require_dspy(), so the skip
+    # is testable without dspy and is the single chokepoint for every caller.
+    reason = _JUDGE_OPTIMIZATION_EXCLUDED.get(module)
+    if reason:
+        print(f"[evolution] Skipping {module}: {reason}")
+        return None
+
     _require_dspy()
     import dspy
 

--- a/evolution/tests/test_dspy_optimizer_exclusion.py
+++ b/evolution/tests/test_dspy_optimizer_exclusion.py
@@ -1,0 +1,58 @@
+"""Tests for LIA-151: excluding the noisy tool_selection judge objective.
+
+The exclusion guard sits at the top of optimize(), ABOVE _require_dspy(), so an
+excluded module short-circuits to None without importing dspy. That placement is
+what makes these tests runnable in CI (which has no dspy) — they assert the
+excluded path returns None and the non-excluded path proceeds far enough to hit
+the dspy requirement and raise ImportError.
+"""
+import pytest
+
+from evolution.optimizer.dspy_optimizer import _JUDGE_OPTIMIZATION_EXCLUDED, optimize
+
+
+def test_tool_selection_is_excluded():
+    """tool_selection is in the denylist with a non-empty reason."""
+    assert "tool_selection" in _JUDGE_OPTIMIZATION_EXCLUDED
+    assert _JUDGE_OPTIMIZATION_EXCLUDED["tool_selection"].strip()
+
+
+def test_valid_modules_not_excluded():
+    """qa and summarization have real objectives and must NOT be excluded."""
+    assert "qa" not in _JUDGE_OPTIMIZATION_EXCLUDED
+    assert "summarization" not in _JUDGE_OPTIMIZATION_EXCLUDED
+
+
+def test_optimize_tool_selection_returns_none_without_dspy():
+    """The guard short-circuits before _require_dspy(), so optimize() returns
+    None for tool_selection even though dspy is not installed. If the guard were
+    placed below _require_dspy(), this would raise ImportError instead."""
+    assert optimize(module="tool_selection") is None
+
+
+def test_optimize_tool_selection_skips_require_dspy(monkeypatch):
+    """Prove the chokepoint: an excluded module never reaches _require_dspy()."""
+    import evolution.optimizer.dspy_optimizer as opt
+
+    def _boom():
+        raise AssertionError("_require_dspy() must not be called for an excluded module")
+
+    monkeypatch.setattr(opt, "_require_dspy", _boom)
+    assert optimize(module="tool_selection") is None
+
+
+def test_optimize_qa_is_not_short_circuited():
+    """A non-excluded module proceeds past the guard to _require_dspy(), which
+    raises ImportError when dspy is absent (verified: _require_dspy raises
+    ImportError exclusively, modules.py). Asserting the exact class — not a bare
+    'raises' — keeps the test precise against future _require_dspy changes.
+
+    Skipped if dspy IS installed (then qa would proceed further and likely fail
+    on missing samples/judge instead)."""
+    try:
+        import dspy  # noqa: F401
+        pytest.skip("dspy installed — qa would proceed past _require_dspy()")
+    except ImportError:
+        pass
+    with pytest.raises(ImportError):
+        optimize(module="qa")

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-31" # auto-bump @1780175202
+last_verified: "2026-05-31" # auto-bump @1780177680
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780175202
+last_verified: "2026-05-31" # auto-bump @1780177680
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## What

Excludes the `tool_selection` module from DSPy GEPA optimization, because its judge objective is currently undefined.

## Why

From the LIA-131 Phase 1 ai-eng-warden review (PR #651): `tool_selection` feeds the LLM judge a bare comma-joined tool-name string as the "response" with `available_tools` hardcoded to a constant (`_build_examples`). The judge dims (`tool_use`/`quality`/`personalization`) score noise on a name list with no args or ground truth → a noisy GEPA objective that rewards arbitrary mutations. `qa` and `summarization` are unaffected.

**Diagnosis (data-verified) — why exclude, not a dedicated metric:**
The issue offered an alternative (precision/recall vs logged `tools_used`). That isn't viable today:
1. The live runtime never logs tool usage — neither `logInteraction` call site in `container-runner.ts` passes `toolsUsed`; it defaults to `[]`.
2. The only populated source (`cc_backfill.py`) logs Claude-Code tool names that aren't in the hardcoded `available_tools` candidate set — so a ground-truth metric would optimize an **unreachable target** (ill-posed).
3. `dspy` isn't installed in the runtime, so `optimize()` is a no-op today — neither path can be smoke-tested live.

Both prerequisites for a real metric (live `tools_used` logging + per-interaction `available_tools`) are tracked in **LIA-154**.

## How

- `_JUDGE_OPTIMIZATION_EXCLUDED` denylist dict (value = logged skip reason) + a module-load `assert` guarding exclusion-key typos.
- An early guard as the **first statement in `optimize()`, above `_require_dspy()`** — the single chokepoint for both callers (auto-trigger + `optimize all`), and reachable by a dspy-free CI test. Returns `None` (same contract as other early-outs), so callers need no change.

## Tests

New dspy-free `evolution/tests/test_dspy_optimizer_exclusion.py` (5 tests): excluded module returns `None` without importing dspy, `_require_dspy` is never reached for it, `qa` is not short-circuited (raises `ImportError`), and the denylist membership invariants. Full evolution suite: 426 passed / 1 pre-existing skip.

## Reviews

plan-reviewer SHIP · code-reviewer SHIP (round 2) · ai-eng-warden SHIP.

Closes LIA-151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)