### PR TITLE
feat(agent-runner): add PreToolUse gate seam to non-Claude tool loops (LIA-197)

### DIFF
--- a/container/agent-runner/src/llama-cpp-backend.gate.test.ts
+++ b/container/agent-runner/src/llama-cpp-backend.gate.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared spies must be hoisted — vi.mock factories run before module-scope
+// const initialization (TDZ), so reference them via vi.hoisted.
+const { mcpExecute, brokerExecute, gateMock } = vi.hoisted(() => ({
+  mcpExecute: vi.fn(),
+  brokerExecute: vi.fn(),
+  gateMock: vi.fn(),
+}));
+
+vi.mock('./tool-broker.js', () => ({
+  createOpenAIMcpToolBridge: vi.fn(async () => ({
+    definitions: [],
+    execute: mcpExecute,
+    close: vi.fn(),
+  })),
+  executeBrokerTool: brokerExecute,
+  getOpenAIToolDefinitions: vi.fn(() => []),
+  resolveGroupAttachmentPath: vi.fn((p: string) => `/workspace/group/${p}`),
+}));
+
+vi.mock('./context-registry.js', () => ({
+  loadRegisteredContextFiles: vi.fn(() => []),
+}));
+
+vi.mock('./pre-tool-use-hook.js', () => ({
+  dispatchPreToolUseGate: gateMock,
+}));
+
+import { DoomLoopDetector } from './doom-loop-detector.js';
+import { runSingleTurn, type ContainerInput } from './llama-cpp-backend.js';
+
+const containerInput = {
+  chatJid: 'test@jid',
+  groupFolder: 'test-group',
+  prompt: 'hello',
+} as unknown as ContainerInput;
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+// First model response asks for one Bash tool call; the second has no calls so
+// runSingleTurn terminates.
+const responseWithCall = {
+  choices: [
+    {
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'Bash',
+              arguments: JSON.stringify({ command: 'ls' }),
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+const terminatingResponse = {
+  choices: [{ message: { role: 'assistant', content: 'done' } }],
+};
+
+describe('runSingleTurn — PreToolUse gate seam (llama-cpp backend)', () => {
+  const originalEnv = { ...process.env };
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, LLAMA_CPP_BASE_URL: 'http://stub/v1' };
+    mcpExecute.mockReset();
+    brokerExecute.mockReset();
+    gateMock.mockReset();
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse(responseWithCall))
+      .mockResolvedValueOnce(jsonResponse(terminatingResponse));
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT execute a tool when the gate blocks it', async () => {
+    gateMock.mockResolvedValue({ block: true, reason: 'denied by warden' });
+    const detector = new DoomLoopDetector();
+    const recordSpy = vi.spyOn(detector, 'record');
+
+    const result = await runSingleTurn(
+      'hello',
+      containerInput,
+      [],
+      () => {},
+      detector,
+    );
+
+    expect(mcpExecute).not.toHaveBeenCalled();
+    expect(brokerExecute).not.toHaveBeenCalled();
+    expect(recordSpy).not.toHaveBeenCalled();
+    expect(gateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: 'Bash', toolUseId: 'call_1' }),
+    );
+    expect(result.result).toBe('done');
+  });
+
+  it('feeds the block reason back to the model as the tool result', async () => {
+    gateMock.mockResolvedValue({ block: true, reason: 'denied by warden' });
+    const detector = new DoomLoopDetector();
+
+    await runSingleTurn('hello', containerInput, [], () => {}, detector);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(
+      (fetchSpy.mock.calls[1][1] as { body: string }).body,
+    );
+    const refusal = (
+      secondBody.messages as Array<Record<string, unknown>>
+    ).find((m) => m.role === 'tool' && m.tool_call_id === 'call_1');
+    expect(refusal).toBeDefined();
+    expect(String(refusal!.content)).toContain('denied by warden');
+  });
+
+  it('executes the tool normally when the gate allows it (control)', async () => {
+    gateMock.mockResolvedValue({ block: false });
+    mcpExecute.mockResolvedValue({ ok: true, exitCode: 0, output: 'files' });
+    const detector = new DoomLoopDetector();
+    const recordSpy = vi.spyOn(detector, 'record');
+
+    await runSingleTurn('hello', containerInput, [], () => {}, detector);
+
+    expect(mcpExecute).toHaveBeenCalledWith('Bash', { command: 'ls' });
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'url';
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { fetchMemoryContext } from './memory-retrieval-hook.js';
 import { DoomLoopDetector, normalizeArgs } from './doom-loop-detector.js';
+import { dispatchPreToolUseGate } from './pre-tool-use-hook.js';
 import {
   type AgentRuntimeId,
   createOpenAIMcpToolBridge,
@@ -308,7 +309,9 @@ function compactMessages(messages: ChatMessage[]): ChatMessage[] {
   return system ? [system, ...truncated] : truncated;
 }
 
-async function runSingleTurn(
+// Exported for unit tests (PreToolUse gate seam). Internal to the conversation
+// driver otherwise.
+export async function runSingleTurn(
   prompt: string,
   containerInput: ContainerInput,
   messages: ChatMessage[],
@@ -382,6 +385,32 @@ async function runSingleTurn(
           >;
         } catch {
           parsedArgs = {};
+        }
+
+        // PreToolUse gate (default-off via HOOK_DISPATCH_ENABLED, fail-open) —
+        // mirrors the Claude SDK's PreToolUse hook. On a block the tool is NOT
+        // executed; the refusal is fed back as the tool result. No doomDetector
+        // record on a block — the detector tracks repeated *execution*, and a
+        // blocked call never ran.
+        const gate = await dispatchPreToolUseGate({
+          toolName: call.function.name,
+          toolInput: parsedArgs,
+          toolUseId: call.id,
+          // sessionId is not available in this scope (the llama-cpp runSingleTurn
+          // tracks state via the messages array, not a response id). The OpenAI
+          // backend passes its responseId; observers must tolerate an absent
+          // session_id on this path.
+        });
+        if (gate.block) {
+          messages.push({
+            role: 'tool',
+            tool_call_id: call.id,
+            content: JSON.stringify({
+              ok: false,
+              error: gate.reason ?? 'Blocked by PreToolUse gate',
+            }),
+          });
+          continue;
         }
 
         let toolResult =

--- a/container/agent-runner/src/openai-backend.gate.test.ts
+++ b/container/agent-runner/src/openai-backend.gate.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared spies must be hoisted — vi.mock factories run before module-scope
+// const initialization (TDZ), so reference them via vi.hoisted.
+const { mcpExecute, brokerExecute, gateMock } = vi.hoisted(() => ({
+  mcpExecute: vi.fn(),
+  brokerExecute: vi.fn(),
+  gateMock: vi.fn(),
+}));
+
+vi.mock('./tool-broker.js', () => ({
+  createOpenAIMcpToolBridge: vi.fn(async () => ({
+    definitions: [],
+    execute: mcpExecute,
+    close: vi.fn(),
+  })),
+  executeBrokerTool: brokerExecute,
+  getOpenAIToolDefinitions: vi.fn(() => []),
+  resolveGroupAttachmentPath: vi.fn((p: string) => `/workspace/group/${p}`),
+}));
+
+vi.mock('./context-registry.js', () => ({
+  loadRegisteredContextFiles: vi.fn(() => []),
+}));
+
+vi.mock('./pre-tool-use-hook.js', () => ({
+  dispatchPreToolUseGate: gateMock,
+}));
+
+import { DoomLoopDetector } from './doom-loop-detector.js';
+import { runSingleTurn, type ContainerInput } from './openai-backend.js';
+
+const containerInput = {
+  chatJid: 'test@jid',
+  groupFolder: 'test-group',
+  prompt: 'hello',
+  imageAttachments: [],
+} as unknown as ContainerInput;
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+// First model response asks for one Bash tool call; the second has no calls so
+// runSingleTurn terminates.
+const responseWithCall = {
+  id: 'resp_1',
+  output: [
+    {
+      type: 'function_call',
+      name: 'Bash',
+      call_id: 'call_1',
+      arguments: JSON.stringify({ command: 'ls' }),
+    },
+  ],
+};
+const terminatingResponse = { id: 'resp_2', output: [], output_text: 'done' };
+
+describe('runSingleTurn — PreToolUse gate seam (OpenAI backend)', () => {
+  const originalEnv = { ...process.env };
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, OPENAI_BASE_URL: 'http://stub/v1' };
+    mcpExecute.mockReset();
+    brokerExecute.mockReset();
+    gateMock.mockReset();
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse(responseWithCall))
+      .mockResolvedValueOnce(jsonResponse(terminatingResponse));
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT execute a tool when the gate blocks it', async () => {
+    gateMock.mockResolvedValue({ block: true, reason: 'denied by warden' });
+    const detector = new DoomLoopDetector();
+    const recordSpy = vi.spyOn(detector, 'record');
+
+    const result = await runSingleTurn(
+      'hello',
+      containerInput,
+      undefined,
+      () => {},
+      detector,
+    );
+
+    // Neither dispatch path ran for the blocked call.
+    expect(mcpExecute).not.toHaveBeenCalled();
+    expect(brokerExecute).not.toHaveBeenCalled();
+    // A blocked call is not an execution → no doom record.
+    expect(recordSpy).not.toHaveBeenCalled();
+    // The gate was consulted for the call.
+    expect(gateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: 'Bash', toolUseId: 'call_1' }),
+    );
+    // The loop still terminated normally.
+    expect(result.result).toBe('done');
+  });
+
+  it('feeds the block reason back to the model as the tool result', async () => {
+    gateMock.mockResolvedValue({ block: true, reason: 'denied by warden' });
+    const detector = new DoomLoopDetector();
+
+    await runSingleTurn('hello', containerInput, undefined, () => {}, detector);
+
+    // Second createResponse call carries the refusal as the function_call_output.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(
+      (fetchSpy.mock.calls[1][1] as { body: string }).body,
+    );
+    const refusal = (secondBody.input as Array<Record<string, unknown>>).find(
+      (i) => i.type === 'function_call_output' && i.call_id === 'call_1',
+    );
+    expect(refusal).toBeDefined();
+    expect(String(refusal!.output)).toContain('denied by warden');
+  });
+
+  it('executes the tool normally when the gate allows it (control)', async () => {
+    gateMock.mockResolvedValue({ block: false });
+    mcpExecute.mockResolvedValue({ ok: true, exitCode: 0, output: 'files' });
+    const detector = new DoomLoopDetector();
+    const recordSpy = vi.spyOn(detector, 'record');
+
+    await runSingleTurn('hello', containerInput, undefined, () => {}, detector);
+
+    // Allowed → the tool ran and the doom detector recorded the execution.
+    expect(mcpExecute).toHaveBeenCalledWith('Bash', { command: 'ls' });
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/container/agent-runner/src/openai-backend.ts
+++ b/container/agent-runner/src/openai-backend.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { fetchMemoryContext } from './memory-retrieval-hook.js';
 import { DoomLoopDetector, normalizeArgs } from './doom-loop-detector.js';
+import { dispatchPreToolUseGate } from './pre-tool-use-hook.js';
 import {
   type AgentRuntimeId,
   createOpenAIMcpToolBridge,
@@ -355,7 +356,9 @@ async function createResponse(
   return assertOpenAIResponse(await res.json());
 }
 
-async function runSingleTurn(
+// Exported for unit tests (PreToolUse gate seam). Internal to the conversation
+// driver otherwise.
+export async function runSingleTurn(
   prompt: string,
   containerInput: ContainerInput,
   previousResponseId: string | undefined,
@@ -408,6 +411,31 @@ async function runSingleTurn(
         } catch {
           parsedArgs = {};
         }
+
+        // PreToolUse gate (default-off via HOOK_DISPATCH_ENABLED, fail-open) —
+        // mirrors the Claude SDK's PreToolUse hook. On a block the tool is NOT
+        // executed; the refusal is fed back as the tool result, exactly how the
+        // Claude SDK surfaces a block reason to the model. No doomDetector
+        // record on a block — the detector tracks repeated *execution*, and a
+        // blocked call never ran.
+        const gate = await dispatchPreToolUseGate({
+          toolName: call.name,
+          toolInput: parsedArgs,
+          toolUseId: call.call_id,
+          sessionId: responseId,
+        });
+        if (gate.block) {
+          input.push({
+            type: 'function_call_output',
+            call_id: call.call_id,
+            output: JSON.stringify({
+              ok: false,
+              error: gate.reason ?? 'Blocked by PreToolUse gate',
+            }),
+          });
+          continue;
+        }
+
         let toolResult =
           (await mcpBridge.execute(call.name, parsedArgs)) ?? undefined;
         if (!toolResult) {
@@ -614,4 +642,3 @@ export async function runOpenAIConversation(ctx: OpenAIContext): Promise<void> {
     prompt = nextMessage;
   }
 }
-

--- a/container/agent-runner/src/pre-tool-use-hook.test.ts
+++ b/container/agent-runner/src/pre-tool-use-hook.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createPreToolUseHook,
+  dispatchPreToolUseGate,
+} from './pre-tool-use-hook.js';
+
+const okResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('dispatchPreToolUseGate', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.HOOK_DISPATCH_ENABLED = 'true';
+    process.env.HOOK_DISPATCH_PORT = '3002';
+    process.env.DEUS_PROXY_HOST = '127.0.0.1';
+    process.env.DEUS_PROXY_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('returns {block:false} with NO fetch when HOOK_DISPATCH_ENABLED is unset', async () => {
+    delete process.env.HOOK_DISPATCH_ENABLED;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+    });
+
+    expect(result).toEqual({ block: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns {block:false} with NO fetch when HOOK_DISPATCH_ENABLED is not exactly "true"', async () => {
+    process.env.HOOK_DISPATCH_ENABLED = '1';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: {},
+    });
+
+    expect(result).toEqual({ block: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns {block:true, reason} when the service responds decision:block', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({ decision: 'block', reason: 'denied by warden' }),
+    );
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: { command: 'rm -rf /' },
+    });
+
+    expect(result).toEqual({ block: true, reason: 'denied by warden' });
+  });
+
+  it('supplies a default reason when a block omits one', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({ decision: 'block' }),
+    );
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Edit',
+      toolInput: {},
+    });
+
+    expect(result.block).toBe(true);
+    expect(result.reason).toBe('Blocked by PreToolUse observer');
+  });
+
+  it('returns {block:false, response} on a non-block success (forwards additionalContext)', async () => {
+    const data = {
+      hookSpecificOutput: { additionalContext: 'note from observer' },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okResponse(data));
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Read',
+      toolInput: { file_path: '/x' },
+    });
+
+    expect(result.block).toBe(false);
+    expect(result.response).toEqual(data);
+  });
+
+  it('fails open ({block:false}) on a non-OK status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({ decision: 'block' }, 500),
+    );
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: {},
+    });
+
+    expect(result).toEqual({ block: false });
+  });
+
+  it('fails open ({block:false}) on a network error / timeout abort', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('AbortError: timed out'),
+    );
+
+    const result = await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: {},
+    });
+
+    expect(result).toEqual({ block: false });
+  });
+
+  it('POSTs a byte-identical body (hardcoded hook_event_name) with the proxy token header', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(okResponse({}));
+
+    await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+      toolUseId: 'tu_1',
+      sessionId: 'sess_1',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://127.0.0.1:3002/hooks/PreToolUse',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'content-type': 'application/json',
+          'x-deus-proxy-token': 'test-token',
+        }),
+        body: JSON.stringify({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+          tool_use_id: 'tu_1',
+          session_id: 'sess_1',
+        }),
+      }),
+    );
+  });
+});
+
+describe('createPreToolUseHook (Claude SDK adapter, no regression)', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.HOOK_DISPATCH_ENABLED = 'true';
+    process.env.DEUS_PROXY_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  const input = {
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'ls' },
+    tool_use_id: 'tu_1',
+    session_id: 'sess_1',
+  };
+
+  it('emits {decision:block, reason} on a block', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({ decision: 'block', reason: 'nope' }),
+    );
+
+    const hook = createPreToolUseHook('127.0.0.1', 3002, 'test-token');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await hook(input as any, undefined as any, {} as any);
+
+    expect(out).toEqual({ decision: 'block', reason: 'nope' });
+  });
+
+  it('forwards the raw dispatch response on a non-block success', async () => {
+    const data = {
+      hookSpecificOutput: { additionalContext: 'ctx' },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okResponse(data));
+
+    const hook = createPreToolUseHook('127.0.0.1', 3002, 'test-token');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await hook(input as any, undefined as any, {} as any);
+
+    expect(out).toEqual(data);
+  });
+
+  it('returns {} on an unreachable service (fail-open)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const hook = createPreToolUseHook('127.0.0.1', 3002, 'test-token');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await hook(input as any, undefined as any, {} as any);
+
+    expect(out).toEqual({});
+  });
+});

