### PR TITLE
fix(agent-runner): route PostToolUse consult to dispatchHost + harden deny-rule traversal (LIA-199)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -946,8 +946,10 @@ async function runQuery(
             hooks.push(createToolAuditHook());
           if (process.env.HOOK_DISPATCH_ENABLED === 'true')
             hooks.push(
+              // host defaults to dispatchHost() (127.0.0.1) — see the WHY on the
+              // createPostToolUseObserverHook default param + dispatchHost() docstring.
               createPostToolUseObserverHook(
-                process.env.DEUS_PROXY_HOST ?? 'host.docker.internal',
+                dispatchHost(),
                 parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10),
                 process.env.DEUS_PROXY_TOKEN,
               ),

--- a/container/agent-runner/src/post-tool-use-observer.test.ts
+++ b/container/agent-runner/src/post-tool-use-observer.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createPostToolUseObserverHook } from './post-tool-use-observer.js';
+
+/**
+ * Regression guard for LIA-199 part 2: the PostToolUse observer consults the
+ * in-container HookDispatchService at 127.0.0.1:3002 via dispatchHost() — NOT
+ * DEUS_PROXY_HOST / host.docker.internal, which addresses HOST-side services and
+ * fails-to-reach from inside the container (observed live in the #744 smoke test
+ * as `[post-tool-use-observer] dispatch failed: fetch failed`).
+ */
+describe('createPostToolUseObserverHook (consult targets the container-local :3002 service)', () => {
+  const originalEnv = { ...process.env };
+
+  const input = {
+    hook_event_name: 'PostToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'ls /workspace' },
+    tool_response: { stdout: '' },
+    tool_use_id: 'tu_1',
+    session_id: 'sess_1',
+  };
+
+  beforeEach(() => {
+    delete process.env.HOOK_DISPATCH_HOST;
+    delete process.env.DEUS_PROXY_HOST;
+    delete process.env.DEUS_PROXY_TOKEN;
+    delete process.env.HOOK_DISPATCH_PORT;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to 127.0.0.1 (dispatchHost), NOT DEUS_PROXY_HOST/host.docker.internal', async () => {
+    process.env.DEUS_PROXY_HOST = 'host.docker.internal'; // must be ignored now
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({} as Response);
+
+    const hook = createPostToolUseObserverHook();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await hook(input as any, undefined as any, {} as any);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      'http://127.0.0.1:3002/hooks/PostToolUse',
+    );
+  });
+
+  it('honors a HOOK_DISPATCH_HOST override', async () => {
+    process.env.HOOK_DISPATCH_HOST = '10.0.0.5';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({} as Response);
+
+    const hook = createPostToolUseObserverHook();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await hook(input as any, undefined as any, {} as any);
+
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      'http://10.0.0.5:3002/hooks/PostToolUse',
+    );
+  });
+
+  it('is non-blocking: returns {} even when the consult rejects', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fetch failed'));
+    // The fire-and-forget .catch() logs a single warn; suppress it to keep output clean.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const hook = createPostToolUseObserverHook();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await hook(input as any, undefined as any, {} as any);
+
+    expect(out).toEqual({});
+  });
+});

