### PR TITLE
fix(code-search): key index to canonical repo root from worktrees (LIA-189)

### DIFF
--- a/scripts/code_search.py
+++ b/scripts/code_search.py
@@ -51,12 +51,45 @@ EMBED_DIM = 768
 DB_PATH = Path("~/.deus/code_search.db").expanduser()
 
 
+def _main_worktree_root(root: Path) -> Path:
+    """Map a linked git worktree (``.git`` is a *file*) to its canonical main-repo
+    root, so the code-search DB keys to a stable path instead of the ephemeral
+    worktree that strands the index on cleanup (LIA-189). No-op for the main
+    worktree, a non-git dir, a submodule, or any git failure.
+    """
+    if not (root / ".git").is_file():
+        return root  # main worktree (.git dir) or non-git — nothing to normalize
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return root
+    out = proc.stdout.strip()
+    if proc.returncode != 0 or not out:
+        return root
+    common = Path(out)
+    common = common.resolve() if common.is_absolute() else (root / common).resolve()
+    # A worktree's common dir is "<main>/.git" → its parent is the canonical
+    # root. Exclude submodules (common dir basename != ".git").
+    if common.name != ".git":
+        return root
+    main_root = common.parent
+    return main_root if main_root.is_dir() else root
+
+
 def _project_root(start: Path | str | None = None) -> Path | None:
-    """Nearest .git/.deus ancestor of ``start`` (default cwd); None if neither."""
+    """Nearest .git/.deus ancestor of ``start`` (default cwd); None if neither.
+
+    A linked git worktree ancestor is normalized to its canonical main-repo root
+    (:func:`_main_worktree_root`) so every consumer — :func:`_resolve_db_path`
+    and :func:`_migrate_legacy_if_match` — keys to one stable per-project DB
+    regardless of which worktree the call ran in (LIA-189)."""
     p = Path(start).resolve() if start is not None else Path.cwd().resolve()
     for candidate in (p, *p.parents):
         if (candidate / ".git").exists() or (candidate / ".deus").exists():
-            return candidate
+            return _main_worktree_root(candidate)
     return None
 
 
@@ -452,6 +485,10 @@ def _init_db(db_path: Path | None = None) -> sqlite3.Connection:
     path = db_path or DB_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     db = sqlite3.connect(str(path))
+    # busy_timeout before WAL so create-time writes are covered: post-LIA-189 all
+    # worktrees share one canonical DB, so concurrent post-commit reindexes can
+    # collide — wait for the lock instead of failing (default 0 → SQLITE_BUSY).
+    db.execute("PRAGMA busy_timeout=30000")
     db.execute("PRAGMA journal_mode=WAL")
     db.execute("PRAGMA synchronous=NORMAL")
     if sqlite_vec is not None:
@@ -677,9 +714,12 @@ def reindex(directory: str, diff_ref: str | None = None) -> dict[str, Any]:
         "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)",
         ("last_indexed_at", time.strftime("%Y-%m-%dT%H:%M:%S")),
     )
+    # Label with the canonical project root (LIA-189), not the literal walked
+    # dir: it must agree with the DB key (also canonical) and never become a
+    # dead worktree pointer. base stays the discovery/--diff source.
     db.execute(
         "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)",
-        ("indexed_directory", str(base)),
+        ("indexed_directory", str(_project_root(base) or base)),
     )
 
     # Auto-populate calibration distribution if missing (needed for retrieval_confidence)
@@ -917,15 +957,28 @@ def status() -> dict[str, Any]:
     db_size = dbp.stat().st_size
     db.close()
 
