### PR TITLE
fix(memory): persist detected contradictions to pending_conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,10 @@ jobs:
         run: scripts/token_bench/ci_coverage_gate.sh origin/${{ github.base_ref }}
 
       - name: Install evolution test dependencies
-        run: python3 -m pip install sqlite-vec==0.1.6
+        # google-genai is import-only for memory_indexer (the network client is
+        # never built in tests); required so test_memory_indexer_contradiction_commit
+        # can import the module. See that test's module docstring.
+        run: python3 -m pip install sqlite-vec==0.1.6 google-genai
 
       - name: Evolution tests
         run: python3 -m pytest evolution/tests/ -v

--- a/evolution/tests/test_memory_indexer_contradiction_commit.py
+++ b/evolution/tests/test_memory_indexer_contradiction_commit.py
@@ -11,35 +11,47 @@ The LLM contradiction check is mocked; only the persistence path is exercised.
 ``google-genai`` is import-only here (the real client is never constructed), so
 it must be installed in CI — see the evolution-deps step in
 ``.github/workflows/ci.yml``.
+
+Import note: ``memory_indexer`` resolves the memory vault AT IMPORT TIME
+(``_vault_root = _load_vault_path()`` at module scope) and ``sys.exit``s with
+AUTH_ERROR when no vault is configured. CI has no vault, so the import is
+deferred into the test and ``DEUS_VAULT_PATH`` (resolution tier 1) is set via
+``monkeypatch.setenv`` first — otherwise pytest crashes at COLLECTION time,
+before any fixture can run. The vault path is never used: the test redirects
+``DB_PATH`` and ``detect_contradictions`` only touches the DB connection.
+``import_module`` returns the cached module on a second import, so if a future
+test adds a module-level ``memory_indexer`` import this becomes order-sensitive;
+today this is the only importer.
 """
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 from pathlib import Path
 
-# Import the scripts/ module without permanently polluting sys.path — otherwise
-# scripts/ would shadow names while OTHER evolution tests are collected. The
-# sibling helpers (_time, _exit_codes, _agent_io) get cached during this import.
 _SCRIPTS = str(Path(__file__).resolve().parents[2] / "scripts")
-_added = _SCRIPTS not in sys.path
-if _added:
-    sys.path.insert(0, _SCRIPTS)
-try:
-    import memory_indexer as mi  # noqa: E402
-finally:
-    if _added:
-        sys.path.remove(_SCRIPTS)
 
 
-def _unit_vec() -> list[float]:
-    vec = [0.0] * mi.EMBED_DIM
-    vec[0] = 1.0
-    return vec
+def _import_memory_indexer():
+    """Import scripts/memory_indexer.py without leaving scripts/ on sys.path
+    (it would shadow names while OTHER evolution tests are collected)."""
+    added = _SCRIPTS not in sys.path
+    if added:
+        sys.path.insert(0, _SCRIPTS)
+    try:
+        return importlib.import_module("memory_indexer")
+    finally:
+        if added:
+            sys.path.remove(_SCRIPTS)
 
 
 def test_detected_conflict_persists_across_connection_close(tmp_path, monkeypatch):
+    # Satisfy import-time vault resolution (tier 1) BEFORE importing — the path
+    # is never touched; the test redirects DB_PATH below. setenv auto-reverts.
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(tmp_path / "vault"))
+    mi = _import_memory_indexer()
     monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
 
     # Force a CONTRADICT verdict without any network call.
@@ -49,7 +61,8 @@ def test_detected_conflict_persists_across_connection_close(tmp_path, monkeypatc
         lambda *a, **k: types.SimpleNamespace(text="CONTRADICT"),
     )
 
-    vec = _unit_vec()
+    vec = [0.0] * mi.EMBED_DIM
+    vec[0] = 1.0
 
     # Seed one existing atom + its embedding so the KNN MATCH returns a candidate.
     db = mi.open_db()

--- a/evolution/tests/test_memory_indexer_contradiction_commit.py
+++ b/evolution/tests/test_memory_indexer_contradiction_commit.py
@@ -1,0 +1,81 @@
+"""Regression test: detected contradictions must PERSIST to pending_conflicts.
+
+Guards the 2026-06-09 bug where ``detect_contradictions`` INSERTed a row into
+``pending_conflicts`` but no commit followed — its only caller (``cmd_extract``)
+does its last ``db.commit()`` BEFORE contradiction detection runs. The
+connection is opened with the default deferred isolation level, so the
+uncommitted INSERT rolled back on connection close and ``--resolve-conflicts``
+was permanently empty (the contradiction-review feature silently never worked).
+
+The LLM contradiction check is mocked; only the persistence path is exercised.
+``google-genai`` is import-only here (the real client is never constructed), so
+it must be installed in CI — see the evolution-deps step in
+``.github/workflows/ci.yml``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+# Import the scripts/ module without permanently polluting sys.path — otherwise
+# scripts/ would shadow names while OTHER evolution tests are collected. The
+# sibling helpers (_time, _exit_codes, _agent_io) get cached during this import.
+_SCRIPTS = str(Path(__file__).resolve().parents[2] / "scripts")
+_added = _SCRIPTS not in sys.path
+if _added:
+    sys.path.insert(0, _SCRIPTS)
+try:
+    import memory_indexer as mi  # noqa: E402
+finally:
+    if _added:
+        sys.path.remove(_SCRIPTS)
+
+
+def _unit_vec() -> list[float]:
+    vec = [0.0] * mi.EMBED_DIM
+    vec[0] = 1.0
+    return vec
+
+
+def test_detected_conflict_persists_across_connection_close(tmp_path, monkeypatch):
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+
+    # Force a CONTRADICT verdict without any network call.
+    monkeypatch.setattr(
+        mi,
+        "_generate_with_fallback",
+        lambda *a, **k: types.SimpleNamespace(text="CONTRADICT"),
+    )
+
+    vec = _unit_vec()
+
+    # Seed one existing atom + its embedding so the KNN MATCH returns a candidate.
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO entries (id, path, date, chunk, type) "
+        "VALUES (1, 'existing.md', '2026-06-09', 'Existing atom text.', 'atom')"
+    )
+    db.execute(
+        "INSERT INTO embeddings (rowid, embedding) VALUES (1, ?)",
+        [mi.serialize(vec)],
+    )
+    db.commit()
+
+    conflicts = mi.detect_contradictions(db, 2, "New contradicting atom text.", vec)
+    assert len(conflicts) == 1, "detection should flag exactly one conflict"
+    db.close()
+
+    # Reopen a fresh connection: the row must survive. Without the write-site
+    # commit this returns [] (the regression).
+    db2 = mi.open_db()
+    rows = db2.execute(
+        "SELECT older_id, newer_id FROM pending_conflicts WHERE resolved = 0"
+    ).fetchall()
+    db2.close()
+
+    assert rows == [(1, 2)], (
+        "pending_conflicts row must persist after the connection closes — "
+        "detect_contradictions must commit at the write site"
+    )

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-08" # auto-bump @1780869610
+last_verified: "2026-06-09" # auto-bump @1780954849
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-08" # auto-bump @1780931406
+last_verified: "2026-06-09" # auto-bump @1780954849
 governs:
   - src/
   - evolution/

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -2421,6 +2421,11 @@ def detect_contradictions(db: sqlite3.Connection, new_atom_id: int,
                         "VALUES (?, ?, ?, ?, ?)",
                         [existing_id, new_atom_id, existing_text, new_atom_text, today],
                     )
