### PR TITLE
fix(skills): make /wardens usable from any project

### DIFF
--- a/.claude/skills/wardens/skill.md
+++ b/.claude/skills/wardens/skill.md
@@ -4,8 +4,10 @@ description: View, toggle, and configure wardens — the quality gates that revi
 user_invocable: true
 ---
 
-If no arguments, run `~/deus/tui/target/release/deus-tui` via Bash (piped mode) and show the full dashboard output directly in chat. If the binary doesn't exist, build it first with `cargo build --release` in `~/deus/tui/`.
+This skill always operates on the canonical Deus install at `~/deus`, regardless of the current working directory — use absolute `~/deus/...` paths so `/wardens` works from any project.
 
-If the user passed arguments after `/wardens` (e.g. `/wardens disable plan-reviewer`), run `python3 scripts/wardens.py <args>` via Bash and show the output.
+If no arguments, run `~/deus/tui/target/release/deus-tui` via Bash (piped mode) and show the full dashboard output directly in chat. If the binary doesn't exist, build it first with `(cd ~/deus/tui && cargo build --release)`.
 
-For `customize <name>`, don't launch `claude -p` — you're already in a session. Instead, read the current `custom_instructions` from `.claude/wardens/config.json` for the named warden, ask the user what behavior they want to customize, help them write it, then save it back to `config.json`.
+If the user passed arguments after `/wardens` (e.g. `/wardens disable plan-reviewer`), run `python3 ~/deus/scripts/wardens.py <args>` via Bash and show the output.
+
+For `customize <name>`, don't launch `claude -p` — you're already in a session. Instead, read the current `custom_instructions` from `~/deus/.claude/wardens/config.json` for the named warden, ask the user what behavior they want to customize, help them write it, then save it back to `~/deus/.claude/wardens/config.json`.

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-02" # auto-bump @1780409427
+last_verified: "2026-06-03" # auto-bump @1780477973
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

Harden the `/wardens` skill's instructions to use absolute `~/deus/...` paths so the skill works when invoked from **any** project, not just `~/deus`.

## Why

`/wardens` was only usable inside `~/deus` because `skill.md` told the agent to use CWD-relative paths:
- `python3 scripts/wardens.py <args>` — fails to locate the script from another CWD
- read/write `.claude/wardens/config.json` — resolves against the wrong CWD

This is being symlinked into `~/.claude/skills/` for global availability, which surfaced the breakage.

## Key finding (diagnosis before treatment)

Both backing tools are **already CWD-independent** — only the skill *text* was pinning behavior to `~/deus` as CWD:
- `scripts/wardens.py:16` — `REPO_ROOT = Path(__file__).resolve().parents[1]` (location-based)
- `tui/src/config/mod.rs:repo_root()` — walks up from `current_exe()` first (finds `~/deus/.claude/wardens`), CWD only as fallback

So **no Rust recompile and no Python change** were needed. The fix is skill.md-only:

| Was (CWD-relative) | Now |
|------|------|
| `python3 scripts/wardens.py` | `python3 ~/deus/scripts/wardens.py` |
| `.claude/wardens/config.json` (read + write) | `~/deus/.claude/wardens/config.json` |
| build: `cargo build --release` in `~/deus/tui/` | `(cd ~/deus/tui && cargo build --release)` |

Plus a one-line preamble stating the skill always targets the canonical `~/deus` install.

## Review

Code-reviewer warden: **SHIP** — all three path claims independently verified against source; `~/deus` hardcoding matches the convention used by `compress`/`resume`/`handoff`; no data-loss/security concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)