### PR TITLE
fix(skills): resolve vault path from cwd .deus/config.json before global config

### DIFF
--- a/.claude/commands/compress.md
+++ b/.claude/commands/compress.md
@@ -1,6 +1,12 @@
 Save this Claude Code session to the vault and update the semantic memory index.
 
-First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+First, resolve the vault path using this **per-instance** order (highest priority first). `$VAULT` means the resolved path:
+
+1. `DEUS_VAULT_PATH` env var, if set.
+2. `vault_path` in `./.deus/config.json` (the current working directory's instance-local config), if that file exists. If the file exists but has no usable `vault_path`, STOP and tell the user it is present but missing `vault_path` — do **not** fall through to the global config (that fall-through is what corrupts another instance's vault).
+3. `vault_path` in `~/.config/deus/config.json` (global fallback).
+
+Tiers 1 and 2 are the per-instance mechanisms: when several Deus instances run on one machine they share the global config (tier 3), so resolving from it alone can silently point this instance's `/compress` at a different instance's vault and corrupt its memory. The instance-local `./.deus/config.json` keeps each instance self-contained. The `memory_indexer.py` calls below resolve the vault by the same order, so their writes land in this instance's vault too.
 
 Review the conversation and create a session log at:
 $VAULT/Session-Logs/YYYY-MM-DD/{topic}.md

--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -2,7 +2,13 @@ Load context from the vault before starting work.
 
 NOTE: This is the home-mode (~/deus) version. For external projects, the user-level /resume skill at ~/.claude/skills/resume/ handles project-focused context loading automatically.
 
-First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+First, resolve the vault path using this **per-instance** order (highest priority first). `$VAULT` means the resolved path:
+
+1. `DEUS_VAULT_PATH` env var, if set.
+2. `vault_path` in `./.deus/config.json` (the current working directory's instance-local config), if that file exists. If the file exists but has no usable `vault_path`, STOP and tell the user it is present but missing `vault_path` — do **not** fall through to the global config (that fall-through is what reads from another instance's vault).
+3. `vault_path` in `~/.config/deus/config.json` (global fallback).
+
+Tiers 1 and 2 are the per-instance mechanisms: when several Deus instances run on one machine they share the global config (tier 3), so resolving from it alone can silently point this instance's `/resume` at a different instance's vault. The instance-local `./.deus/config.json` keeps each instance self-contained. The `memory_indexer.py` calls below resolve the vault by the same order, so their reads come from this instance's vault too.
 
 1. Always read core memory:
    $VAULT/CLAUDE.md

--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -14,7 +14,13 @@ Check if the current working directory is the Deus home directory (`~/deus`). If
 
 ## Resolve vault path
 
-Read `~/.config/deus/config.json` and use the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+Resolve the vault path using this **per-instance** order (highest priority first). `$VAULT` means the resolved path:
+
+1. `DEUS_VAULT_PATH` env var, if set.
+2. `vault_path` in `./.deus/config.json` (the current working directory's instance-local config), if that file exists. If the file exists but has no usable `vault_path`, STOP and tell the user it is present but missing `vault_path` — do **not** fall through to the global config (that fall-through is what corrupts another instance's vault).
+3. `vault_path` in `~/.config/deus/config.json` (global fallback).
+
+Tiers 1 and 2 are the per-instance mechanisms: when several Deus instances run on one machine they share the global config (tier 3), so resolving from it alone can silently point this instance's `/compress` at a different instance's vault and corrupt its memory. The instance-local `./.deus/config.json` keeps each instance self-contained. The `memory_indexer.py` calls below resolve the vault by the same order, so their writes land in this instance's vault too.
 
 ## Check memory level (External Project Mode only)
 

--- a/.claude/skills/resume/skill.md
+++ b/.claude/skills/resume/skill.md
@@ -16,7 +16,13 @@ Check if the current working directory is the Deus home directory (`~/deus`). If
 
 Load context from the vault before starting work.
 
