### PR TITLE
fix(ci): exempt dependency-only package.json bumps from deployment.md drift

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -30,6 +30,7 @@ Usage:
   npm run drift-check
 """
 import argparse
+import json
 import os
 import re
 import subprocess
@@ -232,6 +233,76 @@ def _file_in_changed_set(rel_path: str, changed: set[str], project_root: Path) -
     return False
 
 
+# Top-level package.json keys that describe dependency pins or the package
+# version. A change confined to these does not alter deployment *procedure*
+# (the semantic scope of patterns/deployment.md), so a pure dependabot or
+# release-please bump should not flag deployment.md as drifted. Note: `version`
+# is exempt because no pattern governs package.json for version-tracking policy
+# today — deployment.md is about how to deploy, not when to cut a release.
+_PACKAGE_JSON_DRIFT_EXEMPT_KEYS = frozenset({
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "version",
+})
+
+
+def _git_show_blob(ref: str, rel_path: str, project_root: Path) -> str | None:
+    """Return the contents of `rel_path` at git `ref`, or None if it does not
+    exist there or git is unavailable. Matches the subprocess style used by
+    `_git_commit_time` / `_changed_files_since`."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{rel_path}"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def _is_dependency_only_bump(base_ref: str, project_root: Path) -> bool:
+    """True iff package.json's base_ref..working-tree change touches ONLY
+    dependency pins and/or the package version field.
+
+    Compares package.json at `base_ref` (via `git show`) against the working-tree
+    copy (parallels `_git_commit_time`'s working-tree-first behaviour, so a local
+    uncommitted bump is handled too). Returns True when every top-level key that
+    differs — added, removed, or changed — is in `_PACKAGE_JSON_DRIFT_EXEMPT_KEYS`.
+
+    Fail-safe: returns False (i.e. treat as real drift) on any missing blob, OS
+    error, JSON parse error, or non-object JSON, so a genuine structural change
+    is never silently exempted.
+    """
+    base_text = _git_show_blob(base_ref, "package.json", project_root)
+    if base_text is None:
+        return False
+    try:
+        head_text = (project_root / "package.json").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        base_obj = json.loads(base_text)
+        head_obj = json.loads(head_text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(base_obj, dict) or not isinstance(head_obj, dict):
+        return False
+    for key in set(base_obj) | set(head_obj):
+        if key in _PACKAGE_JSON_DRIFT_EXEMPT_KEYS:
+            continue
+        if base_obj.get(key) != head_obj.get(key):
+            return False
+    return True
+
+
 def main(base_ref: str | None = None, bump: bool = False) -> int:
     patterns = discover_patterns()
     if not patterns:
@@ -291,6 +362,18 @@ def main(base_ref: str | None = None, bump: bool = False) -> int:
 
             # In --base mode: skip governed files not changed in this PR.
             if changed_files is not None and not _file_in_changed_set(rel_path, changed_files, PROJECT_ROOT):
+                continue
+
+            # A package.json change confined to dependency pins / version does
+            # not affect deployment guidance — don't flag deployment.md as
+            # drifted for a pure dependabot/release-please bump. Scoped to
+            # package.json only; every other governed path is unaffected.
+            # (changed_files is not None ⟹ base_ref is a non-empty str.)
+            if (
+                changed_files is not None
+                and rel_path == "package.json"
+                and _is_dependency_only_bump(base_ref, PROJECT_ROOT)
+            ):
                 continue
 
             if governed.is_dir():

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -6,6 +6,7 @@ backtick-quoted path references in its body, and verifies every referenced
 path exists on disk. These tests exercise both sources of references in
 isolation using a temporary project tree.
 """
+import json
 import sys
 from pathlib import Path
 
@@ -644,6 +645,78 @@ class TestFileInChangedSet:
 
     def test_empty_changed_set(self, tmp_path):
         assert not drift_check._file_in_changed_set("src/", set(), tmp_path)
+
+
+# ── _is_dependency_only_bump ─────────────────────────────────────────────────
+
+
+class TestDependencyOnlyBump:
+    """`_is_dependency_only_bump` — exempt pure dependabot/release-please
+    package.json bumps from triggering a false deployment.md drift."""
+
+    def _setup(self, monkeypatch, tmp_path, base_obj, head_obj):
+        """Write the head package.json into tmp_path and stub `git show` of base."""
+        (tmp_path / "package.json").write_text(json.dumps(head_obj), encoding="utf-8")
+        monkeypatch.setattr(
+            drift_check,
+            "_git_show_blob",
+            lambda ref, rel_path, root: json.dumps(base_obj),
+        )
+
+    def test_dependency_pin_bump_is_exempt(self, tmp_path, monkeypatch):
+        base = {"name": "deus", "version": "1.0.0", "dependencies": {"yaml": "2.8.4"}}
+        head = {"name": "deus", "version": "1.0.0", "dependencies": {"yaml": "2.9.0"}}
+        self._setup(monkeypatch, tmp_path, base, head)
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is True
+
+    def test_version_only_bump_is_exempt(self, tmp_path, monkeypatch):
+        """release-please bumps only `version`."""
+        base = {"name": "deus", "version": "1.16.0", "scripts": {"build": "tsc"}}
+        head = {"name": "deus", "version": "1.17.0", "scripts": {"build": "tsc"}}
+        self._setup(monkeypatch, tmp_path, base, head)
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is True
+
+    def test_devdeps_plus_version_is_exempt(self, tmp_path, monkeypatch):
+        base = {"version": "1.0.0", "devDependencies": {"vitest": "4.1.7"}}
+        head = {"version": "1.0.1", "devDependencies": {"vitest": "4.1.8"}}
+        self._setup(monkeypatch, tmp_path, base, head)
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is True
+
+    def test_scripts_change_is_not_exempt(self, tmp_path, monkeypatch):
+        """A real deployment-relevant change (scripts) must still drift."""
+        base = {"version": "1.0.0", "scripts": {"build": "tsc"}, "dependencies": {"yaml": "2.8.4"}}
+        head = {"version": "1.0.0", "scripts": {"build": "tsc -p ."}, "dependencies": {"yaml": "2.9.0"}}
+        self._setup(monkeypatch, tmp_path, base, head)
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is False
+
+    def test_new_nonexempt_key_is_not_exempt(self, tmp_path, monkeypatch):
+        base = {"version": "1.0.0", "dependencies": {"yaml": "2.8.4"}}
+        head = {"version": "1.0.0", "dependencies": {"yaml": "2.9.0"}, "engines": {"node": ">=20"}}
+        self._setup(monkeypatch, tmp_path, base, head)
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is False
+
+    def test_malformed_head_json_fails_safe(self, tmp_path, monkeypatch):
+        (tmp_path / "package.json").write_text("{ not valid json ", encoding="utf-8")
+        monkeypatch.setattr(
+            drift_check,
+            "_git_show_blob",
+            lambda ref, rel_path, root: json.dumps({"version": "1.0.0"}),
+        )
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is False
+
+    def test_missing_base_blob_fails_safe(self, tmp_path, monkeypatch):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"version": "1.0.0"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(drift_check, "_git_show_blob", lambda ref, rel_path, root: None)
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is False
+
+    def test_identity_no_diff_is_exempt(self, tmp_path, monkeypatch):
+        """base == head (whitespace/key-order normalized away) → no non-exempt
+        key differs → exempt."""
+        obj = {"name": "deus", "version": "1.0.0", "scripts": {"build": "tsc"}}
+        self._setup(monkeypatch, tmp_path, obj, dict(obj))
+        assert drift_check._is_dependency_only_bump("origin/main", tmp_path) is True
 
 
 # ── check_shadow ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`drift_check.py`'s `--base` mode compares each governed file's last git-commit time vs its pattern's. `patterns/deployment.md` `governs: package.json`, so **any** PR that commits `package.json` makes it newer than `deployment.md` → false `deployment.md DRIFTED | package.json` → required `ci` check fails.

This blocks **6 open PRs** on the identical line (verified across all six), and recurs on every future bump:
- #672 @linear/sdk · #673 googleapis · #674 @vitest/coverage-v8 · #675 better-sqlite3 · #676 yaml (dependabot)
- #596 release-please 1.17.0 (version bump)

Systemic false-positive → fix belongs in `drift_check.py`, not per-branch `--bump` commits.

## Fix

`_is_dependency_only_bump(base_ref, project_root)`: a `package.json` change whose **differing top-level keys** are all in `{dependencies, devDependencies, peerDependencies, optionalDependencies, version}` does not affect deployment *procedure* (deployment.md's semantic scope), so it's exempted from triggering `deployment.md` drift.

- **Fail-safe**: any non-exempt key change (e.g. `scripts`, a new top-level key), missing base blob, OS error, JSON error, or non-object JSON → treated as **real** drift. A genuine structural change is never silently exempted.
- **Narrowly scoped**: only `rel_path == "package.json"`, only in `--base` mode. The other 5 `deployment.md` governed paths (`tsconfig.json`, `setup/`, `container/build.sh`, `container/Dockerfile`, `packages/`) and every other pattern are untouched. Non-`--base` runs are unaffected.

## Verification

- `pytest scripts/tests/test_drift_check.py` → **98 pass** (8 new `TestDependencyOnlyBump` cases: dep-only, version-only, devdeps+version, scripts→not-exempt, new-key→not-exempt, malformed→fail-safe, missing-base→fail-safe, identity).
- Real-git proof: dep-only bump → exempt; a `scripts` change → not exempt.
- `main()` integration proof: dep-only bump → `deployment.md OK` / rc 0; `scripts` change → `DRIFTED` / rc 1.
- Full local `drift_check.py --all` (no `--base`) → unchanged, exit 0.

No pattern governs `scripts/` broadly, so this PR does not self-drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)