### PR TITLE
fix(auth): proactively refresh OAuth token to prevent overnight 401

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-01" # auto-bump @1780262413
+last_verified: "2026-06-02" # auto-bump @1780407086
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-05-31" # auto-bump @1780259166
+last_verified: "2026-06-02" # auto-bump @1780407086
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/auth-providers/anthropic.ts
+++ b/src/auth-providers/anthropic.ts
@@ -406,6 +406,29 @@ function getDynamicOAuthToken(): string | undefined {
 }
 
 /**
+ * Proactively run the token-read/refresh path so an idle host still renews
+ * the OAuth token before it expires.
+ *
+ * The per-request path (`injectAuth` → `getDynamicOAuthToken`) only fires when
+ * a container actually makes a request. With no overnight traffic the token
+ * silently expires and the next morning's request 401s. This wrapper lets the
+ * always-on host process tick the same path on a timer (see credential-proxy),
+ * reusing the existing 30-min early-expire window + `refreshInFlight`
+ * de-duplication rather than duplicating refresh logic.
+ *
+ * Returns nothing: the token value never leaves this module. The underlying
+ * `getDynamicOAuthToken` already logs (warn) when it serves an expired token
+ * and when a refresh starts / succeeds / fails — so this adds only a
+ * no-secret debug line marking that the proactive check ran.
+ */
+export function triggerProactiveOAuthRefresh(): void {
+  // Discard the returned token — callers must never see it. The side effect
+  // (background refresh-if-expiring inside getDynamicOAuthToken) is the point.
+  void getDynamicOAuthToken();
+  logger.debug('credential-proxy: proactive OAuth refresh check ran');
+}
+
+/**
  * Anthropic auth provider.
  *
  * Supports both API key and OAuth modes. The mode is determined at
@@ -466,6 +489,18 @@ export class AnthropicAuthProvider implements AuthProvider {
   /** Get the auth mode for external consumers (e.g. container-runner). */
   getAuthMode(): AuthMode {
     return this.authMode;
+  }
+
+  /**
+   * True only when this provider serves a *refreshable* OAuth token — i.e.
+   * dynamic credentials read from the file/keychain that flow through
+   * `getDynamicOAuthToken`. False for API-key mode and for a static env token
+   * (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN), neither of which the
+   * refresh path touches. Used by the proxy to decide whether the proactive
+   * refresh timer is worth running at all.
+   */
+  usesRefreshableOAuth(): boolean {
+    return this.authMode === 'oauth' && !this.envOauthToken;
   }
 
   isAvailable(): boolean {

--- a/src/auth-providers/auth-providers.test.ts
+++ b/src/auth-providers/auth-providers.test.ts
@@ -54,6 +54,7 @@ import { ensureDefaultProviders } from './index.js';
 import {
   AnthropicAuthProvider,
   readCredentialsFile,
+  triggerProactiveOAuthRefresh,
   _resetCredentialsCacheForTest,
 } from './anthropic.js';
 import { OpenAIAuthProvider, _resetCodexCacheForTest } from './openai.js';
@@ -945,6 +946,111 @@ describe('AnthropicAuthProvider', () => {
 
       // No crash, no write
       expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Proactive refresh — the issue #625 path: no incoming request, the host
+  // pokes the token-read/refresh path on a timer so an idle token still
+  // refreshes before it expires.
+  // -------------------------------------------------------------------------
+  describe('proactive refresh (triggerProactiveOAuthRefresh)', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('triggers refresh on an expiring token WITHOUT any incoming request', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: 'proactive-fresh-tok',
+            refresh_token: 'proactive-fresh-refresh',
+            expires_in: 28800,
+          }),
+      });
+
+      // Token expiring within the 30-min early-expire window, with refresh_token.
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'old-idle-tok-valid-test-pad',
+            refreshToken: 'idle-refresh',
+            expiresAt: Date.now() + 10 * 60 * 1000,
+          },
+        }),
+      );
+
+      // No provider / injectAuth / isAvailable call — the timer wrapper is the
+      // only thing that runs, exactly as it would on an idle host.
+      triggerProactiveOAuthRefresh();
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://platform.claude.com/v1/oauth/token',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('idle-refresh'),
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          expect.stringContaining('.credentials.json'),
+          expect.stringContaining('proactive-fresh-tok'),
+          expect.objectContaining({ mode: 0o600 }),
+        );
+      });
+    });
+
+    it('does not refresh a comfortably-valid token (tick is just a file read)', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'healthy-idle-tok-valid-test',
+            refreshToken: 'healthy-refresh',
+            expiresAt: Date.now() + 7200000, // 2 hours — outside the window
+          },
+        }),
+      );
+
+      triggerProactiveOAuthRefresh();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // usesRefreshableOAuth — gate for whether the proxy runs the proactive timer
+  // -------------------------------------------------------------------------
+  describe('usesRefreshableOAuth', () => {
+    it('false in API-key mode', () => {
+      mockEnv.ANTHROPIC_API_KEY = 'sk-ant-real-key';
+      const provider = new AnthropicAuthProvider();
+      expect(provider.usesRefreshableOAuth()).toBe(false);
+    });
+
+    it('false when a static env OAuth token is set (not refreshable)', () => {
+      mockEnv.CLAUDE_CODE_OAUTH_TOKEN = 'static-env-oauth-token';
+      const provider = new AnthropicAuthProvider();
+      expect(provider.getAuthMode()).toBe('oauth');
+      expect(provider.usesRefreshableOAuth()).toBe(false);
+    });
+
+    it('true for dynamic file/keychain OAuth credentials', () => {
+      // No API key, no env OAuth token → dynamic (refreshable) OAuth mode.
+      const provider = new AnthropicAuthProvider();
+      expect(provider.getAuthMode()).toBe('oauth');
+      expect(provider.usesRefreshableOAuth()).toBe(true);
     });
   });
 

