### PR TITLE
fix(pipeline): treat container timeout as infra failure → Manual Review, not Backlog (LIA-168)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-05-31" # auto-bump @1780259166
+last_verified: "2026-06-04" # auto-bump @1780561930
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-05-31" # auto-bump @1780259166
+last_verified: "2026-06-04" # auto-bump @1780561930
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780558025
+last_verified: "2026-06-04" # auto-bump @1780561930
 governs:
   - src/
   - evolution/

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -81,6 +81,14 @@ function containsCodeBlock(text: string | null): boolean {
   return /```[\s\S]{10,}?```/.test(text);
 }
 
+/**
+ * Prefix of the error string produced when a container is reaped by the hard
+ * timeout (the resolve site below). Exported so downstream routing can tell an
+ * infrastructure timeout apart from a genuine agent failure (LIA-168) without
+ * brittle ad-hoc string matching.
+ */
+export const CONTAINER_TIMEOUT_ERROR_PREFIX = 'Container timed out after';
+
 function buildContainerArgs(
   mounts: ReturnType<typeof buildVolumeMounts>,
   containerName: string,
@@ -512,7 +520,7 @@ export async function runContainerAgent(
         resolve({
           status: 'error',
           result: null,
-          error: `Container timed out after ${configTimeout}ms`,
+          error: `${CONTAINER_TIMEOUT_ERROR_PREFIX} ${configTimeout}ms`,
         });
         return;
       }

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -125,6 +125,7 @@ import {
   initLinearContext,
   deriveFetchTimeout,
   validateLinearIdentifier,
+  classifyRunFailure,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
@@ -1617,5 +1618,27 @@ describe('validateLinearIdentifier', () => {
     expect(() => validateLinearIdentifier(id)).toThrow(
       `Invalid Linear identifier: "${id}"`,
     );
+  });
+});
+
+describe('classifyRunFailure (LIA-168)', () => {
+  // A container hard-timeout is infra, not an agent failure → route to Manual
+  // Review, never increment the circuit breaker.
+  it.each([
+    'Container timed out after 1800000ms',
+    'Container timed out after 30000ms',
+  ])('classifies the timeout error as infra-timeout: %s', (err) => {
+    expect(classifyRunFailure(err)).toBe('infra-timeout');
+  });
+
+  // Everything else is a genuine agent failure (keeps existing handling).
+  it.each([
+    ['linear API error', 'linear 500'],
+    ['empty error', ''],
+    ['non-zero exit', 'Container exited with code 1'],
+    ['bare phrase without prefix', 'the request timed out'],
+    ['unknown error', 'Unknown error'],
+  ])('classifies %s as agent-failure', (_label, err) => {
+    expect(classifyRunFailure(err)).toBe('agent-failure');
   });
 });

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -34,6 +34,7 @@ import { notifyPipelineStep } from './linear-notifications.js';
 import { escapeXmlForPrompt } from './prompt-utils.js';
 import { resolveVaultPath } from './solutions/store.js';
 import { defaultSession } from './agent-runtimes/types.js';
