### PR TITLE
fix(setup): gate code-search registration on the mcp server dep

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -342,7 +342,7 @@ shortly. They take effect in new Claude Code sessions.
 - `CODEGRAPH_REASON=install_failed` → "codegraph install failed (often a global-npm permissions issue). Run manually: `npm install -g @colbymchenry/codegraph` and re-run this step."
 - `CODEGRAPH_REASON=binary_unverified` → "codegraph installed but didn't run. Often the npm global bin dir isn't on PATH — check `npm bin -g` and add it to your shell PATH, then re-run this step. (Also covers unsupported platforms.) Skipped cleanly — no broken MCP entry left behind."
 - `CODE_SEARCH_REASON=windows_unsupported` → "code-search is macOS/Linux only (needs sqlite_vec + Ollama). Skipped on Windows."
-- `CODE_SEARCH_REASON=sqlite_vec_missing` → "code-search needs the `sqlite_vec` Python package. Run the `memory` step first (`npx tsx setup/index.ts --step memory`), then re-run this step."
+- `CODE_SEARCH_REASON=deps_missing` → "code-search needs the `mcp` and `sqlite_vec` Python packages in the resolved interpreter (`mcp` to run the server, `sqlite_vec` for vector search). Install them — `pip install mcp sqlite_vec` — then re-run this step. (The `memory` step installs `sqlite_vec` but not `mcp`.)"
 - `CODE_SEARCH_REASON=python_not_found` → "No Python found. Install Python 3, then re-run this step."
 - `CODE_SEARCH_INDEX=skipped` with `CODE_SEARCH=success` → "code-search registered but its index isn't built (Ollama absent). After installing Ollama: `python3 scripts/code_search.py reindex .`"
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-03" # auto-bump @1780493934
+last_verified: "2026-06-04" # auto-bump @1780556749
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-03" # auto-bump @1780493934
+last_verified: "2026-06-04" # auto-bump @1780556749
 governs:
   - src/
   - evolution/

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-03" # auto-bump @1780493934
+last_verified: "2026-06-04" # auto-bump @1780556749
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/setup/__tests__/codeintel.test.ts
+++ b/setup/__tests__/codeintel.test.ts
@@ -79,6 +79,21 @@ describe('codeSearchServerCommand', () => {
   });
 });
 
