### PR TITLE
fix(warden): resolve workflow-agent transcripts in codegraph-first gate (RETRO-2026-05-31-01)

### DIFF
--- a/.claude/agents/architecture-snapshot.md
+++ b/.claude/agents/architecture-snapshot.md
@@ -20,8 +20,8 @@ Accuracy > completeness. A precise map of 80% of the system beats a vague map of
    c. Read `$REPO_ROOT/CLAUDE.md` or `$REPO_ROOT/README.md` -- stated architecture (to compare against reality)
    d. `ls $REPO_ROOT/src/` (or equivalent source root) -- module structure
    e. For each top-level module under `src/`: read the `index.ts` / `mod.rs` / `__init__.py` / entry file only -- NOT the full implementation.
-   f. Find entry points: `grep -r "listen\|createServer\|app.start\|main()\|process.argv" $REPO_ROOT/src --include="*.ts" -l | head -10`
-   g. Find key data structures: `grep -r "interface \|type \|struct \|class \|schema" $REPO_ROOT/src --include="*.ts" -l | head -10` -- read the most central-looking 2-3 files
+   f. Find entry points (three-stage protocol, `core-behavioral-rules.md § Code Exploration`): FIRST `codegraph_context` for "entry points / server bootstrap / main" (load via `ToolSearch("select:mcp__codegraph__codegraph_context")` if deferred); CONFIRM only if needed with `grep -r "listen\|createServer\|app.start\|main()\|process.argv" $REPO_ROOT/src --include="*.ts" -l | head -10` (adapt the language glob to the repo)
+   g. Find key data structures: FIRST `codegraph_context` or `search_code` (load deferred tools via `ToolSearch("select:mcp__codegraph__codegraph_context")` or `ToolSearch("select:mcp__code-search__search_code")`) for the core interfaces, types, and schemas; CONFIRM with `grep -r "interface \|type \|struct \|class \|schema" $REPO_ROOT/src --include="*.ts" -l | head -10` -- read the most central-looking 2-3 files
 
 3. **Do NOT read implementation bodies.** If a file has a clear interface (exported types, function signatures), read that. Implementations are noise for a map.
 
@@ -73,7 +73,7 @@ Accuracy > completeness. A precise map of 80% of the system beats a vague map of
 
 ## Rules of engagement
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 - **Accuracy over coverage.** If you didn't read it, don't include it. Mark it in "What This Snapshot Doesn't Cover."
 - **No prescriptions.** Describe, don't prescribe. Don't write "you should refactor X."
 - **Concrete names only.** No "the service", "the handler". Use actual module and file names.

--- a/.claude/agents/threat-modeler.md
+++ b/.claude/agents/threat-modeler.md
@@ -15,7 +15,7 @@ You are the `threat-modeler` Warden -- an architecture-level adversary reviewer.
 2. **Checklists** -- read `$REPO_ROOT/.claude/wardens/threat-modeling-checklists.md`. Cross-reference the STRIDE sections against the design. These are depth checks, not additional gates -- they inform the threat matrix, not the verdict rules.
 3. **The design description** -- provided as the invocation prompt. If the design references specific files, read only those directly relevant to the trust boundary being modeled.
 4. **`$REPO_ROOT/CLAUDE.md`** -- for project-level security posture notes (if present). Skip silently if absent.
-5. **Existing auth/security patterns** -- run `grep -rl "auth\|token\|secret\|session\|credential" $REPO_ROOT/src --include="*.ts" 2>/dev/null | head -5` and read the most relevant 1-2 files for context on current patterns. Adapt the glob to the repo's primary language.
+5. **Existing auth/security patterns** -- follow the three-stage protocol (`core-behavioral-rules.md § Code Exploration`): FIRST `codegraph_context` (load via `ToolSearch("select:mcp__codegraph__codegraph_context")` if deferred) or `search_code` (load via `ToolSearch("select:mcp__code-search__search_code")`) to locate the auth/session/credential surface, then read the most relevant 1-2 files. Use `grep -rl "auth\|token\|secret\|session\|credential" $REPO_ROOT/src --include="*.ts" 2>/dev/null | head -5` only to CONFIRM specific call sites -- not as the first move. Adapt the language glob to the repo.
 6. **Memory** -- discover with `ls $HOME/.claude/projects/*/memory/MEMORY.md 2>/dev/null | grep -i $(basename $REPO_ROOT) | head -1`. If found, check for security-related feedback entries. Skip silently if none.
 
 Do NOT read all source files. Focus on the system described, not the full codebase. If you find yourself reading >6 files, you're over-researching.
