### PR TITLE
feat(wardens): fold verification evidence into the remote completion-gate

### DIFF
--- a/.claude/agents/verification-gate.md
+++ b/.claude/agents/verification-gate.md
@@ -7,6 +7,8 @@ color: red
 
 You are the `verification-gate` Warden — you enforce one rule: **evidence before claims**.
 
+> Note: a completion-specific subset of this evidence check is also folded into the remote `completion-gate` (`.claude/agents/wardens/completion-gate.md`). The two are intentionally diverged and are **not** kept in lockstep — edits here do not need to be mirrored there.
+
 ## At invocation, read first
 
 1. **Standards** — `~/deus/.claude/wardens/standards.md`. Sets the quality floor and mindset.

--- a/.claude/agents/wardens/completion-gate.md
+++ b/.claude/agents/wardens/completion-gate.md
@@ -10,7 +10,7 @@ effort: medium
 fetch_comments: true
 ---
 
-Gate that runs before an issue moves from **In Review** or **In Progress** to **Done**. Ensures all acceptance criteria are met, any code change has a merged PR, and no open questions remain. Prevents premature closure that inflates Done metrics.
+Gate that runs before an issue moves from **In Review** or **In Progress** to **Done**. Ensures all acceptance criteria are met **with concrete evidence that the work actually functions**, any code change has a merged PR, and no open questions remain. Prevents premature closure that inflates Done metrics.
 
 **Bypass:** Issues with the `Done: Pre-implemented` label skip this gate entirely. Use this label when closing an issue that was already implemented outside the normal pipeline (e.g., shipped via another PR, discovered during triage).
 
@@ -18,7 +18,7 @@ Gate that runs before an issue moves from **In Review** or **In Progress** to **
 
 You receive the issue title, description, agent output, PR link (if any), and review comments. Extract the acceptance criteria from the `<!-- gate:agent-readiness-gate:start -->...<!-- gate:agent-readiness-gate:end -->` block in the description. If that block is missing, REVISE — completion cannot be verified against undefined criteria.
 
-Check each acceptance criterion against the evidence in comments and the PR. Produce an enrichment block recording the completion record, then a verdict.
+Check each acceptance criterion against the evidence in comments and the PR. For each criterion, require **concrete evidence it actually works** — cited test output, a green CI run on the linked PR, or demonstrable behavior — not just an assertion that it is done. A green CI run on the linked PR is sufficient test evidence; do **not** REVISE solely because literal test output is absent from comments when CI is green. (Human-closed issues are covered by the `Done: Pre-implemented` bypass above — apply the strict evidence check to agent-completed work.) Produce an enrichment block recording the completion record, then a verdict.
 
 ## Invocation context
 
@@ -47,6 +47,7 @@ If the prompt includes `<invocation-context>pre-merge</invocation-context>`, you
 
 Checklist:
 - [x] All acceptance criteria met — <n> of <n> verified
+- [x] Verification — each met criterion backed by concrete evidence (any one of: test output, green CI, or demonstrable behavior), no unverified claims
 - [x] PR exists and linked (pre-merge) / merged (post-merge) — <URL>
 - [x] No open review threads — all resolved
 - [x] No open questions or blockers
@@ -71,6 +72,7 @@ Safe to close.
 
 Checklist:
 - [ ] All acceptance criteria met — criterion "<criterion>" not met: <what is missing>
+- [ ] Verification — criterion "<criterion>" claimed done but unverified: no test output, CI not green, behavior not demonstrated
 - [ ] PR exists and linked (pre-merge) / merged (post-merge) — no PR linked; issue description implies code change
 - [x] No open review threads
 - [ ] No open questions — <describe open question>
@@ -83,6 +85,8 @@ Required before moving to Done:
 
 Rules:
 - If the `<!-- gate:agent-readiness-gate:start -->` block is absent, REVISE with: "Acceptance criteria block not found — cannot verify completion."
-- Verdict is exactly `## Verdict: SHIP` or `## Verdict: REVISE` — no other values.
-- SHIP only when all four checks pass.
-- Keep report under 35 lines.
+- Verdict is exactly `## Verdict: SHIP` or `## Verdict: REVISE` — no other values. (Fundamental gaps that would be a "BLOCK" elsewhere are reported as REVISE here.)
+- Every "met" criterion must cite concrete evidence (test output, a green CI run on the linked PR, or demonstrable behavior). A completion claim without evidence → REVISE. A green CI run counts as sufficient test evidence — do not REVISE solely because literal test output is absent from comments.
+- SHIP only when all five checks pass.
+- Keep report under 40 lines.
+- Note: the verification check above is an intentional, completion-specific subset of the standalone `verification-gate` agent (`.claude/agents/verification-gate.md`); the two are not kept in lockstep.


### PR DESCRIPTION
## What & why (#8)

Brings the local verification-gate's **"evidence before claims"** rule to the **remote Linear pipeline**. Today the local verification-gate blocks `git commit` without a `.verified` SHIP marker, but the remote pipeline had no equivalent — agent-completed issues could reach **Done** on assertion alone.

Per the chosen design (fold, not a separate gate), this adds a verification-evidence check **into the existing completion-gate** (the Done-gate), so it runs as a universal part of completion for everyone.

## Change (prompt-only, 2 files)
- `.claude/agents/wardens/completion-gate.md`: a 5th **unified** checklist item — each met acceptance criterion must be backed by concrete evidence (*any one of*: test output, a green CI run on the linked PR, or demonstrable behavior). Verdicts stay **SHIP/REVISE only** (completion-gate bans BLOCK → fundamental gaps report as REVISE). **Green CI counts as sufficient test evidence**, so CI-verified agent work isn't falsely REVISE'd; **human-closed** issues keep the existing `Done: Pre-implemented` bypass.
- `.claude/agents/verification-gate.md`: a reciprocal note that the completion-gate carries an intentional, completion-specific **subset** of these checks — the two are deliberately diverged and not kept in lockstep.

## Reviews
plan-reviewer SHIP (2 rounds — resolved the BLOCK-verdict mismatch + fold-vs-OFF-public), code-reviewer SHIP, verification-gate SHIP (all 6 requirements confirmed by inspection).

## Verification
Prompt-only agent-spec change — no automated test validates agent reasoning. Internal consistency verified by inspection (both checklists 5 items, "all five" rule, no contradictions). **Deferred post-merge smoke-test:** run completion-gate against one known-SHIP and one known-REVISE issue through the pipeline to confirm the verification section fires and verdicts parse.

> Part of the enforcement trio. #9b (orchestrator-autonomous merge) depends on this remote "verifications pass" check existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)