### PR TITLE
feat(warden): codegraph-first gate on all threads + fresh-instance grep fallback (LIA-121)

### DIFF
--- a/.claude/agents/general.md
+++ b/.claude/agents/general.md
@@ -2,10 +2,21 @@
 name: general
 model: sonnet
 explores_code: true
+codegraph_gated: true
 description: >
   General-purpose agent for researching complex questions, searching for code,
   and executing multi-step tasks. Use when no specialized agent fits.
   Has full tool access including codegraph for code intelligence.
+# codegraph-first gate (LIA-121): blocks Grep/Glob/Bash-search until a prior
+# codegraph/code_search call exists in this agent's transcript (logic in
+# scripts/codex_warden_hooks.py). Pairs with `codegraph_gated: true` above.
+# settings.json hooks do NOT reach spawned subagents, so gated agents carry it here.
+hooks:
+  PreToolUse:
+    - matcher: "Grep|Glob|Bash"
+      hooks:
+        - type: command
+          command: "bash -c 'python3 \"${CLAUDE_PROJECT_DIR:-.}/scripts/codex_warden_hooks.py\" run codegraph-first-gate'"
 ---
 
 You are a general-purpose agent. You handle research, code exploration, multi-step tasks, and anything that doesn't fit a specialized agent.

--- a/.claude/agents/keystone.md
+++ b/.claude/agents/keystone.md
@@ -9,6 +9,17 @@ description: >
   Never a commit gate.
 model: opus
 explores_code: true
+codegraph_gated: true
+# codegraph-first gate (LIA-121): blocks Grep/Glob/Bash-search until a prior
+# codegraph/code_search call exists in this agent's transcript (logic in
+# scripts/codex_warden_hooks.py). Pairs with `codegraph_gated: true` above.
+# settings.json hooks do NOT reach spawned subagents, so gated agents carry it here.
+hooks:
+  PreToolUse:
+    - matcher: "Grep|Glob|Bash"
+      hooks:
+        - type: command
+          command: "bash -c 'python3 \"${CLAUDE_PROJECT_DIR:-.}/scripts/codex_warden_hooks.py\" run codegraph-first-gate'"
 ---
 
 You are the `keystone` Warden — a single-claim dependency-chain tracer. Your job is to

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,6 +1,8 @@
 ---
 name: planner
 model: sonnet
+explores_code: true
+codegraph_gated: true
 description: >
   Software architect agent for designing implementation plans.
   Use when you need to plan implementation strategy for a task.
@@ -12,6 +14,16 @@ tools:
   - Grep
   - Read
   - ToolSearch
+# codegraph-first gate (LIA-121): blocks Grep/Glob/Bash-search until a prior
+# codegraph/code_search call exists in this agent's transcript (logic in
+# scripts/codex_warden_hooks.py). Pairs with `codegraph_gated: true` above.
+# settings.json hooks do NOT reach spawned subagents, so gated agents carry it here.
+hooks:
+  PreToolUse:
+    - matcher: "Grep|Glob|Bash"
+      hooks:
+        - type: command
+          command: "bash -c 'python3 \"${CLAUDE_PROJECT_DIR:-.}/scripts/codex_warden_hooks.py\" run codegraph-first-gate'"
 ---
 
 You are a software architecture and planning agent. Your job is to design implementation approaches by exploring the codebase and producing detailed, actionable plans.

--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -40,7 +40,7 @@
 - Three-stage protocol: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) `codegraph_callers`/`codegraph_callees`/`codegraph_impact` for structural context (what connects to the candidates), (3) grep/read for exact confirmation. Skip stages when the answer is already known.
 - Before modifying any function, query `codegraph_callers` to know the blast radius. A change with 2 callers is not the same risk as a change with 50.
 - Never open-code `grep -r` or `find -name` as the first move -- semantic search identifies the landscape, structural queries map the connections, exact search confirms specifics.
