### PR TITLE
fix(wardens): admin-merge gate blocks only on required checks (LIA-144)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -809,6 +809,9 @@ _CI_STATUS_GREEN = "green"
 _CI_STATUS_RED = "red"
 _CI_STATUS_PENDING = "pending"
 _CI_STATUS_NO_CHECKS = "no-checks"
+# Checks exist on the PR but none are branch-protection-required — an ambiguous
+# state we fail closed on rather than silently allow an unverified admin-merge.
+_CI_STATUS_NO_REQUIRED = "no-required"
 _CI_STATUS_ERROR = "error"
 
 # Bucket values returned by ``gh pr checks --json bucket``
@@ -817,16 +820,23 @@ _BUCKET_PENDING = frozenset({"pending"})
 _BUCKET_FAIL = frozenset({"fail", "cancel"})
 
 
-def _check_ci_status(pr_ref: str, timeout: int = 3) -> tuple[str, str]:
-    """Query CI status for *pr_ref* via ``gh pr checks``.
+def _query_gh_checks(
+    pr_ref: str, *, required_only: bool, timeout: int = 3
+) -> tuple[str, str, int]:
+    """Run ``gh pr checks`` once and classify the result.
 
-    Returns a ``(status, message)`` pair where status is one of
-    ``_CI_STATUS_*`` constants.  Failure to query defaults to
-    ``_CI_STATUS_ERROR`` so the gate blocks rather than falls open.
+    Returns ``(status, message, num_checks)`` where status is one of the
+    ``_CI_STATUS_*`` constants and num_checks is how many checks were returned.
+    When *required_only* is set, the query is scoped with ``--required`` so the
+    gate sees only branch-protection-required checks. Failure to query defaults
+    to ``_CI_STATUS_ERROR`` so the caller blocks rather than falls open.
     """
+    argv = ["gh", "pr", "checks", pr_ref, "--json", "bucket,name"]
+    if required_only:
+        argv.append("--required")
     try:
         result = subprocess.run(
-            ["gh", "pr", "checks", pr_ref, "--json", "bucket,name"],
+            argv,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -834,34 +844,39 @@ def _check_ci_status(pr_ref: str, timeout: int = 3) -> tuple[str, str]:
             check=False,
         )
     except FileNotFoundError:
-        return _CI_STATUS_ERROR, "gh CLI not found; cannot verify CI status"
+        return _CI_STATUS_ERROR, "gh CLI not found; cannot verify CI status", 0
     except subprocess.TimeoutExpired:
-        return _CI_STATUS_ERROR, f"gh pr checks timed out after {timeout}s"
+        return _CI_STATUS_ERROR, f"gh pr checks timed out after {timeout}s", 0
     except OSError as exc:
-        return _CI_STATUS_ERROR, f"gh pr checks failed: {exc}"
+        return _CI_STATUS_ERROR, f"gh pr checks failed: {exc}", 0
 
     if result.returncode not in (0, 1, 8):
         # Exit code 1 = some checks failed (still parseable).
         # Exit code 8 = checks pending (still parseable).
         # Other codes indicate auth / network errors.
         stderr_snippet = result.stderr.strip()[:200]
-        return _CI_STATUS_ERROR, f"gh pr checks exited {result.returncode}: {stderr_snippet}"
+        return (
+            _CI_STATUS_ERROR,
+            f"gh pr checks exited {result.returncode}: {stderr_snippet}",
+            0,
+        )
 
     raw = result.stdout.strip()
     if not raw:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
 
     try:
         checks = json.loads(raw)
     except json.JSONDecodeError:
-        return _CI_STATUS_ERROR, "gh pr checks returned unparseable output"
+        return _CI_STATUS_ERROR, "gh pr checks returned unparseable output", 0
 
     if not isinstance(checks, list):
-        return _CI_STATUS_ERROR, "gh pr checks returned unexpected JSON shape"
+        return _CI_STATUS_ERROR, "gh pr checks returned unexpected JSON shape", 0
 
     if not checks:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
 
+    n = len(checks)
     buckets = {str(c.get("bucket", "")) for c in checks if isinstance(c, dict)}
     failed = [
         str(c.get("name", "?"))
@@ -875,16 +890,49 @@ def _check_ci_status(pr_ref: str, timeout: int = 3) -> tuple[str, str]:
     ]
 
     if failed:
-        names = ", ".join(failed[:5])
-        return _CI_STATUS_RED, f"failing checks: {names}"
+        return _CI_STATUS_RED, f"failing checks: {', '.join(failed[:5])}", n
     if pending:
-        names = ", ".join(pending[:5])
-        return _CI_STATUS_PENDING, f"pending checks: {names}"
+        return _CI_STATUS_PENDING, f"pending checks: {', '.join(pending[:5])}", n
     if buckets <= _BUCKET_PASS:
-        return _CI_STATUS_GREEN, "all checks passed"
+        return _CI_STATUS_GREEN, "all checks passed", n
 
     unknown = buckets - _BUCKET_PASS - _BUCKET_PENDING - _BUCKET_FAIL
-    return _CI_STATUS_ERROR, f"unknown check buckets: {', '.join(sorted(unknown))}"
+    return _CI_STATUS_ERROR, f"unknown check buckets: {', '.join(sorted(unknown))}", n
+
+
+def _check_ci_status(pr_ref: str, timeout: int = 3) -> tuple[str, str]:
+    """Classify CI for *pr_ref*, scoped to branch-protection-required checks.
+
+    The admin-merge gate must mirror branch protection — only checks the repo
+    actually marks required (e.g. ``ci``) may block a merge, never
+    advisory bots (TrueCourse, the platform test matrix, CodeQL) the repo
+    deliberately left non-required. Applies to every caller of this function
+    (the one-shot approve CLI, the PreToolUse hook, and merge_train).
+
+    Falls closed: an unverifiable status — or a PR that has checks but none
+    required — blocks rather than allowing an unreviewed admin-merge.
+    """
+    status, message, _ = _query_gh_checks(pr_ref, required_only=True, timeout=timeout)
+    if status != _CI_STATUS_NO_CHECKS:
+        return status, message
+
+    # No REQUIRED checks reported. Disambiguate against the unfiltered set:
+    # genuinely zero checks → allowed through (unchanged behaviour); checks
+    # present but none required → ambiguous, fail closed.
+    all_status, all_message, all_n = _query_gh_checks(
+        pr_ref, required_only=False, timeout=timeout
+    )
+    if all_status == _CI_STATUS_ERROR:
+        return all_status, all_message
+    if all_n == 0:
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
+    # Thread the unfiltered status through so the operator sees WHAT is
+    # outstanding (e.g. a failing advisory check), not just the ambiguity.
+    return (
+        _CI_STATUS_NO_REQUIRED,
+        f"{all_n} check(s) present but none are branch-protection-required "
+        f"(unfiltered: {all_status} — {all_message})",
+    )
 
 
 def _ci_block_reason(pr_ref: str, status: str, detail: str) -> str | None:
@@ -903,6 +951,14 @@ def _ci_block_reason(pr_ref: str, status: str, detail: str) -> str | None:
         return (
             f"[admin-merge-gate] CI is pending — autonomy grant is conditional on green. "
             f"Run `gh pr checks {pr_ref}` first.\n\n"
+            f"Detail: {detail}"
+        )
+    if status == _CI_STATUS_NO_REQUIRED:
+        return (
+            f"[admin-merge-gate] Branch protection reports no required checks for "
+            f"{pr_ref}, yet the PR has checks — refusing admin-merge (fail-closed). "
+            f"Inspect with `gh api repos/<owner>/<repo>/branches/main/protection` and "
+            f"confirm the required-check names before merging.\n\n"
             f"Detail: {detail}"
         )
     # _CI_STATUS_ERROR — fail closed

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -1763,6 +1763,169 @@ def _make_gh_run(checks: list[dict] | None = None, returncode: int = 0, stderr: 
     return fake_run
 
 
+def _make_gh_run_split(required_checks, all_checks, *, required_rc=0, all_rc=0):
+    """Fake ``subprocess.run`` returning different ``gh pr checks`` results for
+    the ``--required`` query vs the unfiltered query (LIA-144 fail-closed path).
+    """
+
+    def fake_run(cmd, *args, **kwargs):
+        if (
+            isinstance(cmd, (list, tuple))
+            and len(cmd) >= 3
+            and str(cmd[0]).endswith("gh")
+            and cmd[1] == "pr"
+            and cmd[2] == "checks"
+        ):
+            if "--required" in cmd:
+                payload, rc = required_checks, required_rc
+            else:
+                payload, rc = all_checks, all_rc
+            stdout = json.dumps(payload) if payload is not None else ""
+            return subprocess.CompletedProcess(cmd, rc, stdout=stdout, stderr="")
+        return _REAL_SUBPROCESS_RUN(cmd, *args, **kwargs)
+
+    return fake_run
+
+
+def test_check_ci_status_uses_required_flag(monkeypatch):
+    # LIA-144: the gate must query only branch-protection-required checks.
+    hooks = load_hooks()
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        if (
+            isinstance(cmd, (list, tuple))
+            and len(cmd) >= 3
+            and str(cmd[0]).endswith("gh")
+            and cmd[1] == "pr"
+            and cmd[2] == "checks"
+        ):
+            captured["cmd"] = list(cmd)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps([{"bucket": "pass", "name": "ci"}]), stderr=""
+            )
+        return _REAL_SUBPROCESS_RUN(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+    status, _ = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_GREEN
+    # Strict positional assertion — --required must be passed (not just present
+    # somewhere by accident), scoping the query to required checks only.
+    assert captured["cmd"] == [
+        "gh", "pr", "checks", "123", "--json", "bucket,name", "--required",
+    ]
+
+
+def test_check_ci_status_advisory_pending_does_not_block(monkeypatch):
+    # Required checks all pass; advisory checks (TrueCourse etc.) still pending in
+    # the unfiltered set. The gate sees only required → GREEN (no block).
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(
+            required_checks=[{"bucket": "pass", "name": "ci"}],
+            all_checks=[
+                {"bucket": "pass", "name": "ci"},
+                {"bucket": "pending", "name": "TrueCourse --diff vs main"},
+            ],
+        ),
+    )
+    status, _ = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_GREEN
+
+
+def test_check_ci_status_required_pending_blocks(monkeypatch):
+    # A pending REQUIRED check still blocks.
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(
+            required_checks=[{"bucket": "pending", "name": "ci"}],
+            all_checks=[{"bucket": "pending", "name": "ci"}],
+            required_rc=8,
+            all_rc=8,
+        ),
+    )
+    status, detail = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_PENDING
+    assert "ci" in detail
+
+
+def test_check_ci_status_no_required_but_checks_present_fails_closed(monkeypatch):
+    # --required returns nothing, but the PR has (advisory) checks → ambiguous →
+    # NO_REQUIRED, which must block (fail closed).
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(
+            required_checks=None,
+            all_checks=[{"bucket": "pass", "name": "advisory-only"}],
+        ),
+    )
+    status, detail = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_NO_REQUIRED
+    assert "none are branch-protection-required" in detail
+    assert hooks._ci_block_reason("123", status, detail) is not None
+
+
+def test_check_ci_status_no_checks_anywhere_does_not_block(monkeypatch):
+    # Genuinely zero checks (required AND unfiltered empty) → NO_CHECKS, no block
+    # (unchanged pre-LIA-144 behaviour).
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(required_checks=None, all_checks=None),
+    )
+    status, _ = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_NO_CHECKS
+    assert hooks._ci_block_reason("123", status, "") is None
+
+
+def test_ci_block_reason_no_required_is_distinct_and_blocking():
+    hooks = load_hooks()
+    reason = hooks._ci_block_reason(
+        "123",
+        hooks._CI_STATUS_NO_REQUIRED,
+        "2 check(s) present but none are branch-protection-required",
+    )
+    assert reason is not None
+    assert "fail-closed" in reason
+    assert "no required checks" in reason.lower()
+
+
+def test_admin_merge_gate_ci_check_uses_required_scoping(tmp_path, monkeypatch):
+    # The PreToolUse hook path (run_admin_merge_gate) must also scope its CI
+    # check to required-only — verified by capturing the gh argv it issues.
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    command = "gh pr merge 294 --squash --admin"
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        if (
+            isinstance(cmd, (list, tuple))
+            and len(cmd) >= 3
+            and str(cmd[0]).endswith("gh")
+            and cmd[1] == "pr"
+            and cmd[2] == "checks"
+        ):
+            captured["cmd"] = list(cmd)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps([{"bucket": "pass", "name": "ci"}]), stderr=""
+            )
+        return _REAL_SUBPROCESS_RUN(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+    assert hooks.approve_admin_merge(command, repo) == 0
+    rc = hooks.run_admin_merge_gate(bash_event(repo, command), repo)
+    assert rc == 0
+    assert "--required" in captured["cmd"]
+
+
 def test_check_ci_status_green(monkeypatch):
     hooks = load_hooks()
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

The admin-merge gate (`scripts/codex_warden_hooks.py`, `_check_ci_status`) ran `gh pr checks <pr>` over **all** checks, so it blocked on advisory checks the repo deliberately left **non-required**. Branch protection on `main` requires only `ci` + `Facade flag-lint`, yet the gate waited ~7-10 min on the advisory `TrueCourse --diff` (plus `test-tui/windows/packages`, CodeQL `Analyze`) before allowing an admin-merge. (LIA-144)

## Fix

- Scope the query to `gh pr checks <pr> --required` → the gate mirrors branch protection.
- Refactor the gh call+parse into `_query_gh_checks(pr_ref, *, required_only, timeout)`.
- `_check_ci_status` queries required-first; if `--required` returns nothing, it disambiguates with one unfiltered query:
  - genuinely zero checks → `_CI_STATUS_NO_CHECKS` (no block — unchanged behaviour)
  - checks present but none required → new **`_CI_STATUS_NO_REQUIRED`** → **BLOCKS** (fail-closed) with a dedicated, actionable message (threads the unfiltered status so the operator sees what's outstanding).

## Blast radius (intentional, global)

`_check_ci_status` has **three** callers — the `approve-admin-merge` CLI, the `run_admin_merge_gate` **PreToolUse hook**, and (soon) merge-train. All three become required-only. That's the point: the gate should mirror branch protection at every enforcement point. After this, advisory checks no longer block any admin-merge path; **GitHub still enforces the real required checks at the actual merge.**

## Verification

`python3 -m pytest scripts/tests/test_codex_warden_hooks.py` → **232 passed** (29 prior ci/admin tests + 7 new: strict-positional `--required` argv; advisory-pending-doesn't-block; required-pending-blocks; no-required-but-checks → NO_REQUIRED/block; no-checks-anywhere → no block; the dedicated message; **hook-path argv capture**).

**Live smoke (new code, real gh, real PRs):**
- `gh pr checks 708 --required` → `[ci=pass, Facade=pass]` (2) vs **13** unfiltered → the 11 advisory checks are excluded. `_check_ci_status('708')` → `green`.
- Real hook entrypoint `… run admin-merge-gate` for #708 → CI green produced **no** CI block; the gate correctly proceeded to the marker check (deny, exit 0).
- Open PRs #676/#596 (`ci`=**fail**, advisory mostly pass) → `_check_ci_status` = `red` → **BLOCKS**. The fix doesn't make the gate lenient on real required failures.

## Related / follow-ons

- **LIA-193** — `merge_train.py` (depends on this PR for the fast required-only CI wait) — separate PR.
- **LIA-192** — branch-protection policy review: should `test-*` be promoted to required? (Deliberately out of scope; this PR defers to branch protection as the single source of truth.)

Refs: LIA-144