### PR TITLE
feat(events): cut over LinearUpdater live — delete inline In-Review write (Phase 1 Step 2)

### DIFF
--- a/docs/decisions/event-hub.md
+++ b/docs/decisions/event-hub.md
@@ -144,6 +144,12 @@ A listener ships `DRY_RUN_DEFAULT = true`: it receives events and logs what it
 the emit path on real traffic with **zero behavior change**, then a later cutover
 PR flips it live and deletes the inline write.
 
+Phase 1's LinearUpdater has completed this cutover (Step 2): the listener is now
+the sole writer of the "→ In Review" transition and the dispatcher's inline copy
+was deleted — the "confirm parity → delete inline write" strangler step, done
+after the dry-run line was deliberately observed co-firing with the inline write
+on a real dispatch.
+
 > **Warning:** the dry-run swallows failures and logs at `debug`, so a healthy
 > service is **not** proof the wire fires. Before any cutover, *deliberately*
 > observe the dry-run line on a real event (raise the log level or add a
@@ -156,7 +162,7 @@ Two interleaved tracks. Status as of this ADR:
 
 | Track | Phase | Status |
 |-------|-------|--------|
-| Event hub | 1 -- EventBus + `agent.done` -> dry-run LinearUpdater | **Shipped** (#657) |
+| Event hub | 1 -- EventBus + `agent.done` -> LinearUpdater (Step-2 cutover: listener live, inline In-Review write deleted) | **Shipped** (#657 + cutover) |
 | Event hub | 2 -- `pipeline.transition` emit + dry-run ObservabilitySink | **Shipped** (#660) |
 | Event hub | 3 -- cutover: flip sink live, delete inline `logPipelineEvent` INSERT | Planned |
 | Event hub | 4-6 -- unified-comment, high-value Linear writes, design-to-dev convergence | Planned |

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -92,7 +92,9 @@ sequenceDiagram
     ART-->>PD: output text
     alt success
         PD->>LAPI: createComment(output)
-        PD->>LAPI: updateIssue → In Review
+        PD->>PD: emit agent.done (event hub)
+        Note over PD,LAPI: Event-hub Phase-1 cutover: the In-Review write (+ agent_completed,<br/>circuit_breaker_reset) is now performed by the LinearUpdater listener<br/>on agent.done, not inline in the dispatcher.
+        PD->>LAPI: updateIssue → In Review (via LinearUpdater listener)
     else error
         PD->>LAPI: createComment(error)
         PD->>LAPI: updateIssue → Backlog

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-03" # auto-bump @1780483263
+last_verified: "2026-06-03" # auto-bump @1780487933
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-02" # auto-bump @1780413558
+last_verified: "2026-06-03" # auto-bump @1780487933
 governs:
   - src/
   - evolution/

--- a/src/events/listeners/linear-updater.test.ts
+++ b/src/events/listeners/linear-updater.test.ts
@@ -44,20 +44,10 @@ beforeEach(() => {
 });
 
 describe('registerLinearUpdater', () => {
-  it('dry-run (default): logs only, performs no write or bookkeeping', async () => {
+  it('moves the issue to In Review and fires both follow-ups', async () => {
     const bus = new EventBus();
     const updateIssue = vi.fn().mockResolvedValue(undefined);
-    registerLinearUpdater(bus, mkCtx(updateIssue)); // default dryRun = true
-    await bus.emit(mkDone());
-    expect(updateIssue).not.toHaveBeenCalled();
-    expect(notifyPipelineStep).not.toHaveBeenCalled();
-    expect(logPipelineEvent).not.toHaveBeenCalled();
-  });
-
-  it('live: moves the issue to In Review and fires both follow-ups', async () => {
-    const bus = new EventBus();
-    const updateIssue = vi.fn().mockResolvedValue(undefined);
-    registerLinearUpdater(bus, mkCtx(updateIssue), { dryRun: false });
+    registerLinearUpdater(bus, mkCtx(updateIssue));
     await bus.emit(mkDone());
     expect(updateIssue).toHaveBeenCalledTimes(1);
     expect(updateIssue).toHaveBeenCalledWith('ISS-1', {
@@ -78,10 +68,10 @@ describe('registerLinearUpdater', () => {
     );
   });
 
-  it('live + write fails: emit resolves (isolated) and NEITHER follow-up fires', async () => {
+  it('write fails: emit resolves (isolated) and NEITHER follow-up fires', async () => {
     const bus = new EventBus();
     const updateIssue = vi.fn().mockRejectedValue(new Error('linear 500'));
-    registerLinearUpdater(bus, mkCtx(updateIssue), { dryRun: false });
+    registerLinearUpdater(bus, mkCtx(updateIssue));
     await expect(bus.emit(mkDone())).resolves.toBeUndefined();
     expect(updateIssue).toHaveBeenCalledTimes(1);
     // Load-bearing: a failed transition must NOT fire circuit_breaker_reset
@@ -94,7 +84,7 @@ describe('registerLinearUpdater', () => {
   it('ignores non-issue correlations', async () => {
     const bus = new EventBus();
     const updateIssue = vi.fn().mockResolvedValue(undefined);
-    registerLinearUpdater(bus, mkCtx(updateIssue), { dryRun: false });
+    registerLinearUpdater(bus, mkCtx(updateIssue));
     await bus.emit(mkDone({ correlationId: { kind: 'run', id: 'run-1' } }));
     expect(updateIssue).not.toHaveBeenCalled();
   });

--- a/src/events/listeners/linear-updater.ts
+++ b/src/events/listeners/linear-updater.ts
@@ -5,50 +5,31 @@ import type { LinearContext } from '../../linear-dispatcher.js';
 import type { EventBus } from '../bus.js';
 
 /**
- * Step-1 (dual-run) default: the listener is log-only and the dispatcher's
- * inline write stays authoritative, so we can observe the live emit path on
- * real traffic without changing behavior. At Step-2 cutover this flips to
- * `false` and the inline block in linear-dispatcher.ts is deleted — removing
- * this constant (and the `dryRun` plumbing) IS the cutover diff.
- */
-const DRY_RUN_DEFAULT: boolean = true;
-
-/**
- * The flagship event-hub listener. Phase 1 handles only `agent.done`, absorbing
- * the dispatcher's "-> In Review" transition plus its two success-coupled
- * bookkeeping events (`agent_completed`, `circuit_breaker_reset`).
+ * The flagship event-hub listener. Phase 1 handles only `agent.done` and is the
+ * sole writer of the "-> In Review" transition plus its two success-coupled
+ * bookkeeping events (`agent_completed`, `circuit_breaker_reset`). The
+ * dispatcher's inline copy of this write was deleted at the Step-2 cutover;
+ * `runIssue` now only emits `agent.done`.
  *
  * The three writes are co-located and `updateIssue` is awaited FIRST, so a write
  * failure (caught and isolated by the bus) exits the handler before the
- * follow-ups run — exact parity with the post-run try/catch in the dispatcher's
- * `runIssue`. This is load-bearing: firing `circuit_breaker_reset` on a failed
+ * follow-ups run. This is load-bearing: firing `circuit_breaker_reset` on a failed
  * transition would zero the consecutive-failure counter (`getConsecutiveFailCount`
  * in db.ts) and mask repeat failures.
  *
  * Loop-safe: the write reuses ctx.client (the bot user), so the Linear webhook's
  * bot-actor guard (it skips transitions whose actor is the bot user) suppresses
- * this self-triggered transition exactly as the inline write does today.
+ * this self-triggered transition.
  *
  * Returns an unsubscribe function.
  */
 export function registerLinearUpdater(
   bus: EventBus,
   ctx: LinearContext,
-  opts: { dryRun?: boolean } = {},
 ): () => void {
-  const dryRun = opts.dryRun ?? DRY_RUN_DEFAULT;
-
   return bus.subscribe('agent.done', async (e) => {
     if (e.correlationId.kind !== 'issue') return;
     const issueId = e.correlationId.id;
-
-    if (dryRun) {
-      logger.info(
-        { issueId },
-        'linear-updater[dry-run]: would set In Review + agent_completed + circuit_breaker_reset',
-      );
-      return;
-    }
 
     const identifier = e.correlationId.identifier ?? '';
     const reviewState = ctx.stateByName.get('In Review');

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -1337,28 +1337,12 @@ async function runIssue(
         );
       }
 
-      const reviewState = ctx.stateByName.get('In Review')!;
-      await ctx.client.updateIssue(issueId, {
-        stateId: reviewState.id,
-        assigneeId: ctx.viewerId,
-      });
-      notifyPipelineStep(ctx, issueId, identifier, 'agent_completed').catch(
-        () => {},
-      );
-      logPipelineEvent(
-        issueId,
-        identifier,
-        'circuit_breaker_reset',
-        'agent completed successfully',
-      );
-      logger.info({ issueId }, 'linear-dispatcher: issue moved to In Review');
-
-      // Event-hub Phase 1: emit `agent.done` alongside the inline write above.
-      // The LinearUpdater listener is dry-run (log-only) in Step 1, so the
-      // inline block remains authoritative and behavior is unchanged. At the
-      // Step-2 cutover the inline In-Review block (updateIssue + agent_completed
-      // + circuit_breaker_reset) is deleted and this emit becomes the sole
-      // driver via the live listener.
+      // Event-hub Phase 1 (Step-2 cutover): `agent.done` is now the SOLE driver
+      // of the "-> In Review" transition. The live LinearUpdater listener
+      // (src/events/listeners/linear-updater.ts) performs the updateIssue +
+      // agent_completed + circuit_breaker_reset writes; the former inline copy
+      // here was deleted at cutover. Bus listeners are error-isolated, so a
+      // listener failure surfaces as a bus ERROR log, not via the catch below.
       await ctx.bus.emit({
         type: 'agent.done',
         source: 'linear-dispatcher',
@@ -1371,7 +1355,7 @@ async function runIssue(
   } catch (err) {
     logger.warn(
       { issueId, err },
-      'linear-dispatcher: failed to update Linear issue after run',
+      'linear-dispatcher: post-run Linear update failed',
     );
   } finally {
     ctx.inFlightDispatch.delete(issueId);


### PR DESCRIPTION
## What

Event Hub **Phase-1 Step-2 cutover**. The dry-run `LinearUpdater` listener (shipped in #657) is now the **sole writer** of the `agent.done` "→ In Review" transition; the dispatcher's redundant inline write is deleted. This is the "confirm parity → delete inline write" strangler step from `docs/decisions/event-hub.md`.

## Changes

- **`src/events/listeners/linear-updater.ts`** — remove the `dryRun` plumbing (`DRY_RUN_DEFAULT`, the `opts.dryRun` param, the dry-run early-return). The listener is always-live. The load-bearing atomic ordering (`updateIssue` awaited first → `agent_completed` → `circuit_breaker_reset`) is unchanged.
- **`src/linear-dispatcher.ts`** — delete the inline In-Review block in `runIssue`'s success branch; the `agent.done` emit (unchanged) is now the sole driver. The post-run catch WARN is reworded to `post-run Linear update failed` — In-Review write failures now surface as the bus's per-listener ERROR log, not this catch.
- **tests** — drop the dry-run test + `{dryRun:false}` args (live is the only behavior); the load-bearing "write fails → no false reset" guard is kept.
- **docs** — ADR notes in `event-hub.md` (roadmap + dry-run staging) and `linear-webhook-pipeline.md` (In-Review write now via the LinearUpdater listener).
- **patterns** — drift `last_verified` bump for `general-code.md` (src/) + `documentation.md` (docs/).

## Precondition (met)

The dry-run line `linear-updater[dry-run]: …` was observed **co-firing** with the inline `linear-dispatcher: issue moved to In Review` for the same issue at the same millisecond in the live process — confirming the emit→listener wire and exact parity before the flip.

## Deferred follow-up

Producer-edge test (`runIssue` success emits `agent.done`, a code-reviewer INFO item): **deferred**. `runIssue` is unexported and a real test requires file-level `vi.mock('./db.js')` + `vi.mock('./linear-notifications.js')` that would apply to all 65 dispatcher tests and risk destabilizing them; the emit code is unchanged by this diff.

## Found during testing (filed separately, out of scope)

- **LIA-168** — a dispatch can hang after success (no `turn_complete` → `_close` sentinel never written → container never exits → no `agent.done`); suspected `rate_limit_event` trigger; root cause in `runContainerAgent` untraced.
- **LIA-169** — gate fallback-REVISE on container error re-dispatches the issue (loop); violates `orchestration-rules.md`.

## Verification

- `npm run build` clean; **1429 tests pass** (82 files).
- `prettier --check` on changed `.ts` passes (CI format gate is `src/**/*.ts`).
- `scripts/drift_check.py --all --base origin/main` passes.

Prior: #657 (Phase 1), #660 (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
