### PR TITLE
fix(pipeline): render timestamps in machine-local time, not UTC (LIA-124)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-09" # auto-bump @1780997087 (re-verified: LIA-154 available_tools)
+last_verified: "2026-06-09" # auto-bump @1781032993
 governs:
   - src/
   - evolution/

--- a/src/linear-notifications.test.ts
+++ b/src/linear-notifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildPipelineCommentBody } from './linear-notifications.js';
+import { formatLocalHHMM } from './timezone.js';
 
 describe('buildPipelineCommentBody', () => {
   it('renders empty state', () => {
@@ -27,7 +28,10 @@ describe('buildPipelineCommentBody', () => {
     ];
     const body = buildPipelineCommentBody(events);
     expect(body).toContain('**Pipeline Log**');
-    expect(body).toContain('00:18');
+    // Timestamps now render in machine-local time (LIA-124). Assert against the
+    // same formatter so the test is deterministic across timezones (CI=UTC,
+    // dev=local) rather than hardcoding the old UTC slice ('00:18').
+    expect(body).toContain(formatLocalHHMM('2026-05-23T00:18:00.000Z'));
     expect(body).toContain('Gate → SHIP');
     expect(body).toContain('Agent dispatched');
     expect(body).toContain('PR created');

--- a/src/linear-notifications.ts
+++ b/src/linear-notifications.ts
@@ -18,6 +18,7 @@ import {
   updatePipelineEventStatusSummary,
 } from './db.js';
 import type { LinearContext } from './linear-dispatcher.js';
+import { formatLocalHHMM } from './timezone.js';
 
 export function macosNotify(title: string, message: string): void {
   try {
@@ -80,7 +81,7 @@ export function buildPipelineCommentBody(
     );
   }
   for (const e of visible) {
-    const time = e.created_at.slice(11, 16); // HH:MM
+    const time = formatLocalHHMM(e.created_at);
     const label = EVENT_LABELS[e.event_type] || e.event_type;
     const detail = e.detail ? ` — ${e.detail}` : '';
     lines.push(`${time} — ${label}${detail}`);

--- a/src/linear-pipeline-cli.ts
+++ b/src/linear-pipeline-cli.ts
@@ -22,6 +22,7 @@ import {
 } from './db.js';
 import { readEnvFile } from './env.js';
 import { EVENT_LABELS } from './linear-notifications.js';
+import { formatLocalDateTime } from './timezone.js';
 import {
   initActionContext,
   handleOpenInBrowser,
@@ -535,7 +536,7 @@ function printEvents(
   const detailWidth = Math.max(10, cols - 46);
 
   for (const e of events) {
-    const time = e.created_at.slice(0, 16).replace('T', ' ');
+    const time = formatLocalDateTime(e.created_at);
     const color = colorFor(e.event_type);
     const detail = e.detail
       ? ` ${DIM}— ${truncate(e.detail, detailWidth)}${RESET}`
@@ -1194,7 +1195,7 @@ async function startWatchMode(): Promise<void> {
         );
       }
       for (const e of visible) {
-        const time = e.created_at.slice(0, 16).replace('T', ' ');
+        const time = formatLocalDateTime(e.created_at);
         const color = colorFor(e.event_type);
         const label = EVENT_LABELS[e.event_type] || e.event_type;
         const detailWidth = Math.max(10, cols - 46);

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -4,6 +4,7 @@ import type { EntityWebhookPayloadWithIssueData } from '@linear/sdk/webhooks';
 import { logger } from './logger.js';
 import { executeAgentRun, extractScopeBlock } from './linear-dispatcher.js';
 import { escapeXmlForPrompt } from './prompt-utils.js';
+import { formatLocalHHMM } from './timezone.js';
 import type { LinearContext, GateLabels } from './linear-dispatcher.js';
 import type { GateSpec } from './linear-gate-specs.js';
 import type { RunContext } from './agent-runtimes/types.js';
@@ -786,7 +787,7 @@ async function handleIssueUpdate(
             new Date(lastRun.finished_at).getTime() +
               gateSpec.cooldownMinutes * 60_000,
           );
-          const resetTime = resetAt.toISOString().slice(11, 16);
+          const resetTime = formatLocalHHMM(resetAt.toISOString());
           fireAndForget(
             notifyPipelineStep(
               ctx,

--- a/src/timezone.test.ts
+++ b/src/timezone.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { formatLocalTime } from './timezone.js';
+import {
+  formatLocalTime,
+  formatLocalHHMM,
+  formatLocalDateTime,
+} from './timezone.js';
 
 // --- formatLocalTime ---
 
@@ -25,5 +29,51 @@ describe('formatLocalTime', () => {
     // NY is UTC-4 in summer (EDT), Tokyo is UTC+9
     expect(ny).toContain('8:00');
     expect(tokyo).toContain('9:00');
+  });
+});
+
+// --- formatLocalHHMM (LIA-124) ---
+
+describe('formatLocalHHMM', () => {
+  it('renders local 24-hour HH:MM for an explicit timezone', () => {
+    // 00:18 UTC in Asia/Jerusalem (UTC+3 in June, IDT) = 03:18.
+    expect(formatLocalHHMM('2026-05-23T00:18:00.000Z', 'Asia/Jerusalem')).toBe(
+      '03:18',
+    );
+  });
+
+  it('same instant differs by timezone', () => {
+    const utc = '2026-06-15T12:00:00.000Z';
+    expect(formatLocalHHMM(utc, 'America/New_York')).toBe('08:00'); // EDT -4
+    expect(formatLocalHHMM(utc, 'Asia/Tokyo')).toBe('21:00'); // JST +9
+    expect(formatLocalHHMM(utc, 'UTC')).toBe('12:00');
+  });
+
+  it('normalises midnight to 00:MM (never 24:MM)', () => {
+    expect(formatLocalHHMM('2026-06-15T00:00:00.000Z', 'UTC')).toBe('00:00');
+    // 15:00 UTC + 9h (Asia/Tokyo) = 24:00 = midnight → must render 00:00, not 24:00.
+    expect(formatLocalHHMM('2026-06-15T15:00:00.000Z', 'Asia/Tokyo')).toBe(
+      '00:00',
+    );
+  });
+});
+
+// --- formatLocalDateTime (LIA-124) ---
+
+describe('formatLocalDateTime', () => {
+  it('renders local YYYY-MM-DD HH:MM for an explicit timezone', () => {
+    // 23:30 UTC in Asia/Tokyo (+9) rolls to the next calendar day.
+    expect(formatLocalDateTime('2026-06-15T23:30:00.000Z', 'Asia/Tokyo')).toBe(
+      '2026-06-16 08:30',
+    );
+  });
+
+  it('matches the legacy slice shape for UTC (date+time, zero-padded)', () => {
+    // The replaced code did `iso.slice(0,16).replace('T',' ')` — same shape in UTC.
+    const iso = '2026-06-09T15:30:00.000Z';
+    expect(formatLocalDateTime(iso, 'UTC')).toBe('2026-06-09 15:30');
+    expect(formatLocalDateTime(iso, 'UTC')).toBe(
+      iso.slice(0, 16).replace('T', ' '),
+    );
   });
 });

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -14,3 +14,41 @@ export function formatLocalTime(utcIso: string, timezone: string): string {
     hour12: true,
   });
 }
+
+// Render a UTC ISO timestamp in the machine's local timezone for display;
+// storage stays UTC. `tz` is injectable so tests are deterministic across zones.
+
+/** Machine-local timezone, derived once via the Intl API (no hardcoded offset). */
+const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+function intlParts(utcIso: string, tz: string): Record<string, string> {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date(utcIso));
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  // Intl can emit '24' for midnight in some runtimes; normalise to '00'.
+  if (map.hour === '24') map.hour = '00';
+  return map;
+}
+
+/** Render a UTC ISO string as local `HH:MM` (24-hour). */
+export function formatLocalHHMM(utcIso: string, tz: string = LOCAL_TZ): string {
+  const p = intlParts(utcIso, tz);
+  return `${p.hour}:${p.minute}`;
+}
+
+/** Render a UTC ISO string as local `YYYY-MM-DD HH:MM` (24-hour). */
+export function formatLocalDateTime(
+  utcIso: string,
+  tz: string = LOCAL_TZ,
+): string {
+  const p = intlParts(utcIso, tz);
+  return `${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}`;
+}


### PR DESCRIPTION
## Problem

The pipeline view (`deus --agents` / pipeline CLI), the Linear "Pipeline Log" comments, and the gate cooldown reset time all rendered event timestamps in **raw UTC** instead of machine-local time (e.g. 3h off on an IDT/+0300 box). Root cause: ISO strings were sliced for display (`created_at.slice(0,16)` / `slice(11,16)`) instead of timezone-converted.

## Fix

Single shared formatter in `src/timezone.ts` (satisfies the issue's "fix once" requirement):
- `formatLocalHHMM(utcIso, tz?)` -> local `HH:MM`
- `formatLocalDateTime(utcIso, tz?)` -> local `YYYY-MM-DD HH:MM`

Both use `Intl.DateTimeFormat(...).formatToParts` (hour12:false), default to the machine-local zone derived once via `Intl.DateTimeFormat().resolvedOptions().timeZone`, expose `tz` for deterministic tests, and normalize the Intl `'24'` midnight quirk to `'00'`. All four display sites now route through them:

| Site | Was | Now |
|------|-----|-----|
| `linear-pipeline-cli.ts:538/1197` | `slice(0,16).replace('T',' ')` | `formatLocalDateTime` |
| `linear-notifications.ts:83` | `slice(11,16)` | `formatLocalHHMM` |
| `linear-webhook.ts:789` | `toISOString().slice(11,16)` | `formatLocalHHMM` |

**Storage is unchanged** — DB timestamps stay UTC ISO; only the rendered string changes.

## Notes
- **Cross-platform:** `Intl.DateTimeFormat` is reliable on all Node >=18 (full ICU by default, incl. Windows). No `process.platform`/`os.platform()` or hardcoded offsets.
- **Pattern:** Utility Module - stateless pure helpers sharing a private `intlParts` formatter.
- **Scope discipline:** a stale abandoned branch (`feat/LIA-124-local-time-display`) had fixed only 1 of 4 sites and smuggled an unrelated error-swallowing regression into `updateUnifiedComment`. This PR reuses only the sound helper design and explicitly excludes that change (verification-gate confirmed: `linear-notifications.ts` diff is exactly the import + the timestamp line).

## Tests / verification
- `src/timezone.test.ts` extended with deterministic (explicit-tz) cases for both helpers incl. midnight normalization + legacy-shape-match-in-UTC.
- `src/linear-notifications.test.ts` made TZ-deterministic (`toContain(formatLocalHHMM(...))` instead of a hardcoded UTC slice), so it passes in CI (UTC) and on a local dev box alike.
- Verification-gate (independent run): `tsc` clean; 155/155 vitest across the 4 affected files.

Closes LIA-124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)