-- When authoring a `Workflow` (or dispatching investigation subagents) over a codegraph-indexed repo, bake the codegraph-first mandate INTO the `agent()` prompts -- `workflow-subagent` agents inherit no exploration hook and codegraph is already directly callable from them, so their prompt is the only lever.
+- Codegraph-first is hook-enforced on the main thread (`.claude/settings.json`) and on gated subagents that carry their own frontmatter hook (code-explorer/general/planner/keystone). When authoring a `Workflow` (or dispatching a subagent that has no frontmatter hook) over a codegraph-indexed repo, bake the codegraph-first mandate INTO the `agent()` prompts -- such a `workflow-subagent` inherits no exploration hook (settings.json hooks reach only the main thread), so its prompt is the only lever.
 
 ## Memory & Context
 - Before implementing a feature, search memory (`memory_tree.py query "<topic>"`) for prior decisions and research. Cite the retrieved path.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -99,6 +99,21 @@
             "type": "command",
             "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/format-check.sh\"'",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" codegraph-first-gate'",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/warden-shim.sh\" codegraph-first-gate'",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -583,7 +583,11 @@ def _resolve_agent_transcript(event: dict[str, Any]) -> str:
     Workflow-spawned subagents write their transcript DEEPER, at
     ``.../<session_id>/subagents/workflows/wf_<run>/agent-<agent_id>.jsonl``, so the
     flat derivation misses and the gate would silently fail open (observed: 3
-    ``codegraph-gate CANARY`` fail-opens). When the flat path is absent we resolve
+    ``codegraph-gate CANARY`` fail-opens). Those fires came from a GATED agent (e.g.
+    code-explorer) invoked AS a workflow subagent, carrying its OWN frontmatter hook
+    -- a workflow subagent with no frontmatter hook is not gated at all (settings.json
+    hooks reach only the main thread), which is why ``core-behavioral-rules`` makes the
+    prompt the lever for those. When the flat path is absent we resolve
     the file under this session's ``subagents/workflows/*/`` -- only on a flat-path
     miss, so the common Task path and the "not yet written -> fail open" behavior are
     unchanged.
@@ -623,21 +627,28 @@ def _resolve_agent_transcript(event: dict[str, Any]) -> str:
     return tp
 
 
-def _log_gate_canary(repo_root: Path, message: str) -> None:
-    """Append a LOUD canary entry to the warden audit log.
+def _log_gate_line(repo_root: Path, label: str, message: str) -> None:
+    """Append a labelled codegraph-gate entry to the warden audit log.
 
