### PR TITLE
fix(memory): lazy-resolve vault path so memory_indexer imports without a vault

### DIFF
--- a/evolution/tests/test_memory_indexer_contradiction_commit.py
+++ b/evolution/tests/test_memory_indexer_contradiction_commit.py
@@ -12,16 +12,14 @@ The LLM contradiction check is mocked; only the persistence path is exercised.
 it must be installed in CI — see the evolution-deps step in
 ``.github/workflows/ci.yml``.
 
-Import note: ``memory_indexer`` resolves the memory vault AT IMPORT TIME
-(``_vault_root = _load_vault_path()`` at module scope) and ``sys.exit``s with
-AUTH_ERROR when no vault is configured. CI has no vault, so the import is
-deferred into the test and ``DEUS_VAULT_PATH`` (resolution tier 1) is set via
-``monkeypatch.setenv`` first — otherwise pytest crashes at COLLECTION time,
-before any fixture can run. The vault path is never used: the test redirects
-``DB_PATH`` and ``detect_contradictions`` only touches the DB connection.
-``import_module`` returns the cached module on a second import, so if a future
-test adds a module-level ``memory_indexer`` import this becomes order-sensitive;
-today this is the only importer.
+Import note: ``memory_indexer`` resolves the memory vault LAZILY (first
+``_vault_root()`` call), so importing it needs no vault — CI has none. The
+import is still deferred into the test only to keep ``scripts/`` off
+``sys.path`` during collection of sibling tests. The vault is never touched: the
+test redirects ``DB_PATH`` and ``detect_contradictions`` only uses the DB
+connection. ``import_module`` returns the cached module on a second import, so
+if a future test adds a module-level ``memory_indexer`` import this becomes
+order-sensitive; today this is the only importer.
 """
 
 from __future__ import annotations
@@ -48,9 +46,8 @@ def _import_memory_indexer():
 
 
 def test_detected_conflict_persists_across_connection_close(tmp_path, monkeypatch):
-    # Satisfy import-time vault resolution (tier 1) BEFORE importing — the path
-    # is never touched; the test redirects DB_PATH below. setenv auto-reverts.
-    monkeypatch.setenv("DEUS_VAULT_PATH", str(tmp_path / "vault"))
+    # Vault resolution is lazy and never triggered here (the test redirects
+    # DB_PATH and only touches the DB connection), so no DEUS_VAULT_PATH needed.
     mi = _import_memory_indexer()
     monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
 

--- a/evolution/tests/test_memory_indexer_lazy_vault.py
+++ b/evolution/tests/test_memory_indexer_lazy_vault.py
@@ -1,0 +1,97 @@
+"""Regression tests: memory-vault resolution must be LAZY.
+
+Guards the contract introduced when ``memory_indexer`` stopped resolving the
+vault at module-import scope. Previously ``_vault_root = _load_vault_path()`` ran
+at import and ``sys.exit``ed with AUTH_ERROR when no vault was configured, so the
+module was unimportable in any vault-less environment (CI, fresh checkout) and
+even DB-only commands (``--query``) died at startup. Resolution now happens on
+first actual vault access via ``_vault_root()`` (mirrors the lazy Gemini client,
+PR #677).
+
+Three contracts:
+  1. Import does NOT resolve the vault (cache is None; accessors are callables).
+  2. The ``sys.exit`` on a missing vault is DEFERRED to first ``_vault_root()``
+     call, not raised at import.
+  3. ``_vault_root()`` is the sole resolver and caches (resolves once).
+
+No vault is required to import this module — that is the whole point.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = str(Path(__file__).resolve().parents[2] / "scripts")
+
+
+def _import_memory_indexer():
+    """Import scripts/memory_indexer.py without leaving scripts/ on sys.path
+    (it would shadow names while OTHER evolution tests are collected)."""
+    added = _SCRIPTS not in sys.path
+    if added:
+        sys.path.insert(0, _SCRIPTS)
+    try:
+        return importlib.import_module("memory_indexer")
+    finally:
+        if added:
+            sys.path.remove(_SCRIPTS)
+
+
+def test_import_does_not_resolve_vault():
+    # The headline contract: importing resolves NOTHING. Force a GENUINELY fresh
+    # import (drop the cached module) so module top-level code re-runs — the
+    # cache must come back None regardless of test order. A non-None value would
+    # mean the module eagerly resolved the vault (the old import-time sys.exit
+    # behaviour) — exactly what this change removes.
+    sys.modules.pop("memory_indexer", None)
+    mi = _import_memory_indexer()
+    assert mi._vault_root_cache is None
+    for accessor in (
+        mi._vault_root,
+        mi._vault_session_logs,
+        mi._vault_atoms,
+        mi._vault_entities,
+    ):
+        assert callable(accessor)
+
+
+def test_vault_root_defers_exit_when_unconfigured(tmp_path, monkeypatch):
+    # Force a genuinely vault-less environment (all three resolution tiers miss):
+    # no env override, cwd has no ./.deus/config.json, global CONFIG_PATH absent.
+    mi = _import_memory_indexer()
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)  # no ./.deus/config.json here
+    monkeypatch.setattr(mi, "CONFIG_PATH", tmp_path / "nonexistent" / "config.json")
+    # setattr auto-reverts to the original None, so this never leaks to siblings.
+    monkeypatch.setattr(mi, "_vault_root_cache", None)
+
+    with pytest.raises(SystemExit) as exc:
+        mi._vault_root()
+    assert exc.value.code == mi.AUTH_ERROR
+
+
+def test_vault_root_is_sole_resolver_and_caches(tmp_path, monkeypatch):
+    # _vault_root() resolves exactly once and reuses the cached Path thereafter.
+    mi = _import_memory_indexer()
+    calls = {"n": 0}
+
+    def _fake_load() -> Path:
+        calls["n"] += 1
+        return tmp_path / "vault"
+
+    monkeypatch.setattr(mi, "_load_vault_path", _fake_load)
+    monkeypatch.setattr(mi, "_vault_root_cache", None)
+
+    first = mi._vault_root()
+    second = mi._vault_root()
+    assert first == tmp_path / "vault"
+    assert first is second
+    assert calls["n"] == 1, "the vault must be resolved once and cached"
+    # Derived accessors compose on top of the cached root.
+    assert mi._vault_atoms() == tmp_path / "vault" / "Atoms"
+    assert mi._vault_session_logs() == tmp_path / "vault" / "Session-Logs"
+    assert mi._vault_entities() == tmp_path / "vault" / "Entities"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-09" # auto-bump @1780954849
+last_verified: "2026-06-09" # auto-bump @1780997087
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-09" # auto-bump @1780954849
+last_verified: "2026-06-09" # auto-bump @1780997087
 governs:
   - src/
   - evolution/

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -124,10 +124,34 @@ def _load_vault_path() -> Path:
     sys.exit(AUTH_ERROR)
 
 