+// ── CODE_SEARCH_DEP_CHECK ───────────────────────────────────────────────────
+
+describe('CODE_SEARCH_DEP_CHECK', () => {
+  it('gates on BOTH sqlite_vec and the mcp server import', async () => {
+    // Regression guard: the server needs `mcp` (code_search_mcp.py:40), not just
+    // sqlite_vec — probing only sqlite_vec let a python3 without mcp register a
+    // server that fails to connect. Lock both into the probe.
+    const { CODE_SEARCH_DEP_CHECK } = await import('../codeintel.js');
+    expect(CODE_SEARCH_DEP_CHECK).toContain('sqlite_vec');
+    expect(CODE_SEARCH_DEP_CHECK).toContain('mcp');
+    // Mirrors the server's actual import line so the probe and server agree.
+    expect(CODE_SEARCH_DEP_CHECK).toContain('FastMCP');
+  });
+});
+
 // ── overallStatus roll-up ───────────────────────────────────────────────────
 
 describe('overallStatus', () => {

--- a/setup/codeintel.ts
+++ b/setup/codeintel.ts
@@ -35,6 +35,16 @@ import { emitStatus } from './status.js';
  */
 export const CODEGRAPH_PACKAGE = '@colbymchenry/codegraph@0.9.9';
 
+/**
+ * Python imports the code-search MCP **server** needs to actually start —
+ * mirrors `scripts/code_search_mcp.py:40`. `mcp` is the hard requirement (the
+ * server can't be an MCP endpoint without it); `sqlite_vec` backs vector search.
+ * We probe both before registering so we never register a server that can't run
+ * (a `import sqlite_vec`-only check let a `python3` without `mcp` slip through).
+ */
+export const CODE_SEARCH_DEP_CHECK =
+  'import sqlite_vec; from mcp.server.fastmcp import FastMCP';
+
 /** Background build logs (mirrors ollama's ~/.config/deus/ollama-downloads/). */
 const LOG_DIR = path.join(CONFIG_DIR, 'codeintel');
 
@@ -213,14 +223,21 @@ function setupCodeSearch(repoRoot: string): SubResult {
     return { status: 'skipped', reason: 'python_not_found' };
   }
 
+  // Probe the server's real imports BEFORE any registration. This stays ahead
+  // of registerMcpServer (remove-then-add) on purpose: a deps_missing skip must
+  // be a no-op on an existing registration, never clobbering a working entry.
+  // NOTE(LIA-174): resolvePython() is not guaranteed to point at an MCP-capable
+  // interpreter — the `memory` step installs sqlite_vec but not `mcp`, so on a
+  // fresh machine this probe skips (deps_missing) rather than registering a
+  // broken server. Reliably provisioning `mcp` (or targeting a venv that has it)
+  // is tracked separately.
   try {
-    execFileSync(python, ['-c', 'import sqlite_vec'], {
+    execFileSync(python, ['-c', CODE_SEARCH_DEP_CHECK], {
       stdio: 'ignore',
       timeout: 10000,
     });
   } catch {
-    // The `memory` setup step installs sqlite_vec — direct the user there.
-    return { status: 'skipped', reason: 'sqlite_vec_missing' };
+    return { status: 'skipped', reason: 'deps_missing' };
   }
 
   const mcp: McpStatus = commandExists('claude')
@@ -258,9 +275,9 @@ export async function run(_args: string[]): Promise<void> {
       `codegraph install failed — run manually: npm install -g ${CODEGRAPH_PACKAGE}`,
     );
   }
-  if (codeSearch.reason === 'sqlite_vec_missing') {
+  if (codeSearch.reason === 'deps_missing') {
     notes.push(
-      'code-search needs sqlite_vec — run the `memory` setup step first, then re-run `--step codeintel`.',
+      'code-search needs the `mcp` and `sqlite_vec` Python packages — install them (`pip install mcp sqlite_vec`), then re-run `--step codeintel`.',
     );
   }
   if (codeSearch.status === 'success' && codeSearch.indexBuild === 'skipped') {


### PR DESCRIPTION
## What & why

Fast-follow to #685. A **live smoke run** of the merged `--step codeintel` caught a real bug: the code-search sub-step probed only `import sqlite_vec`, but the MCP server also needs the **`mcp`** package (`scripts/code_search_mcp.py` → `from mcp.server.fastmcp import FastMCP`). `resolvePython()` returns an interpreter that has `sqlite_vec` (the `memory` step installs it) but **not** `mcp` — so the step registered a code-search server that immediately fails to connect, and even overwrote a working `eval/.venv` registration (since restored).

This restores the step's own invariant — **register only when the server will actually run; else skip with a reason** — without auto-installing (PEP 668 risk on managed system pythons; can't be validated on a provisioned box).

## Change
- New exported const `CODE_SEARCH_DEP_CHECK = 'import sqlite_vec; from mcp.server.fastmcp import FastMCP'` (mirrors the server's real import line).
- `setupCodeSearch` probes both via `execFileSync(python, ['-c', CODE_SEARCH_DEP_CHECK])`; skip reason renamed `sqlite_vec_missing` → `deps_missing` (gate + `run()` note + SKILL.md §7c — complete rename, zero orphans).
- The probe stays **before** `registerMcpServer` (remove-then-add), so a `deps_missing` skip is a **no-op on any existing registration** — the exact property whose violation re-broke the working entry during the smoke run.
- Regression test asserts the const covers `sqlite_vec` + `mcp` + `FastMCP`.
- Follow-up flagged as **LIA-174**: `resolvePython()` may not point at an MCP-capable interpreter — reliably provisioning `mcp` so code-search auto-registers on fresh machines is a separate design.

## Verification
- `npx tsc --noEmit` → 0; `npx vitest run` → **1466/1466** (12/12 in the codeintel file); `npx prettier --check` → clean; `grep -rn sqlite_vec_missing` → empty.
- Post-merge live re-verify on this machine (system `python3` lacks `mcp` = deterministic negative fixture): expect `CODE_SEARCH: skipped`, `deps_missing`, existing `eval/.venv` entry untouched + still connected, `codegraph` fine.

Reviewed: plan-reviewer SHIP, code-reviewer SHIP (2 rounds), verification-gate SHIP (2 rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)