### PR TITLE
feat(review): local cross-family code-review advisory (Gemma 4 12B, never a gate) (LIA-179)

### DIFF
--- a/scripts/cross_family_review.py
+++ b/scripts/cross_family_review.py
@@ -1,59 +1,64 @@
 #!/usr/bin/env python3
-"""Cross-family local code reviewer — candidate generator (measure-first increment 1).
+"""Cross-family local code-review ADVISORY (Gemma 4 12B, calibrated-diff).
 
-A *decorrelated second opinion* for the Claude code-reviewer warden. Runs a LOCAL
-model (different family => independent blind spots) over a diff and proposes
-CANDIDATE findings. It is a recall-oriented surfacer, NOT an adjudicator: the
-Claude code-reviewer remains the precision layer that validates each candidate
-against the full rules + diff and renders the SHIP/REVISE/BLOCK verdict.
+A LOCAL, different-family second opinion for a human reviewer — NOT a gate and NOT
+an adjudicator. Runs a local code model (different family => independent blind
+spots) over a diff with the validated *calibrated-diff* prompt and prints, per file,
+a human-readable advisory plus the model's own reasoning so a person can triage each
+flag. Nothing here auto-applies, auto-posts, or blocks a commit.
 
-Status: increment 1 is the MEASURABLE CORE only. It emits candidates to stdout so
-their catch rate / decorrelation value can be measured on real diffs BEFORE any
-integration. Wiring candidates into the code-reviewer prompt, an auto-trigger, a
-blast-radius classifier, and accept/reject logging are DEFERRED.
+WHY ADVISORY-ONLY (LIA-179, n=35 validation — read before trusting any flag):
+  * On real merged diffs the calibrated reviewer false-flags **~29%** of changes,
+    and on first-hand adjudication ALL sampled flags were false — including
+    confident *phantom crashes* ("MAJOR: will throw TypeError" on correct code).
+    So: a human triages every flag; treat "will crash" claims with suspicion.
+  * Recall is only validated on SMALL, single-change diffs (caught 7/7). On a large
+    (~300-LOC) diff it MISSED the real bug and added noise. This tool warns when a
+    file's added-line count exceeds --max-diff-loc; large-diff misses are expected.
+  * This supersedes the earlier "surface candidates for a Claude adjudicator/gate"
+    design (Qwen + runtime rule-digest), which validated net-negative — both the
+    rule digest and the gate framing are gone. Rule-conformance stays with the
+    Claude code-reviewer warden; this tool is scoped to bug/correctness/security.
 
-VALIDATION RESULT (2026-06-04) — PARKED, not yet wired in. Measured on 6 real
-blast-radius commits with two models: general Qwen3.5-9B and code-specialized
-Qwen2.5-Coder-7B. Neither is adjudication-ready at 7-9B / 8k KV / diff-only: real
-finds exist (~15-25%) but are buried in noise, and the highest-confidence flags
-include confident FALSE POSITIVES (e.g. "XML injection" against already-escaped code;
-a rule mis-applied as blocking to every doc edit). Two cross-model root causes: the
-runtime rule digest is net-negative (both models mis-apply rule ids), and diff-only
-context yields unverifiable claims. This harness is retained for future iteration
-(drop the digest, send full-file context, or try a larger code model, then re-measure).
+SERVING (kept out of the repo on purpose — user-agnostic):
+  Point this at a llama-server (OpenAI-compatible) running a 12B-class code model
+  with REASONING DISABLED. gemma models have a thinking mode on by default; if it
+  is left on, llama-server returns EMPTY content (finish_reason=length) and this
+  tool fails loud rather than reporting a false "clean". Disable it at serve time
+  (current llama-server builds: a reasoning-off launch flag — exact flag name varies
+  by build, verify against your binary). Configure the endpoint/model via env or
+  flags (see below); do NOT point this at the deployed Deus service on :8080 (that
+  serves a small model never validated for review — the tool warns if you do).
 
-Design notes:
-- Local model = Qwen3.5-9B Q4_K_M via llama-server's OpenAI-compatible endpoint,
-  temp=0, 8k KV (the user-specified budget). No egress: the model is local, so this
-  reviews public AND private code on a single path.
-- 8k KV is tight. The full code-review-rules.md is ~4.3k tokens — too large to ship
-  to the local model alongside a diff. Instead we derive a CONDENSED rule digest
-  (rule id + severity + "Applies when" trigger) at runtime from the same file, so
-  the local model speaks the repo's rule vocabulary without the token cost and
-  without duplicating rule text (the full rules stay with the Claude adjudicator).
-- Per-file chunking: one model call per changed file. If a single file's diff still
-  overflows the budget we truncate the DIFF ONLY (never the rules/system prompt) and
-  log it; files dropped under --max-files are logged too. No silent caps.
-- Fail-loud: if llama-server is unreachable we exit non-zero — we never fabricate
-  candidates from a failed call.
+  This tool requires a reachable local llama-server (no cloud fallback) and fails
+  loud with an actionable message if none is found. The code itself is
+  cross-platform (git/httpx/pathlib); only the local-server dependency is required.
+
+SECURITY: the diff is untrusted text sent to a LOCAL model with no tools, no file
+access, and no egress; output is advisory text shown to a human and nothing
+auto-executes. Injected instructions inside a diff can at most produce a fabricated
+finding the human discards. If this tool ever gains auto-posting, gating, or
+upstream prompt reuse, add prompt-injection boundaries BEFORE that change.
+
+Environment (review-specific first, then the shared llama-cpp vars):
+    LLAMA_CPP_REVIEW_BASE_URL  OpenAI-compatible base for the reviewer, e.g.
+                               http://127.0.0.1:8099/v1  (preferred)
+    LLAMA_CPP_BASE_URL         shared fallback base URL
+    LLAMA_CPP_PORT             used to build the base URL when neither above is set
+    LLAMA_CPP_REVIEW_MODEL     model name for this surface; falls back to LLAMA_CPP_MODEL
+    LLAMA_CPP_MODEL            catch-all; empty => llama-server uses its loaded model
+
+Agent-native (docs/decisions/printing-press-adoption.md): typed exit codes,
+``--json`` / ``--compact`` / ``--select``; default output stays human text because
+the ADR's own measurement shows JSON regresses for human-facing shapes.
 
 Usage:
-    # Review the current working-tree diff (staged + unstaged):
+    # Advisory review of the current working-tree diff (staged + unstaged):
     python3 scripts/cross_family_review.py
 
-    # Review a historical commit (for the validation pass):
+    # A historical commit / range, or an arbitrary diff file:
     python3 scripts/cross_family_review.py --rev-range <sha>
