### PR TITLE
fix(evolution): grade judge personalization via stored-preference injection

### DIFF
--- a/evolution/config.py
+++ b/evolution/config.py
@@ -131,6 +131,7 @@ EVOLUTION_SKIP_GROUPS: str = os.environ.get("EVOLUTION_SKIP_GROUPS", "")
 # prompt — but the host persona is the PRIMARY user's, so it is injected only for
 # this group. Other groups score personalization ungraded (no cross-user leakage).
 # Empty (default) = opt-in off: no persona is injected for any group until set.
+# Wired into both live judge callers (mcp_server + maintenance) in PR #710.
 JUDGE_PERSONA_GROUP: str = os.environ.get("DEUS_JUDGE_PERSONA_GROUP", "")
 
 # Hard cap (chars) on the injected persona digest. Bounds outbound payload and —

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -124,6 +124,21 @@ JUDGE_RETRY_COUNT = int(os.environ.get("EVOLUTION_JUDGE_RETRY_COUNT", "1"))
 # Interactions from these groups are skipped in cmd_log_interaction without being stored.
 EVOLUTION_SKIP_GROUPS: str = os.environ.get("EVOLUTION_SKIP_GROUPS", "")
 
+# ── Persona injection (judge personalization) ─────────────────────────────────
+
+# group_folder of the primary host user. The judge's `personalization` dimension
+# is gradable only when the user's stored preferences (vault Persona/) are in the
+# prompt — but the host persona is the PRIMARY user's, so it is injected only for
+# this group. Other groups score personalization ungraded (no cross-user leakage).
+# Empty (default) = opt-in off: no persona is injected for any group until set.
+JUDGE_PERSONA_GROUP: str = os.environ.get("DEUS_JUDGE_PERSONA_GROUP", "")
+
+# Hard cap (chars) on the injected persona digest. Bounds outbound payload and —
+# critically — limits PII reaching the external Gemini judge, mirroring
+# JUDGE_MAX_PROMPT/RESPONSE_CHARS. The digest is already scoped to work-style
+# preferences (no names/household/career); this is defense-in-depth.
+JUDGE_MAX_PERSONA_CHARS = int(os.environ.get("EVOLUTION_JUDGE_MAX_PERSONA_CHARS", "500"))
+
 # ── Compaction & Batch Judging ───────────────────────────────────────────────
 
 # Compact scored interactions older than N days (replace with summary, NULL response).

--- a/evolution/judge/base.py
+++ b/evolution/judge/base.py
@@ -34,6 +34,7 @@ class BaseJudge(ABC):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
         ...
 
@@ -43,6 +44,7 @@ class BaseJudge(ABC):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
         """Async variant — default falls back to sync evaluate."""
-        return self.evaluate(prompt, response, tools_used, context)
+        return self.evaluate(prompt, response, tools_used, context, user_profile)

--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -26,13 +26,16 @@ Scoring guide:
   - "quality_level": 2 = significant errors or incomplete
   - "quality_level": 1 = wrong or off-topic
 
