### PR TITLE
fix(agent-runner): harden HookDispatchService listener — loopback bind + token check (LIA-199)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,10 @@ LINEAR_API_TOKEN=
 # Host for the in-container :3002 dispatch consult (the service is container-local,
 # so this targets localhost — NOT DEUS_PROXY_HOST, which addresses host services)
 # HOOK_DISPATCH_HOST=127.0.0.1
+# Per-group token the in-container dispatch service requires on the
+# x-deus-proxy-token header (defense-in-depth behind the loopback bind). Injected
+# automatically per dispatch; when unset the service accepts any loopback caller.
+# DEUS_PROXY_TOKEN=
 # Tool proxy port (credential proxy for container agents)
 # TOOL_PROXY_PORT=3001
 # Asana project management MCP (host-side Claude Code).

--- a/container/agent-runner/src/hook-dispatch-service.test.ts
+++ b/container/agent-runner/src/hook-dispatch-service.test.ts
@@ -1,3 +1,5 @@
+import http from 'http';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { HookDispatchService } from './hook-dispatch-service.js';
@@ -202,5 +204,123 @@ describe('HookDispatchService — HTTP server', () => {
     expect(res.ok).toBe(true);
     const body = await res.json();
     expect(body).toEqual({});
+  });
+});
+
+// LIA-199 listener hardening (threat-model REVISE): the service must bind
+// LOOPBACK only and reject callers without the proxy token.
+describe('HookDispatchService — listener hardening', () => {
+  let service: HookDispatchService;
+  const BASE_PORT = 19300;
+
+  beforeEach(() => {
+    service = new HookDispatchService();
+  });
+
+  afterEach(async () => {
+    await service.stop();
+    vi.restoreAllMocks();
+  });
+
+  it('binds 127.0.0.1 (loopback), never 0.0.0.0', async () => {
+    // Reachability on 127.0.0.1 does NOT prove an exclusive loopback bind (it is
+    // reachable on a 0.0.0.0 listener too). The only valid assertion is the host
+    // argument actually passed to listen(). Stub listen so the test asserts the
+    // bind host without occupying a real port (deterministic in CI).
+    const listenSpy = vi
+      .spyOn(http.Server.prototype, 'listen')
+      .mockImplementation(function (this: http.Server, ...args: unknown[]) {
+        const cb = args[args.length - 1];
+        if (typeof cb === 'function') cb();
+        return this;
+      });
+    await service.start(BASE_PORT);
+    expect(listenSpy).toHaveBeenCalledWith(
+      BASE_PORT,
+      '127.0.0.1',
+      expect.any(Function),
+    );
+  });
+
+  describe('proxy-token validation', () => {
+    const ORIGINAL = process.env.DEUS_PROXY_TOKEN;
+    afterEach(() => {
+      if (ORIGINAL === undefined) delete process.env.DEUS_PROXY_TOKEN;
+      else process.env.DEUS_PROXY_TOKEN = ORIGINAL;
+    });
+
+    it('accepts a request with the correct token and runs the observer', async () => {
+      process.env.DEUS_PROXY_TOKEN = 'secret-token';
+      const port = BASE_PORT + 1;
+      await service.start(port);
+      const cb = vi.fn().mockResolvedValue({ decision: 'approve' });
+      service.registerObserver('PreToolUse', cb);
+
+      const res = await fetch(`http://127.0.0.1:${port}/hooks/PreToolUse`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-deus-proxy-token': 'secret-token',
+        },
+        body: JSON.stringify({ tool_name: 'Bash' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it('rejects (401) a wrong token and does NOT run the observer', async () => {
+      process.env.DEUS_PROXY_TOKEN = 'secret-token';
+      const port = BASE_PORT + 2;
+      await service.start(port);
+      const cb = vi.fn().mockResolvedValue({});
+      service.registerObserver('PreToolUse', cb);
+
+      const res = await fetch(`http://127.0.0.1:${port}/hooks/PreToolUse`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-deus-proxy-token': 'wrong-token',
+        },
+        body: JSON.stringify({ tool_name: 'Bash' }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('rejects (401) a missing token header when a token is configured', async () => {
+      process.env.DEUS_PROXY_TOKEN = 'secret-token';
+      const port = BASE_PORT + 3;
+      await service.start(port);
+      const cb = vi.fn().mockResolvedValue({});
+      service.registerObserver('PreToolUse', cb);
+
+      const res = await fetch(`http://127.0.0.1:${port}/hooks/PreToolUse`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tool_name: 'Bash' }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('accepts any caller when DEUS_PROXY_TOKEN is unset (back-compat)', async () => {
+      delete process.env.DEUS_PROXY_TOKEN;
+      const port = BASE_PORT + 4;
+      await service.start(port);
+      const cb = vi.fn().mockResolvedValue({ decision: 'approve' });
+      service.registerObserver('PreToolUse', cb);
+
+      const res = await fetch(`http://127.0.0.1:${port}/hooks/PreToolUse`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tool_name: 'Bash' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(cb).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/container/agent-runner/src/hook-dispatch-service.ts
+++ b/container/agent-runner/src/hook-dispatch-service.ts
@@ -13,12 +13,33 @@
  * additionalContext strings from all non-empty responses are concatenated.
  */
 
+import crypto from 'crypto';
 import http from 'http';
 
 export type ObserverCallback = (
   event: string,
   payload: unknown,
 ) => Promise<Record<string, unknown>>;
+
+/**
+ * Constant-time check of the `x-deus-proxy-token` header against
+ * `DEUS_PROXY_TOKEN`. Defense-in-depth behind the loopback bind (an in-container
+ * attacker can read the token from its own env; the real value is cross-container
+ * if the bind were ever widened). When DEUS_PROXY_TOKEN is unset, the check is
+ * a no-op (accept) so tests and local runs without a token still work.
+ */
+function isAuthorized(header: string | string[] | undefined): boolean {
+  const expected = process.env.DEUS_PROXY_TOKEN;
+  if (!expected) return true; // no token configured → nothing to enforce
+  const provided = Array.isArray(header) ? header[0] : header;
+  if (typeof provided !== 'string') return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  // timingSafeEqual throws on length mismatch — guard it, and the length check
+  // is itself a (non-secret) early-out since the token length is not sensitive.
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
 
 export class HookDispatchService {
   private readonly observers = new Map<string, ObserverCallback[]>();
@@ -40,7 +61,10 @@ export class HookDispatchService {
    * Aggregation: concatenates additionalContext strings; last-writer-wins
    * for other top-level keys.
    */
-  async fanOut(event: string, payload: unknown): Promise<Record<string, unknown>> {
+  async fanOut(
+    event: string,
+    payload: unknown,
+  ): Promise<Record<string, unknown>> {
     const callbacks = this.observers.get(event) ?? [];
     if (callbacks.length === 0) return {};
 
@@ -93,7 +117,13 @@ export class HookDispatchService {
       });
       this.server = server;
       server.on('error', reject);
-      server.listen(port, () => resolve());
+      // Bind LOOPBACK only. The service is co-located in the same container as
+      // the agent and must never be reachable from other containers on the
+      // Docker bridge. Without the explicit host, `listen(port, cb)` binds
+      // 0.0.0.0 (all interfaces) — contradicting every docstring that claims
+      // loopback and exposing this no-auth decision endpoint cross-container
+      // (LIA-199 threat-model). The host arg makes the bind match the design.
+      server.listen(port, '127.0.0.1', () => resolve());
     });
   }
 
@@ -101,11 +131,19 @@ export class HookDispatchService {
     req: http.IncomingMessage,
     res: http.ServerResponse,
   ): Promise<void> {
-    const match =
-      req.method === 'POST' && req.url?.match(/^\/hooks\/(\w+)$/);
+    const match = req.method === 'POST' && req.url?.match(/^\/hooks\/(\w+)$/);
     if (!match) {
       res.writeHead(404, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'not found' }));
+      return;
+    }
+
+    // Defense-in-depth: reject callers without the proxy token (no-op when
+    // DEUS_PROXY_TOKEN is unset). Loopback bind is the primary control; this
+    // backstops it (LIA-199 threat-model).
+    if (!isAuthorized(req.headers['x-deus-proxy-token'])) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unauthorized' }));
       return;
     }
 
@@ -131,10 +169,10 @@ export class HookDispatchService {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify(result));
     } catch (err) {
-      console.warn(
-        '[HookDispatchService] fanOut error',
-        { event, err: err instanceof Error ? err.message : String(err) },
-      );
+      console.warn('[HookDispatchService] fanOut error', {
+        event,
+        err: err instanceof Error ? err.message : String(err),
+      });
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end('{}');
     }


### PR DESCRIPTION
## LIA-199 part-1 follow-up: harden the listener (do NOT flip the gate)

The LIA-199 part-1 threat-model returned **REVISE**. Rather than flip `HOOK_DISPATCH_ENABLED` on in prod (the deny rule protects only the ephemeral container OS, not `/workspace` user data — low value until redesigned), this PR ships the **listener hardening** the threat-model gated the flip on. The gate stays default-off; no `container-runner` passthrough, no deploy.

### 1. Loopback bind (primary control)
`hook-dispatch-service.ts` did `server.listen(port, () => resolve())` — the second arg is the callback, so Node bound **`0.0.0.0`** (all interfaces), exposing the no-auth `:3002` decision endpoint to co-resident containers on the Docker bridge. Every docstring claimed loopback. Now binds `'127.0.0.1'` explicitly.

### 2. Token validation (defense-in-depth)
`_handleRequest` now 401s callers whose `x-deus-proxy-token` doesn't match `DEUS_PROXY_TOKEN` (constant-time `timingSafeEqual`, length-guarded).

**Design trade-off (why accept-on-unset):** when `DEUS_PROXY_TOKEN` is *unset*, the check is a no-op (accept). This is intentional back-compat — tests and local runs have no token, and real dispatches always inject one. The loopback bind is the load-bearing control; the token is defense-in-depth behind it (an in-container attacker can read the token from its own env anyway — the real value is cross-container). **Mandating** the token (fail-closed on unset) is a deliberate follow-up to pair with the eventual prod flip, once the deny rule is redesigned to protect `/workspace` user data.

### Scope explicitly excluded
- No prod flip (`HOOK_DISPATCH_ENABLED` stays off).
- Deny-rule redesign (protect `/workspace` user data, not the throwaway OS) — separate follow-up.

## Verification
- `npx tsc --noEmit` exit 0; `hook-dispatch-service.test.ts` 19/19 (5 new); prettier clean.
- Full agent-runner suite: 166 pass / 1 fail (`schedule-validator` empty-cron — pre-existing on clean main, tracked in LIA-201, not this PR).
- Bind test asserts the `'127.0.0.1'` host arg via a `listen` spy (reachability on 127.0.0.1 can't prove an *exclusive* loopback bind — it's reachable on a 0.0.0.0 listener too).

**Requires a container rebuild** to take effect (default-off, so no urgency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