-First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+First, resolve the vault path using this **per-instance** order (highest priority first). `$VAULT` means the resolved path:
+
+1. `DEUS_VAULT_PATH` env var, if set.
+2. `vault_path` in `./.deus/config.json` (the current working directory's instance-local config), if that file exists. If the file exists but has no usable `vault_path`, STOP and tell the user it is present but missing `vault_path` — do **not** fall through to the global config (that fall-through is what reads from another instance's vault).
+3. `vault_path` in `~/.config/deus/config.json` (global fallback).
+
+Tiers 1 and 2 are the per-instance mechanisms: when several Deus instances run on one machine they share the global config (tier 3), so resolving from it alone can silently point this instance's `/resume` at a different instance's vault. The instance-local `./.deus/config.json` keeps each instance self-contained. The `memory_indexer.py` calls below resolve the vault by the same order, so their reads come from this instance's vault too.
 
 1. Core + contextual vault files (CLAUDE.md, STUDY.md, INFRA.md):
    Check if the current context already contains `=== VAULT: CLAUDE.md ===` (injected

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -290,7 +290,7 @@ _run_onboarding() {
 _ensure_resume_skill() {
   local skill_dir="$DEUS_SKILLS_DIR/resume"
   local marker="$skill_dir/.deus-version"
-  local current_version="2"
+  local current_version="3"
   if [ -f "$marker" ] && [ "$(cat "$marker")" = "$current_version" ]; then
     return
   fi
@@ -314,7 +314,13 @@ Check if the current working directory is the Deus home directory (`~/deus`). If
 
 Load context from the vault before starting work.
 
-First, resolve the vault path by reading `~/.config/deus/config.json` and using the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+First, resolve the vault path using this **per-instance** order (highest priority first). `$VAULT` means the resolved path:
+
+1. `DEUS_VAULT_PATH` env var, if set.
+2. `vault_path` in `./.deus/config.json` (the current working directory's instance-local config), if that file exists. If the file exists but has no usable `vault_path`, STOP and tell the user it is present but missing `vault_path` — do **not** fall through to the global config (that fall-through is what reads from another instance's vault).
+3. `vault_path` in `~/.config/deus/config.json` (global fallback).
+
+Tiers 1 and 2 are the per-instance mechanisms: when several Deus instances run on one machine they share the global config (tier 3), so resolving from it alone can silently point this instance's `/resume` at a different instance's vault. The instance-local `./.deus/config.json` keeps each instance self-contained. The `memory_indexer.py` calls below resolve the vault by the same order, so their reads come from this instance's vault too.
 
 1. Always read core memory:
    $VAULT/CLAUDE.md
@@ -627,7 +633,7 @@ SKILLEOF
 _ensure_compress_skill() {
   local skill_dir="$DEUS_SKILLS_DIR/compress"
   local marker="$skill_dir/.deus-version"
-  local current_version="2"
+  local current_version="3"
   if [ -f "$marker" ] && [ "$(cat "$marker")" = "$current_version" ]; then
     return
   fi
@@ -649,7 +655,13 @@ Check if the current working directory is the Deus home directory (`~/deus`). If
 
 ## Resolve vault path
 
-Read `~/.config/deus/config.json` and use the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead. All paths below use `$VAULT` to mean this resolved path.
+Resolve the vault path using this **per-instance** order (highest priority first). `$VAULT` means the resolved path:
+
+1. `DEUS_VAULT_PATH` env var, if set.
+2. `vault_path` in `./.deus/config.json` (the current working directory's instance-local config), if that file exists. If the file exists but has no usable `vault_path`, STOP and tell the user it is present but missing `vault_path` — do **not** fall through to the global config (that fall-through is what corrupts another instance's vault).
+3. `vault_path` in `~/.config/deus/config.json` (global fallback).
+
+Tiers 1 and 2 are the per-instance mechanisms: when several Deus instances run on one machine they share the global config (tier 3), so resolving from it alone can silently point this instance's `/compress` at a different instance's vault and corrupt its memory. The instance-local `./.deus/config.json` keeps each instance self-contained. The `memory_indexer.py` calls below resolve the vault by the same order, so their writes land in this instance's vault too.
 
 ## Check memory level (External Project Mode only)
 

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-05-31" # auto-bump @1780177680
+last_verified: "2026-06-02" # auto-bump @1780407457
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-05-31" # auto-bump @1780222145
+last_verified: "2026-06-02" # auto-bump @1780407457
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -60,12 +60,47 @@ ENTITY_PROVIDER = os.environ.get("DEUS_ENTITY_PROVIDER", "auto")
 
 
 def _load_vault_path() -> Path:
-    """Load vault path from config.json or DEUS_VAULT_PATH env var."""
+    """Load vault path with per-instance precedence.
+
+    Resolution order (highest priority first):
+      1. DEUS_VAULT_PATH env var
+      2. ./.deus/config.json in the current working directory (instance-local)
+      3. ~/.config/deus/config.json (global fallback)
+
+    The cwd-local config (tier 2) makes each Deus instance self-contained: when
+    several instances run on one machine and share the global config, this keeps
+    callers writing to the instance's OWN vault instead of silently resolving to
+    whichever vault the global config happens to point at (GH #659).
+    """
     # 1. Environment variable override
     env_path = os.environ.get("DEUS_VAULT_PATH")
     if env_path:
         return Path(env_path).expanduser()
-    # 2. Config file
+    # 2. Instance-local config in the current working directory.
+    #    If this file exists it is authoritative for the running instance — a
+    #    present-but-unusable file fails loud rather than falling through to the
+    #    global config, because that fall-through is exactly the cross-instance
+    #    vault collision the per-instance config is meant to prevent.
+    local_config = Path.cwd() / ".deus" / "config.json"
+    if local_config.exists():
+        try:
+            local_cfg = json.loads(local_config.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print(
+                f"ERROR: Could not read instance-local vault config at {local_config}: {exc}\n"
+                "Fix the file or remove it so the global config is used.",
+                file=sys.stderr,
+            )
+            sys.exit(AUTH_ERROR)
+        if local_cfg.get("vault_path"):
+            return Path(local_cfg["vault_path"]).expanduser()
+        print(
+            f"ERROR: {local_config} exists but has no `vault_path`.\n"
+            "Add a vault_path or remove the file so the global config is used.",
+            file=sys.stderr,
+        )
+        sys.exit(AUTH_ERROR)
+    # 3. Global config file
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text())
@@ -73,10 +108,11 @@ def _load_vault_path() -> Path:
                 return Path(cfg["vault_path"]).expanduser()
         except (json.JSONDecodeError, OSError):
             pass
-    # 3. Fatal — no vault configured
+    # 4. Fatal — no vault configured
     print(
         "ERROR: Memory vault not configured.\n"
-        "Set DEUS_VAULT_PATH or add vault_path to ~/.config/deus/config.json\n"
+        "Set DEUS_VAULT_PATH, add vault_path to ./.deus/config.json (per-instance),\n"
+        "or add vault_path to ~/.config/deus/config.json (global).\n"
         "Run `deus setup` or /setup in Claude Code to configure.",
         file=sys.stderr,
     )

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -88,6 +88,118 @@ def test_db_path_honors_deus_db_env(tmp_path, fresh_vault, monkeypatch):
     assert mod.DB_PATH == custom_db
 
 
+# ── Per-instance vault resolution (GH #659) ───────────────────────────────
+# These tests encode the anti-corruption guarantee: a Deus instance must
+# resolve its vault from its OWN cwd-local config before falling back to the
+# shared global config, so two instances sharing ~/.config/deus/config.json
+# never read/write each other's vault.
+
+
+def test_cwd_local_config_beats_global(tmp_path, monkeypatch):
+    """./.deus/config.json (instance-local) must win over the global config."""
+    # DEUS_VAULT_PATH (tier 1) must be unset so tier 2 vs tier 3 is exercised.
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+    mod = importlib.import_module("memory_indexer")
+
+    instance_root = tmp_path / "instance"
+    (instance_root / ".deus").mkdir(parents=True)
+    local_vault = tmp_path / "local-vault"
+    (instance_root / ".deus" / "config.json").write_text(
+        json.dumps({"vault_path": str(local_vault)})
+    )
+
+    global_vault = tmp_path / "global-vault"
+    global_config = tmp_path / "global-config.json"
+    global_config.write_text(json.dumps({"vault_path": str(global_vault)}))
+    monkeypatch.setattr(mod, "CONFIG_PATH", global_config)
+
+    monkeypatch.chdir(instance_root)
+    assert mod._load_vault_path() == local_vault
+
+
+def test_env_var_beats_cwd_local_config(tmp_path, monkeypatch):
+    """DEUS_VAULT_PATH (tier 1) still wins even when a cwd-local config exists."""
+    instance_root = tmp_path / "instance"
+    (instance_root / ".deus").mkdir(parents=True)
+    (instance_root / ".deus" / "config.json").write_text(
+        json.dumps({"vault_path": str(tmp_path / "local-vault")})
+    )
+    env_vault = tmp_path / "env-vault"
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(env_vault))
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+    mod = importlib.import_module("memory_indexer")
+
+    monkeypatch.chdir(instance_root)
+    assert mod._load_vault_path() == env_vault
+
+
+def test_no_cwd_local_config_falls_back_to_global(tmp_path, monkeypatch):
+    """With no cwd-local config, resolution falls back to the global config."""
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+    mod = importlib.import_module("memory_indexer")
+
+    empty_root = tmp_path / "no-local-config"
+    empty_root.mkdir()
+    global_vault = tmp_path / "global-vault"
+    global_config = tmp_path / "global-config.json"
+    global_config.write_text(json.dumps({"vault_path": str(global_vault)}))
+    monkeypatch.setattr(mod, "CONFIG_PATH", global_config)
+
+    monkeypatch.chdir(empty_root)
+    assert mod._load_vault_path() == global_vault
+
+
+def test_cwd_local_config_without_vault_path_fails_loud(tmp_path, monkeypatch):
+    """A cwd-local config missing vault_path must fail loud, NOT fall through.
+
+    Falling through to the global config is the exact cross-instance vault
+    collision this fix prevents.
+    """
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+    mod = importlib.import_module("memory_indexer")
+
+    instance_root = tmp_path / "instance"
+    (instance_root / ".deus").mkdir(parents=True)
+    # Present but no vault_path key.
+    (instance_root / ".deus" / "config.json").write_text(json.dumps({"name": "amos"}))
+
+    # A perfectly good global config exists — must NOT be used as a fallback.
+    global_config = tmp_path / "global-config.json"
+    global_config.write_text(json.dumps({"vault_path": str(tmp_path / "global-vault")}))
+    monkeypatch.setattr(mod, "CONFIG_PATH", global_config)
+
+    monkeypatch.chdir(instance_root)
+    with pytest.raises(SystemExit):
+        mod._load_vault_path()
+
+
+def test_cwd_local_config_malformed_fails_loud(tmp_path, monkeypatch):
+    """A malformed (unparseable) cwd-local config must fail loud, NOT fall through."""
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    if "memory_indexer" in sys.modules:
+        del sys.modules["memory_indexer"]
+    mod = importlib.import_module("memory_indexer")
+
+    instance_root = tmp_path / "instance"
+    (instance_root / ".deus").mkdir(parents=True)
+    (instance_root / ".deus" / "config.json").write_text("{ not valid json")
+
+    global_config = tmp_path / "global-config.json"
+    global_config.write_text(json.dumps({"vault_path": str(tmp_path / "global-vault")}))
+    monkeypatch.setattr(mod, "CONFIG_PATH", global_config)
+
+    monkeypatch.chdir(instance_root)
+    with pytest.raises(SystemExit):
+        mod._load_vault_path()
+
+
 # ── Reranker configuration defaults ──────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #659

## Problem

When several Deus instances run on one machine they share a single `~/.config/deus/config.json`. `/compress` and `/resume` resolved `vault_path` **exclusively** from that global config. A second instance with no config of its own silently resolved to the **first** instance's vault and wrote its session logs and `CLAUDE.md` edits there — corrupting another instance's memory with no error or warning.

## Fix (issue Option 1 — per-instance config resolution)

Add an instance-local resolution tier. New order, highest priority first:

1. `DEUS_VAULT_PATH` env var (unchanged)
2. `./.deus/config.json` in the current working directory — **NEW**, instance-local
3. `~/.config/deus/config.json` (global fallback, unchanged)

The cwd-local `./.deus/config.json` makes each instance self-contained, so two instances sharing the global config never read/write each other's vault.

### Why the code change is the keystone, not just the prose

The skills are LLM prose that resolve `$VAULT` and then call `scripts/memory_indexer.py`. `/resume`'s `--recent` / `--recent-days` / `--learnings` / `--query` calls pass **no explicit path**, and `/compress`'s `--add` / `--extract` derive their index/atom location from the script's own resolved vault — not from the path argument. `memory_indexer.py` re-resolves the vault at import (`_vault_root = _load_vault_path()`) on every invocation, from the global config. So a prose-only skill edit would be a **false fix**: the skill would write `CLAUDE.md` to the right vault while `memory_indexer` still touched the wrong one.

`_load_vault_path()` now honors tier 2 and **fails loud** if a present `./.deus/config.json` has no usable `vault_path` (malformed JSON or missing key) — it does **not** fall through to the global config, because that fall-through is the exact cross-instance collision this fixes.

### Files changed

- `scripts/memory_indexer.py` — `_load_vault_path()` adds the cwd-local tier + fail-loud (the keystone).
- `scripts/tests/test_memory_indexer.py` — 5 tests encoding the anti-corruption guarantee: cwd-local beats global, env beats cwd-local, no-local falls back to global, and present-but-unusable cwd configs fail loud (malformed + missing `vault_path`).
- `.claude/skills/{compress,resume}/skill.md`, `.claude/commands/{compress,resume}.md` — resolution-order prose updated to the 3-tier order with the fail-loud rule.
- `deus-cmd.sh` — the inlined `/compress` and `/resume` skill heredocs updated to match, with `.deus-version` bumped `2` → `3` so a running instance re-installs the corrected `~/.claude/skills/` copies (without the bump the heredocs are inert).

### Before / after resolution order

Before (both skills):
> Read `~/.config/deus/config.json` and use the `vault_path` value. If the env var `DEUS_VAULT_PATH` is set, use that instead.

After:
> 1. `DEUS_VAULT_PATH` env var, if set.
> 2. `vault_path` in `./.deus/config.json` (instance-local), if that file exists. If present but missing `vault_path`, STOP — do not fall through to the global config.
> 3. `vault_path` in `~/.config/deus/config.json` (global fallback).

## Backward compatibility

Single-instance behavior is unchanged: with no `./.deus/config.json`, resolution falls back to the global config exactly as before. `.deus/` is already gitignored (`.gitignore:81`), so a user's instance-local config with a personal absolute `vault_path` is never committed.

## Scope / honest caveats

- This fix **honors** a per-instance `./.deus/config.json` when present. Each instance must create that file (or export `DEUS_VAULT_PATH`) to opt in. The reporter's exact scenario — a second instance with **no** config of its own — still falls back to the global config until that instance creates its local config. Auto-creating it during `/setup` and surfacing the mechanism in `/setup` output (issue Option 3) are intentionally **out of scope** for this minimal fix.
- This fix prevents wrong-vault **filesystem** writes: session logs, `CLAUDE.md`, and atom files now land in the resolving instance's own vault. The semantic index DB at `~/.deus/memory.db` is still **shared** across instances (the main `entries` table has no `vault_path` column and reads do not scope by it), so `/resume` on one instance can still surface another instance's indexed sessions. Index commingling is a separate, larger gap not addressed here.
- Same global-only resolution exists in `/checkpoint`, `/preserve`, `/handoff`, and the independent resolvers in `evolution/taste_profile.py`, `scripts/linear_vault_sync.py`, `scripts/codex_warden_hooks.py`. Same root cause, **not** addressed here (scoped to `/compress` and `/resume` per the issue).

## Testing

- 5 new `test_memory_indexer.py` tests pass.
- Full `test_memory_indexer.py` suite: 272 pass, 1 pre-existing failure (`test_rebuild_aborts_if_db_contains_evolution_tables` expects exit code `1`, the guard exits `AUTH_ERROR`/`5`) — reproduces unchanged on `origin/main`, unrelated to this change.
- `zsh -n deus-cmd.sh` syntax OK; heredocs balanced; no personal paths/IDs in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)