### PR TITLE
feat(skills): add /add-understand-anything installer skill

### DIFF
--- a/.claude/skills/add-understand-anything/SKILL.md
+++ b/.claude/skills/add-understand-anything/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: add-understand-anything
+description: Install the Understand-Anything plugin so the agent gains /understand, /understand-chat, /understand-dashboard and related codebase-analysis skills (interactive knowledge graphs, guided tours, deep-dive explanations). Claude Code backend only — adds the plugin from its GitHub marketplace end-to-end; non–Claude-Code backends use the upstream install.sh fallback.
+---
+
+# Add Understand-Anything
+
+This skill installs [**Understand-Anything**](https://github.com/Lum1104/Understand-Anything)
+— an LLM-powered codebase-analysis tool that produces interactive knowledge
+graphs, guided tours, and deep-dive explanations of any project. Once installed,
+the agent gains the `/understand*` family of skills.
+
+It ships as a **Claude Code plugin** distributed through a GitHub plugin
+marketplace. This skill runs the whole marketplace flow (add marketplace →
+install plugin → verify) end-to-end so a single `/add-understand-anything`
+completely integrates it — no manual `/plugin` steps.
+
+> **Backend note:** This is a Claude Code installer. The `claude plugin …`
+> commands below only exist when Claude Code is the active backend (Deus's
+> default). On non–Claude-Code backends (Codex, opencode, gemini, …) use the
+> upstream `install.sh` fallback in Phase 0 instead.
+
+## Phase 0: Backend guard
+
+Confirm the Claude Code CLI is available before doing anything else:
+
+```bash
+command -v claude >/dev/null 2>&1 && echo "claude CLI found" || echo "NO claude CLI"
+```
+
+If the `claude` CLI is **not** found, this backend can't use the plugin
+marketplace. Stop here and tell the user to install via the upstream script
+instead (it symlinks the skills into the right place for their runtime):
+
+```bash
+# Replace <platform> with one of: codex, opencode, gemini, pi, vscode, ...
+curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash -s <platform>
+```
+
+Then skip the rest of this skill.
+
+## Phase 1: Pre-flight (idempotent)
+
+Check current state with the read-only `list` commands and branch on their
+output — do not assume how the CLI handles a duplicate add/install.
+
+### Is the marketplace already added?
+
+```bash
+claude plugin marketplace list 2>/dev/null | grep -qF "Lum1104/Understand-Anything" \
+  && echo "MARKETPLACE_PRESENT" || echo "MARKETPLACE_MISSING"
+```
+
+(Match the exact marketplace source `Lum1104/Understand-Anything` — `list`
+prints it as `Source: GitHub (Lum1104/Understand-Anything)` — so an unrelated
+plugin that merely contains the substring `understand-anything` can't trigger a
+false `MARKETPLACE_PRESENT`.)
+
+- `MARKETPLACE_PRESENT` → skip the marketplace-add step in Phase 2.
+- `MARKETPLACE_MISSING` → run it.
+
+### Is the plugin already installed?
+
+```bash
+claude plugin list 2>/dev/null | grep -q "understand-anything@understand-anything" \
+  && echo "PLUGIN_INSTALLED" || echo "PLUGIN_NOT_INSTALLED"
+```
+
+- `PLUGIN_INSTALLED` → tell the user it's already installed and skip straight to **Phase 3: Verify**.
+- `PLUGIN_NOT_INSTALLED` → continue to Phase 2.
+
+## Phase 2: Install and configure
+
+Run only the steps Phase 1 marked as needed. **Check each command's exit status
+— a non-zero exit (network failure, marketplace fetch error, install error) is a
+failure: stop, show the CLI's error output to the user, and do NOT continue to
+Verify or claim success.**
+
+### Add the marketplace (only if `MARKETPLACE_MISSING`)
+
+```bash
+claude plugin marketplace add Lum1104/Understand-Anything
+```
+
+### Install the plugin (only if `PLUGIN_NOT_INSTALLED`)
+
+Installed at **user scope** (the default) so it's available in every Claude Code
+session on this machine. The plugin reference is intentionally version-free so it
+always tracks the marketplace's current release.
+
+```bash
+claude plugin install understand-anything@understand-anything
+```
+
+## Phase 3: Verify
+
+Confirm the plugin is registered:
+
+```bash
+claude plugin list 2>&1 | grep "understand-anything@understand-anything" \
+  && echo "OK: installed" || echo "FAILED: not found"
+```
+
+If this prints `FAILED: not found`, the install did **not** complete — surface
+the error from Phase 2, do not tell the user it's installed, and stop.
+
+If verification passes (`OK: installed`), tell the user:
+
+> **Understand-Anything is installed.** Restart (or reload) your Claude Code
+> session so the new skills load — plugins are read at session start.
+>
+> Once reloaded you'll have:
+> - `/understand` — analyze a codebase into an interactive knowledge graph
+> - `/understand-chat` — ask questions about the codebase via the graph
+> - `/understand-dashboard` — launch the interactive web dashboard
+> - `/understand-diff` — analyze a git diff / PR (changes, affected components, risk)
+> - `/understand-domain` — extract business-domain knowledge and flow graph
+> - `/understand-explain` — deep-dive a specific file, function, or module
+> - `/understand-knowledge` — graph an LLM/wiki knowledge base
+> - `/understand-onboard` — generate an onboarding guide for new team members
+>
+> **Dashboard prerequisite:** `/understand-dashboard` needs Node ≥ 22 and
+> pnpm ≥ 10 — it builds its React dashboard lazily on first launch. The analysis
+> skills (`/understand`, `/understand-explain`, etc.) work without it.
+
+## Removal
+
+To remove Understand-Anything:
+
+1. Uninstall the plugin:
+   ```bash
+   claude plugin uninstall understand-anything@understand-anything
+   ```
+
+2. (Optional) Remove the marketplace too — only if no other plugin from it is in use:
+   ```bash
+   claude plugin marketplace remove understand-anything
+   ```
+
+3. Restart the Claude Code session so the `/understand*` skills unload.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ renaming a repo-owned skill, update this table in the same change.
 | `/add-slack` | Add Slack as a channel |
 | `/add-telegram` | Add Telegram as a channel |
 | `/add-telegram-swarm` | Add Agent Swarm support to Telegram |
+| `/add-understand-anything` | Install the Understand-Anything plugin (codebase knowledge graphs, `/understand*`) |
 | `/add-voice-transcription` | Add OpenAI Whisper voice transcription |
 | `/add-whatsapp` | Add WhatsApp as a channel |
 | `/add-youtube-transcript` | Add YouTube transcript extraction |

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-04" # auto-bump @1780558070
+last_verified: "2026-06-04" # auto-bump @1780582051
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

Adds a repo-owned `/add-understand-anything` installer skill so **every Deus user** can integrate the [Understand-Anything](https://github.com/Lum1104/Understand-Anything) Claude Code plugin in one command.

Running `/add-understand-anything` does the whole integration end-to-end:
- **Phase 0** — backend guard (falls back to the upstream `install.sh` one-liner on non–Claude-Code backends)
- **Phase 1** — idempotent pre-flight (`claude plugin marketplace list` / `claude plugin list`)
- **Phase 2** — `claude plugin marketplace add Lum1104/Understand-Anything` + `claude plugin install understand-anything@understand-anything` (user scope), with explicit non-zero-exit failure handling
- **Phase 3** — verify, restart note, lists the eight `/understand*` skills + dashboard prereq
- **Removal** section

This mirrors the established `/add-*` installer pattern (e.g. `add-youtube-transcript`).

## Why

Today the only way to get Understand-Anything is the manual `/plugin` flow. This makes it a single committed command available to everyone.

## Files
- **New** `.claude/skills/add-understand-anything/SKILL.md`
- `AGENTS.md` — one new skill-table row (enforced by `scripts/sync_agent_skills.py::check_skill_inventory`)
- `patterns/skill-add.md` — `last_verified` freshness bump (auto-committed by the pre-push drift hook, since the change adds a skill)

## Verification
- AGENTS.md row matches the exact enforced substring; inventory check shows **no new drift** from this skill
- All `claude plugin` verbs verified against live `--help`
- Plan-review, code-review, and verification gates: all **SHIP**
- No source code, secrets, or personal IDs — references only the public `Lum1104/Understand-Anything` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)