-_vault_root = _load_vault_path()
-VAULT_SESSION_LOGS = _vault_root / "Session-Logs"
-VAULT_ATOMS = _vault_root / "Atoms"
-VAULT_ENTITIES = _vault_root / "Entities"
+# Lazily resolved by _vault_root() — its sole resolver. Import no longer exits
+# when no vault is configured; resolution (and its sys.exit on a missing vault)
+# is deferred to first actual vault access. Lets vault-free commands (--query is
+# DB-only) and vault-less envs (CI, fresh checkout) import and run. Mirrors the
+# lazy Gemini client (_ensure_client, PR #677). Tests that change the vault env
+# mid-run reset the cache via `memory_indexer._vault_root_cache = None`.
+_vault_root_cache: Path | None = None
+
+
+def _vault_root() -> Path:
+    global _vault_root_cache
+    if _vault_root_cache is None:
+        _vault_root_cache = _load_vault_path()
+    return _vault_root_cache
+
+
+def _vault_session_logs() -> Path:
+    return _vault_root() / "Session-Logs"
+
+
+def _vault_atoms() -> Path:
+    return _vault_root() / "Atoms"
+
+
+def _vault_entities() -> Path:
+    return _vault_root() / "Entities"
+
+
 DEDUP_L2_THRESHOLD = 0.55  # ≈ cosine similarity 0.85 for unit-normalized vectors
 # Recency boost for --query --recency-boost (subtracted from L2 distance).
 RECENCY_BOOST_7D = 0.3    # last 7 days — strong boost
