### PR TITLE
chore(maintenance): cap warden verdict-store .bak retention (LIA-200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: python3 scripts/drift_check.py --all --base origin/${{ github.base_ref }}
 
       - name: Pattern tests (Python)
-        run: python3 -m pytest scripts/tests/test_drift_check.py -v
+        run: python3 -m pytest scripts/tests/test_drift_check.py scripts/tests/test_prune_warden_backups.py -v
 
       - name: Session type contract tests
         run: python3 -m pytest tests/test_session_type_contract.py -v

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -83,6 +83,11 @@ def main():
     results["decay"] = run_task("decay", [indexer, "--decay"], dry_run)
     results["health"] = run_task("health", [indexer, "--health"], dry_run)
 
+    prune_baks = str(SCRIPTS_DIR / "maintenance" / "prune_warden_backups.py")
+    results["prune_warden_baks"] = run_task(
+        "prune_warden_baks", [prune_baks, "--keep", "10"], dry_run
+    )
+
     # ── Weekly tasks (Sunday or --weekly) ────────────────────────────────────
 
     if run_weekly:

--- a/scripts/maintenance/prune_warden_backups.py
+++ b/scripts/maintenance/prune_warden_backups.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# macOS-local maintenance tool — the .claude worktree path layout it scans is
+# specific to a macOS developer machine (matches the sibling orphan_sweep.py).
+"""
+Prune warden verdict-store backups (LIA-200).
+
+`_write_atomic()` in scripts/codex_warden_hooks.py writes a `{name}.bak-<stamp>`
+copy on EVERY warden verdict-store write (stamp = UTC strftime "%Y%m%d%H%M%S",
+14 digits), with no retention cap. The gates fire many times per session across
+all worktrees, so these backups accumulate without bound. They are purely
+defensive dead copies — `os.replace` already makes the live write atomic and
+nothing ever reads a `.bak` back — so capping retention is safe.
+
+This is a standalone maintenance tool (never touches the hot write path). It is
+wired into scripts/maintenance.py's daily block, which launchd runs at 04:30
+(com.deus.maintenance.plist), so it bounds accumulation on a real schedule.
+
+It keeps the N newest backups per store path across the three in-repo families:
+
+    <repo>/.claude/*.bak-*                         (main-worktree flat store)
+    <repo>/.claude/worktree-markers/*/*.bak-*      (per-worktree marker buckets)
+    <repo>/.claude/worktrees/*/.claude/*.bak-*     (full-checkout worktrees)
+
+Because the stamp is fixed-width and zero-padded (YYYYMMDDHHMMSS), a plain
+lexicographic sort of the filename is identical to chronological order, so
+"newest N" needs no stat() and is filesystem-clock-independent.
+
+Run with --help for flags (--keep / --dry-run / --verbose).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# A backup is "<live store name>.bak-<14 digits>". The 14-digit anchor is what
+# keeps this from ever matching a live store file (.warden-verdicts.json) or a
+# tempfile left by an interrupted _write_atomic.
+_BACKUP_SUFFIX = re.compile(r"\.bak-\d{14}$")
+
+# Glob patterns rooted at <repo>/.claude that enumerate every backup family.
+_FAMILY_GLOBS = (
+    "*.bak-*",
+    "worktree-markers/*/*.bak-*",
+    "worktrees/*/.claude/*.bak-*",
+)
+
+
+def _store_key(path: Path) -> str:
+    """Group key = the live store path a backup belongs to (its own dir plus the
+    filename with the `.bak-<stamp>` suffix stripped). Two worktrees that both
+    back up `.warden-verdicts.json` land in DIFFERENT groups because their parent
+    directories differ."""
+    return str(path.parent / _BACKUP_SUFFIX.sub("", path.name))
+
+
+def find_backups(claude_dir: Path) -> list[Path]:
+    """All warden `.bak-<14 digits>` files under a `.claude` directory."""
+    found: list[Path] = []
+    for pattern in _FAMILY_GLOBS:
+        for p in claude_dir.glob(pattern):
+            if p.is_file() and _BACKUP_SUFFIX.search(p.name):
+                found.append(p)
+    return found
+
+
+def prune(
+    claude_dir: Path, keep: int, dry_run: bool, verbose: bool
+) -> tuple[int, int]:
+    """Keep the `keep` newest backups per store path; delete the rest.
+
+    Returns (deleted, kept). Best-effort: a single unlink failure (e.g. a
+    concurrent writer removed the file first) never aborts the run."""
+    groups: dict[str, list[Path]] = {}
+    for f in find_backups(claude_dir):
+        groups.setdefault(_store_key(f), []).append(f)
+
+    deleted = 0
+    kept = 0
+    for key, files in sorted(groups.items()):
+        # Newest first — lexicographic == chronological for fixed-width stamps.
+        files.sort(key=lambda p: p.name, reverse=True)
+        keepers, losers = files[:keep], files[keep:]
+        kept += len(keepers)
+        if verbose:
+            for k in keepers:
+                print(f"  keep   {k}")
+        for old in losers:
+            if dry_run:
+                print(f"  prune  {old}")
+                deleted += 1
+                continue
+            try:
+                old.unlink()
+                deleted += 1
+            except FileNotFoundError:
+                pass  # concurrent prune / writer already removed it
+            except OSError as e:
+                print(f"  WARN could not remove {old}: {e}", file=sys.stderr)
+    return deleted, kept
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--repo", type=Path, default=Path(__file__).resolve().parents[2],
+        help="Repo root (default: inferred from this script's location).",
+    )
+    parser.add_argument(
+        "--keep", type=int, default=10,
+        help="Backups to retain per store path (default: 10).",
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be removed; delete nothing.")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Also print the backups that are kept.")
+    args = parser.parse_args(argv)
+
+    if args.keep < 0:
+        print("--keep must be >= 0", file=sys.stderr)
+        return 1
+
+    claude_dir = args.repo / ".claude"
+    if not claude_dir.is_dir():
+        # Nothing to prune is a success state, not an error.
+        print(f"prune_warden_backups: no {claude_dir} — nothing to prune")
+        return 0
+
+    deleted, kept = prune(claude_dir, args.keep, args.dry_run, args.verbose)
+    verb = "would prune" if args.dry_run else "pruned"
+    print(f"prune_warden_backups: {verb} {deleted}, kept {kept} "
+          f"(keep={args.keep} per store path)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_prune_warden_backups.py
+++ b/scripts/tests/test_prune_warden_backups.py
@@ -1,0 +1,160 @@
+"""Tests for LIA-200 warden-backup pruning (scripts/maintenance/prune_warden_backups.py).
+
+Hermetic: every test builds a throwaway `.claude` tree under pytest's tmp_path,
+so nothing touches the real repo. Backup filenames use the production stamp
+format `{name}.bak-<14 digits>`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1] / "maintenance" / "prune_warden_backups.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("prune_warden_backups", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["prune_warden_backups"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pwb = _load()
+
+
+def _mk_backups(dir_: Path, store: str, stamps: list[str]) -> list[Path]:
+    """Create `{store}.bak-<stamp>` files and return them."""
+    dir_.mkdir(parents=True, exist_ok=True)
+    made = []
+    for s in stamps:
+        p = dir_ / f"{store}.bak-{s}"
+        p.write_text("verdict-snapshot")
+        made.append(p)
+    return made
+
+
+def test_keep_newest_n_lexicographic_is_chronological(tmp_path: Path):
+    claude = tmp_path / ".claude"
+    # 5 backups; lexicographic order on the fixed-width stamp == chronological.
+    stamps = [
+        "20260601000000", "20260605120000", "20260609083702",
+        "20260609103834", "20260609165549",
+    ]
+    _mk_backups(claude, ".warden-verdicts.json", stamps)
+
+    deleted, kept = pwb.prune(claude, keep=2, dry_run=False, verbose=False)
+    assert (deleted, kept) == (3, 2)
+    survivors = sorted(p.name for p in claude.glob("*.bak-*"))
+    # The two newest stamps survive.
+    assert survivors == [
+        ".warden-verdicts.json.bak-20260609103834",
+        ".warden-verdicts.json.bak-20260609165549",
+    ]
+
+
+def test_groups_by_store_path_not_just_basename(tmp_path: Path):
+    claude = tmp_path / ".claude"
+    # Same basename (.warden-verdicts.json) in three different dirs = three groups.
+    _mk_backups(claude, ".warden-verdicts.json",
+                ["20260609000001", "20260609000002", "20260609000003"])
+    _mk_backups(claude / "worktree-markers" / "abc123def456",
+                ".warden-verdicts.json",
+                ["20260609000001", "20260609000002", "20260609000003"])
+    _mk_backups(claude / "worktrees" / "feat-x" / ".claude",
+                ".warden-verdicts.json",
+                ["20260609000001", "20260609000002", "20260609000003"])
+
+    deleted, kept = pwb.prune(claude, keep=1, dry_run=False, verbose=False)
+    # keep=1 PER group across 3 groups → 3 kept, 6 deleted.
+    assert (deleted, kept) == (6, 3)
+    assert len(list(claude.glob("*.bak-*"))) == 1
+    assert len(list((claude / "worktree-markers" / "abc123def456").glob("*.bak-*"))) == 1
+    assert len(list(
+        (claude / "worktrees" / "feat-x" / ".claude").glob("*.bak-*"))) == 1
+
+
+def test_all_three_families_discovered(tmp_path: Path):
+    claude = tmp_path / ".claude"
+    flat = _mk_backups(claude, ".warden-verdicts.json", ["20260609000001"])
+    marker = _mk_backups(claude / "worktree-markers" / "deadbeef0000",
+                         "hooks.json", ["20260609000001"])
+    wt = _mk_backups(claude / "worktrees" / "br" / ".claude",
+                     ".warden-verdicts.json", ["20260609000001"])
+    found = {p.resolve() for p in pwb.find_backups(claude)}
+    assert found == {p.resolve() for p in (flat + marker + wt)}
+
+
+def test_never_touches_live_store_or_tempfiles(tmp_path: Path):
+    claude = tmp_path / ".claude"
+    _mk_backups(claude, ".warden-verdicts.json",
+                ["20260609000001", "20260609000002", "20260609000003"])
+    live = claude / ".warden-verdicts.json"
+    live.write_text("LIVE")
+    log = claude / ".warden-log"
+    log.write_text("audit")
+    # A tempfile left by an interrupted _write_atomic (random name, no stamp).
+    tmpf = claude / "tmp_abc123"
+    tmpf.write_text("partial")
+    # A near-miss: ".bak-" with a non-14-digit suffix must NOT match.
+    near = claude / ".warden-verdicts.json.bak-2026"
+    near.write_text("not a real backup")
+
+    pwb.prune(claude, keep=0, dry_run=False, verbose=False)
+    assert live.read_text() == "LIVE"  # live store untouched
+    assert log.exists()  # unrelated state file untouched
+    assert tmpf.exists()  # in-flight tempfile untouched
+    assert near.exists()  # ".bak-2026" (non-14-digit) is NOT a backup → kept
+    # keep=0 means every REAL (14-digit-stamped) backup is gone.
+    assert list(claude.glob("*.warden-verdicts.json.bak-2026[0-9]*")) == []
+
+
+def test_dry_run_deletes_nothing(tmp_path: Path):
+    claude = tmp_path / ".claude"
+    made = _mk_backups(claude, ".warden-verdicts.json",
+                       ["20260609000001", "20260609000002", "20260609000003"])
+    deleted, kept = pwb.prune(claude, keep=1, dry_run=True, verbose=False)
+    assert deleted == 2 and kept == 1
+    assert all(p.exists() for p in made)  # nothing actually removed
+
+
+def test_concurrent_removal_is_tolerated(tmp_path: Path, monkeypatch):
+    claude = tmp_path / ".claude"
+    _mk_backups(claude, ".warden-verdicts.json",
+                ["20260609000001", "20260609000002", "20260609000003"])
+    real_unlink = Path.unlink
+    calls = {"n": 0}
+
+    def flaky_unlink(self, *a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FileNotFoundError(self)  # simulate a racing writer
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+    # Must not raise; counts the survivable unlink, swallows the FileNotFoundError.
+    deleted, kept = pwb.prune(claude, keep=1, dry_run=False, verbose=False)
+    assert kept == 1
+    assert deleted == 1  # one real removal; the racing one was swallowed
+
+
+def test_missing_claude_dir_is_success(tmp_path: Path):
+    rc = pwb.main(["--repo", str(tmp_path), "--keep", "5"])
+    assert rc == 0
+
+
+def test_main_negative_keep_rejected(tmp_path: Path):
+    rc = pwb.main(["--repo", str(tmp_path), "--keep", "-1"])
+    assert rc == 1
+
+
+def test_main_end_to_end_real_layout(tmp_path: Path):
+    claude = tmp_path / ".claude"
+    _mk_backups(claude, ".warden-verdicts.json",
+                [f"202606090000{i:02d}" for i in range(15)])
+    rc = pwb.main(["--repo", str(tmp_path), "--keep", "10"])
+    assert rc == 0
+    assert len(list(claude.glob("*.bak-*"))) == 10


### PR DESCRIPTION
## Problem

`_write_atomic()` (scripts/codex_warden_hooks.py:3344-3345) writes a `{name}.bak-<stamp>` copy on **every** warden verdict-store write, with no retention cap. Backups accumulate without bound — 159 in-repo today across three families, regenerating every session as the gates fire.

**Verified safe to cap:** `.bak` is never read back (only 2 `.bak` refs in codex_warden_hooks.py — a comment + the write), and `os.replace` already makes the live write atomic, so the backups carry no crash-safety value.

## Fix

`scripts/maintenance/prune_warden_backups.py` — keeps the N newest `.bak-<14-digit>` per store path across all three families:
- `.claude/*.bak-*` (main flat store)
- `.claude/worktree-markers/*/*.bak-*` (per-worktree buckets)
- `.claude/worktrees/*/.claude/*.bak-*` (full-checkout worktrees)

Best-effort (FileNotFoundError swallowed for concurrent writers), stdlib-only, tight 14-digit-anchored glob that can never match the live store or an in-flight tempfile. Lexicographic sort == chronological (fixed-width stamp), so "newest N" needs no `stat()`.

**Not a facade:** wired as a daily `run_task` in `scripts/maintenance.py`, which `com.deus.maintenance.plist` runs via launchd at 04:30 — so it bounds accumulation on a real schedule, never touching the hot write path.

## Tests / verification
- 9 hermetic tests (`scripts/tests/test_prune_warden_backups.py`), CI-gated by name in the Python pattern-tests step.
- Verification-gate (independent run): 9/9 pass; `--dry-run` against the real `.claude` reported "would prune 25, kept 159" with `.bak` count 184→184 (deleted nothing); `maintenance.py --dry-run` shows the task wired.

Closes LIA-200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)