-    Used when the transcript-scanning gate detects a possible parse-blindness
-    condition (rich transcript, no recognized tool_use blocks).  This makes a
-    silent no-op VISIBLE in the warden log rather than invisible.
+    Shared writer for the gate's out-of-band signals (CANARY parse-blindness,
+    FAILOPEN availability fallback) so a silent no-op is VISIBLE in the warden
+    log rather than invisible.
     """
     try:
         log = _audit_log_path(repo_root)
         log.parent.mkdir(parents=True, exist_ok=True)
         stamp = dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         with log.open("a", encoding="utf-8") as fh:
-            fh.write(f"{stamp} | codegraph-gate   | CANARY  | {message}\n")
+            fh.write(f"{stamp} | codegraph-gate   | {label:<8}| {message}\n")
     except Exception:
         pass
+
+
+def _log_gate_canary(repo_root: Path, message: str) -> None:
+    """Log a parse-blindness canary: the transcript-scanning gate detected a
+    rich transcript with zero recognized tool_use blocks, so it may have gone
+    blind to a changed transcript format. Makes the silent no-op visible."""
+    _log_gate_line(repo_root, "CANARY", message)
 
 
 def _bash_is_code_search(command: str) -> bool:
@@ -1278,9 +1289,115 @@ def _codegraph_deny_message(prior_searches: int) -> str:
     return tier2
 
 
+#: Server names that satisfy the codegraph-first gate — mirrors the
+#: ``mcp__codegraph__`` / ``mcp__code-search__`` tool prefixes detected by
+#: ``_line_is_codegraph_toolcall``.
+_CODEGRAPH_SERVER_NAMES = ("codegraph", "code-search")
+
+
+def _codegraph_config_paths(repo_root: Path) -> list[Path]:
+    """Claude Code config files that may register the codegraph/code-search MCP
+    servers. All are read and their server names unioned (order irrelevant).
+    A separate function so tests can monkeypatch the lookup deterministically."""
+    paths: list[Path] = []
+    cfg_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if cfg_dir:
+        paths.append(Path(cfg_dir).expanduser() / ".claude.json")
+    paths.append(Path.home() / ".claude.json")
+    paths.append(repo_root / ".mcp.json")
+    # De-dup (CLAUDE_CONFIG_DIR may alias ~/.claude.json) so we never read a file twice.
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for p in paths:
+        try:
+            key = p.resolve()
+        except OSError:
+            key = p
+        if key not in seen:
+            seen.add(key)
+            out.append(p)
+    return out
+
+
+def _codegraph_mcp_available(repo_root: Path) -> tuple[bool, str]:
+    """Return ``(available, reason)``: is a codegraph/code-search MCP server
+    registered? Reads the configs in ``_codegraph_config_paths`` and unions
+    ``mcpServers`` + ``projects[repo].mcpServers``.
+
+    ``available`` is True ONLY when such a server is found. Every other outcome
+    (not registered, corrupt config, no config at all) returns False so the gate
+    falls back to grep — an agent cannot satisfy a gate for a server it cannot
+    call, so blocking would brick it. ``reason`` distinguishes the cases for the
+    FAILOPEN log. (A real fresh instance has a ``~/.claude.json`` without the
+    server → the "not registered" branch; tests force availability via the
+    autouse fixture's ``CLAUDE_CONFIG_DIR``.)
+    """
+    server_names: set[str] = set()
+    any_file_present = False
+    any_parsed = False
+    for path in _codegraph_config_paths(repo_root):
+        try:
+            if not path.exists():
+                continue
+            any_file_present = True
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        any_parsed = True
+        if not isinstance(data, dict):
+            continue
+        top = data.get("mcpServers")
+        if isinstance(top, dict):
+            server_names.update(top.keys())
+        projects = data.get("projects")
+        if isinstance(projects, dict):
+            proj = projects.get(str(repo_root))
+            if isinstance(proj, dict) and isinstance(proj.get("mcpServers"), dict):
+                server_names.update(proj["mcpServers"].keys())
+    if any(name in server_names for name in _CODEGRAPH_SERVER_NAMES):
+        return True, ""
+    if any_parsed:
+        return False, "no codegraph/code-search MCP server registered — grep allowed (fresh instance?)"
+    if any_file_present:
+        return False, "Claude MCP config unreadable — grep allowed"
+    return False, "no Claude MCP config found — grep allowed"
+
+
+def _log_codegraph_availability_failopen(
+    repo_root: Path, event: dict[str, Any], reason: str
+) -> None:
+    """Record an availability fail-open to the warden log, ONCE per session.
+
+    Dedup marker is session-keyed (from ``transcript_path``) and lives under the
+    state dir (``~/.deus``), not the repo. A legitimately-fresh instance logs once
+    per session (no per-grep spam); a *misread* on an instance that should enforce
+    resurfaces every new session instead of being permanently silenced.
+    """
+    try:
+        tp = str(event.get("transcript_path") or "")
+        session_id = Path(tp).stem if tp else "unknown"
+        if not session_id:
+            session_id = "unknown"
+        state_dir = Path(os.environ.get("DEUS_STATE_DIR", Path.home() / ".deus"))
+        marker = state_dir / f".codegraph-avail-logged-{session_id}"
+        if marker.exists():
+            return
+        state_dir.mkdir(parents=True, exist_ok=True)
+        marker.write_text("", encoding="utf-8")
+    except OSError:
+        pass  # marker unmanageable — fall through and log (best-effort)
+    _log_gate_line(repo_root, "FAILOPEN", reason)
+
+
 def run_codegraph_first_gate(event: dict[str, Any], repo_root: Path) -> int:
-    """Single PreToolUse gate enforcing codegraph-first exploration for gated
-    agents (``codegraph_gated: true``). LIA-121 / RETRO-2026-05-29-01.
+    """Single PreToolUse gate enforcing codegraph-first exploration on every
+    thread where it is wired. LIA-121 / RETRO-2026-05-29-01.
+
+    Wiring (the gate body does NOT read ``codegraph_gated`` — that flag is only a
+    coverage-test marker): the MAIN thread via ``.claude/settings.json`` (the
+    ``Bash`` block + a ``Grep|Glob`` block); gated Task/workflow subagents via
+    their OWN frontmatter ``hooks`` block (settings.json hooks do not reach a
+    spawned subagent), e.g. code-explorer / general / planner / keystone.
 
     IMPLEMENTATION: transcript-scanning (replaces broken marker scheme).
 
@@ -1371,6 +1488,16 @@ def run_codegraph_first_gate(event: dict[str, Any], repo_root: Path) -> int:
                 "run `python3 scripts/drift_check.py --codegraph-format` to validate. "
                 "Failing open to avoid deadlock.",
             )
+            return 0
+
+        # About to block. But if no codegraph/code-search MCP server is
+        # registered (a fresh instance that never ran /setup), the agent CANNOT
+        # satisfy the gate — fall back to grep instead of bricking it. Checked
+        # here (not earlier) so the config read is paid only when we would
+        # otherwise block, i.e. before the first codegraph call of a thread.
+        available, reason = _codegraph_mcp_available(repo_root)
+        if not available:
+            _log_codegraph_availability_failopen(repo_root, event, reason)
             return 0
 
         _block_pre_tool(_codegraph_deny_message(prior_search_attempts))

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -7,6 +7,8 @@ import sys
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "codex_warden_hooks.py"
@@ -3750,6 +3752,122 @@ def test_codegraph_gated_agents_have_hooks_block():
             f"{md.name}: `codegraph_gated` flag and the codegraph gate hook block "
             "are out of sync. Both must be present together or both absent."
         )
+
+
+# ---------------------------------------------------------------------------
+# Availability fail-open: a fresh instance without codegraph falls back to grep
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _codegraph_registered_by_default(tmp_path_factory, monkeypatch):
+    """Gate block-tests now require codegraph to look "registered" (the
+    availability probe). Provide a codegraph-registered config via
+    CLAUDE_CONFIG_DIR so the probe always finds it (its union of config paths
+    short-circuits to available regardless of the host's real ~/.claude.json or
+    CI's absence of one). Availability-specific tests override the whole lookup
+    by monkeypatching _codegraph_config_paths."""
+    cfg_dir = tmp_path_factory.mktemp("ccfg")
+    (cfg_dir / ".claude.json").write_text(
+        json.dumps({"mcpServers": {"codegraph": {}, "code-search": {}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg_dir))
+
+
+def _config_with(tmp_path: Path, servers: dict) -> Path:
+    cfg = tmp_path / "claude_config.json"
+    cfg.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+    return cfg
+
+
+def test_availability_codegraph_registered_enforces(tmp_path, capsys, monkeypatch):
+    """codegraph registered → gate still BLOCKS grep with no prior codegraph call."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    cfg = _config_with(tmp_path, {"codegraph": {}})
+    monkeypatch.setattr(hooks, "_codegraph_config_paths", lambda rr: [cfg])
+    tr = _write_transcript(tmp_path, [_BASH_LINE])
+    assert hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo) == 0
+    assert _deny(capsys) == "deny"
+
+
+def test_availability_not_registered_allows_grep(tmp_path, capsys, monkeypatch):
+    """Fresh instance (config readable, no codegraph/code-search) → grep ALLOWED,
+    fail-open logged to .warden-log."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    cfg = _config_with(tmp_path, {"linear": {}})  # some other server, not codegraph
+    monkeypatch.setattr(hooks, "_codegraph_config_paths", lambda rr: [cfg])
+    monkeypatch.setenv("DEUS_STATE_DIR", str(tmp_path / "state"))
+    tr = _write_transcript(tmp_path, [_BASH_LINE])
+    assert hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo) == 0
+    assert capsys.readouterr().out == ""  # no deny printed
+    assert "FAILOPEN" in (repo / ".claude" / ".warden-log").read_text()
+
+
+def test_availability_corrupt_config_allows_grep(tmp_path, capsys, monkeypatch):
+    """Present-but-unparseable config → grep ALLOWED (cannot confirm codegraph)."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(hooks, "_codegraph_config_paths", lambda rr: [bad])
+    monkeypatch.setenv("DEUS_STATE_DIR", str(tmp_path / "state"))
+    tr = _write_transcript(tmp_path, [_BASH_LINE])
+    assert hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_availability_no_config_files_allows_grep(tmp_path, capsys, monkeypatch):
+    """No config file at all (cannot confirm codegraph) → grep ALLOWED. Blocking
+    when codegraph can't be confirmed would brick a session that can't satisfy
+    the gate; existing block-tests stay deterministic via the autouse fixture."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    monkeypatch.setattr(hooks, "_codegraph_config_paths", lambda rr: [tmp_path / "nope.json"])
+    monkeypatch.setenv("DEUS_STATE_DIR", str(tmp_path / "state"))
+    tr = _write_transcript(tmp_path, [_BASH_LINE])
+    assert hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=tr), repo) == 0
+    assert capsys.readouterr().out == ""  # allowed, no deny
+
+
+def test_availability_failopen_logged_once_per_session(tmp_path, capsys, monkeypatch):
+    """Two fail-opens in one session → ONE log line; a new session logs again."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    cfg = _config_with(tmp_path, {"linear": {}})
+    monkeypatch.setattr(hooks, "_codegraph_config_paths", lambda rr: [cfg])
+    monkeypatch.setenv("DEUS_STATE_DIR", str(tmp_path / "state"))
+
+    def fire(session_name: str):
+        sess = tmp_path / f"{session_name}.jsonl"
+        sess.write_text(_BASH_LINE + "\n", encoding="utf-8")
+        hooks.run_codegraph_first_gate(_gate_event(repo, "Grep", transcript=sess), repo)
+        capsys.readouterr()
+
+    fire("sessionA")
+    fire("sessionA")  # same session id → marker exists → no 2nd log
+    log_path = repo / ".claude" / ".warden-log"
+    assert log_path.read_text().count("FAILOPEN") == 1
+    fire("sessionB")  # different session → logs again
+    assert log_path.read_text().count("FAILOPEN") == 2
+
+
+def test_settings_json_wires_codegraph_first_gate():
+    """Shipped settings.json wires codegraph-first-gate for the MAIN thread on
+    BOTH the Bash block and a Grep|Glob block. Subagents carry it via their own
+    frontmatter (see test_codegraph_gated_agents_have_hooks_block)."""
+    settings = json.loads((ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    pretooluse = settings["hooks"]["PreToolUse"]
+
+    def cmds_for(matcher: str) -> str:
+        block = next((b for b in pretooluse if b.get("matcher") == matcher), None)
+        assert block is not None, f"no PreToolUse block for matcher {matcher!r}"
+        return " ".join(h["command"] for h in block["hooks"])
+
+    assert "codegraph-first-gate" in cmds_for("Bash"), "Bash block must run codegraph-first-gate"
+    assert "codegraph-first-gate" in cmds_for("Grep|Glob"), "Grep|Glob block must run codegraph-first-gate"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends the existing codegraph-first gate (LIA-121) from **code-explorer-only** to **every host-side thread**, so codegraph/code_search is enforced over bash `grep`/`find` across the main agent and exploration subagents — while a fresh instance that hasn't set up codegraph **falls back to grep** instead of being bricked.

### Changes
- **`settings.json`** — wire `codegraph-first-gate` into the **main thread**: appended to the existing `Bash` PreToolUse block + a new `Grep|Glob` block. Appending (vs a standalone block) sidesteps the unverified additive-vs-first-match question.
- **`.claude/agents/{general,planner,keystone}.md`** — add the gate's frontmatter hook + `codegraph_gated: true` (code-explorer already had it). **Authoritative finding (Claude Code docs):** a `settings.json` PreToolUse hook reaches the **main thread only**, not spawned subagents — so each gated subagent must carry its own frontmatter hook. Scope = exploration agents (user decision); review/writing agents intentionally excluded.
- **`codex_warden_hooks.py`** — availability probe (`_codegraph_mcp_available`): if no `codegraph`/`code-search` MCP server is registered (reads `~/.claude.json` / `$CLAUDE_CONFIG_DIR` / project `.mcp.json`), the gate **falls back to grep**. Brick-safe: only a positive match enforces; not-registered / corrupt / no-config all allow grep. Fail-open logged **once per session** to `.warden-log` (session-keyed marker under `~/.deus`). Also fixed the stale `codegraph_gated` docstring and reconciled the `_resolve_agent_transcript` workflow-subagent note.
- **`core-behavioral-rules.md`** — one line reconciled (main-thread hook-enforced; a workflow subagent without a frontmatter hook → prompt-mandate).

## Scope (honest)
Per `docs/decisions/hook-dispatch-facade-correction.md`: hooks are **CLI-triggered**, so this covers **Claude-Code-backed instances only**. Non-Claude backends run unguarded — the ADR's documented known limitation (closing it = its deferred remediation #1), not this PR.

The `bash -c 'grep …'` / `xargs grep` bypass holes are **NOT closed here** (primary-token classification only). Documented, tracked follow-up — one concern per branch.

## Behavior
- Gated: `Grep`/`Glob` tools + Bash where the **primary** command is `grep`/`rg`/`find`/`git grep`/etc. Pipe-filters (`git log | grep`) are never gated.
- Session-level: one codegraph/code_search call unblocks all subsequent searches in that thread (matches on the tool_use **request**, so a registered-but-down call still self-heals).

## Verification

**Tests:** 6 new (availability enforce/allow/corrupt/no-config/log-once + a settings-contract test); the `:3737` `gated == has_block` invariant kept. `238 passed`. `drift_check` clean.

**Real-session smoke** (gate temporarily wired into a live session via gitignored `settings.local.json`, then reverted):
1. DENY — primary `grep` with no prior codegraph call →
   `[codegraph-first-gate] Call a codegraph or code_search tool first (ToolSearch "select:mcp__codegraph__codegraph_context"), then retry. core-behavioral-rules.md § Code Exploration.`
2. Called `mcp__codegraph__codegraph_context` → succeeded.
3. UNBLOCK — re-ran the same `grep` → allowed, executed (exit 0, returned matches).

FAILOPEN (fresh instance) is covered by unit tests only — it can't be live-simulated on this machine since the real `~/.claude.json` has codegraph registered.

## Wardens
plan-reviewer SHIP (3 rounds), code-reviewer SHIP, ai-eng-warden SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)