--- a/src/auth-providers/index.ts
+++ b/src/auth-providers/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   AnthropicAuthProvider,
   CREDENTIALS_PATH,
+  triggerProactiveOAuthRefresh,
   _resetCredentialsCacheForTest,
 } from './anthropic.js';
 export { OpenAIAuthProvider } from './openai.js';

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -526,4 +526,133 @@ describe('credential-proxy', () => {
 
     expect(res.statusCode).toBe(200);
   });
+
+  // -------------------------------------------------------------------------
+  // Proactive OAuth refresh timer (issue #625): an idle host with no incoming
+  // traffic must still refresh the token before it expires. The timer is only
+  // worth running for refreshable (dynamic file/keychain) OAuth credentials.
+  // -------------------------------------------------------------------------
+  describe('proactive OAuth refresh timer', () => {
+    const PROACTIVE_INTERVAL_MS = 30 * 60 * 1000;
+
+    interface IntervalCall {
+      delay: number;
+      unrefed: boolean;
+      handle: ReturnType<typeof setInterval>;
+    }
+
+    function collectIntervals(): {
+      restore: () => void;
+      calls: IntervalCall[];
+    } {
+      const calls: IntervalCall[] = [];
+      const real = global.setInterval;
+      const spy = vi
+        .spyOn(global, 'setInterval')
+        .mockImplementation(
+          (
+            handler: (...handlerArgs: unknown[]) => void,
+            timeout?: number,
+            ...args: unknown[]
+          ) => {
+            const handle = real(handler, timeout, ...args) as ReturnType<
+              typeof setInterval
+            >;
+            // Don't let the test's intervals fire — we only assert on creation.
+            handle.unref();
+            const entry: IntervalCall = {
+              delay: timeout ?? 0,
+              unrefed: false,
+              handle,
+            };
+            const origUnref = handle.unref.bind(handle);
+            handle.unref = () => {
+              entry.unrefed = true;
+              return origUnref();
+            };
+            calls.push(entry);
+            return handle;
+          },
+        );
+      return { restore: () => spy.mockRestore(), calls };
+    }
+
+    it('starts an unref-ed 30-min timer for dynamic file OAuth credentials', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'dynamic-creds-token-valid-test',
+            refreshToken: 'dynamic-refresh',
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          },
+        }),
+      );
+      const { restore, calls } = collectIntervals();
+      try {
+        proxyPort = await startProxy({});
+        const proactive = calls.filter(
+          (c) => c.delay === PROACTIVE_INTERVAL_MS,
+        );
+        expect(proactive).toHaveLength(1);
+        expect(proactive[0].unrefed).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    it('does NOT start the timer in API-key mode', async () => {
+      const { restore, calls } = collectIntervals();
+      try {
+        proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+        expect(
+          calls.filter((c) => c.delay === PROACTIVE_INTERVAL_MS),
+        ).toHaveLength(0);
+      } finally {
+        restore();
+      }
+    });
+
+    it('does NOT start the timer for a static env OAuth token (not refreshable)', async () => {
+      const { restore, calls } = collectIntervals();
+      try {
+        proxyPort = await startProxy({ CLAUDE_CODE_OAUTH_TOKEN: 'env-token' });
+        expect(
+          calls.filter((c) => c.delay === PROACTIVE_INTERVAL_MS),
+        ).toHaveLength(0);
+      } finally {
+        restore();
+      }
+    });
+
+    it('clears the timer when the proxy server closes', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'dynamic-creds-token-valid-test',
+            refreshToken: 'dynamic-refresh',
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          },
+        }),
+      );
+      const { restore, calls } = collectIntervals();
+      const clearSpy = vi.spyOn(global, 'clearInterval');
+      try {
+        const server = await startCredentialProxy(0);
+        proxyServer = server;
+
+        const proactive = calls.find((c) => c.delay === PROACTIVE_INTERVAL_MS);
+        expect(proactive).toBeDefined();
+
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        proxyServer = undefined;
+
+        // The proactive timer handle specifically must be cleared on close.
+        const clearedHandles = clearSpy.mock.calls.map((c) => c[0]);
+        expect(clearedHandles).toContain(proactive!.handle);
+      } finally {
+        clearSpy.mockRestore();
+        restore();
+      }
+    });
+  });
 });

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -28,12 +28,24 @@ import {
   AuthProviderRegistry,
   AnthropicAuthProvider,
   CREDENTIALS_PATH,
+  triggerProactiveOAuthRefresh,
   _resetCredentialsCacheForTest as _resetAnthropicCache,
   ensureDefaultProviders,
 } from './auth-providers/index.js';
 import type { AuthProvider } from './auth-providers/types.js';
 
 export type AuthMode = 'api-key' | 'oauth';