@@ -845,11 +869,11 @@ def cmd_recent(n: int = 3, days: bool = False, compact: bool = False):
     --compact flag): truncates decisions to 60 chars, strips full vault paths,
     collapses cluster children to a count-only header.
     """
-    if not VAULT_SESSION_LOGS.exists():
-        print(f"ERROR: session logs not found at {VAULT_SESSION_LOGS}", file=sys.stderr)
+    if not _vault_session_logs().exists():
+        print(f"ERROR: session logs not found at {_vault_session_logs()}", file=sys.stderr)
         sys.exit(NOT_FOUND)
 
-    log_files = [f for f in VAULT_SESSION_LOGS.rglob("*.md") if ".obsidian" not in str(f)]
+    log_files = [f for f in _vault_session_logs().rglob("*.md") if ".obsidian" not in str(f)]
 
     # Parse date: prefer parent folder name (YYYY-MM-DD), fallback to frontmatter
     def get_date(p: Path) -> str:
@@ -966,8 +990,8 @@ def cmd_recent(n: int = 3, days: bool = False, compact: bool = False):
                 lines.append(fmt_path(path))
 
     # Continuity indicator
-    total_sessions = len(list(VAULT_SESSION_LOGS.rglob("*.md"))) if VAULT_SESSION_LOGS.exists() else 0
-    total_atoms = len(list(VAULT_ATOMS.glob("*.md"))) if VAULT_ATOMS.exists() else 0
+    total_sessions = len(list(_vault_session_logs().rglob("*.md"))) if _vault_session_logs().exists() else 0
+    total_atoms = len(list(_vault_atoms().glob("*.md"))) if _vault_atoms().exists() else 0
     total_days = len(by_date)
     parts = [f"{len(selected)} sessions across {total_days} day{'s' if total_days != 1 else ''}"]
     if total_atoms > 0:
@@ -996,7 +1020,7 @@ def cmd_learnings(since_days: int = 7, max_items: int = 3):
     Delta tracking: compares against ~/.deus/last_resume_learnings.txt to avoid
     showing the same learnings twice. Outputs nothing if no new learnings exist.
     """
-    atom_count = len(list(VAULT_ATOMS.glob("*.md"))) if VAULT_ATOMS.exists() else 0
+    atom_count = len(list(_vault_atoms().glob("*.md"))) if _vault_atoms().exists() else 0
     if atom_count == 0:
         print("## What's Emerging\n- Your learnings will appear here as you use Deus. "
               "Each session extracts atomic facts that grow stronger through corroboration.")
@@ -1013,7 +1037,7 @@ def cmd_learnings(since_days: int = 7, max_items: int = 3):
 
     # Scan all atoms
     candidates: list[dict] = []
-    for atom_path in VAULT_ATOMS.glob("*.md"):
+    for atom_path in _vault_atoms().glob("*.md"):
         content = atom_path.read_text(encoding="utf-8")
         fm = extract_frontmatter(content)
         if not fm:
