### PR TITLE
feat(events): emit pipeline.transition + dry-run ObservabilitySink (Phase 2)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780250270
+last_verified: "2026-05-31" # auto-bump @1780258395
 governs:
   - src/
   - evolution/

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -28,9 +28,50 @@ import {
   getIssuesFromCache,
   reconcileIssueCache,
 } from './db.js';
+import { getBus } from './events/bus.js';
+import type { EventEnvelope } from './events/types.js';
 
 beforeEach(() => {
   _initTestDatabase();
+});
+
+describe('logPipelineEvent -> pipeline.transition emit (Phase 2 strangler seam)', () => {
+  it('emits one pipeline.transition envelope on a successful insert; rowid unchanged', () => {
+    const seen: EventEnvelope[] = [];
+    const unsub = getBus().subscribe('pipeline.transition', (env) => {
+      seen.push(env);
+    });
+    try {
+      const rowid = logPipelineEvent(
+        'ISS-emit',
+        'LIA-emit',
+        'agent_completed',
+        'done',
+      );
+
+      // The added emit does not change the return contract.
+      expect(typeof rowid).toBe('number');
+
+      // The bus delivers synchronously up to its first await, so the listener
+      // has already run by the time logPipelineEvent returns — no await needed.
+      expect(seen).toHaveLength(1);
+      const env = seen[0];
+      expect(env.type).toBe('pipeline.transition');
+      expect(env.source).toBe('db.logPipelineEvent');
+      expect(env.actor).toBe('system');
+      expect(env.correlationId).toEqual({
+        kind: 'issue',
+        id: 'ISS-emit',
+        identifier: 'LIA-emit',
+      });
+      expect(env.payload).toEqual({
+        eventType: 'agent_completed',
+        detail: 'done',
+      });
+    } finally {
+      unsub();
+    }
+  });
 });
 
 // Helper to store a message using the normalized NewMessage interface

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
+import { getBus } from './events/bus.js';
 import {
   AgentRuntimeId,
   defaultSession,
@@ -1529,11 +1530,17 @@ export function getOpenPrsForActiveIssues(): Array<{
 
 // --- Pipeline event accessors ---
 
-export function logPipelineEvent(
+/**
+ * Raw INSERT of one pipeline-event row — the NON-emitting counterpart to
+ * `logPipelineEvent`, used by the ObservabilitySink for loop-safe mirroring
+ * (see `events/listeners/observability-sink.ts`). `createdAt` defaults to now.
+ */
+export function insertPipelineEventRow(
   issueId: string,
   identifier: string,
   eventType: string,
   detail?: string,
+  createdAt?: string,
 ): number | undefined {
   try {
     const result = db
@@ -1546,13 +1553,48 @@ export function logPipelineEvent(
         identifier,
         eventType,
         detail ?? null,
-        new Date().toISOString(),
+        createdAt ?? new Date().toISOString(),
       );
     return Number(result.lastInsertRowid);
   } catch (err) {
     logger.debug({ issueId, eventType, err }, 'pipeline-event: insert failed');
     return undefined;
   }
+}
+
+export function logPipelineEvent(
+  issueId: string,
+  identifier: string,
+  eventType: string,
+  detail?: string,
+): number | undefined {
+  const rowid = insertPipelineEventRow(issueId, identifier, eventType, detail);
+
+  // Strangler seam (Phase 2): the authoritative write above stays inline; we
+  // ALSO emit so the event-hub ObservabilitySink can (later) own the durable
+  // write. Best-effort + success-gated: emit only when the row landed, never
+  // block the synchronous write path, never let a bus failure surface to the
+  // 11 callers that rely on this never throwing. The outer try/catch makes the
+  // no-throw guarantee structural (covers a synchronous throw from the bus
+  // prologue); the inner .catch swallows async listener rejections.
+  if (rowid !== undefined) {
+    try {
+      void getBus()
+        .emit({
+          type: 'pipeline.transition',
+          source: 'db.logPipelineEvent',
+          actor: 'system',
+          correlationId: { kind: 'issue', id: issueId, identifier },
+          ts: new Date().toISOString(),
+          payload: { eventType, detail },
+        })
+        .catch(() => {});
+    } catch {
+      /* emit must never throw into the write path */
+    }
+  }
+
+  return rowid;
 }
 
 export function updatePipelineEventStatusSummary(

--- a/src/events/bus.ts
+++ b/src/events/bus.ts
@@ -35,8 +35,10 @@ export class EventBus {
 
   /**
    * Catch-all subscription — receives every event regardless of type. Reserved
-   * for the Phase-2 ObservabilitySink + pipeline-events mirror; no production
-   * listener uses it yet. Returns an unsubscribe function.
+   * for a future multi-family durability mirror (Phase 4+); no production
+   * listener uses it yet. (Phase 2's ObservabilitySink uses the typed
+   * `subscribe('pipeline.transition')` instead, since it mirrors one family.)
+   * Returns an unsubscribe function.
    */
   on(handler: Handler): () => void {
     this.anyHandlers.push(handler);

--- a/src/events/listeners/observability-sink.test.ts
+++ b/src/events/listeners/observability-sink.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the db module the sink writes through. Both pipeline-event writers are
+// stubbed so the loop-safety test can assert the sink uses the NON-emitting
+// `insertPipelineEventRow` and never `logPipelineEvent` (which would re-emit).
+vi.mock('../../db.js', () => ({
+  insertPipelineEventRow: vi.fn(),
+  logPipelineEvent: vi.fn(),
+}));
+
+import { EventBus } from '../bus.js';
+import { registerObservabilitySink } from './observability-sink.js';
+import { insertPipelineEventRow, logPipelineEvent } from '../../db.js';
+import type { EventEnvelope } from '../types.js';
+
+function mkTransition(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
+  return {
+    type: 'pipeline.transition',
+    source: 'db.logPipelineEvent',
+    actor: 'system',
+    correlationId: { kind: 'issue', id: 'ISS-1', identifier: 'LIA-1' },
+    ts: '2026-05-31T00:00:00.000Z',
+    payload: { eventType: 'agent_completed', detail: 'done' },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('registerObservabilitySink', () => {
+  it('dry-run (default): logs only, writes no row', async () => {
+    const bus = new EventBus();
+    registerObservabilitySink(bus); // default dryRun = true
+    await bus.emit(mkTransition());
+    expect(insertPipelineEventRow).not.toHaveBeenCalled();
+  });
+
+  it('live: mirrors the row via insertPipelineEventRow with the event timestamp', async () => {
+    const bus = new EventBus();
+    registerObservabilitySink(bus, { dryRun: false });
+    await bus.emit(mkTransition());
+    expect(insertPipelineEventRow).toHaveBeenCalledTimes(1);
+    expect(insertPipelineEventRow).toHaveBeenCalledWith(
+      'ISS-1',
+      'LIA-1',
+      'agent_completed',
+      'done',
+      '2026-05-31T00:00:00.000Z',
+    );
+  });
+
+  it('loop-safety: never writes through the emitting logPipelineEvent', async () => {
+    const bus = new EventBus();
+    registerObservabilitySink(bus, { dryRun: false });
+    await bus.emit(mkTransition());
+    // The mirror must go through the non-emitting helper (see sink doc-comment).
+    expect(logPipelineEvent).not.toHaveBeenCalled();
+    expect(insertPipelineEventRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-issue correlations (table is issue-keyed)', async () => {
+    const bus = new EventBus();
+    registerObservabilitySink(bus, { dryRun: false });
+    await bus.emit(
+      mkTransition({ correlationId: { kind: 'run', id: 'run-1' } }),
+    );
+    expect(insertPipelineEventRow).not.toHaveBeenCalled();
+  });
+
+  it('falls back to empty identifier when the issue ref omits one', async () => {
+    const bus = new EventBus();
+    registerObservabilitySink(bus, { dryRun: false });
+    await bus.emit(
+      mkTransition({ correlationId: { kind: 'issue', id: 'ISS-2' } }),
+    );
+    expect(insertPipelineEventRow).toHaveBeenCalledWith(
+      'ISS-2',
+      '',
+      'agent_completed',
+      'done',
+      '2026-05-31T00:00:00.000Z',
+    );
+  });
+});

--- a/src/events/listeners/observability-sink.ts
+++ b/src/events/listeners/observability-sink.ts
@@ -1,0 +1,51 @@
+import { logger } from '../../logger.js';
+import { insertPipelineEventRow } from '../../db.js';
+import type { EventBus } from '../bus.js';
+
+// explicit `: boolean` (not literal `true`) so the live branch below stays
+// reachable/typecheckable; flip to `false` at the Phase-3 cutover.
+const DRY_RUN_DEFAULT: boolean = true;
+
+/**
+ * ObservabilitySink — the event-hub's durability mirror for pipeline events.
+ * Subscribes to `pipeline.transition` and, when live, writes the row to
+ * `linear_pipeline_events`.
+ *
+ * Loop-safety (load-bearing, the canonical statement of this invariant): the
+ * sink writes via `insertPipelineEventRow`, NEVER `logPipelineEvent` — the
+ * latter emits `pipeline.transition`, so a sink routed through it would re-fire
+ * this handler forever. The non-emitting helper makes that structurally impossible.
+ *
+ * Phase 2 is dry-run/log-only: the mirrored row's content equals the
+ * authoritative `logPipelineEvent` row by construction (same args), so the
+ * dry-run only defers the duplicate-row write to the Phase-3 cutover. That
+ * cutover must also re-home one thing the envelope does not carry — the
+ * `status_summary` UPDATE that `notifyPipelineStep` chains off `logPipelineEvent`'s
+ * rowid (one caller); it does not affect this phase.
+ *
+ * Returns an unsubscribe function.
+ */
+export function registerObservabilitySink(
+  bus: EventBus,
+  opts: { dryRun?: boolean } = {},
+): () => void {
+  const dryRun = opts.dryRun ?? DRY_RUN_DEFAULT;
+
+  return bus.subscribe('pipeline.transition', (env) => {
+    if (env.correlationId.kind !== 'issue') return;
+    const { id, identifier } = env.correlationId;
+    const { eventType, detail } = env.payload;
+
+    if (dryRun) {
+      logger.debug(
+        { id, eventType },
+        'observability-sink[dry-run]: would mirror pipeline.transition -> linear_pipeline_events',
+      );
+      return;
+    }
+
+    // Durable write via the non-emitting helper (loop-safe); `env.ts` keeps the
+    // mirrored row's time equal to the originating event's time.
+    insertPipelineEventRow(id, identifier ?? '', eventType, detail, env.ts);
+  });
+}

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -22,13 +22,20 @@ export type CorrelationRef =
   | { kind: 'run'; id: string };
 
 /**
- * Discriminated union of every event the hub carries. Phase 1: `agent.done`
- * only. Add a member here when a phase introduces a new event type.
+ * Discriminated union of every event the hub carries. Phase 1: `agent.done`.
+ * Phase 2 adds `pipeline.transition` (every pipeline-event log becomes an emit,
+ * reusing the existing eventType vocabulary). Add a member here when a phase
+ * introduces a new event type.
  */
-export type DeusEvent = {
-  type: 'agent.done';
-  payload: { output?: string; prUrl?: string };
-};
+export type DeusEvent =
+  | {
+      type: 'agent.done';
+      payload: { output?: string; prUrl?: string };
+    }
+  | {
+      type: 'pipeline.transition';
+      payload: { eventType: string; detail?: string };
+    };
 
 /**
  * What an emitter sends and a handler receives. `actor` is metadata for

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import type { LinearContext } from './linear-dispatcher.js';
 import { loadGateSpecs } from './linear-gate-specs.js';
 import { startLinearWebhookServer } from './linear-webhook.js';
 import { registerLinearUpdater } from './events/listeners/linear-updater.js';
+import { registerObservabilitySink } from './events/listeners/observability-sink.js';
 
 export { getAvailableGroups } from './router-state.js';
 
@@ -395,6 +396,7 @@ async function main(): Promise<void> {
     if (linearCtx) {
       // Register event-hub listeners before the dispatcher can fire any event.
       registerLinearUpdater(linearCtx.bus, linearCtx);
+      registerObservabilitySink(linearCtx.bus);
       startLinearDispatcher(linearCtx);
 
       const wardensDir = path.join(


### PR DESCRIPTION
## Event Hub — Phase 2: pipeline-event strangler seam + ObservabilitySink

Second seam of the orchestrator event-hub strangler (design: `Research/2026-05-31-event-hub-evolution-design.md`, roadmap row 2). Phase 1 (#657) proved the pattern with `agent.done` + a dry-run LinearUpdater. **This PR is additive and behavior-preserving** — the sink is dry-run/log-only; the inline INSERT stays authoritative.

### What changed
- **`logPipelineEvent` (`db.ts`)** now *also* emits `pipeline.transition` alongside its authoritative INSERT — success-gated, fire-and-forget, structural no-throw (`try { void getBus().emit(...).catch(()=>{}) } catch {}`), so none of its 11 callers can ever see a throw and the return contract is unchanged.
- **`insertPipelineEventRow` extracted** — the non-emitting INSERT helper. The ObservabilitySink mirrors rows through this, **never** `logPipelineEvent`, so `emit → sink → emit` is structurally impossible (the load-bearing loop-safety property).
- **`ObservabilitySink`** (new) subscribes `pipeline.transition`, `DRY_RUN_DEFAULT=true` (log-only); its live path writes via `insertPipelineEventRow` with the originating `env.ts`.
- **`DeusEvent`** union gains `pipeline.transition`; the bus `on()` doc updated (Phase 2 uses typed `subscribe`, so `on()` stays reserved for a future multi-family mirror).

### Why dry-run
The mirrored row's content equals the authoritative `logPipelineEvent` row by construction (same args), so the dry-run only defers the duplicate-row write to the **Phase-3 cutover**. Logged at `debug` because `pipeline.transition` is high-frequency.

### Known Phase-3 constraint (documented, not in this PR)
`notifyPipelineStep` (`linear-notifications.ts:190`) is the **only** caller that chains `logPipelineEvent`'s rowid → `updatePipelineEventStatusSummary`. Deleting the inline INSERT at cutover must re-home that chain; the other 10 callers discard the rowid.

### Gates & verification
- plan-reviewer **SHIP** (round 2) · code-reviewer **SHIP** (round 2)
- `npm run build` typecheck clean · `npx vitest run` **1388 passed, 0 failures** · `npx eslint` 0 errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)