### PR TITLE
feat(security): block external-project push/merge by default in the tool-proxy

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780561930
+last_verified: "2026-06-04" # auto-bump @1780578644
 governs:
   - src/
   - evolution/

--- a/src/db.ts
+++ b/src/db.ts
@@ -108,6 +108,7 @@ function createSchema(database: Database.Database): void {
       path TEXT NOT NULL UNIQUE,
       type TEXT,
       readonly INTEGER DEFAULT 0,
+      allow_external_push INTEGER DEFAULT 0,
       created_at TEXT NOT NULL
     );
 
@@ -274,9 +275,20 @@ function createSchema(database: Database.Database): void {
       path TEXT NOT NULL UNIQUE,
       type TEXT,
       readonly INTEGER DEFAULT 0,
+      allow_external_push INTEGER DEFAULT 0,
       created_at TEXT NOT NULL
     );
   `);
+
+  // Add allow_external_push column to projects (migration for existing DBs).
+  // Default 0 = external projects cannot push/merge unless explicitly allowlisted.
+  try {
+    database.exec(
+      `ALTER TABLE projects ADD COLUMN allow_external_push INTEGER DEFAULT 0`,
+    );
+  } catch {
+    /* column already exists */
+  }
 
   // Add channel and is_group columns if they don't exist (migration for existing DBs)
   try {
@@ -1082,6 +1094,51 @@ export function getRegisteredGroup(
   };
 }
 
+export function getRegisteredGroupByFolder(
+  folder: string,
+): (RegisteredGroup & { jid: string }) | undefined {
+  // registered_groups.folder is UNIQUE, so this resolves at most one row.
+  // Used by the tool-proxy push/merge gate to map a request's group folder
+  // (from validateGroupToken) to its project association.
+  const row = db
+    .prepare('SELECT * FROM registered_groups WHERE folder = ?')
+    .get(folder) as
+    | {
+        jid: string;
+        name: string;
+        folder: string;
+        trigger_pattern: string;
+        added_at: string;
+        container_config: string | null;
+        requires_trigger: number | null;
+        is_main: number | null;
+        project_id: string | null;
+      }
+    | undefined;
+  if (!row) return undefined;
+  if (!isValidGroupFolder(row.folder)) {
+    logger.warn(
+      { jid: row.jid, folder: row.folder },
+      'Skipping registered group with invalid folder',
+    );
+    return undefined;
+  }
+  return {
+    jid: row.jid,
+    name: row.name,
+    folder: row.folder,
+    trigger: row.trigger_pattern,
+    added_at: row.added_at,
+    containerConfig: row.container_config
+      ? JSON.parse(row.container_config)
+      : undefined,
+    requiresTrigger:
+      row.requires_trigger === null ? undefined : row.requires_trigger === 1,
+    isControlGroup: row.is_main === 1 ? true : undefined,
+    projectId: row.project_id ?? undefined,
+  };
+}
+
 export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   if (!isValidGroupFolder(group.folder)) {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
@@ -1144,15 +1201,33 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
 
 export function createProject(project: ProjectConfig): void {
   db.prepare(
-    `INSERT INTO projects (id, name, path, type, readonly, created_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO projects (id, name, path, type, readonly, allow_external_push, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     project.id,
     project.name,
     project.path,
     project.type ? JSON.stringify(project.type) : null,
     project.readonly ? 1 : 0,
+    project.allow_external_push ? 1 : 0,
     project.created_at,
+  );
+}
+
+/**
+ * Allowlist (or revoke) an external project for git push/merge through the
+ * tool-proxy. Default is blocked; flip to true to let a trusted external
+ * project push/merge. (No general updateProject exists; this is the dedicated
+ * writer for the one mutable policy flag.) The operator-facing command/skill
+ * that wraps this is deferred to LIA-180; until then flip it via this writer.
+ */
+export function setProjectAllowExternalPush(
+  id: string,
+  allowed: boolean,
+): void {
+  db.prepare(`UPDATE projects SET allow_external_push = ? WHERE id = ?`).run(
+    allowed ? 1 : 0,
+    id,
   );
 }
 
@@ -1164,6 +1239,7 @@ export function getProjectById(id: string): ProjectConfig | undefined {
         path: string;
         type: string | null;
         readonly: number;
+        allow_external_push: number;
         created_at: string;
       }
     | undefined;
