### PR TITLE
fix(pipeline): gate container error halts in Manual Review, not REVISE loop (LIA-169)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780556749
+last_verified: "2026-06-04" # auto-bump @1780558025
 governs:
   - src/
   - evolution/

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -14,6 +14,8 @@ import { extractFrontmatter } from './linear-dispatcher.js';
 import {
   parseEnrichment,
   parseVerdict,
+  gateTransitionAction,
+  gateOutcomeEventType,
   parseRatings,
   mergeEnrichment,
   stripEnrichmentSection,
@@ -363,6 +365,47 @@ Needs work.`),
 
   it('returns null when no verdict', () => {
     expect(parseVerdict('No verdict here.')).toBeNull();
+  });
+});
+
+describe('gateTransitionAction (LIA-169)', () => {
+  // The fix: an errored gate HALTS (parked in a quiescent state), never reverts.
+  it('errored gate halts regardless of mode or verdict', () => {
+    expect(gateTransitionAction('strict', 'REVISE', true)).toBe('halt');
+    expect(gateTransitionAction('advise', 'REVISE', true)).toBe('halt');
+    expect(gateTransitionAction('strict', 'SHIP', true)).toBe('halt');
+    expect(gateTransitionAction('advise', 'BLOCK', true)).toBe('halt');
+  });
+
+  // Regression boundary: a LEGITIMATE strict non-SHIP verdict must STILL revert
+  // (this is the behavior the loop fix must NOT break).
+  it('legitimate strict non-SHIP verdict reverts', () => {
+    expect(gateTransitionAction('strict', 'REVISE', false)).toBe('revert');
+    expect(gateTransitionAction('strict', 'BLOCK', false)).toBe('revert');
+  });
+
+  it('SHIP never reverts', () => {
+    expect(gateTransitionAction('strict', 'SHIP', false)).toBe('none');
+    expect(gateTransitionAction('advise', 'SHIP', false)).toBe('none');
+  });
+
+  it('advise-mode non-SHIP does not revert (advise gates only comment)', () => {
+    expect(gateTransitionAction('advise', 'REVISE', false)).toBe('none');
+    expect(gateTransitionAction('advise', 'BLOCK', false)).toBe('none');
+  });
+});
+
+describe('gateOutcomeEventType (LIA-169)', () => {
+  it('errored gate logs gate_error for any verdict', () => {
+    expect(gateOutcomeEventType('REVISE', true)).toBe('gate_error');
+    expect(gateOutcomeEventType('SHIP', true)).toBe('gate_error');
+    expect(gateOutcomeEventType('BLOCK', true)).toBe('gate_error');
+  });
+
+  it('non-errored gate logs gate_ship / gate_revise by verdict', () => {
+    expect(gateOutcomeEventType('SHIP', false)).toBe('gate_ship');
+    expect(gateOutcomeEventType('REVISE', false)).toBe('gate_revise');
+    expect(gateOutcomeEventType('BLOCK', false)).toBe('gate_revise');
   });
 });
 

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -219,6 +219,30 @@ export function parseVerdict(
   return match ? (match[1] as 'SHIP' | 'REVISE' | 'BLOCK') : null;
 }
 
+/**
+ * LIA-169: An errored gate halts regardless of mode/verdict — its fallback
+ * 'REVISE' would otherwise drive the strict revert and re-dispatch loop.
+ * 'halt' = park (quiescent state); 'revert' = legit strict non-SHIP; 'none' = leave.
+ */
+export function gateTransitionAction(
+  effectiveMode: 'advise' | 'strict',
+  verdict: 'SHIP' | 'REVISE' | 'BLOCK',
+  gateErrored: boolean,
+): 'halt' | 'revert' | 'none' {
+  if (gateErrored) return 'halt';
+  if (effectiveMode === 'strict' && verdict !== 'SHIP') return 'revert';
+  return 'none';
+}
+
+/** LIA-169: an errored gate logs `gate_error`, not the misleading `gate_revise`. */
+export function gateOutcomeEventType(
+  verdict: 'SHIP' | 'REVISE' | 'BLOCK',
+  gateErrored: boolean,
+): 'gate_ship' | 'gate_revise' | 'gate_error' {
+  if (gateErrored) return 'gate_error';
+  return verdict === 'SHIP' ? 'gate_ship' : 'gate_revise';
+}
+
 export function parseEnrichment(output: string): string | null {
   const match = output.match(/^## Enrichment\s*\n([\s\S]*?)(?=^## Verdict)/m);
   return match ? match[1].trim() : null;
@@ -1144,7 +1168,37 @@ async function handleIssueUpdate(
       ? 'strict'
       : gateSpec.mode;
 
-    if (effectiveMode === 'strict' && verdict !== 'SHIP') {
+    const transitionAction = gateTransitionAction(
+      effectiveMode,
+      verdict,
+      gateDidError,
+    );
+    if (transitionAction === 'halt') {
+      // LIA-169: gate errored — park in a quiescent state so no poller re-picks
+      // it (leaving it in "In Review" exposes it to sweepStaleInReview; "Manual
+      // Review Required" is polled by nothing). Warden: Error label is applied
+      // in the finally block.
+      try {
+        const manualState = ctx.stateByName.get('Manual Review Required');
+        if (manualState) {
+          await ctx.client.updateIssue(data.id, { stateId: manualState.id });
+          logger.info(
+            { issueId: data.id, gate: gateSpec.name },
+            'linear-webhook: gate errored — moved to Manual Review Required (halt)',
+          );
+        } else {
+          logger.warn(
+            { issueId: data.id, gate: gateSpec.name },
+            'linear-webhook: Manual Review Required state not found — leaving issue in place',
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          { issueId: data.id, err },
+          'linear-webhook: failed to park errored gate issue in Manual Review Required',
+        );
+      }
+    } else if (transitionAction === 'revert') {
       try {
         let revertStateId = fromStateId;
         let revertStateName = fromState.name;
@@ -1187,7 +1241,7 @@ async function handleIssueUpdate(
 
     finalVerdict = verdict;
     updateWebhookEventStatus(eventKey, 'done', { verdict });
-    const eventType = verdict === 'SHIP' ? 'gate_ship' : 'gate_revise';
+    const eventType = gateOutcomeEventType(verdict, gateDidError);
     const reasonLine =
       verdictText.split('\n').find((l) => l.trim()) || '(no detail)';
     const pipelineDetail =
@@ -1262,8 +1316,10 @@ async function handleIssueUpdate(
       removeIds.push(...scopeLabels.removeIds);
     }
 
-    // Bouncer: apply bounced:<reason> label on REVISE, strip on SHIP
-    if (gateSpec.name === 'bouncer-gate') {
+    // Bouncer: apply bounced:<reason> label on REVISE, strip on SHIP.
+    // LIA-169: skip on gate error — an errored bouncer's REVISE is a fallback,
+    // not a real "unscoped" verdict, so don't stamp a misleading bounced label.
+    if (gateSpec.name === 'bouncer-gate' && !gateDidError) {
       const allBouncedIds = [
         ctx.gateLabels.bouncedUnscoped,
         ctx.gateLabels.bouncedStale,
@@ -1308,7 +1364,10 @@ async function handleIssueUpdate(
       retryLabelUpdate(ctx.client, data.id, update);
     }
 
-    if (finalVerdict && finalEnrichment) {
+    // LIA-169: skip on gate error — the outer catch sets finalVerdict=REVISE +
+    // finalEnrichment, which would otherwise increment the REVISE attempt count
+    // on an infra failure (the gate never actually ran).
+    if (finalVerdict && finalEnrichment && !gateDidError) {
       try {
         await trackGateMetaAndEscalate(
           ctx,
@@ -1529,7 +1588,35 @@ async function runGateForIssue(
       ? 'strict'
       : gateSpec.mode;
 
-    if (effectiveMode === 'strict' && verdict !== 'SHIP') {
+    const transitionAction = gateTransitionAction(
+      effectiveMode,
+      verdict,
+      gateAgentError,
+    );
+    if (transitionAction === 'halt') {
+      // LIA-169: gate errored — park in Manual Review Required (quiescent; no
+      // poller re-picks it). Warden: Error label is applied in the finally block.
+      try {
+        const manualState = ctx.stateByName.get('Manual Review Required');
+        if (manualState) {
+          await ctx.client.updateIssue(issue.id, { stateId: manualState.id });
+          logger.info(
+            { issueId: issue.id, gate: gateSpec.name },
+            'startup-sweep: gate errored — moved to Manual Review Required (halt)',
+          );
+        } else {
+          logger.warn(
+            { issueId: issue.id, gate: gateSpec.name },
+            'startup-sweep: Manual Review Required state not found — leaving issue in place',
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          { issueId: issue.id, err },
+          'startup-sweep: failed to park errored gate issue in Manual Review Required',
+        );
+      }
+    } else if (transitionAction === 'revert') {
       if (gateSpec.revertTo) {
         const revertState = ctx.stateByName.get(gateSpec.revertTo);
         if (revertState) {
@@ -1547,7 +1634,7 @@ async function runGateForIssue(
     }
 
     finalVerdict = verdict;
-    const eventType = verdict === 'SHIP' ? 'gate_ship' : 'gate_revise';
+    const eventType = gateOutcomeEventType(verdict, gateAgentError);
     const sweepReasonLine =
       verdictText.split('\n').find((l) => l.trim()) || '(no detail)';
     const sweepDetail =
@@ -1602,9 +1689,11 @@ async function runGateForIssue(
       { issueId: issue.id, gate: gateSpec.name, err },
       'startup-sweep: gate evaluation failed',
     );
-    // Never fallback-SHIP on infrastructure errors — gate didn't actually run
+    // Never fallback-SHIP on infrastructure errors — gate didn't actually run.
+    // Use gateSpec.fallback for symmetry with handleIssueUpdate (1285); the
+    // !gateAgentError guard below keeps this value out of real behavior anyway.
     gateAgentError = true;
-    finalVerdict = 'REVISE';
+    finalVerdict = gateSpec.fallback;
     finalEnrichment = `Gate infrastructure error (startup sweep): ${errorMsg}`;
   } finally {
     ctx.inFlightGate.delete(issue.id);
@@ -1653,7 +1742,9 @@ async function runGateForIssue(
       retryLabelUpdate(ctx.client, issue.id, update);
     }
 
-    if (finalVerdict && finalEnrichment) {
+    // LIA-169: skip on gate error — see handleIssueUpdate; the outer catch sets
+    // finalVerdict=REVISE + finalEnrichment, which would pollute the attempt count.
+    if (finalVerdict && finalEnrichment && !gateAgentError) {
       try {
         await trackGateMetaAndEscalate(
           ctx,


### PR DESCRIPTION
## What

Fixes **LIA-169** — a gate-pipeline re-dispatch loop. When a gate agent's container exits non-zero (e.g. code 137 / SIGKILL), the gate was treating the failed run as a real `REVISE` verdict (`verdict = gateSpec.fallback`, hard-typed `'REVISE'`). In strict mode that reverted the issue to the gate's `revert_to` ("Ready for Agent" for `output-quality-gate`), where the dispatcher re-picks any `Scoped` issue → re-dispatch → another error → **loop**. Reproduced live on LIA-167 (2026-06-02). Violates `orchestration-rules.md`: *gate fallbacks are errors, not approvals.*

## How

Two new **pure, exported** helpers in `src/linear-webhook.ts` (testable seam — the orchestrators are unexported):

- `gateTransitionAction(mode, verdict, gateErrored) → 'halt' | 'revert' | 'none'` — an errored gate **halts** (parked in **Manual Review Required**, a state verified to be quiescent: not polled by the dispatcher, by `sweepStaleInReview`, or by the startup sweep); a *legitimate* strict non-SHIP verdict still **reverts**.
- `gateOutcomeEventType(verdict, gateErrored)` — an errored gate logs `gate_error`, not the previously-mislabeled `gate_revise`.

Wired at **both** gate orchestrators (`handleIssueUpdate` webhook + `runGateForIssue` startup sweep). Also:
- guard the REVISE attempt-count escalation (`trackGateMetaAndEscalate`) with the error flag so an infra error (whose outer catch sets REVISE+enrichment) doesn't pollute the count;
- guard the bouncer `bounced:*` label so an errored bouncer doesn't stamp a misleading verdict;
- make `runGateForIssue`'s outer-catch fallback use `gateSpec.fallback` for symmetry with `handleIssueUpdate`.

The `Warden: Error` label was already applied in the `finally` blocks — unchanged.

## Why "Manual Review Required" (not leave-in-place)

Leaving the errored issue in "In Review" is **not** a safe halt: `sweepStaleInReview` (`linear-auto-merge.ts:421`) polls all In-Review issues when `LINEAR_AUTO_MERGE=1`, skipping only `warden:skip`. Moving to a state nothing polls closes the hole structurally, independent of that flag. (plan-reviewer round-1 catch.)

## Tests

Full combination matrix for both helpers in `src/linear-webhook.test.ts`, including the **regression boundary**: `gateTransitionAction('strict', 'REVISE', false) === 'revert'` — a legitimate REVISE must still revert.

- `npm run build` clean · `prettier --check` clean · full suite **1472 tests pass (83 files)**.

## Review trail

plan-reviewer **SHIP** (round 2 — round-1 halt-completeness blocker closed by the move-to-MRR design); code-reviewer **SHIP** (2 polish notes folded in: docblock trim + fallback symmetry).

## Follow-up

**LIA-175** filed for the rarer outer-catch *throw* path (control jumps to the outer `catch`, bypassing the in-`try` park). Pre-existing, not the observed LIA-169 trigger (a code-137 container exit returns `{error}` and takes the inline branch, which this PR parks) — verified via `executeAgentRun`'s error contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