@@ -58,7 +58,7 @@ Return a single markdown report. No preamble.
 
 ## Rules of engagement
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
 - **Architecture only.** Code-level findings (injection in a specific function, missing sanitization) go to code-reviewer, not this report.
 - **STRIDE is the frame.** Every threat maps to: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, or Elevation of Privilege.
 - **Cite rule ids.** Every Blocking Gap ties to a specific rule from the rules file.

--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -37,9 +37,10 @@
 - Chat responses always in English. Hebrew only inside artifacts.
 
 ## Code Exploration
-- Three-stage protocol: (1) `search_code` for semantic candidates, (2) `codegraph_callers`/`codegraph_callees`/`codegraph_impact` for structural context (what connects to the candidates), (3) grep/read for exact confirmation. Skip stages when the answer is already known.
+- Three-stage protocol: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) `codegraph_callers`/`codegraph_callees`/`codegraph_impact` for structural context (what connects to the candidates), (3) grep/read for exact confirmation. Skip stages when the answer is already known.
 - Before modifying any function, query `codegraph_callers` to know the blast radius. A change with 2 callers is not the same risk as a change with 50.
 - Never open-code `grep -r` or `find -name` as the first move -- semantic search identifies the landscape, structural queries map the connections, exact search confirms specifics.
+- When authoring a `Workflow` (or dispatching investigation subagents) over a codegraph-indexed repo, bake the codegraph-first mandate INTO the `agent()` prompts -- `workflow-subagent` agents inherit no exploration hook and codegraph is already directly callable from them, so their prompt is the only lever.
 
 ## Memory & Context
 - Before implementing a feature, search memory (`memory_tree.py query "<topic>"`) for prior decisions and research. Cite the retrieved path.

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -506,17 +506,47 @@ def _resolve_agent_transcript(event: dict[str, Any]) -> str:
     Empirically validated (LIA-121): the PreToolUse event for a Task-spawned
     subagent carries ``agent_id`` + ``agent_type``; the derived file exists at
     tool-call time and holds the subagent's ``tool_use`` entries.
