### PR TITLE
feat(integrations): add Odysseus curated-memory MCP bridge

### DIFF
--- a/integrations/odysseus/.gitignore
+++ b/integrations/odysseus/.gitignore
@@ -1,0 +1,6 @@
+# Local config with absolute host paths — never commit.
+.env
+
+# Local build artifacts, if any are produced here.
+*.db
+__pycache__/

--- a/integrations/odysseus/Dockerfile
+++ b/integrations/odysseus/Dockerfile
@@ -1,0 +1,26 @@
+# Deus curated-memory MCP sidecar for Odysseus.
+# Standalone image — does NOT mirror container/Dockerfile (that's the Node agent
+# image). All this needs is Python + mcp + sqlite-vec.
+FROM python:3.11-slim
+
+# mcp: the MCP server framework (FastMCP). sqlite-vec: native vector extension.
+RUN pip install --no-cache-dir "mcp>=1.27" sqlite-vec
+
+# Build-time verification: importing sqlite_vec is NOT enough — it succeeds even
+# when extension loading is disabled, then fails at query time. Exercise the
+# FULL load sequence so a broken image fails the build, not a user's recall.
+RUN python -c "import sqlite3, sqlite_vec; \
+c = sqlite3.connect(':memory:'); \
+c.enable_load_extension(True); \
+sqlite_vec.load(c); \
+print('vec_version:', c.execute('SELECT vec_version()').fetchone()[0]); \
+import mcp; print('mcp ok')"
+
+WORKDIR /app
+COPY _embed.py share_mcp_server.py /app/
+
+# Mounted read-only at runtime; declared so the path exists if no mount is given.
+VOLUME ["/data"]
+EXPOSE 8200
+
+CMD ["python", "share_mcp_server.py"]

