### PR TITLE
fix(drift): default to merge-base mode inside worktrees (LIA-146)

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -102,6 +102,60 @@ def _git_commit_time(path: Path, project_root: Path) -> float:
     return path.stat().st_mtime if path.exists() else 0.0
 
 
+def _git_output(cmd: list[str], project_root: Path) -> str | None:
+    """Run a read-only git command, return stripped stdout or None on failure.
+
+    A thin, monkeypatchable wrapper so the worktree-detection helpers below can
+    have their git interactions faked in tests.
+    """
+    try:
+        r = subprocess.run(
+            ["git", *cmd], cwd=project_root,
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.stdout.strip() if r.returncode == 0 else None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def _in_linked_worktree(project_root: Path) -> bool:
+    """True iff project_root is a LINKED git worktree (git-dir != git-common-dir).
+
+    The main checkout has git-dir == git-common-dir. git may return relative
+    (".git" in the main checkout) or absolute (linked worktree) paths, so anchor
+    BOTH to project_root — `project_root / "/abs"` == "/abs" (pathlib drops the
+    left side when the right is absolute) — which is correct for both forms and
+    removes any dependence on the process CWD.
+    """
+    common = _git_output(["rev-parse", "--git-common-dir"], project_root)
+    gitdir = _git_output(["rev-parse", "--git-dir"], project_root)
+    if not common or not gitdir:
+        return False
+    return (project_root / common).resolve(strict=False) != \
+           (project_root / gitdir).resolve(strict=False)
+
+
+def _worktree_auto_base(project_root: Path) -> str | None:
+    """Interactive default base for a linked worktree: the merge-base with
+    origin/main (authoritative changed-files mode, which kills the mtime
+    false-flags that checkout/symlinked-node_modules cause in a worktree).
+
+    Returns None — i.e. fall back to mtime mode — outside a worktree OR when the
+    merge-base can't be resolved (e.g. origin/main not fetched), so a missing ref
+    NEVER silently masks real drift. Mirrors .husky/pre-push.
+    """
+    if not _in_linked_worktree(project_root):
+        return None
+    base = _git_output(["merge-base", "HEAD", "origin/main"], project_root)
+    if not base:
+        print(
+            "[drift_check] worktree detected but merge-base with origin/main "
+            "unresolved; falling back to mtime mode (pass --base to override).",
+            file=sys.stderr,
+        )
+    return base or None
+
+
 def _dir_commit_time(dir_path: Path, project_root: Path) -> float:
     """Return the commit timestamp of the most recently committed file
     inside `dir_path`, falling back to an mtime walk if the directory has
@@ -2462,6 +2516,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    # Interactive runs inside a linked worktree default to merge-base mode (kills
+    # mtime false-flags); an explicit --base always wins, None elsewhere → mtime.
+    drift_base = args.base or _worktree_auto_base(PROJECT_ROOT)
+
     if args.codegraph_format:
         sys.exit(check_codegraph_transcript_format(PROJECT_ROOT))
     elif args.cache_map:
@@ -2487,7 +2545,7 @@ if __name__ == "__main__":
     elif args.validate is not None:
         sys.exit(check_validate(PROJECT_ROOT, args.validate or None))
     elif args.all:
-        sys.exit(check_all(PROJECT_ROOT, base_ref=args.base))
+        sys.exit(check_all(PROJECT_ROOT, base_ref=drift_base))
     elif args.coverage:
         sys.exit(check_coverage(PROJECT_ROOT))
     elif args.paths:
@@ -2495,6 +2553,6 @@ if __name__ == "__main__":
     elif args.adr:
         sys.exit(check_adr(PROJECT_ROOT))
     elif args.bump:
-        sys.exit(main(bump=True, base_ref=args.base))
+        sys.exit(main(bump=True, base_ref=drift_base))
     else:
-        sys.exit(main(base_ref=args.base))
+        sys.exit(main(base_ref=drift_base))

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1113,3 +1113,70 @@ class TestCheckBenchLabels:
             pytest.skip("benchmark fixture not in repo")
         rc = drift_check.check_bench_labels(repo_root)
         assert rc == 0, "Benchmark labels have drifted from vault — run drift_check.py --bench-labels"
+
+
+# ── worktree merge-base auto-default (LIA-146) ──────────────────────────────────
+
+class TestWorktreeAutoBase:
+    """drift_check defaults to merge-base mode inside a LINKED worktree, killing
+    the mtime false-flags that checkout/symlinked-node_modules cause there — while
+    leaving the main checkout on mtime mode. Hermetic: ``_git_output`` is mocked,
+    so no real git is invoked."""
+
+    @staticmethod
+    def _patch_git(monkeypatch, responses):
+        # responses: {(cmd, tuple): output_str_or_None}
+        monkeypatch.setattr(
+            drift_check, "_git_output",
+            lambda cmd, project_root: responses.get(tuple(cmd)),
+        )
+
+    def test_in_linked_worktree_false_in_main_checkout(self, monkeypatch, tmp_path):
+        # Main checkout: git returns the same dir for both (".git").
+        self._patch_git(monkeypatch, {
+            ("rev-parse", "--git-common-dir"): ".git",
+            ("rev-parse", "--git-dir"): ".git",
+        })
+        assert drift_check._in_linked_worktree(tmp_path) is False
+
+    def test_in_linked_worktree_true_when_dirs_differ(self, monkeypatch, tmp_path):
+        # Linked worktree: git-dir points into .git/worktrees/<name>.
+        self._patch_git(monkeypatch, {
+            ("rev-parse", "--git-common-dir"): "/main/.git",
+            ("rev-parse", "--git-dir"): "/main/.git/worktrees/feat",
+        })
+        assert drift_check._in_linked_worktree(tmp_path) is True
+
+    def test_in_linked_worktree_false_when_git_unavailable(self, monkeypatch, tmp_path):
+        # git failure (None) must not be misread as a worktree.
+        self._patch_git(monkeypatch, {})
+        assert drift_check._in_linked_worktree(tmp_path) is False
+
+    def test_auto_base_none_outside_worktree(self, monkeypatch, tmp_path):
+        # THE main-repo-unchanged guard: outside a worktree -> None -> mtime mode,
+        # even though a merge-base is resolvable (it must NOT be consulted/used).
+        self._patch_git(monkeypatch, {
+            ("rev-parse", "--git-common-dir"): ".git",
+            ("rev-parse", "--git-dir"): ".git",
+            ("merge-base", "HEAD", "origin/main"): "deadbeef",
+        })
+        assert drift_check._worktree_auto_base(tmp_path) is None
+
+    def test_auto_base_merge_base_inside_worktree(self, monkeypatch, tmp_path):
+        self._patch_git(monkeypatch, {
+            ("rev-parse", "--git-common-dir"): "/main/.git",
+            ("rev-parse", "--git-dir"): "/main/.git/worktrees/feat",
+            ("merge-base", "HEAD", "origin/main"): "abc123",
+        })
+        assert drift_check._worktree_auto_base(tmp_path) == "abc123"
+
+    def test_auto_base_none_when_merge_base_unresolved(self, monkeypatch, tmp_path, capsys):
+        # In a worktree but origin/main not fetched -> merge-base None -> fall back
+        # to mtime (None), NEVER silently masking drift; emits a stderr note.
+        self._patch_git(monkeypatch, {
+            ("rev-parse", "--git-common-dir"): "/main/.git",
+            ("rev-parse", "--git-dir"): "/main/.git/worktrees/feat",
+            ("merge-base", "HEAD", "origin/main"): None,
+        })
+        assert drift_check._worktree_auto_base(tmp_path) is None
+        assert "falling back to mtime mode" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

`scripts/drift_check.py` defaulted to **mtime-based** drift comparison, which false-flags `patterns/*.md` against unchanged `packages/`/`src/` inside a git worktree (checkout + symlinked node_modules reset mtimes). This bit a warden run earlier this session (forced a re-stage cycle). Closes **LIA-146**.

**Root cause:** the interactive default uses mtime; the authoritative `--base` mode (only checks files changed since the merge-base) already exists and is used by `.husky/pre-push` (`git merge-base HEAD origin/main`).

**Fix:** when run interactively inside a **linked** worktree with no `--base`, auto-default `base_ref` to the merge-base with `origin/main`. Falls back to mtime mode (with a stderr note) when the merge-base is unresolvable — **never silently masks drift**. Main-repo (non-worktree) behavior is unchanged.

## Changes
- `_git_output` — thin monkeypatchable read-only git wrapper.
- `_in_linked_worktree` — `git-common-dir != git-dir`; both resolves anchored to `project_root` (CWD-independent).
- `_worktree_auto_base` — merge-base in a worktree, else `None`; `None` (mtime fallback) when unresolvable.
- CLI: `drift_base = args.base or _worktree_auto_base(PROJECT_ROOT)` → the three drift paths. `main()`/`check_all()` signatures unchanged; explicit `--base` callers (pre-push, CI) unaffected via short-circuit.

## Tests / verification
- `scripts/tests/test_drift_check.py` (CI-covered): **104 passed**, incl. 6 new `TestWorktreeAutoBase` — the main-repo-unchanged guard and the no-silent-pass (merge-base unresolved → `None`) guard. Hermetic (monkeypatched `_git_output`, no real git).
- **Live-verified** in a worktree: auto-base mode → *All patterns up-to-date*; forced mtime mode → false-flags `deployment.md | package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)