### PR TITLE
fix(telemetry): decouple logInteraction from the output-marker parse (LIA-196)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-07" # auto-bump @1780863060
+last_verified: "2026-06-08" # auto-bump @1780931406
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-07" # auto-bump @1780863060
+last_verified: "2026-06-08" # auto-bump @1780931406
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-07" # auto-bump @1780863060
+last_verified: "2026-06-08" # auto-bump @1780931406
 governs:
   - src/
   - evolution/

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1587,7 +1587,11 @@ def check_codegraph_transcript_format(project_root: Path) -> int:
                 "Re-validate the codegraph fixture against a fresh transcript: "
                 "python3 scripts/drift_check.py --codegraph-format. "
                 "If live shape check passed, the format is still compatible. "
-                "Update meta.json cc_version to silence this warning."
+                "Update meta.json cc_version to silence this warning. "
+                # LIA-196: SDK version bumps can also change the DEUS_OUTPUT marker
+                # shape (LIA-194 was exactly this). Re-run the output contract too.
+                "Also re-validate the container-output contract: "
+                "npx vitest run src/container-runner.test.ts -t 'output contract'."
             )
         elif current_version:
             print(f"OK: CC version {current_version} matches pinned {pinned_version or '(none)'}")

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -163,7 +163,11 @@ import {
   ContainerOutput,
   readToolCalls,
 } from './container-runner.js';
