### PR TITLE
fix(ipc): accept null contextStats tokens/pct to unblock dispatch logging (LIA-194)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -86,6 +86,10 @@ interface ContainerOutput {
   compactionEvent?: CompactionEvent;
 }
 
+// SYNC-REQUIRED with host ContextStatsSchema (src/ipc-protocol.ts), with ONE
+// intentional asymmetry: host types tokens/pct `number|null` (we emit NaN→null
+// when the SDK omits usage, LIA-194). Keep `number` here; do NOT make the host
+// non-null — that drops the output marker and breaks dispatch logging.
 interface ContextStats {
   tokens: number;
   limit: number;

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-07" # auto-bump @1780830591
+last_verified: "2026-06-07" # auto-bump @1780863060
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-07" # auto-bump @1780830591
+last_verified: "2026-06-07" # auto-bump @1780863060
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-07" # auto-bump @1780843918
+last_verified: "2026-06-07" # auto-bump @1780863060
 governs:
   - src/
   - evolution/

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -320,6 +320,17 @@ describe('ContainerOutputSchema Zod validation', () => {
     ).not.toThrow();
   });
 
+  it('accepts contextStats with null tokens/pct (SDK omits usage → NaN→null, LIA-194)', () => {
+    const parsed = ContainerOutputSchema.parse({
+      status: 'success',
+      result: 'ok',
+      contextStats: { tokens: null, limit: 200000, pct: null },
+    });
+    expect(parsed.contextStats?.tokens).toBeNull();
+    expect(parsed.contextStats?.pct).toBeNull();
+    expect(parsed.contextStats?.limit).toBe(200000);
+  });
+
   it('throws on schema-mismatched input (missing required fields)', () => {
     expect(() =>
       ContainerOutputSchema.parse({ notAValidField: true }),
@@ -363,6 +374,41 @@ describe('ContainerOutputSchema Zod validation', () => {
     expect(onOutput).not.toHaveBeenCalled();
 
     // Clean up
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+    vi.useRealTimers();
+  });
+
+  it('streaming parse: marker with null tokens/pct is NOT dropped → onOutput called (LIA-194 regression)', async () => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // The real-world failing marker: SDK omitted usage → tokens/pct null on wire.
+    const nullStatsJson = JSON.stringify({
+      status: 'success',
+      result: 'hello',
+      contextStats: { tokens: null, limit: 200000, pct: null },
+    });
+    fakeProc.stdout.push(
+      `${OUTPUT_START_MARKER}\n${nullStatsJson}\n${OUTPUT_END_MARKER}\n`,
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Marker must parse (not be dropped) → onOutput called with the real result.
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'success', result: 'hello' }),
+    );
+
     fakeProc.emit('close', 0);
     await vi.advanceTimersByTimeAsync(10);
     await resultPromise;

--- a/src/ipc-protocol.ts
+++ b/src/ipc-protocol.ts
@@ -31,9 +31,13 @@ export const RuntimeSessionSchema = z.object({
 });
 
 export const ContextStatsSchema = z.object({
-  tokens: z.number(),
+  // tokens/pct nullable (LIA-194): SDK-omitted usage → container NaN →
+  // JSON `null` on the wire; a strict z.number() dropped the whole output marker
+  // → broke dispatch logging + caused retries. Do NOT re-sync to non-null to
+  // match the container's `number` interface. `limit` stays required.
+  tokens: z.number().nullable(),
   limit: z.number(),
-  pct: z.number(),
+  pct: z.number().nullable(),
   warn: z.boolean().optional(),
   autoCompact: z.boolean().optional(),
 });

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -322,9 +322,11 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
           const lastCompactedAt = getLastCompactedAt(group.folder, backend);
           return {
             backend,
-            tokens: stats?.tokens,
+            // null (SDK omitted usage, LIA-194) → undefined for the ContextInfo
+            // contract; session-commands already treats absent as "unknown".
+            tokens: stats?.tokens ?? undefined,
             limit: stats?.limit,
-            pct: stats?.pct,
+            pct: stats?.pct ?? undefined,
             lastCompactedAt,
           };
         },
@@ -407,8 +409,12 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
         }
 
         if (CONTEXT_NOTIFY && result.status === 'success' && result.result) {
-          if (result.contextStats?.warn) {
-            const s = result.contextStats;
+          // tokens/pct can be null when the SDK omits usage (LIA-194). The
+          // container won't set `warn` in that case, but guard defensively so a
+          // null never reaches `.toLocaleString()`. Bind `s` first so TS narrows
+          // s.tokens/s.pct from the null checks.
+          const s = result.contextStats;
+          if (s?.warn && s.tokens != null && s.pct != null) {
             await channel.sendMessage(
               chatJid,
               `Context at ${s.pct}% (${s.tokens.toLocaleString()} / ${s.limit.toLocaleString()} tokens). Use /compact to free space.`,


### PR DESCRIPTION
## Why (high-impact live bug)

The Claude Agent SDK stopped reporting usage on result messages, so the container computes `contextStats.tokens/pct = NaN`, which `JSON.stringify` serializes to `null` on the wire. The host `ContextStatsSchema` required `z.number()`, so `ContainerOutputSchema.parse()` threw on the final `DEUS_OUTPUT` marker → the marker was **dropped** → `hadStreamingOutput` (set only on a successful marker parse) stayed `false` → affected dispatches were mis-classified as **"timed out with no output" → error path**.

**Live impact since ~Jun 2 (verified on a real WhatsApp dispatch):**
1. **Evolution logging dead** — `logInteraction` is on the success path, never reached on the error path → no `interactions` rows since 2026-06-02 → judge/reflexion/DSPy all starved.
2. **Retry loops** — error path does "rolled back message cursor for retry" → message re-dispatches (observed a 2nd `deus-whatsapp` container).
3. **Broken session continuity** — `newSessionId`/`newSessionRef` (in the dropped marker) lost.

Root cause is the wire `null` (a `JSON.stringify(NaN)` artifact) hitting the strict schema. The Python logging path itself is healthy (manual `cli.py log_interaction` round-trips fine).

## Fix (host-only — no container rebuild)

- **`src/ipc-protocol.ts`** — `ContextStatsSchema.tokens`/`pct` → `z.number().nullable()` (keep `limit`). + SYNC-contract note: host is deliberately more permissive than the container's `number` interface; do NOT re-tighten (reintroduces the outage).
- **`src/message-orchestrator.ts`** — null-guard the context-warn message (bind `s` first so TS narrows); map `null→undefined` in `getContextInfo`.
- **`container/agent-runner/src/index.ts`** — mirror-interface SYNC rationale comment only (no logic, no rebuild).

## Tests (1500/1500)

- `ContainerOutputSchema.parse()` accepts `contextStats:{tokens:null,limit:200000,pct:null}`.
- Streaming regression: a marker with null tokens is **no longer dropped** → `onOutput` is called.

## Unblocks

Restoring logging also closes **LIA-154 inc#1**'s blocked live loop — `tool_calls` will populate once dispatches log again.

## Follow-ups (out of scope, noted by review)

- Container-side: stop emitting `NaN` when SDK omits usage — would also restore auto-compact/context-warn, currently silently degraded (pre-existing, SDK-caused).
- Cross-reference the LIA-194 note in `llama-cpp-backend.ts` / `openai-backend.ts` `ContextStats` interfaces.

Fixes LIA-194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)