### PR TITLE
feat(events): add in-process EventBus + agent.done emit (Phase 1)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780238753
+last_verified: "2026-05-31" # auto-bump @1780241514
 governs:
   - src/
   - evolution/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780239934
+last_verified: "2026-05-31" # auto-bump @1780238753
 governs:
   - src/
   - evolution/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780177680
+last_verified: "2026-05-31" # auto-bump @1780239934
 governs:
   - src/
   - evolution/

--- a/src/events/bus.test.ts
+++ b/src/events/bus.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus, getBus } from './bus.js';
+import type { EventEnvelope } from './types.js';
+
+function mkEnv(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
+  return {
+    type: 'agent.done',
+    source: 'test',
+    actor: 'system',
+    correlationId: { kind: 'issue', id: 'ISS-1', identifier: 'LIA-1' },
+    ts: new Date().toISOString(),
+    payload: { output: 'ok' },
+    ...overrides,
+  };
+}
+
+describe('EventBus', () => {
+  it('delivers an event to a type-matched subscriber', async () => {
+    const bus = new EventBus();
+    const seen: EventEnvelope[] = [];
+    bus.subscribe('agent.done', (e) => {
+      seen.push(e);
+    });
+    await bus.emit(mkEnv());
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe('agent.done');
+  });
+
+  it('delivers every event to catch-all `on` handlers', async () => {
+    const bus = new EventBus();
+    const seen: string[] = [];
+    bus.on((e) => {
+      seen.push(e.type);
+    });
+    await bus.emit(mkEnv());
+    expect(seen).toEqual(['agent.done']);
+  });
+
+  it('awaits async handlers sequentially in registration order', async () => {
+    const bus = new EventBus();
+    const order: number[] = [];
+    // First handler is slower than the second. If emit awaited sequentially the
+    // result is [1, 2]; a parallel/fire-and-forget emit would yield [2, 1].
+    bus.subscribe('agent.done', async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      order.push(1);
+    });
+    bus.subscribe('agent.done', async () => {
+      await new Promise((r) => setTimeout(r, 1));
+      order.push(2);
+    });
+    await bus.emit(mkEnv());
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('isolates a synchronously throwing handler — siblings run, emit resolves', async () => {
+    const bus = new EventBus();
+    const ran: string[] = [];
+    bus.subscribe('agent.done', () => {
+      throw new Error('boom');
+    });
+    bus.subscribe('agent.done', () => {
+      ran.push('second');
+    });
+    await expect(bus.emit(mkEnv())).resolves.toBeUndefined();
+    expect(ran).toEqual(['second']);
+  });
+
+  it('isolates a rejecting async handler too', async () => {
+    const bus = new EventBus();
+    const ran: string[] = [];
+    bus.subscribe('agent.done', async () => {
+      throw new Error('async boom');
+    });
+    bus.subscribe('agent.done', async () => {
+      ran.push('after');
+    });
+    await expect(bus.emit(mkEnv())).resolves.toBeUndefined();
+    expect(ran).toEqual(['after']);
+  });
+
+  it('unsubscribe removes a type subscriber', async () => {
+    const bus = new EventBus();
+    const fn = vi.fn();
+    const off = bus.subscribe('agent.done', fn);
+    off();
+    await bus.emit(mkEnv());
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe removes a catch-all handler', async () => {
+    const bus = new EventBus();
+    const fn = vi.fn();
+    const off = bus.on(fn);
+    off();
+    await bus.emit(mkEnv());
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('getBus returns a stable singleton', () => {
+    expect(getBus()).toBe(getBus());
+  });
+});

--- a/src/events/bus.ts
+++ b/src/events/bus.ts
@@ -1,0 +1,76 @@
+import { logger } from '../logger.js';
+import type { DeusEvent, EventEnvelope, Handler } from './types.js';
+
+/**
+ * In-process observer/pub-sub hub. Three properties are correctness, not style:
+ *  - sequential `await` in `emit` preserves the per-turn ordering the
+ *    orchestrator's output chain already guarantees;
+ *  - per-listener try/catch isolation — a thrown handler cannot break the
+ *    emitter or its siblings (the one thing the private prototype lacks);
+ *  - the contract is pure: `emit` returns Promise<void> and never reports
+ *    per-listener success, so a critical write routed through a listener must
+ *    keep its success-coupled follow-ups inside the same handler.
+ *
+ * Dispatch is O(listeners): a linear scan over [...catch-all, ...by-type].
+ */
+export class EventBus {
+  private readonly anyHandlers: Handler[] = [];
+  private readonly byType = new Map<DeusEvent['type'], Handler[]>();
+
+  /** Subscribe to one event type. Returns an unsubscribe function. */
+  subscribe<T extends DeusEvent['type']>(
+    type: T,
+    handler: Handler<Extract<DeusEvent, { type: T }>>,
+  ): () => void {
+    const list = this.byType.get(type) ?? [];
+    list.push(handler as Handler);
+    this.byType.set(type, list);
+    return () => {
+      const arr = this.byType.get(type);
+      if (!arr) return;
+      const idx = arr.indexOf(handler as Handler);
+      if (idx !== -1) arr.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Catch-all subscription — receives every event regardless of type. Reserved
+   * for the Phase-2 ObservabilitySink + pipeline-events mirror; no production
+   * listener uses it yet. Returns an unsubscribe function.
+   */
+  on(handler: Handler): () => void {
+    this.anyHandlers.push(handler);
+    return () => {
+      const idx = this.anyHandlers.indexOf(handler);
+      if (idx !== -1) this.anyHandlers.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Deliver an envelope to catch-all handlers then type-matched handlers, in
+   * registration order, awaiting each sequentially. A handler that throws is
+   * logged and isolated — it neither stops siblings nor rejects this promise.
+   * Targets are snapshotted at emit time, so (un)subscribing mid-emit is safe.
+   */
+  async emit(env: EventEnvelope): Promise<void> {
+    const targets = [...this.anyHandlers, ...(this.byType.get(env.type) ?? [])];
+    for (const handler of targets) {
+      try {
+        await handler(env);
+      } catch (err) {
+        logger.error(
+          { err, type: env.type, correlationId: env.correlationId },
+          'event-bus: listener threw — isolated',
+        );
+      }
+    }
+  }
+}
+
+let _bus: EventBus | null = null;
+
+/** Lazy app-wide singleton, wired at the composition root (index.ts). */
+export function getBus(): EventBus {
+  if (!_bus) _bus = new EventBus();
+  return _bus;
+}

--- a/src/events/listeners/linear-updater.test.ts
+++ b/src/events/listeners/linear-updater.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the two side-effecting modules the listener writes through. Only the
+// symbols the listener imports are needed; LinearContext is a type-only import
+// so linear-dispatcher.ts is never loaded at runtime.
+vi.mock('../../db.js', () => ({
+  logPipelineEvent: vi.fn(),
+}));
+vi.mock('../../linear-notifications.js', () => ({
+  notifyPipelineStep: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { EventBus } from '../bus.js';
+import { registerLinearUpdater } from './linear-updater.js';
+import { logPipelineEvent } from '../../db.js';
+import { notifyPipelineStep } from '../../linear-notifications.js';
+import type { LinearContext } from '../../linear-dispatcher.js';
+import type { EventEnvelope } from '../types.js';
+
+function mkCtx(updateIssue: ReturnType<typeof vi.fn>): LinearContext {
+  return {
+    client: { updateIssue } as unknown as LinearContext['client'],
+    stateByName: new Map([
+      ['In Review', { id: 'review-id', name: 'In Review' }],
+    ]),
+    viewerId: 'viewer-id',
+  } as unknown as LinearContext;
+}
+
+function mkDone(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
+  return {
+    type: 'agent.done',
+    source: 'test',
+    actor: 'bot',
+    correlationId: { kind: 'issue', id: 'ISS-1', identifier: 'LIA-1' },
+    ts: new Date().toISOString(),
+    payload: { output: 'done' },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('registerLinearUpdater', () => {
+  it('dry-run (default): logs only, performs no write or bookkeeping', async () => {
+    const bus = new EventBus();
+    const updateIssue = vi.fn().mockResolvedValue(undefined);
+    registerLinearUpdater(bus, mkCtx(updateIssue)); // default dryRun = true
+    await bus.emit(mkDone());
+    expect(updateIssue).not.toHaveBeenCalled();
+    expect(notifyPipelineStep).not.toHaveBeenCalled();
+    expect(logPipelineEvent).not.toHaveBeenCalled();
+  });
+
+  it('live: moves the issue to In Review and fires both follow-ups', async () => {
+    const bus = new EventBus();
+    const updateIssue = vi.fn().mockResolvedValue(undefined);
+    registerLinearUpdater(bus, mkCtx(updateIssue), { dryRun: false });
+    await bus.emit(mkDone());
+    expect(updateIssue).toHaveBeenCalledTimes(1);
+    expect(updateIssue).toHaveBeenCalledWith('ISS-1', {
+      stateId: 'review-id',
+      assigneeId: 'viewer-id',
+    });
+    expect(notifyPipelineStep).toHaveBeenCalledWith(
+      expect.anything(),
+      'ISS-1',
+      'LIA-1',
+      'agent_completed',
+    );
+    expect(logPipelineEvent).toHaveBeenCalledWith(
+      'ISS-1',
+      'LIA-1',
+      'circuit_breaker_reset',
+      'agent completed successfully',
+    );
+  });
+
+  it('live + write fails: emit resolves (isolated) and NEITHER follow-up fires', async () => {
+    const bus = new EventBus();
+    const updateIssue = vi.fn().mockRejectedValue(new Error('linear 500'));
+    registerLinearUpdater(bus, mkCtx(updateIssue), { dryRun: false });
+    await expect(bus.emit(mkDone())).resolves.toBeUndefined();
+    expect(updateIssue).toHaveBeenCalledTimes(1);
+    // Load-bearing: a failed transition must NOT fire circuit_breaker_reset
+    // (which would zero the consecutive-fail counter and mask repeat failures)
+    // or agent_completed. The awaited updateIssue throw exits the handler first.
+    expect(notifyPipelineStep).not.toHaveBeenCalled();
+    expect(logPipelineEvent).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-issue correlations', async () => {
+    const bus = new EventBus();
+    const updateIssue = vi.fn().mockResolvedValue(undefined);
+    registerLinearUpdater(bus, mkCtx(updateIssue), { dryRun: false });
+    await bus.emit(mkDone({ correlationId: { kind: 'run', id: 'run-1' } }));
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+});

--- a/src/events/listeners/linear-updater.ts
+++ b/src/events/listeners/linear-updater.ts
@@ -1,0 +1,80 @@
+import { logger } from '../../logger.js';
+import { logPipelineEvent } from '../../db.js';
+import { notifyPipelineStep } from '../../linear-notifications.js';
+import type { LinearContext } from '../../linear-dispatcher.js';
+import type { EventBus } from '../bus.js';
+
+/**
+ * Step-1 (dual-run) default: the listener is log-only and the dispatcher's
+ * inline write stays authoritative, so we can observe the live emit path on
+ * real traffic without changing behavior. At Step-2 cutover this flips to
+ * `false` and the inline block in linear-dispatcher.ts is deleted — removing
+ * this constant (and the `dryRun` plumbing) IS the cutover diff.
+ */
+const DRY_RUN_DEFAULT: boolean = true;
+
+/**
+ * The flagship event-hub listener. Phase 1 handles only `agent.done`, absorbing
+ * the dispatcher's "-> In Review" transition plus its two success-coupled
+ * bookkeeping events (`agent_completed`, `circuit_breaker_reset`).
+ *
+ * The three writes are co-located and `updateIssue` is awaited FIRST, so a write
+ * failure (caught and isolated by the bus) exits the handler before the
+ * follow-ups run — exact parity with the post-run try/catch in the dispatcher's
+ * `runIssue`. This is load-bearing: firing `circuit_breaker_reset` on a failed
+ * transition would zero the consecutive-failure counter (`getConsecutiveFailCount`
+ * in db.ts) and mask repeat failures.
+ *
+ * Loop-safe: the write reuses ctx.client (the bot user), so the Linear webhook's
+ * bot-actor guard (it skips transitions whose actor is the bot user) suppresses
+ * this self-triggered transition exactly as the inline write does today.
+ *
+ * Returns an unsubscribe function.
+ */
+export function registerLinearUpdater(
+  bus: EventBus,
+  ctx: LinearContext,
+  opts: { dryRun?: boolean } = {},
+): () => void {
+  const dryRun = opts.dryRun ?? DRY_RUN_DEFAULT;
+
+  return bus.subscribe('agent.done', async (e) => {
+    if (e.correlationId.kind !== 'issue') return;
+    const issueId = e.correlationId.id;
+
+    if (dryRun) {
+      logger.info(
+        { issueId },
+        'linear-updater[dry-run]: would set In Review + agent_completed + circuit_breaker_reset',
+      );
+      return;
+    }
+
+    const identifier = e.correlationId.identifier ?? '';
+    const reviewState = ctx.stateByName.get('In Review');
+    if (!reviewState) {
+      logger.warn(
+        { issueId },
+        'linear-updater: no "In Review" workflow state — skipping transition',
+      );
+      return;
+    }
+
+    // updateIssue awaited first: a throw here exits the handler (and is isolated
+    // by the bus), skipping both follow-ups below — never a false reset.
+    await ctx.client.updateIssue(issueId, {
+      stateId: reviewState.id,
+      assigneeId: ctx.viewerId,
+    });
+    notifyPipelineStep(ctx, issueId, identifier, 'agent_completed').catch(
+      () => {},
+    );
+    logPipelineEvent(
+      issueId,
+      identifier,
+      'circuit_breaker_reset',
+      'agent completed successfully',
+    );
+    logger.info({ issueId }, 'linear-updater: issue moved to In Review');
+  });
+}

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Event-hub envelope + taxonomy (Phase 1).
+ *
+ * One namespaced envelope unifies the orchestrator's divergent event models so
+ * any number of observers can subscribe by type and react independently — the
+ * pattern is sender -> event -> listener. Phase 1 defines only `agent.done`;
+ * later phases add variants additively.
+ *
+ * See Research/2026-05-31-event-hub-evolution-design.md.
+ */
+
+/**
+ * Correlates an event to the thing it is about. A namespaced union because many
+ * events have no Linear issue — only a group or run — which is what lets ONE bus
+ * carry chat-driven turns AND Linear-driven outcomes. Phase 1 exercises only
+ * `issue`; the other variants are the forward contract.
+ */
+export type CorrelationRef =
+  | { kind: 'issue'; id: string; identifier?: string }
+  | { kind: 'task'; id: string }
+  | { kind: 'group'; id: string }
+  | { kind: 'run'; id: string };
+
+/**
+ * Discriminated union of every event the hub carries. Phase 1: `agent.done`
+ * only. Add a member here when a phase introduces a new event type.
+ */
+export type DeusEvent = {
+  type: 'agent.done';
+  payload: { output?: string; prUrl?: string };
+};
+
+/**
+ * What an emitter sends and a handler receives. `actor` is metadata for
+ * listeners (e.g. 'bot' marks a self-write so downstream consumers can reason
+ * about loops) — it is NOT the Linear webhook actor, which is a separate Linear
+ * API field.
+ */
+export interface EventEnvelope<E extends DeusEvent = DeusEvent> {
+  readonly type: E['type'];
+  readonly source: string;
+  readonly actor: 'agent' | 'bot' | 'human' | 'system';
+  readonly correlationId: CorrelationRef;
+  readonly ts: string; // ISO 8601
+  readonly payload: E['payload'];
+}
+
+export type Handler<E extends DeusEvent = DeusEvent> = (
+  env: EventEnvelope<E>,
+) => void | Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import {
 import type { LinearContext } from './linear-dispatcher.js';
 import { loadGateSpecs } from './linear-gate-specs.js';
 import { startLinearWebhookServer } from './linear-webhook.js';
+import { registerLinearUpdater } from './events/listeners/linear-updater.js';
 
 export { getAvailableGroups } from './router-state.js';
 
@@ -392,6 +393,8 @@ async function main(): Promise<void> {
       logger.error({ err }, 'linear: initialization failed');
     }
     if (linearCtx) {
+      // Register event-hub listeners before the dispatcher can fire any event.
+      registerLinearUpdater(linearCtx.bus, linearCtx);
       startLinearDispatcher(linearCtx);
 
       const wardensDir = path.join(

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -130,6 +130,7 @@ import type {
 } from './linear-dispatcher.js';
 import { RuntimeRegistry } from './agent-runtimes/registry.js';
 import { logger } from './logger.js';
+import { EventBus } from './events/bus.js';
 
 function makeMockDeps(
   overrides: Partial<LinearDispatcherDependencies> = {},
@@ -152,6 +153,7 @@ function makeMockCtx(overrides: Partial<LinearContext> = {}): LinearContext {
   const deps = makeMockDeps();
   return {
     client: {} as LinearContext['client'],
+    bus: new EventBus(),
     stateByName: new Map([
       ['Ready for Agent', { id: 'ready-id', name: 'Ready for Agent' }],
       ['Agent Working', { id: 'working-id', name: 'Agent Working' }],

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -33,6 +33,7 @@ import {
 import { notifyPipelineStep } from './linear-notifications.js';
 import { resolveVaultPath } from './solutions/store.js';
 import { defaultSession } from './agent-runtimes/types.js';
+import { getBus } from './events/bus.js';
 import type {
   RunContext,
   RuntimeEventSink,
@@ -41,6 +42,7 @@ import type {
 import type { RuntimeRegistry } from './agent-runtimes/registry.js';
 import type { GroupQueue } from './group-queue.js';
 import type { RegisteredGroup } from './types.js';
+import type { EventBus } from './events/bus.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -121,6 +123,7 @@ export interface GateLabels {
 
 export interface LinearContext {
   client: LinearClient;
+  bus: EventBus; // app-wide event hub; same singleton at emit- and register-side
   stateByName: Map<string, WorkflowState>;
   stateById: Map<string, WorkflowState>;
   botUserId: string;
@@ -1318,6 +1321,21 @@ async function runIssue(
         'agent completed successfully',
       );
       logger.info({ issueId }, 'linear-dispatcher: issue moved to In Review');
+
+      // Event-hub Phase 1: emit `agent.done` alongside the inline write above.
+      // The LinearUpdater listener is dry-run (log-only) in Step 1, so the
+      // inline block remains authoritative and behavior is unchanged. At the
+      // Step-2 cutover the inline In-Review block (updateIssue + agent_completed
+      // + circuit_breaker_reset) is deleted and this emit becomes the sole
+      // driver via the live listener.
+      await ctx.bus.emit({
+        type: 'agent.done',
+        source: 'linear-dispatcher',
+        actor: 'bot',
+        correlationId: { kind: 'issue', id: issueId, identifier },
+        ts: new Date().toISOString(),
+        payload: { output: body, prUrl: prUrl ?? undefined },
+      });
     }
   } catch (err) {
     logger.warn(
@@ -1828,6 +1846,7 @@ export async function initLinearContext(
 
     return {
       client,
+      bus: getBus(),
       stateByName,
       stateById,
       botUserId,


### PR DESCRIPTION
## Phase 1 — Event Hub first vertical slice

First slice of the orchestrator-wide event hub (design: `Research/2026-05-31-event-hub-evolution-design.md`, in the vault). Proves the **sender → event → listener** pattern end-to-end on one real write. **Additive and behavior-preserving**: the `LinearUpdater` listener defaults to **dry-run (log-only)**, so the dispatcher's inline "→ In Review" write stays authoritative until a later **Step-2 cutover** (separate PR, after observing the dry-run on real traffic).

### What changed
- **`src/events/{types,bus}.ts`** — `EventBus`: sequential-`await` `emit` (preserves per-turn ordering), per-listener `try/catch` isolation (a thrower can't break the emitter or siblings), typed `subscribe` + catch-all `on`, `getBus()` lazy singleton. `agent.done`-only taxonomy (YAGNI).
- **`src/events/listeners/linear-updater.ts`** — `registerLinearUpdater`. On `agent.done` it co-locates the In-Review `updateIssue` + `agent_completed` + `circuit_breaker_reset` as **one atomic unit with `updateIssue` awaited first**, so a write failure (isolated by the bus) skips the follow-ups — never a spurious `circuit_breaker_reset` that would zero the consecutive-fail counter and mask repeat failures. Dry-run by default.
- **`linear-dispatcher.ts`** — `bus` on `LinearContext` (via `getBus()`); emit `agent.done` from the `runIssue` success branch.
- **`index.ts`** — register the listener before the dispatcher starts.
- **tests** — bus (ordering / isolation / type-filter / unsubscribe) + listener (happy path, the **write-fails → no-false-reset** guard, non-issue correlation ignored).

### Constraints honored
- `message-orchestrator.ts` **untouched** — user-send / cursor-advance / error-flag stay inline (the Phase-5 observer move is out of scope).
- Hub is **public** (`src/events/`); the private `src/private/orchestrator/event-bus.ts` is not modified, imported, or bundled.

### Verification
- `npm run typecheck` clean · `npm test` **1371 passed (79 files)** · `eslint` 0 errors.
- **plan-reviewer SHIP** (2 rounds — round 1 caught the `circuit_breaker_reset` coupling, fixed above) · **code-reviewer SHIP** (no blockers).

### Deferred (tracked here)
- The catch-all `on()` and the `task`/`group`/`run` `CorrelationRef` variants are the plan-approved **forward contract** with no caller yet (catch-all → Phase-2 ObservabilitySink; other correlations → chat/run-driven events). See the design-doc roadmap (Phases 2–14). A dedicated Phase-2 Linear tracking issue can be filed on request.
- **Step-2 cutover** (follow-up PR): flip the listener live, delete the inline In-Review block, add an ADR companion note to `docs/decisions/linear-webhook-pipeline.md`, and add a producer-edge emit assertion.

> Note: `ef641e45 chore(patterns): auto-bump drifted patterns` is the repo's pre-push drift-check housekeeping, not part of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
