### PR TITLE
feat(wardens): add opt-in standing autonomy grant for the admin-merge gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 .claude/.plan-reviewed
 .claude/.code-reviewed
 .claude/.threat-modeled
+# Admin-merge gate markers (host-local; contain absolute worktree paths)
+.claude/.admin-merge-approved
+.claude/.admin-merge-standing
 .claude/.warden-verdicts.json.bak-*
 # Per-worktree gate state (markers + verdict store, namespaced by worktree)
 .claude/worktree-markers/

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -407,6 +407,25 @@ def _marker(repo_root: Path, name: str) -> Path:
     return repo_root / ".claude" / name
 
 
+def _marker_dir_for_worktree(repo_root: Path, worktree_root: Path) -> Path:
+    """Like _claude_marker_dir but for an EXPLICIT worktree (no cwd derivation).
+
+    Mirrors _claude_marker_dir's namespacing exactly so callers resolve the
+    SAME per-worktree bucket the code-review/verification gates write to: the
+    main repo -> flat .claude; any other worktree ->
+    .claude/worktree-markers/<sha1(worktree)[:12]>. The admin-merge standing
+    gate uses this to read the verdict store of the worktree being merged
+    deterministically, instead of relying on _current_worktree()'s os.getcwd().
+    """
+    base = repo_root / ".claude"
+    if worktree_root.resolve(strict=False) != repo_root.resolve(strict=False):
+        wt_id = hashlib.sha1(
+            str(worktree_root.resolve(strict=False)).encode()
+        ).hexdigest()[:12]
+        return base / "worktree-markers" / wt_id
+    return base
+
+
 # ---------------------------------------------------------------------------
 # Codegraph-first gate (LIA-121 / RETRO-2026-05-29-01)
 # ---------------------------------------------------------------------------
@@ -898,6 +917,16 @@ def _admin_merge_marker(repo_root: Path) -> Path:
     return _marker(repo_root, ".admin-merge-approved")
 
 
+def _admin_merge_standing_marker(repo_root: Path) -> Path:
+    """Path to the global/flat standing-grant marker.
+
+    NOT per-worktree: a standing autonomy grant is host-wide and time-boxed
+    (records the activating worktree for audit only). Intentionally absent from
+    _PER_WORKTREE_MARKERS and the session-init clear list -- bounded by expiry.
+    """
+    return repo_root / ".claude" / ".admin-merge-standing"
+
+
 def _active_script_path(repo_root: Path) -> Path:
     configured = os.environ.get("DEUS_CODEX_HOOK_SCRIPT_PATH")
     if configured:
@@ -931,6 +960,99 @@ def approve_admin_merge(command: str, repo_root: Path) -> int:
         encoding="utf-8",
     )
     print(f"Approved one admin merge command for {repo_root}")
