### PR TITLE
fix(auth): serve freshest OAuth token across file + keychain (pipeline-gate 401)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780177680
+last_verified: "2026-05-31" # auto-bump @1780238753
 governs:
   - src/
   - evolution/

--- a/src/auth-providers/anthropic.ts
+++ b/src/auth-providers/anthropic.ts
@@ -209,19 +209,44 @@ export async function refreshOAuthToken(
         scope: REFRESH_SCOPES,
       }),
     });
-    if (!res.ok) return undefined;
+    if (!res.ok) {
+      // Log status + the OAuth error CODE only (e.g. "invalid_grant") — never the request
+      // body, which carries the refresh_token. An invalid_grant/400 here is the signal that
+      // the refresh_token was rotated out from under us (e.g. by Claude Code's own refresh).
+      let errorCode: string | undefined;
+      try {
+        errorCode = ((await res.json()) as { error?: string })?.error;
+      } catch {
+        /* body not JSON — the status alone is the signal */
+      }
+      logger.warn(
+        { status: res.status, error: errorCode },
+        'credential-proxy: OAuth refresh endpoint rejected refresh_token',
+      );
+      return undefined;
+    }
     const body = (await res.json()) as {
       access_token?: string;
       refresh_token?: string;
       expires_in?: number;
     };
-    if (!body.access_token) return undefined;
+    if (!body.access_token) {
+      logger.warn(
+        { status: res.status },
+        'credential-proxy: OAuth refresh response missing access_token',
+      );
+      return undefined;
+    }
     return {
       accessToken: body.access_token,
       refreshToken: body.refresh_token ?? refreshToken,
       expiresAt: Date.now() + (body.expires_in ?? 28800) * 1000,
     };
-  } catch {
+  } catch (err) {
+    logger.warn(
+      { err: String(err) },
+      'credential-proxy: OAuth refresh request threw',
+    );
     return undefined;
   }
 }
