### PR TITLE
feat(events): phase 3 cutover — ObservabilitySink owns the durable pipeline-event write (LIA-166)

### DIFF
--- a/docs/decisions/event-hub.md
+++ b/docs/decisions/event-hub.md
@@ -156,6 +156,42 @@ on a real dispatch.
 > temporary heartbeat) -- "no errors in prod" is consistent with the listener
 > receiving zero events.
 
+## Phase-3 cutover amendment (LIA-166): PARTIAL, not literal sole-writer
+
+The Phase-3 ObservabilitySink cutover shipped as a **partial** cutover. The literal
+roadmap goal — "the ObservabilitySink becomes the **sole** writer of
+`linear_pipeline_events`" — is **not cleanly achievable**, so we deviate deliberately:
+
+- **Why notifyPipelineStep stays inline.** `notifyPipelineStep`
+  (`linear-notifications.ts`) needs `logPipelineEvent`'s **synchronous rowid** to chain
+  `updatePipelineEventStatusSummary`, **and** it ends with `await updateUnifiedComment`
+  whose `doUpdateUnifiedComment` does a `getPipelineEvents(...)` **DB read** right after.
+  Moving that insert to the async sink would race the comment read — the just-logged
+  event silently dropping from the pinned Pipeline Log comment — a microtask-ordering
+  landmine the day any `await`-ing catch-all `on()` subscriber is added. So
+  `notifyPipelineStep` keeps a **synchronous `insertPipelineEventRow`** and is a
+  **deliberate second writer**.
+- **What the sink owns.** The fire-and-forget `logPipelineEvent` callers (now emit-only)
+  → the live sink performs their single durable write.
+- **No double-write invariant.** `notifyPipelineStep` deliberately does **not** emit, so
+  the sink never double-writes its rows. The two call sites that previously called BOTH
+  `logPipelineEvent` AND `notifyPipelineStep` for the same event (`linear-auto-merge`
+  `merge_conflict`, the startup-sweep gate event) had their **redundant bare
+  `logPipelineEvent` deleted** (they were already producing duplicate rows).
+- **Emit-coverage gap (recorded decision).** `notifyPipelineStep` events (the high-value
+  `gate_*`, `agent_*`, `pr_created`, `automerge_*`) are **no longer emitted** on the bus.
+  Acceptable under "don't build for consumers that don't exist": the only subscriber is
+  the sink (which would double-write them) and the catch-all `on()` has zero handlers. A
+  future `on()` durability mirror will get **incomplete coverage** unless `notifyPipelineStep`
+  is first re-homed (re-home its synchronous comment-read + status_summary rowid).
+- **Best-effort durability.** For the fire-and-forget callers the durable write is now
+  best-effort via the async sink (a silent sink-insert failure loses the row) — consistent
+  with the best-effort-observer contract; these were already best-effort inline writes.
+- **Known cosmetic limitation.** `getPipelineEvents` orders by `id ASC`; fire-and-forget
+  rows now insert via the async sink while `notifyPipelineStep` rows insert synchronously,
+  so rare same-tick interleaving can reorder ids cosmetically in the comment. Display-only,
+  never data loss; not worth changing the shared query's ordering.
+
 ## Phased roadmap (strangler)
 
 Two interleaved tracks. Status as of this ADR:
@@ -164,7 +200,7 @@ Two interleaved tracks. Status as of this ADR:
 |-------|-------|--------|
 | Event hub | 1 -- EventBus + `agent.done` -> LinearUpdater (Step-2 cutover: listener live, inline In-Review write deleted) | **Shipped** (#657 + cutover) |
 | Event hub | 2 -- `pipeline.transition` emit + dry-run ObservabilitySink | **Shipped** (#660) |
-| Event hub | 3 -- cutover: flip sink live, delete inline `logPipelineEvent` INSERT | Planned |
+| Event hub | 3 -- cutover: flip sink live, delete inline `logPipelineEvent` INSERT (**partial** -- see below) | **Shipped** (LIA-166) |
 | Event hub | 4-6 -- unified-comment, high-value Linear writes, design-to-dev convergence | Planned |
 | CFLL (parallel) | 7-13 -- coding-failure capture -> keyed retrieval -> apply -> graduation | Planned |
 | Observability | 14 -- `agent.action` per-tool events | Planned |

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -291,6 +291,13 @@ Gate agents and dispatch agents run through the same agent runtime as all other 
 
 Every significant pipeline event is logged to the `linear_pipeline_events` table and surfaced in two ways:
 
+> **Event-hub Phase-3 cutover (LIA-166):** the durable write to `linear_pipeline_events`
+> for the fire-and-forget `logPipelineEvent` callers now originates from the event-hub
+> **ObservabilitySink** listener (on `pipeline.transition`), not inline. The
+> `notifyPipelineStep` path keeps a synchronous inline write (it needs the rowid for the
+> status-summary update and the row present before it reads the table to rebuild the
+> comment below). See [Orchestrator Event Hub](event-hub.md#phase-3-cutover-amendment-lia-166-partial-not-literal-sole-writer).
+
 ### Unified pipeline comment
 
 Each issue gets a single rolling **Pipeline Log** comment that updates as events occur. The comment body is rebuilt (materialized view pattern) from the event log on each update. A per-issue promise-chain mutex prevents duplicate comment creation under concurrent events. The comment caps at 50 events with a truncation notice for older entries.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-04" # auto-bump @1780582811
+last_verified: "2026-06-04" # auto-bump @1780585715
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780578644
+last_verified: "2026-06-04" # auto-bump @1780585715
 governs:
   - src/
   - evolution/

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -16,6 +16,8 @@ import {
   getTaskById,
   getSession,
   logPipelineEvent,
+  insertPipelineEventRow,
+  getPipelineEvents,
   setSession,
   setRegisteredGroup,
   storeChatMetadata,
@@ -35,25 +37,27 @@ beforeEach(() => {
   _initTestDatabase();
 });
 
-describe('logPipelineEvent -> pipeline.transition emit (Phase 2 strangler seam)', () => {
-  it('emits one pipeline.transition envelope on a successful insert; rowid unchanged', () => {
+describe('logPipelineEvent -> pipeline.transition emit (Phase 3 cutover: emit-only)', () => {
+  it('emits one pipeline.transition envelope and does NOT insert inline', () => {
     const seen: EventEnvelope[] = [];
     const unsub = getBus().subscribe('pipeline.transition', (env) => {
       seen.push(env);
     });
     try {
-      const rowid = logPipelineEvent(
+      // Phase 3: logPipelineEvent is emit-only and returns void. The durable
+      // write is owned by the ObservabilitySink (not registered in this test),
+      // so logPipelineEvent itself must NOT insert a row.
+      const ret = logPipelineEvent(
         'ISS-emit',
         'LIA-emit',
         'agent_completed',
         'done',
       );
+      expect(ret).toBeUndefined();
+      expect(getPipelineEvents({ issueId: 'ISS-emit' })).toHaveLength(0);
 
-      // The added emit does not change the return contract.
-      expect(typeof rowid).toBe('number');
-
-      // The bus delivers synchronously up to its first await, so the listener
-      // has already run by the time logPipelineEvent returns — no await needed.
+      // Emit is unconditional now (no rowid gate). The bus delivers synchronously
+      // up to its first await, so the listener has already run — no await needed.
       expect(seen).toHaveLength(1);
       const env = seen[0];
       expect(env.type).toBe('pipeline.transition');
@@ -817,14 +821,23 @@ describe('linear_issue_cache', () => {
 });
 
 describe('circuit breaker', () => {
+  // Post-Phase-3 (LIA-166): rows are written by insertPipelineEventRow (the sink's
+  // and notifyPipelineStep's writer); logPipelineEvent is emit-only. These tests
+  // seed rows via the actual writer so they exercise getConsecutiveFailCount /
+  // getLastFailTime against real rows (independent of any registered sink).
   describe('getConsecutiveFailCount', () => {
     it('returns 0 when no events exist', () => {
       expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(0);
     });
 
     it('counts consecutive failures', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'CI failed');
-      logPipelineEvent(
+      insertPipelineEventRow(
+        'issue-1',
+        'LIA-1',
+        'automerge_failed',
+        'CI failed',
+      );
+      insertPipelineEventRow(
         'issue-1',
         'LIA-1',
         'automerge_failed',
@@ -834,10 +847,10 @@ describe('circuit breaker', () => {
     });
 
     it('resets count after agent_completed', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
-      logPipelineEvent('issue-1', 'LIA-1', 'agent_completed');
-      logPipelineEvent(
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'agent_completed');
+      insertPipelineEventRow(
         'issue-1',
         'LIA-1',
         'automerge_failed',
@@ -847,24 +860,34 @@ describe('circuit breaker', () => {
     });
 
     it('resets count after circuit_breaker_reset', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
-      logPipelineEvent('issue-1', 'LIA-1', 'circuit_breaker_reset', 'manual');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
+      insertPipelineEventRow(
+        'issue-1',
+        'LIA-1',
+        'circuit_breaker_reset',
+        'manual',
+      );
       expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(0);
     });
 
     it('counts agent failures separately from automerge failures', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'CI fail');
-      logPipelineEvent('issue-1', 'LIA-1', 'agent_failed', 'agent crash');
-      logPipelineEvent('issue-1', 'LIA-1', 'agent_failed', 'agent crash 2');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'CI fail');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'agent_failed', 'agent crash');
+      insertPipelineEventRow(
+        'issue-1',
+        'LIA-1',
+        'agent_failed',
+        'agent crash 2',
+      );
       expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
       expect(getConsecutiveFailCount('issue-1', 'agent_failed')).toBe(2);
     });
 
     it('isolates counts between different issues', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail');
-      logPipelineEvent('issue-2', 'LIA-2', 'automerge_failed', 'fail');
-      logPipelineEvent('issue-2', 'LIA-2', 'automerge_failed', 'fail 2');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail');
+      insertPipelineEventRow('issue-2', 'LIA-2', 'automerge_failed', 'fail');
+      insertPipelineEventRow('issue-2', 'LIA-2', 'automerge_failed', 'fail 2');
       expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
       expect(getConsecutiveFailCount('issue-2', 'automerge_failed')).toBe(2);
     });
@@ -876,29 +899,44 @@ describe('circuit breaker', () => {
     });
 
     it('returns the most recent event time', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 2');
       const lastTime = getLastFailTime('issue-1', 'automerge_failed');
       expect(lastTime).not.toBeNull();
       expect(typeof lastTime).toBe('string');
     });
 
     it('returns time for correct event type only', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'agent_failed', 'crash');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'agent_failed', 'crash');
       expect(getLastFailTime('issue-1', 'automerge_failed')).toBeNull();
       expect(getLastFailTime('issue-1', 'agent_failed')).not.toBeNull();
     });
 
     it('returns null after reset clears the window', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
-      logPipelineEvent('issue-1', 'LIA-1', 'circuit_breaker_reset', 'manual');
+      insertPipelineEventRow('issue-1', 'LIA-1', 'automerge_failed', 'fail 1');
+      insertPipelineEventRow(
+        'issue-1',
+        'LIA-1',
+        'circuit_breaker_reset',
+        'manual',
+      );
       expect(getLastFailTime('issue-1', 'automerge_failed')).toBeNull();
     });
 
     it('returns time only from current failure epoch', () => {
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'old fail');
-      logPipelineEvent('issue-1', 'LIA-1', 'agent_completed');
-      logPipelineEvent('issue-1', 'LIA-1', 'automerge_failed', 'new fail');
+      insertPipelineEventRow(
+        'issue-1',
+        'LIA-1',
+        'automerge_failed',
+        'old fail',
+      );
+      insertPipelineEventRow('issue-1', 'LIA-1', 'agent_completed');
+      insertPipelineEventRow(
+        'issue-1',
+        'LIA-1',
+        'automerge_failed',
+        'new fail',
+      );
       const lastTime = getLastFailTime('issue-1', 'automerge_failed');
       expect(lastTime).not.toBeNull();
       expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);

--- a/src/db.ts
+++ b/src/db.ts
@@ -1648,34 +1648,27 @@ export function logPipelineEvent(
   identifier: string,
   eventType: string,
   detail?: string,
-): number | undefined {
-  const rowid = insertPipelineEventRow(issueId, identifier, eventType, detail);
-
-  // Strangler seam (Phase 2): the authoritative write above stays inline; we
-  // ALSO emit so the event-hub ObservabilitySink can (later) own the durable
-  // write. Best-effort + success-gated: emit only when the row landed, never
-  // block the synchronous write path, never let a bus failure surface to the
-  // 11 callers that rely on this never throwing. The outer try/catch makes the
-  // no-throw guarantee structural (covers a synchronous throw from the bus
-  // prologue); the inner .catch swallows async listener rejections.
-  if (rowid !== undefined) {
-    try {
-      void getBus()
-        .emit({
-          type: 'pipeline.transition',
-          source: 'db.logPipelineEvent',
-          actor: 'system',
-          correlationId: { kind: 'issue', id: issueId, identifier },
-          ts: new Date().toISOString(),
-          payload: { eventType, detail },
-        })
-        .catch(() => {});
-    } catch {
-      /* emit must never throw into the write path */
-    }
+): void {
+  // Emit-only (Phase-3 cutover, LIA-166): the ObservabilitySink owns the durable
+  // write off this `pipeline.transition`. notifyPipelineStep does NOT route here —
+  // it inserts synchronously (it needs the rowid + the row present before its
+  // updateUnifiedComment read). Emit is unconditional: the sink is the row-landing.
+  // Never-throw is load-bearing (callers rely on it): the outer try/catch is a
+  // structural no-throw guarantee; the inner .catch swallows async listener rejections.
+  try {
+    void getBus()
+      .emit({
+        type: 'pipeline.transition',
+        source: 'db.logPipelineEvent',
+        actor: 'system',
+        correlationId: { kind: 'issue', id: issueId, identifier },
+        ts: new Date().toISOString(),
+        payload: { eventType, detail },
+      })
+      .catch(() => {});
+  } catch {
+    /* emit must never throw into the write path */
   }
-
-  return rowid;
 }
 
 export function updatePipelineEventStatusSummary(

--- a/src/events/listeners/observability-sink.test.ts
+++ b/src/events/listeners/observability-sink.test.ts
@@ -1,16 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-// Mock the db module the sink writes through. Both pipeline-event writers are
-// stubbed so the loop-safety test can assert the sink uses the NON-emitting
-// `insertPipelineEventRow` and never `logPipelineEvent` (which would re-emit).
-vi.mock('../../db.js', () => ({
-  insertPipelineEventRow: vi.fn(),
-  logPipelineEvent: vi.fn(),
-}));
-
-import { EventBus } from '../bus.js';
+// Real-DB integration tests (Phase-3 cutover, LIA-166): the sink is now the
+// live durable writer, so we assert actual ROW COUNTS in a temp DB rather than
+// mock the writers. Row-count assertions also prove loop-safety: a re-emit loop
+// would yield >1 row (or hang), so "exactly one row per emit" is the guard.
+import { EventBus, getBus } from '../bus.js';
 import { registerObservabilitySink } from './observability-sink.js';
-import { insertPipelineEventRow, logPipelineEvent } from '../../db.js';
+import {
+  _initTestDatabase,
+  getPipelineEvents,
+  insertPipelineEventRow,
+  logPipelineEvent,
+} from '../../db.js';
 import type { EventEnvelope } from '../types.js';
 
 function mkTransition(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
@@ -25,62 +26,98 @@ function mkTransition(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
   };
 }
 
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
 beforeEach(() => {
-  vi.clearAllMocks();
+  _initTestDatabase();
 });
 
-describe('registerObservabilitySink', () => {
-  it('dry-run (default): logs only, writes no row', async () => {
+describe('ObservabilitySink (Phase 3 — live)', () => {
+  it('writes exactly one row per emitted pipeline.transition, preserving env.ts', async () => {
     const bus = new EventBus();
-    registerObservabilitySink(bus); // default dryRun = true
+    registerObservabilitySink(bus);
     await bus.emit(mkTransition());
-    expect(insertPipelineEventRow).not.toHaveBeenCalled();
+
+    const rows = getPipelineEvents({ issueId: 'ISS-1' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      identifier: 'LIA-1',
+      event_type: 'agent_completed',
+      detail: 'done',
+      created_at: '2026-05-31T00:00:00.000Z',
+    });
   });
 
-  it('live: mirrors the row via insertPipelineEventRow with the event timestamp', async () => {
+  it('loop-safe: one emit yields one row (no re-emit storm)', async () => {
     const bus = new EventBus();
-    registerObservabilitySink(bus, { dryRun: false });
+    registerObservabilitySink(bus);
     await bus.emit(mkTransition());
-    expect(insertPipelineEventRow).toHaveBeenCalledTimes(1);
-    expect(insertPipelineEventRow).toHaveBeenCalledWith(
-      'ISS-1',
-      'LIA-1',
-      'agent_completed',
-      'done',
-      '2026-05-31T00:00:00.000Z',
-    );
-  });
-
-  it('loop-safety: never writes through the emitting logPipelineEvent', async () => {
-    const bus = new EventBus();
-    registerObservabilitySink(bus, { dryRun: false });
-    await bus.emit(mkTransition());
-    // The mirror must go through the non-emitting helper (see sink doc-comment).
-    expect(logPipelineEvent).not.toHaveBeenCalled();
-    expect(insertPipelineEventRow).toHaveBeenCalledTimes(1);
+    expect(getPipelineEvents({ issueId: 'ISS-1' })).toHaveLength(1);
   });
 
   it('ignores non-issue correlations (table is issue-keyed)', async () => {
     const bus = new EventBus();
-    registerObservabilitySink(bus, { dryRun: false });
+    registerObservabilitySink(bus);
     await bus.emit(
       mkTransition({ correlationId: { kind: 'run', id: 'run-1' } }),
     );
-    expect(insertPipelineEventRow).not.toHaveBeenCalled();
+    expect(getPipelineEvents()).toHaveLength(0);
   });
 
   it('falls back to empty identifier when the issue ref omits one', async () => {
     const bus = new EventBus();
-    registerObservabilitySink(bus, { dryRun: false });
+    registerObservabilitySink(bus);
     await bus.emit(
       mkTransition({ correlationId: { kind: 'issue', id: 'ISS-2' } }),
     );
-    expect(insertPipelineEventRow).toHaveBeenCalledWith(
-      'ISS-2',
-      '',
-      'agent_completed',
-      'done',
-      '2026-05-31T00:00:00.000Z',
-    );
+    const rows = getPipelineEvents({ issueId: 'ISS-2' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].identifier).toBe('');
+  });
+
+  it('microtask-ordering guard: an awaiting catch-all on() does not starve the sink write', async () => {
+    // The live-wire confirmation: even with a slow (awaiting) catch-all ahead of
+    // the sink in the sequential-await chain, the sink's row must still land. This
+    // is the landmine the advisor flagged — guard it deterministically.
+    const bus = new EventBus();
+    let onRan = false;
+    bus.on(async () => {
+      await Promise.resolve();
+      onRan = true;
+    });
+    registerObservabilitySink(bus);
+    await bus.emit(mkTransition());
+
+    expect(onRan).toBe(true);
+    expect(getPipelineEvents({ issueId: 'ISS-1' })).toHaveLength(1);
+  });
+});
+
+describe('Phase 3 no-double-write (production wiring via getBus)', () => {
+  it('logPipelineEvent (emit-only) + live sink → exactly one row', async () => {
+    const unsub = registerObservabilitySink(getBus());
+    try {
+      // logPipelineEvent no longer inserts inline — it only emits; the live sink
+      // performs the single durable write. Exactly one row, never two.
+      logPipelineEvent('ISS-9', 'LIA-9', 'gate_ship', 'ok');
+      await flush();
+      expect(getPipelineEvents({ issueId: 'ISS-9' })).toHaveLength(1);
+    } finally {
+      unsub();
+    }
+  });
+
+  it('insertPipelineEventRow (notifyPipelineStep path, no emit) + live sink → exactly one row', async () => {
+    const unsub = registerObservabilitySink(getBus());
+    try {
+      // notifyPipelineStep's path inserts synchronously and does NOT emit, so the
+      // sink is not triggered — no double-write. (Covers the merge_conflict path
+      // after its redundant bare logPipelineEvent was deleted.)
+      insertPipelineEventRow('ISS-10', 'LIA-10', 'merge_conflict', 'url');
+      await flush();
+      expect(getPipelineEvents({ issueId: 'ISS-10' })).toHaveLength(1);
+    } finally {
+      unsub();
+    }
   });
 });

--- a/src/events/listeners/observability-sink.ts
+++ b/src/events/listeners/observability-sink.ts
@@ -1,48 +1,31 @@
-import { logger } from '../../logger.js';
 import { insertPipelineEventRow } from '../../db.js';
 import type { EventBus } from '../bus.js';
 
-// explicit `: boolean` (not literal `true`) so the live branch below stays
-// reachable/typecheckable; flip to `false` at the Phase-3 cutover.
-const DRY_RUN_DEFAULT: boolean = true;
-
 /**
  * ObservabilitySink — the event-hub's durability mirror for pipeline events.
- * Subscribes to `pipeline.transition` and, when live, writes the row to
- * `linear_pipeline_events`.
+ * On `pipeline.transition` it writes the row to `linear_pipeline_events`. As of
+ * the Phase-3 cutover it is LIVE and is the durable writer for every emitted
+ * pipeline event (the fire-and-forget `logPipelineEvent` callers); the inline
+ * write in `logPipelineEvent` was deleted.
  *
  * Loop-safety (load-bearing, the canonical statement of this invariant): the
  * sink writes via `insertPipelineEventRow`, NEVER `logPipelineEvent` — the
  * latter emits `pipeline.transition`, so a sink routed through it would re-fire
  * this handler forever. The non-emitting helper makes that structurally impossible.
  *
- * Phase 2 is dry-run/log-only: the mirrored row's content equals the
- * authoritative `logPipelineEvent` row by construction (same args), so the
- * dry-run only defers the duplicate-row write to the Phase-3 cutover. That
- * cutover must also re-home one thing the envelope does not carry — the
- * `status_summary` UPDATE that `notifyPipelineStep` chains off `logPipelineEvent`'s
- * rowid (one caller); it does not affect this phase.
+ * NOT the sole writer (partial cutover, see docs/decisions/event-hub.md): the
+ * `notifyPipelineStep` path keeps a synchronous `insertPipelineEventRow` because
+ * it needs the rowid for `status_summary` AND the row present before its
+ * `updateUnifiedComment` DB-read; those events are deliberately NOT emitted, so
+ * the sink never double-writes them.
  *
  * Returns an unsubscribe function.
  */
-export function registerObservabilitySink(
-  bus: EventBus,
-  opts: { dryRun?: boolean } = {},
-): () => void {
-  const dryRun = opts.dryRun ?? DRY_RUN_DEFAULT;
-
+export function registerObservabilitySink(bus: EventBus): () => void {
   return bus.subscribe('pipeline.transition', (env) => {
     if (env.correlationId.kind !== 'issue') return;
     const { id, identifier } = env.correlationId;
     const { eventType, detail } = env.payload;
-
-    if (dryRun) {
-      logger.debug(
-        { id, eventType },
-        'observability-sink[dry-run]: would mirror pipeline.transition -> linear_pipeline_events',
-      );
-      return;
-    }
 
     // Durable write via the non-emitting helper (loop-safe); `env.ts` keeps the
     // mirrored row's time equal to the originating event's time.

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -618,8 +618,8 @@ export async function checkConflictingPrs(ctx: LinearContext): Promise<void> {
         continue;
       }
 
-      // Log the conflict event
-      logPipelineEvent(issue_id, ident, 'merge_conflict', pr_url);
+      // notifyPipelineStep is the authoritative writer (row + status_summary +
+      // comment); a bare logPipelineEvent here would double-write via the sink.
       notifyPipelineStep(ctx, issue_id, ident, 'merge_conflict', pr_url).catch(
         () => {},
       );

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -11,7 +11,7 @@ import { execFile } from 'child_process';
 import { logger } from './logger.js';
 import { fireAndForget } from './async/index.js';
 import {
-  logPipelineEvent,
+  insertPipelineEventRow,
   getPipelineEvents,
   upsertPipelineComment,
   getPipelineCommentId,
@@ -188,7 +188,13 @@ export async function notifyPipelineStep(
   eventType: string,
   detail?: string,
 ): Promise<void> {
-  const rowId = logPipelineEvent(issueId, identifier, eventType, detail);
+  // Phase-3 cutover (LIA-166): insert SYNCHRONOUSLY here, not via logPipelineEvent
+  // (which is now emit-only → the live ObservabilitySink inserts). This path must
+  // stay synchronous because it needs (a) the rowid for the status_summary UPDATE
+  // below and (b) the row present before updateUnifiedComment's getPipelineEvents
+  // read at the end. It deliberately does NOT emit, so the sink never double-writes
+  // this row.
+  const rowId = insertPipelineEventRow(issueId, identifier, eventType, detail);
 
   const label = EVENT_LABELS[eventType] || eventType;
   macosNotify('Deus', `${identifier}: ${label}`);

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -1644,6 +1644,8 @@ async function runGateForIssue(
             140,
           )
         : `${gateSpec.name}: ${verdict} (startup sweep)`;
+    // notifyPipelineStep is the authoritative writer (row + status_summary +
+    // comment); a bare logPipelineEvent here would double-write via the sink.
     fireAndForget(
       notifyPipelineStep(
         ctx,
@@ -1654,7 +1656,6 @@ async function runGateForIssue(
       ),
       { name: 'linear-webhook.notify-pipeline' },
     );
-    logPipelineEvent(issue.id, issue.identifier, eventType, sweepDetail);
     logger.info(
       { issueId: issue.id, gate: gateSpec.name, verdict, mode: effectiveMode },
       'startup-sweep: gate evaluation complete',


### PR DESCRIPTION
## What

Event Hub **Phase 3 cutover** (LIA-166): the dry-run `ObservabilitySink` goes **live** as the durable writer to `linear_pipeline_events` for the fire-and-forget `logPipelineEvent` callers (off `pipeline.transition`). The inline insert in `logPipelineEvent` is deleted — it is now **emit-only** and returns `void`.

## Deliberate PARTIAL cutover (ADR amended)

The ADR's literal goal — *"ObservabilitySink becomes the **sole** writer"* — is **not cleanly achievable**, verified: `notifyPipelineStep` needs `logPipelineEvent`'s **synchronous rowid** for `updatePipelineEventStatusSummary`, **and** it ends with `await updateUnifiedComment` whose `doUpdateUnifiedComment` does a `getPipelineEvents()` **DB read right after**. Moving that insert to the async sink would race the read and silently drop the newest event from the pinned Pipeline Log comment (a microtask-ordering landmine the day any `await`-ing catch-all `on()` subscriber is added).

So `notifyPipelineStep` keeps a **synchronous `insertPipelineEventRow`** and deliberately **does not emit** — the sink fires only on emitted events, so it never double-writes that row.

## How

- **`observability-sink.ts`** — live (drop `dryRun` plumbing); write via the non-emitting `insertPipelineEventRow` with `env.ts` (loop-safe).
- **`db.ts` `logPipelineEvent`** — emit-only, unconditional emit (the sink is the row-landing), returns `void`.
- **`linear-notifications.ts` `notifyPipelineStep`** — `insertPipelineEventRow` directly (keeps rowid + row-before-comment-read), no emit.
- **`linear-auto-merge.ts` / `linear-webhook.ts`** — delete the redundant bare `logPipelineEvent` at the two sites that *also* call `notifyPipelineStep` for the same event (pre-existing duplicate rows; would double-write post-cutover). Audited all four caller files — these are the only same-event double-calls.
- **ADRs** — `event-hub.md` amendment + `linear-webhook-pipeline.md` companion note: partial cutover, the emit-coverage gap (notifyPipelineStep events no longer on the bus — acceptable, the only subscriber is the sink), best-effort durability, the `id`-ordering cosmetic limitation.

## No-double-write invariant

Each event flows through exactly one writer: bare `logPipelineEvent` → emit → sink inserts (1 row); `notifyPipelineStep` → direct insert, no emit (1 row). Guarded by tests (incl. the `merge_conflict` path).

## Tests

- `observability-sink.test.ts` rewritten as **real-DB row-count** guards: one-row-per-emit; non-issue ignored; empty-identifier fallback; **microtask-ordering guard** (an `await`-ing `on()` catch-all doesn't starve the sink write — the deterministic live-wire confirmation, stronger than eyeballing a prod debug line); **no-double-write** via `getBus()` for both the emit-only and the direct-insert paths.
- `db.test.ts`: the emit test → emit-only/`void`/no-inline-insert; circuit-breaker tests reseed rows via `insertPipelineEventRow` (since `logPipelineEvent` no longer inserts).
- `npm run build` clean · `prettier --check` clean · full suite **1494 tests pass (84 files)** · CI drift (`--base origin/main`) passes.

## Review trail

plan-reviewer **SHIP** (round 2 — round-1 blocker was a missed `merge_conflict` double-call, fixed); code-reviewer **SHIP** (loop-safety, no-double-write, void-return, row-before-read, test quality, ADR honesty all confirmed under adversarial review).

## Follow-up (recorded in the ADR)

A future `on()` durability mirror that needs full event coverage must first re-home `notifyPipelineStep`'s synchronous comment-read + status_summary rowid (then its events can emit). Not built — no such consumer exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