+
+/**
+ * How often the always-on host pokes the OAuth token-read/refresh path even
+ * with no incoming container traffic. Chosen to equal the early-expire window
+ * (EARLY_EXPIRE_WINDOW_MS = 30 min): interval ≤ window guarantees a tick lands
+ * inside the refresh window before the token expires, leaving no blind spot.
+ * It also matches the launchd job's cadence (StartInterval 1800). A tick on a
+ * comfortably-valid token is just a single file read (getDynamicOAuthToken
+ * fast-paths it); the keychain/refresh only fire inside the window.
+ */
+const PROACTIVE_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
 
 export interface ProxyConfig {
   authMode: AuthMode;
@@ -137,15 +149,44 @@ export function startCredentialProxy(
   ensureDefaultProviders();
   const registry = AuthProviderRegistry.default();
 
-  // Get the Anthropic provider for logging the auth mode
+  // Get the Anthropic provider for logging the auth mode + deciding whether the
+  // proactive refresh timer is worth running (only for refreshable OAuth creds).
   let authMode: AuthMode = 'oauth';
+  let usesRefreshableOAuth = false;
   try {
     const anthropic = registry.get('anthropic');
     if (anthropic instanceof AnthropicAuthProvider) {
       authMode = anthropic.getAuthMode();
+      usesRefreshableOAuth = anthropic.usesRefreshableOAuth();
     }
   } catch {
     // No Anthropic provider registered — unusual but not fatal
+  }
+
+  // Proactive OAuth refresh timer. The per-request refresh in the Anthropic
+  // provider only fires when a container makes a request; an idle host (no
+  // overnight traffic) never triggers it, so the token expires and the next
+  // morning's request 401s (issue #625). This in-process timer pokes the same
+  // token-read/refresh path on an interval so refresh happens proactively.
+  //
+  // Cross-platform defense-in-depth: the launchd job (scheduleOAuthRefresh) is
+  // macOS-only and can fail to load silently, leaving Linux/Windows hosts with
+  // no proactive refresh at all. This timer lives in the always-on host process
+  // and covers every platform. Overlap with a request-triggered refresh or the
+  // launchd CLI is already handled (in-process `refreshInFlight` flag + the
+  // CLI's file lock; credential writes are atomic).
+  let proactiveRefreshTimer: ReturnType<typeof setInterval> | undefined;
+  if (usesRefreshableOAuth) {
+    proactiveRefreshTimer = setInterval(
+      triggerProactiveOAuthRefresh,
+      PROACTIVE_REFRESH_INTERVAL_MS,
+    );
+    // Don't keep the Node process alive on the timer alone (tests/shutdown).
+    proactiveRefreshTimer.unref();
+    logger.info(
+      { intervalMs: PROACTIVE_REFRESH_INTERVAL_MS },
+      'Credential proxy: proactive OAuth refresh timer started',
+    );
   }
 
   return new Promise((resolve, reject) => {
@@ -343,6 +384,7 @@ export function startCredentialProxy(
 
     server.on('close', () => {
       clearInterval(rateLimitCleanupInterval);
+      if (proactiveRefreshTimer) clearInterval(proactiveRefreshTimer);
     });
 
     let retries = 0;


### PR DESCRIPTION
Closes #625

## Root cause

OAuth token refresh is only triggered on the per-request path:
`injectAuth` → `getDynamicOAuthToken` → `triggerRefresh`. That path runs
**only when a container actually makes a request**. On an idle host with no
overnight traffic, nothing pokes the token, so it silently expires and the
next morning's request 401s:

```
API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}
```

### "Don't we already refresh proactively?"

Partly — but only on macOS. The existing proactive refresh is a launchd job
(`scheduleOAuthRefresh` → `src/auth-refresh.ts`, scheduled every 30 min).
It has two gaps that produced this bug:

- It is **macOS-only**. Linux/Windows hosts have *no* proactive refresh at all.
- `launchctl bootstrap`/`load` failures are swallowed (service.ts), so even on
  macOS the job can silently fail to load and leave the token unrefreshed.

## The fix

Add an in-process timer in `startCredentialProxy` that calls the existing
token-read/refresh path on an interval, so refresh happens proactively even
with zero incoming requests. It reuses the existing 30-min early-expire window
and `refreshInFlight` de-duplication rather than duplicating refresh logic, via
a thin exported wrapper `triggerProactiveOAuthRefresh()`.

- **Interval = 30 min**, equal to `EARLY_EXPIRE_WINDOW_MS`. With
  interval ≤ window, a tick always lands inside the refresh window *before*
  the token expires, leaving no blind spot. It also matches the launchd
  cadence (`StartInterval` 1800). A tick on a comfortably-valid token is just
  a single file read — `getDynamicOAuthToken` fast-paths it, and the
  keychain/network refresh only fire inside the window.
- **Only for refreshable OAuth.** The timer starts only when the provider uses
  dynamic file/keychain OAuth credentials (`usesRefreshableOAuth()`), not in
  API-key mode and not for a static env token
  (`CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_AUTH_TOKEN`) — neither of which the
  refresh path touches.
- **No secret leakage.** The wrapper discards `getDynamicOAuthToken`'s return
  value (the token never leaves the auth module) and logs only a no-secret
  `logger.debug` line that the check ran.

### Why `unref()` + cleanup matter

- `timer.unref()` means the timer **does not keep the Node process alive on its
  own**. The always-on host server keeps the event loop alive; the timer just
  piggybacks. Without `unref()`, the timer would hold the process open across
  graceful shutdown and in tests — a cross-platform correctness issue. This
  mirrors the existing `rateLimitCleanupInterval.unref()`.
- `clearInterval` on `server.on('close')` prevents a leaked timer after the
  proxy shuts down (again mirroring the rate-limit interval cleanup).

## Alternatives considered

- **Reuse `runRefresh()` from `auth-refresh.ts`** (the launchd CLI's core):
  rejected. It sends user-facing failure notifications (control-group IPC +
  macOS desktop notification). Calling it in-process *and* from launchd would
  double the failure notifications on macOS. The per-request path is the
  cleaner reuse and adds no new cross-process race (writes are atomic;
  `pickFresher` prevents downgrades).
- **Fix only the launchd job / port it to systemd**: rejected as the primary
  fix — it stays OS-specific and still fails silently. The in-process timer is
  cross-platform defense-in-depth and complements the launchd job.

## Scope / honesty

This closes the **idle-running-process** gap and the **Linux/no-launchd** gap.
It does **not** help if the machine is asleep or the Deus host process isn't
running — neither `setInterval` nor launchd `StartInterval` fires while the
host is asleep. Framed for the deployed, always-on Deus host.

The in-process refresh can still race the launchd CLI on `refresh_token`
rotation (one side may get a benign `invalid_grant` warning). This is
pre-existing behavior, not introduced here.

## Tests

Added 9 tests (all green):

- `auth-providers.test.ts` — `triggerProactiveOAuthRefresh` triggers a refresh
  on an expiring token with no incoming request; does not refresh a
  comfortably-valid token; `usesRefreshableOAuth()` is false in API-key mode and
  for a static env token, true for dynamic file/keychain creds.
- `credential-proxy.test.ts` — the proactive timer is started unref'd at 30 min
  for dynamic OAuth creds; NOT started in API-key mode or for a static env
  token; and the timer handle is cleared on server close.

```
$ npx vitest run src/credential-proxy.test.ts src/auth-providers/auth-providers.test.ts src/auth-refresh.test.ts
 Test Files  3 passed (3)
      Tests  100 passed (100)

$ npm run build      # tsc — exit 0
$ npm run lint       # 0 errors (197 pre-existing warnings, none in changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