--- a/container/agent-runner/src/pre-tool-use-hook.ts
+++ b/container/agent-runner/src/pre-tool-use-hook.ts
@@ -1,12 +1,21 @@
 /**
- * PreToolUse hook — dispatches PreToolUseHookInput to HookDispatchService
- * before each tool call executes.
+ * PreToolUse gate — consulted before each tool call executes.
  *
- * Blocking: if the dispatch service responds { decision: 'block' } the SDK
- * is instructed to block the tool call.
+ * `dispatchPreToolUseGate` is the backend-neutral core: it POSTs the tool call
+ * to the HookDispatchService and honors a `{ decision: 'block' }` response. It
+ * is shared by the Claude SDK adapter (`createPreToolUseHook`) AND the
+ * handwritten OpenAI / llama-cpp tool loops, so all three backends enforce with
+ * one identical posture.
  *
- * Failure mode: unreachable / timeout → returns {} (silent degradation,
- * same pattern as memory-retrieval-hook.ts BRIDGE_TIMEOUT_MS / line 12).
+ * Enable gate: returns `{ block: false }` with NO fetch unless
+ * `HOOK_DISPATCH_ENABLED === 'true'` — mirroring how the Claude SDK only wires
+ * the PreToolUse hook when enabled (index.ts). Default off ⇒ zero behavior
+ * change.
+ *
+ * Failure mode: unreachable / non-OK / timeout → `{ block: false }` (fail-open,
+ * silent degradation — same pattern as memory-retrieval-hook.ts). The gate is
+ * defense-in-depth for an already-authenticated turn, not the sole control; an
+ * unreachable gate must not brick the turn.
  * Timeout: 4000 ms.
  */
 
