### PR TITLE
docs: correct embedding default in KNOWN_LIMITATIONS (LIA-172)

### DIFF
--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -17,7 +17,7 @@ Deus now has a backend-neutral host runtime with per-group and per-task backend 
 **What IS swappable:**
 - **Container agent backend** — `claude` or `openai`, selected globally or overridden per group/task
 - **Eval/evolution judges** — can use Ollama (local, free), Gemini, or Claude
-- **Embedding model** — pluggable via `EMBEDDING_PROVIDER` env var (default: Gemini). See `evolution/providers/embeddings.py` to add providers
+- **Embedding model** — pluggable via `EMBEDDING_PROVIDER` env var (default: `auto` → Ollama first, Gemini fallback). See `evolution/providers/embeddings.py` to add providers
 - **Memory indexer** — uses the pluggable embedding provider
 - **Transcription** — local Whisper, independent of any API
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-02" # auto-bump @1780409372
+last_verified: "2026-06-03" # auto-bump @1780481497
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary
`docs/KNOWN_LIMITATIONS.md` stated the embedding model default is "Gemini". The actual default is `auto` → Ollama-first with Gemini fallback (`evolution/providers/embeddings.py:232`). One-line doc correction.

Closes LIA-172. Surfaced during the lazy-init Gemini investigation (#677).

🤖 Generated with [Claude Code](https://claude.com/claude-code)