@@ -1174,6 +1250,7 @@ export function getProjectById(id: string): ProjectConfig | undefined {
     path: row.path,
     type: row.type ? JSON.parse(row.type) : null,
     readonly: row.readonly === 1,
+    allow_external_push: row.allow_external_push === 1,
     created_at: row.created_at,
   };
 }
@@ -1188,6 +1265,7 @@ export function getProjectByPath(hostPath: string): ProjectConfig | undefined {
         path: string;
         type: string | null;
         readonly: number;
+        allow_external_push: number;
         created_at: string;
       }
     | undefined;
@@ -1198,6 +1276,7 @@ export function getProjectByPath(hostPath: string): ProjectConfig | undefined {
     path: row.path,
     type: row.type ? JSON.parse(row.type) : null,
     readonly: row.readonly === 1,
+    allow_external_push: row.allow_external_push === 1,
     created_at: row.created_at,
   };
 }
@@ -1211,6 +1290,7 @@ export function getAllProjects(): ProjectConfig[] {
     path: string;
     type: string | null;
     readonly: number;
+    allow_external_push: number;
     created_at: string;
   }>;
   return rows.map((row) => ({
@@ -1219,6 +1299,7 @@ export function getAllProjects(): ProjectConfig[] {
     path: row.path,
     type: row.type ? JSON.parse(row.type) : null,
     readonly: row.readonly === 1,
+    allow_external_push: row.allow_external_push === 1,
     created_at: row.created_at,
   }));
 }