-
-    # Review an arbitrary diff file:
-    python3 scripts/cross_family_review.py --diff-file /tmp/some.diff --out /tmp/cands.json
-
-Environment (mirrors the per-surface convention in evolution/config.py; no import
-coupling — defaults are replicated inline so a config.py change can't silently move
-this script's endpoint):
-    LLAMA_CPP_BASE_URL     OpenAI-compatible base, e.g. http://127.0.0.1:8080/v1
-    LLAMA_CPP_PORT         used to build the base URL when LLAMA_CPP_BASE_URL is unset
-    LLAMA_CPP_REVIEW_MODEL model name for this surface; falls back to LLAMA_CPP_MODEL
-    LLAMA_CPP_MODEL        catch-all model; empty => llama-server uses its loaded model
+    python3 scripts/cross_family_review.py --diff-file /tmp/some.diff --out /tmp/adv.json
 """
 from __future__ import annotations
 
@@ -63,7 +68,20 @@ import os
 import re
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _agent_io import agent_output, is_agent_context  # noqa: E402
+from _exit_codes import (  # noqa: E402
+    ABSTAIN,
+    INTERNAL_ERROR,
+    NOT_FOUND,
+    SUCCESS,
+    USAGE_ERROR,
+)
 
 try:
     import httpx
@@ -72,21 +90,65 @@ except ImportError:  # pragma: no cover - actionable guard for fresh clones
         "[cross-family-review] missing dependency 'httpx'. Install it:\n"
         "    python3 -m pip install httpx\n"
     )
-    sys.exit(2)
+    sys.exit(USAGE_ERROR)
 
-# ── Token budgeting (rough; char/4 heuristic with margin — we don't have the
-# model's tokenizer in-process, so we stay conservative). ──────────────────────
+# ── Sampling (matches the validated n=35 config; deterministic) ─────────────────
+TEMPERATURE = 0
+TOP_P = 1.0
+SEED = 42
+MAX_TOKENS = 1024
+
+# ── Token budgeting (rough chars/4 heuristic; the diff is the only thing we ever
+# truncate, never the prompt). The 12B is served with a KV window >= --ctx. ──────
 CHARS_PER_TOKEN = 4
-DEFAULT_CTX = 8192          # 8k KV — the user-specified budget
-OUTPUT_RESERVE_TOKENS = 1024  # headroom for the model's JSON answer
-SYSTEM_SAFETY_TOKENS = 256    # slack so we never exactly hit the wall
+DEFAULT_CTX = 8192            # deliberate conservative secondary net (see size guard)
+OUTPUT_RESERVE_TOKENS = MAX_TOKENS
+SYSTEM_SAFETY_TOKENS = 256
+
+# ── Recall guard: recall was only validated on small single-change diffs. This is
+# a HEURISTIC warn threshold (added code lines per file), NOT a measured safe cap. ─
+DEFAULT_MAX_DIFF_LOC = 60
+
+CLEAN_SENTINEL = "NO ISSUES FOUND"
+
+SYSTEM = "You are a senior software engineer performing a thorough code review."
+
+# The validated calibrated-diff prompt (STAGE0 "after" preamble + conservative bar,
+# retargeted to a unified diff). Verbatim from the n=35 validation runner.
+USER_CALIBRATED_DIFF = (
+    "You are reviewing a unified-diff EXCERPT of {lang} code from a larger, working "
+    "codebase. In the diff, lines starting with `+` are added, `-` are removed, and "
+    "unmarked lines are unchanged surrounding context. Review the CHANGE (the added "
+    "lines, in the context shown). "
+    "Assume every import, type, and module-level constant or variable referenced "
+    "but not shown here is correctly defined elsewhere; review ONLY the logic that "
+    "is visible.\n\n"
+    "Most code you review is correct. Report an issue ONLY if you are confident it "
+    "is a REAL defect that would cause wrong behavior, a security vulnerability, or "
+    "a crash under normal, in-contract use. Do NOT report: style/formatting "
+    "preferences, naming, missing comments, defensive-programming suggestions, or "
+    "hypothetical edge cases that cannot occur given the function's contract. When "
+    "in doubt, do NOT report it.\n\n"
+    "For each genuine issue give: severity (CRITICAL/MAJOR/MINOR), the location, and "
+    "a one-sentence explanation. If the change has no real defect, reply exactly "
+    "NO ISSUES FOUND.\n\n```diff\n{code}\n```"
+)
+
+
+class ReviewError(Exception):
+    """A fatal review failure carrying a typed exit code for main() to return."""
+
+    def __init__(self, code: int, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 def _est_tokens(text: str) -> int:
     return (len(text) + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN
 
 
-# ── Repo / rules loading (CWD-independent) ─────────────────────────────────────
+# ── Repo / diff acquisition (fail-loud; never let a failure look like an empty tree) ─
 def repo_root() -> str:
     try:
         out = subprocess.run(
@@ -95,87 +157,38 @@ def repo_root() -> str:
         )
         return out.stdout.strip()
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        sys.stderr.write(f"[cross-family-review] not a git repo / git missing: {exc}\n")
-        sys.exit(2)
+        raise ReviewError(USAGE_ERROR, f"not a git repo / git missing: {exc}")
 
 
 def _read(path: str) -> str:
     try:
         with open(path, "r", encoding="utf-8") as fh:
             return fh.read()
-    except OSError:
-        return ""
+    except OSError as exc:
+        raise ReviewError(NOT_FOUND, f"cannot read {path}: {exc}")
 
 
-def load_standards(root: str) -> str:
-    """The adversarial/evidence-bound mindset (small — ~900 tok). Sent verbatim."""
-    return _read(os.path.join(root, ".claude", "wardens", "standards.md")).strip()
-
-
-def derive_rule_digest(root: str) -> str:
-    """Condense code-review-rules.md to `id — severity — Applies when` lines.
-
-    Runtime-derived (not a copy) so it tracks the source file and stays small. The
-    full Check/Rule text is intentionally omitted: that detail is the Claude
-    adjudicator's job; the local model only needs the rule vocabulary + triggers.
-    """
-    text = _read(os.path.join(root, ".claude", "wardens", "code-review-rules.md"))
-    if not text:
-        return ""
-    lines = text.splitlines()
-    entries: list[str] = []
-    rule_id = severity = applies = ""
-
-    def flush() -> None:
-        nonlocal rule_id, severity, applies
-        if rule_id:
-            sev = f" [{severity}]" if severity else ""
-            trig = f" — {applies}" if applies else ""
-            entries.append(f"- {rule_id}{sev}{trig}")
-        rule_id = severity = applies = ""
-
-    for line in lines:
-        if line.startswith("## "):
-            flush()
-            rule_id = line[3:].strip()
-        elif line.startswith("**Severity:**"):
-            severity = line.split("**Severity:**", 1)[1].strip()
-        elif line.startswith("**Applies when:**"):
-            applies = line.split("**Applies when:**", 1)[1].strip()
-    flush()
-    return "\n".join(entries)
-
-
-# ── Diff acquisition + per-file splitting ──────────────────────────────────────
 def get_diff(root: str, rev_range: str | None, diff_file: str | None) -> str:
-    # Fail-loud everywhere: a failed diff acquisition must NOT masquerade as an
-    # empty tree (which main() would treat as "nothing to review" and exit 0).
     if diff_file:
         if not os.path.exists(diff_file):
-            sys.stderr.write(f"[cross-family-review] --diff-file not found: {diff_file}\n")
-            sys.exit(2)
+            raise ReviewError(NOT_FOUND, f"--diff-file not found: {diff_file}")
         return _read(diff_file)
     if rev_range:
         # Single sha => that commit vs its first parent; ranges (a..b) pass through.
         spec = [rev_range] if (".." in rev_range) else [f"{rev_range}^!"]
         out = subprocess.run(
-            ["git", "-C", root, "diff", *spec],
-            capture_output=True, text=True,
+            ["git", "-C", root, "diff", *spec], capture_output=True, text=True,
         )
         if out.returncode != 0:
-            sys.stderr.write(
-                f"[cross-family-review] git diff failed for '{rev_range}': {out.stderr.strip()}\n"
-            )
-            sys.exit(2)
+            raise ReviewError(INTERNAL_ERROR,
+                              f"git diff failed for '{rev_range}': {out.stderr.strip()}")
         return out.stdout
     # Default: working-tree review = staged + unstaged, against HEAD.
     out = subprocess.run(
-        ["git", "-C", root, "diff", "HEAD"],
-        capture_output=True, text=True,
+        ["git", "-C", root, "diff", "HEAD"], capture_output=True, text=True,
     )
     if out.returncode != 0:
-        sys.stderr.write(f"[cross-family-review] git diff HEAD failed: {out.stderr.strip()}\n")
-        sys.exit(2)
+        raise ReviewError(INTERNAL_ERROR, f"git diff HEAD failed: {out.stderr.strip()}")
     return out.stdout
 
 
@@ -186,7 +199,12 @@ def split_by_file(diff: str) -> list[tuple[str, str]]:
     chunks = re.split(r"(?m)^(?=diff --git )", diff)
     pairs: list[tuple[str, str]] = []
     for chunk in chunks:
-        if not chunk.strip():
+        # Skip any leading preamble that is not a file diff — e.g. the commit
+        # header `git show` emits before the first `diff --git` (the working-tree
+        # and rev-range paths use `git diff`, which has none, but `--diff-file`
+        # may be fed a `git show` dump). Without this, that prose becomes a
+        # phantom <unknown> "file" sent to the reviewer.
+        if not chunk.lstrip().startswith("diff --git "):
             continue
         m = re.search(r"^\+\+\+ b/(.+)$", chunk, re.MULTILINE)
         if not m:
@@ -196,43 +214,53 @@ def split_by_file(diff: str) -> list[tuple[str, str]]:
     return pairs
 
 
-# ── Prompt construction ────────────────────────────────────────────────────────
-SYSTEM_TMPL = """You are a LOCAL, decorrelated second-opinion code reviewer. A separate, \
-more powerful reviewer will independently validate every candidate you produce and \
-render the final verdict — so your job is RECALL: surface real, specific candidate \
-defects another reviewer might miss. You are not the final word.
+def added_code_lines(chunk: str) -> int:
+    """Count added lines that carry real code (non-blank, non-comment-only).
 
-Hard rules:
-- EVIDENCE-BOUND: every candidate must cite an exact file path and line number from \
-the diff. No line number => do not emit it. Never invent code that is not in the diff.
-- Hunt for REAL defects: logic bugs, security boundary issues, concurrency/async races, \
-data loss/overwrite, resource leaks, error-path gaps, broken cross-platform assumptions. \
-"Looks fine" is a hypothesis to disprove — but an unsupported flag is noise and will be \
-dismissed by the validator. When unsure, still surface it, but say why it's uncertain.
-- Prefer the repo's rule vocabulary below when a candidate matches one (set rule_hint to \
-the rule id); use a short free-text category otherwise.
-
-Review standards (mindset):
-{standards}
-
-Repo rule vocabulary (id — severity — applies when):
-{digest}
-
-OUTPUT: a single JSON object, no prose, no markdown fences:
-{{"candidates": [{{"file": "path", "line": 123, "rule_hint": "rule-id-or-category", \
-"severity_guess": "blocking|warning|info", "claim": "one-sentence defect", \
-"why": "brief evidence/uncertainty"}}]}}
-If you find nothing real in this file, return {{"candidates": []}}."""
+    Used by the recall size guard. Mirrors the harvest heuristic used to size the
+    validation diffs; approximate by design (a cheap proxy for diff weight).
+    """
+    n = 0
+    for ln in chunk.splitlines():
+        if ln.startswith("+++") or not ln.startswith("+"):
+            continue
+        body = ln[1:].strip()
+        if not body:
+            continue
+        if body.startswith(("//", "#", "*", "/*", '"""', "'''")):
+            continue
+        n += 1
+    return n
 
 
-def build_system(standards: str, digest: str) -> str:
-    return SYSTEM_TMPL.format(standards=standards or "(standards unavailable)",
-                              digest=digest or "(rule digest unavailable)")
+def lang_of(path: str) -> str:
+    if path.endswith(".py"):
+        return "Python"
+    if path.endswith((".ts", ".tsx")):
+        return "TypeScript"
+    if path.endswith((".js", ".jsx", ".mjs", ".cjs")):
+        return "JavaScript"
+    return "code"
 
 
-# ── Model call (OpenAI-compatible /chat/completions) ───────────────────────────
+def is_flagged(review: str) -> bool:
+    """Return True if the review flags an issue.
+
+    Clean iff the LAST non-empty line contains the sentinel — reasoning-off output
+    can deliberate in the body and conclude with the verdict, so the FINAL line is
+    authoritative (a full-text scan would false-negative on a mid-text mention).
+    Empty content must NOT reach here as "clean" — callers treat empty as an error.
+    """
+    lines = [ln for ln in review.strip().splitlines() if ln.strip()]
+    if not lines:
+        return True  # defensive: empty is handled as an error upstream
+    return CLEAN_SENTINEL not in lines[-1].upper()
+
+
+# ── Endpoint / model resolution (review-specific first; warns on the :8080 footgun) ─
 def resolve_base_url() -> str:
-    base = os.environ.get("LLAMA_CPP_BASE_URL", "").strip()
+    base = (os.environ.get("LLAMA_CPP_REVIEW_BASE_URL", "").strip()
+            or os.environ.get("LLAMA_CPP_BASE_URL", "").strip())
     if base:
         return base.rstrip("/")
     port = os.environ.get("LLAMA_CPP_PORT", "8080").strip() or "8080"
@@ -244,10 +272,37 @@ def resolve_model() -> str:
             or os.environ.get("LLAMA_CPP_MODEL", "").strip())
 
 
