### PR TITLE
feat(memory): ollama fallback for atom extraction — keyless --extract/--add (LIA-170)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ CREDENTIAL_PROXY_HOST_UNSAFE=
 
 # === Evolution / Eval ===
 EMBEDDING_PROVIDER=auto
+# Atom extraction backend: auto (Ollama first, Gemini fallback), ollama, or gemini.
+# "auto" lets `--extract`/`--add` run without a Gemini key when Ollama is up.
+DEUS_ATOM_PROVIDER=auto
+# Ollama model used for atom extraction when DEUS_ATOM_PROVIDER is auto/ollama.
+DEUS_OLLAMA_ATOM_MODEL=gemma4:e4b
 EVOLUTION_ENABLED=1
 # Comma-separated list of group folder names to opt out of evolution tracking.
 # Interactions from these groups are silently skipped and not logged to the DB.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -76,6 +76,8 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `LLAMA_CPP_JUDGE_MODEL` | (falls back to `LLAMA_CPP_MODEL`) | Per-surface override for the evolution-loop judge provider |
 | `LLAMA_CPP_EMBED_MODEL` | (falls back to `LLAMA_CPP_MODEL`) | Per-surface override for embeddings (reserved; embedding swap is ADR-gated per Phase 4) |
 | `EMBEDDING_PROVIDER` | `auto` | Embedding backend: `auto`, `gemini`, or `ollama` |
+| `DEUS_ATOM_PROVIDER` | `auto` | Atom-extraction backend: `auto` (Ollama first, Gemini fallback), `ollama`, or `gemini`. `auto` lets `--extract`/`--add` run without a Gemini key when Ollama is up |
+| `DEUS_OLLAMA_ATOM_MODEL` | `gemma4:e4b` | Ollama model used for atom extraction (auto/ollama) |
 
 ## Evolution / Eval
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-03" # auto-bump @1780481497
+last_verified: "2026-06-03" # auto-bump @1780483263
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-03" # auto-bump @1780472607
+last_verified: "2026-06-03" # auto-bump @1780483263
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -58,9 +58,9 @@ HEALTH_LOG_PATH = Path("~/.deus/memory_health.jsonl").expanduser()
 # "ollama" uses Ollama only.  "gemini" skips Ollama entirely.
 ENTITY_PROVIDER = os.environ.get("DEUS_ENTITY_PROVIDER", "auto")
 
-# Atom extraction provider: same semantics as ENTITY_PROVIDER. "auto" (default)
-# tries Ollama first so atom extraction (--extract / --add) works without a
-# Gemini key; falls back to the Gemini cascade when Ollama is unreachable.
+# Atom extraction provider (LIA-170): same semantics as ENTITY_PROVIDER. "auto"
+# (default) tries Ollama first so atom extraction (--extract / --add) works
+# without a Gemini key; falls back to the Gemini cascade when Ollama is down.
 ATOM_PROVIDER = os.environ.get("DEUS_ATOM_PROVIDER", "auto")
 
 
@@ -1913,6 +1913,7 @@ def _extract_atoms_ollama(content: str) -> "list[dict] | None":
 
     prompt = _atom_prompt(content)
     ollama_url = os.environ.get("DEUS_OLLAMA_URL", "http://localhost:11434")
