### PR TITLE
feat(evolution): capture available_tools manifest per dispatch (LIA-154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,5 +172,8 @@ MAX_MESSAGE_LENGTH=50000
 LOG_LEVEL=info
 # DEUS_TOOL_AUDIT_LOG=0
 # DEUS_TOOL_SIZE_LOG=0
+# Capture the offered tool manifest per dispatch for evolution observability
+# (LIA-154; default on). Set to 0 to disable.
+# DEUS_AVAILABLE_TOOLS_LOG=0
 # DEUS_USAGE_LOG=0
 # DEUS_LISTEN_NO_CLIPBOARD=0

--- a/container/agent-runner/src/available-tools-log.ts
+++ b/container/agent-runner/src/available-tools-log.ts
@@ -1,0 +1,38 @@
+/**
+ * Available-tools manifest capture for evolution tool observability (LIA-154).
+ * Mirrors tool-call-log.ts. Writes the OFFERED tool set for this dispatch to a
+ * per-interaction file the host reads back (readAvailableTools) into the
+ * `available_tools` column — the "menu" ground truth that unblocks LIA-151.
+ * Observability only (no live-scoring consumer); best-effort, never throws.
+ * Opt-out via DEUS_AVAILABLE_TOOLS_LOG=0.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { safeInteractionId } from './safe-interaction-id.js';
+
+const LOG_DIR = '/workspace/group/logs/available-tools';
+
+/**
+ * Write the offered tool manifest for this dispatch. Best-effort: a missing
+ * interaction id (no host join key) or any fs error is swallowed — capture must
+ * never affect the dispatch. Written once per dispatch (not per tool call), so
+ * a plain overwrite is correct.
+ */
+export function writeAvailableTools(
+  interactionId: string | undefined,
+  tools: string[],
+): void {
+  try {
+    if (!interactionId) return; // no join key → host can't read it back
+    const logPath = path.join(
+      LOG_DIR,
+      `${safeInteractionId(interactionId)}.json`,
+    );
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    fs.writeFileSync(logPath, JSON.stringify(tools));
+  } catch {
+    // Capture must never crash a dispatch.
+  }
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -35,6 +35,7 @@ import { runLlamaCppConversation } from './llama-cpp-backend.js';
 import { DoomLoopDetector, createDoomLoopHook } from './doom-loop-detector.js';
 import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 import { createToolCallLogHook } from './tool-call-log.js';
+import { writeAvailableTools } from './available-tools-log.js';
 import type { AgentRuntimeId } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
 import { createPreToolUseHook, dispatchHost } from './pre-tool-use-hook.js';
@@ -829,6 +830,37 @@ async function runQuery(
 
   const doomDetector = new DoomLoopDetector();
 
+  // The OFFERED tool manifest for this dispatch (Claude backend). Hoisted to a
+  // const so it can be both passed to query() AND captured for evolution
+  // observability (LIA-154) — the "menu" the agent chose from, which unblocks
+  // LIA-151's tool_selection ground truth. The openai/llama-cpp backends branch
+  // out earlier (index.ts ~1104/1119) and never reach here, so available_tools
+  // is intentionally empty for them in v1.
+  const allowedTools = [
+    'Bash',
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'WebSearch',
+    'WebFetch',
+    'Task',
+    'TaskOutput',
+    'TaskStop',
+    ...(teamsNeeded ? ['TeamCreate', 'TeamDelete', 'SendMessage'] : []),
+    'TodoWrite',
+    'ToolSearch',
+    'Skill',
+    'NotebookEdit',
+    'mcp__deus__*',
+    ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
+    ...(hasLinearMcp ? ['mcp__linear__*'] : []),
+  ];
+  if (process.env.DEUS_AVAILABLE_TOOLS_LOG !== '0') {
+    writeAvailableTools(process.env.DEUS_INTERACTION_ID, allowedTools);
+  }
+
   for await (const message of query({
     prompt: stream,
     options: {
@@ -844,27 +876,7 @@ async function runQuery(
             append: systemAppend,
           }
         : undefined,
-      allowedTools: [
-        'Bash',
-        'Read',
-        'Write',
-        'Edit',
-        'Glob',
-        'Grep',
-        'WebSearch',
-        'WebFetch',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-        ...(teamsNeeded ? ['TeamCreate', 'TeamDelete', 'SendMessage'] : []),
-        'TodoWrite',
-        'ToolSearch',
-        'Skill',
-        'NotebookEdit',
-        'mcp__deus__*',
-        ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
-        ...(hasLinearMcp ? ['mcp__linear__*'] : []),
-      ],
+      allowedTools,
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -857,6 +857,7 @@ async function runQuery(
     ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
     ...(hasLinearMcp ? ['mcp__linear__*'] : []),
   ];
+  // LIA-154: capture the offered manifest (default-on; DEUS_AVAILABLE_TOOLS_LOG=0 opts out).
   if (process.env.DEUS_AVAILABLE_TOOLS_LOG !== '0') {
     writeAvailableTools(process.env.DEUS_INTERACTION_ID, allowedTools);
   }

--- a/container/agent-runner/src/safe-interaction-id.test.ts
+++ b/container/agent-runner/src/safe-interaction-id.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeInteractionId } from './safe-interaction-id.js';
+
+describe('safeInteractionId', () => {
+  it('passes through filename-safe characters unchanged', () => {
+    expect(safeInteractionId('whatsapp_main-1780863677424')).toBe(
+      'whatsapp_main-1780863677424',
+    );
+    expect(safeInteractionId('a.b_c-1')).toBe('a.b_c-1');
+  });
+
+  it('replaces every non-[A-Za-z0-9._-] char with underscore', () => {
+    expect(safeInteractionId('group/folder@jid:1')).toBe('group_folder_jid_1');
+    expect(safeInteractionId('a b\tc')).toBe('a_b_c');
+  });
+
+  it('stays byte-identical to the host transform in container-runner.ts', () => {
+    // The host (readToolCalls / readAvailableTools) inlines this exact regex.
+    // If this assertion ever fails the container and host resolve DIFFERENT
+    // files and capture silently drops — keep them in lockstep.
+    const hostTransform = (id: string): string =>
+      id.replace(/[^A-Za-z0-9._-]/g, '_');
+    for (const sample of [
+      'whatsapp_main-1780863677424',
+      'group/folder@jid:1',
+      'telegram:123/abc',
+      'a b\tc',
+      '',
+    ]) {
+      expect(safeInteractionId(sample)).toBe(hostTransform(sample));
+    }
+  });
+});

--- a/container/agent-runner/src/safe-interaction-id.ts
+++ b/container/agent-runner/src/safe-interaction-id.ts
@@ -1,0 +1,10 @@
+/**
+ * Filename-safe interaction id, shared by every in-container capture log
+ * (tool-call-log.ts, available-tools-log.ts) and MUST stay byte-identical to
+ * the host's transform in `container-runner.ts` (readToolCalls /
+ * readAvailableTools) so both sides resolve the same per-interaction file
+ * (LIA-154). Single source of truth — do not re-implement.
+ */
+export function safeInteractionId(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, '_');
+}

--- a/container/agent-runner/src/tool-call-log.ts
+++ b/container/agent-runner/src/tool-call-log.ts
@@ -21,16 +21,9 @@ import type {
   PostToolUseHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
 
-const LOG_DIR = '/workspace/group/logs/tool-calls';
+import { safeInteractionId } from './safe-interaction-id.js';
 
-/**
- * Filename-safe interaction id. MUST stay byte-identical to the host's
- * transform in container-runner.ts `readToolCalls` so both resolve the same
- * per-interaction file (LIA-154).
- */
-function safeInteractionId(id: string): string {
-  return id.replace(/[^A-Za-z0-9._-]/g, '_');
-}
+const LOG_DIR = '/workspace/group/logs/tool-calls';
 
 // Cap free-text args so each JSONL line stays well under PIPE_BUF (4096B) —
 // keeps concurrent appendFileSync writes atomic (no torn/interleaved lines) and

--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -238,6 +238,11 @@ def cmd_log_interaction(json_str: str) -> None:
     if not isinstance(tool_calls, list):
         tool_calls = None
 
+    # LIA-154: offered tool manifest (observability only; unblocks LIA-151).
+    available_tools = params.get("available_tools")
+    if not isinstance(available_tools, list):
+        available_tools = None
+
     iid = log_interaction(
         prompt=params.get("prompt", ""),
         response=params.get("response"),
@@ -251,6 +256,7 @@ def cmd_log_interaction(json_str: str) -> None:
         context_tokens=context_tokens,
         has_code=has_code,
         tool_calls=tool_calls,
+        available_tools=available_tools,
     )
 
     # Batch judge: check if we've accumulated enough unjudged interactions

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -25,6 +25,7 @@ def log_interaction(
     context_tokens: Optional[int] = None,
     has_code: Optional[int] = None,
     tool_calls: Optional[list[dict]] = None,
+    available_tools: Optional[list[str]] = None,
 ) -> str:
     """
     Persist one agent interaction.  Returns the interaction ID.
@@ -49,6 +50,8 @@ def log_interaction(
         has_code=has_code,
         # LIA-154: structured tool-call records (observability only, not scored).
         tool_calls=json.dumps(tool_calls or []),
+        # LIA-154: offered tool manifest (observability only; unblocks LIA-151).
+        available_tools=json.dumps(available_tools or []),
     )
     return iid
 

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -92,6 +92,9 @@ def _score_single(row: dict, judge) -> dict | None:
         result = judge.evaluate(
             prompt=row["prompt"],
             response=row.get("response") or "",
+            # Deliberately NOT passing available_tools (LIA-154) — it is
+            # observability-only; feeding it to the judge prompt would move live
+            # scores. Tool-aware scoring is LIA-151's scope.
             tools_used=row.get("tools_used"),
             user_profile=digest_for_group(row.get("group_folder")),
         )

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -58,6 +58,7 @@ class StorageProvider(ABC):
         context_tokens: Optional[int] = None,
         has_code: Optional[int] = None,
         tool_calls: Optional[str] = None,
+        available_tools: Optional[str] = None,
     ) -> str:
         """Persist one agent interaction. Returns the interaction ID."""
         ...

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -267,6 +267,9 @@ class SQLiteStorageProvider(StorageProvider):
             # JSON array of structured tool-call records (LIA-154 observability;
             # captured live but not yet scored — activation deferred).
             ("tool_calls", "TEXT"),
+            # JSON array of the OFFERED tool manifest per dispatch (LIA-154
+            # observability; no live consumer — unblocks LIA-151 ground truth).
+            ("available_tools", "TEXT"),
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list
@@ -329,6 +332,7 @@ class SQLiteStorageProvider(StorageProvider):
         context_tokens: Optional[int] = None,
         has_code: Optional[int] = None,
         tool_calls: Optional[str] = None,
+        available_tools: Optional[str] = None,
     ) -> str:
         db = self._connect()
         db.execute(
@@ -336,14 +340,14 @@ class SQLiteStorageProvider(StorageProvider):
             INSERT OR REPLACE INTO interactions
                 (id, timestamp, group_folder, prompt, response, tools_used,
                  latency_ms, eval_suite, session_id, domain_presets, user_signal,
-                 context_tokens, has_code, tool_calls)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 context_tokens, has_code, tool_calls, available_tools)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 interaction_id, timestamp, group_folder, prompt, response,
                 tools_used, latency_ms, eval_suite, session_id,
                 domain_presets, user_signal, context_tokens, has_code,
-                tool_calls,
+                tool_calls, available_tools,
             ),
         )
         db.commit()

--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -192,6 +192,76 @@ def test_cmd_log_interaction_stores_domain_presets(mock_judge, mock_embed, mock_
     assert "engineering" in parsed
 
 
+def test_cmd_log_interaction_stores_available_tools(mock_judge, mock_embed, mock_reflection_generator):
+    """LIA-154: the offered tool manifest should round-trip into available_tools."""
+    from evolution.cli import cmd_log_interaction
+
+    iid = "test-iid-avail-tools"
+    manifest = ["Bash", "Read", "Edit", "mcp__deus__*", "mcp__linear__*"]
+    payload = json.dumps({
+        "id": iid,
+        "prompt": "Do a thing",
+        "response": "Done",
+        "group_folder": "g",
+        "available_tools": manifest,
+    })
+    cmd_log_interaction(payload)
+
+    conn = open_db()
+    row = conn.execute(
+        "SELECT available_tools FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert json.loads(row["available_tools"]) == manifest
+
+
+def test_cmd_log_interaction_available_tools_defaults_empty(mock_judge, mock_embed, mock_reflection_generator):
+    """Omitting available_tools persists an empty JSON array, never crashes."""
+    from evolution.cli import cmd_log_interaction
+
+    iid = "test-iid-avail-empty"
+    payload = json.dumps({
+        "id": iid,
+        "prompt": "No tools offered case",
+        "response": "ok",
+        "group_folder": "g",
+    })
+    cmd_log_interaction(payload)
+
+    conn = open_db()
+    row = conn.execute(
+        "SELECT available_tools FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    # ilog wrapper serializes None → "[]" (consistent with tool_calls).
+    assert json.loads(row["available_tools"]) == []
+
+
+def test_cmd_log_interaction_available_tools_non_list_ignored(mock_judge, mock_embed, mock_reflection_generator):
+    """A non-list available_tools payload is coerced to None (→ "[]"), not stored raw."""
+    from evolution.cli import cmd_log_interaction
+
+    iid = "test-iid-avail-bad"
+    payload = json.dumps({
+        "id": iid,
+        "prompt": "bad type",
+        "response": "ok",
+        "group_folder": "g",
+        "available_tools": "Bash,Read",  # string, not a list
+    })
+    cmd_log_interaction(payload)
+
+    conn = open_db()
+    row = conn.execute(
+        "SELECT available_tools FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert json.loads(row["available_tools"]) == []
+
+
 def test_cmd_log_interaction_with_explicit_interaction_id(mock_judge, mock_embed, mock_reflection_generator):
     """Explicit interaction ID should be preserved."""
     from evolution.cli import cmd_log_interaction

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-08" # auto-bump @1780931406
+last_verified: "2026-06-09" # auto-bump @1781026737
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-08" # auto-bump @1780931406
+last_verified: "2026-06-09" # auto-bump @1781026737
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-09" # auto-bump @1780997087
+last_verified: "2026-06-09" # auto-bump @1780997087 (re-verified: LIA-154 available_tools)
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-09" # auto-bump @1780997087
+last_verified: "2026-06-09" # auto-bump @1780997087 (re-verified: LIA-154 available_tools)
 governs:
   - src/
   - evolution/

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -162,6 +162,7 @@ import {
   runContainerAgent,
   ContainerOutput,
   readToolCalls,
+  readAvailableTools,
 } from './container-runner.js';
 import {
   getActivePrompt,
@@ -2083,5 +2084,67 @@ describe('readToolCalls (LIA-154)', () => {
       { name: 'Read', file_path: '/a.ts' },
       { name: 'Edit', file_path: '/b.ts' },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readAvailableTools — LIA-154 per-interaction offered-tool manifest read-back
+// ---------------------------------------------------------------------------
+describe('readAvailableTools (LIA-154)', () => {
+  const fsMocked = vi.mocked(
+    (fsMod as unknown as { default: typeof fsMod }).default,
+  );
+  const logsDir = '/group/logs';
+
+  afterEach(() => {
+    fsMocked.readFileSync.mockReset();
+    fsMocked.readFileSync.mockReturnValue('');
+  });
+
+  it('reads the per-interaction file (logsDir/available-tools/<safeId>.json)', () => {
+    fsMocked.readFileSync.mockClear();
+    fsMocked.readFileSync.mockReturnValue('[]');
+    readAvailableTools(logsDir, 'grp/main-123');
+    const calledPath = String(fsMocked.readFileSync.mock.calls[0][0]);
+    expect(calledPath).toContain('available-tools');
+    // path separators in the id are sanitized so the filename is one segment
+    expect(calledPath).toContain('grp_main-123.json');
+  });
+
+  it('returns the parsed string array', () => {
+    fsMocked.readFileSync.mockReturnValue(
+      JSON.stringify(['Bash', 'Read', 'mcp__deus__*']),
+    );
+    expect(readAvailableTools(logsDir, 'g-1')).toEqual([
+      'Bash',
+      'Read',
+      'mcp__deus__*',
+    ]);
+  });
+
+  it('returns [] when the file does not exist', () => {
+    fsMocked.readFileSync.mockImplementation(() => {
+      const e = new Error('ENOENT') as NodeJS.ErrnoException;
+      e.code = 'ENOENT';
+      throw e;
+    });
+    expect(readAvailableTools(logsDir, 'g-1')).toEqual([]);
+  });
+
+  it('returns [] on malformed JSON', () => {
+    fsMocked.readFileSync.mockReturnValue('not json [');
+    expect(readAvailableTools(logsDir, 'g-1')).toEqual([]);
+  });
+
+  it('filters out non-string entries (defensive)', () => {
+    fsMocked.readFileSync.mockReturnValue(
+      JSON.stringify(['Bash', 42, null, 'Read']),
+    );
+    expect(readAvailableTools(logsDir, 'g-1')).toEqual(['Bash', 'Read']);
+  });
+
+  it('returns [] when the JSON is not an array', () => {
+    fsMocked.readFileSync.mockReturnValue(JSON.stringify({ tools: ['Bash'] }));
+    expect(readAvailableTools(logsDir, 'g-1')).toEqual([]);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -254,6 +254,32 @@ export function readToolCalls(
   return out;
 }
 
+/**
+ * Read this dispatch's offered tool manifest from the in-container capture file
+ * (LIA-154). Best-effort: missing/malformed → []. The safeId transform MUST stay
+ * byte-identical to the container's safe-interaction-id.ts (else they resolve
+ * different files and capture silently drops).
+ */
+export function readAvailableTools(
+  logsDir: string,
+  interactionId: string,
+): string[] {
+  const safeId = interactionId.replace(/[^A-Za-z0-9._-]/g, '_');
+  try {
+    const raw = fs.readFileSync(
+      path.join(logsDir, 'available-tools', `${safeId}.json`),
+      'utf8',
+    );
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((t): t is string => typeof t === 'string');
+    }
+  } catch {
+    // no file / malformed = no manifest captured this dispatch
+  }
+  return [];
+}
+
 export async function runContainerAgent(
   group: RegisteredGroup,
   input: ContainerInput,
@@ -544,6 +570,7 @@ export async function runContainerAgent(
           contextTokens: estimateTokens(input.prompt),
           hasCode: containsCodeBlock(response),
           toolCalls: readToolCalls(logsDir, interactionId),
+          availableTools: readAvailableTools(logsDir, interactionId),
         });
       };
       // Reaped paths (idle-after-output, non-zero-after-output) resolve long after

--- a/src/evolution-client.ts
+++ b/src/evolution-client.ts
@@ -52,6 +52,8 @@ export interface LogInteractionParams {
   toolsUsed?: string[];
   /** Structured per-call records (LIA-154 observability; not yet scored). */
   toolCalls?: ToolCall[];
+  /** Offered tool manifest for this dispatch (LIA-154; unblocks LIA-151). */
+  availableTools?: string[];
   sessionId?: string;
   domainPresets?: string[];
   userSignal?: string;
@@ -154,6 +156,7 @@ export function logInteraction(params: LogInteractionParams): void {
     latency_ms: params.latencyMs,
     tools_used: params.toolsUsed ?? [],
     tool_calls: params.toolCalls ?? [],
+    available_tools: params.availableTools ?? [],
     session_id: params.sessionId,
     domain_presets: params.domainPresets ?? [],
     user_signal: params.userSignal ?? null,


### PR DESCRIPTION
## LIA-154: capture the `available_tools` manifest per dispatch (observability-only)

Captures the OFFERED tool set (the `allowedTools` array the agent was given) per dispatch into a new `available_tools` evolution.db column — the "menu the agent chose from". This is the missing ground truth that **unblocks LIA-151's DSPy `tool_selection` re-enable**. Mirrors the LIA-154 inc#1 `tool_calls` capture pattern.

### Observability-only — NO score movement
`available_tools` has **no live consumer** (verified, and independently re-verified by ai-eng-warden tracing the full judge path): not read by `maintenance.py _score_single` nor `ollama_judge`'s prompt builder; the only reader is `dspy_optimizer`'s stub, replaced under LIA-151.

This PR deliberately does **NOT** populate `tools_used` — that field *is* fed to the live judge prompt (`maintenance.py:95` → `ollama_judge.py:159`), and with the judge actively scoring (1,679/1,681 in 7d), populating it would move live scores. That's a separate, deliberate, score-moving change.

### Capture path (mirrors `tool_calls`)
- **container**: new `available-tools-log.ts` writes `available-tools/<id>.json` once per dispatch; `allowedTools` hoisted to a const in `index.ts` so it's both passed to `query()` and captured. `safeInteractionId` extracted to a shared module (was duplicated in `tool-call-log.ts`) — honors "never duplicate" within the same build unit.
- **host**: `readAvailableTools()` reads it at logInteraction time → threaded through `evolution-client` → `cli.py` → `ilog` → sqlite provider → `available_tools` column (additive `ALTER TABLE` migration).

### Notes for the LIA-151 implementer
- **v1 captures the Claude backend only.** openai/llama-cpp branch out before `allowedTools`, so `available_tools = []` for them (intentional). When re-enabling `tool_selection`, **filter empty manifests** from the devset (empty = vacuous training signal) and update `dspy_optimizer._build_examples` to read the column instead of the hardcoded stub.
- Added a **write-barrier comment** at `maintenance.py:95` so a future scorer change can't silently start feeding `available_tools` to the judge.

## Verification
- host tsc 0, container tsc 0; TS tests **73** (host 63 incl 6 new `readAvailableTools`; container 10 incl new `safeInteractionId` byte-parity guard).
- `pytest evolution/tests/` — **110** (38 cli/ilog incl 3 new `available_tools` round-trip; 72 storage/db). prettier + drift clean.
- **Live container smoke test**: a real dispatch (`deus-agent:latest`, worktree src mounted, `DEUS_INTERACTION_ID=smoke-lia154-123`) wrote `available-tools/smoke-lia154-123.json = ["Bash","Read",…,"mcp__deus__*"]` (16 tools — no Team/gcal/linear, exactly the conditional behavior), and the host's byte-identical `safeId` transform resolves that exact file → valid `string[]`. End-to-end confirmed.

**Requires a container rebuild** (`./container/build.sh`) to capture live.

(`schedule-validator.test.ts` is red on clean main — pre-existing, tracked in LIA-201, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