-    return {
+    directory_val = directory[0] if directory else None
+    # A stored indexed_directory that no longer exists signals a stale/broken
+    # index (e.g. a pre-fix index keyed to a since-deleted worktree, LIA-189) —
+    # surface it loudly instead of silently degrading callers to grep.
+    stale = bool(directory_val) and not Path(directory_val).expanduser().exists()
+
+    result: dict[str, Any] = {
         "indexed": True,
         "total_chunks": total,
         "embedded_chunks": embedded,
         "files": files,
         "last_indexed": last[0] if last else "never",
-        "directory": directory[0] if directory else "unknown",
+        "directory": directory_val or "unknown",
         "db_size_mb": round(db_size / 1024 / 1024, 2),
+        "stale": stale,
     }
+    if stale:
+        result["message"] = (
+            f"indexed_directory {directory_val!r} no longer exists — "
+            "index may be stale; re-run reindex"
+        )
+    return result
 
 
 # ── Fixture Generation ────────────────────────────────────────────────────────

--- a/scripts/tests/test_code_search_resolver.py
+++ b/scripts/tests/test_code_search_resolver.py
@@ -11,14 +11,50 @@ These tests self-isolate (the repo conftest only patches `memory_tree`, not
 from __future__ import annotations
 
 import hashlib
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 _SCRIPTS = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 import code_search  # noqa: E402
+
+_GIT = shutil.which("git")
+_needs_git = pytest.mark.skipif(_GIT is None, reason="git not available")
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run a git command with a hermetic identity (no global/system config)."""
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+    subprocess.run(
+        [_GIT, *args], cwd=str(cwd), env=env,
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _make_main_and_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A real main repo (one commit) + a linked worktree. Returns resolved roots."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-q")
+    (main / "f.txt").write_text("x")
+    _git(main, "add", "f.txt")
+    _git(main, "commit", "-q", "-m", "init")
+    wt = tmp_path / "wt"
+    _git(main, "worktree", "add", "-q", str(wt), "-b", "feature")
+    return main.resolve(), wt.resolve()
 
 
 def _expected_per_project(home: Path, root: Path) -> Path:
@@ -131,3 +167,95 @@ def test_legacy_migration_noop_when_no_legacy(monkeypatch, tmp_path):
     dbp = tmp_path / "pp" / "code_search.db"
     code_search._migrate_legacy_if_match((tmp_path / "proj").resolve(), dbp)
     assert not dbp.exists()
+
+
+# ── LIA-189: linked worktree normalizes to the canonical main-repo root ───────
+
+@_needs_git
+def test_worktree_keys_to_main_root(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEUS_CODE_SEARCH_DB", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    main, wt = _make_main_and_worktree(tmp_path)
+
+    # the worktree resolves to the canonical main root, not its own path
+    assert code_search._main_worktree_root(wt) == main
+    assert code_search._project_root(wt) == main
+    # → the per-project DB is keyed by the MAIN digest, not the worktree's
+    assert code_search._resolve_db_path(wt) == _expected_per_project(home, main)
+    assert code_search._resolve_db_path(wt) != _expected_per_project(home, wt)
+
+
+@_needs_git
+def test_main_worktree_root_noop(tmp_path):
+    main, _wt = _make_main_and_worktree(tmp_path)
+    # main worktree (.git is a dir) → unchanged
+    assert code_search._main_worktree_root(main) == main
+    # plain non-git dir → unchanged
+    nogit = tmp_path / "plain"
+    nogit.mkdir()
+    assert code_search._main_worktree_root(nogit) == nogit
+
+
+@_needs_git
+def test_main_worktree_root_submodule_noop(tmp_path):
+    """A submodule's .git is also a *file*, but its common dir is
+    <super>/.git/modules/<name> (basename != '.git') — must NOT normalize to a
+    parent, or it would key the submodule to a garbage path."""
+    main, _wt = _make_main_and_worktree(tmp_path)
+    sub_src = tmp_path / "sub_src"
+    sub_src.mkdir()
+    _git(sub_src, "init", "-q")
+    (sub_src / "g.txt").write_text("y")
+    _git(sub_src, "add", "g.txt")
+    _git(sub_src, "commit", "-q", "-m", "sub init")
+    # local-path submodule add needs protocol.file.allow=always on modern git
+    _git(main, "-c", "protocol.file.allow=always", "submodule", "add", str(sub_src), "sub")
+    submod = (main / "sub").resolve()
+    assert (submod / ".git").is_file()  # confirm the submodule marker shape
+    assert code_search._main_worktree_root(submod) == submod  # no-op, not normalized
+
+
+@_needs_git
+def test_read_path_from_worktree_cwd(monkeypatch, tmp_path):
+    """The user-visible win: search()/status()/MCP read path call _resolve_db_path()
+    with NO arg (cwd-based). From inside a worktree it must key to canonical."""
+    monkeypatch.delenv("DEUS_CODE_SEARCH_DB", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    main, wt = _make_main_and_worktree(tmp_path)
+    sub = wt / "a" / "b"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+    assert code_search._resolve_db_path() == _expected_per_project(home, main)
+
+
+# ── LIA-189: status() surfaces a stale (missing) indexed_directory ────────────
+
+def _seed_status_db(db_path: Path, indexed_directory: str) -> None:
+    db = code_search._init_db(db_path)
+    db.execute(
+        "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('indexed_directory', ?)",
+        (indexed_directory,),
+    )
+    db.commit()
+    db.close()
+
+
+def test_status_stale_flag_when_directory_missing(monkeypatch, tmp_path):
+    db_path = tmp_path / "cs.db"
+    monkeypatch.setenv("DEUS_CODE_SEARCH_DB", str(db_path))
+    _seed_status_db(db_path, str(tmp_path / "deleted-worktree"))
+    result = code_search.status()
+    assert result["indexed"] is True
+    assert result["stale"] is True
+    assert "message" in result
+
+
+def test_status_not_stale_when_directory_exists(monkeypatch, tmp_path):
+    db_path = tmp_path / "cs.db"
+    monkeypatch.setenv("DEUS_CODE_SEARCH_DB", str(db_path))
+    _seed_status_db(db_path, str(tmp_path))  # tmp_path exists
+    result = code_search.status()
+    assert result["stale"] is False
+    assert "message" not in result


### PR DESCRIPTION
## Problem (LIA-189)

`code_search.py` keys each project's semantic-search DB by `md5(realpath of the nearest .git/.deus ancestor)` → `~/.config/deus/projects/<digest>/code_search.db`. Inside a **linked git worktree** the nearest `.git` is the worktree's *ephemeral* path, so the index keys to a directory that evaporates on worktree cleanup — leaving the canonical repo unindexed and `search_code` silently degrading to grep.

Verified: the legacy global DB stored `indexed_directory = .../.claude/worktrees/event-hub-phase1-step2-cutover` (a deleted worktree). The trigger is automated and recurring — `.husky/post-commit` runs `code_search.py reindex "$(git rev-parse --show-toplevel)" --diff HEAD~1 &` on every commit, and `--show-toplevel` resolves to the worktree.

## Fix

- **`_main_worktree_root()`** — maps a linked worktree (`.git` is a *file*) to its canonical main-repo root via `git rev-parse --git-common-dir`. Guarded to `common.name == ".git"` (excludes submodules, whose common dir is `<super>/.git/modules/<name>`); fail-safe to a no-op on any non-git / git failure. No git-version dependency.
- **`_project_root()`** funnels through it, so `_resolve_db_path` and `_migrate_legacy_if_match` both key to one stable per-project DB regardless of which worktree the call ran in.
- **`_init_db()`**: `PRAGMA busy_timeout=30000` as the first statement after `connect()` (before WAL). Consolidating to one canonical DB means concurrent background post-commit reindexes from different worktrees now share it — they serialize on the write lock instead of failing immediately with `SQLITE_BUSY`.
- **`reindex()`**: label `indexed_directory` with the canonical root (agrees with the DB key, never a dead pointer). File discovery + `--diff` stay on the walked dir.
- **`status()`**: add a `stale` flag (+ message) when the stored `indexed_directory` no longer exists, so a broken/legacy index surfaces loudly instead of degrading to grep.

## Tradeoff (decided)

One canonical DB means **last-writer-wins per file across diverging branches** (chunks key by relative `file_path` with soft-delete-then-insert). Chosen: mixed-but-fresh over per-branch isolation — semantic search is fuzzy ranked retrieval to *locate* code, and an always-present index beats the per-worktree fragmentation (which also evaporates) this fixes.

## Verification

- 14/14 resolver tests pass (`scripts/tests/test_code_search_resolver.py`), incl. 6 new cases using a **real** `git init` + `git worktree add` + `git submodule add` (skip when git absent).
- Live: `_resolve_db_path(<worktree>)` → the canonical `~/deus` digest; `status` from a worktree reads the real `~/deus` index with `stale: false`.
- No Rust/TS consumer strictly deserializes status JSON (only `code_search_mcp.py` `json.dumps`); the 38 unrelated failures in the full suite are pre-existing on clean `main`.

## Out of scope

No `.husky` hook change; no file-discovery redirect (would break the incremental `--diff`); no flock (busy_timeout covers the realistic collision); legacy global DB stays orphaned per `no-db-deletion.md`.

Closes LIA-189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)