### PR TITLE
feat(setup): auto-init codegraph + code-search MCP servers in /setup

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -312,6 +312,44 @@ Tell the user: "Model `{MODEL}` is already pulled — no action needed."
 Tell the user: "Model pull failed (see ERROR field). You can retry with `ollama pull {MODEL}` and set `OLLAMA_MODEL={MODEL}` in `~/.config/deus/.env` manually."
 
 
+## 7c. Code Intelligence (Optional)
+
+Run `npx tsx setup/index.ts --step codeintel` and parse the status block.
+
+This registers the two code-intelligence MCP servers Deus uses during
+development — **codegraph** (third-party npm global) and **code-search**
+(first-party semantic search) — via the official `claude mcp add --scope user`
+CLI. It is **optional and non-fatal**: each server is best-effort and skips
+cleanly if its prerequisites are missing. Run it **after** step 7b — code-search
+builds its index using Ollama embeddings.
+
+> **Note:** codegraph installs the third-party package `@colbymchenry/codegraph`
+> globally via npm (version-pinned). This is the standard Deus code-intelligence
+> tool; if you prefer not to auto-install it, skip this step and install it
+> manually later.
+
+Per-server fields are `CODEGRAPH` / `CODE_SEARCH` (`success` | `skipped` with a
+`*_REASON`), `*_MCP` (`registered` | `failed` | `skipped`), and `*_INDEX`
+(`started` | `failed` | `skipped`). The build logs live in `LOG_DIR`.
+
+**If STATUS=success or partial:**
+Tell the user which servers registered. For any `*_INDEX=started`, note the
+index is building in the background (logs in `LOG_DIR`) and will be ready
+shortly. They take effect in new Claude Code sessions.
+
+**Common skip reasons (all non-fatal — report and continue):**
+- `CODEGRAPH_REASON=npm_not_installed` → "codegraph needs Node/npm. Install Node, then re-run `npx tsx setup/index.ts --step codeintel`."
+- `CODEGRAPH_REASON=install_failed` → "codegraph install failed (often a global-npm permissions issue). Run manually: `npm install -g @colbymchenry/codegraph` and re-run this step."
+- `CODEGRAPH_REASON=binary_unverified` → "codegraph installed but didn't run. Often the npm global bin dir isn't on PATH — check `npm bin -g` and add it to your shell PATH, then re-run this step. (Also covers unsupported platforms.) Skipped cleanly — no broken MCP entry left behind."
+- `CODE_SEARCH_REASON=windows_unsupported` → "code-search is macOS/Linux only (needs sqlite_vec + Ollama). Skipped on Windows."
+- `CODE_SEARCH_REASON=sqlite_vec_missing` → "code-search needs the `sqlite_vec` Python package. Run the `memory` step first (`npx tsx setup/index.ts --step memory`), then re-run this step."
+- `CODE_SEARCH_REASON=python_not_found` → "No Python found. Install Python 3, then re-run this step."
+- `CODE_SEARCH_INDEX=skipped` with `CODE_SEARCH=success` → "code-search registered but its index isn't built (Ollama absent). After installing Ollama: `python3 scripts/code_search.py reindex .`"
+
+**Verify (optional):** `claude mcp list` should show `codegraph` and/or
+`code-search` once their background indexes finish.
+
+
 ## 8. Personality Kickstarter (Optional)
 
 AskUserQuestion: "Want to load curated behavioral defaults into your Deus config?" Options:

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-02" # auto-bump @1780406120
+last_verified: "2026-06-03" # auto-bump @1780493934
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-03" # auto-bump @1780487933
+last_verified: "2026-06-03" # auto-bump @1780493934
 governs:
   - src/
   - evolution/

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-03" # auto-bump @1780477973
+last_verified: "2026-06-03" # auto-bump @1780493934
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/setup/__tests__/codeintel.test.ts
+++ b/setup/__tests__/codeintel.test.ts
@@ -11,6 +11,7 @@
  * step's live-run verification (see the plan's Verification section).
  */
 import { describe, it, expect } from 'vitest';
