### PR TITLE
fix(judge): suppress Gemma4 thinking in the Ollama judge call

### DIFF
--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -56,10 +56,15 @@ def _check_model_pulled(model: str) -> None:
 
 def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
     """Synchronous Ollama generate call."""
-    # Qwen is no longer the default, but keep the /no_think suffix in case a
-    # user sets OLLAMA_MODEL=qwen*: without it the thinking mode returns empty.
+    # Suppress model "thinking" for structured output — otherwise the thinking
+    # preamble slows the call and can corrupt the JSON-grammar response. The
+    # mechanism is family-specific: Qwen uses the /no_think prompt suffix; Gemma4
+    # (the default OLLAMA_MODEL) uses the "think": false request-body key. Prior
+    # to this fix the default judge ran with thinking ON and no suppression.
+    # Scoped to gemma4 specifically — the only Gemma we run — rather than all
+    # "gemma*" so earlier variants aren't sent a key they may not support.
     full_prompt = f"{prompt}\n/no_think" if "qwen" in model.lower() else prompt
-    body = json.dumps({
+    payload = {
         "model": model,
         "prompt": full_prompt,
         "stream": False,
@@ -80,7 +85,10 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
             "temperature": 0,
             "seed": 42,
         },
-    }).encode()
+    }
+    if "gemma4" in model.lower():
+        payload["think"] = False
+    body = json.dumps(payload).encode()
     req = urllib.request.Request(
         _ollama_url("/api/generate"),
         data=body,

--- a/evolution/tests/test_ollama_judge.py
+++ b/evolution/tests/test_ollama_judge.py
@@ -1,0 +1,63 @@
+"""Unit tests for evolution/judge/ollama_judge.py — family-specific thinking
+suppression in the Ollama judge request body (LIA-186)."""
+import json
+from unittest.mock import patch, MagicMock
+
+from evolution.judge.ollama_judge import _call_ollama
+
+
+def _capturing_urlopen(captured: dict):
+    """urlopen replacement that records the decoded request body and returns a
+    minimal valid (empty-object) judge response."""
+
+    def _fake(req, *args, **kwargs):
+        captured["body"] = json.loads(req.data.decode())
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({"response": "{}"}).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    return _fake
+
+
+def test_gemma4_suppresses_thinking_via_body_key():
+    # Gemma4: "think": false at the TOP level (not under options), no prompt suffix.
+    captured = {}
+    with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+        _call_ollama("rate this response", model="gemma4:e4b")
+    body = captured["body"]
+    assert body.get("think") is False
+    assert "think" not in body.get("options", {})
+    assert "/no_think" not in body["prompt"]
+
+
+def test_qwen_suppresses_thinking_via_prompt_suffix():
+    # Qwen keeps the /no_think prompt-suffix mechanism and no body-level key.
+    captured = {}
+    with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+        _call_ollama("rate this response", model="qwen3:4b")
+    body = captured["body"]
+    assert body["prompt"].endswith("/no_think")
+    assert "think" not in body
+
+
+def test_non_thinking_model_sends_no_controls():
+    # A model from neither family gets no thinking controls at all.
+    captured = {}
+    with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+        _call_ollama("rate this response", model="llama3.1:8b")
+    body = captured["body"]
+    assert "think" not in body
+    assert "/no_think" not in body["prompt"]
+
+
+def test_earlier_gemma_variants_excluded_from_think_key():
+    # Boundary canary: the body-key suppression is scoped to gemma4 only. Earlier
+    # Gemma variants must NOT receive "think" — guards against widening the
+    # predicate to a bare "gemma" substring (which would match gemma2/gemma3).
+    for model in ("gemma2:9b", "gemma3:27b"):
+        captured = {}
+        with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+            _call_ollama("rate this response", model=model)
+        assert "think" not in captured["body"], f"{model} should not get think key"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-06" # auto-bump @1780743019
+last_verified: "2026-06-06" # auto-bump @1780743524
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780585715
+last_verified: "2026-06-06" # auto-bump @1780743524
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary

`evolution/judge/ollama_judge.py:_call_ollama` suppressed model "thinking" **only for Qwen** (via the `/no_think` prompt suffix). But the default `OLLAMA_MODEL` is `gemma4:e4b` (`evolution/config.py:39`) and Gemma4 has thinking **ON by default** — so the production judge ran with no suppression at all: slower calls and a thinking preamble that can corrupt the JSON-grammar response.

Gemma4's suppression mechanism is the request-body key `"think": false` (top-level), **not** a prompt suffix. This adds it.

## Scope decision

The key is applied only when `"gemma4" in model.lower()` — not a bare `"gemma"` substring — so earlier Gemma variants (gemma2/gemma3) aren't sent a key they may not support. Qwen keeps its `/no_think` suffix. Other models get neither (we don't run other thinking models through the judge; gemma4 is the default).

Verified on live Ollama 0.30.5: `think:false` is in fact accepted gracefully by non-gemma models too (deepseek-r1, llama3.2 both returned `done_reason=stop`), but scoping to gemma4 keeps the contract precise and matches the function's existing family-branching design.

## Efficiency

Same fix shipped on the memory atom-extraction path (PR #707) cut gemma4 latency ~2× (16.4s→8.2s, same model). The judge call uses the same model + structured-output grammar, so it benefits identically.

## Tests

New `evolution/tests/test_ollama_judge.py` captures the actual request body (via a `urlopen` side_effect) and asserts:
- gemma4 → top-level `think:false` (not under `options`), no `/no_think`
- qwen → `/no_think` suffix, no body key
- other model → neither control
- **boundary canary:** gemma2/gemma3 → no `think` key (guards against re-widening the predicate)

`python3 -m pytest evolution/tests/` (judge suite) → 180 passed, 1 skipped; new file → 4 passed.

## Notes

- The judge `format` schema already marks all fields `required`, so the missing-field drop bug fixed in PR #707 (LIA-187) does **not** apply here — only thinking suppression was missing.
- Includes one `chore(patterns): auto-bump` commit from the pre-push drift hook (LIA-146 worktree mtime false-positive).

Refs: LIA-186