### PR TITLE
feat(evolution): capture structured tool calls for observability (LIA-154 inc#1)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -34,6 +34,7 @@ import { runOpenAIConversation } from './openai-backend.js';
 import { runLlamaCppConversation } from './llama-cpp-backend.js';
 import { DoomLoopDetector, createDoomLoopHook } from './doom-loop-detector.js';
 import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
+import { createToolCallLogHook } from './tool-call-log.js';
 import type { AgentRuntimeId } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
 import { createPreToolUseHook } from './pre-tool-use-hook.js';
@@ -931,6 +932,9 @@ async function runQuery(
           hooks.push(createDoomLoopHook(doomDetector));
           if (process.env.DEUS_TOOL_SIZE_LOG !== '0')
             hooks.push(createToolSizeLogHook());
+          // LIA-154: structured per-call capture for evolution tool observability
+          if (process.env.DEUS_TOOL_CALL_LOG !== '0')
+            hooks.push(createToolCallLogHook());
           if (process.env.DEUS_TOOL_AUDIT_LOG !== '0')
             hooks.push(createToolAuditHook());
           if (process.env.HOOK_DISPATCH_ENABLED === 'true')

--- a/container/agent-runner/src/tool-call-log.test.ts
+++ b/container/agent-runner/src/tool-call-log.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractToolCallFields } from './tool-call-log.js';
+
+describe('extractToolCallFields', () => {
+  it('extracts file_path for Read/Edit/Write', () => {
+    for (const name of ['Read', 'Edit', 'Write']) {
+      const f = extractToolCallFields(
+        name,
+        { file_path: '/a/b.ts' },
+        undefined,
+      );
+      expect(f).toEqual({ name, file_path: '/a/b.ts', is_error: false });
+    }
+  });
+
+  it('extracts notebook_path for NotebookEdit', () => {
+    const f = extractToolCallFields(
+      'NotebookEdit',
+      { notebook_path: '/n.ipynb' },
+      undefined,
+    );
+    expect(f.file_path).toBe('/n.ipynb');
+  });
+
+  it('extracts command for Bash', () => {
+    const f = extractToolCallFields(
+      'Bash',
+      { command: 'git status' },
+      undefined,
+    );
+    expect(f).toEqual({ name: 'Bash', command: 'git status', is_error: false });
+  });
+
+  it('extracts subagent_type for Agent and Task', () => {
+    for (const name of ['Agent', 'Task']) {
+      const f = extractToolCallFields(
+        name,
+        { subagent_type: 'code-reviewer' },
+        undefined,
+      );
+      expect(f.subagent_type).toBe('code-reviewer');
+    }
+  });
+
+  it('caps long command/file_path at 1024 chars', () => {
+    const long = 'x'.repeat(5000);
+    expect(
+      extractToolCallFields('Bash', { command: long }, undefined).command,
+    ).toHaveLength(1024);
+    expect(
+      extractToolCallFields('Read', { file_path: long }, undefined).file_path,
+    ).toHaveLength(1024);
+  });
+
+  it('detects is_error from {is_error} and {error} shapes, defaults false', () => {
+    expect(
+      extractToolCallFields('Bash', { command: 'x' }, { is_error: true })
+        .is_error,
+    ).toBe(true);
+    expect(
+      extractToolCallFields('Bash', { command: 'x' }, { error: 'boom' })
+        .is_error,
+    ).toBe(true);
+    expect(
+      extractToolCallFields('Bash', { command: 'x' }, 'plain string output')
+        .is_error,
+    ).toBe(false);
+    expect(
+      extractToolCallFields('Bash', { command: 'x' }, undefined).is_error,
+    ).toBe(false);
+    expect(
+      extractToolCallFields('Bash', { command: 'x' }, { is_error: false })
+        .is_error,
+    ).toBe(false);
+  });
+
+  it('omits args for unknown tools and tolerates non-object input', () => {
+    expect(
+      extractToolCallFields('mcp__x__y', { foo: 'bar' }, undefined),
+    ).toEqual({
+      name: 'mcp__x__y',
+      is_error: false,
+    });
+    expect(extractToolCallFields('Bash', null, undefined)).toEqual({
+      name: 'Bash',
+      is_error: false,
+    });
+    // empty-string fields are omitted, not emitted as ''
+    expect(
+      extractToolCallFields('Read', { file_path: '' }, undefined).file_path,
+    ).toBeUndefined();
+  });
+});

--- a/container/agent-runner/src/tool-call-log.ts
+++ b/container/agent-runner/src/tool-call-log.ts
@@ -1,0 +1,132 @@
+/**
+ * Structured per-tool-call capture for evolution tool observability (LIA-154).
+ *
+ * Mirrors createToolSizeLogHook / tool-audit.ts: a fire-and-forget PostToolUse
+ * hook that appends one structured record per tool call to a PER-INTERACTION,
+ * host-mounted log `/workspace/group/logs/tool-calls/<interaction_id>.jsonl`.
+ * The host reads that one file back at logInteraction time (readToolCalls) and
+ * stores it in evolution.db's `tool_calls` column. Per-interaction (not one
+ * shared append-only log) bounds each host read to the dispatch and avoids
+ * unbounded single-file growth. OBSERVABILITY ONLY — nothing in the live
+ * scoring path reads the column yet (activation deferred; see LIA-154).
+ *
+ * Measurement only: never modifies tool output the model sees, never throws.
+ * Opt-out via DEUS_TOOL_CALL_LOG=0.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type {
+  HookCallback,
+  PostToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
+
+const LOG_DIR = '/workspace/group/logs/tool-calls';
+
+/**
+ * Filename-safe interaction id. MUST stay byte-identical to the host's
+ * transform in container-runner.ts `readToolCalls` so both resolve the same
+ * per-interaction file (LIA-154).
+ */
+function safeInteractionId(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+// Cap free-text args so each JSONL line stays well under PIPE_BUF (4096B) —
+// keeps concurrent appendFileSync writes atomic (no torn/interleaved lines) and
+// bounds secret/PII exposure from e.g. a Bash command carrying a token.
+const MAX_FIELD = 1024;
+
+export interface ToolCallFields {
+  name: string;
+  file_path?: string;
+  command?: string;
+  subagent_type?: string;
+  is_error: boolean;
+}
+
+function cap(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value.length > MAX_FIELD ? value.slice(0, MAX_FIELD) : value;
+}
+
+function isErrorResponse(toolResponse: unknown): boolean {
+  if (toolResponse && typeof toolResponse === 'object') {
+    const r = toolResponse as Record<string, unknown>;
+    if (typeof r.is_error === 'boolean') return r.is_error;
+    if ('error' in r && r.error) return true;
+  }
+  return false;
+}
+
+/**
+ * Project a tool call down to the scoring-relevant fields the offline
+ * mechanical scorers consume (evolution/judge/mechanical.py): name, plus
+ * file_path (Read/Edit/Write), command (Bash), or subagent_type (Agent/Task).
+ * Pure + capped — unit-tested independently of the hook/fs.
+ */
+export function extractToolCallFields(
+  name: string,
+  toolInput: unknown,
+  toolResponse: unknown,
+): ToolCallFields {
+  const input =
+    toolInput && typeof toolInput === 'object'
+      ? (toolInput as Record<string, unknown>)
+      : {};
+  const fields: ToolCallFields = {
+    name,
+    is_error: isErrorResponse(toolResponse),
+  };
+
+  if (
+    name === 'Read' ||
+    name === 'Edit' ||
+    name === 'Write' ||
+    name === 'NotebookEdit'
+  ) {
+    const fp = cap(input.file_path ?? input.notebook_path);
+    if (fp !== undefined) fields.file_path = fp;
+  } else if (name === 'Bash') {
+    const cmd = cap(input.command);
+    if (cmd !== undefined) fields.command = cmd;
+  } else if (name === 'Agent' || name === 'Task') {
+    const st = cap(input.subagent_type);
+    if (st !== undefined) fields.subagent_type = st;
+  }
+
+  return fields;
+}
+
+export function createToolCallLogHook(): HookCallback {
+  return async (input): Promise<Record<string, unknown>> => {
+    try {
+      // Per-dispatch join key, threaded in via the container env (fresh
+      // `docker run` per dispatch, LIA-154). The filename encodes it, so no
+      // join key is stored in the records themselves.
+      const interactionId = process.env.DEUS_INTERACTION_ID;
+      if (!interactionId) return {}; // no join key → host can't read it back
+      const hookInput = input as PostToolUseHookInput;
+      const fields = extractToolCallFields(
+        hookInput.tool_name,
+        hookInput.tool_input,
+        hookInput.tool_response,
+      );
+      const entry = {
+        ts: new Date().toISOString(),
+        session_id: hookInput.session_id ?? null,
+        tool_use_id: hookInput.tool_use_id,
+        ...fields,
+      };
+      const logPath = path.join(
+        LOG_DIR,
+        `${safeInteractionId(interactionId)}.jsonl`,
+      );
+      fs.mkdirSync(LOG_DIR, { recursive: true });
+      fs.appendFileSync(logPath, JSON.stringify(entry) + '\n');
+    } catch {
+      // Capture must never crash a tool call.
+    }
+    return {};
+  };
+}

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -233,6 +233,11 @@ def cmd_log_interaction(json_str: str) -> None:
 
     session_id = params.get("session_id")
 
+    # LIA-154: structured tool-call records (observability only; not yet scored).
+    tool_calls = params.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        tool_calls = None
+
     iid = log_interaction(
         prompt=params.get("prompt", ""),
         response=params.get("response"),
@@ -245,6 +250,7 @@ def cmd_log_interaction(json_str: str) -> None:
         user_signal=user_signal,
         context_tokens=context_tokens,
         has_code=has_code,
+        tool_calls=tool_calls,
     )
 
     # Batch judge: check if we've accumulated enough unjudged interactions

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -24,6 +24,7 @@ def log_interaction(
     user_signal: Optional[str] = None,
     context_tokens: Optional[int] = None,
     has_code: Optional[int] = None,
+    tool_calls: Optional[list[dict]] = None,
 ) -> str:
     """
     Persist one agent interaction.  Returns the interaction ID.
@@ -46,6 +47,8 @@ def log_interaction(
         user_signal=user_signal,
         context_tokens=context_tokens,
         has_code=has_code,
+        # LIA-154: structured tool-call records (observability only, not scored).
+        tool_calls=json.dumps(tool_calls or []),
     )
     return iid
 

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -57,6 +57,7 @@ class StorageProvider(ABC):
         user_signal: Optional[str] = None,
         context_tokens: Optional[int] = None,
         has_code: Optional[int] = None,
+        tool_calls: Optional[str] = None,
     ) -> str:
         """Persist one agent interaction. Returns the interaction ID."""
         ...

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -264,6 +264,9 @@ class SQLiteStorageProvider(StorageProvider):
             ("has_code", "INTEGER DEFAULT 0"),
             ("correction_mined_at", "TEXT"),
             ("judge_schema_version", "INTEGER DEFAULT NULL"),
+            # JSON array of structured tool-call records (LIA-154 observability;
+            # captured live but not yet scored — activation deferred).
+            ("tool_calls", "TEXT"),
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list
@@ -325,6 +328,7 @@ class SQLiteStorageProvider(StorageProvider):
         user_signal: Optional[str] = None,
         context_tokens: Optional[int] = None,
         has_code: Optional[int] = None,
+        tool_calls: Optional[str] = None,
     ) -> str:
         db = self._connect()
         db.execute(
@@ -332,13 +336,14 @@ class SQLiteStorageProvider(StorageProvider):
             INSERT OR REPLACE INTO interactions
                 (id, timestamp, group_folder, prompt, response, tools_used,
                  latency_ms, eval_suite, session_id, domain_presets, user_signal,
-                 context_tokens, has_code)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 context_tokens, has_code, tool_calls)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 interaction_id, timestamp, group_folder, prompt, response,
                 tools_used, latency_ms, eval_suite, session_id,
                 domain_presets, user_signal, context_tokens, has_code,
+                tool_calls,
             ),
         )
         db.commit()

--- a/evolution/tests/test_storage_provider.py
+++ b/evolution/tests/test_storage_provider.py
@@ -744,3 +744,51 @@ class TestLegacyMigration:
         provider = SQLiteStorageProvider()
         # Should create a fresh evolution.db (via _migrate), not copy from legacy
         assert provider.count_interactions() == 0
+
+
+# ── LIA-154: tool_calls column (observability only, not scored) ───────────────
+
+
+class TestToolCallsColumn:
+    def test_log_interaction_with_tool_calls_round_trips(self, sqlite_provider):
+        tc = '[{"name": "Bash", "command": "git status", "is_error": false}]'
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2024-01-01T00:00:00Z", interaction_id="tc1",
+            tool_calls=tc,
+        )
+        row = sqlite_provider.get_interaction("tc1")
+        assert row is not None
+        assert row["tool_calls"] == tc
+
+    def test_log_interaction_without_tool_calls_defaults_null(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2024-01-01T00:00:00Z", interaction_id="tc2",
+            tools_used='["Read"]', context_tokens=11, has_code=1,
+        )
+        row = sqlite_provider.get_interaction("tc2")
+        assert row is not None
+        assert row["tool_calls"] is None
+        # the new column does not regress neighbouring fields
+        assert row["tools_used"] == '["Read"]'
+        assert row["context_tokens"] == 11
+        assert row["has_code"] == 1
+
+    def test_migrate_adds_tool_calls_column_idempotently(self, sqlite_provider):
+        from evolution.storage.providers import sqlite as sqlite_mod
+
+        db = sqlite_provider._connect()
+        cols = [r[1] for r in db.execute("PRAGMA table_info(interactions)")]
+        db.close()
+        assert "tool_calls" in cols
+
+        # Force a second migrate on the same DB: the ALTER must be caught
+        # (column already exists), not raise — i.e. migration is idempotent.
+        sqlite_mod._migrated_paths.clear()
+        SQLiteStorageProvider()._connect().close()
+
+        db2 = sqlite_provider._connect()
+        cols2 = [r[1] for r in db2.execute("PRAGMA table_info(interactions)")]
+        db2.close()
+        assert cols2.count("tool_calls") == 1

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-04" # auto-bump @1780561930
+last_verified: "2026-06-07" # auto-bump @1780830591
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-04" # auto-bump @1780561930
+last_verified: "2026-06-07" # auto-bump @1780830591
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-06" # auto-bump @1780764602
+last_verified: "2026-06-07" # auto-bump @1780830591
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-06" # auto-bump @1780764602
+last_verified: "2026-06-07" # auto-bump @1780830591
 governs:
   - src/
   - evolution/

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1575,13 +1575,16 @@ describe.skipIf(onWindows)('Backend parity — system-level equivalence', () => 
       'DEUS_OPENAI_MODEL',
     ]);
 
-    // All non-auth env vars must be identical
-    const claudeNonAuth = new Map(
-      [...claudeEnv].filter(([k]) => !authKeys.has(k)),
-    );
-    const openaiNonAuth = new Map(
-      [...openaiEnv].filter(([k]) => !authKeys.has(k)),
-    );
+    // Per-dispatch, non-deterministic env (value is `${group}-${Date.now()}`).
+    // Shared identically across backends by construction, but its VALUE differs
+    // between two separate dispatches, so exclude it from the value-parity check
+    // (LIA-154 DEUS_INTERACTION_ID).
+    const perDispatchKeys = new Set(['DEUS_INTERACTION_ID']);
+    const excluded = (k: string) => authKeys.has(k) || perDispatchKeys.has(k);
+
+    // All non-auth, non-per-dispatch env vars must be identical
+    const claudeNonAuth = new Map([...claudeEnv].filter(([k]) => !excluded(k)));
+    const openaiNonAuth = new Map([...openaiEnv].filter(([k]) => !excluded(k)));
     expect(claudeNonAuth).toEqual(openaiNonAuth);
   });
 

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -158,7 +158,11 @@ vi.mock('child_process', async () => {
   };
 });
 
-import { runContainerAgent, ContainerOutput } from './container-runner.js';
+import {
+  runContainerAgent,
+  ContainerOutput,
+  readToolCalls,
+} from './container-runner.js';
 import { getActivePrompt, getReflections } from './evolution-client.js';
 import type { RegisteredGroup } from './types.js';
 
@@ -1726,3 +1730,70 @@ describe.skipIf(onWindows)(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// readToolCalls — LIA-154 per-interaction structured tool-call read-back
+// (fs is mocked in this file; drive readFileSync to exercise parse/skip)
+// ---------------------------------------------------------------------------
+describe('readToolCalls (LIA-154)', () => {
+  const fsMocked = vi.mocked(
+    (fsMod as unknown as { default: typeof fsMod }).default,
+  );
+  const logsDir = '/group/logs';
+
+  afterEach(() => {
+    fsMocked.readFileSync.mockReset();
+    fsMocked.readFileSync.mockReturnValue('');
+  });
+
+  it('reads the per-interaction file path (logsDir/tool-calls/<safeId>.jsonl)', () => {
+    fsMocked.readFileSync.mockClear();
+    fsMocked.readFileSync.mockReturnValue('');
+    readToolCalls(logsDir, 'grp/main-123');
+    const calledPath = String(fsMocked.readFileSync.mock.calls[0][0]);
+    // path separators in the id are sanitized so the filename is one segment
+    expect(calledPath).toContain('tool-calls');
+    expect(calledPath).toContain('grp_main-123.jsonl');
+  });
+
+  it('returns [] when the file does not exist', () => {
+    fsMocked.readFileSync.mockImplementation(() => {
+      const e = new Error('ENOENT') as NodeJS.ErrnoException;
+      e.code = 'ENOENT';
+      throw e;
+    });
+    expect(readToolCalls(logsDir, 'g-1')).toEqual([]);
+  });
+
+  it('returns every record in the interaction file (no cross-interaction filter needed)', () => {
+    fsMocked.readFileSync.mockReturnValue(
+      [
+        JSON.stringify({ name: 'Read', file_path: '/a.ts', is_error: false }),
+        JSON.stringify({
+          name: 'Bash',
+          command: 'git status',
+          is_error: false,
+        }),
+      ].join('\n'),
+    );
+    expect(readToolCalls(logsDir, 'g-1')).toEqual([
+      { name: 'Read', file_path: '/a.ts', is_error: false },
+      { name: 'Bash', command: 'git status', is_error: false },
+    ]);
+  });
+
+  it('skips malformed/torn lines but keeps valid ones', () => {
+    fsMocked.readFileSync.mockReturnValue(
+      [
+        JSON.stringify({ name: 'Read', file_path: '/a.ts' }),
+        '{"name":"Bash","command":"git', // torn line
+        '',
+        JSON.stringify({ name: 'Edit', file_path: '/b.ts' }),
+      ].join('\n'),
+    );
+    expect(readToolCalls(logsDir, 'g-1')).toEqual([
+      { name: 'Read', file_path: '/a.ts' },
+      { name: 'Edit', file_path: '/b.ts' },
+    ]);
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -54,6 +54,7 @@ import {
   getActivePrompt,
   getReflections,
   logInteraction,
+  type ToolCall,
 } from './evolution-client.js';
 import { estimateTokens } from './token-counter.js';
 import { detectUserSignal } from './user-signal.js';
@@ -93,6 +94,7 @@ function buildContainerArgs(
   mounts: ReturnType<typeof buildVolumeMounts>,
   containerName: string,
   backend: AgentRuntimeId,
+  interactionId: string,
   group?: RegisteredGroup,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
@@ -100,6 +102,9 @@ function buildContainerArgs(
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
   args.push('-e', `DEUS_PROXY_TOKEN=${getOrCreateGroupToken(group?.folder)}`);
+  // LIA-154: exact per-dispatch join key for the in-container tool-call capture
+  // hook → tool-calls/<id>.jsonl → readToolCalls() back on the host.
+  args.push('-e', `DEUS_INTERACTION_ID=${interactionId}`);
   // Tool proxy URL — containers call host CLIs through this endpoint.
   // Uses CONTAINER_HOST_GATEWAY so the URL resolves to the host from inside the container.
   args.push(
@@ -214,6 +219,41 @@ function buildContainerArgs(
   return args;
 }
 
+/**
+ * Read this dispatch's structured tool calls from the in-container capture log
+ * (LIA-154). The hook writes one PER-INTERACTION file at
+ * `<logsDir>/tool-calls/<interactionId>.jsonl`, so each read is bounded to this
+ * dispatch (no unbounded single-file scan). Best-effort: a missing file (no
+ * tools used) or a torn/partial line is skipped, never thrown — capture must
+ * not affect the response pipeline.
+ */
+export function readToolCalls(
+  logsDir: string,
+  interactionId: string,
+): ToolCall[] {
+  const out: ToolCall[] = [];
+  // MUST stay byte-identical to the container hook's safeInteractionId()
+  // (tool-call-log.ts) so both resolve the same per-interaction file.
+  const safeId = interactionId.replace(/[^A-Za-z0-9._-]/g, '_');
+  try {
+    const raw = fs.readFileSync(
+      path.join(logsDir, 'tool-calls', `${safeId}.jsonl`),
+      'utf8',
+    );
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        out.push(JSON.parse(line) as ToolCall);
+      } catch {
+        // skip a malformed/torn line, keep the rest
+      }
+    }
+  } catch {
+    // no file = no tools used this dispatch
+  }
+  return out;
+}
+
 export async function runContainerAgent(
   group: RegisteredGroup,
   input: ContainerInput,
@@ -221,6 +261,10 @@ export async function runContainerAgent(
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
+  // Interaction ID for evolution logging (stable per container run). Computed
+  // here (not just before logging) so it can be threaded into the container env
+  // for the LIA-154 tool-call capture join.
+  const interactionId = `${group.folder}-${startTime}`;
 
   // Detect user signal BEFORE reflections prepend — reflections inflate prompt
   // length past MAX_SIGNAL_LENGTH, causing false-null on short feedback messages.
@@ -302,6 +346,7 @@ export async function runContainerAgent(
     mounts,
     containerName,
     input.backend || 'claude',
+    interactionId,
     group,
   );
 
@@ -465,9 +510,6 @@ export async function runContainerAgent(
       clearTimeout(timeout);
       timeout = setTimeout(killOnTimeout, timeoutMs);
     };
-
-    // Interaction ID for evolution logging (stable per container run)
-    const interactionId = `${group.folder}-${startTime}`;
 
     container.on('close', (code) => {
       clearTimeout(timeout);
@@ -658,6 +700,7 @@ export async function runContainerAgent(
                 : undefined,
             contextTokens: estimateTokens(input.prompt),
             hasCode: false,
+            toolCalls: readToolCalls(logsDir, interactionId),
           });
           resolve({
             status: 'success',
@@ -721,6 +764,7 @@ export async function runContainerAgent(
               : undefined,
           contextTokens: estimateTokens(input.prompt),
           hasCode: containsCodeBlock(output.result),
+          toolCalls: readToolCalls(logsDir, interactionId),
         });
 
         resolve(output);

--- a/src/evolution-client.ts
+++ b/src/evolution-client.ts
@@ -27,6 +27,22 @@ const EVOLUTION_ENABLED = process.env.EVOLUTION_ENABLED !== '0';
 const OPTIMIZED_PROMPTS_ENABLED =
   process.env.EVOLUTION_OPTIMIZED_PROMPTS === '1';
 
+/**
+ * One structured tool call captured in-container (LIA-154). Mirrors the fields
+ * the offline mechanical scorers consume (evolution/judge/mechanical.py).
+ * Observability only — not read by the live scoring path yet.
+ */
+export interface ToolCall {
+  name: string;
+  file_path?: string;
+  command?: string;
+  subagent_type?: string;
+  is_error?: boolean;
+  tool_use_id?: string;
+  session_id?: string | null;
+  ts?: string;
+}
+
 export interface LogInteractionParams {
   id: string;
   prompt: string;
@@ -34,6 +50,8 @@ export interface LogInteractionParams {
   groupFolder: string;
   latencyMs?: number;
   toolsUsed?: string[];
+  /** Structured per-call records (LIA-154 observability; not yet scored). */
+  toolCalls?: ToolCall[];
   sessionId?: string;
   domainPresets?: string[];
   userSignal?: string;
@@ -135,6 +153,7 @@ export function logInteraction(params: LogInteractionParams): void {
     group_folder: params.groupFolder,
     latency_ms: params.latencyMs,
     tools_used: params.toolsUsed ?? [],
+    tool_calls: params.toolCalls ?? [],
     session_id: params.sessionId,
     domain_presets: params.domainPresets ?? [],
     user_signal: params.userSignal ?? null,


### PR DESCRIPTION
## Why

The evolution loop has **zero tool observability**: baseline audit (`~/.deus/evolution.db`, n=1674) shows `tools_used` empty for **100%** of interactions, and the `tool_economy`/`gate_audit` mechanical judge dims sit at the neutral 1.0 default across **all 1,409 scored rows**. We can't tell if the agent picks the right tools, whether calls succeed, or what they cost. (LIA-154)

## What (increment #1 — observability only)

End-to-end capture pipeline into a **new `tool_calls` column that nothing in the live scoring path reads** — so it is **provably zero-score-movement**. Activation (wiring the mechanical scorers + re-weighting the composite — the "score cliff" where ~1,409 starved rows drop to real values) is a deliberate follow-up.

- **container** — new `createToolCallLogHook` (fire-and-forget PostToolUse, mirrors `createToolSizeLogHook`) writes one **per-interaction** file `groups/<g>/logs/tool-calls/<id>.jsonl` with the fields the offline mechanical scorers consume (`name` + `file_path`/`command`/`subagent_type` + `is_error`), capped at 1KB (torn-write < PIPE_BUF + PII bound). Opt-out via `DEUS_TOOL_CALL_LOG=0`.
- **host** — threads the per-dispatch `interactionId` into the container env (`DEUS_INTERACTION_ID`, fresh `docker run` per dispatch); `readToolCalls()` reads that one per-interaction file at both `logInteraction` sites. Per-interaction files bound each read to the dispatch (no unbounded single-file scan — code-review fix).
- **bridge** — `ToolCall` type + `toolCalls` param + `tool_calls` payload. `tools_used` left untouched, so the LLM-judge prompt is unchanged.
- **python** — `tool_calls TEXT` threaded through the **live** storage write surface (`SQLiteStorageProvider` migrate/sig/INSERT, abstract provider, `ilog` wrapper, cli passthrough); insert-only (not in `_UPDATABLE_INTERACTION_COLS`).

## Zero-score-movement guarantee (verified by code-reviewer + ai-eng-warden)

- The new column is read by nothing live: mechanical scorers run only in `cc_backfill.py` + `diagnostics/`, never the live judge; `maintenance._score_single` passes only `prompt`/`response`/`tools_used`/`user_profile` to `judge.evaluate()`.
- `tools_used` stays `[]` → LLM-judge prompt byte-identical. `COMPOSITE_WEIGHTS`/`criteria.py` untouched.
- Immediate consumer for validation: `mechanical_dims_diagnostic.py` can score the captured column offline to preview the real distribution before the activation PR.

## Tests (green)

- container `extractToolCallFields` 7/7 + tsc; host `readToolCalls` (path / missing-file / returns-all / skip-malformed) — 56/56 + tsc; `evolution/tests/` 469 passed (natural order); root lint/format clean.

## Deploy / follow-ups

- **Container rebuild required** to pick up the hook: `./container/build.sh` (+ `npm run build` + kickstart for the host side).
- Deferred to a follow-up PR (out of scope here): populate `tools_used`, wire mechanical scorers into the live judge, re-weight the composite (the cliff); `available_tools` manifest (LIA-151); token/cost join (LIA-149); log rotation + gate-token-aware truncation before activation.
- The `chore(patterns): auto-bump` commit is the standard pre-push drift bump for `evolution/` changes (`eval-change.md`).

## ⚠️ Pre-merge gate

`hook-pr-smoke-test`: this adds a PostToolUse hook, which requires real-session evidence before merge. **Smoke-test evidence (container rebuild + live dispatch showing `tool-calls/<id>.jsonl` populated and the `tool_calls` DB column written) will be added to this PR before merge** — do not merge until it's here.

Part of LIA-154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)