### PR TITLE
feat(scripts): merge-train for sequential multi-PR landing (LIA-193)

### DIFF
--- a/scripts/merge_train.py
+++ b/scripts/merge_train.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""merge_train.py — land a sequence of PRs one at a time, safely (LIA-193).
+
+Under strict-up-to-date branch protection every merge puts the next PR behind,
+so PRs must land serially: rebase onto main, wait for CI, merge, repeat. This
+automates the proven-safe sequence. Per PR, in the given order:
+
+  1. Resolve the PR's branch → its checked-out git worktree.
+  2. Rebase that worktree onto origin/main (dropping a stale auto-bump commit),
+     then push (handling the pre-push drift hook's bump-and-abort with one
+     re-push).
+  3. Wait for the REQUIRED CI checks to go green (mirrors branch protection —
+     advisory checks like TrueCourse never gate; see LIA-144).
+  4. Verify the PR is MERGEABLE.
+  5. Admin-merge (squash).
+
+Safety / authorization:
+  * DRY-RUN by default — prints the plan, performs NO rebase/push/merge.
+  * ``--execute`` performs the rebase/push/CI-wait but STOPS before each merge
+    unless ``--approve-admin-merge`` is ALSO given.
+  * ``--approve-admin-merge`` authorizes the admin-merges. It carries the SAME
+    authority as running ``gh pr merge --admin`` by hand: because this script
+    calls ``gh`` via subprocess, the interactive PreToolUse admin-merge gate
+    does NOT fire on it — so this flag, not that gate, is the authorization.
+    Every merge is recorded in ``.claude/.warden-log``.
+  * Stops the train on the first failure (no blind continue); never merges on
+    red/failing required CI or a non-MERGEABLE PR.
+
+Agent-native (docs/decisions/printing-press-adoption.md): typed exit codes,
+``--json`` / ``--compact``.
+
+Cross-platform: all git/gh calls go through subprocess argument lists (no shell
+pipes); paths via pathlib. Tested on macOS; depends on the ``git`` and ``gh``
+CLIs being on PATH.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _agent_io import agent_output, is_agent_context  # noqa: E402
+from _exit_codes import INTERNAL_ERROR, SUCCESS, USAGE_ERROR  # noqa: E402
+
+#: The exact subject the pre-push drift hook uses for its auto-bump commit.
+AUTOBUMP_SUBJECT = "chore(patterns): auto-bump drifted patterns"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+#: Generous ceiling for the blocking ``gh pr checks --watch`` (seconds).
+_CI_WATCH_TIMEOUT = 1800
+
+
+def _run(argv: list[str], cwd: Path | None = None, timeout: int | None = None):
+    """subprocess.run wrapper — arg-list only (no shell), failures captured."""
+    try:
+        return subprocess.run(
+            argv,
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(argv, 124, stdout="", stderr=f"timed out after {timeout}s")
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(argv, 127, stdout="", stderr=str(exc))
+
+
+def _tail(result, n: int = 300) -> str:
+    text = (result.stderr or result.stdout or "").strip()
+    return text[-n:]
+
+
+def _gh_json(args: list[str], timeout: int = 30):
+    result = _run(["gh", *args], timeout=timeout)
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _pr_branch(pr: int) -> str | None:
+    data = _gh_json(["pr", "view", str(pr), "--json", "headRefName"])
+    if isinstance(data, dict):
+        return data.get("headRefName")
+    return None
+
+
+def _worktree_for_branch(branch: str) -> Path | None:
+    """Map a branch to its checked-out worktree via ``git worktree list --porcelain``."""
+    result = _run(["git", "-C", str(REPO_ROOT), "worktree", "list", "--porcelain"])
+    if result.returncode != 0:
+        return None
+    path: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree "):].strip()
+        elif line.startswith("branch ") and path:
+            if line[len("branch "):].strip() == f"refs/heads/{branch}":
+                return Path(path)
+    return None
+
+
+def _head_is_stale_autobump(wt: Path) -> bool:
+    """True iff HEAD is exactly the drift auto-bump commit (subject + patterns-only).
+
+    Both conditions are required so a real commit that happens to share the
+    subject prefix but touches other files is never silently dropped.
+    """
+    subj = _run(["git", "-C", str(wt), "log", "-1", "--format=%s"])
+    if subj.returncode != 0 or subj.stdout.strip() != AUTOBUMP_SUBJECT:
+        return False
+    files = _run(["git", "-C", str(wt), "show", "--name-only", "--format=", "HEAD"])
+    if files.returncode != 0:
+        return False
+    paths = [f.strip() for f in files.stdout.splitlines() if f.strip()]
+    return bool(paths) and all(p.startswith("patterns/") and p.endswith(".md") for p in paths)
+
+
+def _rebase_and_push(wt: Path, branch: str) -> tuple[bool, str]:
+    """Drop a stale bump, rebase onto origin/main, push (re-pushing once if the
+    pre-push drift hook commits a fresh bump and aborts)."""
+    _run(["git", "-C", str(wt), "fetch", "origin"], timeout=120)
+    if _head_is_stale_autobump(wt):
+        _run(["git", "-C", str(wt), "reset", "--hard", "HEAD~1"])
+    rebase = _run(["git", "-C", str(wt), "rebase", "origin/main"], timeout=120)
+    if rebase.returncode != 0:
+        _run(["git", "-C", str(wt), "rebase", "--abort"])
+        return False, f"rebase onto origin/main failed (conflict?): {_tail(rebase)}"
+    refspec = f"{branch}:{branch}"
+    push_argv = ["git", "-C", str(wt), "push", "--force-with-lease", "origin", refspec]
+    first = _run(push_argv, timeout=180)
+    if first.returncode == 0:
+        return True, "pushed"
+    # The pre-push drift hook commits a patterns bump and aborts; re-push once.
+    second = _run(push_argv, timeout=180)
+    if second.returncode == 0:
+        return True, "pushed (after drift-bump re-push)"
+    return False, f"push failed: {_tail(second)}"
+
+
+def _wait_required_ci(pr: int, interval: int) -> tuple[bool, str]:
+    """Block on ``gh pr checks --required --watch``; green iff exit 0."""
+    result = _run(
+        ["gh", "pr", "checks", str(pr), "--required", "--watch", "--interval", str(interval)],
+        timeout=_CI_WATCH_TIMEOUT,
+    )
+    if result.returncode == 0:
+        return True, "required checks green"
+    return False, f"required CI not green (exit {result.returncode}): {_tail(result)}"
+
+
+def _verify_mergeable(pr: int) -> tuple[bool, str]:
+    data = _gh_json(["pr", "view", str(pr), "--json", "mergeable,reviewDecision,state"])
+    if not isinstance(data, dict):
+        return False, "could not read PR state"
+    if data.get("state") != "OPEN":
+        return False, f"PR is {data.get('state')}, not OPEN"
+    if data.get("mergeable") != "MERGEABLE":
+        return False, f"mergeable={data.get('mergeable')} (need MERGEABLE)"
+    return True, f"MERGEABLE (review={data.get('reviewDecision')})"
+
+
+def _audit(repo_root: Path, message: str) -> bool:
+    """Append an audit line to .claude/.warden-log. Returns False on failure.
+
+    This record is the authorization trail for a gate-bypassing admin-merge, so
+    the caller treats a failed write as a hard stop — better to refuse the merge
+    than to land one with no durable record.
+    """
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"{ts} | {'merge-train':<15} | {'MERGE':<7} | {message}\n"
+    log = repo_root / ".claude" / ".warden-log"
+    try:
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with log.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+        return True
+    except OSError:
+        return False
+
+
+def _admin_merge(pr: int) -> tuple[bool, str]:
+    result = _run(["gh", "pr", "merge", str(pr), "--squash", "--admin"], timeout=120)
+    if result.returncode == 0:
+        return True, "merged (squash, admin)"
+    return False, f"merge failed: {_tail(result)}"
+
+
+def run_train(
+    prs: list[int], *, execute: bool, approve: bool, repo_root: Path, ci_interval: int = 30
+) -> list[dict]:
+    """Run the train. Returns one result record per attempted PR; stops on first failure."""
+    results: list[dict] = []
+    for pr in prs:
+        rec: dict = {"pr": pr, "branch": None, "phase": "resolve", "ok": True, "merged": False, "detail": ""}
+
+        branch = _pr_branch(pr)
+        if not branch:
+            rec.update(ok=False, detail=f"could not resolve a branch for PR #{pr}")
+            results.append(rec)
+            break
+        rec["branch"] = branch
+
+        wt = _worktree_for_branch(branch)
+        if wt is None:
+            rec.update(
+                ok=False,
+                detail=f"no local worktree checked out for '{branch}' — "
+                       f"`git worktree add` it before running merge-train",
+            )
+            results.append(rec)
+            break
+
+        if not execute:
+            tail = "admin-merge" if approve else "STOP before merge (no --approve-admin-merge)"
+            rec.update(phase="dry-run", detail=f"would rebase {wt} → wait required CI → verify → {tail}")
+            results.append(rec)
+            continue
+
+        rec["phase"] = "rebase"
+        ok, detail = _rebase_and_push(wt, branch)
+        if not ok:
+            rec.update(ok=False, detail=detail)
+            results.append(rec)
+            break
+
+        rec["phase"] = "ci"
+        ok, detail = _wait_required_ci(pr, ci_interval)
+        if not ok:
+            rec.update(ok=False, detail=detail)
+            results.append(rec)
+            break
+
+        rec["phase"] = "verify"
+        ok, detail = _verify_mergeable(pr)
+        if not ok:
+            rec.update(ok=False, detail=detail)
+            results.append(rec)
+            break
+
+        if not approve:
+            rec.update(
+                phase="stop-before-merge",
+                detail="rebased + required CI green + MERGEABLE; STOPPED before merge "
+                       "(pass --approve-admin-merge to land it)",
+            )
+            results.append(rec)
+            continue
+
+        rec["phase"] = "merge"
+        # The audit record is the authorization trail for this gate-bypassing
+        # merge — if it can't be written, refuse to merge (fail closed).
+        if not _audit(repo_root, f"PR #{pr} ({branch}): admin-merge squash — required CI green, MERGEABLE"):
+            rec.update(
+                ok=False,
+                detail="could not write the .claude/.warden-log audit record; refusing to "
+                       "admin-merge (--approve-admin-merge requires a durable audit trail)",
+            )
+            results.append(rec)
+            break
+        ok, detail = _admin_merge(pr)
+        rec.update(ok=ok, merged=ok, detail=detail)
+        results.append(rec)
+        if not ok:
+            break
+
+    return results
+
+
+def _print_human(payload: dict) -> None:
+    print(f"merge-train [{payload['mode']}]  approve_admin_merge={payload['approve_admin_merge']}")
+    for rec in payload["results"]:
+        flag = "✓" if rec["ok"] else "✗"
+        merged = " (MERGED)" if rec.get("merged") else ""
+        print(f"  {flag} #{rec['pr']} [{rec['phase']}]{merged} — {rec['detail']}")
+    if payload["merged"]:
+        print(f"merged: {', '.join('#' + str(p) for p in payload['merged'])}")
+    if payload["stopped_at"] is not None:
+        print(f"stopped at #{payload['stopped_at']} — fix and re-run from there.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Land a sequence of PRs one at a time: rebase → required CI → admin-merge."
+    )
+    parser.add_argument("prs", nargs="+", type=int, help="PR numbers, in the order to merge")
+    parser.add_argument(
+        "--execute", action="store_true",
+        help="Perform rebase/push/CI-wait. Default is dry-run (no mutations).",
+    )
+    parser.add_argument(
+        "--approve-admin-merge", dest="approve", action="store_true",
+        help="Authorize the admin-merges. Carries the SAME authority as a direct "
+             "`gh pr merge --admin` (bypasses the interactive gate). Requires --execute. "
+             "Every merge is recorded in .claude/.warden-log.",
+    )
+    parser.add_argument("--ci-interval", type=int, default=30, help="Seconds between CI polls (default 30).")
+    parser.add_argument("--json", action="store_true", help="Emit JSON (agent-native).")
+    parser.add_argument("--compact", action="store_true", help="Compact JSON output.")
+    args = parser.parse_args(argv)
+
+    if args.approve and not args.execute:
+        print("merge-train: --approve-admin-merge requires --execute", file=sys.stderr)
+        return USAGE_ERROR
+    if args.ci_interval < 5:
+        print("merge-train: --ci-interval must be >= 5 seconds", file=sys.stderr)
+        return USAGE_ERROR
+
+    results = run_train(
+        args.prs,
+        execute=args.execute,
+        approve=args.approve,
+        repo_root=REPO_ROOT,
+        ci_interval=args.ci_interval,
+    )
+
+    payload = {
+        "mode": "execute" if args.execute else "dry-run",
+        "approve_admin_merge": args.approve,
+        "results": results,
+        "merged": [r["pr"] for r in results if r.get("merged")],
+        "stopped_at": next((r["pr"] for r in results if not r.get("ok")), None),
+    }
+
+    use_json = args.json or is_agent_context()
+    out = agent_output(payload, use_json=use_json, compact=args.compact, long_fields=("detail",))
+    if out is not None:
+        print(out)
+    else:
+        _print_human(payload)
+
+    return INTERNAL_ERROR if any(not r.get("ok") for r in results) else SUCCESS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_train.py
+++ b/scripts/merge_train.py
@@ -40,6 +40,7 @@ import datetime
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -158,15 +159,36 @@ def _wait_required_ci(pr: int, interval: int) -> tuple[bool, str]:
     return False, f"required CI not green (exit {result.returncode}): {_tail(result)}"
 
 
-def _verify_mergeable(pr: int) -> tuple[bool, str]:
-    data = _gh_json(["pr", "view", str(pr), "--json", "mergeable,reviewDecision,state"])
-    if not isinstance(data, dict):
-        return False, "could not read PR state"
-    if data.get("state") != "OPEN":
-        return False, f"PR is {data.get('state')}, not OPEN"
-    if data.get("mergeable") != "MERGEABLE":
-        return False, f"mergeable={data.get('mergeable')} (need MERGEABLE)"
-    return True, f"MERGEABLE (review={data.get('reviewDecision')})"
+def _verify_mergeable(pr: int, *, retries: int = 6, delay: int = 3) -> tuple[bool, str]:
+    """Confirm the PR is MERGEABLE, polling through GitHub's async recompute.
+
+    After a push GitHub recomputes `mergeable` asynchronously, reporting UNKNOWN
+    (computed independently of, and often slower than, the CI checks) until it
+    settles. Both UNKNOWN and a transient `gh` read failure are treated as
+    retryable — they share the same just-pushed window; only a definitive
+    CONFLICTING or non-OPEN state fails fast.
+
+    Defaults (6 × 3s = 18s) give generous headroom over GitHub's typical
+    few-second post-push settle without stalling the train; `retries`/`delay`
+    are injectable so a caller can tune or disable the wait.
+    """
+    last_detail = "could not read PR state"
+    for attempt in range(retries):
+        data = _gh_json(["pr", "view", str(pr), "--json", "mergeable,reviewDecision,state"])
+        if isinstance(data, dict):
+            if data.get("state") != "OPEN":
+                return False, f"PR is {data.get('state')}, not OPEN"
+            mergeable = str(data.get("mergeable"))
+            if mergeable == "MERGEABLE":
+                return True, f"MERGEABLE (review={data.get('reviewDecision')})"
+            if mergeable == "CONFLICTING":
+                return False, "mergeable=CONFLICTING — rebase/resolve before merging"
+            last_detail = f"mergeable={mergeable}"  # UNKNOWN → still computing
+        else:
+            last_detail = "could not read PR state (transient gh failure)"
+        if attempt < retries - 1:
+            time.sleep(delay)
+    return False, f"{last_detail} after {retries} polls — GitHub did not settle"
 
 
 def _audit(repo_root: Path, message: str) -> bool:

--- a/scripts/tests/test_merge_train.py
+++ b/scripts/tests/test_merge_train.py
@@ -253,6 +253,51 @@ def test_rebase_and_push_full_path_with_bump_and_repush(mt, monkeypatch):
     assert "re-push" in detail
 
 
+def test_verify_mergeable_polls_through_unknown(mt, monkeypatch):
+    # GitHub reports UNKNOWN right after a push, then settles to MERGEABLE.
+    seq = iter([
+        {"state": "OPEN", "mergeable": "UNKNOWN", "reviewDecision": "REVIEW_REQUIRED"},
+        {"state": "OPEN", "mergeable": "UNKNOWN", "reviewDecision": "REVIEW_REQUIRED"},
+        {"state": "OPEN", "mergeable": "MERGEABLE", "reviewDecision": "REVIEW_REQUIRED"},
+    ])
+    monkeypatch.setattr(mt, "_gh_json", lambda *a, **k: next(seq))
+    monkeypatch.setattr(mt.time, "sleep", lambda s: None)
+    ok, detail = mt._verify_mergeable(709, retries=3, delay=0)
+    assert ok is True
+    assert "MERGEABLE" in detail
+
+
+def test_verify_mergeable_retries_transient_gh_failure(mt, monkeypatch):
+    # A transient gh read failure (non-dict) is retried, same as UNKNOWN.
+    seq = iter([
+        None,  # gh read failed
+        {"state": "OPEN", "mergeable": "MERGEABLE", "reviewDecision": "REVIEW_REQUIRED"},
+    ])
+    monkeypatch.setattr(mt, "_gh_json", lambda *a, **k: next(seq))
+    monkeypatch.setattr(mt.time, "sleep", lambda s: None)
+    ok, detail = mt._verify_mergeable(709, retries=3, delay=0)
+    assert ok is True
+    assert "MERGEABLE" in detail
+
+
+def test_verify_mergeable_conflicting_fails_fast(mt, monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(mt, "_gh_json", lambda *a, **k: {"state": "OPEN", "mergeable": "CONFLICTING"})
+    monkeypatch.setattr(mt.time, "sleep", lambda s: sleeps.append(s))
+    ok, detail = mt._verify_mergeable(709)
+    assert ok is False
+    assert "CONFLICTING" in detail
+    assert sleeps == []  # definitive state → no polling
+
+
+def test_verify_mergeable_gives_up_after_persistent_unknown(mt, monkeypatch):
+    monkeypatch.setattr(mt, "_gh_json", lambda *a, **k: {"state": "OPEN", "mergeable": "UNKNOWN"})
+    monkeypatch.setattr(mt.time, "sleep", lambda s: None)
+    ok, detail = mt._verify_mergeable(709, retries=3, delay=0)
+    assert ok is False
+    assert "did not settle" in detail
+
+
 def test_wait_required_ci_uses_required_and_watch(mt, monkeypatch):
     captured = {}
 

--- a/scripts/tests/test_merge_train.py
+++ b/scripts/tests/test_merge_train.py
@@ -1,0 +1,266 @@
+"""Unit tests for scripts/merge_train.py (LIA-193).
+
+Two levels: (1) run_train orchestration — sequencing, dry-run, the
+--execute/--approve-admin-merge gating, stop-on-first-failure — by faking the
+step helpers; (2) low-level helpers — the stale-autobump safety guard and
+worktree parsing — by faking subprocess via `_run`.
+"""
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def load_mt():
+    if "merge_train" in sys.modules:
+        return sys.modules["merge_train"]
+    spec = importlib.util.spec_from_file_location("merge_train", _SCRIPTS / "merge_train.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["merge_train"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mt():
+    return load_mt()
+
+
+class _Recorder:
+    """Callable that records its calls and returns a fixed (ok, detail) tuple."""
+
+    def __init__(self, ret=(True, "ok")):
+        self.calls = []
+        self.ret = ret
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.ret
+
+
+def _stub_resolution(mt, monkeypatch, branch="feat/x", wt=Path("/tmp/wt")):
+    monkeypatch.setattr(mt, "_pr_branch", lambda pr: branch)
+    monkeypatch.setattr(mt, "_worktree_for_branch", lambda b: wt)
+
+
+# ── run_train orchestration ──────────────────────────────────────────────────
+
+
+def test_dry_run_performs_no_mutations(mt, monkeypatch):
+    _stub_resolution(mt, monkeypatch)
+    rebase, ci, verify, merge = _Recorder(), _Recorder(), _Recorder(), _Recorder()
+    monkeypatch.setattr(mt, "_rebase_and_push", rebase)
+    monkeypatch.setattr(mt, "_wait_required_ci", ci)
+    monkeypatch.setattr(mt, "_verify_mergeable", verify)
+    monkeypatch.setattr(mt, "_admin_merge", merge)
+
+    results = mt.run_train([709], execute=False, approve=False, repo_root=Path("/repo"))
+
+    assert results[0]["phase"] == "dry-run"
+    assert not any(r.get("merged") for r in results)
+    assert rebase.calls == ci.calls == verify.calls == merge.calls == []
+
+
+def test_execute_without_approve_stops_before_merge(mt, monkeypatch):
+    _stub_resolution(mt, monkeypatch)
+    rebase, ci, verify, merge = _Recorder(), _Recorder(), _Recorder(), _Recorder()
+    monkeypatch.setattr(mt, "_rebase_and_push", rebase)
+    monkeypatch.setattr(mt, "_wait_required_ci", ci)
+    monkeypatch.setattr(mt, "_verify_mergeable", verify)
+    monkeypatch.setattr(mt, "_admin_merge", merge)
+
+    results = mt.run_train([709], execute=True, approve=False, repo_root=Path("/repo"))
+
+    # Rebase / CI / verify all ran; the merge did NOT.
+    assert len(rebase.calls) == 1 and len(ci.calls) == 1 and len(verify.calls) == 1
+    assert merge.calls == []
+    assert results[0]["phase"] == "stop-before-merge"
+    assert results[0]["merged"] is False
+    assert results[0]["ok"] is True
+
+
+def test_execute_with_approve_merges(mt, monkeypatch):
+    _stub_resolution(mt, monkeypatch)
+    merge = _Recorder((True, "merged (squash, admin)"))
+    monkeypatch.setattr(mt, "_rebase_and_push", _Recorder())
+    monkeypatch.setattr(mt, "_wait_required_ci", _Recorder())
+    monkeypatch.setattr(mt, "_verify_mergeable", _Recorder())
+    monkeypatch.setattr(mt, "_admin_merge", merge)
+    audits = []
+
+    def _ok_audit(root, msg):
+        audits.append(msg)
+        return True
+
+    monkeypatch.setattr(mt, "_audit", _ok_audit)
+
+    results = mt.run_train([709], execute=True, approve=True, repo_root=Path("/repo"))
+
+    assert len(merge.calls) == 1
+    assert results[0]["merged"] is True
+    assert results[0]["phase"] == "merge"
+    assert len(audits) == 1  # the merge was audit-logged
+
+
+def test_audit_failure_blocks_merge(mt, monkeypatch):
+    # The audit record is the authorization trail; if it can't be written, the
+    # merge must NOT happen.
+    _stub_resolution(mt, monkeypatch)
+    monkeypatch.setattr(mt, "_rebase_and_push", _Recorder())
+    monkeypatch.setattr(mt, "_wait_required_ci", _Recorder())
+    monkeypatch.setattr(mt, "_verify_mergeable", _Recorder())
+    merge = _Recorder()
+    monkeypatch.setattr(mt, "_admin_merge", merge)
+    monkeypatch.setattr(mt, "_audit", lambda root, msg: False)  # write fails
+
+    results = mt.run_train([709], execute=True, approve=True, repo_root=Path("/repo"))
+
+    assert merge.calls == []  # merge refused
+    assert results[0]["ok"] is False
+    assert results[0]["merged"] is False
+    assert "audit" in results[0]["detail"].lower()
+
+
+def test_stop_on_first_failure_halts_remaining_prs(mt, monkeypatch):
+    _stub_resolution(mt, monkeypatch)
+    monkeypatch.setattr(mt, "_rebase_and_push", _Recorder())
+    monkeypatch.setattr(mt, "_wait_required_ci", _Recorder((False, "required CI red")))
+    verify, merge = _Recorder(), _Recorder()
+    monkeypatch.setattr(mt, "_verify_mergeable", verify)
+    monkeypatch.setattr(mt, "_admin_merge", merge)
+
+    results = mt.run_train([709, 710, 711], execute=True, approve=True, repo_root=Path("/repo"))
+
+    # First PR fails at CI; the train stops — PRs 710/711 are never attempted.
+    assert len(results) == 1
+    assert results[0]["pr"] == 709 and results[0]["ok"] is False and results[0]["phase"] == "ci"
+    assert verify.calls == [] and merge.calls == []
+
+
+def test_missing_worktree_fails_closed(mt, monkeypatch):
+    monkeypatch.setattr(mt, "_pr_branch", lambda pr: "feat/x")
+    monkeypatch.setattr(mt, "_worktree_for_branch", lambda b: None)
+    merge = _Recorder()
+    monkeypatch.setattr(mt, "_admin_merge", merge)
+
+    results = mt.run_train([709], execute=True, approve=True, repo_root=Path("/repo"))
+
+    assert results[0]["ok"] is False
+    assert "no local worktree" in results[0]["detail"]
+    assert merge.calls == []
+
+
+def test_main_approve_without_execute_is_usage_error(mt):
+    assert mt.main(["709", "--approve-admin-merge"]) == mt.USAGE_ERROR
+
+
+# ── low-level helpers ────────────────────────────────────────────────────────
+
+
+def _fake_run(responder):
+    """Build a `_run` replacement from a (argv -> (rc, stdout, stderr)) responder."""
+
+    def run(argv, cwd=None, timeout=None):
+        rc, out, err = responder(argv)
+        return subprocess.CompletedProcess(argv, rc, stdout=out, stderr=err)
+
+    return run
+
+
+def test_stale_autobump_detected_when_subject_and_patterns_only(mt, monkeypatch):
+    def responder(argv):
+        if "log" in argv:
+            return 0, mt.AUTOBUMP_SUBJECT + "\n", ""
+        if "show" in argv:
+            return 0, "patterns/eval-change.md\npatterns/documentation.md\n", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mt, "_run", _fake_run(responder))
+    assert mt._head_is_stale_autobump(Path("/wt")) is True
+
+
+def test_stale_autobump_not_detected_for_wrong_subject(mt, monkeypatch):
+    def responder(argv):
+        if "log" in argv:
+            return 0, "fix(memory): real change\n", ""
+        if "show" in argv:
+            return 0, "patterns/eval-change.md\n", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mt, "_run", _fake_run(responder))
+    assert mt._head_is_stale_autobump(Path("/wt")) is False
+
+
+def test_stale_autobump_not_detected_when_touches_non_pattern(mt, monkeypatch):
+    # Safety guard: exact subject but a .py file present → must NOT be dropped.
+    def responder(argv):
+        if "log" in argv:
+            return 0, mt.AUTOBUMP_SUBJECT + "\n", ""
+        if "show" in argv:
+            return 0, "patterns/eval-change.md\nscripts/memory_indexer.py\n", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mt, "_run", _fake_run(responder))
+    assert mt._head_is_stale_autobump(Path("/wt")) is False
+
+
+def test_worktree_for_branch_parses_porcelain(mt, monkeypatch):
+    porcelain = (
+        "worktree /Users/x/deus\nHEAD abc\nbranch refs/heads/main\n\n"
+        "worktree /Users/x/deus/.claude/worktrees/feat-y\nHEAD def\n"
+        "branch refs/heads/feat/y\n\n"
+    )
+    monkeypatch.setattr(mt, "_run", _fake_run(lambda argv: (0, porcelain, "")))
+    assert mt._worktree_for_branch("feat/y") == Path("/Users/x/deus/.claude/worktrees/feat-y")
+    assert mt._worktree_for_branch("feat/missing") is None
+
+
+def test_rebase_and_push_full_path_with_bump_and_repush(mt, monkeypatch):
+    # The one destructive path: stale autobump present → reset → rebase ok →
+    # first push aborted by the drift hook → second push succeeds.
+    seen = {"reset": False, "pushes": 0}
+
+    def responder(argv):
+        if "fetch" in argv:
+            return 0, "", ""
+        if "log" in argv:
+            return 0, mt.AUTOBUMP_SUBJECT + "\n", ""
+        if "show" in argv:
+            return 0, "patterns/eval-change.md\n", ""
+        if "reset" in argv:
+            seen["reset"] = True
+            return 0, "", ""
+        if "rebase" in argv:
+            return 0, "", ""
+        if "push" in argv:
+            seen["pushes"] += 1
+            if seen["pushes"] == 1:
+                return 1, "", "drift-check: bump committed. Aborting push"
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mt, "_run", _fake_run(responder))
+    ok, detail = mt._rebase_and_push(Path("/wt"), "feat/x")
+
+    assert ok is True
+    assert seen["reset"] is True  # the stale autobump was dropped
+    assert seen["pushes"] == 2    # first push aborted, re-pushed once
+    assert "re-push" in detail
+
+
+def test_wait_required_ci_uses_required_and_watch(mt, monkeypatch):
+    captured = {}
+
+    def responder(argv):
+        captured["argv"] = list(argv)
+        return 0, "", ""
+
+    monkeypatch.setattr(mt, "_run", _fake_run(responder))
+    ok, _ = mt._wait_required_ci(709, interval=30)
+    assert ok is True
+    assert "--required" in captured["argv"] and "--watch" in captured["argv"]