-import { getActivePrompt, getReflections } from './evolution-client.js';
+import {
+  getActivePrompt,
+  getReflections,
+  logInteraction,
+} from './evolution-client.js';
 import type { RegisteredGroup } from './types.js';
 
 const testGroup: RegisteredGroup = {
@@ -308,6 +312,152 @@ describe('container-runner timeout behavior', () => {
 });
 
 // ---------------------------------------------------------------------------
+// logInteraction fires on EVERY output-producing completion path (LIA-196).
+// Before LIA-196 the idle-after-output and non-zero-after-output paths resolved
+// success but never logged. These tests pin logInteraction to all four close
+// paths and guard the per-site hasCode derivation + the reaped-latency anchor.
+// ---------------------------------------------------------------------------
+
+describe('logInteraction on all output-producing paths (LIA-196)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    vi.mocked(logInteraction).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('idle timeout after output still logs the interaction (reaped path)', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'streamed answer',
+      newSessionId: 'session-idle',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Idle period elapses → the hard timeout reaps the container after output.
+    await vi.advanceTimersByTimeAsync(1830000);
+    fakeProc.emit('close', 137);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('success');
+
+    expect(vi.mocked(logInteraction)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(logInteraction).mock.calls[0][0];
+    expect(call.response).toBeNull();
+    expect(call.hasCode).toBe(false);
+    expect(call.groupFolder).toBe('test-group');
+    // Latency anchors to the last output, NOT the ~30min reaped lifetime.
+    expect(call.latencyMs).toBeLessThan(60000);
+  });
+
+  it('non-zero exit after output still logs the interaction (reaped path)', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'streamed answer',
+      newSessionId: 'session-nonzero',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Container killed externally (non-zero) AFTER producing output — no timeout.
+    fakeProc.emit('close', 137);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('success');
+
+    expect(vi.mocked(logInteraction)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(logInteraction).mock.calls[0][0];
+    expect(call.response).toBeNull();
+    expect(call.hasCode).toBe(false);
+  });
+
+  it('streaming success logs exactly once (no double-log on a single close)', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'streamed answer',
+      newSessionId: 'session-clean',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await resultPromise;
+    expect(vi.mocked(logInteraction)).toHaveBeenCalledTimes(1);
+  });
+
+  it('legacy path derives hasCode=true from a code-bearing result', async () => {
+    // No onOutput → legacy (accumulate stdout + parse-on-close) path.
+    const resultPromise = runContainerAgent(testGroup, testInput, () => {});
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'Here you go:\n```js\nconsole.log("hi there");\n```',
+      newSessionId: 'session-legacy-code',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('success');
+
+    expect(vi.mocked(logInteraction)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(logInteraction).mock.calls[0][0];
+    expect(call.hasCode).toBe(true);
+    expect(call.response).toContain('console.log');
+  });
+
+  it('legacy path derives hasCode=false from a plain result', async () => {
+    const resultPromise = runContainerAgent(testGroup, testInput, () => {});
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'just a plain text answer, nothing fenced here',
+      newSessionId: 'session-legacy-plain',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await resultPromise;
+    expect(vi.mocked(logInteraction)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(logInteraction).mock.calls[0][0];
+    expect(call.hasCode).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ContainerOutputSchema Zod validation tests
 // ---------------------------------------------------------------------------
 
@@ -341,6 +491,54 @@ describe('ContainerOutputSchema Zod validation', () => {
     expect(() =>
       ContainerOutputSchema.parse({ status: 'unknown', result: null }),
     ).toThrow();
+  });
+
+  // ── Output contract + optional-block resilience (LIA-196) ──────────────────
+
+  it('output contract: parses a real CC-2.1.168 DEUS_OUTPUT shape', () => {
+    // captured from a live dispatch (docker logs), incl. the null-token usage shape
+    const real = {
+      status: 'success',
+      result: 'Hey! What is up?',
+      newSessionRef: {
+        backend: 'claude',
+        session_id: 'a4258741-addf-4f66-bbd4-3c966bbafb96',
+      },
+      newSessionId: 'a4258741-addf-4f66-bbd4-3c966bbafb96',
+      contextStats: { tokens: null, limit: 200000, pct: null },
+    };
+    const parsed = ContainerOutputSchema.parse(real);
+    expect(parsed.status).toBe('success');
+    expect(parsed.result).toBe('Hey! What is up?');
+    expect(parsed.newSessionId).toBe('a4258741-addf-4f66-bbd4-3c966bbafb96');
+  });
+
+  it('output contract: a malformed OPTIONAL contextStats degrades to undefined, marker still parses', () => {
+    const parsed = ContainerOutputSchema.parse({
+      status: 'success',
+      result: 'ok',
+      newSessionId: 's1',
+      contextStats: { tokens: 'not-a-number', limit: 'bad' }, // garbage
+    });
+    // core fields preserved; the bad optional block dropped to undefined (LIA-196)
+    expect(parsed.status).toBe('success');
+    expect(parsed.result).toBe('ok');
+    expect(parsed.newSessionId).toBe('s1');
+    expect(parsed.contextStats).toBeUndefined();
+  });
+
+  it('output contract: a malformed OPTIONAL compactionEvent degrades to undefined', () => {
+    const parsed = ContainerOutputSchema.parse({
+      status: 'success',
+      result: 'ok',
+      compactionEvent: { trigger: 'not-a-valid-trigger' }, // garbage enum
+    });
+    expect(parsed.result).toBe('ok');
+    expect(parsed.compactionEvent).toBeUndefined();
+  });
+
+  it('output contract: load-bearing fields stay strict (missing status still throws)', () => {
+    expect(() => ContainerOutputSchema.parse({ result: 'ok' })).toThrow();
   });
 
   it('streaming parse: schema-mismatched output chunk logs error and does not call onOutput', async () => {
@@ -405,6 +603,47 @@ describe('ContainerOutputSchema Zod validation', () => {
     await vi.advanceTimersByTimeAsync(10);
 
     // Marker must parse (not be dropped) → onOutput called with the real result.
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'success', result: 'hello' }),
+    );
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+    vi.useRealTimers();
+  });
+
+  it('streaming parse: a garbage OPTIONAL contextStats does NOT drop the marker → onOutput fires (LIA-194 recurrence guard)', async () => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // The LIA-194 vector, generalized: a malformed OPTIONAL sub-block on the wire.
+    // Before the schema .catch (LIA-196) the strict parse threw, the marker was
+    // discarded, hadStreamingOutput stayed false, and the dispatch was
+    // mis-classified as "timed out with no output" → no onOutput, no logging.
+    // Raw push: garbage contextStats can't satisfy the ContainerOutput type, so
+    // emitOutputMarker is unusable here.
+    const garbageStatsJson = JSON.stringify({
+      status: 'success',
+      result: 'hello',
+      contextStats: { tokens: 'not-a-number', limit: 'bad' },
+    });
+    fakeProc.stdout.push(
+      `${OUTPUT_START_MARKER}\n${garbageStatsJson}\n${OUTPUT_END_MARKER}\n`,
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Marker still parses (bad block degraded to undefined) → onOutput fires.
+    expect(onOutput).toHaveBeenCalledTimes(1);
     expect(onOutput).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'success', result: 'hello' }),
     );

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -437,6 +437,7 @@ export async function runContainerAgent(
               newSessionId = parsed.newSessionId;
             }
             hadStreamingOutput = true;
+            lastOutputAt = Date.now();
             // Activity detected — reset the hard timeout
             resetTimeout();
             // Call onOutput for all markers (including null results)
@@ -476,6 +477,10 @@ export async function runContainerAgent(
 
     let timedOut = false;
     let hadStreamingOutput = false;
+    // Epoch of the last real output marker — used as the latency anchor on the
+    // reaped completion paths so an idle-then-reaped dispatch records its response
+    // time, not the full (up to IDLE_TIMEOUT) container lifetime (LIA-196).
+    let lastOutputAt = 0;
     const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
     // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
     // graceful _close sentinel has time to trigger before the hard kill fires.
@@ -515,6 +520,37 @@ export async function runContainerAgent(
       clearTimeout(timeout);
       const duration = Date.now() - startTime;
 
+      // Single logInteraction seam (LIA-196): every output-producing completion
+      // path logs through this, so a malformed marker / unusual exit can no
+      // longer silently drop the interaction.
+      const logDispatch = (
+        response: string | null,
+        sessionId: string | undefined,
+        latencyMs: number,
+      ): void => {
+        logInteraction({
+          id: interactionId,
+          prompt: input.prompt,
+          response,
+          groupFolder: group.folder,
+          latencyMs,
+          sessionId,
+          domainPresets: domains.length > 0 ? domains : undefined,
+          userSignal: userSignal ?? undefined,
+          retrievedReflectionIds:
+            reflections.reflectionIds.length > 0
+              ? reflections.reflectionIds
+              : undefined,
+          contextTokens: estimateTokens(input.prompt),
+          hasCode: containsCodeBlock(response),
+          toolCalls: readToolCalls(logsDir, interactionId),
+        });
+      };
+      // Reaped paths (idle-after-output, non-zero-after-output) resolve long after
+      // the response; anchor latency to the last output, not the container lifetime.
+      const reapedLatencyMs = () =>
+        (lastOutputAt > 0 ? lastOutputAt : Date.now()) - startTime;
+
       if (timedOut) {
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
         const timeoutLog = path.join(logsDir, `container-${ts}.log`);
@@ -540,6 +576,8 @@ export async function runContainerAgent(
             'Container timed out after output (idle cleanup)',
           );
           outputChain.then(() => {
+            // Produced output -> still log for the evolution loop (LIA-196).
+            logDispatch(null, input.sessionRef?.session_id, reapedLatencyMs());
             resolve({
               status: 'success',
               result: null,
@@ -643,6 +681,8 @@ export async function runContainerAgent(
             'Container exited non-zero after output (treating as success)',
           );
           outputChain.then(() => {
+            // Produced output -> still log for the evolution loop (LIA-196).
+            logDispatch(null, input.sessionRef?.session_id, reapedLatencyMs());
             resolve({
               status: 'success',
               result: null,
@@ -685,23 +725,7 @@ export async function runContainerAgent(
             'Container completed (streaming mode)',
           );
           // Post-dispatch: log interaction for evolution loop (fire-and-forget)
-          logInteraction({
-            id: interactionId,
-            prompt: input.prompt,
-            response: null,
-            groupFolder: group.folder,
-            latencyMs: duration,
-            sessionId: input.sessionRef?.session_id,
-            domainPresets: domains.length > 0 ? domains : undefined,
-            userSignal: userSignal ?? undefined,
-            retrievedReflectionIds:
-              reflections.reflectionIds.length > 0
-                ? reflections.reflectionIds
-                : undefined,
-            contextTokens: estimateTokens(input.prompt),
-            hasCode: false,
-            toolCalls: readToolCalls(logsDir, interactionId),
-          });
+          logDispatch(null, input.sessionRef?.session_id, duration);
           resolve({
             status: 'success',
             result: null,
@@ -746,26 +770,13 @@ export async function runContainerAgent(
         );
 
         // Post-dispatch: log interaction for evolution loop (fire-and-forget)
-        logInteraction({
-          id: interactionId,
-          prompt: input.prompt,
-          response: output.result,
-          groupFolder: group.folder,
-          latencyMs: duration,
-          sessionId:
-            input.sessionRef?.session_id ??
+        logDispatch(
+          output.result,
+          input.sessionRef?.session_id ??
             output.newSessionRef?.session_id ??
             output.newSessionId,
-          domainPresets: domains.length > 0 ? domains : undefined,
-          userSignal: userSignal ?? undefined,
-          retrievedReflectionIds:
-            reflections.reflectionIds.length > 0
-              ? reflections.reflectionIds
-              : undefined,
-          contextTokens: estimateTokens(input.prompt),
-          hasCode: containsCodeBlock(output.result),
-          toolCalls: readToolCalls(logsDir, interactionId),
-        });
+          duration,
+        );
 
         resolve(output);
       } catch (err) {

--- a/src/ipc-protocol.ts
+++ b/src/ipc-protocol.ts
@@ -14,6 +14,8 @@
 
 import { z } from 'zod';
 
+import { logger } from './logger.js';
+
 // ── IPC marker constants ────────────────────────────────────────────────────
 // Previously defined in container-runner.ts with a SYNC-REQUIRED comment.
 // Canonical definition lives here; container/agent-runner/src/index.ts
@@ -51,14 +53,28 @@ export const CompactionEventSchema = z.object({
 // ── ContainerOutput ─────────────────────────────────────────────────────────
 
 export const ContainerOutputSchema = z.object({
+  // Load-bearing fields stay strict — a marker missing these is genuinely unusable.
   status: z.enum(['success', 'error']),
   result: z.string().nullable(),
   newSessionRef: RuntimeSessionSchema.optional(),
   newSessionId: z.string().optional(),
   error: z.string().optional(),
   prUrl: z.string().optional(),
-  contextStats: ContextStatsSchema.optional(),
-  compactionEvent: CompactionEventSchema.optional(),
+  // Optional sub-blocks degrade to `undefined` rather than failing the WHOLE
+  // marker parse (LIA-196) — be liberal in optional extras. The warn keeps the
+  // degradation observable; a silent .catch would hide future wire drift.
+  contextStats: ContextStatsSchema.optional().catch(() => {
+    logger.warn(
+      'ContainerOutput: malformed contextStats dropped to undefined (LIA-196)',
+    );
+    return undefined;
+  }),
+  compactionEvent: CompactionEventSchema.optional().catch(() => {
+    logger.warn(
+      'ContainerOutput: malformed compactionEvent dropped to undefined (LIA-196)',
+    );
+    return undefined;
+  }),
 });
 
 /** Derived TypeScript type — single source of truth. */


### PR DESCRIPTION
## Summary

Prevention layer for the LIA-194 outage. LIA-194 was a one-field schema mismatch (`contextStats.tokens` NaN→null vs a strict `z.number()`) that took down **all** dispatch logging and caused retry loops: telemetry (`logInteraction`) was gated behind a strict parse of an *optional* stats block, so one bad field dropped the whole `DEUS_OUTPUT` marker → `hadStreamingOutput=false` → "timed out with no output" → no logging. The `.nullable()` patch fixed that one field; this closes the systemic class so any future SDK field change can't recur it.

(LIA-195 was the detection layer — the logging heartbeat. This is prevention.)

## Changes

| # | File | Change |
|---|------|--------|
| 1 | `src/ipc-protocol.ts` | `ContainerOutputSchema` wraps the **optional** `contextStats` / `compactionEvent` sub-blocks in zod `.catch()` so a malformed value degrades to `undefined` with an observable `logger.warn`, instead of failing the whole marker parse. Load-bearing fields (`status`/`result`/`newSessionRef`/`newSessionId`) stay strict. LIA-194 nullable `tokens`/`pct` retained. |
| 2 | `src/container-runner.ts` | A single `logDispatch()` seam in the close handler fires `logInteraction` on **all four** output-producing paths (idle-after-output, non-zero-after-output, streaming-success, legacy). Previously only the latter two logged, so a reaped dispatch was invisible to the evolution loop. `hasCode` is derived per-response (no per-site regression); reaped paths anchor latency to the last output (`lastOutputAt`), not the up-to-30min container lifetime. |
| 3 | `src/container-runner.test.ts` | Wire-contract (real CC-2.1.168 null-tokens shape, garbage optional blocks → `undefined`, missing `status` still throws) + four-path `logInteraction` coverage + `hasCode` truthy/false derivation + reaped-latency anchor + the LIA-194 streaming recurrence guard. |
| 4 | `scripts/drift_check.py` | The CC-version-bump WARN now also reminds to re-validate the output contract via vitest. |

## Why decouple (not just patch the field)

A malformed/evolving **optional** sub-block must never (a) discard the marker or (b) prevent telemetry. Be liberal in everything except the load-bearing `status`/`result`. One `close` per container ⇒ exactly one `logInteraction` per dispatch (`interactionId` PK + `INSERT OR REPLACE` upsert is the backstop).

## Verification

- `npx vitest run` → **1510 passed** (84 files)
- `npx tsc --noEmit` → clean
- `npm run lint` → 0 errors · `npm run format:check` → clean
- `python3 scripts/drift_check.py --all --base origin/main` → ALL CHECKS PASSED
- `pytest scripts/tests/test_drift_check.py` → 98 passed

Host-only `src/` change → deploy is `npm run build` + kickstart (no container rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)