### PR TITLE
feat(agent-runner): add blocking PreToolUse observer + fix consult host (LIA-197)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,9 @@ LINEAR_API_TOKEN=
 # Hook dispatch (Linear webhook pipeline)
 # HOOK_DISPATCH_ENABLED=0
 # HOOK_DISPATCH_PORT=3005
+# Host for the in-container :3002 dispatch consult (the service is container-local,
+# so this targets localhost — NOT DEUS_PROXY_HOST, which addresses host services)
+# HOOK_DISPATCH_HOST=127.0.0.1
 # Tool proxy port (credential proxy for container agents)
 # TOOL_PROXY_PORT=3001
 # Asana project management MCP (host-side Claude Code).

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -37,7 +37,8 @@ import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 import { createToolCallLogHook } from './tool-call-log.js';
 import type { AgentRuntimeId } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
-import { createPreToolUseHook } from './pre-tool-use-hook.js';
+import { createPreToolUseHook, dispatchHost } from './pre-tool-use-hook.js';
+import { createBlockingPreToolUseObserver } from './pre-tool-use-gate-observer.js';
 import { createPostToolUseObserverHook } from './post-tool-use-observer.js';
 
 interface RuntimeSession {
@@ -914,7 +915,9 @@ async function runQuery(
                 {
                   hooks: [
                     createPreToolUseHook(
-                      process.env.DEUS_PROXY_HOST ?? 'host.docker.internal',
+                      // The :3002 service is co-located in THIS container, so the
+                      // consult targets localhost — not DEUS_PROXY_HOST (host services).
+                      dispatchHost(),
                       parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10),
                       process.env.DEUS_PROXY_TOKEN,
                     ),
@@ -1065,6 +1068,15 @@ async function main(): Promise<void> {
     const dispatchSvc = new HookDispatchService();
     try {
       await dispatchSvc.start(dispatchPort);
+      // Register the single blocking PreToolUse observer. Inside the try on
+      // purpose: if start() throws, the catch keeps fail-open and the observer
+      // is simply never registered. With one deny-capable observer, fanOut's
+      // last-writer-wins merge is correct; revisit block-precedence if a second
+      // (allow-capable) observer is ever added.
+      dispatchSvc.registerObserver(
+        'PreToolUse',
+        createBlockingPreToolUseObserver(),
+      );
       log(`HookDispatchService started on :${dispatchPort}`);
     } catch (err) {
       console.warn(

--- a/container/agent-runner/src/pre-tool-use-gate-observer.test.ts
+++ b/container/agent-runner/src/pre-tool-use-gate-observer.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createBlockingPreToolUseObserver,
+  isRecursiveForceRmOutsideWorkspace,
+} from './pre-tool-use-gate-observer.js';
+
+describe('createBlockingPreToolUseObserver', () => {
+  const observer = createBlockingPreToolUseObserver();
+
+  it('blocks rm -rf targeting outside /workspace', async () => {
+    const result = await observer('PreToolUse', {
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /tmp/deus-delete-me' },
+    });
+    expect(result.decision).toBe('block');
+    expect(String(result.reason)).toMatch(/outside \/workspace/);
+  });
+
+  it('allows rm -rf inside /workspace', async () => {
+    const result = await observer('PreToolUse', {
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /workspace/tmp/build' },
+    });
+    expect(result).toEqual({});
+  });
+
+  it('allows non-Bash tools even with a matching command string', async () => {
+    const result = await observer('PreToolUse', {
+      tool_name: 'Write',
+      tool_input: { file_path: '/tmp/foo', content: 'rm -rf /etc' },
+    });
+    expect(result).toEqual({});
+  });
+
+  it('does not block (or throw) on a malformed payload', async () => {
+    expect(await observer('PreToolUse', null)).toEqual({});
+    expect(await observer('PreToolUse', 'nope')).toEqual({});
+    expect(await observer('PreToolUse', { tool_name: 'Bash' })).toEqual({});
+    expect(
+      await observer('PreToolUse', { tool_name: 'Bash', tool_input: {} }),
+    ).toEqual({});
+  });
+});
+
+describe('isRecursiveForceRmOutsideWorkspace', () => {
+  it.each([
+    // recursive + force, absolute target outside /workspace → block
+    ['rm -rf /tmp/x', true],
+    ['rm -fr /etc/foo', true],
+    ['rm -r -f /var/data', true],
+    ['rm --recursive --force /opt/x', true],
+    ['rm -rf /', true],
+    ['rm -rf /workspaces/x', true], // sibling dir is genuinely outside /workspace
+    // in-workspace → allow
+    ['rm -rf /workspace', false],
+    ['rm -rf /workspace/tmp/x', false],
+    ['rm -rf relative/path', false], // relative → in-workspace assumption
+    // not both flags → allow
+    ['rm -r /tmp/x', false],
+    ['rm -f /tmp/x', false],
+    ['rm /tmp/x', false],
+    // not rm → allow
+    ['ls -la /tmp', false],
+    ['', false],
+  ])('classifies %j as %s', (cmd, expected) => {
+    expect(isRecursiveForceRmOutsideWorkspace(cmd as string)).toBe(expected);
+  });
+});

--- a/container/agent-runner/src/pre-tool-use-gate-observer.ts
+++ b/container/agent-runner/src/pre-tool-use-gate-observer.ts
@@ -1,0 +1,87 @@
+/**
+ * Blocking PreToolUse observer — the first observer that can DENY a tool call
+ * via `HookDispatchService`. Returning `{ decision: 'block', reason }` is honored
+ * by both consult consumers (`dispatchPreToolUseGate` for the openai/llama-cpp
+ * loops, `createPreToolUseHook` for the Claude SDK), so one observer gates every
+ * backend. Deny rule is minimal + conservative (fail-open): block a Bash
+ * recursive-force `rm` whose absolute target escapes `/workspace`; anything not
+ * positively classified as out-of-`/workspace` is allowed, malformed payload → {}.
+ */
+
+import type { ObserverCallback } from './hook-dispatch-service.js';
+
+/**
+ * True when `command` is a recursive-force `rm` with at least one ABSOLUTE
+ * target outside `/workspace`. Conservative by construction — unparseable or
+ * relative targets degrade to `false` (allow), never to a false block.
+ */
+export function isRecursiveForceRmOutsideWorkspace(command: string): boolean {
+  // Whitespace tokenization is deliberately simple: we do not parse quotes,
+  // pipes, or subshells. Those degrade to "allow", never to a false block.
+  const tokens = command.split(/\s+/).filter(Boolean);
+  // First bare `rm` (or an absolute-path `rm`, e.g. /bin/rm). A stray `rm` token
+  // inside e.g. an `echo` over-matches, but that only ever over-blocks a benign
+  // command — acceptable for a default-off defense-in-depth guard.
+  const rmIdx = tokens.findIndex((t) => t === 'rm' || t.endsWith('/rm'));
+  if (rmIdx === -1) return false;
+
+  let recursive = false;
+  let force = false;
+  const targets: string[] = [];
+
+  for (const arg of tokens.slice(rmIdx + 1)) {
+    if (arg === '--recursive') recursive = true;
+    else if (arg === '--force') force = true;
+    else if (/^-[a-zA-Z]+$/.test(arg)) {
+      // Short flag cluster, e.g. -rf, -fr, -Rf, -r, -f.
+      if (/[rR]/.test(arg)) recursive = true;
+      if (/f/.test(arg)) force = true;
+    } else if (!arg.startsWith('-')) {
+      targets.push(arg);
+    }
+  }
+
+  if (!recursive || !force) return false;
+
+  // Block only ABSOLUTE targets that escape /workspace. Relative paths are
+  // treated as in-workspace (the container cwd) and allowed — conservative.
+  return targets.some((t) => t.startsWith('/') && !isInsideWorkspace(t));
+}
+
+function isInsideWorkspace(absPath: string): boolean {
+  return absPath === '/workspace' || absPath.startsWith('/workspace/');
+}
+
+/**
+ * Factory for the blocking PreToolUse observer. Matches the
+ * `ObserverCallback = (event, payload) => Promise<Record<string, unknown>>`
+ * contract from `hook-dispatch-service.ts`. Reads `payload.tool_name` and
+ * `payload.tool_input.command` — the exact shape posted by both consult paths.
+ */
+export function createBlockingPreToolUseObserver(): ObserverCallback {
+  return async (
+    _event: string,
+    payload: unknown,
+  ): Promise<Record<string, unknown>> => {
+    if (!payload || typeof payload !== 'object') return {};
+    const p = payload as Record<string, unknown>;
+    if (p.tool_name !== 'Bash') return {};
+
+    const toolInput =
+      p.tool_input && typeof p.tool_input === 'object'
+        ? (p.tool_input as Record<string, unknown>)
+        : {};
+    const command =
+      typeof toolInput.command === 'string' ? toolInput.command : '';
+
+    if (isRecursiveForceRmOutsideWorkspace(command)) {
+      return {
+        decision: 'block',
+        reason:
+          'Blocked by PreToolUse gate: recursive-force `rm` outside /workspace is not permitted.',
+      };
+    }
+
+    return {};
+  };
+}

--- a/container/agent-runner/src/pre-tool-use-hook.test.ts
+++ b/container/agent-runner/src/pre-tool-use-hook.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createPreToolUseHook,
+  dispatchHost,
   dispatchPreToolUseGate,
 } from './pre-tool-use-hook.js';
 
@@ -206,5 +207,45 @@ describe('createPreToolUseHook (Claude SDK adapter, no regression)', () => {
     const out = await hook(input as any, undefined as any, {} as any);
 
     expect(out).toEqual({});
+  });
+});
+
+describe('dispatchHost (consult targets the container-local :3002 service)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to 127.0.0.1, NOT DEUS_PROXY_HOST (which addresses host services)', () => {
+    delete process.env.HOOK_DISPATCH_HOST;
+    process.env.DEUS_PROXY_HOST = 'host.docker.internal';
+    expect(dispatchHost()).toBe('127.0.0.1');
+  });
+
+  it('honors a HOOK_DISPATCH_HOST override', () => {
+    process.env.HOOK_DISPATCH_HOST = '10.0.0.5';
+    expect(dispatchHost()).toBe('10.0.0.5');
+  });
+
+  it('dispatchPreToolUseGate POSTs to dispatchHost(), ignoring DEUS_PROXY_HOST', async () => {
+    process.env.HOOK_DISPATCH_ENABLED = 'true';
+    process.env.HOOK_DISPATCH_PORT = '3002';
+    process.env.DEUS_PROXY_HOST = 'host.docker.internal'; // must be ignored now
+    delete process.env.HOOK_DISPATCH_HOST;
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(okResponse({}));
+
+    await dispatchPreToolUseGate({
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://127.0.0.1:3002/hooks/PreToolUse',
+      expect.anything(),
+    );
   });
 });

--- a/container/agent-runner/src/pre-tool-use-hook.ts
+++ b/container/agent-runner/src/pre-tool-use-hook.ts
@@ -26,12 +26,20 @@ import type {
 
 const DISPATCH_TIMEOUT_MS = 4000;
 
+/**
+ * Host for the container-local HookDispatchService (:3002) consult: localhost,
+ * NOT DEUS_PROXY_HOST (which addresses host-side services). Override: HOOK_DISPATCH_HOST.
+ */
+export function dispatchHost(): string {
+  return process.env.HOOK_DISPATCH_HOST ?? '127.0.0.1';
+}
+
 export interface PreToolUseGateArgs {
   toolName: string;
   toolInput: unknown;
   toolUseId?: string;
   sessionId?: string;
-  /** Defaults to DEUS_PROXY_HOST ?? 'host.docker.internal'. */
+  /** Defaults to `dispatchHost()` (HOOK_DISPATCH_HOST ?? '127.0.0.1'). */
   host?: string;
   /** Defaults to HOOK_DISPATCH_PORT ?? 3002. */
   port?: number;
@@ -60,8 +68,7 @@ export async function dispatchPreToolUseGate(
 ): Promise<PreToolUseGateResult> {
   if (process.env.HOOK_DISPATCH_ENABLED !== 'true') return { block: false };
 
-  const host =
-    args.host ?? process.env.DEUS_PROXY_HOST ?? 'host.docker.internal';
+  const host = args.host ?? dispatchHost();
   const port =
     args.port ?? parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10);
   const token = args.token ?? process.env.DEUS_PROXY_TOKEN;
@@ -123,7 +130,7 @@ export async function dispatchPreToolUseGate(
  * dispatch response forwarded on a non-block success, `{}` otherwise.
  */
 export function createPreToolUseHook(
-  host: string = process.env.DEUS_PROXY_HOST ?? 'host.docker.internal',
+  host: string = dispatchHost(),
   port: number = parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10),
   token: string | undefined = process.env.DEUS_PROXY_TOKEN,
 ): HookCallback {


### PR DESCRIPTION
## What
The first **blocking** PreToolUse observer on the in-container `HookDispatchService`, so the consult seam shipped in #740 actually denies — backend-neutral (Claude SDK + the openai/llama-cpp loops all consult `:3002`). Plus a consult-host fix so the in-container observer is reachable. LIA-197 follow-up; builds on #740.

## Why
After #740 all backends *consult* `:3002`, but nothing denied:
1. The service registered **zero** observers.
2. Every consult defaulted its host to `DEUS_PROXY_HOST ?? 'host.docker.internal'`, but the service binds **in-container** — so the consult hit the host machine (no listener), and an in-container observer was **never reachable** (registering one alone would have shipped a new facade).

This PR registers the observer **and** fixes the host so it is actually reachable.

## Changes
- **`pre-tool-use-gate-observer.ts`** (new): `createBlockingPreToolUseObserver()` — blocks a Bash recursive-force `rm` whose **absolute** target escapes `/workspace`. Conservative fail-open: relative/unparseable targets → allow; malformed payload → `{}`. Returning `{decision:'block', reason}` is honored by both consult consumers (`dispatchPreToolUseGate` for the non-Claude loops, `createPreToolUseHook` for the Claude SDK), so one observer gates every backend.
- **`dispatchHost()`** (new, in `pre-tool-use-hook.ts`): `HOOK_DISPATCH_HOST ?? '127.0.0.1'`. The `:3002` service is container-co-located, so the gate consult targets localhost — not `DEUS_PROXY_HOST` (which addresses host services like the credential proxy and memory retrieval). Applied at the gate consult sites (both non-Claude loops auto-corrected via the default; the Claude SDK hook at `index.ts` updated).
- Observer registered inside the existing `HOOK_DISPATCH_ENABLED` guard (**default-off; production unchanged**).
- Unit tests for the observer + a `dispatchHost` regression test; `.env.example` documents `HOOK_DISPATCH_HOST`.

## Verification
`container/agent-runner` is **not** covered by root CI (own tsconfig/vitest; only built in the Docker image), so validated locally:
- `tsc --noEmit` clean; touched-file tests **32/32**; full suite 151/152 (the 1 failure is a pre-existing, unrelated `schedule-validator` empty-cron test — that file is untouched on this branch).
- **Live container smoke test** — real Claude turn, image built from this branch, `HOOK_DISPATCH_ENABLED=true`:
  - **BLOCK**: model attempted `Bash rm -rf /smoke-target` (outside `/workspace`) → result *"blocked by a security policy … recursive force deletion (`rm -rf`) outside of the `/workspace` directory"*; host-mounted canary outside `/workspace` **SURVIVED** (rm never ran).
  - **ALLOW**: model ran `rm -rf /workspace/canary.txt` (inside `/workspace`) → *"has been removed"*; canary inside `/workspace` **DELETED** (rm executed).
  - **Differential proof**: both runs show `[post-tool-use-observer] dispatch failed: fetch failed` (the deliberately-unfixed, out-of-scope PostToolUse consult still targets `host.docker.internal`) while the PreToolUse consult **succeeded** — confirming the `dispatchHost()` fix is precisely what makes the in-container observer reachable.

## Out of scope (documented siblings — tracked for follow-up)
- PostToolUse observer still targets `host.docker.internal` (telemetry, non-blocking — no active consumer).
- `HOOK_DISPATCH_ENABLED` container passthrough in `container-runner.ts` (production enablement is a separate decision; the consult-host fix means enabling is then just flipping the flag).
- Deny-rule hardening: `..` path-traversal inside an absolute path, quoted/piped commands, flag-order edge cases (deferred; conservative fail-open today).

## Container rebuild
Touches `container/agent-runner/` → requires `./container/build.sh` to take effect (the smoke test already confirmed a clean build). Default-off, so inert in production until explicitly enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
