### PR TITLE
feat(cli): deus init|onboard + per-project code_search DBs

### DIFF
--- a/.claude/skills/onboard/skill.md
+++ b/.claude/skills/onboard/skill.md
@@ -1,0 +1,64 @@
+---
+name: onboard
+description: Onboard the current project into Deus code intelligence — index it for codegraph + code_search and register it so memory and search work here.
+user_invocable: true
+---
+
+# /onboard
+
+Make Deus's code-intelligence engines work in the **current project**. This
+indexes the repo with both engines and registers it with Deus:
+
+- **codegraph** — a per-repo `.codegraph/` knowledge graph (symbols, callers,
+  callees, impact). Powers the `codegraph_*` MCP tools.
+- **code_search** — a per-project semantic index under
+  `~/.config/deus/projects/<id>/code_search.db` (sqlite-vec + Ollama). Powers
+  the `search_code` MCP tool. Per-project, so onboarding one project never
+  clobbers another's index.
+- **registration** — writes `~/.config/deus/projects/<id>.json` so the project
+  appears in Deus with its own memory settings.
+
+## How to run it
+
+This is a thin wrapper over the `deus init` CLI. Run it in the project you want
+to onboard:
+
+```bash
+deus init
+```
+
+`onboard` is an alias — `deus onboard` is identical. Onboard a different
+directory by passing a path: `deus init /path/to/project`.
+
+After it finishes, relay the summary to the user: which engines indexed, the
+DB location, and whether the project was newly registered or already known
+(existing memory settings are preserved on re-run, never overwritten).
+
+## Safety gate
+
+`deus init` refuses to index unless the target is a git repository, and refuses
+git repos with more than 5000 tracked files. This guards against accidentally
+indexing a home directory or an unbounded tree. If the user genuinely wants to
+onboard a non-git folder or a very large repo, re-run with `--force`:
+
+```bash
+deus init --force
+```
+
+Onboarding a non-git folder with `--force` drops a small `.deus/` marker in it
+so its index stays isolated (not merged into the shared legacy DB).
+
+## Idempotent
+
+Re-running `deus init` in an already-onboarded project just refreshes the
+indexes (codegraph `sync`, code_search reindex) and updates the last-accessed
+timestamp. It never overwrites the project's memory settings.
+
+## Notes
+
+- macOS/Linux only (bash + git + codegraph), consistent with the rest of the
+  `deus` CLI.
+- If `codegraph` or the code_search prerequisites (python3 + Ollama) are
+  missing, that engine is skipped with a warning — onboarding still completes
+  for whatever is available. Run `/setup` to register the code-intelligence
+  MCP servers if they are missing.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -229,7 +229,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc  # or ~/.bashrc
 
 ## 6c. Install Core Skills
 
