### PR TITLE
fix(whatsapp): back off reconnects to stop the reason-408 storm (#305)

### DIFF
--- a/packages/mcp-whatsapp/src/reconnect-backoff.test.ts
+++ b/packages/mcp-whatsapp/src/reconnect-backoff.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+
+import { reconnectDelayMs, ReconnectController } from './reconnect-backoff.js';
+
+/**
+ * Deterministic fake clock so backoff timing is asserted without real delays.
+ * `clearBehavesAsNoop` simulates the race where a timer has already elapsed and
+ * clearTimeout can no longer stop it — used to exercise the epoch-cancellation guard.
+ */
+class FakeClock {
+  private cbs: Array<{ id: number; cb: () => void; due: number }> = [];
+  private now = 0;
+  private nextId = 1;
+  constructor(private readonly clearBehavesAsNoop = false) {}
+
+  setTimeoutFn = (
+    cb: () => void,
+    ms: number,
+  ): ReturnType<typeof setTimeout> => {
+    const id = this.nextId++;
+    this.cbs.push({ id, cb, due: this.now + ms });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  };
+
+  clearTimeoutFn = (handle: ReturnType<typeof setTimeout>): void => {
+    if (this.clearBehavesAsNoop) return;
+    const id = handle as unknown as number;
+    this.cbs = this.cbs.filter((c) => c.id !== id);
+  };
+
+  /** Advance time, firing every callback whose deadline has passed (in order). */
+  advance(ms: number): void {
+    this.now += ms;
+    // Loop so callbacks that schedule further timers within the window still fire.
+    for (;;) {
+      const due = this.cbs
+        .filter((c) => c.due <= this.now)
+        .sort((a, b) => a.due - b.due);
+      if (due.length === 0) break;
+      this.cbs = this.cbs.filter((c) => c.due > this.now);
+      for (const c of due) c.cb();
+    }
+  }
+
+  get pendingCount(): number {
+    return this.cbs.length;
+  }
+}
+
+const opts = (clock: FakeClock, jitter: () => number = () => 1) => ({
+  baseMs: 1000,
+  capMs: 60000,
+  stableMs: 30000,
+  jitter,
+  setTimeoutFn: clock.setTimeoutFn,
+  clearTimeoutFn: clock.clearTimeoutFn,
+});
+
+describe('reconnectDelayMs', () => {
+  it('attempt 0 with full jitter is the base delay', () => {
+    expect(reconnectDelayMs(0, { jitter: () => 1 })).toBe(1000);
+  });
+
+  it('jitter floor is 50% of the exponential value', () => {
+    expect(reconnectDelayMs(0, { jitter: () => 0 })).toBe(500);
+  });
+
+  it('grows exponentially with the attempt', () => {
+    const d1 = reconnectDelayMs(1, { jitter: () => 1 });
+    const d3 = reconnectDelayMs(3, { jitter: () => 1 });
+    expect(d1).toBe(2000);
+    expect(d3).toBe(8000);
+    expect(d3).toBeGreaterThan(d1);
+  });
+
+  it('caps at capMs no matter how large the attempt', () => {
+    expect(reconnectDelayMs(100, { jitter: () => 1 })).toBe(60000);
+  });
+
+  it('stays within [50%, 100%] of the uncapped exponential', () => {
+    for (const attempt of [0, 1, 2, 5]) {
+      const exp = Math.min(60000, 1000 * 2 ** attempt);
+      expect(
+        reconnectDelayMs(attempt, { jitter: () => 0.5 }),
+      ).toBeGreaterThanOrEqual(Math.round(exp * 0.5));
+      expect(
+        reconnectDelayMs(attempt, { jitter: () => 1 }),
+      ).toBeLessThanOrEqual(exp);
+    }
+  });
+
+  it('treats negative attempts as 0', () => {
+    expect(reconnectDelayMs(-5, { jitter: () => 1 })).toBe(1000);
+  });
+});
+
+describe('ReconnectController — single-flight (the storm regression)', () => {
+  it('100 rapid schedules arm exactly one reconnect', () => {
+    const clock = new FakeClock();
+    const c = new ReconnectController(opts(clock));
+    let calls = 0;
+    const action = () => {
+      calls += 1;
+    };
+
+    const first = c.schedule(action);
+    let nullReturns = 0;
+    for (let i = 0; i < 99; i++) {
+      if (c.schedule(action) === null) nullReturns += 1;
+    }
+
+    expect(first).toBe(1000); // first schedule returns the delay
+    expect(nullReturns).toBe(99); // every redundant call is suppressed
+    expect(clock.pendingCount).toBe(1); // only one timer armed
+
+    clock.advance(1000);
+    expect(calls).toBe(1); // exactly one reconnect, not 100
+  });
+});
+
+describe('ReconnectController — backoff growth', () => {
+  it('each successive reconnect waits longer, up to the cap', () => {
+    const clock = new FakeClock();
+    const c = new ReconnectController(opts(clock));
+    const noop = () => {};
+
+    const delays: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      const d = c.schedule(noop);
+      expect(d).not.toBeNull();
+      delays.push(d as number);
+      clock.advance(d as number); // let it fire so the next schedule is allowed
+    }
+
+    expect(delays.slice(0, 4)).toEqual([1000, 2000, 4000, 8000]);
+    expect(delays[delays.length - 1]).toBe(60000); // capped
+    for (let i = 1; i < delays.length; i++) {
+      expect(delays[i]).toBeGreaterThanOrEqual(delays[i - 1]);
+    }
+  });
+});
+
+describe('ReconnectController — stability resets backoff only after a stable window', () => {
+  it('resets backoff after the connection survives stableMs', () => {
+    const clock = new FakeClock();
+    const c = new ReconnectController(opts(clock));
+    const noop = () => {};
+
+    c.schedule(noop);
+    clock.advance(1000);
+    c.schedule(noop);
+    clock.advance(2000); // attempts now advanced
+    expect(c.attempts).toBe(2);
+
+    c.markConnected();
+    clock.advance(30000); // survives the stability window
+    expect(c.attempts).toBe(0);
+
+    expect(c.schedule(noop)).toBe(1000); // back to base delay
+  });
+
+  it('a flap shorter than stableMs does NOT reset backoff', () => {
+    const clock = new FakeClock();
+    const c = new ReconnectController(opts(clock));
+    const noop = () => {};
+
+    c.schedule(noop);
+    clock.advance(1000);
+    c.schedule(noop);
+    clock.advance(2000);
+    expect(c.attempts).toBe(2);
+
+    c.markConnected();
+    clock.advance(5000); // open only 5s …
+    c.markDisconnected(); // … then drops — not stable
+    expect(c.attempts).toBe(2); // backoff preserved
+
+    expect(c.schedule(noop)).toBe(4000); // continues from attempt 2
+  });
+});
+
+describe('ReconnectController — reset()', () => {
+  it('cancels the pending reconnect and returns the next delay to base', () => {
+    const clock = new FakeClock();
+    const c = new ReconnectController(opts(clock));
+    let calls = 0;
+
+    c.schedule(() => {
+      calls += 1;
+    });
+    expect(clock.pendingCount).toBe(1);
+
+    c.reset();
+    expect(clock.pendingCount).toBe(0); // pending timer cleared
+    clock.advance(60000);
+    expect(calls).toBe(0); // never fired
+
+    expect(c.schedule(() => {})).toBe(1000); // backoff reset to base
+  });
+
+  it('epoch guard: a timer that fires after reset() does not run its action', () => {
+    // clearTimeout is a no-op here → the timer WILL fire despite reset(),
+    // exercising the generation/epoch invalidation guard.
+    const clock = new FakeClock(true);
+    const c = new ReconnectController(opts(clock));
+    let calls = 0;
+
+    c.schedule(() => {
+      calls += 1;
+    });
+    c.reset(); // increments epoch; clearTimeout no-ops so the timer remains armed
+    clock.advance(1000); // stale timer fires …
+
+    expect(calls).toBe(0); // … but the epoch guard suppresses the action
+  });
+});