--- a/src/external-push-gate.test.ts
+++ b/src/external-push-gate.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _initTestDatabase,
+  createProject,
+  getProjectById,
+  getRegisteredGroupByFolder,
+  setProjectAllowExternalPush,
+  setRegisteredGroup,
+} from './db.js';
+import { SENSITIVE_FILE_PATTERNS } from './project-registry.js';
+import { externalPushDenialReason, isPushOrMergeTool } from './tool-proxy.js';
+import type { ProjectConfig, RegisteredGroup } from './types.js';
+
+function group(
+  overrides: Partial<RegisteredGroup> & { folder: string },
+): RegisteredGroup {
+  return {
+    name: overrides.folder,
+    trigger: '!deus',
+    added_at: '2026-06-04T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function project(id: string, allow?: boolean): ProjectConfig {
+  return {
+    id,
+    name: id,
+    path: `/host/${id}`,
+    type: null,
+    readonly: false,
+    allow_external_push: allow,
+    created_at: '2026-06-04T00:00:00Z',
+  };
+}
+
+describe('isPushOrMergeTool', () => {
+  it('flags the dedicated push tool unconditionally', () => {
+    expect(isPushOrMergeTool('deus-git-push', [])).toBe(true);
+    expect(isPushOrMergeTool('deus-git-push', ['--force'])).toBe(true);
+  });
+
+  it('flags gh pr merge / pr create / merge alias by subcommand position', () => {
+    expect(isPushOrMergeTool('gh', ['pr', 'merge', '294', '--squash'])).toBe(
+      true,
+    );
+    expect(isPushOrMergeTool('gh', ['pr', 'create', '--fill'])).toBe(true);
+    expect(isPushOrMergeTool('gh', ['merge'])).toBe(true);
+    // global flags before the subcommand are skipped (value-consuming -R/--repo)
+    expect(isPushOrMergeTool('gh', ['-R', 'o/r', 'pr', 'merge', '1'])).toBe(
+      true,
+    );
+    expect(isPushOrMergeTool('gh', ['--repo', 'o/r', 'pr', 'merge'])).toBe(
+      true,
+    );
+    // equals-form flag is one token (does NOT consume the next as a value)
+    expect(isPushOrMergeTool('gh', ['--hostname=h', 'pr', 'merge'])).toBe(true);
+  });
+
+  it('does NOT flag non-push gh subcommands (incl. pr close, which is not a merge)', () => {
+    expect(isPushOrMergeTool('gh', ['pr', 'view', '294'])).toBe(false);
+    expect(isPushOrMergeTool('gh', ['pr', 'list'])).toBe(false);
+    expect(isPushOrMergeTool('gh', ['pr', 'close', '294', '--merge'])).toBe(
+      false,
+    );
+    expect(isPushOrMergeTool('gh', ['issue', 'create'])).toBe(false);
+  });
+
+  it('does not flag unrelated tools', () => {
+    expect(isPushOrMergeTool('ripgrep', ['pr', 'merge'])).toBe(false);
+  });
+});
+
+describe('externalPushDenialReason (db-backed)', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+  });
+
+  it('allows the home/control project (no projectId)', () => {
+    setRegisteredGroup(
+      'home@jid',
+      group({ folder: 'main', isControlGroup: true }),
+    );
+    expect(externalPushDenialReason('main')).toBeNull();
+  });
+
+  it('blocks an external project that is not allowlisted', () => {
+    createProject(project('projA'));
+    setRegisteredGroup(
+      'extA@jid',
+      group({ folder: 'extproj', projectId: 'projA' }),
+    );
+    const reason = externalPushDenialReason('extproj');
+    expect(reason).toContain('projA');
+    expect(reason).toContain('blocked');
+  });
+
+  it('allows an external project once allowlisted', () => {
+    createProject(project('projB'));
+    setRegisteredGroup(
+      'extB@jid',
+      group({ folder: 'extallow', projectId: 'projB' }),
+    );
+    expect(externalPushDenialReason('extallow')).not.toBeNull(); // blocked by default
+    setProjectAllowExternalPush('projB', true);
+    expect(externalPushDenialReason('extallow')).toBeNull(); // now allowed
+  });
+
+  it('fail-closed: denies an unregistered group folder', () => {
+    expect(externalPushDenialReason('ghost')).toContain('not registered');
+  });
+
+  it('fail-closed: denies when no group folder resolved (no token)', () => {
+    expect(externalPushDenialReason(null)).toContain('blocked');
+  });
+});
+
+describe('projects.allow_external_push persistence', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+  });
+
+  it('round-trips through createProject/getProjectById and defaults to false', () => {
+    createProject(project('p-default'));
+    expect(getProjectById('p-default')?.allow_external_push).toBe(false);
+
+    createProject(project('p-true', true));
+    expect(getProjectById('p-true')?.allow_external_push).toBe(true);
+  });
+
+  it('setProjectAllowExternalPush flips the flag', () => {
+    createProject(project('p-flip'));
+    expect(getProjectById('p-flip')?.allow_external_push).toBe(false);
+    setProjectAllowExternalPush('p-flip', true);
+    expect(getProjectById('p-flip')?.allow_external_push).toBe(true);
+    setProjectAllowExternalPush('p-flip', false);
+    expect(getProjectById('p-flip')?.allow_external_push).toBe(false);
+  });
+
+  it('getRegisteredGroupByFolder resolves the group + projectId', () => {
+    createProject(project('p-g'));
+    setRegisteredGroup('g@jid', group({ folder: 'gfolder', projectId: 'p-g' }));
+    const g = getRegisteredGroupByFolder('gfolder');
+    expect(g?.projectId).toBe('p-g');
+    expect(g?.jid).toBe('g@jid');
+    expect(getRegisteredGroupByFolder('nope')).toBeUndefined();
+  });
+});
+
+describe('SENSITIVE_FILE_PATTERNS', () => {
+  it('shadows git credential stores', () => {
+    expect(SENSITIVE_FILE_PATTERNS).toContain('.git-credentials');
+    expect(SENSITIVE_FILE_PATTERNS).toContain('.netrc');
+  });
+});