+def review_endpoint_explicit(cli_base_url: str | None) -> bool:
+    """True when the user explicitly chose a reviewer endpoint (not the shared default)."""
+    return bool(cli_base_url) or bool(os.environ.get("LLAMA_CPP_REVIEW_BASE_URL", "").strip())
+
+
+def fetch_loaded_model(base_url: str, timeout: float) -> str | None:
+    """Best-effort: ask the server which model it loaded so we can print it loudly.
+
+    Never fatal — a missing /models endpoint just yields an '(unknown)' label.
+    """
+    try:
+        resp = httpx.get(f"{base_url}/models", timeout=timeout)
+        if resp.status_code == 200:
+            data = (resp.json() or {}).get("data") or []
+            if data and isinstance(data[0], dict):
+                return data[0].get("id")
+    except (httpx.HTTPError, ValueError, KeyError, IndexError, TypeError):
+        return None
+    return None
+
+
+# ── Model call (OpenAI-compatible /chat/completions) ────────────────────────────
 @dataclass
 class CallResult:
     ok: bool
-    text: str
+    content: str = ""
+    reasoning: str = ""
+    finish_reason: str = ""
+    gen_tokens: int | None = None
+    gen_tps: float | None = None
+    wall_s: float = 0.0
     error: str = ""
 
 
