### PR TITLE
feat(setup): register codegraph + code_search MCP servers in /setup

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -273,6 +273,24 @@ if failed:
 
 **After installing:** Tell the user that `/compress`, `/resume`, `/checkpoint`, `/preserve`, `/preferences`, and `/project-settings` are now available in any project directory.
 
+## 6d. Code Intelligence (codegraph + code_search)
+
+Install and register Deus's two code-intelligence MCP servers so they work in **every** project — not just the Deus repo — and reproducibly on a fresh clone. **Non-fatal:** missing prerequisites warn and continue.
+
+```bash
+bash scripts/setup_code_intel.sh
+```
+
+- **codegraph** — per-repo structural call graph (npm global `@colbymchenry/codegraph`). A global developer tool, like Node/Docker/Ollama — this is the one sanctioned public-registry install outside step 0; it is **not** channel code.
+- **code-search** — repo-native semantic search (`scripts/code_search_mcp.py`), registered against this repo's venv python.
+- Both register at **user scope** (`~/.claude.json`) → available in all projects. Idempotent — skips anything already registered.
+
+**Prerequisites (warn, not fatal):** codegraph needs Node.js; code_search needs the eval venv + Ollama. Re-run this step after installing any that were missing.
+
+**Note:** codegraph builds a **per-repo** index, so its tools only return results in a project that has been indexed (`codegraph init . && codegraph index` inside that project); code_search indexes on demand. A `deus init` command that automates per-project onboarding for both is added in a follow-up.
+
+**After registering:** restart the session (MCP servers load at session start only) and tell the user codegraph + code_search are now available in every project.
+
 ## 7. Verify
 
 Run `npx tsx setup/index.ts --step verify` and parse the status block.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -533,6 +533,8 @@ Host-side tools that give agents structural and semantic awareness of the codeba
 | **Understand-Anything** | "How does this whole project fit together?" / "Walk me through the architecture." | Claude Code plugin. Interactive knowledge graph -- `/understand` for full analysis, `/understand-chat` for Q&A, `/understand-dashboard` for visualization. | Human operator (learning/onboarding) |
 | **Mermaid** | "Show me a diagram of X." | MCP server. Diagram generation from Mermaid DSL. | architecture-snapshot, any agent producing visual output |
 
