### PR TITLE
feat(evolution): opt-in judge model override (EVOLUTION_OLLAMA_JUDGE_MODEL)

### DIFF
--- a/docs/decisions/gemma4-12b-local-model-evaluation.md
+++ b/docs/decisions/gemma4-12b-local-model-evaluation.md
@@ -129,3 +129,39 @@ These surfaced during the evaluation and stand regardless of the Gemma 4 decisio
   - `Research/2026-06-04-local-model-runtime-selection-m3pro.md` (vault) — "the task is the bottleneck, not the model."
 - Parked generation pipeline: `Session-Logs/2026-04-09/gemma4-finetune-pipeline.md` (vault).
 - Full session write-up: `Session-Logs/2026-06-05/gemma4-benchmark-scoping.md` (vault).
+
+---
+
+## Addendum (2026-06-07): PR #713 — judge-surface agreement benchmark + opt-in per-surface override
+
+**New evidence, judge surface only.** Decision item 1 (keep `e4b` for the judge) rested on the
+ranking probe above, which **ceiled** (e4b 100% / 12b 93% on 15 cases; the ADR's own caveat:
+"absence of evidence… N small, no statistical test"). PR #713 built a clean **n=200** Gemini-labeled
+benchmark (current rubric + persona digest, graded digest-symmetric on the deployed Ollama path) — a
+*finer agreement task* the ranking probe could not resolve. Result (paired bootstrap, same rows):
+
+| model | composite agreement | 95% CI | paired vs e4b |
+|---|---|---|---|
+| `gemma4:e4b` (default) | 0.655 | [0.576, 0.726] | — |
+| `gemma4:12b` | **0.742** | [0.680, 0.795] | **+0.088, CI [+0.026, +0.151], P=1.00** |
+| `gemma4:26b` | 0.575 | [0.492, 0.649] | −0.076, P=0.02 (regresses) |
+
+On the judge surface, 12b **does** out-agree e4b by a statistically clear margin, and 26b *regresses*.
+This refines — does not refute — item 2: the finer task surfaced a benefit the coarse, ceiled probe hid.
+
+**What changed in code (default unchanged).** Added `EVOLUTION_OLLAMA_JUDGE_MODEL`
+(`config.OLLAMA_JUDGE_MODEL`, defaulting to `OLLAMA_MODEL`) and pointed `OllamaProvider.default_model`
+at it — a per-surface A/B knob mirroring the `LLAMA_CPP_JUDGE_MODEL` precedent. **The default stays
+`gemma4:e4b`**: env unset → true no-op (production scoring byte-identical). This is the
+per-surface-override *mechanism* that item 3(b) sanctioned — note item 3(b) exemplified it for
+**reflexion**, not the judge; here it is applied to the **judge** surface on the strength of #713's
+new evidence. It is not a global default switch and not a claim the ADR pre-authorized the judge
+surface. Measured costs stand (12b ~2.25× latency, ~2.3× resident RAM, requires `think:false` — now
+shipped per Consequence #2); the hot-path judge is fire-and-forget (`mcp_server.py` async) so judge
+latency is off the user's path, and the knob drives **both** hot + batch judges so stored labels stay
+consistent (mixed models contaminated the DB in #713). The chosen override model must be pulled in
+Ollama or judge construction raises (swallowed on the async hot path).
+
+**Decision: unchanged default, new opt-in lever.** Item 1 holds (e4b default). Operators may A/B
+`gemma4:12b` on the judge via `EVOLUTION_OLLAMA_JUDGE_MODEL=gemma4:12b`, weighed against the documented
+costs. Do not use 26b (regresses). Evidence: PR #713; `Research/2026-06-07-*` (vault).

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -38,6 +38,14 @@ _ENV_SEARCH_PATHS: list[Path] = [CONFIG_ENV, USER_CONFIG_ENV]
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
 
+# Judge-specific Ollama model override (per-surface A/B knob, mirrors LLAMA_CPP_JUDGE_MODEL).
+# Defaults to OLLAMA_MODEL → a true no-op until EVOLUTION_OLLAMA_JUDGE_MODEL is set (production
+# scoring stays byte-identical); applies to the judge only, not extraction/generative. Rationale,
+# benchmark, and costs live in docs/decisions/gemma4-12b-local-model-evaluation.md (2026-06-07
+# addendum) — default stays e4b. NOTE: the override model must be pulled in Ollama, else judge
+# construction raises (and the exception is swallowed on the fire-and-forget hot path).
+OLLAMA_JUDGE_MODEL = os.environ.get("EVOLUTION_OLLAMA_JUDGE_MODEL", OLLAMA_MODEL)
+
 # ── llama.cpp ────────────────────────────────────────────────────────────────
 
 # Base URL for the local llama-server (OpenAI-compatible /v1 prefix).

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from .base import BaseJudge, JudgeResult
 from .criteria import RUBRIC, compose_score, _normalize_dim
-from ..config import OLLAMA_HOST, OLLAMA_MODEL
+from ..config import OLLAMA_HOST, OLLAMA_MODEL, OLLAMA_JUDGE_MODEL
 
 
 def _ollama_url(path: str) -> str:
@@ -233,6 +233,11 @@ def _parse_result(raw: str) -> JudgeResult:
 
 
 
-def make_runtime_judge(model: str = OLLAMA_MODEL) -> OllamaRuntimeJudge:
-    """Return an OllamaRuntimeJudge for scoring production interactions."""
+def make_runtime_judge(model: str = OLLAMA_JUDGE_MODEL) -> OllamaRuntimeJudge:
+    """Return an OllamaRuntimeJudge for scoring production interactions.
+
+    Default honors the judge-specific override (OLLAMA_JUDGE_MODEL, which itself
+    defaults to OLLAMA_MODEL). Production callers go through the provider registry,
+    not this helper; the default is kept consistent for direct/script/test callers.
+    """
     return OllamaRuntimeJudge(model=model)

--- a/evolution/judge/providers/ollama.py
+++ b/evolution/judge/providers/ollama.py
@@ -18,8 +18,10 @@ class OllamaProvider(JudgeProvider):
 
     @property
     def default_model(self) -> str:
-        from ...config import OLLAMA_MODEL
-        return OLLAMA_MODEL
+        # Judge-specific override; defaults to OLLAMA_MODEL (no-op until set). Sole
+        # default-model source for all production judges (hot + batch). See config.py.
+        from ...config import OLLAMA_JUDGE_MODEL
+        return OLLAMA_JUDGE_MODEL
 
     def is_available(self) -> bool:
         from ..ollama_judge import is_ollama_available

--- a/evolution/tests/test_ollama_judge_model_override.py
+++ b/evolution/tests/test_ollama_judge_model_override.py
@@ -1,0 +1,70 @@
+"""Tests for the judge-specific Ollama model override (EVOLUTION_OLLAMA_JUDGE_MODEL).
+
+Verifies config.OLLAMA_JUDGE_MODEL falls back to OLLAMA_MODEL when unset (a true
+no-op default → production scoring byte-identical) and overrides when set, and that
+OllamaProvider.default_model — the sole default-model source for all production
+judges (hot + batch) — reflects it. Deterministic; no Ollama calls.
+
+Mirrors test_per_surface_config.py (the LLAMA_CPP_JUDGE_MODEL precedent).
+"""
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+
+@pytest.fixture(autouse=True)
+def reload_config():
+    """Reload evolution.config so each test picks up patched env vars, and restore
+    the baseline afterward. importlib.reload (not module deletion) keeps other tests'
+    import references valid."""
+    import evolution.config
+    importlib.reload(evolution.config)
+    yield
+    importlib.reload(evolution.config)
+
+
+def test_judge_model_falls_back_to_ollama_model(monkeypatch):
+    """Unset → OLLAMA_JUDGE_MODEL == OLLAMA_MODEL (true no-op default)."""
+    monkeypatch.setenv("OLLAMA_MODEL", "gemma4:e4b")
+    monkeypatch.delenv("EVOLUTION_OLLAMA_JUDGE_MODEL", raising=False)
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.OLLAMA_JUDGE_MODEL == cfg.OLLAMA_MODEL == "gemma4:e4b"
+
+
+def test_judge_model_override_wins(monkeypatch):
+    """Set → OLLAMA_JUDGE_MODEL is the override; OLLAMA_MODEL (extraction surface) untouched."""
+    monkeypatch.setenv("OLLAMA_MODEL", "gemma4:e4b")
+    monkeypatch.setenv("EVOLUTION_OLLAMA_JUDGE_MODEL", "gemma4:12b")
+    import evolution.config
+    cfg = importlib.reload(evolution.config)
+    assert cfg.OLLAMA_JUDGE_MODEL == "gemma4:12b"
+    assert cfg.OLLAMA_MODEL == "gemma4:e4b"   # atom/entity extraction surface unchanged
+
+
+def test_provider_default_model_unset_is_noop(monkeypatch):
+    """OllamaProvider.default_model == OLLAMA_MODEL when override unset (byte-identical prod)."""
+    monkeypatch.setenv("OLLAMA_MODEL", "gemma4:e4b")
+    monkeypatch.delenv("EVOLUTION_OLLAMA_JUDGE_MODEL", raising=False)
+    import evolution.config
+    importlib.reload(evolution.config)
+    import evolution.judge.providers.ollama as op
+    importlib.reload(op)
+    assert op.OllamaProvider().default_model == "gemma4:e4b"
+
+
+def test_provider_default_model_reflects_override(monkeypatch):
+    """OllamaProvider.default_model returns the override when set (the hot + batch injection point)."""
+    monkeypatch.setenv("OLLAMA_MODEL", "gemma4:e4b")
+    monkeypatch.setenv("EVOLUTION_OLLAMA_JUDGE_MODEL", "gemma4:12b")
+    import evolution.config
+    importlib.reload(evolution.config)
+    import evolution.judge.providers.ollama as op
+    importlib.reload(op)
+    assert op.OllamaProvider().default_model == "gemma4:12b"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-06" # auto-bump @1780736900
+last_verified: "2026-06-07" # auto-bump @1780842105
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-07" # auto-bump @1780830591
+last_verified: "2026-06-07" # auto-bump @1780842105
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-07" # auto-bump @1780830591
+last_verified: "2026-06-07" # auto-bump @1780842105
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## What

Opt-in judge-specific Ollama model override: `EVOLUTION_OLLAMA_JUDGE_MODEL` → `config.OLLAMA_JUDGE_MODEL`, defaulting to `OLLAMA_MODEL`. Points `OllamaProvider.default_model` (the sole default-model source for all production judges — hot path `mcp_server` + batch) at it. Mirrors the existing `LLAMA_CPP_JUDGE_MODEL` per-surface precedent.

**Default unchanged.** Env unset → the knob is a true no-op (production scoring byte-identical). Judge-only by design: extraction (`OLLAMA_MODEL`), generative, and `DSPY_OLLAMA_MODEL` are untouched.

## Why

PR #713's clean n=200 Gemini-labeled benchmark measured `gemma4:12b` out-agreeing the deployed `gemma4:e4b` judge on the **judge surface** (composite 0.742 vs 0.655; paired +0.088, 95% CI [+0.026, +0.151], P=1.00); `gemma4:26b` regresses. That is a finer agreement task than the 2026-06-05 ADR's ranking probe, which *ceiled* (e4b 100% / 12b 93%, n=25).

The ADR (`docs/decisions/gemma4-12b-local-model-evaluation.md`) keeps e4b as default and sanctions the per-surface-override *mechanism*. This PR ships that mechanism for the judge so 12b can be A/B'd against the documented costs (~2.25× latency, ~2.3× RAM, requires `think:false`). **The default stays e4b — no flip.** A 2026-06-07 ADR addendum records #713 as new judge-surface evidence (explicit that the ADR's override sanction exemplified *reflexion*, and the judge application rests on #713's data).

## Files
- `evolution/config.py` — `OLLAMA_JUDGE_MODEL`
- `evolution/judge/providers/ollama.py` — `default_model` → `OLLAMA_JUDGE_MODEL`
- `evolution/judge/ollama_judge.py` — module-level `make_runtime_judge` default
- `docs/decisions/gemma4-12b-local-model-evaluation.md` — addendum
- `evolution/tests/test_ollama_judge_model_override.py` — 4 deterministic tests

## Verification
- Full evolution suite: **470 passed, 1 skipped**
- Prediction: unset → `default_model == "gemma4:e4b"` (byte-identical); `=gemma4:12b` → flips, extraction (`OLLAMA_MODEL`) unchanged
- `flag_lint --base origin/main`: exit 0 (EVOLUTION_*, not a net-new DEUS_* gate)
- Caller audit: all 6 production judge callers route through `default_model`; generative/DSPy/extraction untouched
- plan-reviewer **SHIP** + code-reviewer **SHIP**

## Deferred (not in this PR)
Pre-existing: an un-pulled override model → `_check_model_pulled` raises in `OllamaRuntimeJudge.__init__`, swallowed on the fire-and-forget hot path. Documented (config comment + ADR addendum). A DEBUG-log ops win is a possible follow-up; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