@@ -17,6 +26,102 @@ import type {
 
 const DISPATCH_TIMEOUT_MS = 4000;
 
+export interface PreToolUseGateArgs {
+  toolName: string;
+  toolInput: unknown;
+  toolUseId?: string;
+  sessionId?: string;
+  /** Defaults to DEUS_PROXY_HOST ?? 'host.docker.internal'. */
+  host?: string;
+  /** Defaults to HOOK_DISPATCH_PORT ?? 3002. */
+  port?: number;
+  /** Defaults to DEUS_PROXY_TOKEN. */
+  token?: string;
+}
+
+export interface PreToolUseGateResult {
+  block: boolean;
+  reason?: string;
+  /**
+   * The raw dispatch response on a non-block success (so the Claude SDK adapter
+   * can forward `additionalContext` and any other SDK-relevant fields, exactly
+   * as the pre-refactor hook did via `return data`). Undefined when disabled,
+   * non-OK, or on error.
+   */
+  response?: Record<string, unknown>;
+}
+
+/**
+ * Backend-neutral PreToolUse gate. See file header for the enable/failure
+ * contract. Returns `{ block: true, reason }` to refuse the tool call.
+ */
+export async function dispatchPreToolUseGate(
+  args: PreToolUseGateArgs,
+): Promise<PreToolUseGateResult> {
+  if (process.env.HOOK_DISPATCH_ENABLED !== 'true') return { block: false };
+
+  const host =
+    args.host ?? process.env.DEUS_PROXY_HOST ?? 'host.docker.internal';
+  const port =
+    args.port ?? parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10);
+  const token = args.token ?? process.env.DEUS_PROXY_TOKEN;
+  const url = `http://${host}:${port}/hooks/PreToolUse`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DISPATCH_TIMEOUT_MS);
+
+  try {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    if (token) headers['x-deus-proxy-token'] = token;
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        // Hardcoded — this gate only ever serves PreToolUse. Keeps the body
+        // byte-identical to the Claude SDK hook's so an observer reading
+        // payload.hook_event_name sees the same value on every backend.
+        hook_event_name: 'PreToolUse',
+        tool_name: args.toolName,
+        tool_input: args.toolInput,
+        tool_use_id: args.toolUseId,
+        session_id: args.sessionId,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return { block: false };
+
+    const data = (await res.json()) as Record<string, unknown>;
+
+    if (data.decision === 'block') {
+      return {
+        block: true,
+        reason:
+          typeof data.reason === 'string'
+            ? data.reason
+            : 'Blocked by PreToolUse observer',
+      };
+    }
+
+    return { block: false, response: data };
+  } catch {
+    console.warn(
+      '[pre-tool-use-hook] HookDispatchService unreachable, skipping',
+    );
+    return { block: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Claude SDK adapter over `dispatchPreToolUseGate`. Behavior is identical to the
+ * pre-refactor hook: `{ decision: 'block', reason }` on a block, the raw
+ * dispatch response forwarded on a non-block success, `{}` otherwise.
+ */
 export function createPreToolUseHook(
   host: string = process.env.DEUS_PROXY_HOST ?? 'host.docker.internal',
   port: number = parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10),
@@ -24,53 +129,23 @@ export function createPreToolUseHook(
 ): HookCallback {
   return async (input): Promise<Record<string, unknown>> => {
     const hookInput = input as PreToolUseHookInput;
-    const url = `http://${host}:${port}/hooks/PreToolUse`;
+    const gate = await dispatchPreToolUseGate({
+      toolName: hookInput.tool_name,
+      toolInput: hookInput.tool_input,
+      toolUseId: hookInput.tool_use_id,
+      sessionId: hookInput.session_id,
+      host,
+      port,
+      token,
+    });
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), DISPATCH_TIMEOUT_MS);
-
-    try {
-      const headers: Record<string, string> = {
-        'content-type': 'application/json',
+    if (gate.block) {
+      return {
+        decision: 'block' as const,
+        reason: gate.reason ?? 'Blocked by PreToolUse observer',
       };
-      if (token) headers['x-deus-proxy-token'] = token;
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          hook_event_name: hookInput.hook_event_name,
-          tool_name: hookInput.tool_name,
-          tool_input: hookInput.tool_input,
-          tool_use_id: hookInput.tool_use_id,
-          session_id: hookInput.session_id,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!res.ok) return {};
-
-      const data = (await res.json()) as Record<string, unknown>;
-
-      // Forward block decision back to the SDK
-      if (data.decision === 'block') {
-        return {
-          decision: 'block' as const,
-          reason:
-            typeof data.reason === 'string'
-              ? data.reason
-              : 'Blocked by PreToolUse observer',
-        };
-      }
-
-      return data;
-    } catch {
-      console.warn(
-        '[pre-tool-use-hook] HookDispatchService unreachable, skipping',
-      );
-      return {};
-    } finally {
-      clearTimeout(timer);
     }
+
+    return gate.response ?? {};
   };
 }


### PR DESCRIPTION
## Summary

Branch 2 of the LIA-197 program (branch 1 = path-a Odysseus `/v1` channel, #732). Adds a **PreToolUse enforcement seam** to the container's two handwritten non-Claude agent tool loops (OpenAI + llama-cpp), which previously dispatched every tool call with **no pre-execution interception** — while the Claude SDK path already has a gated PreToolUse hook. Closes that gap per ADR `docs/decisions/hook-dispatch-facade-correction.md`.

When `HOOK_DISPATCH_ENABLED=true`, both loops now consult the **same** `HookDispatchService` gate the Claude SDK consults, before executing each tool, and honor a `{decision:'block'}` response. **Default-off**, so zero behavior change in today's config; enabling a non-Claude backend later becomes a config flip, not a security project.

## What changed

- **`pre-tool-use-hook.ts`** — extracted a backend-neutral `dispatchPreToolUseGate()` from the Claude SDK hook. Self-gates on `HOOK_DISPATCH_ENABLED === 'true'` (no fetch when off), reuses the same POST body / 4s timeout / fail-open / block-decision parsing, and stamps a hardcoded `hook_event_name:'PreToolUse'` so the wire payload is byte-identical across backends. `createPreToolUseHook` is now a thin adapter over it — **behavior-identical refactor** (block → `{decision:'block',reason}`, non-block → forwards the raw dispatch response, error/disabled/non-OK → `{}`).
- **`openai-backend.ts` / `llama-cpp-backend.ts`** — call the gate inside the tool loop **before** the `mcpBridge.execute(...) ?? executeBrokerTool(...)` dispatch. On a block: feed the refusal back as the tool result and `continue` (skip execution). **No `doomDetector.record()` on a block** — the detector tracks repeated *execution*, and a blocked call never ran (this also sidesteps the pre-existing openai-vs-llama doom-warning asymmetry, leaving doom-loop behavior untouched).
- **Tests** — gate unit tests (no-fetch-when-disabled, block, default-reason, response-forwarding, fail-open, byte-identical body, adapter no-regression) + per-loop tests for both backends (blocked call not executed — both `mcpBridge.execute` and `executeBrokerTool` asserted not-called — reason fed back, no doom record, plus an allow-path control).

## Scope & non-goals

- **Mechanism parity only.** This makes the non-Claude loops *consult* the gate. It does **not** register a *blocking* warden observer — today `:3002`'s fan-out is observer-only (doom-loop/tool-audit telemetry), so the gate is inert until one is registered. That registration (e.g. wiring `scripts/codex_warden_hooks.py` as a `HookDispatchService` observer) is **backend-neutral** (it gates Claude and non-Claude equally) and is an explicit **follow-up branch**.
- No PostToolUse tool-audit / no full parity (intentionally "seam only").
- No new env vars; reuses `HOOK_DISPATCH_ENABLED`, `HOOK_DISPATCH_PORT`, `DEUS_PROXY_HOST`, `DEUS_PROXY_TOKEN`.

## Verification

- agent-runner `tsc --noEmit`: clean · root `tsc --noEmit` (CI gate): clean · prettier `--check`: clean · eslint: clean (source files; container test files are out of lint scope).
- 17 new tests pass. Full agent-runner suite: **130/131** — the 1 failure (`schedule-validator.test.ts > rejects an empty cron expression`, a cron-parser empty-string behavior) is **pre-existing and unrelated** (this diff touches none of those files; it's invisible to CI because agent-runner vitest isn't wired into any CI job).
- **Real end-to-end HTTP smoke** (real `HookDispatchService` + real `dispatchPreToolUseGate`/adapter over real `fetch`, not mocks):

```
ALLOW   dispatchPreToolUseGate => {"block":false,"response":{"hookSpecificOutput":{"additionalContext":"observed ok"}}}
        wire payload received   => {"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls"},"tool_use_id":"tu_allow"}
BLOCK   dispatchPreToolUseGate => {"block":true,"reason":"smoke-deny: destructive command refused"}
        adapter                 => {"decision":"block","reason":"smoke-deny: destructive command refused"}
DISABLED dispatchPreToolUseGate => {"block":false}   (service saw a request? false)
FAIL-OPEN dispatchPreToolUseGate => {"block":false}  (service unreachable)
```

- Wardens: plan-reviewer **SHIP**, code-reviewer **SHIP**, verification-gate **SHIP**.

## ⚠️ Operational notes

- **Rebuild the container** (`./container/build.sh`) to pick up this change — it ships in the agent-runner image.
- **Deferred obligation:** the first time a *real block* ships through a live Claude Code session is on the **blocking-observer follow-up branch** — `hook-pr-smoke-test` (real-session block+allow evidence) must be re-run there. This PR's block path is proven only via the real-HTTP harness + a throwaway block observer, because the live block path structurally requires that out-of-scope observer.

Tracked under **LIA-197**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