--- a/container/agent-runner/src/post-tool-use-observer.ts
+++ b/container/agent-runner/src/post-tool-use-observer.ts
@@ -12,9 +12,13 @@ import type {
   HookCallback,
   PostToolUseHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
+import { dispatchHost } from './pre-tool-use-hook.js';
 
 export function createPostToolUseObserverHook(
-  host: string = process.env.DEUS_PROXY_HOST ?? 'host.docker.internal',
+  // The :3002 HookDispatchService is co-located in THIS container, so the
+  // consult targets localhost via dispatchHost() — NOT DEUS_PROXY_HOST, which
+  // addresses HOST-side services and fails-to-reach here (see LIA-199 / #744).
+  host: string = dispatchHost(),
   port: number = parseInt(process.env.HOOK_DISPATCH_PORT ?? '3002', 10),
   token: string | undefined = process.env.DEUS_PROXY_TOKEN,
 ): HookCallback {

--- a/container/agent-runner/src/pre-tool-use-gate-observer.test.ts
+++ b/container/agent-runner/src/pre-tool-use-gate-observer.test.ts
@@ -24,6 +24,15 @@ describe('createBlockingPreToolUseObserver', () => {
     expect(result).toEqual({});
   });
 
+  it('blocks `..` traversal that escapes /workspace via a /workspace/ prefix', async () => {
+    const result = await observer('PreToolUse', {
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /workspace/../etc' },
+    });
+    expect(result.decision).toBe('block');
+    expect(String(result.reason)).toMatch(/outside \/workspace/);
+  });
+
   it('allows non-Bash tools even with a matching command string', async () => {
     const result = await observer('PreToolUse', {
       tool_name: 'Write',
@@ -51,9 +60,16 @@ describe('isRecursiveForceRmOutsideWorkspace', () => {
     ['rm --recursive --force /opt/x', true],
     ['rm -rf /', true],
     ['rm -rf /workspaces/x', true], // sibling dir is genuinely outside /workspace
+    // `..` traversal: textually startsWith('/workspace/') but resolves outside → block
+    ['rm -rf /workspace/../etc', true],
+    ['rm -rf /workspace/../../etc', true],
+    ['rm -rf /workspace/..', true], // resolves to '/'
     // in-workspace → allow
     ['rm -rf /workspace', false],
+    ['rm -rf /workspace/', false], // trailing slash normalizes to '/workspace'
     ['rm -rf /workspace/tmp/x', false],
+    ['rm -rf /workspace/./tmp', false], // dot-segment normalizes back inside
+    ['rm -rf /workspace/../workspace/foo', false], // detour that resolves back inside
     ['rm -rf relative/path', false], // relative → in-workspace assumption
     // not both flags → allow
     ['rm -r /tmp/x', false],

--- a/container/agent-runner/src/pre-tool-use-gate-observer.ts
+++ b/container/agent-runner/src/pre-tool-use-gate-observer.ts
@@ -8,6 +8,8 @@
  * positively classified as out-of-`/workspace` is allowed, malformed payload → {}.
  */
 
+import path from 'node:path';
+
 import type { ObserverCallback } from './hook-dispatch-service.js';
 
 /**
@@ -49,7 +51,12 @@ export function isRecursiveForceRmOutsideWorkspace(command: string): boolean {
 }
 
 function isInsideWorkspace(absPath: string): boolean {
-  return absPath === '/workspace' || absPath.startsWith('/workspace/');
+  // Normalize FIRST so embedded `..` can't escape via a textual prefix match:
+  // `/workspace/../etc` startsWith('/workspace/') but resolves to `/etc` (outside).
+  // `path.posix` is deliberate — the container is always Linux, so a POSIX-path
+  // normalize is correct regardless of the host OS this code is compiled on.
+  const normalized = path.posix.normalize(absPath);
+  return normalized === '/workspace' || normalized.startsWith('/workspace/');
 }
 
 /**


### PR DESCRIPTION
## LIA-199 parts 2+3 (deferred siblings of #744)

Finishes the consult-host correctness work #744 started, plus the deny-rule bypass code-reviewer flagged in #744. **Part 1** (HOOK_DISPATCH_ENABLED prod enablement — a live security-control flip) is **deferred** to a threat-reviewed follow-up and is NOT in this PR.

### Part 2 — PostToolUse observer host fix
The in-container `HookDispatchService` binds `127.0.0.1:3002`, so the PostToolUse consult must target localhost via `dispatchHost()` — not `DEUS_PROXY_HOST`/`host.docker.internal` (which address HOST-side services). Both sites now use `dispatchHost()`:
- `post-tool-use-observer.ts` default param
- `index.ts` call site

Same bug class #744 fixed for PreToolUse; observed live in the #744 smoke test as `[post-tool-use-observer] dispatch failed: fetch failed`.

### Part 3 — deny-rule `..` path-traversal hardening
`isInsideWorkspace()` now `path.posix.normalize()`s **before** the prefix check, closing the bypass where `rm -rf /workspace/../etc` (textually `startsWith('/workspace/')` but resolves to `/etc`) was allowed. Now correctly classified outside `/workspace` → blocked.

### Scope note
Parts 2+3 bundled in one PR: same security surface, different files, no shared test surface (plan-reviewer SHIP'd this).

Both fixed paths are gated behind `HOOK_DISPATCH_ENABLED` (default-off in prod), so no live behavior change until the deferred part 1 — lands in the next container build.

## Verification
- `npx tsc --noEmit` → exit 0
- 28/28 unit tests (extended `pre-tool-use-gate-observer.test.ts` +7 cases incl. all `..` vectors; new `post-tool-use-observer.test.ts`)
- `npx prettier --check` clean

### Differential real-session container smoke test (`hook-pr-smoke-test`)
`deus-agent:latest`, `HOOK_DISPATCH_ENABLED=true`, real Claude session making a Bash tool call. **Same image + same prompt + same tool calls**, only the `src` differs:

| | PreToolUse consult | PostToolUse dispatch |
|---|---|---|
| **baked pre-fix src** (no mount) | `HookDispatchService unreachable, skipping` | **`dispatch failed: fetch failed`** ← bug reproduced |
| **fixed src** (mounted into `/app/src`) | clean (reaches `:3002`) | **clean** (reaches `:3002`) ← fix |

The old-code run reproduces the warn under identical conditions; the fixed run is silent → the `dispatchHost()` switch is the load-bearing change. (`HookDispatchService` only logs fanOut *errors*, not success receipts, so absence-of-warn is the signal — controlled by the differential.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
