### PR TITLE
fix(ci): repair @deus-ai MCP package publish pipeline

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,22 +23,48 @@ jobs:
         run: |
           npm install
           npm run build
-          npm publish --access public || echo "::warning::channel-core already published at this version"
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          # Publish only if this exact version isn't on npm yet. A real 404 (E404 = not
+          # published) means publish; a transient registry error must NOT be mistaken for a
+          # 404, so it hard-fails rather than trigger a publish-over-existing on re-runs.
+          # Any real publish error (auth/build/registry) still hard-fails — never swallowed.
+          if view_err=$(npm view "$name@$version" version 2>&1); then
+            echo "::notice::$name@$version already on npm — skipping publish"
+          elif [[ "$view_err" == *E404* ]]; then
+            npm publish --access public
+          else
+            echo "::error::npm view failed for $name@$version (not a 404): $view_err"
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build and publish channel packages
         run: |
+          # channel-core version is identical for every package — read it once, up front.
+          cc_ver=$(node -p "require('./packages/mcp-channel-core/package.json').version")
           for pkg in packages/mcp-*/; do
             [ "$pkg" = "packages/mcp-channel-core/" ] && continue
             name=$(node -p "require('./$pkg/package.json').name")
-            echo "::group::Publishing $name"
+            version=$(node -p "require('./$pkg/package.json').version")
+            echo "::group::Publishing $name@$version"
             cd "$pkg"
-            # Point to published @deus-ai/channel-core instead of local file path
-            npm pkg set 'dependencies.@deus-ai/channel-core=^1.0.0'
+            # Build against the LOCAL channel-core (file: dep, carries current exports), then
+            # rewrite the dep to the published range for the published metadata only
+            # (runner-only mutation; never committed).
             npm install
             npm run build
-            npm publish --access public || echo "::warning::Failed to publish $name (may already exist)"
+            npm pkg set "dependencies.@deus-ai/channel-core=^$cc_ver"
+            # Same guarded publish as channel-core above (E404 = publish; other view error = fail).
+            if view_err=$(npm view "$name@$version" version 2>&1); then
+              echo "::notice::$name@$version already on npm — skipping publish"
+            elif [[ "$view_err" == *E404* ]]; then
+              npm publish --access public
+            else
+              echo "::error::npm view failed for $name@$version (not a 404): $view_err"
+              exit 1
+            fi
             cd ../..
             echo "::endgroup::"
           done

--- a/packages/mcp-channel-core/package.json
+++ b/packages/mcp-channel-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/channel-core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared types and base server logic for Deus MCP channel servers",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-discord/package.json
+++ b/packages/mcp-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/discord-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Discord MCP server — standalone Discord bot integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-gcal/package.json
+++ b/packages/mcp-gcal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/gcal-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Google Calendar MCP server \u2014 exposes calendar tools for any MCP client",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-gmail/package.json
+++ b/packages/mcp-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/gmail-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Gmail MCP server — standalone Gmail integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-slack/package.json
+++ b/packages/mcp-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/slack-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Slack MCP server — standalone Slack bot integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-telegram/package.json
+++ b/packages/mcp-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/telegram-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Telegram MCP server — standalone Telegram bot integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-whatsapp/package.json
+++ b/packages/mcp-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/whatsapp-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "WhatsApp MCP server — standalone WhatsApp Web integration for any MCP client",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-x/package.json
+++ b/packages/mcp-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deus-ai/x-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "X (Twitter) MCP server — post, like, reply, retweet, and quote tweets via the Twitter API v2",
   "type": "module",
   "main": "dist/index.js",

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-06-06" # auto-bump @1780704994
+last_verified: "2026-06-08" # auto-bump @1780941703
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-06" # auto-bump @1780704994
+last_verified: "2026-06-08" # auto-bump @1780941703
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
## Problem

`Publish MCP Packages` (`publish-packages.yml`) has **failed on all 8 runs since 2026-04-27** (latest: v1.17.0). Surfaced while auditing npm-token exposure for the Miasma/Phantom-Gyp npm worm — the diagnosis showed the failures are **not** an auth problem (the `NPM_TOKEN` secret is present; the job dies at `tsc` before `npm publish` runs).

### Root cause — three layered bugs
1. **Versions never bump.** `release-please-config.json` manages only the root package; the 8 workspace packages (`@deus-ai/channel-core` + 7 `mcp-*`) are pinned at `1.0.0` locally and on npm, so every publish targets an already-published version.
2. **Failures swallowed.** Both steps used `npm publish --access public || echo "::warning::…"`, hiding the "cannot publish over existing 1.0.0" failure — so the stale `@deus-ai/channel-core@1.0.0` (missing the `resizeAndEncode` export) was never replaced.
3. **Downstream built against the stale published version.** The channel-packages step rewrote each dep to the published `^1.0.0`, installed the stale channel-core, and `tsc` failed: `src/discord.ts(24,10): error TS2305: … no exported member 'resizeAndEncode'` → exit 2.

## Fix
- **Bump all 8 workspace packages `1.0.0 → 1.1.0`** so publishing targets fresh versions (version-line only; no dep reordering).
- **Build channel packages against the LOCAL `file:` channel-core** (which carries the current exports), then rewrite the dep to `^<channel-core version>` (read dynamically, once before the loop) for the published metadata only — runner-side, never committed.
- **Idempotency-guarded hard-fail publish** replaces the swallowing `|| echo` in both steps: skip when the exact version already exists, publish on a real `E404`, and **fail the job on any other error** (auth/build/registry/transient `npm view` error) instead of hiding it.
- `permissions: contents: read` kept (token-based publish; not the OIDC trusted-publishing surface the Miasma worm abused).

## Verification (local; no real publish — that needs the CI token + a release event)
- `channel-core` builds; `resizeAndEncode` present in `dist/index.d.ts`.
- `discord` installs + builds against the local channel-core, `tsc` exit 0 (TS2305 resolved).
- `npm pack --dry-run` after the dep rewrite shows `@deus-ai/channel-core: ^1.1.0` (not `file:`) with `dist/` included; the working tree was restored so only the version bump is committed.
- Guard simulated under `bash -eo pipefail`: existing `1.0.0` → SKIP, missing `1.1.0` → PUBLISH (E404); `set -e` does not trip on the in-condition `npm view` failure. YAML parses.

Reviewed via plan-reviewer (SHIP) and code-reviewer (SHIP, with its `npm view` hardening recommendation applied).

## Follow-ups (intentionally out of scope)
- Automate workspace-package version bumps via release-please (linked-versions) so future releases bump these without manual edits.
- **The CI `NPM_TOKEN`'s validity is still unverified** — the build died before publish on every prior run. The first real publish after this merge is where it finally gets exercised; if it's expired, the workflow will now **hard-fail with an auth error** (no longer swallowed), which is the point at which the 2FA-gated npm token rotation becomes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
