### PR TITLE
docs(evolution): fix mcp_server invocation comment + document EVOLUTION_OLLAMA_JUDGE_MODEL (LIA-173)

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -67,7 +67,8 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
-| `OLLAMA_MODEL` | `gemma4:e4b` | Ollama judge model |
+| `OLLAMA_MODEL` | `gemma4:e4b` | Default Ollama judge model (override per-surface with `EVOLUTION_OLLAMA_JUDGE_MODEL`) |
+| `EVOLUTION_OLLAMA_JUDGE_MODEL` | (falls back to `OLLAMA_MODEL`) | Per-surface override for the evolution-loop Ollama judge model (mirrors `LLAMA_CPP_JUDGE_MODEL`). The override model must be pulled in Ollama or judge construction fails |
 | `OLLAMA_EMBED_MODEL` | `embeddinggemma` | Ollama embedding model |
 | `LLAMA_CPP_BASE_URL` | `http://localhost:8080/v1` | llama.cpp HTTP base URL (OpenAI-compatible `/v1` prefix); consumed by evolution-loop providers |
 | `LLAMA_CPP_MODEL` | (empty — server default) | Catch-all model override. Empty = use whatever llama-server has loaded (single-model) OR auto-pick (router mode) |

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -6,7 +6,7 @@ server (Claude Code, OpenClaw, NemoClaw) can log interactions and retrieve
 reflections without Python knowledge.
 
 Usage:
-    python -m evolution mcp_server   # stdio (for Claude Code settings.json)
+    python -m evolution.mcp_server   # stdio (for Claude Code settings.json)
     python evolution/mcp_server.py   # direct
 
 Register in ~/.claude/settings.json:

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-08" # auto-bump @1780902523
+last_verified: "2026-06-08" # auto-bump @1780918638
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-08" # auto-bump @1780869610
+last_verified: "2026-06-08" # auto-bump @1780918638
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-08" # auto-bump @1780931406
+last_verified: "2026-06-08" # auto-bump @1780937397
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary

Two doc-surface fixes surfaced by code review of PR #684 (editor integration guide). Docs/comment only — no behavior change.

1. **Module-invocation typo** — `evolution/mcp_server.py` header comment showed `python -m evolution mcp_server` (space), which is syntactically wrong for a submodule. Corrected to `python -m evolution.mcp_server` (dot), matching `~/.claude.json`, `docs/EDITOR_INTEGRATION.md`, and `docs/MULTI_BACKEND.md`. Verified the space form appears nowhere else in the repo.
2. **Document the configurable judge model** — `docs/ENVIRONMENT.md` now documents `EVOLUTION_OLLAMA_JUDGE_MODEL`, the per-surface override for the Ollama judge model (`evolution/config.py:47` — `os.environ.get("EVOLUTION_OLLAMA_JUDGE_MODEL", OLLAMA_MODEL)`, falls back to `OLLAMA_MODEL`), and clarifies the existing `OLLAMA_MODEL` row points to it.

Bumps `last_verified` on `patterns/{general-code,eval-change,documentation}.md` (which govern the touched `evolution/` and `docs/` trees) to satisfy the pattern drift check.

## Test plan

- `python3 scripts/drift_check.py --all --base origin/main` → **ALL CHECKS PASSED** (exit 0) locally.
- No code logic changed; no unit tests affected.

Closes LIA-173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)