--- a/integrations/odysseus/README.md
+++ b/integrations/odysseus/README.md
@@ -1,0 +1,88 @@
+# Odysseus ↔ Deus integration
+
+Connects [Odysseus](https://github.com/pewdiepie-archdaemon/odysseus) (a
+self-hosted AI workspace) with Deus, in two independent directions.
+
+## ① Odysseus → Deus curated memory (this directory)
+
+A small read-only MCP **sidecar** that lets the Odysseus web agent recall a
+**curated subset** of your Deus memory. The sidecar runs in its own container on
+Odysseus's Docker network and mounts only a pre-built index — it has no vault
+access and imports no Deus code.
+
+### Security model — read this first
+
+The Odysseus agent is prompt-injectable and (per Odysseus's own `THREAT_MODEL.md`)
+runs with **no shell/filesystem sandbox**. Anything reachable through `recall`
+can, in principle, be surfaced and exfiltrated by a successful injection (e.g. a
+poisoned page during Deep Research). No transport or auth removes this risk.
+
+Mitigations built into this design:
+- **Curated, pre-baked index.** Only files you place in the vault `Shareable/`
+  folder are indexed. The sidecar physically cannot read anything else.
+- **Read-only, single tool.** `recall` only searches; it cannot write or delete.
+- **Network-internal only.** No host port; reachable only as `deus-memory` on
+  `odysseus_default`.
+- **Audit log.** Every query is appended to a host-side log so you can review
+  what was asked after the fact.
+
+**Your job: keep `Shareable/` conservative.** Treat everything in it as visible
+to Odysseus.
+
+### Setup
+
+```bash
+# 0. One-time: curate. Create the folder and add only non-sensitive notes.
+mkdir -p "$(python3 scripts/memory_tree.py vault 2>/dev/null)/Shareable"   # or wherever your vault is
+
+# 1. Build the curated index (run in the Deus venv; needs Ollama running).
+python integrations/odysseus/build_share_index.py
+
+# 2. Configure paths.
+cd integrations/odysseus
+cp .env.example .env            # then edit: set DEUS_SHARE_DB_PATH + DEUS_RECALL_LOG
+touch "$DEUS_RECALL_LOG"        # create the log file so Docker mounts a file, not a dir
+
+# 3. Start the sidecar on Odysseus's network.
+docker compose up -d --build
+
+# 4. Register in Odysseus: Settings → MCP → Add server
+#      transport: http   url: http://deus-memory:8200/mcp   name: deus-memory
+```
+
+Re-run step 1 whenever you change `Shareable/` — the index is a snapshot. The
+index is stamped with the embedding model it was built with; the sidecar refuses
+to serve recalls if the configured model later differs (rebuild to fix).
+
+> **Operational note (by design, not pending work):** step 4 — registering the
+> MCP server in Odysseus — is a **permanent one-time manual** admin action. It is
+> not deferred wiring awaiting automation: Odysseus is a separately-managed
+> third-party app, so Deus deliberately never writes to its config. There is
+> intentionally no Deus runtime hook for it. Treat it as a setup step, like
+> adding any MCP server in Odysseus's own UI.
+
+### Teardown / rollback
+
+```bash
+docker compose down                    # stop the sidecar
+# In Odysseus: Settings → MCP → remove "deus-memory" (or DELETE /api/servers/<id>)
+```
+
+## ② Deus terminal → Odysseus
+
+Host-side Claude Code can drive Odysseus (todos, calendar, memory, documents,
+read-only email) through Odysseus's scoped `/api/codex/*` API. That wiring lives
+in host config (`~/.claude/skills/odysseus/` + `~/.deus/odysseus.env`), not in
+this repo, because it contains a personal API token. See the project notes for
+the Deus-authored skill; it uses only a thin curl wrapper, no upstream code.
+
+## Files
+
+| File | Role |
+|------|------|
+| `_embed.py` | Shared Ollama embedder (stdlib-only, no Deus imports). |
+| `build_share_index.py` | Host ETL: `Shareable/*.md` → self-contained sqlite-vec DB. |
+| `share_mcp_server.py` | The sidecar: one read-only `recall` MCP tool. |
+| `Dockerfile` | `python:3.11-slim` + `mcp` + `sqlite-vec`, with full load-sequence verify. |
+| `docker-compose.yml` | Runs the sidecar on `odysseus_default`, no host port. |
+| `.env.example` | Template for the gitignored `.env` (absolute host paths). |

--- a/integrations/odysseus/_embed.py
+++ b/integrations/odysseus/_embed.py
@@ -1,0 +1,90 @@
+"""Shared Ollama embedder for the Odysseus curated-memory bridge.
+
+Used by BOTH the build-time indexer (``build_share_index.py``) and the runtime
+sidecar (``share_mcp_server.py``) so query vectors and stored vectors are
+produced by the exact same code path — guaranteeing parity.
+
+Deliberately stdlib-only and self-contained: it does NOT import any Deus
+package. That keeps the Docker sidecar image tiny and, more importantly, means
+the sidecar never imports code that could reach the vault or other databases.
+It only knows how to turn text into a 768-dim vector via Ollama.
+
+API shape mirrors Deus production (``evolution/providers/embeddings.py``):
+    POST {OLLAMA_HOST}/api/embed
+    body  {"model": "embeddinggemma", "input": [text], "keep_alive": "30m"}
+    resp  {"embeddings": [[float, ... 768]]}   # read ["embeddings"][0]
+Vectors are normalized to EMBED_DIM (truncate if longer, zero-pad if shorter),
+identical to the production ``_normalize_vec``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+EMBED_DIM = 768
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+OLLAMA_EMBED_MODEL = os.environ.get("OLLAMA_EMBED_MODEL", "embeddinggemma")
+OLLAMA_EMBED_KEEP_ALIVE = os.environ.get("OLLAMA_EMBED_KEEP_ALIVE", "30m")
+_TIMEOUT = float(os.environ.get("OLLAMA_EMBED_TIMEOUT", "60"))
+
+
+def _normalize_vec(vec: list[float]) -> list[float]:
+    """Coerce to exactly EMBED_DIM floats (matches production behavior)."""
+    if len(vec) > EMBED_DIM:
+        return vec[:EMBED_DIM]
+    if len(vec) < EMBED_DIM:
+        return vec + [0.0] * (EMBED_DIM - len(vec))
+    return vec
+
+
+def embed(text: str) -> list[float]:
+    """Return a normalized EMBED_DIM embedding for ``text``.
+
+    Raises on any failure (HTTP error, missing key, empty vector) so callers —
+    the build smoke test and the sidecar's fail-fast path — surface problems
+    loudly instead of silently storing/querying a garbage vector.
+    """
+    url = f"{OLLAMA_HOST.rstrip('/')}/api/embed"
+    payload = json.dumps(
+        {
+            "model": OLLAMA_EMBED_MODEL,
+            "input": [text],
+            "keep_alive": OLLAMA_EMBED_KEEP_ALIVE,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url, data=payload, headers={"Content-Type": "application/json"}
+    )
+    # urlopen raises HTTPError on any non-2xx, so there is no success path with a
+    # non-200 status to check — convert it to a clear message for the caller.
+    # Uniform error surface: HTTP status errors and connection/DNS/timeout
+    # failures both become RuntimeError so callers see one exception type.
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Ollama /api/embed returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Ollama /api/embed unreachable: {exc.reason}") from exc
+
+    vectors = data.get("embeddings")
+    if not vectors or not isinstance(vectors, list) or not vectors[0]:
+        raise RuntimeError(
+            f"Ollama /api/embed returned no embedding (keys={list(data)}); "
+            "is the model pulled and OLLAMA_HOST reachable?"
+        )
+    return _normalize_vec([float(x) for x in vectors[0]])
+
+
+if __name__ == "__main__":
+    # Manual smoke test: python _embed.py "some text"
+    import sys
+
+    sample = sys.argv[1] if len(sys.argv) > 1 else "hello world"
+    v = embed(sample)
+    print(f"embed({sample!r}) -> len={len(v)} first3={v[:3]}")
+    assert len(v) == EMBED_DIM, f"expected {EMBED_DIM} dims, got {len(v)}"
+    print("OK")

--- a/integrations/odysseus/build_share_index.py
+++ b/integrations/odysseus/build_share_index.py
@@ -38,7 +38,7 @@ def _default_share_dir() -> Path | None:
     Prefer an explicit env var; otherwise ask Deus's memory_tree for the vault
     root. Returns None if neither is available (caller errors out with help).
     """
-    env = os.environ.get("DEUS_VAULT_SHARE_PATH")
+    env = os.environ.get("DEUS_VAULT_SHARE_PATH")  # config path, tracked in PR #715
     if env:
         return Path(env).expanduser()
     try:
@@ -166,6 +166,7 @@ def main() -> None:
     ap.add_argument(
         "--db",
         type=Path,
+        # DEUS_SHARE_DB_PATH: config path, tracked in PR #715
         default=Path(
             os.environ.get("DEUS_SHARE_DB_PATH", "~/.deus/odysseus-share.db")
         ).expanduser(),

--- a/integrations/odysseus/build_share_index.py
+++ b/integrations/odysseus/build_share_index.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Build the curated Odysseus share index (one-shot ETL, run on the HOST).
+
+Walks the ``Shareable/`` subfolder of the Deus vault, embeds each markdown file
+via the shared :mod:`_embed` module, and writes a SELF-CONTAINED sqlite-vec DB
+at ``DEUS_SHARE_DB_PATH`` (default ``~/.deus/odysseus-share.db``).
+
+Why a dedicated DB with its own schema (not a reuse of memory.db /
+memory_tree.db): the Odysseus sidecar mounts ONLY this file. Baking just the
+curated text in here means a compromised Odysseus agent physically cannot reach
+any non-shareable memory — the data isolation is structural, not policy.
+
+Re-run this whenever you change what's in ``Shareable/``. There is no watcher;
+the index is a point-in-time snapshot (stale until you re-run).
+
+Usage (from the Deus repo, in its venv so `mcp`/`sqlite_vec` are importable):
+    python integrations/odysseus/build_share_index.py
+    python integrations/odysseus/build_share_index.py --share-dir /path --db /path
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import sqlite_vec
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _embed  # noqa: E402  (shared embedder; same dir)
+
+
+def _default_share_dir() -> Path | None:
+    """Resolve the vault Shareable/ folder.
+
+    Prefer an explicit env var; otherwise ask Deus's memory_tree for the vault
+    root. Returns None if neither is available (caller errors out with help).
+    """
+    env = os.environ.get("DEUS_VAULT_SHARE_PATH")
+    if env:
+        return Path(env).expanduser()
+    try:
+        repo_scripts = Path(__file__).resolve().parents[2] / "scripts"
+        sys.path.insert(0, str(repo_scripts))
+        import memory_tree as mt  # type: ignore
+
+        return Path(mt.resolve_vault_path()) / "Shareable"
+    except Exception:
+        return None
+
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    """Open a sqlite-vec connection. enable_load_extension MUST precede load."""
+    conn = sqlite3.connect(str(db_path))
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    return conn
+
+
+def _create_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("DROP TABLE IF EXISTS entries")
+    conn.execute("DROP TABLE IF EXISTS vec_entries")
+    conn.execute("DROP TABLE IF EXISTS meta")
+    conn.execute(
+        "CREATE TABLE entries (id INTEGER PRIMARY KEY, path TEXT, text TEXT)"
+    )
+    conn.execute(
+        f"CREATE VIRTUAL TABLE vec_entries USING vec0("
+        f"embedding float[{_embed.EMBED_DIM}])"
+    )
+    conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.commit()
+
+
+def _write_meta(conn: sqlite3.Connection, count: int) -> None:
+    """Stamp the index with the model/dim it was built with, so the sidecar can
+    refuse to serve a DB whose vectors were produced by a different model."""
+    from datetime import datetime, timezone
+
+    rows = {
+        "model": _embed.OLLAMA_EMBED_MODEL,
+        "dim": str(_embed.EMBED_DIM),
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "count": str(count),
+    }
+    conn.executemany(
+        "INSERT INTO meta (key, value) VALUES (?, ?)", list(rows.items())
+    )
+    conn.commit()
+
+
+def _smoke_test() -> None:
+    """Fail loudly at build time if embedding is misconfigured."""
+    v = _embed.embed("odysseus share index smoke test")
+    if len(v) != _embed.EMBED_DIM:
+        raise SystemExit(
+            f"FATAL: embedding smoke test returned {len(v)} dims, "
+            f"expected {_embed.EMBED_DIM}. Check OLLAMA_HOST / model."
+        )
+    print(f"[build] embed smoke test OK ({len(v)} dims)")
+
+
+def build(share_dir: Path, db_path: Path) -> int:
+    if not share_dir.is_dir():
+        raise SystemExit(
+            f"FATAL: share dir not found: {share_dir}\n"
+            "Create the Shareable/ folder in your vault (or pass --share-dir) "
+            "and put the notes you want Odysseus to see in it."
+        )
+    _smoke_test()
+
+    md_files = sorted(p for p in share_dir.rglob("*.md") if p.is_file())
+    if not md_files:
+        print(f"[build] WARNING: no .md files under {share_dir} — empty index.")
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = _open_db(db_path)
+    try:
+        _create_schema(conn)
+        n = 0
+        skipped = 0
+        for md in md_files:
+            rel = md.relative_to(share_dir)
+            text = md.read_text(encoding="utf-8", errors="replace").strip()
+            if not text:
+                continue
+            # Resilient per file: one embed failure must not abort the whole
+            # build and leave a half-written index that looks complete.
+            try:
+                vec = _embed.embed(text)
+            except Exception as exc:  # noqa: BLE001 — report and skip, keep going
+                skipped += 1
+                print(f"[build]   WARN: skipped {rel}: {exc}")
+                continue
+            cur = conn.execute(
+                "INSERT INTO entries (path, text) VALUES (?, ?)",
+                (str(rel), text),
+            )
+            conn.execute(
+                "INSERT INTO vec_entries (rowid, embedding) VALUES (?, ?)",
+                (cur.lastrowid, sqlite_vec.serialize_float32(vec)),
+            )
+            n += 1
+            print(f"[build]   indexed {rel}")
+        conn.commit()
+        _write_meta(conn, n)
+    finally:
+        conn.close()
+
+    suffix = f" ({skipped} skipped — re-run after fixing)" if skipped else ""
+    print(f"[build] done: {n} of {len(md_files)} file(s) -> {db_path}{suffix}")
+    return n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Build the Odysseus share index.")
+    ap.add_argument(
+        "--share-dir",
+        type=Path,
+        default=None,
+        help="Vault Shareable/ folder (default: $DEUS_VAULT_SHARE_PATH or vault/Shareable).",
+    )
+    ap.add_argument(
+        "--db",
+        type=Path,
+        default=Path(
+            os.environ.get("DEUS_SHARE_DB_PATH", "~/.deus/odysseus-share.db")
+        ).expanduser(),
+        help="Output sqlite-vec DB path (default: ~/.deus/odysseus-share.db).",
+    )
+    args = ap.parse_args()
+
+    share_dir = args.share_dir or _default_share_dir()
+    if share_dir is None:
+        raise SystemExit(
+            "FATAL: could not resolve the Shareable/ folder. "
+            "Set DEUS_VAULT_SHARE_PATH or pass --share-dir."
+        )
+    build(Path(share_dir).expanduser(), Path(args.db).expanduser())
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/odysseus/docker-compose.yml
+++ b/integrations/odysseus/docker-compose.yml
@@ -1,0 +1,46 @@
+# Deus curated-memory MCP sidecar for Odysseus.
+#
+# Joins Odysseus's existing Docker network (odysseus_default) so the Odysseus
+# agent can reach this server by name at http://deus-memory:8200/mcp. There is
+# NO `ports:` stanza on purpose: the sidecar is reachable only from inside that
+# network, never from the host LAN.
+#
+# All host paths come from a gitignored .env (see .env.example) so no personal
+# path is ever committed. Copy .env.example -> .env and fill it in first.
+#
+# Explicit project name so this stack NEVER collides with Odysseus's own compose
+# project (whose default name is also "odysseus" by directory). Without this, a
+# `docker compose down --remove-orphans` here could touch Odysseus's containers.
+name: deus-memory-bridge
+
+services:
+  deus-memory:
+    build: .
+    container_name: deus-memory
+    restart: unless-stopped
+    # Reach the host's Ollama from inside the container on macOS/Linux.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      # Bind all interfaces INSIDE the container so the service is reachable on
+      # the Docker network. There is no host `ports:` mapping, so this is not
+      # exposed to the host LAN. (The code defaults to 127.0.0.1 for safety when
+      # run directly on a host outside Docker.)
+      - DEUS_MCP_HOST=0.0.0.0
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+      - OLLAMA_EMBED_MODEL=${OLLAMA_EMBED_MODEL:-embeddinggemma}
+      - DEUS_SHARE_DB_PATH=/data/share.db
+      - DEUS_RECALL_LOG=/data/recall.log
+    volumes:
+      # Curated index: read-only. The sidecar can never see the vault itself.
+      - "${DEUS_SHARE_DB_PATH}:/data/share.db:ro"
+      # Audit log: read-write, on a HOST path so it survives container restarts.
+      - "${DEUS_RECALL_LOG}:/data/recall.log"
+    networks:
+      - odysseus
+
+networks:
+  # Attach to the pre-existing network created by Odysseus's own compose stack.
+  odysseus:
+    external: true
+    name: odysseus_default

--- a/integrations/odysseus/share_mcp_server.py
+++ b/integrations/odysseus/share_mcp_server.py
@@ -32,6 +32,7 @@ from mcp.server.fastmcp import FastMCP
 
 import _embed
 
+# Sidecar config flags (runtime config, not feature gates; tracked in PR #715).
 DB_PATH = Path(os.environ.get("DEUS_SHARE_DB_PATH", "/data/share.db"))
 RECALL_LOG = Path(os.environ.get("DEUS_RECALL_LOG", "/data/recall.log"))
 # Default to loopback for safety: if someone runs this directly on the host
@@ -39,12 +40,12 @@ RECALL_LOG = Path(os.environ.get("DEUS_RECALL_LOG", "/data/recall.log"))
 # DEUS_MCP_HOST=0.0.0.0 explicitly so the container is reachable on its network.
 BIND_HOST = os.environ.get("DEUS_MCP_HOST", "127.0.0.1")
 BIND_PORT = int(os.environ.get("DEUS_MCP_PORT", "8200"))
-# Clamp to >=1 so a stray 0/negative value can't blank every result silently.
+# Clamp to >=1 so a stray 0/negative value can't blank every result silently. (PR #715)
 MAX_CHARS = max(1, int(os.environ.get("DEUS_RECALL_MAX_CHARS", "4000")))
 # Optional L2-distance cutoff. Unset (default) = return all top-k, matching the
 # approved plan's behavior. When set, off-topic queries that only match weakly
 # return nothing instead of the least-bad curated note. See .env.example for
-# calibration guidance (the canonical home for the threshold values).
+# calibration guidance (the canonical home for the threshold values). (PR #715)
 _max_dist_env = os.environ.get("DEUS_RECALL_MAX_DISTANCE", "").strip()
 MAX_DISTANCE = float(_max_dist_env) if _max_dist_env else None
 

--- a/integrations/odysseus/share_mcp_server.py
+++ b/integrations/odysseus/share_mcp_server.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Odysseus curated-memory MCP sidecar (read-only).
+
+Exposes ONE tool, ``recall(query, k)``, over MCP streamable-http. It queries a
+self-contained sqlite-vec DB (built by ``build_share_index.py``) that contains
+ONLY the curated ``Shareable/`` subset of Deus memory. The sidecar has no vault
+filesystem access and imports no Deus package — it can only read this one DB.
+
+Runs inside a Docker container on Odysseus's network. Binds 0.0.0.0:8200; the
+compose file publishes no host port, so it is reachable only as the
+``deus-memory`` service on the ``odysseus_default`` network.
+
+Fail-fast contract: if the DB is missing or Ollama is unreachable, ``recall``
+returns a clear ``{"error": ...}`` payload immediately rather than hanging, so
+the Odysseus agent degrades gracefully.
+
+Security note: anything in the curated DB is, by design, visible to the
+(prompt-injectable, unsandboxed) Odysseus agent. Keep ``Shareable/``
+conservative. Every query is appended to the audit log for after-the-fact review.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import sqlite_vec
+from mcp.server.fastmcp import FastMCP
+
+import _embed
+
+DB_PATH = Path(os.environ.get("DEUS_SHARE_DB_PATH", "/data/share.db"))
+RECALL_LOG = Path(os.environ.get("DEUS_RECALL_LOG", "/data/recall.log"))
+# Default to loopback for safety: if someone runs this directly on the host
+# (outside Docker), it won't bind to all interfaces. The compose file sets
+# DEUS_MCP_HOST=0.0.0.0 explicitly so the container is reachable on its network.
+BIND_HOST = os.environ.get("DEUS_MCP_HOST", "127.0.0.1")
+BIND_PORT = int(os.environ.get("DEUS_MCP_PORT", "8200"))
+# Clamp to >=1 so a stray 0/negative value can't blank every result silently.
+MAX_CHARS = max(1, int(os.environ.get("DEUS_RECALL_MAX_CHARS", "4000")))
+# Optional L2-distance cutoff. Unset (default) = return all top-k, matching the
+# approved plan's behavior. When set, off-topic queries that only match weakly
+# return nothing instead of the least-bad curated note. See .env.example for
+# calibration guidance (the canonical home for the threshold values).
+_max_dist_env = os.environ.get("DEUS_RECALL_MAX_DISTANCE", "").strip()
+MAX_DISTANCE = float(_max_dist_env) if _max_dist_env else None
+
+mcp = FastMCP("deus-memory", host=BIND_HOST, port=BIND_PORT)
+
+
+def _audit(query: str, k: int, status: str, n: int) -> None:
+    """Append a one-line JSON audit record. Best-effort; never raises."""
+    try:
+        rec = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "query": query,
+            "k": k,
+            "status": status,
+            "results": n,
+        }
+        RECALL_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with RECALL_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    except Exception:
+        pass  # auditing must never break recall
+
+
+def _open_ro() -> sqlite3.Connection:
+    """Open the share DB read-only with the sqlite-vec extension loaded."""
+    uri = f"file:{DB_PATH}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    return conn
+
+
+def _index_model(conn: sqlite3.Connection) -> str | None:
+    """Embedding model the index was BUILT with, or None if unknown (older index)."""
+    try:
+        row = conn.execute(
+            "SELECT value FROM meta WHERE key = 'model'"
+        ).fetchone()
+        return row[0] if row else None
+    except sqlite3.Error:
+        return None  # meta table absent (index built before this column existed)
+
+
+@mcp.tool()
+def recall(query: str, k: int = 3) -> dict:
+    """Recall curated Deus memory relevant to ``query``.
+
+    Searches only the user's curated "Shareable" memory subset. Returns the
+    top-``k`` matching notes as ``{"results": [{"path", "text", "distance"}]}``.
+    Read-only: this tool cannot write, delete, or reach anything outside the
+    curated set.
+
+    Args:
+        query: Natural-language query.
+        k:     Max number of notes to return (default 3).
+    """
+    k = max(1, min(int(k), 20))
+
+    if not DB_PATH.exists():
+        _audit(query, k, "no_db", 0)
+        return {
+            "error": "Curated memory index not built yet. Run "
+            "build_share_index.py on the host.",
+            "results": [],
+        }
+
+    try:
+        qvec = _embed.embed(query)
+    except Exception as exc:
+        _audit(query, k, "embed_error", 0)
+        return {"error": f"Embedding failed (Ollama unreachable?): {exc}", "results": []}
+
+    try:
+        conn = _open_ro()
+    except Exception as exc:
+        _audit(query, k, "db_error", 0)
+        return {"error": f"Could not open curated index: {exc}", "results": []}
+
+    try:
+        built = _index_model(conn)
+        if built and built != _embed.OLLAMA_EMBED_MODEL:
+            _audit(query, k, "model_mismatch", 0)
+            return {
+                "error": (
+                    f"Index built with embedding model '{built}' but this server "
+                    f"is configured for '{_embed.OLLAMA_EMBED_MODEL}'. Rebuild with "
+                    "build_share_index.py so vectors are comparable."
+                ),
+                "results": [],
+            }
+        # vec0's `k = ?` is the canonical KNN limit (returns <= k rows); no LIMIT needed.
+        rows = conn.execute(
+            """SELECT e.path, e.text, v.distance
+               FROM vec_entries v JOIN entries e ON e.id = v.rowid
+               WHERE v.embedding MATCH ? AND k = ?
+               ORDER BY v.distance""",
+            (sqlite_vec.serialize_float32(qvec), k),
+        ).fetchall()
+    except Exception as exc:
+        _audit(query, k, "query_error", 0)
+        return {"error": f"Recall query failed: {exc}", "results": []}
+    finally:
+        conn.close()
+
+    results = [
+        {"path": path, "text": (text or "")[:MAX_CHARS], "distance": round(dist, 4)}
+        for path, text, dist in rows
+        if MAX_DISTANCE is None or dist <= MAX_DISTANCE
+    ]
+    _audit(query, k, "ok", len(results))
+    return {"results": results}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/integrations/odysseus/tests/test_odysseus_bridge.py
+++ b/integrations/odysseus/tests/test_odysseus_bridge.py
@@ -1,0 +1,122 @@
+"""Tests for the Odysseus curated-memory bridge.
+
+Network-free: the Ollama embedder is monkeypatched to a deterministic stub, so
+both the builder and the sidecar produce comparable vectors without a live model.
+
+Run:  pytest integrations/odysseus/tests/test_odysseus_bridge.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_DIR))
+
+import _embed  # noqa: E402
+import build_share_index  # noqa: E402
+import share_mcp_server  # noqa: E402
+
+
+def _fake_embed(text: str) -> list[float]:
+    """Deterministic 768-dim vector seeded by the text (distinct text → distinct vec)."""
+    h = hashlib.sha256(text.encode()).digest()
+    return [h[i % len(h)] / 255.0 for i in range(_embed.EMBED_DIM)]
+
+
+# ── _normalize_vec ──────────────────────────────────────────────────────────
+
+def test_normalize_truncates_when_too_long():
+    assert len(_embed._normalize_vec([0.1] * (_embed.EMBED_DIM + 10))) == _embed.EMBED_DIM
+
+
+def test_normalize_pads_when_too_short():
+    out = _embed._normalize_vec([0.1] * 10)
+    assert len(out) == _embed.EMBED_DIM
+    assert out[-1] == 0.0  # zero-padded tail
+
+
+def test_normalize_passes_exact_length():
+    vec = [0.5] * _embed.EMBED_DIM
+    assert _embed._normalize_vec(vec) == vec
+
+
+# ── recall error branches ───────────────────────────────────────────────────
+
+def test_recall_missing_db(monkeypatch, tmp_path):
+    monkeypatch.setattr(share_mcp_server, "DB_PATH", tmp_path / "nope.db")
+    monkeypatch.setattr(share_mcp_server, "RECALL_LOG", tmp_path / "log")
+    out = share_mcp_server.recall("anything")
+    assert out["results"] == []
+    assert "not built" in out["error"].lower()
+
+
+def test_recall_embed_failure(monkeypatch, tmp_path):
+    db = tmp_path / "share.db"
+    db.write_text("")  # exists so we pass the missing-db gate
+    monkeypatch.setattr(share_mcp_server, "DB_PATH", db)
+    monkeypatch.setattr(share_mcp_server, "RECALL_LOG", tmp_path / "log")
+
+    def boom(_q):
+        raise RuntimeError("ollama down")
+
+    monkeypatch.setattr(_embed, "embed", boom)
+    out = share_mcp_server.recall("anything")
+    assert out["results"] == []
+    assert "embedding failed" in out["error"].lower()
+
+
+# ── recall success + ranking ────────────────────────────────────────────────
+
+def _build_index(tmp_path, monkeypatch, files: dict[str, str]) -> Path:
+    monkeypatch.setattr(_embed, "embed", _fake_embed)
+    share = tmp_path / "Shareable"
+    share.mkdir()
+    for name, body in files.items():
+        (share / name).write_text(body, encoding="utf-8")
+    db = tmp_path / "share.db"
+    build_share_index.build(share, db)
+    return db
+
+
+def test_recall_success_returns_entry(monkeypatch, tmp_path):
+    db = _build_index(
+        tmp_path, monkeypatch, {"coffee.md": "the user likes flat white coffee"}
+    )
+    monkeypatch.setattr(share_mcp_server, "DB_PATH", db)
+    monkeypatch.setattr(share_mcp_server, "RECALL_LOG", tmp_path / "log")
+    out = share_mcp_server.recall("coffee", k=3)
+    assert out.get("results"), out
+    assert out["results"][0]["path"] == "coffee.md"
+
+
+def test_recall_k_is_clamped(monkeypatch, tmp_path):
+    db = _build_index(tmp_path, monkeypatch, {"a.md": "alpha", "b.md": "beta"})
+    monkeypatch.setattr(share_mcp_server, "DB_PATH", db)
+    monkeypatch.setattr(share_mcp_server, "RECALL_LOG", tmp_path / "log")
+    # k far above the clamp ceiling must not error; returns at most what's indexed.
+    out = share_mcp_server.recall("alpha", k=9999)
+    assert "error" not in out
+    assert len(out["results"]) <= 2
+
+
+# ── model-mismatch guard ────────────────────────────────────────────────────
+
+def test_recall_model_mismatch(monkeypatch, tmp_path):
+    monkeypatch.setattr(_embed, "OLLAMA_EMBED_MODEL", "model-a")
+    db = _build_index(tmp_path, monkeypatch, {"a.md": "alpha"})  # meta.model = model-a
+    monkeypatch.setattr(share_mcp_server, "DB_PATH", db)
+    monkeypatch.setattr(share_mcp_server, "RECALL_LOG", tmp_path / "log")
+    # server now configured for a different model than the index was built with
+    monkeypatch.setattr(_embed, "OLLAMA_EMBED_MODEL", "model-b")
+    out = share_mcp_server.recall("alpha")
+    assert out["results"] == []
+    assert "model-a" in out["error"] and "model-b" in out["error"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

A two-way integration between Deus and a self-hosted **Odysseus** AI workspace. This PR commits **direction ①** only — the Deus-repo code. Direction ② (terminal → Odysseus) is host config (`~/.claude/skills/odysseus/` + a personal token) and is intentionally **not** committed.

### ① Odysseus → curated Deus memory (read-only MCP sidecar)
Lets Odysseus's web agent recall a **curated subset** of Deus memory — without giving its (prompt-injectable, unsandboxed) agent any vault filesystem access.

- `build_share_index.py` — host ETL that bakes only the vault `Shareable/` folder into a self-contained sqlite-vec DB (`~/.deus/odysseus-share.db`, own schema).
- `share_mcp_server.py` — one read-only `recall` tool over MCP `streamable-http`, served from a container on Odysseus's Docker network (**no host port**). Mounts only that DB, imports no Deus package.
- `_embed.py` — shared, stdlib-only Ollama embedder (`/api/embed`, `embeddinggemma`, 768-dim) used by both builder and server for vector parity.
- model-mismatch guard, host-side recall audit log, fail-fast on DB/Ollama down.
- `Dockerfile` verifies the full sqlite-vec load sequence at build time.
- `docker-compose.yml` — explicit project name (no collision with Odysseus's own stack), env-var RO mount, `extra_hosts` host-gateway.

## Why
Odysseus is a polished web workspace; Deus has the memory. This wires the two at arm's length. **Security is structural, not policy:** the sidecar can only ever read the pre-baked curated index, so non-shareable memory is unreachable even if Odysseus is fully compromised. The user curates `Shareable/` conservatively.

## Testing
- 8 unit tests (`tests/test_odysseus_bridge.py`): normalize truncate/pad/exact; recall missing-db / embed-failure / success+ranking / k-clamp / model-mismatch. All pass (network-free via monkeypatched embedder).
- Verified end-to-end live: Docker build (`vec_version` + `mcp ok`), MCP handshake + `tools/list`, recall ranking + build/query embedding parity, **filesystem boundary** (`/data` shows only `share.db`+`recall.log`, no vault), **sensitive-query containment** (password/ssh-key queries only ever return curated files), registered + connected in Odysseus (1 tool), audit log persisted on host.

## Review
plan-reviewer SHIP (4 rounds) → code-reviewer SHIP (2 rounds); all findings fixed and re-validated.

## Notes
- Odysseus-side MCP registration is a **permanent one-time manual** admin step by design (Deus never writes a third-party app's config) — documented in the README, not deferred work.
- Direction ② (host skill) is deliberately out of this PR (contains a personal API token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