@@ -230,6 +255,7 @@ export async function refreshOAuthToken(
 function triggerRefresh(refreshToken: string): void {
   if (refreshInFlight) return;
   refreshInFlight = true;
+  logger.info('credential-proxy: OAuth token refresh started (background)');
   refreshOAuthToken(refreshToken)
     .then((newCreds) => {
       if (newCreds) {
@@ -239,11 +265,99 @@ function triggerRefresh(refreshToken: string): void {
           fetchedAt: Date.now(),
           tokenExpiresAt: newCreds.expiresAt,
         };
+        logger.info(
+          {
+            expiresInSec:
+              newCreds.expiresAt === Infinity
+                ? null
+                : Math.floor((newCreds.expiresAt - Date.now()) / 1000),
+          },
+          'credential-proxy: OAuth token refresh succeeded',
+        );
+      } else {
+        // refreshOAuthToken already logged the specific reason (status/error code).
+        logger.warn(
+          'credential-proxy: OAuth token refresh failed — token not renewed',
+        );
       }
     })
     .finally(() => {
       refreshInFlight = false;
     });
+}
+
+/**
+ * Pick the credential with the later expiry.
+ * The `Infinity` sentinel means "expiry unknown" (both readers default `expiresAt ?? Infinity`)
+ * and is treated as OLDEST (`-Infinity`) so a no-expiry token can't mask a freshly-refreshed
+ * one. Tie — equal expiry, or both unknown — resolves to `fileCreds`: it is the already-synced,
+ * stable source, so preferring it avoids a needless re-write.
+ */
+function pickFresher(
+  fileCreds: OAuthCredentials | undefined,
+  keychainCreds: OAuthCredentials | undefined,
+): OAuthCredentials | undefined {
+  if (!fileCreds) return keychainCreds;
+  if (!keychainCreds) return fileCreds;
+  const expFile =
+    fileCreds.expiresAt === Infinity ? -Infinity : fileCreds.expiresAt;
+  const expKeychain =
+    keychainCreds.expiresAt === Infinity ? -Infinity : keychainCreds.expiresAt;
+  return expKeychain > expFile ? keychainCreds : fileCreds;
+}
+
+/**
+ * Resolve the freshest OAuth credentials across the credentials file and the OS keychain.
+ *
+ * macOS-specific hazard this guards against: Claude Code refreshes the OAuth token in the
+ * **keychain**, while `~/.claude/.credentials.json` is a Deus-managed cache that only Deus
+ * writes — so the file can lag the keychain. A gate request landing on a token-expiry
+ * boundary previously read the stale (expired) file token and never consulted the still-valid
+ * keychain token → upstream 401 (the recurring pipeline-gate failure). We now read whichever
+ * source is freshest instead of blindly trusting the file.
+ *
+ * Fast path: a comfortably-valid file token returns immediately WITHOUT spawning the keychain
+ * `security`/`secret-tool` subprocess. The keychain is consulted only when the file is missing,
+ * within the early-expire window, or expired. On Linux the file is Claude-Code-authoritative
+ * and a missing keychain reader simply returns `undefined`, so the file still wins there.
+ */
+function resolveFreshestCredentials(now: number): OAuthCredentials | undefined {
+  const file = readCredentialsFile();
+
+  // Fast path: file token comfortably valid → skip the keychain subprocess entirely.
+  if (
+    file &&
+    file.expiresAt !== Infinity &&
+    file.expiresAt >= now + EARLY_EXPIRE_WINDOW_MS
+  ) {
+    return file;
+  }
+
+  // File missing / expiring / expired → consult the keychain and keep the fresher source.
+  const keychain = readKeychainCredentials();
+  const chosen = pickFresher(file, keychain);
+  if (!chosen) return undefined;
+
+  // Sync + log only when the freshest source actually differs from the file (compare by token
+  // VALUE — the readers return fresh objects each call, so identity would always differ): the
+  // keychain superseded a stale file. The steady state (file wins) stays silent. `chosen` is by
+  // construction the later-expiry source, so this can never downgrade the file to a staler token.
+  // The write is crash-safe (tmp-write + atomic rename in writeCredentialsFile).
+  if (chosen.accessToken !== file?.accessToken) {
+    writeCredentialsFile(chosen);
+    logger.info(
+      {
+        source: chosen === keychain ? 'keychain' : 'file',
+        expiresInSec:
+          chosen.expiresAt === Infinity
+            ? null
+            : Math.floor((chosen.expiresAt - now) / 1000),
+        expired: chosen.expiresAt !== Infinity && chosen.expiresAt <= now,
+      },
+      'credential-proxy: switched to fresher OAuth token source',
+    );
+  }
+  return chosen;
 }
 
 function getDynamicOAuthToken(): string | undefined {
@@ -257,12 +371,8 @@ function getDynamicOAuthToken(): string | undefined {
       return credentialsCache.token;
   }
 
-  // Try file first, then keychain fallback
-  let creds = readCredentialsFile();
-  if (!creds) {
-    creds = readKeychainCredentials();
-    if (creds) writeCredentialsFile(creds); // sync to disk
-  }
+  // Read whichever of {file, keychain} is freshest — never blindly trust a stale file.
+  const creds = resolveFreshestCredentials(now);
   if (!creds) return undefined;
 
   // Trigger background refresh if token is expiring within the window
@@ -271,6 +381,20 @@ function getDynamicOAuthToken(): string | undefined {
     creds.expiresAt < now + EARLY_EXPIRE_WINDOW_MS;
   if (aboutToExpire && creds.refreshToken) {
     triggerRefresh(creds.refreshToken);
+  }
+
+  // Don't serve a dead token silently. Reaching here with an already-expired token means BOTH
+  // sources are expired — the idle-container case the scheduled auth-refresh guard prevents.
+  // We still return it (clock-skew tolerance; the refresh triggered above renews it for the
+  // next request), but log loudly so the next intermittent 401 is diagnosable.
+  if (creds.expiresAt !== Infinity && creds.expiresAt <= now) {
+    logger.warn(
+      {
+        expiredForSec: Math.floor((now - creds.expiresAt) / 1000),
+        hasRefreshToken: !!creds.refreshToken,
+      },
+      'credential-proxy: serving an EXPIRED OAuth token — no fresher source available; refresh triggered',
+    );
   }
 
   credentialsCache = {

--- a/src/auth-providers/auth-providers.test.ts
+++ b/src/auth-providers/auth-providers.test.ts
@@ -57,6 +57,7 @@ import {
   _resetCredentialsCacheForTest,
 } from './anthropic.js';
 import { OpenAIAuthProvider, _resetCodexCacheForTest } from './openai.js';
+import { logger } from '../logger.js';
 
 const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
 const mockWriteFileSync = writeFileSync as ReturnType<typeof vi.fn>;
@@ -944,6 +945,236 @@ describe('AnthropicAuthProvider', () => {
 
       // No crash, no write
       expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Credential freshness — prefer the freshest of {file, keychain}.
+  // Regression guard for the recurring pipeline-gate 401: at the incident the
+  // macOS keychain held a VALID token while ~/.claude/.credentials.json held an
+  // EXPIRED one, and the file-first reader served the dead token. These tests
+  // reconstruct that exact state — the honest verification for a bug whose
+  // expiry timing can't be forced end-to-end.
+  // -------------------------------------------------------------------------
+  describe('credential freshness (file vs keychain)', () => {
+    const HOUR = 60 * 60 * 1000;
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      // Logger isn't reset by the parent beforeEach — clear so assertions are scoped.
+      vi.mocked(logger.info).mockClear();
+      vi.mocked(logger.warn).mockClear();
+      // Stub fetch so any background refresh a test triggers can't hit the network.
+      // Default response mimics a rotated/invalid refresh_token (the rotation signal).
+      fetchSpy = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'invalid_grant' }),
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('incident reconstruction: file token EXPIRED + keychain VALID → injects the keychain token', () => {
+      platformMock.IS_MACOS = true;
+      const now = Date.now();
+      // File holds the expired token (the 04:41 credentials.json state)
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'file-expired-token-padding',
+            refreshToken: 'file-refresh',
+            expiresAt: now - 60_000,
+          },
+        }),
+      );
+      // Keychain holds the valid token Claude Code refreshed (the 04:39 keychain state)
+      mockExecFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'keychain-valid-token-padding',
+            refreshToken: 'keychain-refresh',
+            expiresAt: now + 5 * HOUR,
+          },
+        }),
+      );
+
+      const provider = new AnthropicAuthProvider();
+      const headers: Record<string, string | string[] | undefined> = {
+        authorization: 'Bearer placeholder',
+      };
+      provider.injectAuth(headers);
+
+      // The fix: the fresher keychain token wins over the expired file token.
+      expect(headers['authorization']).toBe(
+        'Bearer keychain-valid-token-padding',
+      );
+      // Winner differs from file → synced to disk for the next read.
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('.credentials.json'),
+        expect.stringContaining('keychain-valid-token-padding'),
+        expect.objectContaining({ mode: 0o600 }),
+      );
+    });
+
+    it('Infinity edge (a): file has no expiry + keychain valid finite → keychain wins (no-expiry treated as oldest)', () => {
+      platformMock.IS_MACOS = true;
+      const now = Date.now();
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'file-noexpiry-token-pad',
+            refreshToken: 'fr',
+          }, // no expiresAt → Infinity sentinel
+        }),
+      );
+      mockExecFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'keychain-finite-token-pad',
+            expiresAt: now + 2 * HOUR,
+          },
+        }),
+      );
+
+      const provider = new AnthropicAuthProvider();
+      const headers: Record<string, string | string[] | undefined> = {
+        authorization: 'Bearer placeholder',
+      };
+      provider.injectAuth(headers);
+      expect(headers['authorization']).toBe('Bearer keychain-finite-token-pad');
+    });
+
+    it('Infinity edge (b): file finite (soon-expiring) + keychain has no expiry → file wins over unknown-expiry', () => {
+      platformMock.IS_MACOS = true;
+      const now = Date.now();
+      // File finite but within the early-expire window so the keychain is consulted.
+      // No refreshToken → no background refresh fires (keeps the assertion synchronous).
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'file-finite-soon-token-pad',
+            expiresAt: now + 10 * 60 * 1000,
+          },
+        }),
+      );
+      mockExecFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: { accessToken: 'keychain-noexpiry-token-pad' },
+        }),
+      );
+
+      const provider = new AnthropicAuthProvider();
+      const headers: Record<string, string | string[] | undefined> = {
+        authorization: 'Bearer placeholder',
+      };
+      provider.injectAuth(headers);
+      expect(headers['authorization']).toBe(
+        'Bearer file-finite-soon-token-pad',
+      );
+    });
+
+    it('Infinity edge (c): both sources have no expiry → file wins (tie-break to the stable, already-synced source)', () => {
+      platformMock.IS_MACOS = true;
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: { accessToken: 'file-both-inf-token-padding' },
+        }),
+      );
+      mockExecFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: { accessToken: 'keychain-both-inf-token-pad' },
+        }),
+      );
+
+      const provider = new AnthropicAuthProvider();
+      const headers: Record<string, string | string[] | undefined> = {
+        authorization: 'Bearer placeholder',
+      };
+      provider.injectAuth(headers);
+      expect(headers['authorization']).toBe(
+        'Bearer file-both-inf-token-padding',
+      );
+      // Tie → file wins → no redundant sync write.
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('both sources expired: serves the less-expired token but logs a loud warning (not silent)', () => {
+      platformMock.IS_MACOS = true;
+      const now = Date.now();
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'file-expired-2-token-padding',
+            refreshToken: 'fr',
+            expiresAt: now - 2 * 60 * 1000,
+          },
+        }),
+      );
+      mockExecFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'keychain-expired-token-pad',
+            refreshToken: 'kr',
+            expiresAt: now - 60 * 1000, // less-expired of the two
+          },
+        }),
+      );
+
+      const provider = new AnthropicAuthProvider();
+      const headers: Record<string, string | string[] | undefined> = {
+        authorization: 'Bearer placeholder',
+      };
+      provider.injectAuth(headers);
+
+      // Clock-skew tolerance: still returns the least-stale token...
+      expect(headers['authorization']).toBe(
+        'Bearer keychain-expired-token-pad',
+      );
+      // ...but the all-expired condition is logged loudly so it isn't silent.
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.objectContaining({ expiredForSec: expect.any(Number) }),
+        expect.stringContaining('serving an EXPIRED OAuth token'),
+      );
+    });
+
+    it('refresh observability: a rejected refresh logs status + OAuth error code, never the refresh_token', async () => {
+      const now = Date.now();
+      // File expiring within the window with a refresh_token → background refresh fires.
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'file-refreshlog-token-pad',
+            refreshToken: 'secret-refresh-token-value',
+            expiresAt: now + 10 * 60 * 1000,
+          },
+        }),
+      );
+
+      const provider = new AnthropicAuthProvider();
+      const headers: Record<string, string | string[] | undefined> = {
+        authorization: 'Bearer placeholder',
+      };
+      provider.injectAuth(headers);
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 400, error: 'invalid_grant' }),
+          expect.stringContaining('rejected refresh_token'),
+        );
+      });
+
+      // No log line — info, warn, or error — may contain the refresh_token value.
+      const logged = JSON.stringify([
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+      ]);
+      expect(logged).not.toContain('secret-refresh-token-value');
     });
   });
 });


