### PR TITLE
test(memory): fix stale exit-code assertion in test_rebuild_aborts (LIA-171)

### DIFF
--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -1442,7 +1442,8 @@ def test_rebuild_aborts_if_db_contains_evolution_tables(mi, tmp_path, fresh_vaul
 
     with pytest.raises(SystemExit) as exc_info:
         mi.cmd_rebuild()
-    assert exc_info.value.code == 1
+    # INTERNAL_ERROR, not 1 — exit codes were centralized in #421.
+    assert exc_info.value.code == mi.INTERNAL_ERROR
 
     # DB should NOT have been deleted
     assert mi.DB_PATH.exists()


### PR DESCRIPTION
## Summary
Fixes a pre-existing red test on `main`. `test_rebuild_aborts_if_db_contains_evolution_tables` asserted the abort exit code `== 1`, but `cmd_rebuild` deliberately aborts with `sys.exit(INTERNAL_ERROR)` (`==5`) since exit codes were centralized into `scripts/_exit_codes.py` in #421. The test's magic number was never updated, so it failed (`assert 5 == 1`).

Asserts `mi.INTERNAL_ERROR` (the constant) instead — robust to future renumbering.

## Test plan
- `python3 -m pytest scripts/tests/test_memory_indexer.py::test_rebuild_aborts_if_db_contains_evolution_tables -q` → passes.
- Test-only change; pre-existing failure (proven independent of recent work during #677), not a regression.

Closes LIA-171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)