+    return 0
+
+
+#: Standing-grant expiry defaults. The grant is a HARD time box; expiry_hours is
+#: clamped to [0, MAX] so a config typo (e.g. 100000) cannot grant effectively
+#: permanent autonomy, and <= 0 makes every grant immediately expired.
+_STANDING_GRANT_DEFAULT_EXPIRY_HOURS = 24.0
+_STANDING_GRANT_MAX_EXPIRY_HOURS = 168.0
+
+
+def _standing_grant_config(repo_root: Path) -> tuple[bool, float]:
+    """Read .claude/wardens/config.json admin-merge-gate.standing_grant.
+
+    Returns (enabled, expiry_hours).  Fail-safe: an absent/non-dict/malformed
+    config yields (False, default) so the gate falls back to strict one-shot.
+    ``enabled`` is honoured only when it is exactly ``True``.
+    """
+    config = _wardens_config(repo_root)
+    gate = config.get("admin-merge-gate")
+    sg = gate.get("standing_grant") if isinstance(gate, dict) else None
+    if not isinstance(sg, dict):
+        return (False, _STANDING_GRANT_DEFAULT_EXPIRY_HOURS)
+    enabled = sg.get("enabled") is True
+    raw = sg.get("expiry_hours", _STANDING_GRANT_DEFAULT_EXPIRY_HOURS)
+    # bool is a subclass of int -- reject it so `expiry_hours: true` is not 1h.
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raw = _STANDING_GRANT_DEFAULT_EXPIRY_HOURS
+    expiry = max(0.0, min(float(raw), _STANDING_GRANT_MAX_EXPIRY_HOURS))
+    return (enabled, expiry)
+
+
+def _standing_grant_config_stanza(repo_root: Path) -> str:
+    cfg = repo_root / ".claude" / "wardens" / "config.json"
+    return (
+        "[admin-merge-gate] Standing autonomy is OFF. To enable it, set this in\n"
+        f"{cfg} (gitignored, host-local) and retry:\n\n"
+        "  {\n"
+        '    "admin-merge-gate": {\n'
+        '      "standing_grant": { "enabled": true, "expiry_hours": 24 }\n'
+        "    }\n"
+        "  }\n\n"
+        "While enabled, `gh pr merge --admin` runs without per-command approval "
+        "for a PR whose branch matches the current worktree and whose "
+        "code-review + verification verdicts are SHIP (CI must be green). The "
+        f"grant expires after expiry_hours (max {int(_STANDING_GRANT_MAX_EXPIRY_HOURS)})."
+    )
+
+
+def approve_admin_merge_standing(repo_root: Path, worktree_root: Path) -> int:
+    """Activate a time-boxed standing admin-merge autonomy grant.
+
+    Requires the admin-merge-gate.standing_grant toggle to already be enabled in
+    wardens/config.json (the durable opt-in); this records the activation time
+    (the expiry anchor) and the activating worktree (audit only). No CI check
+    here -- a standing grant spans multiple PRs, so CI is enforced per-merge at
+    the gate, against the actual PR being merged.
+    """
+    enabled, expiry_hours = _standing_grant_config(repo_root)
+    if not enabled:
+        print(_standing_grant_config_stanza(repo_root), file=sys.stderr)
+        return 1
+
+    marker = _admin_merge_standing_marker(repo_root)
+    reactivated = marker.exists()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    # Plain write (mirrors the one-shot .admin-merge-approved sibling) rather
+    # than _write_atomic: the marker is tiny ephemeral state, a torn write is
+    # fail-closed by the gate's guarded parse, and _write_atomic would leave
+    # .bak-* files containing the prior absolute worktree_root.
+    marker.write_text(
+        json.dumps(
+            {
+                "worktree_root": str(worktree_root),
+                "created_at": dt.datetime.now(dt.UTC).isoformat(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if reactivated:
+        print(
+            "[admin-merge-gate] NOTE: a standing grant was already active; "
+            "its expiry clock has been reset to now.",
+            file=sys.stderr,
+        )
+    print(
+        f"Standing admin-merge grant active for ~{expiry_hours:g}h "
+        f"(activated from {worktree_root}). Each merge still requires green CI, "
+        "a branch match to its worktree, and SHIP code-review + verification "
+        "verdicts."
+    )
     return 0
 
 
@@ -1043,6 +1165,7 @@ def regenerate_codebase_map(repo_root: Path) -> int:
 
 def run_session_init(repo_root: Path) -> int:
     global _PATTERN_ROUTES_CACHE
+    # .admin-merge-standing is intentionally absent -- it is bounded by expiry, not session lifetime.
     for name in (
         ".plan-reviewed",
         ".code-reviewed",
@@ -1523,9 +1646,179 @@ def run_verification_invalidator(event: dict[str, Any], repo_root: Path) -> int:
     return 0
 
 
+#: Standing-grant action outcomes returned by _evaluate_standing_grant.
+_GRANT_ALLOW = "allow"
+_GRANT_BLOCK = "block"
+_GRANT_FALL_THROUGH = "fall_through"
+
+#: Mandatory wardens (must be present AND SHIP) vs conditional (if present must
+#: be SHIP; absence is fine -- a non-LLM / non-plan change legitimately never
+#: ran ai-eng / threat-model / plan-review). Marker names map to warden keys via
+#: MARKER_NAMES.
+_STANDING_MANDATORY_MARKERS = ("code-reviewed", "verified")
+_STANDING_CONDITIONAL_MARKERS = ("plan-reviewed", "ai-eng-reviewed", "threat-modeled")
+
+
+def _parse_iso_utc(raw: Any) -> dt.datetime | None:
+    """Parse an ISO-8601 timestamp into a tz-aware UTC datetime, or None.
+
+    A naive timestamp is assumed UTC. Guards against the classic naive-vs-aware
+    comparison TypeError -- the caller compares against ``dt.datetime.now(dt.UTC)``.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _verdict_in(verdicts: dict[str, Any], marker_name: str) -> str | None:
+    """Return the verdict string for *marker_name* from a verdicts dict."""
+    warden = MARKER_NAMES.get(marker_name)
+    entry = verdicts.get(warden) if warden else None
+    if isinstance(entry, dict):
+        v = entry.get("verdict")
+        return v if isinstance(v, str) else None
+    return None
+
+
+def _gh_pr_head_branch(ref: str, timeout: int = 3) -> str | None:
+    """Resolve a PR ref (number or URL) to its head branch via ``gh pr view``.
+
+    Returns None on any failure so the caller fails safe (treats it as an
+    unverifiable match and falls through to the one-shot approval path).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", ref, "--json", "headRefName"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    head = data.get("headRefName") if isinstance(data, dict) else None
+    return head if isinstance(head, str) and head else None
+
+
+def _pr_matches_worktree(command: str, wt: Path) -> tuple[bool, str]:
+    """True iff the PR referenced by *command* has head branch == *wt*'s branch.
+
+    A no-ref ``gh pr merge --admin`` targets the current branch (inherently
+    *wt*'s PR). An explicit branch name is compared directly; a PR number/URL is
+    resolved via ``gh pr view``. Anything unverifiable returns (False, reason).
+    This binds the verdicts we read (this worktree's) to the PR being merged.
+    """
+    wt_branch = _git(wt, "rev-parse", "--abbrev-ref", "HEAD")
+    if not wt_branch:
+        return (False, "[admin-merge-gate] could not resolve the worktree branch")
+    wt_branch = wt_branch.strip()
+    ref = _extract_pr_ref(command)
+    if ref is None or ref == wt_branch:
+        return (True, "")
+    head = _gh_pr_head_branch(ref)
+    if head is None:
+        return (
+            False,
+            f"[admin-merge-gate] could not verify PR '{ref}' belongs to this worktree",
+        )
+    if head == wt_branch:
+        return (True, "")
+    return (
+        False,
+        f"[admin-merge-gate] PR head branch '{head}' != worktree branch '{wt_branch}'",
+    )
+
+
+def _evaluate_standing_grant(
+    repo_root: Path, wt: Path, command: str, expiry_hours: float
+) -> tuple[str, str]:
+    """Decide a standing admin-merge grant; return (action, reason).
+
+    action is one of _GRANT_ALLOW / _GRANT_BLOCK / _GRANT_FALL_THROUGH. Pure
+    except for the deliberate unlink of an expired/corrupt marker. Fail-closed:
+    an unparseable marker, malformed timestamp, expiry, or any missing/non-SHIP
+    mandatory verdict blocks -- never silently allows.
+    """
+    marker = _admin_merge_standing_marker(repo_root)
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        marker.unlink(missing_ok=True)
+        return (
+            _GRANT_BLOCK,
+            "[admin-merge-gate] standing grant marker is unreadable/corrupt and "
+            "was cleared. Re-activate with `approve-admin-merge --standing`.",
+        )
+    if not isinstance(data, dict):
+        marker.unlink(missing_ok=True)
+        return (
+            _GRANT_BLOCK,
+            "[admin-merge-gate] standing grant marker is malformed and was "
+            "cleared. Re-activate with `approve-admin-merge --standing`.",
+        )
+
+    created = _parse_iso_utc(data.get("created_at"))
+    if created is None:
+        marker.unlink(missing_ok=True)
+        return (
+            _GRANT_BLOCK,
+            "[admin-merge-gate] standing grant has no valid created_at and was "
+            "cleared. Re-activate with `approve-admin-merge --standing`.",
+        )
+    age_hours = (dt.datetime.now(dt.UTC) - created).total_seconds() / 3600.0
+    if age_hours >= expiry_hours:
+        marker.unlink(missing_ok=True)
+        return (
+            _GRANT_BLOCK,
+            f"[admin-merge-gate] standing grant expired (age {age_hours:.1f}h >= "
+            f"{expiry_hours:g}h limit) and was cleared. Re-activate with "
+            "`approve-admin-merge --standing`.",
+        )
+
+    matched, why = _pr_matches_worktree(command, wt)
+    if not matched:
+        return (_GRANT_FALL_THROUGH, why)
+
+    verdicts = _read_verdicts_at(_verdicts_path_for_worktree(repo_root, wt))
+    for name in _STANDING_MANDATORY_MARKERS:
+        v = _verdict_in(verdicts, name)
+        if v != "SHIP":
+            warden = MARKER_NAMES.get(name, name)
+            return (
+                _GRANT_BLOCK,
+                f"[admin-merge-gate] standing grant requires a SHIP {warden} "
+                f"verdict for this worktree; found {v or 'none'}. Run the "
+                f"{warden} warden to SHIP, then retry.",
+            )
+    for name in _STANDING_CONDITIONAL_MARKERS:
+        v = _verdict_in(verdicts, name)
+        if v is not None and v != "SHIP":
+            warden = MARKER_NAMES.get(name, name)
+            return (
+                _GRANT_BLOCK,
+                f"[admin-merge-gate] standing grant blocked: {warden} verdict is "
+                f"{v} (must be SHIP or absent). Re-run {warden}, then retry.",
+            )
+    return (_GRANT_ALLOW, "")
+
+
 def run_admin_merge_gate(event: dict[str, Any], repo_root: Path) -> int:
     cwd = Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)
-    if _worktree_for_cwd(cwd, repo_root) is None:
+    wt = _worktree_for_cwd(cwd, repo_root)
+    if wt is None:
         return 0
 
     tool_input = event.get("tool_input")
@@ -1540,6 +1833,23 @@ def run_admin_merge_gate(event: dict[str, Any], repo_root: Path) -> int:
     if ci_block:
         _block_pre_tool(ci_block)
         return 0
+
+    # Standing autonomy grant (opt-in via wardens/config.json). CI-green is
+    # already enforced above. When the toggle is on and an unexpired standing
+    # marker exists, allow the merge WITHOUT per-command approval iff the PR's
+    # branch matches this worktree and its mandatory verdicts (code-review +
+    # verification) are SHIP. Verdicts are read from the worktree being merged,
+    # so the grant can never authorise an unreviewed PR. A branch mismatch falls
+    # through to the one-shot path; an unmet/expired condition blocks.
+    enabled, expiry_hours = _standing_grant_config(repo_root)
+    if enabled and _admin_merge_standing_marker(repo_root).exists():
+        action, reason = _evaluate_standing_grant(repo_root, wt, command, expiry_hours)
+        if action == _GRANT_ALLOW:
+            return 0
+        if action == _GRANT_BLOCK:
+            _block_pre_tool(reason)
+            return 0
+        # _GRANT_FALL_THROUGH -> require the one-shot approval below.
 
     marker = _admin_merge_marker(repo_root)
     command_hash = _command_hash(command)
@@ -2233,6 +2543,13 @@ def _verdicts_path(repo_root: Path) -> Path:
     return _claude_marker_dir(repo_root) / ".warden-verdicts.json"
 
 
+def _verdicts_path_for_worktree(repo_root: Path, worktree_root: Path) -> Path:
+    # Deterministic verdict store for an EXPLICIT worktree (the admin-merge
+    # standing gate resolves the cwd worktree itself rather than relying on
+    # _current_worktree()'s os.getcwd() derivation). Mirrors _verdicts_path.
+    return _marker_dir_for_worktree(repo_root, worktree_root) / ".warden-verdicts.json"
+
+
 def _audit_log_path(repo_root: Path) -> Path:
     # Deliberately GLOBAL (flat), not per-worktree: this is an append-only audit
     # trail that aggregates verdicts across every worktree. Do not namespace it.
@@ -2276,8 +2593,8 @@ def _is_bg_session() -> bool:
     return bool(os.environ.get("CLAUDE_JOB_DIR"))
 
 
-def _read_verdicts(repo_root: Path) -> dict[str, Any]:
-    path = _verdicts_path(repo_root)
+def _read_verdicts_at(path: Path) -> dict[str, Any]:
+    """Read a .warden-verdicts.json at an EXPLICIT path (no cwd derivation)."""
     if not path.exists():
         return {}
     try:
@@ -2285,6 +2602,10 @@ def _read_verdicts(repo_root: Path) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _read_verdicts(repo_root: Path) -> dict[str, Any]:
+    return _read_verdicts_at(_verdicts_path(repo_root))
 
 
 def _read_verdict(marker_name: str, repo_root: Path) -> str | None:
@@ -3150,7 +3471,24 @@ def build_parser() -> argparse.ArgumentParser:
 
     approve_parser = subparsers.add_parser("approve-admin-merge")
     approve_parser.add_argument("--repo-root", default=Path(__file__).resolve().parents[1])
-    approve_parser.add_argument("--command", dest="admin_command", required=True)
+    approve_parser.add_argument(
+        "--command", dest="admin_command", required=False, default=None,
+        help="The exact `gh pr merge --admin ...` command to approve (one-shot). "
+             "Required unless --standing is given.",
+    )
+    approve_parser.add_argument(
+        "--standing", action="store_true",
+        help="Activate a time-boxed standing autonomy grant instead of approving "
+             "a single command. Requires the admin-merge-gate.standing_grant "
+             "toggle in .claude/wardens/config.json. While active, admin merges "
+             "run without per-command approval for a PR whose branch matches its "
+             "worktree and whose code-review + verification verdicts are SHIP.",
+    )
+    approve_parser.add_argument(
+        "--worktree-root", default=None,
+        help="Worktree recorded on the standing grant (audit only; defaults to "
+             "the worktree of the current cwd). Only used with --standing.",
+    )
 
     mark_parser = subparsers.add_parser("mark")
     mark_parser.add_argument("marker_name", choices=sorted(MARKER_NAMES))
@@ -3250,9 +3588,28 @@ def main(argv: list[str] | None = None) -> int:
             lambda: mark_batch_wardens(args.specs, repo_root),
         )
     if args.action == "approve-admin-merge":
-        return approve_admin_merge(
-            args.admin_command, Path(args.repo_root).resolve(strict=False)
-        )
+        repo_root = Path(args.repo_root).resolve(strict=False)
+        if args.standing:
+            if args.worktree_root:
+                wt = Path(args.worktree_root).resolve(strict=False)
+            else:
+                wt = _worktree_for_cwd(Path.cwd(), repo_root)
+                if wt is None:
+                    print(
+                        "[admin-merge-gate] WARNING: cwd is not inside a worktree "
+                        f"of {repo_root}; recording the main repo as the activating "
+                        "worktree. Pass --worktree-root to be explicit.",
+                        file=sys.stderr,
+                    )
+                    wt = repo_root
+            return approve_admin_merge_standing(repo_root, wt)
+        if not args.admin_command:
+            print(
+                "[admin-merge-gate] --command is required unless --standing is given.",
+                file=sys.stderr,
+            )
+            return 2
+        return approve_admin_merge(args.admin_command, repo_root)
     if args.action == "install":
         return install(args)
     if args.action == "check":

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -3956,3 +3956,273 @@ def test_mark_cli_worktree_root_writes_namespaced(tmp_path):
     assert hooks._marker(repo, ".plan-reviewed").exists()
     # main() restored the override after the call.
     assert hooks.main is not None  # sanity; override reset happens in finally
+
+
+# ── Admin-merge standing autonomy grant (#9a) ───────────────────────────────
+
+import datetime as _dt  # noqa: E402  (section-local; mirrors hook's dt usage)
+
+
+def _commit_repo(repo: Path) -> None:
+    """Give the repo a born HEAD so `rev-parse --abbrev-ref HEAD` resolves."""
+    (repo / "README.md").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+def _enable_standing(repo: Path, expiry_hours=24) -> None:
+    wardens = repo / ".claude" / "wardens"
+    wardens.mkdir(parents=True, exist_ok=True)
+    (wardens / "config.json").write_text(
+        json.dumps(
+            {"admin-merge-gate": {"standing_grant": {"enabled": True, "expiry_hours": expiry_hours}}}
+        ),
+        encoding="utf-8",
+    )
+
+
+def _utc_iso(offset_hours: float = 0.0) -> str:
+    return (
+        _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(hours=offset_hours)
+    ).isoformat()
+
+
+def _write_standing_marker(repo: Path, created_at: str, worktree_root: Path | None = None) -> Path:
+    marker = repo / ".claude" / ".admin-merge-standing"
+    marker.write_text(
+        json.dumps({"worktree_root": str(worktree_root or repo), "created_at": created_at}),
+        encoding="utf-8",
+    )
+    return marker
+
+
+def _write_verdicts(repo: Path, verdicts: dict) -> None:
+    data = {k: {"verdict": v, "ts": "t", "reason": "r", "source": "test"} for k, v in verdicts.items()}
+    (repo / ".claude" / ".warden-verdicts.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _green_ci(hooks, monkeypatch) -> None:
+    monkeypatch.setattr(hooks, "_check_ci_status", lambda *a, **k: (hooks._CI_STATUS_GREEN, "ok"))
+
+
+def test_standing_grant_allows_when_ci_green_branch_match_verdicts_ship(
+    tmp_path, capsys, monkeypatch
+):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    _green_ci(hooks, monkeypatch)
+    _enable_standing(repo)
+    marker = _write_standing_marker(repo, _utc_iso())
+    _write_verdicts(repo, {"code-reviewer": "SHIP", "verification-gate": "SHIP"})
+
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge --admin"), repo)
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""  # allowed: no deny JSON, no approval prompt
+    assert marker.exists()  # standing grant is NOT consumed on use
+
+
+def test_standing_grant_blocks_on_conditional_revise(tmp_path, capsys, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    _green_ci(hooks, monkeypatch)
+    _enable_standing(repo)
+    marker = _write_standing_marker(repo, _utc_iso())
+    _write_verdicts(
+        repo,
+        {"code-reviewer": "SHIP", "verification-gate": "SHIP", "ai-eng-warden": "REVISE"},
+    )
+
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge --admin"), repo)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "ai-eng-warden" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert marker.exists()  # not consumed — fix the warden and retry within the window
+
+
+def test_standing_grant_blocks_on_missing_mandatory_verdict(tmp_path, capsys, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    _green_ci(hooks, monkeypatch)
+    _enable_standing(repo)
+    _write_standing_marker(repo, _utc_iso())
+    _write_verdicts(repo, {"code-reviewer": "SHIP"})  # verification-gate absent
+
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge --admin"), repo)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "verification-gate" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_standing_grant_blocks_and_consumes_when_expired(tmp_path, capsys, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    _green_ci(hooks, monkeypatch)
+    _enable_standing(repo, expiry_hours=24)
+    marker = _write_standing_marker(repo, _utc_iso(offset_hours=-48))
+    _write_verdicts(repo, {"code-reviewer": "SHIP", "verification-gate": "SHIP"})
+
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge --admin"), repo)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "expired" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert not marker.exists()  # expired marker is consumed
+
+
+def test_standing_grant_ci_red_blocks_before_grant(tmp_path, capsys, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    monkeypatch.setattr(hooks, "_check_ci_status", lambda *a, **k: (hooks._CI_STATUS_RED, "boom"))
+    _enable_standing(repo)
+    marker = _write_standing_marker(repo, _utc_iso())
+    _write_verdicts(repo, {"code-reviewer": "SHIP", "verification-gate": "SHIP"})
+
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge --admin"), repo)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "CI is red" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert marker.exists()  # CI gate fires before the standing block; marker untouched
+
+
+def test_standing_grant_toggle_off_falls_through_to_one_shot(tmp_path, capsys, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    _green_ci(hooks, monkeypatch)
+    # No config => toggle off. A leftover standing marker must be ignored.
+    marker = _write_standing_marker(repo, _utc_iso())
+    _write_verdicts(repo, {"code-reviewer": "SHIP", "verification-gate": "SHIP"})
+
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge --admin"), repo)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "fresh explicit approval" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert marker.exists()  # toggle off => standing logic skipped, marker untouched
+
+
+def test_standing_grant_branch_mismatch_falls_through(tmp_path, capsys, monkeypatch):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)
+    _green_ci(hooks, monkeypatch)
+    monkeypatch.setattr(hooks, "_gh_pr_head_branch", lambda *a, **k: "some-other-branch")
+    _enable_standing(repo)
+    marker = _write_standing_marker(repo, _utc_iso())
+    _write_verdicts(repo, {"code-reviewer": "SHIP", "verification-gate": "SHIP"})
+
+    # Explicit foreign PR ref => resolves to a branch != this worktree's branch.
+    rc = hooks.run_admin_merge_gate(bash_event(repo, "gh pr merge 999 --admin"), repo)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "fresh explicit approval" in out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert marker.exists()  # mismatch => one-shot path, standing marker preserved
+
+
+def test_approve_standing_without_toggle_prints_stanza(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.approve_admin_merge_standing(repo, repo)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "standing_grant" in err and "enabled" in err
+    assert not (repo / ".claude" / ".admin-merge-standing").exists()
+
+
+def test_approve_standing_with_toggle_writes_marker(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _enable_standing(repo)
+
+    rc = hooks.approve_admin_merge_standing(repo, repo)
+
+    assert rc == 0
+    marker = repo / ".claude" / ".admin-merge-standing"
+    assert marker.exists()
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["worktree_root"] == str(repo)
+    assert hooks._parse_iso_utc(data["created_at"]) is not None
+
+
+def test_approve_admin_merge_requires_command_without_standing(tmp_path, capsys):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.main(["approve-admin-merge", "--repo-root", str(repo)])
+
+    assert rc == 2
+    assert "--command is required" in capsys.readouterr().err
+
+
+def test_standing_grant_config_clamps_and_guards(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    # Absent config => fail-safe disabled.
+    assert hooks._standing_grant_config(repo) == (False, 24.0)
+
+    wardens = repo / ".claude" / "wardens"
+    wardens.mkdir(parents=True)
+
+    def cfg(val):
+        (wardens / "config.json").write_text(
+            json.dumps(
+                {"admin-merge-gate": {"standing_grant": {"enabled": True, "expiry_hours": val}}}
+            ),
+            encoding="utf-8",
+        )
+        return hooks._standing_grant_config(repo)
+
+    assert cfg(100000) == (True, 168.0)  # clamped to max
+    assert cfg(-5) == (True, 0.0)  # clamped to 0 (always-expired)
+    assert cfg(True) == (True, 24.0)  # bool rejected -> default
+    assert cfg("nope") == (True, 24.0)  # non-numeric rejected -> default
+
+
+def test_standing_marker_not_cleared_by_session_init(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    marker = _write_standing_marker(repo, _utc_iso())
+
+    assert hooks.run_session_init(repo) == 0
+
+    assert marker.exists()  # bounded by expiry, not session lifetime
+
+
+def test_pr_matches_worktree_fails_safe_on_unborn_head(tmp_path):
+    # git_repo has no commits -> `git rev-parse --abbrev-ref HEAD` errors ->
+    # _git returns None -> the guard must NOT silently report a match.
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)  # no _commit_repo: HEAD is unborn
+
+    matched, reason = hooks._pr_matches_worktree("gh pr merge --admin", repo)
+
+    assert matched is False
+    assert "worktree branch" in reason
+
+
+def test_pr_matches_worktree_no_ref_matches_current_branch(tmp_path):
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    _commit_repo(repo)  # born HEAD
+
+    matched, _ = hooks._pr_matches_worktree("gh pr merge --admin", repo)
+
+    assert matched is True  # no explicit ref => current branch => this worktree's PR


### PR DESCRIPTION
## What

Opt-in, time-boxed **standing autonomy grant** for the local `admin-merge-gate`
(PreToolUse Bash hook). Today every `gh pr merge --admin` needs a fresh
per-command approval; this lets a trusted host agent admin-merge without that
interruption — **without weakening any safety property**. Enforcement-trio item **#9a**.

Default **OFF** → strict one-shot (today's behavior, unchanged). Enable via
`.claude/wardens/config.json` (gitignored):

```json
{ "admin-merge-gate": { "standing_grant": { "enabled": true, "expiry_hours": 24 } } }
```

`approve-admin-merge --standing` activates a grant (prints the stanza above if the
toggle is off). While active, `gh pr merge --admin` is allowed **only when ALL hold**:

- CI is green for the PR (already enforced);
- **branch-bind**: the PR's head branch == the cwd worktree's branch — so the verdicts
  checked are the ones for the work being merged. This closes a fail-open where a grant
  approved in worktree A could authorise an unreviewed PR built in worktree B (CI is
  per-PR, but the warden-SHIP check must also be per-PR);
- the worktree's **mandatory** verdicts (`code-reviewer` + `verification-gate`) are SHIP,
  and **conditional** ones (`plan-reviewer`/`ai-eng-warden`/`threat-modeler`) are SHIP-or-absent;
- the grant has not expired (`expiry_hours` clamped `[0,168]`; ≤0 ⇒ always-expired).

**Fail-closed everywhere:** unparseable marker / malformed-or-missing timestamp / expiry /
any missing-or-non-SHIP mandatory verdict → BLOCK. Expired/corrupt markers are consumed;
other blocks preserve the marker. A branch mismatch or unverifiable PR falls through to the
existing one-shot approval path.

Out of scope: the orchestrator-autonomous merge (`src/linear-auto-merge.ts`, a host
child_process that does NOT pass through this PreToolUse hook) — that's **#9b**.

## Design notes

- Standing marker is **global/flat** (`.claude/.admin-merge-standing`, gitignored), holds
  `{worktree_root (audit only), created_at}`, no `command_hash` (covers any admin merge
  while active). Verdicts are resolved from the **cwd** worktree (branch-bound), not the
  stored one. Intentionally **not** cleared at session-init (bounded by expiry).
- `.gitignore` now also ignores the sibling `.admin-merge-approved` (same class; both hold
  absolute worktree paths).
- `--command` is now optional (required only for the one-shot path).
- New helpers `_marker_dir_for_worktree` / `_verdicts_path_for_worktree` mirror
  `_claude_marker_dir` / `_verdicts_path` exactly, so they read the same per-worktree
  verdict store the code-review/verification gates write.

## Tests

15 new + 210 existing = **225 pass**. Coverage: allow-without-consume, expiry→BLOCK+consume,
missing-mandatory→BLOCK, conditional-REVISE→BLOCK, CI-red→BLOCK, toggle-off→one-shot,
branch-mismatch→fall-through, fail-safe unborn-HEAD, no-ref→current-branch match, config
clamp/guards, `--standing` toggle-off→stanza+rc1, `--standing` toggle-on→marker, one-shot
missing `--command`→rc2, session-init preserves marker.

Plan-reviewer **SHIP** (r5) · code-reviewer **SHIP** (r2) · verification-gate **SHIP** (r2).
`py_compile` clean · `drift_check --all` clean · 0 TS/`src/**` files touched.

## Real-session smoke (hook-pr-smoke-test)

Invoked the **actual hook entry point** `codex_warden_hooks.py run admin-merge-gate` (the
exact path `warden-shim.sh` calls) with piped PreToolUse JSON, isolated temp `repo_root`
(no live `.claude/` touched), **real CI** via merged PR #690 (all checks `pass`; head
`fix/lia-168-dispatch-hang`):

- **toggle OFF** → standing skipped → `deny` ("fresh explicit approval"), exit 0.
- **toggle ON + EXPIRED marker** → `deny` ("standing grant expired (age 48.0h >= 24h limit)
  and was cleared") → **marker CONSUMED**, exit 0.
- **toggle ON + VALID marker + verdicts SHIP, branch unresolvable** → fail-safe
  **fall-through** to one-shot `deny` → **marker PRESERVED**, exit 0.

> ALLOW-path smoke (CI-green + branch-match + mandatory-SHIP) against this PR's own green CI
> is added in a follow-up comment once checks pass — the security-critical path's required evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