### PR DESCRIPTION
## Problem

The Linear pipeline **completion-gate** intermittently 401'd with `Invalid authentication credentials` from the Anthropic API, then self-recovered hours later (LIA-151: 401 at 04:41 UTC → SHIP on retry at 07:31 UTC). Recurring — prior GitHub #605, #600. The earlier fix (LIA-73 / #616) only made gate infra-errors *escalate*; it never addressed the token root cause.

## Root cause (evidence-backed)

Forensic logs + timestamps proved:
- Both 401s came from the **host credential proxy on :3001** (`Credential proxy received 401 from upstream`). The gate container routes Anthropic traffic through it (`src/container-runner.ts:198`).
- At 04:41 the macOS **keychain held a VALID token** (issued 04:39, expires 12:39 UTC), but `~/.claude/.credentials.json` held the **EXPIRED** token (file rewritten only at 07:37, *after* the retry).
- `getDynamicOAuthToken()` reads the **file first**, and `readCredentialsFile()` has **no `expiresAt > now` check**, so it served the expired file token and never consulted the fresher keychain → proxy injected a dead Bearer token → 401.
- The fire-and-forget `triggerRefresh` was **silent** (no logging), so the failure was undiagnosable from logs.

On macOS, Claude Code refreshes the OAuth token in the keychain; `credentials.json` is a Deus-managed cache that can lag it. The proxy trusted the staler source.