-**personalization**: Did the response adapt to the user's known preferences?
-  - "recalled_preference": true  (referenced or applied a stored user preference)
-  - "recalled_preference": false (no evidence of using stored preferences)
-  - "format_matched": true  (structural choices — bullets vs prose, length, code vs explanation — match user's observed pattern)
-  - "format_matched": false (used generic formatting, didn't match user's pattern)
-  - "tone_matched": true  (register, directness, formality consistent with user's prior interactions)
-  - "tone_matched": false (generic or mismatched tone)
+**personalization**: Did the response adapt to the user's stored preferences? Grade ONLY
+against a "**Known user preferences (stored profile)**" section if one is provided above —
+never against assumptions. If no such section is provided, set all three sub-fields to false.
+  - "recalled_preference": true ONLY if the response demonstrably applied a SPECIFIC preference
+    listed in the stored profile (name which one in your analysis); false otherwise.
+  - "recalled_preference": false (no profile provided, or no specific listed preference applied)
+  - "format_matched": true  (structural choices — bullets vs prose, length, code vs explanation — match a format preference in the stored profile)
+  - "format_matched": false (generic formatting, or no profile to match against)
+  - "tone_matched": true  (register, directness, formality match a tone preference in the stored profile)
+  - "tone_matched": false (generic/mismatched tone, or no profile to match against)
 
 **tool_use**: How well did the agent execute tool calls?
   - "execution_quality": 5 = perfect args + response fully addresses the task

--- a/evolution/judge/gemini_judge.py
+++ b/evolution/judge/gemini_judge.py
@@ -73,16 +73,17 @@ class GeminiRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
         # Truncate before sending to Gemini to cap payload size and PII exposure.
         prompt = prompt[:JUDGE_MAX_PROMPT_CHARS]
         response = (response or "")[:JUDGE_MAX_RESPONSE_CHARS]
-        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = _call_gemini(eval_prompt, self.model)
         result = _parse_result(raw)
         if result.is_parse_error:
             for _ in range(JUDGE_RETRY_COUNT):
-                raw = _call_gemini(_build_eval_prompt(prompt, response, tools_used, context, strict_json=True), self.model)
+                raw = _call_gemini(_build_eval_prompt(prompt, response, tools_used, context, user_profile, strict_json=True), self.model)
                 result = _parse_result(raw)
                 if not result.is_parse_error:
                     break
@@ -94,17 +95,18 @@ class GeminiRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
         # Truncate before sending to Gemini to cap payload size and PII exposure.
         prompt = prompt[:JUDGE_MAX_PROMPT_CHARS]
         response = (response or "")[:JUDGE_MAX_RESPONSE_CHARS]
-        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = await _call_gemini_async(eval_prompt, self.model)
         result = _parse_result(raw)
         if result.is_parse_error:
             for _ in range(JUDGE_RETRY_COUNT):
                 raw = await _call_gemini_async(
-                    _build_eval_prompt(prompt, response, tools_used, context, strict_json=True), self.model
+                    _build_eval_prompt(prompt, response, tools_used, context, user_profile, strict_json=True), self.model
                 )
                 result = _parse_result(raw)
                 if not result.is_parse_error:
@@ -117,11 +119,14 @@ def _build_eval_prompt(
     response: str,
     tools_used: Optional[list[str]],
     context: Optional[str],
+    user_profile: Optional[str] = None,
     strict_json: bool = False,
 ) -> str:
     parts = [RUBRIC, "\n## Interaction to evaluate\n"]
     if context:
         parts.append(f"**Context:** {context}\n")
+    if user_profile:
+        parts.append(f"**Known user preferences (stored profile):**\n{user_profile}\n")
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")

--- a/evolution/judge/llama_cpp_judge.py
+++ b/evolution/judge/llama_cpp_judge.py
@@ -115,8 +115,9 @@ class LlamaCppRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
-        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = _call_llama_cpp(eval_prompt, self.model)
         return _parse_result(raw)
 
@@ -126,8 +127,9 @@ class LlamaCppRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
-        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = await _call_llama_cpp_async(eval_prompt, self.model)
         return _parse_result(raw)
 
@@ -137,10 +139,13 @@ def _build_eval_prompt(
     response: str,
     tools_used: Optional[list[str]],
     context: Optional[str],
+    user_profile: Optional[str] = None,
 ) -> str:
     parts = [RUBRIC, "\n## Interaction to evaluate\n"]
     if context:
         parts.append(f"**Context:** {context}\n")
+    if user_profile:
+        parts.append(f"**Known user preferences (stored profile):**\n{user_profile}\n")
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -124,8 +124,9 @@ class OllamaRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
-        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = _call_ollama(eval_prompt, self.model)
         return _parse_result(raw)
 
@@ -135,8 +136,9 @@ class OllamaRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,
     ) -> JudgeResult:
-        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = await _call_ollama_async(eval_prompt, self.model)
         return _parse_result(raw)
 
@@ -146,10 +148,13 @@ def _build_eval_prompt(
     response: str,
     tools_used: Optional[list[str]],
     context: Optional[str],
+    user_profile: Optional[str] = None,
 ) -> str:
     parts = [RUBRIC, "\n## Interaction to evaluate\n"]
     if context:
         parts.append(f"**Context:** {context}\n")
+    if user_profile:
+        parts.append(f"**Known user preferences (stored profile):**\n{user_profile}\n")
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")

--- a/evolution/judge/providers/claude_proxy.py
+++ b/evolution/judge/providers/claude_proxy.py
@@ -20,6 +20,7 @@ class ClaudeProxyRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,  # accepted for interface parity; unused
     ) -> JudgeResult:
         return JudgeResult(
             score=0.5,

--- a/evolution/judge/providers/mock.py
+++ b/evolution/judge/providers/mock.py
@@ -18,6 +18,7 @@ class MockRuntimeJudge(BaseJudge):
         response: str,
         tools_used: Optional[list[str]] = None,
         context: Optional[str] = None,
+        user_profile: Optional[str] = None,  # accepted for interface parity; unused
     ) -> JudgeResult:
         return JudgeResult(
             score=self._score,

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -86,12 +86,14 @@ def is_maintenance_due(*, interaction_count: Optional[int] = None) -> bool:
 def _score_single(row: dict, judge) -> dict | None:
     """Score a single interaction. Returns score info dict or None on failure."""
     from .ilog.interaction_log import update_score
+    from .persona import digest_for_group
 
     try:
         result = judge.evaluate(
             prompt=row["prompt"],
             response=row.get("response") or "",
             tools_used=row.get("tools_used"),
+            user_profile=digest_for_group(row.get("group_folder")),
         )
         dims = {
             "quality": result.quality,

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -141,12 +141,14 @@ async def _async_judge_and_reflect(
 ) -> None:
     """Judge the interaction and generate reflections if score is low."""
     from .config import REFLECTION_THRESHOLD, MAX_REFLECTIONS_TO_GENERATE
+    from .persona import digest_for_group
     try:
         judge = make_runtime_judge()
         result = await judge.a_evaluate(
             prompt=prompt,
             response=response,
             tools_used=tools_used,
+            user_profile=digest_for_group(group_folder),
         )
         dims = {
             "quality": result.quality,

--- a/evolution/persona.py
+++ b/evolution/persona.py
@@ -1,0 +1,99 @@
+"""Compact persona digest loader for the Evolution judge.
+
+Without the user's stored preferences in the prompt, the judge's
+``personalization`` dimension is ungradable (the model can't know which
+preferences exist). This loads a compact, work-style-only digest of the user's
+preferences (from ``Persona/INDEX.md``) so the judge can grade it.
+
+Three deliberate choices:
+- **Fail-soft** — any failure returns ``None`` → personalization stays ungraded
+  exactly as before the fix (no crash, no regression).
+- **Primary-user scoped** — ``digest_for_group`` injects only for the configured
+  ``DEUS_JUDGE_PERSONA_GROUP``; other groups get ``None`` (no cross-user leakage).
+- **PII-scoped** — only the ``work-style`` section is loaded. The taste/life/
+  career sections carry names, household, and employer data that are irrelevant
+  to grading personalization and must not reach the external Gemini judge.
+"""
+import logging
+import re
+from typing import Optional
+
+from .config import JUDGE_MAX_PERSONA_CHARS, JUDGE_PERSONA_GROUP
+from .vault import load_vault_path
+
+log = logging.getLogger(__name__)
+
+# Module-level cache. ``_DIGEST_LOADED`` distinguishes "loaded, result was None"
+# (vault/persona absent — don't retry every call) from "not yet loaded".
+_DIGEST_CACHE: Optional[str] = None
+_DIGEST_LOADED: bool = False
+
+_WORKSTYLE_HEADING = re.compile(r"^##\s*work-style/?\s*$", re.MULTILINE)
+_NEXT_SECTION = re.compile(r"^##\s", re.MULTILINE)
+
+
+def _extract_workstyle(text: str) -> Optional[str]:
+    """Return only the ``## work-style/`` section of ``Persona/INDEX.md``.
+
+    Excludes taste/life/career — those carry PII (names, household, employer)
+    irrelevant to grading personalization and unsafe to send to an external
+    judge API. The work-style lines (communication + learning preferences) are
+    exactly what the rubric needs. Returns ``None`` if the section is absent.
+    """
+    m = _WORKSTYLE_HEADING.search(text)
+    if not m:
+        return None
+    rest = text[m.end():]
+    nxt = _NEXT_SECTION.search(rest)
+    section = (rest[: nxt.start()] if nxt else rest).strip()
+    return section or None
+
+
+def _load_digest() -> Optional[str]:
+    """Load the work-style digest from the vault. Fail-soft → ``None``."""
+    try:
+        index = load_vault_path() / "Persona" / "INDEX.md"
+        text = index.read_text(encoding="utf-8")
+    except (RuntimeError, ValueError, OSError) as exc:
+        log.debug("persona digest unavailable (%s); personalization stays ungraded", exc)
+        return None
+    section = _extract_workstyle(text)
+    if not section:
+        return None
+    digest = f"Work-style preferences:\n{section}"
+    if len(digest) > JUDGE_MAX_PERSONA_CHARS:
+        digest = digest[:JUDGE_MAX_PERSONA_CHARS].rstrip()
+    return digest
+
+
+def get_digest() -> Optional[str]:
+    """Lazily load + cache the persona digest. ``None`` if unavailable.
+
+    Cached for the process lifetime (persona changes rarely; the judge runs many
+    times/day). NOTE: the cache survives vault writes within the same process — a
+    long-running maintenance loop won't observe a mid-run persona edit. Tests call
+    ``_reset_cache_for_tests()`` to force a reload.
+    """
+    global _DIGEST_CACHE, _DIGEST_LOADED
+    if not _DIGEST_LOADED:
+        _DIGEST_CACHE = _load_digest()
+        _DIGEST_LOADED = True
+    return _DIGEST_CACHE
+
+
+def digest_for_group(group_folder: Optional[str]) -> Optional[str]:
+    """Return the persona digest only for the configured primary host group.
+
+    Every other group (and the unconfigured default) gets ``None`` so the host
+    user's preferences never grade a different user's interaction.
+    """
+    if not JUDGE_PERSONA_GROUP or group_folder != JUDGE_PERSONA_GROUP:
+        return None
+    return get_digest()
+
+
+def _reset_cache_for_tests() -> None:
+    """Test hook — clears the module cache so monkeypatched env takes effect."""
+    global _DIGEST_CACHE, _DIGEST_LOADED
+    _DIGEST_CACHE = None
+    _DIGEST_LOADED = False

--- a/evolution/taste_profile.py
+++ b/evolution/taste_profile.py
@@ -7,11 +7,8 @@ approach (arxiv:2505.00038): abductive LLM inference over behavioral evidence.
 
 Functional pipeline pattern: gather -> infer -> detect_conflicts -> write.
 """
-import json
 import logging
-import os
 import re
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -20,6 +17,7 @@ from .config import GEN_MODEL
 from .generative import generate
 from .ilog.interaction_log import get_recent
 from .storage import get_storage
+from .vault import load_vault_path as _load_vault_path
 
 log = logging.getLogger(__name__)
 
@@ -76,34 +74,6 @@ Example format:
 - Prefers flat file structure over deeply nested directories
 - Values explicit error messages over silent failures
 """
-
-
-def _load_vault_path() -> Path:
-    """Resolve vault path from config or env var. Anchored to home or /tmp."""
-    env_path = os.environ.get("DEUS_VAULT_PATH")
-    if env_path:
-        resolved = Path(env_path).expanduser().resolve()
-    elif (Path.home() / ".config" / "deus" / "config.json").exists():
-        config_path = Path.home() / ".config" / "deus" / "config.json"
-        try:
-            with config_path.open() as f:
-                config = json.load(f)
-            resolved = Path(config["vault_path"]).expanduser().resolve()
-        except (json.JSONDecodeError, KeyError) as exc:
-            raise RuntimeError(
-                f"Failed to read vault_path from config.json: {exc}"
-            ) from exc
-    else:
-        raise RuntimeError(
-            "Cannot resolve vault path. Set DEUS_VAULT_PATH or configure vault_path in ~/.config/deus/config.json"
-        )
-
-    allowed = (Path.home(), Path("/tmp").resolve(), Path(tempfile.gettempdir()).resolve())
-    if not any(resolved == a or resolved.is_relative_to(a) for a in allowed):
-        raise ValueError(
-            f"Vault path {resolved} is outside allowed prefixes ({Path.home()}, /tmp)"
-        )
-    return resolved
 
 
 def _profile_path() -> Path:

--- a/evolution/tests/test_judge_persona_injection.py
+++ b/evolution/tests/test_judge_persona_injection.py
@@ -1,0 +1,113 @@
+"""Tests for persona-digest injection into the Evolution judge prompt (B).
+
+Deterministic — no model calls. Covers the 3 prompt builders (block present iff a
+profile is given; no-profile path byte-identical to legacy; gemini strict_json
+retry carries the block) and the persona loader (trim, fail-soft, group-scoping).
+"""
+import pytest
+
+from evolution.judge.ollama_judge import _build_eval_prompt as ollama_build
+from evolution.judge.gemini_judge import _build_eval_prompt as gemini_build
+from evolution.judge.llama_cpp_judge import _build_eval_prompt as llama_build
+from evolution import persona
+
+PROFILE = "- communication: concise + direct\n- learning: visuals + analogies"
+BLOCK = "**Known user preferences (stored profile):**"
+
+ALL_BUILDERS = [ollama_build, gemini_build, llama_build]
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_profile_block_present_when_profile_given(build):
+    out = build("p", "r", None, None, PROFILE)
+    assert BLOCK in out
+    assert "concise + direct" in out
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_no_block_when_profile_absent(build):
+    assert BLOCK not in build("p", "r", None, None)
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_absent_profile_byte_identical_to_legacy(build):
+    """Passing no user_profile must reproduce the pre-change prompt exactly."""
+    legacy = build("p", "r", ["Bash"], "some context")
+    explicit_none = build("p", "r", ["Bash"], "some context", None)
+    assert legacy == explicit_none
+    assert BLOCK not in legacy
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_profile_block_after_context_before_user_prompt(build):
+    out = build("p", "r", None, "ctx", PROFILE)
+    assert out.index("**Context:**") < out.index(BLOCK) < out.index("**User prompt:**")
+
+
+def test_gemini_strict_json_retry_keeps_block():
+    out = gemini_build("p", "r", None, None, PROFILE, strict_json=True)
+    assert BLOCK in out
+    assert "valid JSON object" in out  # strict_json instruction still appended
+
+
+# ── persona loader ────────────────────────────────────────────────────────────
+
+def test_extract_workstyle_excludes_pii_sections():
+    # Fixture uses fictional placeholders only (no real personal data in the public repo).
+    raw = (
+        "---\nid: x\ntype: persona-index\n---\n# Persona Index\n\n"
+        "## taste/\n- movies: crime; roommate Alice likes romance\n\n"
+        "## life/\n- household: Bob, Carol replacing Bob Aug 2099\n\n"
+        "## work-style/\n- communication: concise+direct\n- learning: visuals+analogies\n\n"
+        "## career/\n- employer: ExampleCorp interview salary notes\n"
+    )
+    out = persona._extract_workstyle(raw)
+    assert out is not None
+    assert "concise+direct" in out and "visuals+analogies" in out
+    # PII-bearing sections must be excluded from anything sent to an external judge
+    for pii in ("Alice", "Bob", "Carol", "ExampleCorp"):
+        assert pii not in out, f"PII '{pii}' leaked into the digest"
+
+
+def test_extract_workstyle_none_when_section_absent():
+    assert persona._extract_workstyle("# Persona\n## taste/\n- movies\n") is None
+
+
+def test_digest_respects_char_cap(monkeypatch, tmp_path):
+    (tmp_path / "Persona").mkdir()
+    (tmp_path / "Persona" / "INDEX.md").write_text(
+        "## work-style/\n- communication: " + ("x" * 2000) + "\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(persona, "load_vault_path", lambda: tmp_path)
+    monkeypatch.setattr(persona, "JUDGE_MAX_PERSONA_CHARS", 120)
+    persona._reset_cache_for_tests()
+    assert len(persona.get_digest()) <= 120
+
+
+def test_get_digest_failsoft_on_resolver_error(monkeypatch):
+    def boom():
+        raise RuntimeError("vault not configured")
+    monkeypatch.setattr(persona, "load_vault_path", boom)
+    persona._reset_cache_for_tests()
+    assert persona.get_digest() is None
+
+
+def test_digest_for_group_scopes_to_primary(monkeypatch, tmp_path):
+    (tmp_path / "Persona").mkdir()
+    (tmp_path / "Persona" / "INDEX.md").write_text(
+        "---\nid: x\n---\n# Persona\n\n## work-style/\n- communication: concise\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(persona, "load_vault_path", lambda: tmp_path)
+    monkeypatch.setattr(persona, "JUDGE_PERSONA_GROUP", "primary")
+    persona._reset_cache_for_tests()
+
+    digest = persona.digest_for_group("primary")
+    assert digest is not None and "concise" in digest
+    assert persona.digest_for_group("other") is None   # cross-user → no leakage
+    assert persona.digest_for_group(None) is None
+
+
+def test_digest_for_group_off_by_default(monkeypatch):
+    monkeypatch.setattr(persona, "JUDGE_PERSONA_GROUP", "")
+    persona._reset_cache_for_tests()
+    assert persona.digest_for_group("anything") is None

--- a/evolution/tests/test_taste_profile.py
+++ b/evolution/tests/test_taste_profile.py
@@ -145,9 +145,9 @@ def test_vault_path_traversal(monkeypatch):
     """Vault path outside home/tmp is rejected."""
     monkeypatch.setenv("DEUS_VAULT_PATH", "/evil")
 
-    from evolution.taste_profile import _load_vault_path
+    from evolution.vault import load_vault_path
     with pytest.raises(ValueError, match="outside allowed prefixes"):
-        _load_vault_path()
+        load_vault_path()
 
 
 def test_vault_path_prefix_collision(monkeypatch):
@@ -155,9 +155,9 @@ def test_vault_path_prefix_collision(monkeypatch):
     home = str(Path.home())
     monkeypatch.setenv("DEUS_VAULT_PATH", home + "-evil/vault")
 
-    from evolution.taste_profile import _load_vault_path
+    from evolution.vault import load_vault_path
     with pytest.raises(ValueError, match="outside allowed prefixes"):
-        _load_vault_path()
+        load_vault_path()
 
 
 def test_consolidation_sentinel_guard(vault_dir, monkeypatch):

--- a/evolution/vault.py
+++ b/evolution/vault.py
@@ -1,0 +1,51 @@
+"""Canonical vault-path resolver for the Evolution loop.
+
+Single source of truth for locating the user's Deus vault on the host. Public-
+repo-safe: NO hardcoded personal path — resolves only from the ``DEUS_VAULT_PATH``
+env var or ``~/.config/deus/config.json``, and raises if neither is configured.
+
+Both ``evolution/taste_profile.py`` and ``evolution/persona.py`` import
+``load_vault_path()`` from here (the logic previously lived only in
+``taste_profile`` as a private ``_load_vault_path``).
+"""
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+def load_vault_path() -> Path:
+    """Resolve the Deus vault path from env or config. Anchored to home or /tmp.
+
+    Resolution order: ``DEUS_VAULT_PATH`` env → ``~/.config/deus/config.json``
+    (``vault_path`` field). Raises ``RuntimeError`` if neither is set and
+    ``ValueError`` if the resolved path escapes the allowed prefixes (home, /tmp,
+    the system tempdir) — a containment guard so a malformed config can't point
+    the loop at an arbitrary filesystem location.
+    """
+    env_path = os.environ.get("DEUS_VAULT_PATH")
+    if env_path:
+        resolved = Path(env_path).expanduser().resolve()
+    elif (Path.home() / ".config" / "deus" / "config.json").exists():
+        config_path = Path.home() / ".config" / "deus" / "config.json"
+        try:
+            with config_path.open() as f:
+                config = json.load(f)
+            resolved = Path(config["vault_path"]).expanduser().resolve()
+        except (json.JSONDecodeError, KeyError) as exc:
+            raise RuntimeError(
+                f"Failed to read vault_path from config.json: {exc}"
+            ) from exc
+    else:
+        raise RuntimeError(
+            "Cannot resolve vault path. Set DEUS_VAULT_PATH or configure "
+            "vault_path in ~/.config/deus/config.json"
+        )
+
+    allowed = (Path.home(), Path("/tmp").resolve(), Path(tempfile.gettempdir()).resolve())
+    if not any(resolved == a or resolved.is_relative_to(a) for a in allowed):
+        raise ValueError(
+            f"Vault path {resolved} is outside allowed prefixes "
+            f"(home {Path.home()} or system temp {tempfile.gettempdir()})"
+        )
+    return resolved

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-06" # auto-bump @1780743524
+last_verified: "2026-06-06" # auto-bump @1780764602
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-06" # auto-bump @1780743524
+last_verified: "2026-06-06" # auto-bump @1780764602
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Problem

The local Evolution judge scores a `personalization` dimension (`recalled_preference` / `format_matched` / `tone_matched`) — but the live caller passed **no context** and the prompt held **no profile**, so the model never saw the user's stored preferences. The dimension was **ungradable by construction**: base `gemma4:e4b` emitted `recalled_preference=false` (→0.0), Gemini guessed `true` (→1.0).

Measured base vs Gemini on a held-out 37 (mlx Q4, the deployment stack): **personalization Pearson −0.138 / MAE 0.782** — a ground-truth artifact, while quality (0.608) and tool_use (0.605) are already fine and safety is degenerate. Those unreliable personalization labels feed the whole evolution loop.

> Measure-first: this was diagnosed empirically before any code. Re-measuring the prior judge-LoRA's motivating gap showed it was a Q8_0/Ollama cross-stack artifact, and the personalization gap is a *labeling* problem, not a model-quality one — so the fix is to make the dimension gradable, **not** to train a model.

## Fix

Inject a compact, **work-style-scoped** persona digest (vault `Persona/INDEX.md`) into the judge prompt:

- **`evolution/persona.py`** — fail-soft loader (`None` on any failure → personalization stays ungraded, no crash), process-cached, **work-style-only** (taste/life/career sections excluded so names/household/employer PII never reach the external Gemini payload), capped at `JUDGE_MAX_PERSONA_CHARS` (default 500).
- **`evolution/vault.py`** — canonical `load_vault_path()` extracted from `taste_profile` (de-dup); env/config-only, **no hardcoded personal path**; home/tmp containment guard.
- **Judge layer** — keyword-only `user_profile` across `base` + 5 impls; the 3 `_build_eval_prompt`s render a distinct `**Known user preferences (stored profile):**` block (gemini incl. its `strict_json` retry path); `mock`/`claude_proxy` accept + ignore.
- **`criteria.py`** — tightened rubric: `recalled_preference=true` only when a **specific listed** preference was applied; all-false when no profile is provided (guards against flipping to Gemini's always-true bias).
- **Both live callers** wired via one helper — `mcp_server.py` (real-time) + `maintenance.py` (batch) — `digest_for_group(group_folder)`, scoped to `DEUS_JUDGE_PERSONA_GROUP` so one group's persona never grades another's interaction.

### Scope guards (deliberate)
- **Opt-in / off by default** — `DEUS_JUDGE_PERSONA_GROUP` is unset by default; no persona is injected for any group until configured.
- **Forward-only** — history is not re-scored (current preferences are anachronistic for old interactions).
- **No model training**, **primary host user only** (per-group persona is future work).

## Verification
- **466 evolution tests pass**, 1 env-skip (19 new persona-injection tests incl. PII-exclusion + char-cap; existing judge/taste/config suites green; `user_profile` kwarg is backward-compatible).
- **Empirical (production path, gemma4:e4b):** personalization goes from **constant 0.0** (without digest) to **varying {0.0, 0.25}** (with digest), rationales grounded in the actual profile ("concise+direct"), **no bias-flip** to always-true, **no PII** in the payload.

## Reviews
- plan-reviewer: **SHIP** (3 rounds — caught a public-repo path leak, an API-surface gap, a missed real-time call site, a duplicate resolver).
- code-reviewer: **SHIP** (3 rounds — caught a Gemini PII leak in the full digest → fixed via work-style scoping + cap; caught real roommate names in a test fixture → genericized).

## Follow-ons (out of scope, tracked)
- **B3 — bench/dataset drift** (separate branch): `bench_judge_lora.py:parse_judge_response` silently returns 0.000 on current-rubric output, and `build_judge_lora_dataset.py` has a target/prompt schema mismatch. Only relevant if judge-tuning is ever revived; documented, not fixed here.
- **Enhancement:** the digest is the `Persona/INDEX.md` work-style one-liners (enough for format/tone grading). Loading `work-style/communication.md` body would strengthen `recalled_preference` grounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)