### PR TITLE
fix(memory): lazy-init Gemini client so --query/--rebuild work without GEMINI_API_KEY

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-02" # auto-bump @1780407457
+last_verified: "2026-06-03" # auto-bump @1780472607
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -176,6 +176,8 @@ RERANKER_MODEL = os.environ.get("DEUS_RERANKER_MODEL", "BAAI/bge-reranker-v2-m3"
 RERANKER_TOP_K = int(os.environ.get("DEUS_RERANKER_CANDIDATES", "20"))
 
 _cross_encoder = None
+# Lazily constructed by _ensure_client() — its sole mutator. Tests that need a
+# client should monkeypatch this directly rather than call _ensure_client.
 _client: genai.Client | None = None
 
 
@@ -187,6 +189,20 @@ def load_api_key() -> str:
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(AUTH_ERROR)
+
+
+def _ensure_client() -> genai.Client:
+    """Lazily construct the Gemini client on first generation call.
+
+    Building the client requires GEMINI_API_KEY (load_api_key sys.exits when it
+    is absent). Deferring construction to the point where generation is actually
+    needed lets key-free commands — --query, --rebuild, --add --no-extract —
+    run on Ollama embeddings alone, instead of dying at startup on a missing key.
+    """
+    global _client
+    if _client is None:
+        _client = genai.Client(api_key=load_api_key())
+    return _client
 
 
 def embed(text: str) -> list[float]:
@@ -1814,9 +1830,7 @@ def _generate_with_fallback(
     Returns the response object on first success, or None if all models are
     quota-exhausted.
     """
-    if _client is None:
-        # Keep parity with callers that would otherwise crash on attribute access.
-        raise RuntimeError("Gemini client not initialized (call main() entry first).")
+    client = _ensure_client()
 
     kwargs = {"contents": prompt}
     if config is not None:
@@ -1825,7 +1839,7 @@ def _generate_with_fallback(
     for model in GEN_MODELS:
         for attempt in (1, 2):
             try:
-                return _client.models.generate_content(model=model, **kwargs)
+                return client.models.generate_content(model=model, **kwargs)
             except Exception as exc:
                 if _is_quota_error(exc):
                     if attempt == 1:
@@ -4305,7 +4319,6 @@ def main() -> int:
     if os.getenv("DEUS_EMBED_WARMUP") == "1":
         warmup_embedding_provider()
 
-    global _client
     # Commands that need no API key
     if args.wander is not None:
         cmd_wander(args.wander or [], steps=args.steps, top_k=args.top or 10, graph=args.graph)
@@ -4382,8 +4395,6 @@ def main() -> int:
               f"total={stats['total']}", file=sys.stderr)
         db.close()
         return
-
-    _client = genai.Client(api_key=load_api_key())
 
     if args.compile is not None:
         cmd_compile(None if args.compile == "__AUTO__" else args.compile)

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -4467,3 +4467,39 @@ def test_promote_atoms_classifier_failure_graceful(mi, tmp_path, monkeypatch):
     content = Path(promoted[0]).read_text()
     assert "kind: knowledge" in content
     db.close()
+
+
+# ── Lazy Gemini client init (#3: key-free indexing/query) ──────────────────────
+
+def test_ensure_client_lazy_constructs_and_caches(mi, monkeypatch):
+    """_ensure_client builds the client on first call and caches it.
+
+    The key check (load_api_key) must happen only when generation is actually
+    needed, so non-generating commands (--query/--rebuild) can run key-free.
+    """
+    calls = []
+    monkeypatch.setattr(mi, "load_api_key", lambda: calls.append(1) or "fake-key")
+    monkeypatch.setattr(mi, "_client", None)
+
+    first = mi._ensure_client()
+    assert first is not None
+    assert mi._client is first          # cached on the module global
+    second = mi._ensure_client()
+    assert second is first              # idempotent — no reconstruction
+    assert len(calls) == 1              # load_api_key consulted exactly once
+
+
+def test_ensure_client_defers_missing_key_failure(mi, monkeypatch):
+    """A missing key fails through _ensure_client, not at startup.
+
+    Regression guard: the old code called load_api_key eagerly in main() and
+    killed every command (incl. --query) when the key was absent. Now the
+    failure only surfaces when generation is actually attempted.
+    """
+    def _boom():
+        raise SystemExit(mi.AUTH_ERROR)
+
+    monkeypatch.setattr(mi, "load_api_key", _boom)
+    monkeypatch.setattr(mi, "_client", None)
+    with pytest.raises(SystemExit):
+        mi._ensure_client()


### PR DESCRIPTION
## Summary

Lazy-init the Gemini client in `memory_indexer.py` so memory commands that don't generate text — `--query`, `--rebuild`, `--add --no-extract` — no longer hard-fail when `GEMINI_API_KEY` is absent.

**Root cause:** `main()` constructed `genai.Client(api_key=load_api_key())` unconditionally before command dispatch. `load_api_key()` calls `sys.exit(AUTH_ERROR)` on a missing key, so on a fresh machine without the key, *every* command died at startup — even `--query`, which is pure embed+retrieve (embeddings already default to Ollama via `EMBEDDING_PROVIDER=auto`). The eager init also pre-empted the existing 429→fallback chain in `_generate_with_fallback`.

**Fix:** Defer client construction to the first actual generation call via a new `_ensure_client()` helper — the sole mutator of the `_client` global.

## Test plan

- **Keyless `--query`**: before → `SystemExit(4)` (AUTH_ERROR); after → `rc=0` with results. Verified with forced-empty `_ENV_SEARCH_PATHS` + unset `GEMINI_API_KEY`.
- **289 tests pass** (`test_memory_indexer.py` + `test_memory_indexer_ner.py`). 1 pre-existing failure (`test_rebuild_aborts_if_db_contains_evolution_tables`, `assert 5 == 1`) is unrelated — proven pre-existing via stash-base comparison; tracked separately.
- **+2 regression tests** for the lazy-init contract (lazy construct+cache; deferred missing-key failure).

## Out of scope (follow-up)

Routing `extract_atoms` through an Ollama generation fallback so `--extract`/`--add` also work without a Gemini key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