+    # DEUS_OLLAMA_ATOM_MODEL: per-task Ollama model override (LIA-170).
     ollama_model = os.environ.get("DEUS_OLLAMA_ATOM_MODEL", "gemma4:e4b")
     body = json.dumps({
         "model": ollama_model,

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -58,6 +58,11 @@ HEALTH_LOG_PATH = Path("~/.deus/memory_health.jsonl").expanduser()
 # "ollama" uses Ollama only.  "gemini" skips Ollama entirely.
 ENTITY_PROVIDER = os.environ.get("DEUS_ENTITY_PROVIDER", "auto")
 
+# Atom extraction provider: same semantics as ENTITY_PROVIDER. "auto" (default)
+# tries Ollama first so atom extraction (--extract / --add) works without a
+# Gemini key; falls back to the Gemini cascade when Ollama is unreachable.
+ATOM_PROVIDER = os.environ.get("DEUS_ATOM_PROVIDER", "auto")
+
 
 def _load_vault_path() -> Path:
     """Load vault path with per-instance precedence.
@@ -1869,9 +1874,9 @@ def _generate_with_fallback(
     return None
 
 
-def extract_atoms(content: str) -> list[dict]:
-    """Call Gemini Flash to extract 2-5 atomic facts from a session log."""
-    prompt = (
+def _atom_prompt(content: str) -> str:
+    """Build the atom-extraction prompt (shared by the Ollama + Gemini paths)."""
+    return (
         "You are an atomic fact extractor for a personal knowledge system.\n\n"
         "Given a session log, extract 2-5 atomic facts worth remembering across future sessions. "
         "Each fact must be:\n"
@@ -1895,9 +1900,77 @@ def extract_atoms(content: str) -> list[dict]:
         "If nothing is worth extracting (casual/social session with no stable decisions), respond with: []\n\n"
         f"SESSION LOG:\n{_extract_content_for_llm(content)}"
     )
+
+
+def _extract_atoms_ollama(content: str) -> "list[dict] | None":
+    """Extract atoms via Ollama (Gemma4). Mirrors _extract_entities_ollama.
+
+    Returns the parsed atom list, or None when Ollama is unreachable (so the
+    caller can fall back to Gemini). Other failures return [] (skip extraction).
+    Keyless — this is the path that lets --extract/--add run without a Gemini key.
+    """
+    import urllib.request  # lazy: only needed when the Ollama path is taken
+
+    prompt = _atom_prompt(content)
+    ollama_url = os.environ.get("DEUS_OLLAMA_URL", "http://localhost:11434")
+    ollama_model = os.environ.get("DEUS_OLLAMA_ATOM_MODEL", "gemma4:e4b")
+    body = json.dumps({
+        "model": ollama_model,
+        "prompt": prompt,
+        "stream": False,
+        # Object-wrapper schema (Ollama structured output; top-level array is
+        # undefined — mirror the entity path's object form).
+        "format": {
+            "type": "object",
+            "properties": {
+                "atoms": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "text": {"type": "string"},
+                            "category": {"type": "string"},
+                        },
+                    },
+                },
+            },
+            "required": ["atoms"],
+        },
+        # temperature=0.1 for parity with _extract_atoms_gemini; seed for repro.
+        "options": {"temperature": 0.1, "seed": 42},
+    }).encode()
+    req = urllib.request.Request(
+        f"{ollama_url}/api/generate",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode())
+        raw = data.get("response", "").strip()
+        result = json.loads(raw)
+        # Cap defensively (prompt asks for 2-5), mirroring the entity path's ceiling.
+        atoms = (result.get("atoms", []) if isinstance(result, dict) else [])[:10]
+        return [a for a in atoms if isinstance(a, dict) and "text" in a and "category" in a]
+    except urllib.error.HTTPError as exc:
+        print(f"  WARN: Ollama atom extraction HTTP {exc.code}: {str(exc)[:120]}", file=sys.stderr)
+        return []
+    except (ConnectionRefusedError, OSError):
+        return None
+    except json.JSONDecodeError as exc:
+        print(f"  WARN: Ollama atom extraction malformed JSON: {str(exc)[:120]}", file=sys.stderr)
+        return []
+    except Exception as exc:
+        print(f"  WARN: Ollama atom extraction failed: {exc}", file=sys.stderr)
+        return []
+
+
+def _extract_atoms_gemini(content: str) -> list[dict]:
+    """Extract atoms via the Gemini cascade (original path)."""
     try:
         response = _generate_with_fallback(
-            prompt,
+            _atom_prompt(content),
             config=genai_types.GenerateContentConfig(temperature=0.1, max_output_tokens=1024),
             label="extract_atoms",
         )
@@ -1917,6 +1990,36 @@ def extract_atoms(content: str) -> list[dict]:
         return [a for a in atoms if isinstance(a, dict) and "text" in a and "category" in a]
     except json.JSONDecodeError:
         return []
+
+
+def extract_atoms(content: str) -> list[dict]:
+    """Extract 2-5 atomic facts from a session log.
+
+    Strategy routing via DEUS_ATOM_PROVIDER (default "auto"), mirroring
+    extract_entities_and_relations:
+      - "auto"   — try Ollama (keyless) first; fall back to Gemini if Ollama down.
+      - "ollama" — require Ollama; return [] if unreachable.
+      - "gemini" — use the Gemini cascade only (original behavior).
+    """
+    provider = ATOM_PROVIDER.lower()
+
+    if provider == "gemini":
+        return _extract_atoms_gemini(content)
+
+    # "auto" or "ollama": attempt Ollama first (keyless).
+    ollama_result = _extract_atoms_ollama(content)
+
+    if ollama_result is None:
+        if provider == "ollama":
+            print(
+                "  WARN: DEUS_ATOM_PROVIDER=ollama but Ollama not reachable.",
+                file=sys.stderr,
+            )
+            return []
+        # auto: fall back to Gemini.
+        return _extract_atoms_gemini(content)
+
+    return ollama_result
 
 
 def find_duplicate_atom(db: sqlite3.Connection, vec: list[float]) -> int | None:

--- a/scripts/tests/test_memory_indexer_ner.py
+++ b/scripts/tests/test_memory_indexer_ner.py
@@ -303,3 +303,68 @@ def test_provider_ollama_strict_uses_ollama_when_available(mi_ollama):
 
     assert result["entities"][0]["name"] == "torch"
     assert result["relationships"][0]["rel_type"] == "uses"
+
+
+# ── Ollama atom extraction (LIA-170) ─────────────────────────────────────────
+
+def test_ollama_extracts_atoms(mi):
+    # Ollama returns the object-wrapper {"atoms": [...]} shape.
+    result_dict = {"atoms": [
+        {"text": "Deus uses sqlite-vec for vector storage", "category": "fact"},
+        {"text": "Vitest is the monorepo test runner", "category": "decision"},
+    ]}
+    with patch("urllib.request.urlopen", return_value=_mock_ollama_response(result_dict)):
+        atoms = mi._extract_atoms_ollama("Deus uses sqlite-vec; Vitest runs tests.")
+    assert atoms is not None
+    assert len(atoms) == 2
+    assert atoms[0]["category"] == "fact"
+
+
+def test_ollama_atoms_filters_malformed(mi):
+    # Entries missing "text" or "category" are dropped (mirrors the Gemini filter).
+    result_dict = {"atoms": [
+        {"text": "valid", "category": "fact"},
+        {"text": "no category"},
+        {"category": "no text"},
+        "not a dict",
+    ]}
+    with patch("urllib.request.urlopen", return_value=_mock_ollama_response(result_dict)):
+        atoms = mi._extract_atoms_ollama("x")
+    assert atoms == [{"text": "valid", "category": "fact"}]
+
+
+def test_ollama_atoms_connection_refused_returns_none(mi):
+    # Unreachable Ollama → None, so the router can fall back to Gemini.
+    with patch("urllib.request.urlopen", side_effect=ConnectionRefusedError()):
+        assert mi._extract_atoms_ollama("x") is None
+
+
+def test_extract_atoms_auto_falls_back_to_gemini_when_ollama_down(mi, monkeypatch):
+    monkeypatch.setattr(mi, "ATOM_PROVIDER", "auto")
+    monkeypatch.setattr(mi, "_extract_atoms_ollama", lambda c: None)  # Ollama down
+    sentinel = [{"text": "from gemini", "category": "fact"}]
+    monkeypatch.setattr(mi, "_extract_atoms_gemini", lambda c: sentinel)
+    assert mi.extract_atoms("x") == sentinel
+
+
+def test_extract_atoms_gemini_provider_skips_ollama(mi, monkeypatch):
+    monkeypatch.setattr(mi, "ATOM_PROVIDER", "gemini")
+    called = {"ollama": False}
+    def _boom(c):
+        called["ollama"] = True
+        return None
+    monkeypatch.setattr(mi, "_extract_atoms_ollama", _boom)
+    monkeypatch.setattr(mi, "_extract_atoms_gemini", lambda c: [{"text": "g", "category": "fact"}])
+    result = mi.extract_atoms("x")
+    assert called["ollama"] is False
+    assert result == [{"text": "g", "category": "fact"}]
+
+
+def test_extract_atoms_ollama_provider_unreachable_returns_empty(mi, monkeypatch):
+    monkeypatch.setattr(mi, "ATOM_PROVIDER", "ollama")
+    monkeypatch.setattr(mi, "_extract_atoms_ollama", lambda c: None)
+    # ollama-only + unreachable → [] (must NOT fall back to Gemini)
+    def _fail_gemini(c):
+        raise AssertionError("ollama-only provider must not fall back to Gemini")
+    monkeypatch.setattr(mi, "_extract_atoms_gemini", _fail_gemini)
+    assert mi.extract_atoms("x") == []


### PR DESCRIPTION
## Summary

Adds an **Ollama fallback for atom extraction** so `--extract` and `--add` (with extraction) work **without a `GEMINI_API_KEY`** — completing the keyless-memory work started in #677 (which only covered query/rebuild). Closes **LIA-170**.

Mirrors the proven entity-extraction Strategy (`extract_entities_and_relations`): `extract_atoms` now routes via `DEUS_ATOM_PROVIDER` (default `auto`):
- `auto` → try **Ollama first** (keyless), fall back to the Gemini cascade only when Ollama is unreachable.
- `ollama` → Ollama only (returns `[]` if unreachable).
- `gemini` → original Gemini-only behavior.

`_extract_atoms_ollama` POSTs to `/api/generate` with an object-wrapper JSON schema `{"atoms":[{text,category}]}`; `_atom_prompt` is shared by both paths for output parity; `_extract_atoms_gemini` is the unchanged original cascade.

## Test plan

- **6 new tests** (`test_memory_indexer_ner.py`): parse, malformed-filter, unreachable→None, `auto`→Gemini fallback, `gemini` skips Ollama, `ollama`-only→`[]`.
- Full `test_memory_indexer_ner.py` (21) and `test_memory_indexer.py` green (the branch merges `main`, which includes the #5 `test_rebuild_aborts` fix).
- **Empirical:** with no Gemini key anywhere + Ollama up, `extract_atoms` returned 3 correctly-categorized atoms via Ollama, no `AUTH_ERROR`.
- Documents `DEUS_ATOM_PROVIDER` + `DEUS_OLLAMA_ATOM_MODEL` in `.env.example` + `docs/ENVIRONMENT.md`.

## Notes (pre-empt reviewer confusion)

- **Extraction-only** — atoms are stored/embedded identically; no retrieval-pipeline change (retrieval-sweep concerns N/A).
- The `atom-fallback-evaluation.md` ADR governs the **retrieval** fallback (`DEUS_ATOM_DIST`) — **orthogonal** to this **extraction-provider** change; no conflict.
- **Out of scope:** Ollama-vs-Gemini atom-quality benchmark (separate eval follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