## Fix

- **`resolveFreshestCredentials()`** — read whichever of `{file, keychain}` has the later expiry instead of blindly trusting the file. A comfortably-valid file token takes a **fast path** that skips the keychain `security`/`secret-tool` subprocess. The winner is synced to disk only when its token actually differs (compare by value) — and since the winner is by construction the later-expiry source, **the sync can never downgrade the file to a staler token** (`writeCredentialsFile` is crash-safe: tmp-write + atomic rename).
- **Never serve a dead token silently** — if even the freshest source is already expired (both stale, the idle case), log loudly and still return it (clock-skew tolerance; the background refresh fires for the next request).
- **Refresh observability** — `triggerRefresh` + `refreshOAuthToken` now log start/success/failure with `status` + the OAuth `error` code (e.g. `invalid_grant`). **Never logs the request body / refresh_token.** An `invalid_grant`/400 here is the signal that confirms-or-refutes the refresh-token-rotation hypothesis (currently *logged, not fixed* — no handling built until it's observed).

## Tests

New `credential freshness` suite reconstructs the exact incident — the honest verification for a bug whose expiry timing can't be forced end-to-end:
- file expired + keychain valid → keychain token injected (**confirmed to FAIL on the pre-fix code**, `Received: "Bearer file-expired-token-padding"`)
- Infinity-expiry edges (both directions + tie-break)
- both-expired → logs loud warning (not silent)
- refresh-log redaction (asserts the refresh_token value never appears in any log line)

`npm run build` clean; **77/77 tests pass** across `auth-providers` + `credential-proxy`.

## Out of scope (deliberate)

- **`com.deus.oauth-refresh` launchd guard** — confirmed not installed on the host; it's the idle-case fix (incident A). Handled as a **separate operational step**, not bundled into this code PR.
- **Refresh-token rotation handling** — logged, not built, until `invalid_grant` is observed in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)