+import path from 'path';
 
 // ── buildMcpAddArgs ─────────────────────────────────────────────────────────
 
@@ -61,9 +62,14 @@ describe('codeSearchServerCommand', () => {
     const { codeSearchServerCommand } = await import('../codeintel.js');
     const [python, script] = codeSearchServerCommand('python3', '/home/u/deus');
     expect(python).toBe('python3');
-    expect(script).toBe('/home/u/deus/scripts/code_search_mcp.py');
-    // The portability bug being fixed: must NOT reference the old eval venv.
-    expect(script).not.toContain('eval/.venv');
+    // Use path.join for the expectation so it matches the impl's native
+    // separator on every OS (Windows uses backslashes).
+    expect(script).toBe(
+      path.join('/home/u/deus', 'scripts', 'code_search_mcp.py'),
+    );
+    // The portability bug being fixed: must NOT reference the old eval venv
+    // (separator-agnostic so the assertion holds on Windows too).
+    expect(script).not.toContain('.venv');
   });
 
   it('uses the resolved interpreter (not a fixed venv path)', async () => {

--- a/setup/__tests__/codeintel.test.ts
+++ b/setup/__tests__/codeintel.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for setup/codeintel.ts — code-intelligence MCP setup step.
+ *
+ * Mirrors ollama.test.ts: unit-tests the pure exported helpers (registration
+ * command construction, server-command derivation, status roll-up, the pinned
+ * package const) plus the shared commandExists integration.
+ *
+ * NOT unit-tested (parity with ollama.test.ts): the detached background-build
+ * path (`child.unref()` via `startBackgroundBuild`) and the subprocess-driven
+ * sub-steps (`setupCodegraph`/`setupCodeSearch`). Those are covered by the
+ * step's live-run verification (see the plan's Verification section).
+ */
+import { describe, it, expect } from 'vitest';
+
+// ── buildMcpAddArgs ─────────────────────────────────────────────────────────
+
+describe('buildMcpAddArgs', () => {
+  it('builds the codegraph registration argv with a -- separator', async () => {
+    const { buildMcpAddArgs } = await import('../codeintel.js');
+    expect(
+      buildMcpAddArgs('codegraph', 'user', ['codegraph', 'serve', '--mcp']),
+    ).toEqual([
+      'mcp',
+      'add',
+      '--scope',
+      'user',
+      'codegraph',
+      '--',
+      'codegraph',
+      'serve',
+      '--mcp',
+    ]);
+  });
+
+  it('places the server command after -- so flags are not parsed by claude', async () => {
+    const { buildMcpAddArgs } = await import('../codeintel.js');
+    const args = buildMcpAddArgs('code-search', 'user', [
+      '/usr/bin/python3',
+      '/repo/scripts/code_search_mcp.py',
+    ]);
+    const sep = args.indexOf('--');
+    expect(sep).toBeGreaterThan(-1);
+    expect(args.slice(sep + 1)).toEqual([
+      '/usr/bin/python3',
+      '/repo/scripts/code_search_mcp.py',
+    ]);
+    // name comes before the separator
+    expect(args.slice(0, sep)).toContain('code-search');
+  });
+
+  it('honors the requested scope', async () => {
+    const { buildMcpAddArgs } = await import('../codeintel.js');
+    expect(buildMcpAddArgs('x', 'project', ['cmd'])).toContain('project');
+  });
+});
+
+// ── codeSearchServerCommand ─────────────────────────────────────────────────
+
+describe('codeSearchServerCommand', () => {
+  it('derives [python, <repo>/scripts/code_search_mcp.py] — never hardcoded', async () => {
+    const { codeSearchServerCommand } = await import('../codeintel.js');
+    const [python, script] = codeSearchServerCommand('python3', '/home/u/deus');
+    expect(python).toBe('python3');
+    expect(script).toBe('/home/u/deus/scripts/code_search_mcp.py');
+    // The portability bug being fixed: must NOT reference the old eval venv.
+    expect(script).not.toContain('eval/.venv');
+  });
+
+  it('uses the resolved interpreter (not a fixed venv path)', async () => {
+    const { codeSearchServerCommand } = await import('../codeintel.js');
+    const [python] = codeSearchServerCommand('python', '/repo');
+    expect(python).toBe('python');
+  });
+});
+
+// ── overallStatus roll-up ───────────────────────────────────────────────────
+
+describe('overallStatus', () => {
+  it('success only when both succeed', async () => {
+    const { overallStatus } = await import('../codeintel.js');
+    expect(overallStatus('success', 'success')).toBe('success');
+  });
+
+  it('partial when exactly one succeeds (either order)', async () => {
+    const { overallStatus } = await import('../codeintel.js');
+    expect(overallStatus('success', 'skipped')).toBe('partial');
+    expect(overallStatus('skipped', 'success')).toBe('partial');
+  });
+
+  it('skipped when neither succeeds', async () => {
+    const { overallStatus } = await import('../codeintel.js');
+    expect(overallStatus('skipped', 'skipped')).toBe('skipped');
+  });
+});
+
+// ── pinned package const (supply-chain) ─────────────────────────────────────
+
+describe('CODEGRAPH_PACKAGE', () => {
+  it('is version-pinned for supply-chain reproducibility', async () => {
+    const { CODEGRAPH_PACKAGE } = await import('../codeintel.js');
+    expect(CODEGRAPH_PACKAGE).toMatch(
+      /^@colbymchenry\/codegraph@\d+\.\d+\.\d+$/,
+    );
+  });
+});
+
+// ── commandExists (shared platform helper the step gates on) ─────────────────
+
+describe('commandExists integration', () => {
+  it('returns true for a command that definitely exists', async () => {
+    const { commandExists } = await import('../platform.js');
+    expect(commandExists('node')).toBe(true);
+  });
+
+  it('returns false for a command that does not exist', async () => {
+    const { commandExists } = await import('../platform.js');
+    expect(commandExists('definitely_not_a_real_command_xyz_abc_123')).toBe(
+      false,
+    );
+  });
+});

--- a/setup/codeintel.ts
+++ b/setup/codeintel.ts
@@ -1,0 +1,294 @@
+/**
+ * Step: codeintel — install + register the two code-intelligence MCP servers
+ * Deus relies on: **codegraph** (third-party npm global) and **code-search**
+ * (first-party `scripts/code_search_mcp.py`).
+ *
+ * Non-fatal contract: setup must NEVER fail because optional tooling is absent,
+ * so every external call is individually wrapped — a failure becomes a reported
+ * skip, not a thrown error. The two sub-steps are independent (codegraph's npm
+ * path never blocks code-search's python path).
+ *
+ * Registration delegates to `claude mcp add/remove --scope user` — we never
+ * hand-edit `~/.claude.json` (no clobber risk). remove-then-add is idempotent
+ * (safe re-runs) and scope-correct (immune to a stale project `.mcp.json`; a
+ * re-run also refreshes a stale user-scope entry like the old `eval/.venv` one).
+ *
+ * Mirrors `setup/ollama.ts`.
+ */
+import { execFileSync, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { resolvePython } from '../src/checks.js';
+import { CONFIG_DIR } from '../src/config.js';
+import { logger } from '../src/logger.js';
+// TODO(windows-sot-phase1): update import to '../src/platform.js' once
+// setup/platform.ts is consolidated into src/platform.ts
+// (see project_windows_sot_plan.md Phase 1).
+import { commandExists, getPlatform } from './platform.js';
+import { emitStatus } from './status.js';
+
+/**
+ * codegraph npm package, version-pinned for supply-chain reproducibility.
+ * pinned 2026-06-03 (latest stable via `npm view @colbymchenry/codegraph`);
+ * bump after testing.
+ */
+export const CODEGRAPH_PACKAGE = '@colbymchenry/codegraph@0.9.9';
+
+/** Background build logs (mirrors ollama's ~/.config/deus/ollama-downloads/). */
+const LOG_DIR = path.join(CONFIG_DIR, 'codeintel');
+
+type SubStatus = 'success' | 'skipped';
+type McpStatus = 'registered' | 'failed' | 'skipped';
+type IndexStatus = 'started' | 'failed' | 'skipped';
+
+interface SubResult {
+  status: SubStatus;
+  reason?: string;
+  mcp?: McpStatus;
+  indexBuild?: IndexStatus;
+}
+
+// ── Pure helpers (unit-tested) ─────────────────────────────────────────────
+
+/** Build argv for `claude mcp add --scope <scope> <name> -- <serverCommand...>`. */
+export function buildMcpAddArgs(
+  name: string,
+  scope: string,
+  serverCommand: string[],
+): string[] {
+  return ['mcp', 'add', '--scope', scope, name, '--', ...serverCommand];
+}
+
+/** stdio server command for code-search: `<python> <repo>/scripts/code_search_mcp.py`. */
+export function codeSearchServerCommand(
+  python: string,
+  repoRoot: string,
+): string[] {
+  return [python, path.join(repoRoot, 'scripts', 'code_search_mcp.py')];
+}
+
+/** Roll up the two sub-step statuses into one step-level status. */
+export function overallStatus(
+  a: SubStatus,
+  b: SubStatus,
+): 'success' | 'partial' | 'skipped' {
+  if (a === 'success' && b === 'success') return 'success';
+  if (a === 'success' || b === 'success') return 'partial';
+  return 'skipped';
+}
+
+// ── Side-effecting helpers (covered by live-run verification) ───────────────
+
+/**
+ * Register an MCP server at user scope, idempotently (remove-then-add).
+ * Non-fatal: returns 'failed' rather than throwing.
+ */
+function registerMcpServer(name: string, serverCommand: string[]): McpStatus {
+  // Remove first so a re-run refreshes a stale entry; ignore failure (the
+  // entry may not exist, which is the common first-run case).
+  try {
+    execFileSync('claude', ['mcp', 'remove', '--scope', 'user', name], {
+      stdio: 'ignore',
+      timeout: 15000,
+    });
+  } catch {
+    // not registered yet — expected on first run
+  }
+  try {
+    execFileSync('claude', buildMcpAddArgs(name, 'user', serverCommand), {
+      stdio: 'ignore',
+      timeout: 15000,
+    });
+    return 'registered';
+  } catch (err) {
+    logger.warn({ name, err: (err as Error).message }, 'claude mcp add failed');
+    return 'failed';
+  }
+}
+
+/** Spawn a detached background build, logging to LOG_DIR/<stem>.log. */
+function startBackgroundBuild(
+  stem: string,
+  command: string,
+  args: string[],
+  cwd: string,
+): IndexStatus {
+  try {
+    if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, { recursive: true });
+    const out = fs.openSync(path.join(LOG_DIR, `${stem}.log`), 'a');
+    const child = spawn(command, args, {
+      cwd,
+      detached: true,
+      stdio: ['ignore', out, out],
+    });
+    child.unref();
+    if (!child.pid) {
+      logger.warn({ stem }, 'background build spawned without a pid');
+      return 'failed';
+    }
+    return 'started';
+  } catch (err) {
+    logger.warn(
+      { stem, err: (err as Error).message },
+      'background build failed to start',
+    );
+    return 'failed';
+  }
+}
+
+// ── Sub-step A: codegraph (attempted all platforms, gated on a runnable binary) ──
+
+function setupCodegraph(repoRoot: string): SubResult {
+  if (!commandExists('npm')) {
+    return { status: 'skipped', reason: 'npm_not_installed' };
+  }
+
+  if (!commandExists('codegraph')) {
+    try {
+      // Array form (not a shell string) — no shell-interpolation surface.
+      execFileSync('npm', ['install', '-g', CODEGRAPH_PACKAGE], {
+        stdio: 'pipe',
+        timeout: 300000,
+      });
+    } catch (err) {
+      logger.warn(
+        { err: (err as Error).message },
+        'codegraph npm install failed',
+      );
+      return { status: 'skipped', reason: 'install_failed' };
+    }
+  }
+
+  // Verify the binary actually runs — covers Windows-unsupported AND broken
+  // installs uniformly, so we never report success while leaving a dead MCP
+  // entry behind.
+  try {
+    execFileSync('codegraph', ['--version'], {
+      stdio: 'ignore',
+      timeout: 10000,
+    });
+  } catch {
+    return { status: 'skipped', reason: 'binary_unverified' };
+  }
+
+  // Initialize the project index (cheap, idempotent) then background a full
+  // index — large repos index slowly.
+  let indexBuild: IndexStatus = 'skipped';
+  try {
+    if (!fs.existsSync(path.join(repoRoot, '.codegraph'))) {
+      execFileSync('codegraph', ['init', repoRoot], {
+        stdio: 'ignore',
+        timeout: 30000,
+      });
+    }
+    indexBuild = startBackgroundBuild(
+      'codegraph-index',
+      'codegraph',
+      ['index', repoRoot],
+      repoRoot,
+    );
+  } catch (err) {
+    logger.warn({ err: (err as Error).message }, 'codegraph init failed');
+    indexBuild = 'failed';
+  }
+
+  const mcp: McpStatus = commandExists('claude')
+    ? registerMcpServer('codegraph', ['codegraph', 'serve', '--mcp'])
+    : 'skipped';
+
+  return { status: 'success', mcp, indexBuild };
+}
+
+// ── Sub-step B: code-search (macOS/Linux only, first-party) ──────────────────
+
+function setupCodeSearch(repoRoot: string): SubResult {
+  if (getPlatform() === 'windows') {
+    // code_search_mcp.py hard-exits on win32 (needs sqlite_vec + Ollama).
+    return { status: 'skipped', reason: 'windows_unsupported' };
+  }
+
+  const python = resolvePython();
+  if (!python) {
+    return { status: 'skipped', reason: 'python_not_found' };
+  }
+
+  try {
+    execFileSync(python, ['-c', 'import sqlite_vec'], {
+      stdio: 'ignore',
+      timeout: 10000,
+    });
+  } catch {
+    // The `memory` setup step installs sqlite_vec — direct the user there.
+    return { status: 'skipped', reason: 'sqlite_vec_missing' };
+  }
+
+  const mcp: McpStatus = commandExists('claude')
+    ? registerMcpServer(
+        'code-search',
+        codeSearchServerCommand(python, repoRoot),
+      )
+    : 'skipped';
+
+  // Index build needs Ollama embeddings; background it when Ollama is present.
+  const indexBuild: IndexStatus = commandExists('ollama')
+    ? startBackgroundBuild(
+        'code-search-reindex',
+        python,
+        [path.join(repoRoot, 'scripts', 'code_search.py'), 'reindex', '.'],
+        repoRoot,
+      )
+    : 'skipped';
+
+  return { status: 'success', mcp, indexBuild };
+}
+
+// ── Step entry point ────────────────────────────────────────────────────────
+
+export async function run(_args: string[]): Promise<void> {
+  const repoRoot = process.cwd();
+
+  const codegraph = setupCodegraph(repoRoot);
+  const codeSearch = setupCodeSearch(repoRoot);
+
+  // Human-facing notes: manual fallbacks + background-build pointers.
+  const notes: string[] = [];
+  if (codegraph.reason === 'install_failed') {
+    notes.push(
+      `codegraph install failed — run manually: npm install -g ${CODEGRAPH_PACKAGE}`,
+    );
+  }
+  if (codeSearch.reason === 'sqlite_vec_missing') {
+    notes.push(
+      'code-search needs sqlite_vec — run the `memory` setup step first, then re-run `--step codeintel`.',
+    );
+  }
+  if (codeSearch.status === 'success' && codeSearch.indexBuild === 'skipped') {
+    notes.push(
+      'code-search index not built (Ollama absent). After installing Ollama: python3 scripts/code_search.py reindex .',
+    );
+  }
+  if (
+    codegraph.indexBuild === 'started' ||
+    codeSearch.indexBuild === 'started'
+  ) {
+    notes.push(
+      `Index build(s) running in the background — logs in ${LOG_DIR}/`,
+    );
+  }
+  for (const n of notes) console.log(`  - ${n}`);
+
+  // The step itself always succeeds — optional tooling never fails setup.
+  emitStatus('CODEINTEL', {
+    STATUS: overallStatus(codegraph.status, codeSearch.status),
+    CODEGRAPH: codegraph.status,
+    CODEGRAPH_REASON: codegraph.reason ?? 'none',
+    CODEGRAPH_MCP: codegraph.mcp ?? 'skipped',
+    CODEGRAPH_INDEX: codegraph.indexBuild ?? 'skipped',
+    CODE_SEARCH: codeSearch.status,
+    CODE_SEARCH_REASON: codeSearch.reason ?? 'none',
+    CODE_SEARCH_MCP: codeSearch.mcp ?? 'skipped',
+    CODE_SEARCH_INDEX: codeSearch.indexBuild ?? 'skipped',
+    LOG_DIR,
+  });
+}

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -23,6 +23,7 @@ const STEPS: Record<
   cli: () => import('./cli.js'),
   verify: () => import('./verify.js'),
   ollama: () => import('./ollama.js'),
+  codeintel: () => import('./codeintel.js'),
   'smoke-test': () => import('./smoke-test.js'),
 };
 