--- a/src/project-registry.ts
+++ b/src/project-registry.ts
@@ -159,6 +159,12 @@ export const SENSITIVE_FILE_PATTERNS = [
   '.env.production',
   '.env.staging',
   '.env.test',
+  // Git credential stores — shadowed so a container cannot read them to push
+  // with the host's credentials, closing the direct-Bash bypass of the
+  // tool-proxy push/merge gate. (`.netrc` is also blocked at the mount layer in
+  // mount-security.ts — a SEPARATE enforcement layer, intentionally not removed.)
+  '.git-credentials',
+  '.netrc',
 ];
 
 /**

--- a/src/tool-proxy.ts
+++ b/src/tool-proxy.ts
@@ -23,6 +23,7 @@ import { createServer, Server } from 'http';
 import { execFile } from 'child_process';
 
 import { DEUS_PROXY_AUTH_ENABLED } from './config.js';
+import { getProjectById, getRegisteredGroupByFolder } from './db.js';
 import { validateGroupToken } from './group-tokens.js';
 import { logger } from './logger.js';
 import { loadRegistry, isAllowed, getToolConfig } from './tool-registry.js';
@@ -48,6 +49,61 @@ function validateArg(arg: string): string | null {
   return null;
 }
 
+/** `gh` global flags that consume the following token as their value. */
+const GH_FLAGS_WITH_VALUE = new Set(['-R', '--repo', '--hostname']);
+
+/**
+ * True if this tool invocation pushes to / publishes on a remote (git push, or
+ * `gh pr merge`/`gh pr create`/`gh merge`). Detection is by SUBCOMMAND POSITION,
+ * not substring — so `gh pr merge --help` or a branch literally named "push"
+ * does not false-trip. Platform-neutral (tool names + arg tokens only).
+ *
+ * Note: `gh pr close` is NOT a merge (it closes without merging) and is allowed.
+ */
+export function isPushOrMergeTool(toolName: string, args: string[]): boolean {
+  // The dedicated push tool is always a push.
+  if (toolName === 'deus-git-push') return true;
+  if (toolName === 'gh') {
+    // Collect the first two positional (non-flag) tokens, skipping global flags
+    // and their values, to read the subcommand path.
+    const positional: string[] = [];
+    for (let i = 0; i < args.length && positional.length < 2; i++) {
+      const a = args[i];
+      if (a.startsWith('-')) {
+        if (GH_FLAGS_WITH_VALUE.has(a)) i++; // skip the flag's value token
+        continue;
+      }
+      positional.push(a);
+    }
+    const [c0, c1] = positional;
+    if (c0 === 'merge') return true; // `gh merge` top-level alias
+    if (c0 === 'pr' && (c1 === 'merge' || c1 === 'create')) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns a denial message if a push/merge from *groupFolder* must be blocked,
+ * or null if allowed. Allowed = the home/control project (no projectId) or an
+ * external project with `allow_external_push`. Fail-closed: an unresolvable
+ * group or unregistered folder is denied (we cannot prove it is internal).
+ */
+export function externalPushDenialReason(
+  groupFolder: string | null,
+): string | null {
+  if (!groupFolder) {
+    return 'External-project git push/merge is blocked: caller group could not be resolved (no proxy token).';
+  }
+  const group = getRegisteredGroupByFolder(groupFolder);
+  if (!group) {
+    return `External-project git push/merge is blocked: group "${groupFolder}" is not registered.`;
+  }
+  if (!group.projectId) return null; // home/control project — allowed
+  const project = getProjectById(group.projectId);
+  if (project?.allow_external_push === true) return null; // allowlisted external
+  return `External-project git push/merge is blocked for project "${group.projectId}". Allowlist this project to enable push/merge (operator action — see LIA-180).`;
+}
+
 export function startToolProxy(
   port: number,
   host = '127.0.0.1',
@@ -60,19 +116,20 @@ export function startToolProxy(
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
-        // ── Auth gate (same as credential-proxy) ──────────────────────────
-        if (DEUS_PROXY_AUTH_ENABLED) {
-          const token = req.headers['x-deus-proxy-token'] as string | undefined;
-          const groupFolder = token ? validateGroupToken(token) : null;
-          if (!groupFolder) {
-            logger.warn(
-              { url: req.url, hasToken: !!token },
-              'Tool proxy rejected unauthenticated request',
-            );
-            res.writeHead(401);
-            res.end('Unauthorized');
-            return;
-          }
+        // ── Resolve caller's group folder ─────────────────────────────────
+        // Resolved ALWAYS (independent of auth enforcement) because the
+        // push/merge gate below needs it even when DEUS_PROXY_AUTH is disabled
+        // (dev). Auth ENFORCEMENT (401) stays gated on DEUS_PROXY_AUTH_ENABLED.
+        const token = req.headers['x-deus-proxy-token'] as string | undefined;
+        const groupFolder = token ? validateGroupToken(token) : null;
+        if (DEUS_PROXY_AUTH_ENABLED && !groupFolder) {
+          logger.warn(
+            { url: req.url, hasToken: !!token },
+            'Tool proxy rejected unauthenticated request',
+          );
+          res.writeHead(401);
+          res.end('Unauthorized');
+          return;
         }
 
         // ── Route: POST /tool/:name ────────────────────────────────────────
@@ -138,6 +195,24 @@ export function startToolProxy(
         }
 
         const safeArgs = args as string[];
+
+        // ── Push/merge gate ────────────────────────────────────────────────
+        // External projects cannot git push/merge by default. Allowed only for
+        // the home/control project or an allowlisted external project (and
+        // fail-closed when the caller group is unresolvable). Default-block
+        // applies to everyone, independent of the auth-enforcement flag.
+        if (isPushOrMergeTool(rawName, safeArgs)) {
+          const denial = externalPushDenialReason(groupFolder);
+          if (denial) {
+            logger.warn(
+              { tool: rawName, groupFolder },
+              'Tool proxy blocked external push/merge',
+            );
+            res.writeHead(403, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: denial }));
+            return;
+          }
+        }
 
         // Resolve tool config (binary path + injected env)
         const toolConfig = getToolConfig(rawName);

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,9 @@ export interface ProjectConfig {
   path: string; // Absolute host path
   type: ProjectType | null; // Detected project type, null if unknown
   readonly: boolean; // Whether the mount is read-only (default: false)
+  // Whether this external project may git push/merge through the tool-proxy.
+  // Optional/undefined ⇒ blocked (the gate fail-closes on `!== true`).
+  allow_external_push?: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
## What

When `deus` runs an agent container on an **external** project, git push / PR
merge through the tool-proxy was ungated — a container could push or merge to the
project's remote using the host's credentials. This blocks external push/merge
**by default**, allowing only the Deus home/control project or an explicitly
allowlisted external project, and shadows git credential files to close the
direct-Bash bypass. Enforcement-trio item **#2**.

## How

- **Gate** (`src/tool-proxy.ts`): the caller's group folder is now resolved on
  every request (hoisted out of the `DEUS_PROXY_AUTH_ENABLED` block so it works
  in dev too; the 401 auth-enforcement stays gated on that flag). For a
  push/merge tool the request is denied unless the caller resolves to the
  home/control project (no `projectId`) or an external project with
  `allow_external_push`. **Fail-closed**: an unresolvable / unregistered caller
  is denied. `isPushOrMergeTool` detects by **subcommand position** —
  `deus-git-push` always; `gh pr merge` / `gh pr create` / `gh merge` alias —
  skipping value-consuming global flags (`-R`/`--repo`/`--hostname`). `gh pr
  close` is **not** a merge and is allowed.
- **Storage** (`src/db.ts`): new `allow_external_push` column on `projects`
  (idempotent `ALTER TABLE … ADD COLUMN … DEFAULT 0` + both `CREATE TABLE`
  blocks; `0` = blocked). Read in `createProject` + all three project readers;
  `ProjectConfig.allow_external_push` is optional (gate fail-closes on
  `!== true`). New `getRegisteredGroupByFolder` (folder is `UNIQUE`) maps a
  request's folder → project; new `setProjectAllowExternalPush` writer flips the
  flag.
- **Creds shadow** (`src/project-registry.ts`): `.git-credentials` + `.netrc`
  added to `SENSITIVE_FILE_PATTERNS` (`.netrc` is also blocked at the mount layer
  in `mount-security.ts` — a separate enforcement layer, intentionally kept in
  both; `.git/config` is deliberately NOT shadowed — it would break git).

## Allowlisting a project (interim)

The operator-facing command/skill is tracked in **LIA-180**. Until it lands,
flip the flag via the DB writer `setProjectAllowExternalPush('<project-id>',
true)` (or raw SQL `UPDATE projects SET allow_external_push = 1 WHERE id =
'<project-id>'`). Default is blocked.

## Tests

13 new (`src/external-push-gate.test.ts`): detection matrix (incl. `pr close`
≠ merge, equals-form global flag), fail-closed denial paths (null / unregistered
/ external-blocked / allowlisted / home-allowed), `allow_external_push`
persistence + flip, `getRegisteredGroupByFolder`, and the creds-shadow patterns.
122 regression tests (db / project-registry / container-mounter /
credential-proxy) green. tsc / eslint / prettier clean.

Plan-reviewer **SHIP** (r4) · code-reviewer **SHIP** (r2) · verification-gate **SHIP** (r2).

## Scope note

This gates the tool-proxy path (`/tool/:name`), which all backends route through.
The credential shadow closes the direct-Bash path. The registered push tools are
exactly `gh` and `deus-git-push` (no plain `git` tool), so there is no
unproxied-git bypass in the current registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