-Install Deus's 6 core memory skills to `~/.claude/skills/` so they work in any directory (home mode AND external project mode).
+Install Deus's core skills to `~/.claude/skills/` so they work in any directory (home mode AND external project mode). This is the 6 memory skills plus `onboard` (project code-intelligence onboarding).
 
 Run using Python (cross-platform — macOS, Linux, Windows):
 ```bash
@@ -240,7 +240,7 @@ from pathlib import Path
 repo = Path.cwd()
 src_base = repo / '.claude' / 'skills'
 dest_base = Path.home() / '.claude' / 'skills'
-skills = ['compress', 'resume', 'checkpoint', 'preserve', 'preferences', 'project-settings']
+skills = ['compress', 'resume', 'checkpoint', 'preserve', 'preferences', 'project-settings', 'onboard']
 failed = []
 
 for skill in skills:
@@ -271,7 +271,7 @@ if failed:
 
 **If any skill fails:** warn the user and continue — the other skills still install. The commands at `.claude/commands/` (home-mode-only) remain as fallback.
 
-**After installing:** Tell the user that `/compress`, `/resume`, `/checkpoint`, `/preserve`, `/preferences`, and `/project-settings` are now available in any project directory.
+**After installing:** Tell the user that `/compress`, `/resume`, `/checkpoint`, `/preserve`, `/preferences`, `/project-settings`, and `/onboard` are now available in any project directory.
 
 ## 7. Verify
 

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -923,6 +923,48 @@ SKILLEOF
 _deus_freshness_check "$1"
 
 case "$1" in
+  init|onboard)
+    # Onboard a project into Deus code intelligence (codegraph + code_search)
+    # and register it. scripts/deus_init.sh owns the safety gate + indexing;
+    # registration stays here so it can use _write_project_config (single
+    # source of truth — the script can't reach it without sourcing this file's
+    # top-level dispatch). The realpath is resolved ONCE here and passed to the
+    # script, so the DB md5 (computed by code_search from the same dir) and the
+    # config md5 (computed below) are guaranteed equal. macOS/Linux only.
+    shift
+    init_force=""
+    init_target=""
+    for a in "$@"; do
+      case "$a" in
+        --force) init_force="--force" ;;
+        -h|--help) exec "$SCRIPT_DIR/scripts/deus_init.sh" --help ;;
+        -*) ;;  # ignore unknown flags (forward-compat)
+        *) [ -z "$init_target" ] && init_target="$a" ;;
+      esac
+    done
+    init_base="${init_target:-$PWD}"
+    if [ ! -d "$init_base" ]; then
+      echo "deus init: not a directory: $init_base" >&2; exit 1
+    fi
+    init_root="$(cd "$init_base" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)" || init_root=""
+    [ -z "$init_root" ] && init_root="$init_base"
+    init_root="$(cd "$init_root" 2>/dev/null && pwd -P)" || { echo "deus init: cannot resolve: $init_base" >&2; exit 1; }
+    # Index + safety gate. The script exits non-zero iff the gate refuses; only
+    # then do we skip registration (do not register an un-onboarded dir).
+    if "$SCRIPT_DIR/scripts/deus_init.sh" "$init_root" $init_force; then
+      # Register — merge, never clobber: preserve any existing memory settings.
+      if [ -z "$(_read_project_config "$init_root")" ]; then
+        _write_project_config "$init_root" "standard" "true"
+        echo "  ✓ registered (memory=standard, summaries=on) — change with /project-settings"
+      else
+        _update_project_access "$init_root"
+        echo "  ✓ already registered — existing settings preserved"
+      fi
+      echo "Done. Deus code intelligence is active for $(basename "$init_root")."
+    else
+      exit $?
+    fi
+    ;;
   auth)
     # `deus auth refresh [--dry-run]` → proactive OAuth refresh CLI
     # (keeps idle containers from hitting /login after 8h token expiry).
@@ -1895,12 +1937,14 @@ $STARTUP_INSTRUCTION"
     esac
     ;;
   *)
-    echo "Usage: deus [claude|codex] [home|auth|build|web|backend|gcal|listen|logs|model|provider|pipeline|solution|sweep|tui] [--agents]"
+    echo "Usage: deus [claude|codex] [home|init|auth|build|web|backend|gcal|listen|logs|model|provider|pipeline|solution|sweep|tui] [--agents]"
     echo ""
     echo "  deus            Launch in current directory (external project mode if not ~/deus)"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
     echo "  deus fcc        Launch with proxy model (see: deus provider, deus model)"
     echo "  deus home       Launch in home mode (~/deus) regardless of current directory"
+    echo "  deus init       Onboard the current project: index it for code intelligence"
+    echo "                    (codegraph + code_search) and register it (alias: onboard, --force)"
     echo "  deus auth       Validate credentials and rebuild+restart"
     echo "  deus auth refresh [--dry-run]  Proactive OAuth token refresh (scheduled every 30 min by launchd)"
     echo "  deus build      Compile TypeScript and restart the service (--no-restart, --quiet)"

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -5,8 +5,13 @@ DEUS_SKILLS_DIR="$HOME/.claude/skills"
 
 # Resolve symlinks so SCRIPT_DIR always points to the repo, even when
 # called via /usr/local/bin/deus → ~/deus/deus-cmd.sh symlink.
+# Seed from $ZSH_ARGZERO, not $0: inside a zsh function $0 is the function name
+# (FUNCTION_ARGZERO, on by default), so $0 here would be "_resolve_script_dir"
+# and SCRIPT_DIR would collapse to cwd from any foreign directory — breaking
+# subcommands like `deus init` that run from inside another project.
+# $ZSH_ARGZERO holds the real argv[0] (the path/symlink used to invoke).
 _resolve_script_dir() {
-  local src="$0"
+  local src="${ZSH_ARGZERO:-$0}"
   while [ -L "$src" ]; do
     local dir="$(cd "$(dirname "$src")" && pwd)"
     src="$(readlink "$src")"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-03" # auto-bump @1780477973
+last_verified: "2026-06-04" # auto-bump @1780562076
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/ci/flag_lint.py
+++ b/scripts/ci/flag_lint.py
@@ -46,7 +46,9 @@ CODE_EXTS = (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".sh", ".bash"
 SHELL_EXTS = (".sh", ".bash", ".zsh")
 
 # Ops/framework DEUS_* vars that gate nothing and need no citation; extend as needed.
-ALLOWLIST: frozenset[str] = frozenset()
+# DEUS_REPO: internal computed repo-root path (scripts/deus_init.sh) — never read as
+# an env gate, gates nothing; resolved from the script's own location.
+ALLOWLIST: frozenset[str] = frozenset({"DEUS_REPO"})
 
 # Env-gate forms across TS/JS and Python. The flag name is the capture group.
 _GENERAL_GATE_PATTERNS = (

--- a/scripts/code_search.py
+++ b/scripts/code_search.py
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import secrets
+import shutil
 import sqlite3
 import struct
 import subprocess
@@ -44,9 +45,65 @@ except ImportError:
     sqlite_vec = None
 
 EMBED_DIM = 768
-DB_PATH = Path(os.environ.get(
-    "DEUS_CODE_SEARCH_DB", "~/.deus/code_search.db"
-)).expanduser()
+# Legacy shared DB (tier-3 fallback). Per-project resolution lives in
+# _resolve_db_path(); DB_PATH stays a stable constant so the fallback is
+# import-order-safe and patchable in tests (no import-time env read).
+DB_PATH = Path("~/.deus/code_search.db").expanduser()
+
+
+def _project_root(start: Path | str | None = None) -> Path | None:
+    """Nearest .git/.deus ancestor of ``start`` (default cwd); None if neither."""
+    p = Path(start).resolve() if start is not None else Path.cwd().resolve()
+    for candidate in (p, *p.parents):
+        if (candidate / ".git").exists() or (candidate / ".deus").exists():
+            return candidate
+    return None
+
+
+def _resolve_db_path(project_dir: Path | str | None = None) -> Path:
+    """Resolve the code-search DB for a project (3-tier Strategy).
+
+    1. ``DEUS_CODE_SEARCH_DB`` env override (tests / power users).
+    2. Per-project, centralized:
+       ``~/.config/deus/projects/<md5(realpath)>/code_search.db`` — md5 matches
+       the deus-cmd.sh ``_project_config_path`` convention; non-security path
+       keying, so collisions over a handful of project paths are negligible.
+    3. Legacy shared DB (kept forever per docs/decisions/no-db-deletion.md).
+    """
+    override = os.environ.get("DEUS_CODE_SEARCH_DB")
+    if override:
+        return Path(override).expanduser()
+    root = _project_root(project_dir)
+    if root is not None:
+        digest = hashlib.md5(str(root).encode()).hexdigest()
+        return Path("~/.config/deus/projects").expanduser() / digest / "code_search.db"
+    return DB_PATH
+
+
+def _migrate_legacy_if_match(root: Path | None, dbp: Path) -> None:
+    """Self-healing one-time copy of the legacy shared DB into a per-project DB.
+
+    Fires only when ``dbp`` is absent, the legacy DB exists, and its stored
+    ``indexed_directory`` equals ``root``. Copy (never move) — legacy is kept
+    per no-db-deletion.md. Idempotent: once ``dbp`` exists it never refires. In
+    practice this matches only the single project the shared DB currently holds.
+    """
+    if root is None or dbp == DB_PATH or dbp.exists() or not DB_PATH.exists():
+        return
+    try:
+        legacy = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+        try:
+            row = legacy.execute(
+                "SELECT value FROM index_meta WHERE key = 'indexed_directory'"
+            ).fetchone()
+        finally:
+            legacy.close()
+    except sqlite3.Error:
+        return
+    if not row or Path(row[0]).resolve() != root:
+        return
+    dbp.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(DB_PATH, dbp)
 
 DEFAULT_TOP_K = 10
 DEFAULT_RRF_K = int(os.environ.get("DEUS_CODE_SEARCH_RRF_K", "60"))
@@ -541,7 +598,9 @@ def reindex(directory: str, diff_ref: str | None = None) -> dict[str, Any]:
     if not base.is_dir():
         return {"error": f"Not a directory: {directory}"}
 
-    db = _init_db()
+    dbp = _resolve_db_path(base)
+    _migrate_legacy_if_match(_project_root(base), dbp)
+    db = _init_db(dbp)
 
     if diff_ref:
         if not re.match(r'^[a-zA-Z0-9_.^~/-]+$', diff_ref):
@@ -702,10 +761,12 @@ def search(
     via percentile rank against a stored calibration distribution. Below
     0.3 = likely out-of-domain.
     """
-    if not DB_PATH.exists():
-        return [{"error": "No index. Run: code_search.py reindex <directory>"}]
+    dbp = _resolve_db_path()
+    _migrate_legacy_if_match(_project_root(), dbp)
+    if not dbp.exists():
+        return [{"error": f"No index at {dbp}. Run: code_search.py reindex <directory>"}]
 
-    db = _init_db()
+    db = _init_db(dbp)
     results: list[dict[str, Any]] = []
     top_vec_distance: float = 2.0
 
@@ -838,10 +899,12 @@ def search(
 # ── Status ────────────────────────────────────────────────────────────────────
 
 def status() -> dict[str, Any]:
-    if not DB_PATH.exists():
+    dbp = _resolve_db_path()
+    _migrate_legacy_if_match(_project_root(), dbp)
+    if not dbp.exists():
         return {"indexed": False, "message": "No index found"}
 
-    db = _init_db()
+    db = _init_db(dbp)
     total = db.execute("SELECT COUNT(*) FROM chunks WHERE orphaned_at IS NULL").fetchone()[0]
     embedded = db.execute(
         "SELECT COUNT(*) FROM chunks WHERE orphaned_at IS NULL AND embedded_at IS NOT NULL"
@@ -851,7 +914,7 @@ def status() -> dict[str, Any]:
     ).fetchone()[0]
     last = db.execute("SELECT value FROM index_meta WHERE key = 'last_indexed_at'").fetchone()
     directory = db.execute("SELECT value FROM index_meta WHERE key = 'indexed_directory'").fetchone()
-    db_size = DB_PATH.stat().st_size
+    db_size = dbp.stat().st_size
     db.close()
 
     return {
@@ -1026,8 +1089,9 @@ def generate_fixture(
         print(f"Wrote {len(items)} fixture items to {out_path}", file=sys.stderr)
 
     # Store calibration distribution (in-domain query distances) for percentile confidence
-    if DB_PATH.exists():
-        db = _init_db()
+    dbp = _resolve_db_path()
+    if dbp.exists():
+        db = _init_db(dbp)
         cal_distances: list[float] = []
         for item in items:
             if item.get("abstain"):

--- a/scripts/deus_init.sh
+++ b/scripts/deus_init.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# deus_init.sh — onboard a project into Deus code intelligence.
+#
+# Resolves the project root (git toplevel → realpath), runs a safety gate, then
+# indexes the project with BOTH code-intelligence engines:
+#   • codegraph   — per-repo .codegraph/ knowledge graph
+#   • code_search — per-project sqlite-vec DB under ~/.config/deus/projects/<md5>/
+#
+# Registration of the project config (~/.config/deus/projects/<md5>.json) is
+# done by the calling `deus init|onboard` arm via _write_project_config — NOT
+# here. _write_project_config is a deus-cmd.sh function; sourcing that file to
+# reach it would also run its unconditional top-level dispatch. The arm resolves
+# the realpath once and passes it in, so the md5 keying the code_search DB and
+# the md5 keying the config are guaranteed identical.
+#
+# Cross-platform: macOS/Linux only (bash + git + codegraph), consistent with the
+# Windows-pending markers in deus-cmd.sh.
+#
+# Usage: deus_init.sh [project-dir] [--force]
+#   project-dir  Defaults to $PWD. From the `deus init` arm this is the already
+#                realpath-resolved git toplevel; re-resolving it here is a no-op.
+#   --force      Bypass the safety gate (non-git dirs, or >5000 tracked files).
+#
+# Exit codes: 0 = onboarded (indexing attempted; a missing engine warns, does
+#                 not fail). 1 = safety gate refused / invalid directory — the
+#                 caller MUST NOT register the project on a non-zero exit.
+
+set -u
+
+FORCE=0
+TARGET=""
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    -h|--help) sed -n '2,26p' "$0" | sed 's/^#\{1,\} \{0,1\}//'; exit 0 ;;
+    -*) echo "deus init: unknown flag: $arg" >&2; exit 1 ;;
+    *) [ -z "$TARGET" ] && TARGET="$arg" ;;
+  esac
+done
+
+# Deus repo root (where code_search.py lives), following symlinks on $0.
+_self="$0"
+while [ -L "$_self" ]; do
+  _d="$(cd "$(dirname "$_self")" && pwd)"; _self="$(readlink "$_self")"
+  [[ "$_self" != /* ]] && _self="$_d/$_self"
+done
+DEUS_REPO="$(cd "$(dirname "$_self")/.." && pwd -P)"
+
+# Resolve the project root: nearest git toplevel, else the dir itself; then
+# canonicalize with `pwd -P` so the realpath string equals Python's
+# Path.resolve() → identical md5 in code_search and the project config.
+# Idempotent on an already-resolved toplevel (toplevel-of-toplevel == toplevel).
+base="${TARGET:-$PWD}"
+if [ ! -d "$base" ]; then
+  echo "deus init: not a directory: $base" >&2; exit 1
+fi
+root="$(cd "$base" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)" || root=""
+[ -z "$root" ] && root="$base"
+root="$(cd "$root" 2>/dev/null && pwd -P)" || { echo "deus init: cannot resolve: $base" >&2; exit 1; }
+
+is_git=0
+git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 && is_git=1
+
+# ─── Safety gate ───
+# Refuse to index home/huge trees unless --force. File-count + git-ness only
+# (no `du` — sidesteps the macOS/Linux size-divergence the plan-reviewer flagged).
+if [ "$FORCE" -ne 1 ]; then
+  if [ "$is_git" -ne 1 ]; then
+    echo "deus init: '$root' is not a git repository." >&2
+    echo "  Refusing to index a non-repo directory (this could be your home folder)." >&2
+    echo "  Re-run with --force if you really mean to onboard it." >&2
+    exit 1
+  fi
+  tracked="$(git -C "$root" ls-files 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "${tracked:-0}" -gt 5000 ]; then
+    echo "deus init: '$root' has $tracked tracked files (> 5000)." >&2
+    echo "  Indexing a tree this large is slow and may be unintended." >&2
+    echo "  Re-run with --force to proceed." >&2
+    exit 1
+  fi
+fi
+
+name="$(basename "$root")"
+echo "Onboarding $name ($([ "$is_git" -eq 1 ] && echo git || echo non-git): $root)"
+
+# ─── Non-git isolation marker ───
+# code_search keys its per-project DB on the nearest .git/.deus ancestor. A
+# non-git root has no .git, so without a marker its index falls through to the
+# SHARED legacy DB — and a second non-git onboard would clobber the first. Drop
+# a .deus/ marker (the existing instance-local convention) so the resolver
+# isolates this root per-project. Git repos use .git and need no marker.
+if [ "$is_git" -ne 1 ] && [ ! -d "$root/.deus" ]; then
+  mkdir -p "$root/.deus"
+  cat > "$root/.deus/README" <<'MARKER'
+This directory marks the project root for Deus code intelligence so its
+code-search index is isolated per-project rather than shared. Created by
+`deus init` because this folder is not a git repository. Safe to remove if you
+stop using Deus here.
+MARKER
+  echo "  • created .deus/ marker (non-git isolation)"
+fi
+
+# ─── codegraph (warn, not fatal) ───
+if command -v codegraph >/dev/null 2>&1; then
+  if [ -d "$root/.codegraph" ]; then
+    echo "  • codegraph: syncing existing index…"
+    codegraph sync "$root" || echo "  ! codegraph sync failed (non-fatal)" >&2
+  else
+    echo "  • codegraph: initializing + indexing…"
+    codegraph init "$root" >/dev/null 2>&1
+    codegraph index "$root" || echo "  ! codegraph index failed (non-fatal)" >&2
+  fi
+else
+  echo "  ! codegraph not installed — skipping (run /setup to register code intel)" >&2
+fi
+
+# ─── code_search (warn, not fatal) ───
+# reindex resolves the per-project DB from this directory arg and self-migrates
+# the legacy shared DB on first miss (handled inside code_search.py).
+cs="$DEUS_REPO/scripts/code_search.py"
+if command -v python3 >/dev/null 2>&1 && [ -f "$cs" ]; then
+  echo "  • code_search: reindexing…"
+  python3 "$cs" reindex "$root" || echo "  ! code_search reindex failed (non-fatal — is Ollama running?)" >&2
+else
+  echo "  ! code_search unavailable — skipping (need python3 + $cs)" >&2
+fi
+
+echo "  ✓ indexing complete"
+exit 0

--- a/scripts/tests/test_code_search_resolver.py
+++ b/scripts/tests/test_code_search_resolver.py
@@ -1,0 +1,133 @@
+"""Tests for code_search's per-project DB resolver + lazy legacy migration.
+
+These tests self-isolate (the repo conftest only patches `memory_tree`, not
+`code_search`):
+  - the env-override and per-project cases use `monkeypatch.setenv` + a tmp HOME;
+  - the legacy-fallback and migration cases use
+    `monkeypatch.setattr(code_search, "DB_PATH", ...)` — DB_PATH is read at
+    import time, so mutating the env after import would not reach the tier-3
+    fallback.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import code_search  # noqa: E402
+
+
+def _expected_per_project(home: Path, root: Path) -> Path:
+    digest = hashlib.md5(str(root.resolve()).encode()).hexdigest()
+    return home / ".config" / "deus" / "projects" / digest / "code_search.db"
+
+
+# ── tier 1: explicit env override ────────────────────────────────────────────
+
+def test_env_override_wins(monkeypatch, tmp_path):
+    target = tmp_path / "custom.db"
+    monkeypatch.setenv("DEUS_CODE_SEARCH_DB", str(target))
+    assert code_search._resolve_db_path() == target
+    # env wins even when a project dir is passed
+    assert code_search._resolve_db_path(tmp_path) == target
+
+
+# ── tier 2: per-project, keyed by md5(realpath) ──────────────────────────────
+
+def test_per_project_path_from_cwd(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEUS_CODE_SEARCH_DB", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    monkeypatch.chdir(proj)
+    assert code_search._resolve_db_path() == _expected_per_project(home, proj)
+
+
+def test_walk_up_from_subdir(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEUS_CODE_SEARCH_DB", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    sub = proj / "a" / "b"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+    # query from a deep subdir resolves to the SAME per-project DB as the root
+    assert code_search._resolve_db_path() == _expected_per_project(home, proj)
+
+
+def test_dotdeus_marker_also_roots(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEUS_CODE_SEARCH_DB", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = tmp_path / "proj"
+    (proj / ".deus").mkdir(parents=True)  # no .git, only .deus
+    assert code_search._resolve_db_path(proj) == _expected_per_project(home, proj)
+
+
+# ── tier 3: legacy fallback (patch DB_PATH directly, not env) ────────────────
+
+def test_no_root_falls_back_to_legacy(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEUS_CODE_SEARCH_DB", raising=False)
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.setattr(code_search, "DB_PATH", legacy)
+    nogit = tmp_path / "nogit"
+    nogit.mkdir()
+    assert code_search._resolve_db_path(nogit) == legacy
+
+
+# ── lazy migration: copy-on-match, skip-on-mismatch, idempotent ──────────────
+
+def _seed_legacy(db_path: Path, indexed_directory: Path) -> None:
+    db = code_search._init_db(db_path)
+    db.execute(
+        "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('indexed_directory', ?)",
+        (str(indexed_directory.resolve()),),
+    )
+    db.commit()
+    db.close()
+
+
+def test_legacy_migration_copies_on_match(monkeypatch, tmp_path):
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.setattr(code_search, "DB_PATH", legacy)
+    _seed_legacy(legacy, proj)
+
+    dbp = tmp_path / "per-project" / "code_search.db"
+    assert not dbp.exists()
+    code_search._migrate_legacy_if_match(proj.resolve(), dbp)
+    assert dbp.exists()       # copied into the per-project location
+    assert legacy.exists()    # legacy kept (no-db-deletion)
+
+    # idempotent: a second call is a no-op (dbp already exists)
+    before = dbp.stat().st_mtime_ns
+    code_search._migrate_legacy_if_match(proj.resolve(), dbp)
+    assert dbp.stat().st_mtime_ns == before
+
+
+def test_legacy_migration_skips_on_mismatch(monkeypatch, tmp_path):
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    other = tmp_path / "other"
+    other.mkdir()
+    legacy = tmp_path / "legacy.db"
+    monkeypatch.setattr(code_search, "DB_PATH", legacy)
+    _seed_legacy(legacy, other)  # legacy indexed a DIFFERENT project
+
+    dbp = tmp_path / "pp" / "code_search.db"
+    code_search._migrate_legacy_if_match(proj.resolve(), dbp)
+    assert not dbp.exists()
+
+
+def test_legacy_migration_noop_when_no_legacy(monkeypatch, tmp_path):
+    monkeypatch.setattr(code_search, "DB_PATH", tmp_path / "absent-legacy.db")
+    dbp = tmp_path / "pp" / "code_search.db"
+    code_search._migrate_legacy_if_match((tmp_path / "proj").resolve(), dbp)
+    assert not dbp.exists()


### PR DESCRIPTION
## What

`deus init` (alias `onboard`) + a `/onboard` skill that make both
code-intelligence engines work in **any** project, and removes a
single-active-project clobber footgun in code_search by giving every project
its own DB.

## Changes

**Per-project code_search resolver** (`scripts/code_search.py`)
- `_resolve_db_path()` — 3-tier Strategy: `DEUS_CODE_SEARCH_DB` env override →
  per-project `~/.config/deus/projects/<md5(realpath)>/code_search.db` →
  legacy shared DB (kept forever per `no-db-deletion.md`).
- `_migrate_legacy_if_match()` — lazy, self-healing copy (never move) of the
  legacy DB into a per-project DB on first miss; idempotent.
- 8 resolver unit tests (self-isolating; conftest does not cover this module).

**`deus init` / `/onboard`**
- `scripts/deus_init.sh` (new): realpath root → safety gate (refuse non-git, or
  >5000 tracked files, unless `--force`) → codegraph init/sync → code_search
  reindex. Missing engines warn, never fail. A non-git `--force` onboard drops a
  `.deus/` marker so its per-project DB stays isolated instead of falling
  through to the shared legacy DB.
- `deus-cmd.sh`: new `init|onboard)` arm. Resolves the realpath **once** and
  passes it to the script, so the code_search DB md5 and the config md5 are
  guaranteed identical. Registration merges, never clobbers existing memory
  settings (re-run bumps `last_accessed` only). Adds `deus init` to help.
- `.claude/skills/onboard/skill.md` (new): thin `/onboard` → `deus init`.
- `.claude/skills/setup/SKILL.md`: step 6c installs `onboard` user-scope.

**Bundled latent-bug fix** (`fix(cli): resolve SCRIPT_DIR via ZSH_ARGZERO`)
- `_resolve_script_dir` seeded `local src="$0"`, but inside a zsh function `$0`
  is the function name (`FUNCTION_ARGZERO`), so `SCRIPT_DIR` collapsed to cwd
  from any foreign directory. Latent because `deus init` is the first
  subcommand designed to run from inside another project. Fixed via
  `$ZSH_ARGZERO` (the real argv[0]); the existing symlink loop then resolves
  `/usr/local/bin/deus` → the repo.

## Verification (live, through a `/usr/local/bin/deus`-style symlink)

- md5 match: config `<md5>.json` basename == DB parent dir name.
- No cross-project clobber: project A held its chunk count after onboarding B.
- Non-git `--force`: `.deus/` marker → per-project DB, not the legacy shared DB.
- Safety refusal on a non-git dir without `--force` (exit 1).
- Idempotent re-run: codegraph `sync`, code_search reuse, non-default
  `memory_level` preserved with `last_accessed` bumped.
- `.husky/post-merge` needs no change (reindex keys off its `$REPO_ROOT` arg).
- Resolver tests (8) + deus-cmd prefix test (2) green.

## Scope / platform

macOS/Linux (bash + git + codegraph). `deus init --map/--seed/--deep`
onboarding extras are deferred to a follow-up PR (PR3) that extends
`deus_init.sh`.

## Note

Edits `.claude/skills/setup/SKILL.md` (step 6c) — overlaps with the sibling PR
`feat/code-intel-mcp-registration` (a different step). Whichever merges second
needs a trivial rebase on that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