@@ -258,190 +313,294 @@ def call_model(base_url: str, model: str, system: str, user: str, timeout: float
             {"role": "system", "content": system},
             {"role": "user", "content": user},
         ],
-        "temperature": 0,
-        "top_p": 1,
+        "temperature": TEMPERATURE,
+        "top_p": TOP_P,
+        "seed": SEED,
+        "max_tokens": MAX_TOKENS,
         "stream": False,
-        "max_tokens": OUTPUT_RESERVE_TOKENS,  # bound output: candidates are short; never run unbounded
-        "cache_prompt": True,  # llama-server reuses the identical system prefix across per-file calls
-        # Qwen3.5 is a reasoning model; its chain-of-thought eats the token budget and
-        # truncates the JSON. Disable it — we want direct candidate extraction, not CoT.
-        "chat_template_kwargs": {"enable_thinking": False},
-        "response_format": {"type": "json_object"},
+        # llama-server reuses the identical system prefix across per-file calls.
+        "cache_prompt": True,
+        # NOTE: no request-body thinking key. The validated config disables gemma's
+        # thinking mode at SERVE time (reasoning-off launch flag); the request-body
+        # mechanisms differ across runtimes and were not validated. We fail loud on
+        # empty content instead of guessing a key here.
     }
     if model:
         payload["model"] = model
+    t0 = time.time()
     try:
         resp = httpx.post(endpoint, json=payload, timeout=timeout)
     except httpx.HTTPError as exc:
-        return CallResult(False, "", f"connection error to {endpoint}: {exc}")
+        return CallResult(False, error=f"connection error to {endpoint}: {exc}")
+    wall = round(time.time() - t0, 2)
     if resp.status_code != 200:
-        return CallResult(False, "", f"HTTP {resp.status_code} from {endpoint}: {resp.text[:200]}")
+        return CallResult(False, wall_s=wall,
+                          error=f"HTTP {resp.status_code} from {endpoint}: {resp.text[:200]}")
     try:
-        content = resp.json()["choices"][0]["message"]["content"]
-    except (KeyError, IndexError, ValueError) as exc:
-        return CallResult(False, "", f"unexpected response shape: {exc}")
-    return CallResult(True, content)
+        body = resp.json()
+        choice = body["choices"][0]
+        msg = choice["message"]
+        content = (msg.get("content") or "").strip()
+        reasoning = (msg.get("reasoning_content") or "").strip()
+        finish = choice.get("finish_reason") or ""
+        timings = body.get("timings") or {}
+        usage = body.get("usage") or {}
+        gen_tokens = timings.get("predicted_n") or usage.get("completion_tokens")
+        gtps = timings.get("predicted_per_second")
+    except (KeyError, IndexError, ValueError, TypeError) as exc:
+        return CallResult(False, wall_s=wall, error=f"unexpected response shape: {exc}")
+    return CallResult(
+        True, content=content, reasoning=reasoning, finish_reason=finish,
+        gen_tokens=gen_tokens, gen_tps=round(gtps, 1) if gtps else None, wall_s=wall,
+    )
 
 
-# ── Robust JSON extraction (a 9B at temp=0 may still fence/preamble) ────────────
-def extract_candidates(text: str) -> list[dict]:
-    if not text or not text.strip():
-        return []
-    candidates: list | None = None
-    # 1) direct object/array parse
-    for blob in (text, _strip_fences(text)):
-        try:
-            data = json.loads(blob)
-            candidates = data.get("candidates") if isinstance(data, dict) else data
-            if candidates is not None:
-                break
-        except (ValueError, AttributeError):
-            continue
-    # 2) regex-rescue the first {...candidates...} object or [...] array
-    if candidates is None:
-        m = re.search(r'\{[^{}]*"candidates"\s*:\s*(\[.*?\])[^{}]*\}', text, re.DOTALL)
-        if m:
-            try:
-                candidates = json.loads(m.group(1))
-            except ValueError:
-                candidates = None
-    if candidates is None:
-        m = re.search(r"\[.*\]", text, re.DOTALL)
-        if m:
-            try:
-                candidates = json.loads(m.group(0))
-            except ValueError:
-                candidates = None
-    if not isinstance(candidates, list):
-        return []
-    return [c for c in candidates if isinstance(c, dict)]
+# ── Orchestration ───────────────────────────────────────────────────────────────
+@dataclass
+class ReviewConfig:
+    base_url: str
+    model: str
+    ctx: int = DEFAULT_CTX
+    max_files: int = 20
+    max_diff_loc: int = DEFAULT_MAX_DIFF_LOC
+    skip_large: bool = False
+    timeout: float = 180.0
 
 
-def _strip_fences(text: str) -> str:
-    t = text.strip()
-    t = re.sub(r"^```(?:json)?\s*", "", t)
-    t = re.sub(r"\s*```$", "", t)
-    return t.strip()
-
-
-# ── Orchestration ──────────────────────────────────────────────────────────────
-def review(root: str, diff: str, *, base_url: str, model: str, ctx: int,
-           max_files: int, timeout: float) -> dict:
-    standards = load_standards(root)
-    digest = derive_rule_digest(root)
-    system = build_system(standards, digest)
-
-    system_tokens = _est_tokens(system) + SYSTEM_SAFETY_TOKENS
-    per_file_budget = ctx - system_tokens - OUTPUT_RESERVE_TOKENS
+def review(diff: str, cfg: ReviewConfig) -> dict:
+    overhead = (_est_tokens(SYSTEM) + _est_tokens(USER_CALIBRATED_DIFF)
+                + SYSTEM_SAFETY_TOKENS)
+    per_file_budget = cfg.ctx - overhead - OUTPUT_RESERVE_TOKENS
     if per_file_budget < 256:
