### PR TITLE
fix(scripts): add config.json vault resolution to drift_check and memory_tree

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -2122,11 +2122,23 @@ def check_bench_labels(project_root: Path) -> int:
         print(f"Benchmark fixture not found: {_BENCH_FIXTURE} (skipped)")
         return 0
 
-    # Resolve vault path (same logic as memory_tree.py)
+    # Resolve vault path: env var → config.json → legacy fallback
     vault_env = os.environ.get("DEUS_VAULT_PATH")
-    vault = Path(vault_env).expanduser() if vault_env else Path(
-        "~/Desktop/אישי/Brain Dump/Second Brain/Deus"
-    ).expanduser()
+    if vault_env:
+        vault = Path(vault_env).expanduser()
+    else:
+        cfg_path = Path("~/.config/deus/config.json").expanduser()
+        vault = None
+        if cfg_path.exists():
+            try:
+                cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+                vp = cfg.get("vault_path")
+                if isinstance(vp, str) and vp:
+                    vault = Path(vp).expanduser()
+            except (OSError, json.JSONDecodeError):
+                pass
+        if vault is None:
+            vault = Path("~/Desktop/אישי/Brain Dump/Second Brain/Deus").expanduser()
 
     vault_paths = _collect_vault_paths(vault) if vault.is_dir() else set()
     auto_paths = _collect_auto_memory_paths()

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -854,9 +854,16 @@ def resolve_vault_path() -> Path:
     vault = os.environ.get(VAULT_PATH_ENV)
     if vault:
         return Path(vault).expanduser()
-    # Fallback: the Deus default used elsewhere.
-    default = Path("~/Desktop/אישי/Brain Dump/Second Brain/Deus").expanduser()
-    return default
+    cfg_path = Path("~/.config/deus/config.json").expanduser()
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            vp = cfg.get("vault_path")
+            if isinstance(vp, str) and vp:
+                return Path(vp).expanduser()
+        except (OSError, json.JSONDecodeError):
+            pass
+    return Path("~/Desktop/אישי/Brain Dump/Second Brain/Deus").expanduser()
 
 
 def iter_tree_files(vault: Path) -> list[Path]:


### PR DESCRIPTION
## Summary
- `drift_check.py` and `memory_tree.py` resolved the vault path via env var with a hardcoded fallback to `~/Desktop/אישי/...`, while four sibling scripts already read `~/.config/deus/config.json`
- Added the same config.json lookup between env var and legacy fallback, matching the pattern in `codex_warden_hooks.py` and `memory_benchmark.py`

## Test plan
- [x] `drift_check.py --bench-labels` passes with vault resolved via config.json
- [x] `drift_check.py --all` passes in worktree
- [x] Pre-push hook passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)