+import { CONTAINER_TIMEOUT_ERROR_PREFIX } from './container-runner.js';
 import { getBus } from './events/bus.js';
 import type {
   RunContext,
@@ -75,6 +76,21 @@ export function validateLinearIdentifier(id: string): void {
   if (!LINEAR_ID_RE.test(id)) {
     throw new Error(`Invalid Linear identifier: "${id}"`);
   }
+}
+
+/**
+ * LIA-168: classify an agent-run error. A container hard-timeout is an
+ * INFRASTRUCTURE failure, not an agent failure — it must not wear "Agent run
+ * failed", land in Backlog, or count toward the circuit breaker. Everything
+ * else (non-zero exit, parse failure, spawn error, etc.) is a genuine agent
+ * failure and keeps the existing handling.
+ */
+export function classifyRunFailure(
+  error: string,
+): 'infra-timeout' | 'agent-failure' {
+  return error.startsWith(CONTAINER_TIMEOUT_ERROR_PREFIX)
+    ? 'infra-timeout'
+    : 'agent-failure';
 }
 
 // Trailing '/' = prefix match; exact names match literally (prevents .env matching .envrc)
@@ -1264,7 +1280,37 @@ async function runIssue(
   }
 
   try {
-    if (error) {
+    if (error && classifyRunFailure(error) === 'infra-timeout') {
+      // LIA-168: a container hard-timeout is an INFRASTRUCTURE failure, not an
+      // agent failure. The agent may well have completed — any work it produced
+      // persists in its branch/PR; only the Linear transition + text summary were
+      // lost. Park for human inspection in Manual Review Required WITHOUT a
+      // "failed" verdict and WITHOUT touching the circuit-breaker count: we emit a
+      // neutral `agent_timeout` event, never `agent_failed` (which is what
+      // getConsecutiveFailCount keys on).
+      // No early-return here — the finally below handles worktree cleanup for all
+      // paths through this branch.
+      const manualReviewState = ctx.stateByName.get('Manual Review Required');
+      const parkState = manualReviewState ?? ctx.stateByName.get('Backlog')!;
+      await ctx.client.updateIssue(issueId, { stateId: parkState.id });
+      await ctx.client.createComment({
+        issueId,
+        body:
+          `**Container timed out** (infrastructure timeout) — the run was reaped after exceeding the container time limit.\n\n` +
+          `The agent may have completed; any work it produced will be in its branch/PR (if one exists). This is **not** counted as an agent failure. Moved to **${parkState.name}** for inspection.\n\n` +
+          `\`\`\`\n${error}\n\`\`\`\n\n---\n*To retry: investigate (check the container logs), then move back to **Ready for Agent**.*`,
+      });
+      // notifyPipelineStep (not a bare logPipelineEvent) so the pinned Pipeline
+      // Log comment reflects the timeout like every other terminal state.
+      fireAndForget(
+        notifyPipelineStep(ctx, issueId, identifier, 'agent_timeout', error),
+        { name: 'linear-dispatcher.notify-pipeline' },
+      );
+      logger.warn(
+        { issueId, error },
+        'linear-dispatcher: container timed out (infra) — parked in Manual Review Required, not counted as agent failure',
+      );
+    } else if (error) {
       await ctx.client.createComment({
         issueId,
         body: `**Agent run failed**\n\n\`\`\`\n${error}\n\`\`\`\n\n---\n*To retry: move to **Todo**, then to **Ready for Agent**.*`,

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -46,6 +46,7 @@ export const EVENT_LABELS: Record<string, string> = {
   agent_started: 'Agent started working',
   agent_completed: 'Agent completed',
   agent_failed: 'Agent failed',
+  agent_timeout: 'Container timed out (infra)',
   pr_created: 'PR created',
   automerge_pending: 'Auto-merge pending',
   automerge_done: 'Auto-merged → Done',


### PR DESCRIPTION
## What

Fixes **LIA-168** — a dispatch hang where a container produces `status:success` but the host's stdout `'data'` never delivers it, so `onOutput`/`turn_complete`/`_close` never fire and the container idles until the **existing** 30-min hard timeout reaps it. That timeout resolved `{status:'error', error:'Container timed out after Nms'}`, and `runIssue`'s error branch then posted **"Agent run failed"**, fired `agent_failed`, **incremented the circuit breaker**, and moved the issue to **Backlog** — discarding a likely-successful run (whose work persists in git) and polluting the breaker. Reproduced on LIA-167.

## How

Reclassify a container timeout as an **infrastructure failure** — the same defect class as LIA-169's gate-error fix (an infra failure masquerading as a domain outcome):

- **`container-runner.ts`** — export `CONTAINER_TIMEOUT_ERROR_PREFIX` and build the timeout error from it (no behavior change), so the signal is matchable rather than loose-matched.
- **`linear-dispatcher.ts`** — new pure exported `classifyRunFailure(error) → 'infra-timeout' | 'agent-failure'`. In `runIssue`'s error branch, an **infra-timeout** parks the issue in **Manual Review Required** with an honest comment and emits a **neutral `agent_timeout`** pipeline event — never `agent_failed`, so the circuit breaker (which keys on `getConsecutiveFailCount('agent_failed')`) is untouched. Genuine agent failures keep the existing handling unchanged.
- **`linear-notifications.ts`** — register the `agent_timeout` pipeline-log label.

Why park (not recover the output here): the agent's work is already durable in git (branch/commit/PR created before final output); only the Linear transition + text summary are lost (and the summary is in the PR). Recovering the lost output would require reading the agent-runner's IPC output files, but that channel is shared per group folder with a colliding seq counter under concurrent dispatch — unsafe without run-scoping. Deferred to **LIA-176**.

## Root-cause honesty

This is **root-cause-agnostic**: it treats the timeout *outcome* regardless of *why* stdout didn't deliver (the `rate_limit_event` correlate). That root cause is **unconfirmed and NOT fixed here** — this PR fixes the misrouting/mislabeling/breaker-pollution, not the hang itself.

## Tests

Pure `classifyRunFailure` unit-tested (`linear-dispatcher.test.ts`): timeout strings → `infra-timeout`; `linear 500` / `''` / non-zero-exit / bare `'timed out'` → `agent-failure`. The control-flow restructure (`if (error && infra-timeout) / else if (error) / else`) preserves the agent-failure and success paths exactly; worktree cleanup is handled by the existing `finally` (the branch has no early-return).

- `npm run build` clean · `prettier --check` clean · full suite **1473 tests pass (83 files)** · CI drift gate (`--base origin/main`) passes.

## Review trail

plan-reviewer **SHIP**; code-reviewer **SHIP** (round 2 — round-1 wiring finding `agent_timeout` label + the `logPipelineEvent`→`notifyPipelineStep` consistency switch folded in; circuit-breaker invariant independently re-traced and confirmed intact).

## Follow-ups

- **LIA-176** — run-scoped IPC output recovery (recover the lost output + kill the 30-min latency; needs container rebuild).
- **LIA-177** — suspected per-group `_close`/seq concurrency race (verify-first, not confirmed to bite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