-        sys.stderr.write(
-            f"[cross-family-review] rules+mindset (~{system_tokens} tok) leave only "
-            f"{per_file_budget} tok for the diff under ctx={ctx}. Raise ctx or trim rules.\n"
+        raise ReviewError(
+            USAGE_ERROR,
+            f"prompt overhead (~{overhead} tok) leaves only {per_file_budget} tok "
+            f"for the diff under ctx={cfg.ctx}. Raise --ctx.",
         )
-        sys.exit(2)
 
     files = split_by_file(diff)
-    dropped: list[str] = []
-    if max_files and len(files) > max_files:
-        dropped = [p for p, _ in files[max_files:]]
-        files = files[:max_files]
+    dropped_max: list[str] = []
+    if cfg.max_files and len(files) > cfg.max_files:
+        dropped_max = [p for p, _ in files[cfg.max_files:]]
+        files = files[:cfg.max_files]
         sys.stderr.write(
-            f"[cross-family-review] --max-files={max_files}: skipped {len(dropped)} "
-            f"file(s): {', '.join(dropped)}\n"
+            f"[cross-family-review] --max-files={cfg.max_files}: skipped "
+            f"{len(dropped_max)} file(s): {', '.join(dropped_max)}\n"
         )
 
-    all_candidates: list[dict] = []
-    truncated: list[str] = []
-    failures: list[str] = []
     budget_chars = per_file_budget * CHARS_PER_TOKEN
+    results: list[dict] = []
+    truncated: list[str] = []
+    skipped_large: list[dict] = []
 
     for path, chunk in files:
-        user = chunk
-        if _est_tokens(user) > per_file_budget:
-            # Truncate the DIFF ONLY — never the rules/system prompt. Cut on a line
-            # boundary so the model never receives a broken partial diff line.
-            # NOTE: _est_tokens is a chars/4 heuristic; multi-byte-heavy files may
-            # under-count, so this bound is approximate, not exact.
-            clipped = chunk[:budget_chars]
+        loc = added_code_lines(chunk)
+        oversize = loc > cfg.max_diff_loc
+        if oversize and cfg.skip_large:
+            skipped_large.append({"file": path, "added_loc": loc})
+            results.append({
+                "file": path, "lang": lang_of(path), "added_loc": loc,
+                "oversize": True, "skipped": True, "flagged": None,
+                "review": "", "reasoning": "",
+            })
+            sys.stderr.write(
+                f"[cross-family-review] --skip-large: skipped {path} "
+                f"({loc} added LOC > {cfg.max_diff_loc}).\n"
+            )
+            continue
+
+        lang = lang_of(path)
+        code = chunk
+        was_truncated = False
+        if _est_tokens(code) > per_file_budget:
+            clipped = code[:budget_chars]
             nl = clipped.rfind("\n")
             if nl > 0:
                 clipped = clipped[:nl]
-            user = clipped + "\n[... diff truncated to fit context ...]\n"
+            code = clipped + "\n[... diff truncated to fit context ...]\n"
+            was_truncated = True
             truncated.append(path)
             sys.stderr.write(f"[cross-family-review] truncated diff for {path} to fit ctx.\n")
-        result = call_model(base_url, model, system, user, timeout)
-        if not result.ok:
-            # Connection-class failure => fail loud (the server is the dependency).
-            if "connection error" in result.error or "HTTP" in result.error:
-                sys.stderr.write(f"[cross-family-review] FATAL: {result.error}\n")
-                sys.stderr.write(
-                    "[cross-family-review] is llama-server running? See /add-llama-cpp.\n"
-                )
-                sys.exit(3)
-            failures.append(f"{path}: {result.error}")
-            continue
-        cands = extract_candidates(result.text)
-        if not cands and result.text.strip() not in ('{"candidates": []}', '{"candidates":[]}'):
-            failures.append(f"{path}: unparseable model output")
-        for c in cands:
-            c.setdefault("file", path)
-            # Coerce a string-typed line ("42") to int — the schema example says int,
-            # so downstream consumers can rely on the type.
-            if not isinstance(c.get("line"), int):
-                try:
-                    c["line"] = int(str(c.get("line")).strip())
-                except (ValueError, TypeError):
-                    pass
-        all_candidates.extend(cands)
 
+        user = USER_CALIBRATED_DIFF.format(lang=lang, code=code)
+        r = call_model(cfg.base_url, cfg.model, SYSTEM, user, cfg.timeout)
+        if not r.ok:
+            raise ReviewError(
+                INTERNAL_ERROR,
+                f"{path}: {r.error}\n"
+                "Is a llama-server with a 12B-class reviewer reachable at the "
+                "configured endpoint? (See this script's module docstring for serving.)",
+            )
+        if not r.content:
+            raise ReviewError(
+                INTERNAL_ERROR,
+                f"{path}: model returned EMPTY content (finish_reason={r.finish_reason!r}). "
+                "This is the gemma thinking-trap — serve llama-server with reasoning "
+                "DISABLED. Empty content is never treated as 'clean'.",
+            )
+
+        results.append({
+            "file": path, "lang": lang, "added_loc": loc,
+            "oversize": oversize, "skipped": False,
+            "flagged": is_flagged(r.content),
+            "truncated": was_truncated,
+            # Non-empty content that stopped on the token limit is a PARTIAL review
+            # (the verdict line may be missing) — surface it so the human doesn't
+            # act on an incomplete advisory. Empty content already failed loud above.
+            "output_truncated": r.finish_reason == "length",
+            "review": r.content, "reasoning": r.reasoning,
+            "finish_reason": r.finish_reason, "gen_tokens": r.gen_tokens,
+            "gen_tps": r.gen_tps, "wall_s": r.wall_s,
+        })
+
+    reviewed = [r for r in results if not r.get("skipped")]
+    flagged = [r for r in reviewed if r.get("flagged")]
     return {
-        "candidates": all_candidates,
+        "results": results,
         "meta": {
-            "files_reviewed": len(files),
-            "files_dropped": dropped,
+            "model": cfg.model or "(loaded)",
+            # loaded_model / footgun_default_8080 describe the ENDPOINT, not the
+            # review, so main() injects them after the call — that keeps review()
+            # decoupled from server probing and CLI-arg parsing.
+            "loaded_model": None,
+            "base_url": cfg.base_url,
+            "footgun_default_8080": False,
+            "files_reviewed": len(reviewed),
+            "files_flagged": len(flagged),
+            "files_skipped_large": skipped_large,
+            "files_dropped_max": dropped_max,
             "files_truncated": truncated,
-            "parse_failures": failures,
-            "model": model or "(loaded)",
-            "ctx": ctx,
-            "per_file_budget_tokens": per_file_budget,
+            "max_diff_loc": cfg.max_diff_loc,
+            "ctx": cfg.ctx,
         },
     }
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description="Local cross-family code-review candidate generator.")
-    src = ap.add_mutually_exclusive_group()
-    src.add_argument("--rev-range", help="commit sha or a..b range to review (default: working tree)")
-    src.add_argument("--diff-file", help="path to a unified diff file to review")
-    ap.add_argument("--out", help="write the JSON result here (also printed to stdout)")
-    ap.add_argument("--base-url", help="override LLAMA_CPP_BASE_URL")
-    ap.add_argument("--model", help="override LLAMA_CPP_REVIEW_MODEL")
-    ap.add_argument("--ctx", type=int, default=DEFAULT_CTX, help=f"context budget (default {DEFAULT_CTX})")
-    ap.add_argument("--max-files", type=int, default=20, help="cap files reviewed (0 = no cap)")
-    ap.add_argument("--timeout", type=float, default=180.0, help="per-call timeout seconds")
-    args = ap.parse_args()
+# ── Human-readable rendering (the default; --json is the agent-native path) ──────
+BANNER = (
+    "═══ ADVISORY: local cross-family second opinion — NOT a gate ═══\n"
+    "Validation (LIA-179, n=35): ~29% of real merged diffs get a FALSE flag, "
+    "including confident PHANTOM CRASHES. Recall is validated only on SMALL diffs. "
+    "A human must triage every flag; never auto-apply, auto-post, or gate on this."
+)
 
-    root = repo_root()
-    diff = get_diff(root, args.rev_range, args.diff_file)
-    if not diff.strip():
-        sys.stderr.write("[cross-family-review] empty diff — nothing to review.\n")
-        print(json.dumps({"candidates": [], "meta": {"files_reviewed": 0}}, indent=2))
-        return 0
 