### PR DESCRIPTION
## What & why

Fresh-machine triage **observation #1**: `/setup` never initialized or registered the two code-intelligence MCP servers Deus relies on — **codegraph** (third-party npm global `@colbymchenry/codegraph`) and **code-search** (first-party `scripts/code_search_mcp.py`). New users had no path to them and had to install + register by hand (the user's question: *"how is a new user supposed to integrate codegraph?"*).

This adds a new **optional, non-fatal** `codeintel` setup step that automates both, mirroring the existing `setup/ollama.ts` idiom.

## Design

Two **independent best-effort sub-steps** (one can't block the other), each a chain of guard clauses. **Never throws** — every external call is individually `try`/caught; a missing prerequisite becomes a reported *skip with a reason*, never a setup failure.

- **codegraph** (attempted all platforms): install pinned `@colbymchenry/codegraph@0.9.9` → verify the binary actually runs (`codegraph --version`) → `codegraph init` + background `codegraph index` → register MCP.
- **code-search** (macOS/Linux only — `code_search_mcp.py` hard-exits on Windows): resolve the interpreter via `resolvePython()` (the same one `setup/memory.ts` provisions with `sqlite_vec`) → verify `import sqlite_vec` → register MCP with **derived** paths (fixes the old hardcoded `eval/.venv` entry) → background `reindex` when Ollama is present.

**Registration delegates to the official `claude mcp remove/add --scope user` CLI** — no hand-editing `~/.claude.json` (no clobber risk). `remove`-then-`add` is **idempotent** and **scope-correct** (immune to a stale project `.mcp.json`; refreshes a stale user-scope entry on re-run).

**Supply chain:** codegraph is version-pinned with a dated bump comment; auto-install is graceful-skip if npm is absent or the install fails (prints the manual command).

## Files
- `setup/codeintel.ts` (new) — the step
- `setup/index.ts` — register `codeintel` in the STEPS map
- `.claude/skills/setup/SKILL.md` — new `## 7c. Code Intelligence (Optional)` with status-block branches for every skip reason
- `setup/__tests__/codeintel.test.ts` (new) — unit tests for the pure helpers

## Verification
- `npx tsc --noEmit` → exit 0
- `npx vitest run` → **1465/1465** tests pass (11/11 in the new file); no regressions
- `npx prettier --check` → clean
- Live, **non-destructive** check of `claude mcp remove/add --scope user` idempotency (throwaway server name; real codegraph/code-search entries untouched)
- The detached background-spawn path is intentionally not unit-tested (parity with `ollama.test.ts`), documented in the test header

Reviewed by plan-reviewer (SHIP, 2 rounds), code-reviewer (SHIP), and verification-gate (SHIP).

> Note: the `chore(patterns): auto-bump drifted patterns` commit is the repo's own drift-check pre-push auto-maintenance (CC-version bump), kept as a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)