### PR TITLE
docs: update QUALITY_GRADES.md audit dates after 2026-06-01 scan

### DIFF
--- a/docs/QUALITY_GRADES.md
+++ b/docs/QUALITY_GRADES.md
@@ -8,9 +8,9 @@ Per-subsystem health at a glance. Updated manually or by the doc-gardening agent
 |-----------|-------|-------------|----------|---------------|
 | Memory tree | B | 2026-05-16 | Atom fallback disabled pending benchmark | [atom-fallback-evaluation](decisions/atom-fallback-evaluation.md) |
 | Scheduler/cron | A | 2026-05-16 | -- | -- |
-| Warden gates | B | 2026-05-16 | No remediation instructions | -- |
-| Backends (Claude/OpenAI) | B | 2026-05-16 | Codex hook parity open | [AAG-010](agent-agnostic-debt.md) |
+| Warden gates | B | 2026-06-01 | No remediation instructions | -- |
+| Backends (Claude/OpenAI) | B | 2026-06-01 | Codex hook parity open | [AAG-010](agent-agnostic-debt.md) |
 | Eval/benchmarks | A | 2026-05-16 | -- | [benchmark-regression-gate](decisions/benchmark-regression-gate.md) |
 | Channel layer | B | 2026-05-16 | Agent-native migration WIP | -- |
 | TUI/CLI | C | 2026-05-16 | Visual verification deferred 6+ times | [tui-agent-orchestration](decisions/tui-agent-orchestration.md) |
-| Pattern verification | C | 2026-05-16 | 4/5 gaps open | [pattern-verification-deferred](decisions/pattern-verification-deferred.md) |
+| Pattern verification | C | 2026-06-01 | 4/5 gaps open | [pattern-verification-deferred](decisions/pattern-verification-deferred.md) |

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-02" # auto-bump @1780405989
+last_verified: "2026-06-02" # auto-bump @1780409372
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
Closes #664

Updates the "Last audited" date to 2026-06-01 for the three rows reviewed during the weekly doc-gardener scan on 2026-06-01: Warden gates, Backends (Claude/OpenAI), and Pattern verification. Grades are unchanged.