-    base_url = (args.base_url or resolve_base_url()).rstrip("/")
-    model = args.model or resolve_model()
-
-    result = review(
-        root, diff,
-        base_url=base_url, model=model, ctx=args.ctx,
-        max_files=args.max_files, timeout=args.timeout,
+def _footgun_warning(loaded_model: str | None, base_url: str) -> str:
+    return (
+        f"⚠ ENDPOINT WARNING: resolved to {base_url} with no reviewer-specific config.\n"
+        f"  Loaded model: {loaded_model or '(unknown)'}. :8080 is typically the deployed "
+        "Deus service running a SMALL model that was NEVER validated for code review.\n"
+        "  Set LLAMA_CPP_REVIEW_BASE_URL (and/or LLAMA_CPP_REVIEW_MODEL) to a "
+        "llama-server running a 12B-class code model with reasoning disabled."
     )
-    payload = json.dumps(result, indent=2)
-    print(payload)
-    if args.out:
-        with open(args.out, "w", encoding="utf-8") as fh:
-            fh.write(payload)
-    return 0
+
+
+def render_human(result: dict) -> None:
+    meta = result["meta"]
+    print(BANNER)
+    print(f"\nEndpoint: {meta['base_url']}  |  loaded model: "
+          f"{meta.get('loaded_model') or '(unknown)'}")
+    if meta.get("footgun_default_8080"):
+        print("\n" + _footgun_warning(meta.get("loaded_model"), meta["base_url"]))
+
+    for r in result["results"]:
+        print("\n" + "─" * 72)
+        if r.get("skipped"):
+            print(f"## {r['file']}  — SKIPPED (large: {r['added_loc']} added LOC > "
+                  f"{meta['max_diff_loc']} threshold; recall unreliable)")
+            continue
+        tag = "FLAGGED" if r.get("flagged") else "NO ISSUES"
+        extra = ", TRUNCATED" if r.get("truncated") else ""
+        print(f"## {r['file']}  [{tag}]  ({r['lang']}, {r['added_loc']} added LOC{extra})")
+        if r.get("oversize"):
+            print(f"  ⚠ large file: {r['added_loc']} added LOC > {meta['max_diff_loc']} — "
+                  "recall is unreliable on large diffs; a MISS here is expected, not safety.")
+        if r.get("output_truncated"):
+            print("  ⚠ output hit the generation token cap — this review is PARTIAL; the "
+                  "verdict line may be missing. Treat it as inconclusive.")
+        if r.get("reasoning"):
+            print(f"\n[reasoning]\n{r['reasoning']}")
+        print(f"\n{r['review']}")
+
+    print("\n" + "═" * 72)
+    summary = (f"Summary: {meta['files_reviewed']} reviewed, "
+               f"{meta['files_flagged']} flagged")
+    if meta["files_skipped_large"]:
+        summary += f", {len(meta['files_skipped_large'])} skipped-large"
+    if meta.get("files_dropped_max"):
+        summary += f", {len(meta['files_dropped_max'])} dropped (--max-files cap)"
+    print(summary)
+    if meta.get("files_dropped_max"):
+        print("Dropped (NOT reviewed): " + ", ".join(meta["files_dropped_max"]))
+    flagged_files = [r["file"] for r in result["results"] if r.get("flagged")]
+    if flagged_files:
+        print("Flagged: " + ", ".join(flagged_files))
+    print("Reminder: these are UNVERIFIED candidates. ~29% are false (incl. phantom "
+          "crashes) — read the cited line yourself before acting. Not a gate.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Local cross-family code-review ADVISORY (Gemma 4 12B, never a gate).",
+    )
+    src = ap.add_mutually_exclusive_group()
+    src.add_argument("--rev-range", help="commit sha or a..b range (default: working tree)")
+    src.add_argument("--diff-file", help="path to a unified diff file to review")
+    ap.add_argument("--out", help="also write the full JSON result to this file")
+    ap.add_argument("--base-url", help="override the reviewer base URL")
+    ap.add_argument("--model", help="override the reviewer model name")
+    ap.add_argument("--ctx", type=int, default=DEFAULT_CTX,
+                    help=f"context budget (default {DEFAULT_CTX}); serve KV must be >= this")
+    ap.add_argument("--max-files", type=int, default=20, help="cap files reviewed (0 = no cap)")
+    ap.add_argument("--max-diff-loc", type=int, default=DEFAULT_MAX_DIFF_LOC,
+                    help=f"per-file added-LOC warn threshold (heuristic, default {DEFAULT_MAX_DIFF_LOC})")
+    ap.add_argument("--skip-large", action="store_true",
+                    help="skip (don't review) files over --max-diff-loc instead of warning")
+    ap.add_argument("--timeout", type=float, default=180.0, help="per-call timeout seconds")
+    ap.add_argument("--json", action="store_true", help="emit JSON (agent-native)")
+    ap.add_argument("--compact", action="store_true",
+                    help="compact JSON (strip nulls, truncate long fields)")
+    ap.add_argument("--select", help="comma-separated dot-paths to project from the JSON")
+    args = ap.parse_args(argv)
+
+    try:
+        root = repo_root()
+        diff = get_diff(root, args.rev_range, args.diff_file)
+        if not diff.strip():
+            sys.stderr.write("[cross-family-review] empty diff — nothing to review.\n")
+            return ABSTAIN
+
+        base_url = (args.base_url or resolve_base_url()).rstrip("/")
+        model = args.model or resolve_model()
+        loaded_model = fetch_loaded_model(base_url, timeout=min(args.timeout, 15.0))
+        footgun = (":8080" in base_url) and not review_endpoint_explicit(args.base_url)
+
+        cfg = ReviewConfig(
+            base_url=base_url, model=model, ctx=args.ctx, max_files=args.max_files,
+            max_diff_loc=args.max_diff_loc, skip_large=args.skip_large, timeout=args.timeout,
+        )
+        result = review(diff, cfg)
+        result["meta"]["loaded_model"] = loaded_model
+        result["meta"]["footgun_default_8080"] = footgun
+
+        use_json = args.json or is_agent_context()
+        out = agent_output(
+            result, use_json=use_json, compact=args.compact, select=args.select,
+            long_fields=("review", "reasoning"),
+        )
+        if out is not None:
+            print(out)
+        else:
+            render_human(result)
+
+        if args.out:
+            with open(args.out, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps(result, indent=2))
+        return SUCCESS
+
+    except ReviewError as exc:
+        sys.stderr.write(f"[cross-family-review] {exc.message}\n")
+        return exc.code
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_cross_family_review.py
+++ b/scripts/tests/test_cross_family_review.py
@@ -1,0 +1,288 @@
+"""Tests for scripts/cross_family_review.py — the pure, network-free logic.
+
+No llama-server is contacted: these cover the verdict classifier, diff splitting,
+the size-guard line counter, language detection, endpoint/model resolution, and the
+two typed-exit-code paths in main() that short-circuit before any model call
+(missing --diff-file → NOT_FOUND; empty diff → ABSTAIN).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure scripts/ is importable.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import cross_family_review as cfr
+from _exit_codes import ABSTAIN, INTERNAL_ERROR, NOT_FOUND
+
+
+# ── is_flagged: clean iff the LAST non-empty line contains the sentinel ──────────
+
+def test_flagged_clean_exact_sentinel():
+    assert cfr.is_flagged("NO ISSUES FOUND") is False
+
+
+def test_flagged_clean_with_markdown_and_punctuation():
+    assert cfr.is_flagged("**NO ISSUES FOUND.**") is False
+
+
+def test_flagged_clean_after_deliberation_then_verdict():
+    # reasoning-off output deliberates in the body, then concludes with the sentinel.
+    review = (
+        "Let me check the added lines.\n"
+        "The guard handles the None case and the loop bound is correct.\n"
+        "NO ISSUES FOUND\n"
+    )
+    assert cfr.is_flagged(review) is False
+
+
+def test_flagged_when_issue_reported():
+    assert cfr.is_flagged("MAJOR: null deref at foo.py:12 — config may be None.") is True
+
+
+def test_flagged_embedded_sentinel_midtext_but_final_line_is_a_flag():
+    # The refinement over a full-text substring scan: a mid-text mention of the
+    # sentinel must NOT mask a real flag on the final line.
+    review = (
+        "I first thought this was NO ISSUES FOUND, but on closer reading:\n"
+        "MAJOR: off-by-one at gate.ts:42 truncates the last element.\n"
+    )
+    assert cfr.is_flagged(review) is True
+
+
+def test_flagged_empty_is_defensively_flagged():
+    # Empty content is handled as an error upstream; the classifier must never
+    # call it "clean".
+    assert cfr.is_flagged("") is True
+    assert cfr.is_flagged("   \n  \n") is True
+
+
+# ── split_by_file ───────────────────────────────────────────────────────────────
+
+_TWO_FILE_DIFF = """diff --git a/scripts/foo.py b/scripts/foo.py
+index 111..222 100644
+--- a/scripts/foo.py
++++ b/scripts/foo.py
+@@ -1,2 +1,3 @@
+ import os
++x = 1
+diff --git a/src/bar.ts b/src/bar.ts
+index 333..444 100644
+--- a/src/bar.ts
++++ b/src/bar.ts
+@@ -1 +1,2 @@
+ const a = 1;
++const b = 2;
+"""
+
+
+def test_split_by_file_two_files():
+    pairs = cfr.split_by_file(_TWO_FILE_DIFF)
+    assert [p for p, _ in pairs] == ["scripts/foo.py", "src/bar.ts"]
+    assert pairs[0][1].startswith("diff --git a/scripts/foo.py")
+    assert "const b = 2;" in pairs[1][1]
+
+
+def test_split_by_file_empty():
+    assert cfr.split_by_file("") == []
+    assert cfr.split_by_file("   \n") == []
+
+
+def test_split_by_file_skips_git_show_commit_preamble():
+    # `git show` prepends a commit header before the first `diff --git`. That
+    # preamble must NOT become a phantom <unknown> "file" sent to the reviewer.
+    git_show = (
+        "commit deadbeef1234\n"
+        "Author: Someone <s@example.com>\n"
+        "Date:   Mon Jun 9 12:00:00 2026 +0000\n"
+        "\n"
+        "    feat: add a thing\n"
+        "\n"
+        + _TWO_FILE_DIFF
+    )
+    pairs = cfr.split_by_file(git_show)
+    assert [p for p, _ in pairs] == ["scripts/foo.py", "src/bar.ts"]
+    assert all(p != "<unknown>" for p, _ in pairs)
+
+
+# ── added_code_lines (size-guard counter) ───────────────────────────────────────
+
+def test_added_code_lines_counts_only_real_added_code():
+    chunk = (
+        "diff --git a/x.py b/x.py\n"
+        "--- a/x.py\n"
+        "+++ b/x.py\n"          # must NOT count (starts with +++)
+        "@@ -1 +1,5 @@\n"
+        " context_line\n"        # context, not added
+        "-removed_line\n"        # removed, not added
+        "+real = 1\n"            # +1
+        "+    another = 2\n"     # +1
+        "+# a comment\n"         # comment-only, excluded
+        "+\n"                    # blank, excluded
+        "+x = 3  # trailing\n"   # +1 (code with trailing comment counts)
+    )
+    assert cfr.added_code_lines(chunk) == 3
+
+
+# ── lang_of ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path,lang", [
+    ("scripts/foo.py", "Python"),
+    ("src/bar.ts", "TypeScript"),
+    ("src/widget.tsx", "TypeScript"),
+    ("web/app.js", "JavaScript"),
+    ("README.md", "code"),
+    ("Makefile", "code"),
+])
+def test_lang_of(path, lang):
+    assert cfr.lang_of(path) == lang
+
+
+# ── endpoint / model resolution + footgun precedence ────────────────────────────
+
+_ENV_VARS = (
+    "LLAMA_CPP_REVIEW_BASE_URL", "LLAMA_CPP_BASE_URL", "LLAMA_CPP_PORT",
+    "LLAMA_CPP_REVIEW_MODEL", "LLAMA_CPP_MODEL",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for v in _ENV_VARS:
+        monkeypatch.delenv(v, raising=False)
+    return monkeypatch
+
+
+def test_resolve_base_url_prefers_review_specific(clean_env):
+    clean_env.setenv("LLAMA_CPP_REVIEW_BASE_URL", "http://127.0.0.1:8099/v1/")
+    clean_env.setenv("LLAMA_CPP_BASE_URL", "http://127.0.0.1:8080/v1")
+    assert cfr.resolve_base_url() == "http://127.0.0.1:8099/v1"  # trailing slash stripped
+
+
+def test_resolve_base_url_falls_back_to_shared(clean_env):
+    clean_env.setenv("LLAMA_CPP_BASE_URL", "http://host:9000/v1")
+    assert cfr.resolve_base_url() == "http://host:9000/v1"
+
+
+def test_resolve_base_url_default_is_8080(clean_env):
+    # The footgun default — nothing configured.
+    assert cfr.resolve_base_url() == "http://127.0.0.1:8080/v1"
+
+
+def test_resolve_model_precedence(clean_env):
+    clean_env.setenv("LLAMA_CPP_MODEL", "catch-all")
+    assert cfr.resolve_model() == "catch-all"
+    clean_env.setenv("LLAMA_CPP_REVIEW_MODEL", "reviewer-12b")
+    assert cfr.resolve_model() == "reviewer-12b"
+    assert cfr.resolve_model() != "catch-all"
+
+
+def test_resolve_model_empty_when_unset(clean_env):
+    assert cfr.resolve_model() == ""
+
+
+def test_review_endpoint_explicit(clean_env):
+    assert cfr.review_endpoint_explicit(None) is False
+    assert cfr.review_endpoint_explicit("http://x/v1") is True  # cli override counts
+    clean_env.setenv("LLAMA_CPP_REVIEW_BASE_URL", "http://127.0.0.1:8099/v1")
+    assert cfr.review_endpoint_explicit(None) is True           # env override counts
+
+
+# ── main() typed exit codes on the pre-network short-circuit paths ───────────────
+
+def test_main_missing_diff_file_returns_not_found(capsys):
+    rc = cfr.main(["--diff-file", "/nonexistent/path/to.diff"])
+    assert rc == NOT_FOUND
+    assert "not found" in capsys.readouterr().err.lower()
+
+
+def test_main_empty_diff_file_returns_abstain(tmp_path, capsys):
+    empty = tmp_path / "empty.diff"
+    empty.write_text("")
+    rc = cfr.main(["--diff-file", str(empty)])
+    assert rc == ABSTAIN
+    assert "nothing to review" in capsys.readouterr().err.lower()
+
+
+# ── review() orchestrator (call_model mocked — no server) ────────────────────────
+
+_ONE_FILE_DIFF = """diff --git a/scripts/foo.py b/scripts/foo.py
+index 111..222 100644
+--- a/scripts/foo.py
++++ b/scripts/foo.py
+@@ -1,2 +1,3 @@
+ import os
++x = 1
+"""
+
+
+def _big_diff(path: str = "src/big.py", n: int = 70) -> str:
+    header = (f"diff --git a/{path} b/{path}\nindex 1..2 100644\n"
+              f"--- a/{path}\n+++ b/{path}\n@@ -1 +1,{n} @@\n")
+    body = "".join(f"+line_{i} = {i}\n" for i in range(n))
+    return header + body
+
+
+def _cr(content: str, finish: str = "stop") -> "cfr.CallResult":
+    return cfr.CallResult(True, content=content, finish_reason=finish)
+
+
+def _cfg(**kw) -> "cfr.ReviewConfig":
+    return cfr.ReviewConfig(base_url="http://x/v1", model="m", **kw)
+
+
+def test_review_classifies_each_file():
+    with patch.object(cfr, "call_model",
+                      side_effect=[_cr("NO ISSUES FOUND"), _cr("MAJOR: bug at bar.ts:1")]):
+        result = cfr.review(_TWO_FILE_DIFF, _cfg())
+    meta = result["meta"]
+    assert meta["files_reviewed"] == 2
+    assert meta["files_flagged"] == 1
+    by_file = {r["file"]: r for r in result["results"]}
+    assert by_file["scripts/foo.py"]["flagged"] is False
+    assert by_file["src/bar.ts"]["flagged"] is True
+
+
+def test_review_skip_large_does_not_call_model():
+    with patch.object(cfr, "call_model") as mock_call:
+        result = cfr.review(_big_diff("src/big.py", 70), _cfg(max_diff_loc=60, skip_large=True))
+    mock_call.assert_not_called()
+    r = result["results"][0]
+    assert r["skipped"] is True and r["flagged"] is None and r["added_loc"] == 70
+    assert result["meta"]["files_reviewed"] == 0
+    assert result["meta"]["files_skipped_large"] == [{"file": "src/big.py", "added_loc": 70}]
+
+
+def test_review_oversize_tagged_when_not_skipping():
+    with patch.object(cfr, "call_model", side_effect=[_cr("NO ISSUES FOUND")]):
+        result = cfr.review(_big_diff("src/big.py", 70), _cfg(max_diff_loc=60, skip_large=False))
+    r = result["results"][0]
+    assert r["oversize"] is True and r["skipped"] is False
+    assert r["flagged"] is False
+
+
+def test_review_empty_content_fails_loud():
+    with patch.object(cfr, "call_model", side_effect=[_cr("")]):
+        with pytest.raises(cfr.ReviewError) as ei:
+            cfr.review(_ONE_FILE_DIFF, _cfg())
+    assert ei.value.code == INTERNAL_ERROR
+
+
+def test_review_connection_error_fails_loud():
+    with patch.object(cfr, "call_model",
+                      side_effect=[cfr.CallResult(False, error="connection error to x")]):
+        with pytest.raises(cfr.ReviewError) as ei:
+            cfr.review(_ONE_FILE_DIFF, _cfg())
+    assert ei.value.code == INTERNAL_ERROR
+
+
+def test_review_marks_output_truncated_on_length_finish():
+    with patch.object(cfr, "call_model", side_effect=[_cr("MAJOR: partial...", finish="length")]):
+        result = cfr.review(_ONE_FILE_DIFF, _cfg())
+    assert result["results"][0]["output_truncated"] is True


### PR DESCRIPTION
## What

Reworks the parked `scripts/cross_family_review.py` into a **local, different-family, never-gate code-review advisory** backed by Gemma 4 12B with the n=35-validated *calibrated-diff* prompt. Closes the implementation for **LIA-179** (under a narrower framing — see below).

Default `python3 scripts/cross_family_review.py` reviews the working-tree diff per file, surfaces the model's reasoning, and prints a flagged/clean verdict behind a loud banner that a human must triage every flag.

## Why this, and why advisory-only

The 2026-06-04 SHELVED verdict on LIA-179 was decisive **for the gate/adjudicate framing** it tested (Qwen 7B–30B, "NOT Gemma", surfacing candidates for a Claude gate). That still stands. This PR ships a **different, smaller proposition** the prior verdict didn't cover: a human-triaged second opinion that **never gates**.

The n=35 validation is honest about the ceiling — on real merged diffs the calibrated reviewer false-flags **~29%** of changes (all sampled flags false on first-hand adjudication, including confident *phantom crashes*), and recall is only validated on **small** single-change diffs (it missed the bug in a 305-LOC diff). So: never a gate, surfaces reasoning, human dismisses bad flags.

## Key design decisions

- **Calibrated-diff prompt** (fairness preamble + conservative bar), scoped to bug/correctness/security. Dropped the old Qwen rule-digest + standards injection + JSON-candidate machinery.
- **Per-file granularity (validated), not per-hunk** — size, not granularity, is the recall killer; per-hunk is unmeasured and multiplies FP draws. Kept per-file + a heuristic `--max-diff-loc` size-guard *warning*.
- **gemma thinking-trap** disabled at serve time (`--reasoning off`); no request-body thinking key (the validated path); **fail loud on empty content** — empty is never "clean".
- **Endpoint footgun** — warns when defaulting to `:8080` (the deployed e4b service, never validated for review). Reviewer endpoint/model via `LLAMA_CPP_REVIEW_BASE_URL` / `LLAMA_CPP_REVIEW_MODEL`. No personal paths in the script (public-repo).
- **Agent-native protocol** — typed exit codes + `--json`/`--compact`/`--select` (`printing-press-adoption.md`); default output stays human text per the ADR's own measurement.
- No auto-trigger / blast-radius classifier / accept-reject logging / warden-gate wiring (out of scope; advisory-only).

## Verification

- `scripts/tests/test_cross_family_review.py` — **30 unit tests** (verdict classifier incl. embedded-sentinel + empty + truncated, file splitting incl. `git show` preamble, size counter, endpoint/model resolution, and `review()` orchestration with `call_model` mocked). All pass.
- **End-to-end against a locally-served 12B**: recall probe FLAGGED with the correct mechanism; clean control NO ISSUES; size-guard warning fired on a 305-LOC diff; deterministic across runs; footgun warning fires on default `:8080`.

## Gates

plan-reviewer **SHIP** (3 rounds) · code-reviewer **SHIP** (2 rounds) · ai-eng-warden **SHIP** (2 rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