@@ -1675,8 +1699,8 @@ def cmd_wander(seeds: list[str], steps: int = 3, top_k: int = 10, graph: bool = 
         return
     from collections import defaultdict
 
-    if not VAULT_SESSION_LOGS.exists():
-        print(f"ERROR: session logs not found at {VAULT_SESSION_LOGS}", file=sys.stderr)
+    if not _vault_session_logs().exists():
+        print(f"ERROR: session logs not found at {_vault_session_logs()}", file=sys.stderr)
         sys.exit(NOT_FOUND)
 
     today = local_now().date()
@@ -1685,7 +1709,7 @@ def cmd_wander(seeds: list[str], steps: int = 3, top_k: int = 10, graph: bool = 
     edge_weight: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
     topic_sessions: dict[str, list[str]] = defaultdict(list)
 
-    log_files = sorted(VAULT_SESSION_LOGS.rglob("*.md"))
+    log_files = sorted(_vault_session_logs().rglob("*.md"))
     log_files = [f for f in log_files if ".obsidian" not in str(f)]
 
     for log_file in log_files:
@@ -2591,7 +2615,7 @@ def _entity_article_prompt(entity: dict, relationships: list[dict], atoms: list[
 
 def generate_entity_article(db: sqlite3.Connection, entity_id: int) -> Path:
     """Generate a markdown article for an entity from its graph context."""
-    VAULT_ENTITIES.mkdir(parents=True, exist_ok=True)
+    _vault_entities().mkdir(parents=True, exist_ok=True)
 
     entity_row = db.execute(
         "SELECT name, entity_type, domain, summary FROM entities WHERE id = ?", [entity_id]
@@ -2644,7 +2668,7 @@ def generate_entity_article(db: sqlite3.Connection, entity_id: int) -> Path:
         return Path()
 
     slug = slugify(entity["name"])
-    path = VAULT_ENTITIES / f"{slug}.md"
+    path = _vault_entities() / f"{slug}.md"
     today = local_now().strftime("%Y-%m-%d")
     source_hash = _compute_entity_source_hash(db, entity_id)
 
@@ -3070,9 +3094,9 @@ def cmd_blind_spots(top: int = 10):
     gaps: list[tuple[str, str, int]] = []  # (name, source, score)
 
     # 1. Topic-based gaps (from cmd_gaps logic)
-    if VAULT_SESSION_LOGS.exists():
+    if _vault_session_logs().exists():
         session_topic_count: dict[str, int] = {}
-        for log_file in VAULT_SESSION_LOGS.rglob("*.md"):
+        for log_file in _vault_session_logs().rglob("*.md"):
             if ".obsidian" in str(log_file):
                 continue
             fm = extract_frontmatter(log_file.read_text(encoding="utf-8"))
@@ -3084,8 +3108,8 @@ def cmd_blind_spots(top: int = 10):
                     session_topic_count[t] = session_topic_count.get(t, 0) + 1
 
         atom_coverage: dict[str, int] = {}
-        if VAULT_ATOMS.exists():
-            for atom_file in VAULT_ATOMS.glob("*.md"):
+        if _vault_atoms().exists():
+            for atom_file in _vault_atoms().glob("*.md"):
                 body = atom_file.read_text(encoding="utf-8").lower()
                 for topic in session_topic_count:
                     if topic in body:
@@ -3219,17 +3243,17 @@ def write_atom_file(atom: dict, source_path: str, today: str,
                     privacy: str = "internal", kind: str = "knowledge",
                     triggers: list[str] | None = None) -> Path:
     """Write an atom to the vault Atoms/ directory and return its path."""
-    VAULT_ATOMS.mkdir(parents=True, exist_ok=True)
+    _vault_atoms().mkdir(parents=True, exist_ok=True)
     cat = atom["category"]
     conf = CONFIDENCE_PRIOR.get(cat, 0.50)
     ttl_map = {"fact": None, "decision": None, "preference": 365, "constraint": 365, "belief": 90}
     ttl = ttl_map.get(cat, 365)
     ttl_line = f"ttl_days: {ttl}" if ttl is not None else "ttl_days: null"
     slug = slugify(atom["text"])
-    path = VAULT_ATOMS / f"{cat}-{slug}.md"
+    path = _vault_atoms() / f"{cat}-{slug}.md"
     counter = 2
     while path.exists():
-        path = VAULT_ATOMS / f"{cat}-{slug}-{counter}.md"
+        path = _vault_atoms() / f"{cat}-{slug}-{counter}.md"
         counter += 1
     # Build source_excerpt block for frontmatter (truncated to cap file size)
     excerpt_lines = ""
@@ -3581,8 +3605,8 @@ def cmd_extract(session_path: str, no_contradict: bool = False):
 
 
 def cmd_rebuild():
-    if not VAULT_SESSION_LOGS.exists():
-        print(f"ERROR: session logs not found at {VAULT_SESSION_LOGS}", file=sys.stderr)
+    if not _vault_session_logs().exists():
+        print(f"ERROR: session logs not found at {_vault_session_logs()}", file=sys.stderr)
         sys.exit(NOT_FOUND)
 
     # Tables that CAN be rebuilt from disk (session logs + atom .md files):
@@ -3632,7 +3656,7 @@ def cmd_rebuild():
     db = open_db()
     db.close()
 
-    log_files = sorted(VAULT_SESSION_LOGS.rglob("*.md"))
+    log_files = sorted(_vault_session_logs().rglob("*.md"))
     log_files = [f for f in log_files if ".obsidian" not in str(f)]
     print(f"Found {len(log_files)} session logs. Indexing...")
 
@@ -3646,8 +3670,8 @@ def cmd_rebuild():
 
     # Re-index atoms (skip files already in DB with matching updated_at — mtime guard)
     atom_ok = 0
-    if VAULT_ATOMS.exists():
-        atom_files = sorted(VAULT_ATOMS.glob("*.md"))
+    if _vault_atoms().exists():
+        atom_files = sorted(_vault_atoms().glob("*.md"))
         print(f"\nFound {len(atom_files)} atoms. Re-indexing...")
         db = open_db()
         for af in atom_files:
@@ -3779,8 +3803,8 @@ def _collect_health_metrics(db: sqlite3.Connection) -> dict:
             "source_chunk_coverage": 0.0, "categories": {}, "expired": 0, "domains": {},
         })
     snapshot["sessions"] = (
-        len([f for f in VAULT_SESSION_LOGS.rglob("*.md") if ".obsidian" not in str(f)])
-        if VAULT_SESSION_LOGS.exists() else 0
+        len([f for f in _vault_session_logs().rglob("*.md") if ".obsidian" not in str(f)])
+        if _vault_session_logs().exists() else 0
     )
     # Phase 2: graph metrics
     try:
@@ -4101,13 +4125,13 @@ def cmd_invalidate(path_str: str, reason: str):
 
 def cmd_gaps(top: int = 10):
     """Identify knowledge gaps: high-frequency session topics with low atom coverage."""
-    if not VAULT_SESSION_LOGS.exists():
-        print(f"ERROR: session logs not found at {VAULT_SESSION_LOGS}", file=sys.stderr)
+    if not _vault_session_logs().exists():
+        print(f"ERROR: session logs not found at {_vault_session_logs()}", file=sys.stderr)
         sys.exit(ABSTAIN)
 
     # 1. Count topic frequency across sessions
     session_topic_count: dict[str, int] = {}
-    log_files = [f for f in VAULT_SESSION_LOGS.rglob("*.md") if ".obsidian" not in str(f)]
+    log_files = [f for f in _vault_session_logs().rglob("*.md") if ".obsidian" not in str(f)]
     for log_file in log_files:
         fm = extract_frontmatter(log_file.read_text(encoding="utf-8"))
         if not fm.get("topics"):
@@ -4119,8 +4143,8 @@ def cmd_gaps(top: int = 10):
 
     # 2. Count atom coverage per topic
     atom_topic_coverage: dict[str, int] = {}
-    if VAULT_ATOMS.exists():
-        for atom_file in VAULT_ATOMS.glob("*.md"):
+    if _vault_atoms().exists():
+        for atom_file in _vault_atoms().glob("*.md"):
             body = atom_file.read_text(encoding="utf-8").lower()
             for topic in session_topic_count:
                 if topic in body:

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -3890,7 +3890,7 @@ def test_invalidate_conflict_expires_atom(mi):
     """--invalidate-conflict should expire the older atom after user confirmation."""
     db = mi.open_db()
     # Create atom + conflict
-    atom_path = mi.VAULT_ATOMS
+    atom_path = mi._vault_atoms()
     atom_path.mkdir(parents=True, exist_ok=True)
     af = atom_path / "fact-conflict-test.md"
     af.write_text("---\ntype: atom\n---\nOld fact\n")


### PR DESCRIPTION
## Summary

Lazy-resolve the memory vault in `scripts/memory_indexer.py` so the module imports without a vault — fixing both CI/fresh-checkout unimportability and vault-less `--query`. Handoff item-1 follow-up to #741; mirrors #677's lazy Gemini client.

**Root cause:** `_vault_root = _load_vault_path()` ran at module-import scope, and `_load_vault_path()` `sys.exit(AUTH_ERROR)`s when no vault is configured. So on any vault-less box (CI, fresh checkout) *every* command died at import — even `--query`, which is pure DB read (`cmd_query` has zero `VAULT_*` refs; `DB_PATH` is env-resolved, vault-independent).

**Fix:** Defer resolution to first vault access via `_vault_root()` (sole resolver, caches) + `_vault_session_logs()`/`_vault_atoms()`/`_vault_entities()`; convert the 34 internal `VAULT_*` references.

## Behavior
- `--query` now runs without a vault configured (verified — returns results).
- `--rebuild` still errors without a vault: deferred to first access, identical message (verified).
- Import no longer `sys.exit`s without a vault (verified — cache `None` at import; `SystemExit(4)` deferred to the `_vault_root()` call).

## Tests
- **New** `evolution/tests/test_memory_indexer_lazy_vault.py` (CI-visible — CI runs `evolution/tests/`, not `scripts/tests/test_memory_indexer.py`): 3 contract tests (import resolves nothing; exit deferred; sole-resolver caches).
- Fixed an external `mi.VAULT_ATOMS` reference in `scripts/tests/test_memory_indexer.py:3893` (removed global) and dropped the now-unnecessary import-time `setenv` workaround in the contradiction test.
- `scripts/tests/test_memory_indexer.py` + `_ner.py`: **298 passed**. `evolution/tests/` lazy + contradiction: 4 passed.

## Out of scope
- `_load_vault_path()` resolution tiers unchanged; `DB_PATH` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)