--- a/packages/mcp-whatsapp/src/reconnect-backoff.ts
+++ b/packages/mcp-whatsapp/src/reconnect-backoff.ts
@@ -1,0 +1,152 @@
+/**
+ * Reconnect backoff for the WhatsApp socket.
+ *
+ * Background: a sustained reason-408 ("connection lost") made the old handler
+ * reconnect with zero delay — `connectInternal()` resolves as soon as the socket
+ * is built, so the 408 arrives later as a `'close'` event and never throws, so
+ * the only backoff (in `.catch`) was dead code. The result was a tight reconnect
+ * loop (~25/sec; 90k+ reconnects in an hour) that also produced the
+ * MaxListenersExceededWarning ("drain listeners on [Socket]") of issue #305.
+ *
+ * Design: `ReconnectController` is a **single-flight scheduler** (at most one
+ * pending reconnect) with **epoch (generation-token) cancellation** so a timer
+ * that fires after `reset()` is a no-op, plus an internal **stability timer**
+ * that only resets the backoff once a connection has survived `stableMs` — a
+ * brief flap does not reset it. All timers/jitter are injectable so the
+ * storm-prevention behaviour is unit-testable without a real socket.
+ */
+
+export interface BackoffOptions {
+  /** First-attempt delay before jitter (default 1s). */
+  baseMs?: number;
+  /** Maximum delay after exponential growth (default 60s). */
+  capMs?: number;
+  /** Returns a value in [0,1]; defaults to Math.random. Injected in tests. */
+  jitter?: () => number;
+}
+
+/**
+ * Exponential backoff with full-ish jitter: `min(cap, base * 2**attempt)` scaled
+ * to 50–100% of that value. Jitter spreads reconnects so many clients don't
+ * retry in lockstep. Negative attempts are clamped to 0.
+ */
+export function reconnectDelayMs(
+  attempt: number,
+  opts: BackoffOptions = {},
+): number {
+  const base = opts.baseMs ?? 1000;
+  const cap = opts.capMs ?? 60000;
+  const jitter = opts.jitter ?? Math.random;
+  const exp = Math.min(cap, base * 2 ** Math.max(0, attempt));
+  return Math.round(exp * (0.5 + 0.5 * jitter()));
+}
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface ReconnectControllerOptions extends BackoffOptions {
+  /** A connection must stay open this long before the backoff resets (default 30s). */
+  stableMs?: number;
+  setTimeoutFn?: (cb: () => void, ms: number) => TimerHandle;
+  clearTimeoutFn?: (handle: TimerHandle) => void;
+}
+
+export class ReconnectController {
+  private attempt = 0;
+  private pendingTimer: TimerHandle | null = null;
+  private stableTimer: TimerHandle | null = null;
+  /** Epoch token; bumped by reset() to invalidate any in-flight pending timer. */
+  private generation = 0;
+
+  private readonly baseMs: number;
+  private readonly capMs: number;
+  private readonly stableMs: number;
+  private readonly jitter: () => number;
+  private readonly setTimeoutFn: (cb: () => void, ms: number) => TimerHandle;
+  private readonly clearTimeoutFn: (handle: TimerHandle) => void;
+
+  constructor(opts: ReconnectControllerOptions = {}) {
+    this.baseMs = opts.baseMs ?? 1000;
+    this.capMs = opts.capMs ?? 60000;
+    this.stableMs = opts.stableMs ?? 30000;
+    this.jitter = opts.jitter ?? Math.random;
+    this.setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+    this.clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+  }
+
+  /**
+   * Schedule one reconnect after the current backoff delay. Single-flight: if a
+   * reconnect is already pending, this is a no-op and returns `null`; otherwise
+   * it returns the delay it scheduled. `action` must handle its own errors
+   * (void-returning, no floating promise).
+   */
+  schedule(action: () => void): number | null {
+    if (this.pendingTimer !== null) return null;
+    const delay = reconnectDelayMs(this.attempt, {
+      baseMs: this.baseMs,
+      capMs: this.capMs,
+      jitter: this.jitter,
+    });
+    this.attempt += 1;
+    const gen = this.generation;
+    this.pendingTimer = this.setTimeoutFn(() => {
+      this.pendingTimer = null;
+      if (gen !== this.generation) return; // invalidated by reset()
+      action();
+    }, delay);
+    return delay;
+  }
+
+  /**
+   * Mark the connection open. Starts a stability window; if the connection is
+   * still up after `stableMs`, the backoff resets so the next outage reconnects
+   * promptly. A flap that closes before `stableMs` does not reset it.
+   */
+  markConnected(): void {
+    this.clearStable();
+    this.stableTimer = this.setTimeoutFn(() => {
+      this.stableTimer = null;
+      this.attempt = 0;
+    }, this.stableMs);
+  }
+
+  /** Mark the connection closed: cancel the pending stability window. */
+  markDisconnected(): void {
+    this.clearStable();
+  }
+
+  /**
+   * Cancel any pending reconnect and reset the backoff to base. Bumps the epoch
+   * so an already-elapsed timer's callback becomes a no-op (it does not await
+   * in-flight timers).
+   */
+  reset(): void {
+    this.attempt = 0;
+    this.generation += 1;
+    this.clearPending();
+    this.clearStable();
+  }
+
+  /** True while a reconnect is armed (test/inspection helper). */
+  get pending(): boolean {
+    return this.pendingTimer !== null;
+  }
+
+  /** Current backoff attempt count (test/inspection helper). */
+  get attempts(): number {
+    return this.attempt;
+  }
+
+  private clearPending(): void {
+    if (this.pendingTimer !== null) {
+      this.clearTimeoutFn(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+  }
+
+  private clearStable(): void {
+    if (this.stableTimer !== null) {
+      this.clearTimeoutFn(this.stableTimer);
+      this.stableTimer = null;
+    }
+  }
+}

--- a/packages/mcp-whatsapp/src/whatsapp.ts
+++ b/packages/mcp-whatsapp/src/whatsapp.ts
@@ -39,6 +39,8 @@ import type {
 } from '@deus-ai/channel-core';
 import { resizeAndEncode } from '@deus-ai/channel-core';
 
+import { ReconnectController } from './reconnect-backoff.js';
+
 // ── Config from env vars ──────────────────────────────────────────────────────
 
 const AUTH_DIR =
@@ -76,6 +78,12 @@ export class WhatsAppProvider implements ChannelProvider {
   private saveChatsTimer: ReturnType<typeof setTimeout> | null = null;
   private readyPromise: Promise<void> | null = null;
   private readyResolve: (() => void) | null = null;
+  // Exponential-backoff reconnect scheduler (single-flight). Prevents the
+  // zero-delay reason-408 reconnect storm; see reconnect-backoff.ts.
+  private reconnect = new ReconnectController();
+  // True while an intentional disconnect() is in progress, so the resulting
+  // 'close' event does not re-arm a reconnect.
+  private intentionalDisconnect = false;
 
   // Set by server-base.ts — called for every incoming message
   onMessage: (msg: IncomingMessage) => void = () => {};
@@ -84,6 +92,7 @@ export class WhatsAppProvider implements ChannelProvider {
   onReaction?: (reaction: IncomingReaction) => void;
 
   async connect(): Promise<void> {
+    this.intentionalDisconnect = false;
     this.readyPromise = new Promise<void>((resolve) => {
       this.readyResolve = resolve;
     });
@@ -147,25 +156,35 @@ export class WhatsAppProvider implements ChannelProvider {
         const reason = (
           lastDisconnect?.error as { output?: { statusCode?: number } }
         )?.output?.statusCode;
-        const shouldReconnect = reason !== DisconnectReason.loggedOut;
+        const shouldReconnect =
+          reason !== DisconnectReason.loggedOut && !this.intentionalDisconnect;
         logger.info({ reason, shouldReconnect }, 'Connection closed');
 
         if (shouldReconnect) {
-          logger.info('Reconnecting...');
-          this.connectInternal().catch((err) => {
-            logger.error({ err }, 'Failed to reconnect, retrying in 5s');
-            setTimeout(() => {
-              this.connectInternal().catch((err2) => {
-                logger.error({ err: err2 }, 'Reconnection retry failed');
-              });
-            }, 5000);
+          // The connection didn't prove stable — let the backoff keep growing.
+          this.reconnect.markDisconnected();
+          // Single-flight + exponential backoff. Replaces the old zero-delay
+          // reconnect that turned a sustained reason-408 into a storm (#305).
+          const delay = this.reconnect.schedule(() => {
+            this.connectInternal().catch((err) => {
+              logger.error({ err }, 'Reconnect attempt failed');
+            });
           });
+          if (delay !== null) {
+            logger.info(
+              { delayMs: delay, attempt: this.reconnect.attempts },
+              'Reconnecting...',
+            );
+          }
         } else {
           logger.info('Logged out. Re-authenticate to continue.');
         }
       } else if (connection === 'open') {
         this.connected = true;
         this.connectTime = Date.now();
+        // Begin a stability window; the backoff resets only if the connection
+        // survives it (a brief flap keeps backing off).
+        this.reconnect.markConnected();
         logger.info('Connected to WhatsApp');
 
         this.sock.sendPresenceUpdate('available').catch(() => {});
@@ -436,6 +455,10 @@ export class WhatsAppProvider implements ChannelProvider {
   }
 
   async disconnect(): Promise<void> {
+    // Intentional teardown: cancel any pending/armed reconnect and flag so the
+    // 'close' event from end() does not re-arm one.
+    this.intentionalDisconnect = true;
+    this.reconnect.reset();
     this.connected = false;
     this.sock?.end(undefined);
   }

--- a/packages/mcp-whatsapp/tsconfig.json
+++ b/packages/mcp-whatsapp/tsconfig.json
@@ -12,5 +12,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/mcp-whatsapp/vitest.config.ts
+++ b/packages/mcp-whatsapp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+// Package-local config so `vitest run` discovers tests under this package's
+// src/ (the repo-root vitest.config.ts scopes include to the root's src/).
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-05-30" # auto-bump @1780173549
+last_verified: "2026-06-06" # auto-bump @1780704994
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780556749
+last_verified: "2026-06-06" # auto-bump @1780704994
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
## Problem

The WhatsApp `connection.update` `'close'` handler reconnected with **zero delay**. `connectInternal()` resolves as soon as `makeWASocket` returns, so a reason-408 ("connection lost") arrives *later* as a `'close'` event and never makes it throw — the existing 5s backoff (in `connectInternal().catch`) was dead code for the 408 case.

Result: a sustained 408 became a tight reconnect loop. Production logs (`logs/deus.error.log`):
- single pid, `reason=408`, reconnects **~4ms apart**
- **90,173 reconnects in one hour** (2026-06-02 08:00); 187,631 reason-408 reconnects over 6 days
- this churn is what produced **#305** (`MaxListenersExceededWarning: ... drain listeners on [Socket]`) — the warnings land only on storm days, proportional to intensity.

## Fix

`ReconnectController` (`packages/mcp-whatsapp/src/reconnect-backoff.ts`):
- **single-flight** scheduler — at most one pending reconnect (turns N rapid closes into one reconnect)
- **exponential backoff + jitter**, 1s → 60s cap
- **epoch-token cancellation** — a timer that fires after `reset()` is a no-op
- **stability timer** — backoff resets only after a connection survives 30s; a brief flap keeps backing off

Wired into the open/close handlers; `disconnect()` is guarded (`intentionalDisconnect`) so an intentional teardown doesn't re-arm a reconnect. `connectTime` (uptime display) is untouched.

## TDD

Test-first. `reconnect-backoff.test.ts` (12 cases, deterministic fake clock + injected jitter): delay curve (base/growth/cap/jitter bounds), the **single-flight storm regression** (100 rapid `schedule()` → exactly one reconnect), backoff growth, stability-reset vs flap, and epoch cancellation. RED confirmed before implementing, GREEN after.

## Scope

Backoff only (one concern). Old-socket teardown on reconnect was considered and **deferred** — slowing the churn already removes the drain-listener pileup behind #305.

## Verify

- `cd packages/mcp-whatsapp && npx vitest run` → 12 passed
- `npm run build` (tsc) → clean (after building `mcp-channel-core`, per CI order); test files excluded from the build
- eslint → 0 errors

Plan-reviewed (SHIP) before implementation.

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
