### PR TITLE
docs(rules): decompose-first parallelism (replace blunt parallel-everything line)

### DIFF
--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -31,7 +31,7 @@
 ## Workflow
 - Feature branch before implementing. Use git worktree, never checkout in main.
 - One concern per branch. Unrelated changes bundled together are harder to review, revert, and bisect.
-- Before parallelizing, map independent vs dependent subtasks. Fan out the independent ones with explicit output contracts and a reconcile step; plan→review→implement→test is ordered by necessity — agents on stale inputs produce stale outputs, and a chunk without full context hallucinates its interfaces.
+- Before parallelizing, map independent vs dependent subtasks. Fan out only the independent ones with explicit output contracts and a reconcile step; never parallelize a dependency chain — plan→review→implement→test is sequential by necessity, agents on stale inputs produce stale outputs, and a subtask without full interface context hallucinates its contracts.
 - Default subagent model is Sonnet. Escalate to Opus only with stated reason.
 - Default to cross-platform. Flag OS-specific code loudly in PRs.
 - Chat responses always in English. Hebrew only inside artifacts.

--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -31,7 +31,7 @@
 ## Workflow
 - Feature branch before implementing. Use git worktree, never checkout in main.
 - One concern per branch. Unrelated changes bundled together are harder to review, revert, and bisect.
-- All independent work runs parallel + background. Don't ask, just do it.
+- Before parallelizing, map independent vs dependent subtasks. Fan out the independent ones with explicit output contracts and a reconcile step; plan→review→implement→test is ordered by necessity — agents on stale inputs produce stale outputs, and a chunk without full context hallucinates its interfaces.
 - Default subagent model is Sonnet. Escalate to Opus only with stated reason.
 - Default to cross-platform. Flag OS-specific code loudly in PRs.
 - Chat responses always in English. Hebrew only inside artifacts.


### PR DESCRIPTION
## Why this change

The replaced line — \`All independent work runs parallel + background. Don't ask, just do it.\` — was a correctness trap. It invited fake-parallelizing dependency chains and had no guard against agents working on stale inputs. This PR replaces it with a decompose-first rule that includes an explicit prohibition.

## Three failures this prevents

1. **Stale-input agents.** The ordered chain \`plan→review→implement→test\` is sequential by necessity: each step consumes the output of the prior one. Dispatching agents on stale (or not-yet-existent) inputs produces stale outputs. The old line gave no guard against this.

2. **Interface hallucination.** A subtask given incomplete scope hallucinates the interfaces it shares with sibling agents — it can't know what it doesn't see. This session's own case study: two parallel agents independently named the same method two different ways, incurring reconciliation cost. The new rule requires explicit output contracts before fan-out.

3. **Unbudgeted reconciliation cost.** Parallel agents that diverge on shared surfaces always incur a reconcile step. The old line implied "just parallelize" with no accounting for integration. The new rule makes the reconcile step explicit and required.

## The new rule

\`\`\`
- Before parallelizing, map independent vs dependent subtasks. Fan out only the independent ones with explicit output contracts and a reconcile step; never parallelize a dependency chain — plan→review→implement→test is sequential by necessity, agents on stale inputs produce stale outputs, and a subtask without full interface context hallucinates its contracts.
\`\`\`

**Why two commits:** the first commit softened the prohibition to a description ("is ordered by necessity" instead of "never parallelize a dependency chain"). An adversarial review caught this regression. The second commit restores the explicit prohibition and fixes vague language ("chunk" → "subtask").

**Token delta:** old line ~18 tokens → new line ~55 tokens, +~37 tokens. Projected file total: ~519 / 800-token budget. Well within headroom.

## Supporting evidence

- \`docs/decisions/multi-agent-orchestration-research.md\` (line 54) already codified this: "Parallel fan-out is for reads (research/retrieval), not writes (implementation). Implementation and review run sequentially." This rule brings the always-loaded behavioral file into alignment with that settled ADR.
- \`scripts/bench/attention_dilution_probe.py\` pre-registers H4 (bloated-context performance degrades pairwise vs production context) and H6 (bug-recall under bloated context is ≥10pp lower). These are **pre-registered predictions — no run results exist yet** — and are not claimed as evidence here, only as motivation for the interface-hallucination concern.

## Warden review notes

**Warden dispatch (Agent/Task) was unavailable in the executing environment.** Reviews below are author self-reviews conducted inline against each warden's published rule file — not independent automated warden runs. The PR is DRAFT specifically to allow a human reviewer to apply independent scrutiny before any merge.

| Warden rule file | Self-review finding | Author verdict |
|--------|---------|-------------|
| plan-review-rules.md | Single-file doc edit; public-repo clean; aligns with multi-agent-orchestration-research.md ADR; H4/H6 cited as pre-registered predictions only | SHIP |
| ai-engineering-rules.md | Rule file is LLM-consumed context; explicit prohibition added; token delta earns its place | SHIP |
| copy-rules.md | Prose is direct/active; "never parallelize a dependency chain" is a clear gate; "subtask without full interface context" is precise | SHIP |
| code-review-rules.md | Token budget preserved ~519/800; public-repo clean; no cross-platform concerns | SHIP |
| verification-rules.md | git diff verified; both commits confirmed; explicit prohibition present; budget verified | SHIP |

**Independent reviewer action required:** verify (1) the explicit prohibition survives in the final wording, (2) the rule fits the "terse what+why" house style, (3) token budget holds.

## Out of scope

The matching local \`~/.claude\` atom (user-scope behavioral rules) is updated separately by the author. Bundling personal tooling into a public-repo PR violates the repo's hard rule (\`core-behavioral-rules.md\` § Data & Security: "Never bundle personal ~/.claude/ tooling into public-repo PRs").

## Do not merge

This is a **DRAFT PR** for human review. Do not merge without explicit author approval.