+
+    Workflow-spawned subagents write their transcript DEEPER, at
+    ``.../<session_id>/subagents/workflows/wf_<run>/agent-<agent_id>.jsonl``, so the
+    flat derivation misses and the gate would silently fail open (observed: 3
+    ``codegraph-gate CANARY`` fail-opens). When the flat path is absent we resolve
+    the file under this session's ``subagents/workflows/*/`` -- only on a flat-path
+    miss, so the common Task path and the "not yet written -> fail open" behavior are
+    unchanged.
     """
     tp = str(event.get("transcript_path") or "")
     if not tp:
         return ""
     agent_id = str(event.get("agent_id") or "")
     if agent_id:
-        # Path(agent_id).name strips any directory components -- defense in depth
-        # against a malformed agent_id (the scan is read-only, but make the
-        # "agent_id is a bare identifier" assumption explicit, no traversal).
+        # Path().name strips directory components; the regex below then ENFORCES the
+        # "bare identifier" assumption -- a crafted agent_id with glob metacharacters
+        # (*, ?, []) could otherwise match a SIBLING agent's file via the glob and
+        # falsely unblock a grep-first agent. On an unexpected shape we fail open via
+        # the flat path rather than glob.
         safe_id = Path(agent_id).name
-        return str(Path(tp).with_suffix("") / "subagents" / f"agent-{safe_id}.jsonl")
+        subagents_dir = Path(tp).with_suffix("") / "subagents"
+        direct = subagents_dir / f"agent-{safe_id}.jsonl"
+        if direct.exists():
+            return str(direct)
+        # Flat path absent: resolve the deeper workflow location with a precise,
+        # non-recursive glob (known layout: subagents/workflows/wf_*/). A future
+        # layout change is caught by drift_check.check_codegraph_transcript_format,
+        # not silently absorbed here.
+        if re.fullmatch(r"[A-Za-z0-9_-]+", safe_id):
+            try:
+                match = next(
+                    iter(subagents_dir.glob(f"workflows/*/agent-{safe_id}.jsonl")),
+                    None,
+                )
+            except OSError:
+                match = None
+            if match is not None:
+                return str(match)
+        # Not-yet-written, or an unexpected id shape: return the flat path so the
+        # scan fails open (unchanged prior behavior).
+        return str(direct)
     return tp
 
 

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1539,6 +1539,44 @@ def check_codegraph_transcript_format(project_root: Path) -> int:
     else:
         print("SKIP: no subagent transcripts found — cannot verify path derivation")
 
+    # Workflow-subagent path-derivation invariant (SEPARATE from the flat check
+    # above). Workflow agents write at <session>/subagents/workflows/wf_*/agent-*.jsonl;
+    # round-trip the real resolver against a real workflow file so a CC layout change
+    # FAILs here instead of silently failing the gate open. SKIP (never FAIL) when no
+    # workflow transcripts exist (cold environment).
+    resolve = getattr(cwh, "_resolve_agent_transcript", None)
+    if resolve is None:
+        print(
+            "FAIL: _resolve_agent_transcript not found in codex_warden_hooks.py — "
+            "the workflow-path fallback was removed or renamed."
+        )
+        return 1
+    wf_files = list(projects_dir.rglob("subagents/workflows/*/agent-*.jsonl"))
+    if wf_files:
+        wf_sample = max(wf_files, key=lambda p: p.stat().st_mtime)
+        # Reconstruct <proj>/<session_id>.jsonl from the session-boundary 'subagents'.
+        # Use the LAST occurrence so a project dir literally named 'subagents' can't
+        # shift the boundary; it is guaranteed present (we globbed on it).
+        parts = wf_sample.parts
+        sidx = max(i for i, p in enumerate(parts) if p == "subagents")
+        session_dir = Path(*parts[:sidx])  # <proj>/<session_id>
+        parent_file = session_dir.parent / (session_dir.name + ".jsonl")
+        wf_agent_id = wf_sample.stem[len("agent-"):]
+        derived = resolve({"transcript_path": str(parent_file), "agent_id": wf_agent_id})
+        if Path(derived) != wf_sample:
+            print(
+                f"FAIL: workflow subagent path derivation no longer resolves the real "
+                f"file (sample {wf_sample}, derived {derived}). Update the glob-fallback "
+                "in _resolve_agent_transcript in codex_warden_hooks.py."
+            )
+            return 1
+        print(f"OK: workflow subagent path-derivation intact ({wf_sample.name})")
+    else:
+        print(
+            "SKIP: no workflow subagent transcripts found — "
+            "cannot verify workflow path derivation"
+        )
+
     return 0
 
 

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -3355,6 +3355,108 @@ def test_codegraph_gate_fail_open_missing_transcript(tmp_path, capsys):
     assert capsys.readouterr().out == ""  # fail open, no deny
 
 
+# --- _resolve_agent_transcript: workflow-spawned agents (bounded glob-fallback) ---
+# Regression for the silent fail-open bug where a workflow agent's transcript lives
+# at subagents/workflows/wf_*/agent-<id>.jsonl but the flat derivation looked under
+# subagents/agent-<id>.jsonl (3 codegraph-gate CANARY fail-opens observed live).
+
+
+def test_resolve_agent_transcript_workflow_layout(tmp_path):
+    """A workflow agent's deeper transcript is found via the bounded glob-fallback."""
+    hooks = load_hooks()
+    session_id = "sessW"
+    parent = tmp_path / f"{session_id}.jsonl"
+    parent.write_text("", encoding="utf-8")
+    agent_id = "aWorkflow01"
+    wf_dir = tmp_path / session_id / "subagents" / "workflows" / "wf_abc123"
+    wf_dir.mkdir(parents=True)
+    wf_file = wf_dir / f"agent-{agent_id}.jsonl"
+    wf_file.write_text(_BASH_LINE + "\n", encoding="utf-8")
+
+    event = {"transcript_path": str(parent), "agent_id": agent_id}
+    assert hooks._resolve_agent_transcript(event) == str(wf_file)
+
+
+def test_resolve_agent_transcript_flat_subagent_unchanged(tmp_path):
+    """The common flat Task-subagent path still resolves to subagents/agent-<id>.jsonl."""
+    hooks = load_hooks()
+    session_id = "sessF"
+    parent = tmp_path / f"{session_id}.jsonl"
+    parent.write_text("", encoding="utf-8")
+    agent_id = "aFlat02"
+    flat_dir = tmp_path / session_id / "subagents"
+    flat_dir.mkdir(parents=True)
+    flat_file = flat_dir / f"agent-{agent_id}.jsonl"
+    flat_file.write_text(_BASH_LINE + "\n", encoding="utf-8")
+
+    event = {"transcript_path": str(parent), "agent_id": agent_id}
+    assert hooks._resolve_agent_transcript(event) == str(flat_file)
+
+
+def test_resolve_agent_transcript_missing_returns_flat_path(tmp_path):
+    """Not-yet-written (neither flat nor workflow file): return the flat path so the
+    scan fails open, exactly as before the fix."""
+    hooks = load_hooks()
+    session_id = "sessM"
+    parent = tmp_path / f"{session_id}.jsonl"
+    parent.write_text("", encoding="utf-8")
+    agent_id = "aMissing03"
+    expected_flat = tmp_path / session_id / "subagents" / f"agent-{agent_id}.jsonl"
+
+    event = {"transcript_path": str(parent), "agent_id": agent_id}
+    assert hooks._resolve_agent_transcript(event) == str(expected_flat)
+
+
+def test_codegraph_gate_resolves_workflow_subagent_transcript(tmp_path, capsys):
+    """End-to-end: a workflow-spawned agent with a prior codegraph call is unblocked;
+    without one it is blocked. Before the fix the gate silently failed open here."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    session_id = "wsess"
+    parent = tmp_path / f"{session_id}.jsonl"
+    parent.write_text("", encoding="utf-8")
+    wf_dir = tmp_path / session_id / "subagents" / "workflows" / "wf_xyz"
+    wf_dir.mkdir(parents=True)
+
+    # Agent WITH a codegraph call → grep allowed.
+    aid_ok = "aWfOk"
+    (wf_dir / f"agent-{aid_ok}.jsonl").write_text(_MCP_CODEGRAPH_LINE + "\n", encoding="utf-8")
+    ev_ok = tool_event(repo, "Grep")
+    ev_ok["transcript_path"] = str(parent)
+    ev_ok["agent_id"] = aid_ok
+    assert hooks.run_codegraph_first_gate(ev_ok, repo) == 0
+    assert capsys.readouterr().out == ""  # unblocked
+
+    # Agent WITHOUT a codegraph call → grep now actually blocked (was a silent no-op).
+    aid_block = "aWfBlock"
+    (wf_dir / f"agent-{aid_block}.jsonl").write_text(_BASH_LINE + "\n", encoding="utf-8")
+    ev_block = tool_event(repo, "Grep")
+    ev_block["transcript_path"] = str(parent)
+    ev_block["agent_id"] = aid_block
+    assert hooks.run_codegraph_first_gate(ev_block, repo) == 0
+    assert _deny(capsys) == "deny"
+
+
+def test_resolve_agent_transcript_rejects_glob_metacharacter_id(tmp_path):
+    """A crafted agent_id with glob metacharacters must NOT match a sibling file
+    (gate-bypass guard) -- it fails open via the literal flat path instead."""
+    hooks = load_hooks()
+    session_id = "sessGlob"
+    parent = tmp_path / f"{session_id}.jsonl"
+    parent.write_text("", encoding="utf-8")
+    # A real sibling workflow file exists and HAS a codegraph call.
+    wf_dir = tmp_path / session_id / "subagents" / "workflows" / "wf_1"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "agent-aRealSibling.jsonl").write_text(
+        _MCP_CODEGRAPH_LINE + "\n", encoding="utf-8"
+    )
+    # Attacker-shaped id "*" would glob-match the sibling (and falsely unblock) if
+    # the metacharacter guard were missing.
+    resolved = hooks._resolve_agent_transcript({"transcript_path": str(parent), "agent_id": "*"})
+    assert resolved == str(tmp_path / session_id / "subagents" / "agent-*.jsonl")
+    assert "aRealSibling" not in resolved
+
+
 def test_codegraph_gate_fail_open_unreadable_transcript(tmp_path, capsys):
     """Unreadable transcript path → fail open (no deny)."""
     hooks = load_hooks()

--- a/scripts/vault_context_hook.py
+++ b/scripts/vault_context_hook.py
@@ -23,7 +23,6 @@ from pathlib import Path
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 
 SEMANTIC_CACHE = Path.home() / ".deus" / "resume_semantic_cache.txt"
-INDEX_STALE_FLAG = Path.home() / ".deus" / "index_stale.flag"
 SEMANTIC_TTL = 14400  # 4 hours
 MAX_SECTION_CHARS = 12000
 
@@ -104,39 +103,14 @@ def _load_semantic_cache() -> str:
         return ""
 
 
-def _check_index_stale() -> str:
-    """Return a warning string if the claude-context index is known to be stale."""
-    try:
-        if INDEX_STALE_FLAG.exists():
-            return (
-                "⚠️ claude-context index is stale — commits have landed since the last reindex.\n"
-                "Semantic code search (`search_code`) results may be outdated.\n"
-                "To reindex now: call `index_codebase` with the repo root."
-            )
-    except OSError:
-        pass
-    return ""
-
-
 def main() -> None:
     try:
         sys.stdin.read()
     except (OSError, UnicodeDecodeError):
         pass
 
-    # Check stale flag before any guards — warn all session types (CLI + GUI)
-    stale_warning = _check_index_stale()
-
     if os.environ.get("DEUS_VAULT_PRELOADED") == "1":
-        # CLI sessions already have vault context injected; only emit stale warning if needed
-        if stale_warning:
-            output = {
-                "hookSpecificOutput": {
-                    "hookEventName": "SessionStart",
-                    "additionalContext": stale_warning,
-                }
-            }
-            json.dump(output, sys.stdout)
+        # CLI sessions already have vault context injected; nothing to add.
         return
 
     cwd = Path.cwd()
@@ -149,10 +123,6 @@ def main() -> None:
         return
 
     sections = []
-
-    # Prepend stale-index warning so it surfaces prominently at session start
-    if stale_warning:
-        sections.append(stale_warning)
 
     vault_files = _load_vault_files(vault, config)
     if vault_files:


### PR DESCRIPTION
## Why

Across the 2026-05-31 GroupAuth + event-hub session, the semantic-search infra (codegraph + code_search) was barely used on the **indexed** `~/deus` — even by the agents whose whole job is investigation. Re-baselined this session:

- **7 `workflow-subagent` design agents** investigating indexed `~/deus`: **1** semantic call vs **76 Read + 40 Bash** (18 of the Bash were grep/find — all classic codegraph use-cases).
- **Main thread:** **0** semantic vs **156 Bash + 28 Read**.

The handoff's original fix (expand the codegraph-first **blocking gate** past `code-explorer`) was found **structurally unable to reach the measured offenders**, verified two ways:

1. Per LIA-121's live-tested findings: **settings.json hooks fire in the main session only, never in subagents**; frontmatter hooks reach only **named `.claude/agents/*.md` agents**. The offenders are `agentType: workflow-subagent` → maps to **no `.md` file** → no hook reaches them.
2. An empirical test workflow this session confirmed it end-to-end and surfaced a **real bug**: a `code-explorer`-typed workflow agent ran grep-first and was **not** blocked — the gate's hook fired but **failed open** (3 `codegraph-gate CANARY` entries) because `_resolve_agent_transcript` derived the wrong path for workflow agents. It also showed codegraph is **already directly callable** from workflow agents (no ToolSearch needed) — so for that population the gap is **habit, not availability**.

So the fix is **prompt + de-friction + a contained gate bugfix**, NOT blocking-gate expansion to multi-purpose agents (LIA-121 explicitly rejected gating `general` because it greps logs/data and the gate can't tell code-grep from log-grep).

## What changed

- **`scripts/codex_warden_hooks.py`** — `_resolve_agent_transcript` now resolves workflow-agent transcripts at `subagents/workflows/wf_*/agent-<id>.jsonl` via a **bounded, non-recursive glob** that fires only on a flat-path miss. **Regex-guarded** (`[A-Za-z0-9_-]+`) against glob-metacharacter injection (a crafted `agent_id` could otherwise match a sibling and falsely unblock). Task-subagent path + fail-open-until-written semantics preserved.
- **`scripts/tests/test_codex_warden_hooks.py`** — +5 tests (workflow resolution, flat unchanged, missing→flat, end-to-end gate, and an injection-guard security test).
- **`scripts/drift_check.py`** — a **separate** workflow-layout invariant (the flat-path invariant is untouched) that round-trips the real resolver against a real workflow file; SKIPs (never FAILs) when no workflow transcripts exist. Uses last-occurrence of `subagents` so a project dir named `subagents` can't shift the boundary.
- **`.claude/agents/threat-modeler.md`, `architecture-snapshot.md`** — two playbook steps that **hardcoded `grep -r` as the first move** now lead with `codegraph_context`/`search_code` (with `ToolSearch` load hints for both deferred tools), grep demoted to confirm-only. Protocol enumerations name `codegraph_context` as the composite primary. (Other 8 `explores_code` agents already correct — untouched.)
- **`.claude/rules/core-behavioral-rules.md`** — one bullet: Workflow `agent()` prompts over an indexed repo must carry the codegraph-first mandate (the only lever for `workflow-subagent` agents).
- **`scripts/vault_context_hook.py`** — removed the dead `_check_index_stale` SessionStart nudge. Its writer was stripped in #536 and claude-context replaced by native code_search in #589; the orphan flag fired a perpetual false "stale" warning pointing at deprecated tools (`claude-context`, `index_codebase`).

## Out of scope / deferred

- **Local de-friction (`alwaysLoad`)** on codegraph + code-search lives in `~/.claude.json` (a personal venv path) and is applied by the maintainer **between sessions** — editing the live file from inside a running session would be reverted on exit. Not bundled here.
- Blocking-gate expansion to multi-purpose agents (false-block hazard, LIA-121) and auto-reindex-on-stale (premature) were explicitly excluded.

## Note for reviewers

`index_stale.flag` had **no in-repo writer** (read-only orphan) — confirmed by grep + git history (writer removed in #536). The removal is not a half-deletion; nothing else needs cleanup.

## Verification

- `pytest scripts/tests/test_codex_warden_hooks.py` → **203 passed**
- `pytest scripts/tests/test_drift_check.py` → **90 passed**
- `python3 scripts/drift_check.py --all --base origin/main` → **ALL CHECKS PASSED** (both flat + workflow path-derivation invariants OK)
- **Post-fix deterministic smoke test** (LIA-121 "deterministic-on-real-data") against the real workflow transcript that previously failed open:
  ```
  resolved -> .../subagents/workflows/wf_02a314ad-5cb/agent-a805f50901ed10a29.jsonl  (exists: True)
  scan (found, turns, tool_uses, prior_searches): (False, 8, 4, 3)
  GATE DECISION: deny   <-- pre-fix this was a silent fail-open (CANARY)
  ```

Reviewed by code-reviewer, ai-eng-warden, and verification-gate (all SHIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
