### PR TITLE
fix(memory): force category in Gemma4 atom schema + suppress Ollama thinking

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-06" # re-verified for gemma4-12b-local-model-evaluation ADR
+last_verified: "2026-06-06" # auto-bump @1780743019
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -1919,6 +1919,10 @@ def _extract_atoms_ollama(content: str) -> "list[dict] | None":
         "model": ollama_model,
         "prompt": prompt,
         "stream": False,
+        # Gemma4 has thinking ON by default; suppress it for structured output.
+        # ~2x faster (16s -> 8s on a real session log) and avoids a thinking
+        # preamble that can corrupt the response under a JSON grammar.
+        "think": False,
         # Object-wrapper schema (Ollama structured output; top-level array is
         # undefined — mirror the entity path's object form).
         "format": {
@@ -1932,6 +1936,10 @@ def _extract_atoms_ollama(content: str) -> "list[dict] | None":
                             "text": {"type": "string"},
                             "category": {"type": "string"},
                         },
+                        # Force both fields: without this, Gemma4 constrained
+                        # decoding omits "category" on every atom, so the
+                        # post-parse filter below drops 100% of them (LIA-187).
+                        "required": ["text", "category"],
                     },
                 },
             },
@@ -2213,6 +2221,12 @@ def _extract_entities_ollama(content: str) -> "dict | None":
         "model": ollama_model,
         "prompt": prompt,
         "stream": False,
+        # Suppress Gemma4 thinking for structured output (same ~2x speedup as the
+        # atom path). Items are intentionally NOT marked "required" here: unlike
+        # the atom "category" field, Gemma4 reliably emits all entity/relationship
+        # fields without it (verified on gemma4:e4b, 2026-06), so adding it would
+        # be unproven hardening.
+        "think": False,
         "format": {
             "type": "object",
             "properties": {

--- a/scripts/tests/test_memory_indexer_ner.py
+++ b/scripts/tests/test_memory_indexer_ner.py
@@ -339,6 +339,51 @@ def test_ollama_atoms_connection_refused_returns_none(mi):
         assert mi._extract_atoms_ollama("x") is None
 
 
+def test_ollama_atoms_request_body_shape(mi):
+    """Guard the Gemma4 fixes: think:false must be sent TOP-LEVEL (not under
+    options), and the items schema must require both text+category — otherwise
+    Gemma4 constrained decoding omits category and the post-parse filter drops
+    100% of atoms (LIA-185 / LIA-187)."""
+    captured = {}
+    result_dict = {"atoms": [{"text": "x", "category": "fact"}]}
+
+    def _capture(req, *args, **kwargs):
+        captured["body"] = json.loads(req.data.decode())
+        return _mock_ollama_response(result_dict)
+
+    with patch("urllib.request.urlopen", side_effect=_capture):
+        mi._extract_atoms_ollama("some session content")
+
+    body = captured["body"]
+    # LIA-185: thinking suppressed at the request top level, not under "options".
+    assert body.get("think") is False
+    assert "think" not in body.get("options", {})
+    # Structured-output parsing depends on a non-streamed response.
+    assert body.get("stream") is False
+    # LIA-187: items schema forces both fields so category is always emitted.
+    items = body["format"]["properties"]["atoms"]["items"]
+    assert set(items["required"]) == {"text", "category"}
+
+
+def test_ollama_entities_request_suppresses_thinking(mi_auto):
+    """The entity path shares the Gemma4 think:false fix (top-level, not under
+    options). It deliberately does NOT force `required` on items — Gemma4 emits
+    all entity fields without it (verified), so that would be unproven hardening."""
+    captured = {}
+    result_dict = {"entities": [], "relationships": []}
+
+    def _capture(req, *args, **kwargs):
+        captured["body"] = json.loads(req.data.decode())
+        return _mock_ollama_response(result_dict)
+
+    with patch("urllib.request.urlopen", side_effect=_capture):
+        mi_auto._extract_entities_ollama("Deus uses Ollama.")
+
+    body = captured["body"]
+    assert body.get("think") is False
+    assert "think" not in body.get("options", {})
+
+
 def test_extract_atoms_auto_falls_back_to_gemini_when_ollama_down(mi, monkeypatch):
     monkeypatch.setattr(mi, "ATOM_PROVIDER", "auto")
     monkeypatch.setattr(mi, "_extract_atoms_ollama", lambda c: None)  # Ollama down


### PR DESCRIPTION
## Summary

The keyless Ollama atom-extraction path (`_extract_atoms_ollama`, LIA-170) was silently returning **zero atoms in production**. Two verified Gemma4 issues, both diagnosed with live probes against `gemma4:e4b`.

## Bug 1 — missing `required` drops 100% of atoms (LIA-187, the live bug)

The structured-output `format` schema marked `category` optional (`items.properties` with no `required`). Under constrained decoding Gemma4 omits it on every atom, and the post-parse filter `[a for a in atoms if "text" in a and "category" in a]` then drops them all.

| schema | `done_reason` | parsed atoms | valid after filter |
|---|---|---|---|
| current (no `required`) | stop | 4 | **0** |
| `required:[text,category]` | stop | 4 | **4** |

Fix: add `"required": ["text", "category"]` to the items object → Gemma4 emits `category` on every atom.

## Bug 2 — no `think:false` (LIA-185)

Gemma4 thinking is ON by default; the request sent no suppression. Adding `"think": false` (top-level):

| body | latency (same input + seed) |
|---|---|
| no `think` key | 16.4s |
| `think: false` | **8.2s** (~2x faster) |

The suspected thinking-*corruption* failure mode (empty `response` / `done_reason=length`) did **not** reproduce, so the function's `[]`-vs-`None` return contract is **intentionally unchanged** — `None` = Ollama unreachable (Gemini fallback), `[]` = skip. Flipping it would have defeated the keyless path (LIA-170).

## Sibling path: `_extract_entities_ollama`

Found during review. Applied `think:false` there too (same model, same ~2x speedup). **`required` deliberately NOT added** — a live probe showed Gemma4 emits all entity/relationship fields without it (10/10 entities, 7/7 relationships valid both ways), so it would be unproven hardening. Rationale documented inline.

## Tests

Adds request-body-shape tests (capturing the actual `urlopen` request) asserting `think:false` is top-level (not under `options`), `stream:false`, and the atom items `required` fields — for both the atom and entity paths. `python3 -m pytest scripts/tests/test_memory_indexer_ner.py` → **23 passed**.

## Notes

- The sibling judge-path fix (`evolution/judge/ollama_judge.py`, **LIA-186**) is a separate branch/PR by design (different subsystem, independent revert boundary).
- Includes one `chore(patterns): auto-bump` commit from the pre-push drift hook (LIA-146 worktree mtime false-positive).

Refs: LIA-185, LIA-187