+> **Setup & reproducibility:** CodeGraph and code_search are installed and registered as **user-scope** MCP servers by `/setup` (`scripts/setup_code_intel.sh`) — so a fresh clone reproduces them in every project, not just this repo. CodeGraph keeps a **per-repo** index (`codegraph init && codegraph index`); code_search indexes on demand.
+
 ### Code exploration protocol
 
 Agents follow a three-stage pattern when exploring code. Each stage narrows the search space for the next:

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-02" # auto-bump @1780409372
+last_verified: "2026-06-04" # auto-bump @1780562169
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-03" # auto-bump @1780477973
+last_verified: "2026-06-04" # auto-bump @1780562169
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/setup_code_intel.sh
+++ b/scripts/setup_code_intel.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# setup_code_intel.sh — install + register Deus's code-intelligence MCP servers.
+#
+# Idempotent. Registers two USER-scope MCP servers (available in EVERY project,
+# reproducibly on a fresh clone):
+#   - codegraph   : per-repo structural call graph (npm @colbymchenry/codegraph)
+#   - code-search : semantic search (repo-native scripts/code_search_mcp.py)
+#
+# Invoked by /setup (step 6d); safe to re-run anytime.
+#
+# NOTE: codegraph is a GLOBAL developer tool (like Node/Docker/Ollama, which
+# /setup also installs) — NOT channel code. This is the one sanctioned
+# public-registry global install outside setup step 0.
+#
+# Platform: macOS/Linux (consistent with deus-cmd.sh Windows-pending markers).
+# No `set -e` — every sub-step is non-fatal (warn + continue), so a missing
+# prerequisite never aborts the rest of setup.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+# Prefer the eval venv (has sqlite_vec + mcp); fall back to system python3.
+if [ -x "$REPO_ROOT/eval/.venv/bin/python3" ]; then
+  VENV_PY="$REPO_ROOT/eval/.venv/bin/python3"
+else
+  VENV_PY="$(command -v python3 || true)"
+fi
+
+ok()   { printf '  \xe2\x9c\x93 %s\n' "$1"; }
+warn() { printf '  \xe2\x9a\xa0 %s\n' "$1" >&2; }
+
+# ── codegraph: global npm tool ───────────────────────────────────────────────
+if command -v codegraph >/dev/null 2>&1; then
+  ok "codegraph already installed ($(codegraph --version 2>/dev/null || echo present))"
+elif command -v npm >/dev/null 2>&1; then
+  echo "  installing @colbymchenry/codegraph (global)…"
+  if npm i -g @colbymchenry/codegraph >/dev/null 2>&1; then
+    ok "codegraph installed"
+  else
+    warn "codegraph install failed — check Node/npm, then re-run this step"
+  fi
+else
+  warn "npm not found — codegraph needs Node.js; install Node, then re-run this step"
+fi
+
+# ── register MCP servers (USER scope = all projects) ─────────────────────────
+# Idempotent via exit code: `claude mcp get <name>` returns 0 when registered.
+if command -v claude >/dev/null 2>&1; then
+  if command -v codegraph >/dev/null 2>&1; then
+    if claude mcp get codegraph >/dev/null 2>&1; then
+      ok "codegraph MCP already registered (user scope)"
+    elif claude mcp add -s user codegraph -- codegraph serve --mcp >/dev/null 2>&1; then
+      ok "codegraph MCP registered (user scope)"
+    else
+      warn "codegraph MCP registration failed — run: claude mcp add -s user codegraph -- codegraph serve --mcp"
+    fi
+  fi
+
+  if [ -n "$VENV_PY" ] && [ -f "$REPO_ROOT/scripts/code_search_mcp.py" ]; then
+    if claude mcp get code-search >/dev/null 2>&1; then
+      ok "code-search MCP already registered (user scope)"
+    elif claude mcp add -s user code-search -- "$VENV_PY" "$REPO_ROOT/scripts/code_search_mcp.py" >/dev/null 2>&1; then
+      ok "code-search MCP registered (user scope)"
+    else
+      warn "code-search MCP registration failed — run: claude mcp add -s user code-search -- \"$VENV_PY\" \"$REPO_ROOT/scripts/code_search_mcp.py\""
+    fi
+  else
+    warn "code-search prerequisites missing (python3 + scripts/code_search_mcp.py) — skipping registration"
+  fi
+else
+  warn "claude CLI not found — cannot register MCP servers; install Claude Code, then re-run this step"
+fi
+
+# ── prerequisite advisory (non-fatal) ────────────────────────────────────────
+command -v ollama >/dev/null 2>&1 || \
+  warn "Ollama not found — code_search embeddings need it (install from https://ollama.ai)"
+
+echo "  code-intelligence setup complete (idempotent — safe to re-run)"


### PR DESCRIPTION
## What

Makes the two code-intelligence engines **reproducible on a fresh clone** by
registering them in `/setup`. Today both are added manually via
`claude mcp add -s user`, so a freshly-set-up Deus has neither.

- **codegraph** (`@colbymchenry/codegraph`, user-scope MCP)
- **code-search** (`scripts/code_search_mcp.py`, sqlite-vec + Ollama)

## Changes

- `scripts/setup_code_intel.sh` (new): idempotent installer.
  - `command -v codegraph || npm i -g @colbymchenry/codegraph`
  - Registers BOTH servers user-scope, idempotent via `claude mcp get <name>` exit code
    (`claude mcp get <name> >/dev/null 2>&1 || claude mcp add -s user …`).
  - Prereqs (Node, venv/Ollama) **warn, not fatal** (lesson from the deprecated
    `add-claude-context` skill).
  - User-agnostic: all paths resolved, no `/Users/...` literals, never commits `~/.claude.json`.
- `.claude/skills/setup/SKILL.md`: new step that invokes the installer.
- `docs/ARCHITECTURE.md`: codegraph reproducibility note.

## Scope / platform

macOS/Linux (consistent with the deus-cmd.sh Windows-pending markers).

## Note

Touches `.claude/skills/setup/SKILL.md` (a new step) — overlaps with the sibling
PR `feat/deus-init-onboarding`, which edits a *different* step in the same file.
Whichever merges second needs a trivial rebase on that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
