### PR TITLE
docs(spec): remove stale file entries from SPEC.md directory tree

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -159,7 +159,6 @@ deus/
 ├── README.md                      # User documentation
 ├── package.json                   # Node.js dependencies
 ├── tsconfig.json                  # TypeScript configuration
-├── .mcp.json                      # MCP server configuration (reference)
 ├── .gitignore
 │
 ├── src/
@@ -175,7 +174,6 @@ deus/
 │   ├── db.ts                      # SQLite database initialization and queries
 │   ├── group-queue.ts             # Per-group queue with global concurrency limit
 │   ├── mount-security.ts          # Mount allowlist validation for containers
-│   ├── whatsapp-auth.ts           # Standalone WhatsApp authentication
 │   ├── task-scheduler.ts          # Runs scheduled tasks when due
 │   └── container-runner.ts        # Spawns agents in containers
 │

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-01" # auto-bump @1780261540
+last_verified: "2026-06-02" # auto-bump @1780405989
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
Closes #663

Removes two stale directory-tree entries from `docs/SPEC.md`: `.mcp.json` (deleted file) and `whatsapp-auth.ts` (deleted file), so the tree reflects the actual repo layout.