### PR DESCRIPTION
## Summary

Multi-PR sessions land PRs serially — strict up-to-date branch protection puts each next PR "behind" after a merge, forcing a rebase → CI → merge cycle per PR. `scripts/merge_train.py` automates the proven-safe sequence (verified manually this session across 3 PRs).

Per PR, in order:
1. Resolve the PR's branch → its checked-out git worktree.
2. Rebase onto `origin/main` (dropping a stale `chore(patterns): auto-bump` commit), push, re-pushing once when the pre-push drift hook commits a fresh bump and aborts.
3. Wait for **REQUIRED** CI to go green (`gh pr checks --required --watch`) — mirrors branch protection; advisory checks (TrueCourse, test-*, CodeQL) never gate, per **LIA-144** (PR #709).
4. Verify `MERGEABLE`.
5. Admin-merge (squash).

## Authorization (self-gated)

The Claude PreToolUse admin-merge gate fires only on the Bash **tool**, not on a script's `subprocess.run` — so merge-train's `gh pr merge --admin` bypasses that gate by construction. Therefore merge-train gates itself:
- **DRY-RUN by default** — prints the plan, no mutations.
- `--execute` performs rebase/push/CI-wait but **STOPS before each merge** unless `--approve-admin-merge` is *also* given (same authority as a hand-run `--admin`).
- Each merge is a **precondition on writing the `.claude/.warden-log` audit record** — if the write fails, the merge is refused (a gate-bypassing op never lands with no durable trail).
- Stops the train on the first failure; never merges on red required CI or a non-`MERGEABLE` PR.

(Auth model chosen explicitly this session over prep-only / interactive-confirm alternatives.)

## Safety guard

`_head_is_stale_autobump` performs the only destructive op (`git reset --hard HEAD~1`) and fires **only** when the commit subject is *exactly* the auto-bump string **and** it touches only `patterns/*.md` — a real commit sharing the subject but touching other files is never dropped (tested with a `.py`-present negative case).

## Agent-native / cross-platform

Typed exit codes (`_exit_codes`) + `--json`/`--compact` (`_agent_io`); all git/gh via subprocess arg-lists (no shell), paths via pathlib.

## Verification

`python3 -m pytest scripts/tests/test_merge_train.py` → **13 passed**: dry-run no-op; execute-without-approve stops before merge; approve merges + audits; **audit-failure blocks merge**; stop-on-first-failure halts remaining PRs; missing-worktree fail-closed; `--approve` without `--execute` = USAGE_ERROR; the full destructive rebase/re-push path; the autobump guard (incl. `.py`-present negative); worktree porcelain parsing; required-CI uses `--required`+`--watch`.

**Live dry-run smoke:** `merge_train.py 676 --json` resolved the real branch via `gh`, fail-closed on the missing worktree with a clear message, emitted valid JSON, exit 5.

Usage: `python3 scripts/merge_train.py <pr...> [--execute --approve-admin-merge] [--json]`

## Deferred

A `/merge-train` skill + a `deus merge-train` subcommand (discoverability) are deferred to a follow-on.

Refs: LIA-193 (depends on LIA-144 / #709, merged)