+                    # Commit at the write site: the only caller (cmd_extract) does
+                    # its last commit BEFORE contradiction detection, so without this
+                    # the deferred transaction rolls back on connection close and the
+                    # conflict is lost — making --resolve-conflicts permanently empty.
+                    db.commit()
                 except Exception:
                     pass
                 print(f"  CONFLICT DETECTED (pending review): atom {existing_id} "


### PR DESCRIPTION
## Summary

`detect_contradictions()` detected and **printed** "logged for review" for every
contradiction, but the rows never reached `pending_conflicts` — so
`--resolve-conflicts` was permanently empty and the contradiction-review feature
has silently never worked (the table had 0 rows, ever).

## Root cause (verified two ways)

- **Code read:** `detect_contradictions()` runs `INSERT OR IGNORE INTO pending_conflicts`
  but never commits. Its only caller, `cmd_extract()`, runs its last `db.commit()`
  *before* contradiction detection. The connection is opened with the default
  deferred isolation level, so the uncommitted INSERT is rolled back on connection close.
- **Empirical:** reproduced the rollback on the exact connection config — an
  uncommitted INSERT followed by reopen returns `[]`.

Discovered when a `/compress` run printed `CONFLICT DETECTED ... logged for review`
yet `pending_conflicts` was empty afterward.

## Fix

One line: `db.commit()` at the write site, immediately after the INSERT.

## Test

`evolution/tests/test_memory_indexer_contradiction_commit.py` seeds an atom +
embedding, mocks the judge to force `CONTRADICT`, and asserts the row survives a
connection reopen.

- **Fails without the fix** (reopen returns `[]`).
- **Passes with the fix.**
- Full `evolution/tests/` still collects (502 tests); 67 neighbors pass.

## CI

Added `google-genai` to the evolution-deps step — it's import-only for
`memory_indexer` (the network client is never built in the test), required so the
test can import the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
