### PR TITLE
feat(evolution): add generic per-task metrics tracking layer

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -243,6 +243,17 @@ def cmd_log_interaction(json_str: str) -> None:
     if not isinstance(available_tools, list):
         available_tools = None
 
+    # Fire-and-forget path: a malformed metrics payload must not lose the
+    # interaction itself — warn and drop the metrics instead of raising.
+    metrics = params.get("metrics")
+    if metrics is not None:
+        from .metrics import validate_metrics
+        try:
+            validate_metrics(metrics)
+        except ValueError as exc:
+            log.warning('evolution: invalid metrics dropped — %s', exc)
+            metrics = None
+
     iid = log_interaction(
         prompt=params.get("prompt", ""),
         response=params.get("response"),
@@ -257,6 +268,7 @@ def cmd_log_interaction(json_str: str) -> None:
         has_code=has_code,
         tool_calls=tool_calls,
         available_tools=available_tools,
+        metrics=metrics,
     )
 
     # Batch judge: check if we've accumulated enough unjudged interactions
@@ -363,6 +375,104 @@ def _handle_retrieved_reflections(
 
     for rid in retrieved_reflection_ids:
         increment_helpful(rid)
+
+
+def cmd_log_metrics(json_str: str) -> None:
+    """Attach metrics to an existing interaction (post-hoc path)."""
+    try:
+        params = json.loads(json_str)
+    except json.JSONDecodeError:
+        print(json.dumps({"error": "Invalid JSON"}))
+        return
+
+    from .metrics import update_metrics
+    try:
+        final = update_metrics(
+            params.get("interaction_id", ""),
+            params.get("metrics") or {},
+            merge=bool(params.get("merge", True)),
+        )
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}))
+        return
+    print(json.dumps({"status": "ok", "metrics": final}))
+
+
+def cmd_metrics(
+    action: str,
+    group: Optional[str] = None,
+    days: int = 30,
+    key: Optional[str] = None,
+    as_json: bool = False,
+) -> None:
+    """Analyze task metrics: summary | trend | calibration | breaks."""
+    from .metrics import (
+        break_report,
+        confidence_calibration,
+        fetch_metrics_rows,
+        metric_trend,
+        summarize_metrics,
+    )
+
+    if action == "trend" and not key:
+        print(json.dumps({"error": "trend requires --key"}))
+        sys.exit(1)
+
+    rows = fetch_metrics_rows(group_folder=group, days=days)
+    if action == "summary":
+        result = summarize_metrics(rows, key=key)
+    elif action == "trend":
+        result = metric_trend(rows, key)
+    elif action == "calibration":
+        result = confidence_calibration(rows)
+    else:  # breaks
+        result = break_report(rows)
+
+    if as_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    scope = f"group: {group}" if group else "all groups"
+    if action == "summary":
+        print(f"\n=== Metrics Summary (last {days} days, {scope}) ===")
+        if not result["keys"]:
+            print("  No metrics logged yet.")
+        for k, entry in sorted(result["keys"].items()):
+            if entry["type"] == "numeric":
+                print(
+                    f"  {k}: n={entry['count']} mean={entry['mean']:.2f} "
+                    f"min={entry['min']} max={entry['max']} sum={entry['sum']}"
+                )
+            else:
+                values = ", ".join(f"{v}={n}" for v, n in entry["values"].items())
+                print(f"  {k}: n={entry['count']} ({values})")
+        print(f"  ({result['interactions']} interactions)")
+    elif action == "trend":
+        print(f"\n=== Trend: {key} (last {days} days, {scope}) ===")
+        if not result:
+            print("  No numeric data for this key.")
+        for row in result:
+            print(f"  {row['day']}  avg={row['avg']:.2f}  ({row['count']} interactions)")
+    elif action == "calibration":
+        print(f"\n=== Confidence Calibration (last {days} days, {scope}) ===")
+        if not result["buckets"]:
+            print("  No rows with both confidence and judge_score.")
+        for b in result["buckets"]:
+            print(
+                f"  {b['band']:<7} n={b['n']:<4} confidence={b['avg_confidence']:.2f} "
+                f"judge={b['avg_judge_score']:.2f} gap={b['gap']:+.2f}"
+            )
+        if result["overall_gap"] is not None:
+            print(f"  Overall gap: {result['overall_gap']:+.3f} (positive = overconfident)")
+    else:  # breaks
+        print(f"\n=== Break Report (last {days} days, {scope}) ===")
+        print(
+            f"  {result['interactions_with_breaks']}/{result['interactions']} "
+            f"interactions with breaks, {result['total_breaks']} total"
+        )
+        for cat, n in result["by_category"].items():
+            print(f"  {cat}: {n}")
+    print()
 
 
 def cmd_reflect(interaction_id: str) -> None:
@@ -580,6 +690,18 @@ def main() -> None:
     p_log = sub.add_parser("log_interaction", help="Log an interaction and run judge")
     p_log.add_argument("json_str", help="JSON interaction payload")
 
+    # log_metrics
+    p_logm = sub.add_parser("log_metrics", help="Attach metrics to an existing interaction")
+    p_logm.add_argument("json_str", help='JSON: {"interaction_id": "...", "metrics": {...}, "merge": true}')
+
+    # metrics
+    p_metrics = sub.add_parser("metrics", help="Analyze task metrics")
+    p_metrics.add_argument("action", choices=["summary", "trend", "calibration", "breaks"])
+    p_metrics.add_argument("--group", help="Filter by group folder")
+    p_metrics.add_argument("--days", type=int, default=30, help="Window in days (default: 30)")
+    p_metrics.add_argument("--key", help="Metric key (required for trend, optional filter for summary)")
+    p_metrics.add_argument("--json", action="store_true", dest="as_json", help="Output raw JSON")
+
     # reflect
     p_reflect = sub.add_parser("reflect", help="Manually generate reflection for interaction")
     p_reflect.add_argument("interaction_id")
@@ -672,6 +794,13 @@ def main() -> None:
         cmd_get_active_prompt(args.module)
     elif args.cmd == "log_interaction":
         cmd_log_interaction(args.json_str)
+    elif args.cmd == "log_metrics":
+        cmd_log_metrics(args.json_str)
+    elif args.cmd == "metrics":
+        cmd_metrics(
+            args.action, group=args.group, days=args.days,
+            key=args.key, as_json=args.as_json,
+        )
     elif args.cmd == "reflect":
         cmd_reflect(args.interaction_id)
     elif args.cmd == "optimize":

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
+from ..metrics import validate_metrics
 from ..storage import get_storage
 
 
@@ -26,11 +27,21 @@ def log_interaction(
     has_code: Optional[int] = None,
     tool_calls: Optional[list[dict]] = None,
     available_tools: Optional[list[str]] = None,
+    metrics: Optional[dict] = None,
 ) -> str:
     """
     Persist one agent interaction.  Returns the interaction ID.
     Judge score is written later by update_score().
+
+    metrics is a flat dict of task metrics (see evolution.metrics) — validated
+    here so a malformed payload fails loudly at log time, not at analysis time.
     """
+    # Canonical validation gate: the MCP path calls this directly with no
+    # other check (errors propagate to the caller by design). cli.py
+    # pre-validates only to add drop-on-error semantics for its
+    # fire-and-forget path — that duplication is intentional.
+    if metrics is not None:
+        validate_metrics(metrics)
     iid = interaction_id or str(uuid.uuid4())
     ts = datetime.now(timezone.utc).isoformat()
     store = get_storage()
@@ -52,6 +63,7 @@ def log_interaction(
         tool_calls=json.dumps(tool_calls or []),
         # LIA-154: offered tool manifest (observability only; unblocks LIA-151).
         available_tools=json.dumps(available_tools or []),
+        metrics=json.dumps(metrics) if metrics is not None else None,
     )
     return iid
 

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -120,10 +120,12 @@ def _score_single(row: dict, judge) -> dict | None:
 def _reflect_single(scored: dict, config: dict) -> bool:
     """Generate reflection(s) for a scored interaction. Returns True on success."""
     from .config import MAX_REFLECTIONS_TO_GENERATE
+    from .metrics import parse_metrics
     from .reflexion.generator import generate_reflection, generate_positive_reflection
     from .reflexion.store import save_reflection
 
     row = scored["row"]
+    metrics = parse_metrics(row.get("metrics"))
     try:
         if scored["score"] < config["reflection_threshold"]:
             generated_contents: set[str] = set()
@@ -135,6 +137,7 @@ def _reflect_single(scored: dict, config: dict) -> bool:
                     dims=scored["dims"],
                     rationale=scored["rationale"],
                     tools_used=row.get("tools_used"),
+                    metrics=metrics,
                 )
                 if content in generated_contents:
                     break  # LLM returned identical text; stop early
@@ -156,6 +159,7 @@ def _reflect_single(scored: dict, config: dict) -> bool:
                     dims=scored["dims"],
                     rationale=scored["rationale"],
                     tools_used=row.get("tools_used"),
+                    metrics=metrics,
                 )
                 if content in generated_contents:
                     break  # LLM returned identical text; stop early

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -61,11 +61,19 @@ def _run_mcp_server() -> None:
         tools_used: Optional[list[str]] = None,
         session_id: Optional[str] = None,
         interaction_id: Optional[str] = None,
+        metrics: Optional[dict] = None,
     ) -> dict:
         """
         Log one agent interaction.  Triggers async judge evaluation.
         Returns the interaction ID for follow-up feedback.
+
+        metrics: optional flat dict of task outcomes (e.g. tests_passed,
+        breaks, confidence, warden_rounds). Values must be scalars or lists
+        of scalars. Seen by reflection generation, never by the judge.
         """
+        # Invalid metrics raise ValueError out of log_interaction on purpose:
+        # MCP callers get a real error signal (unlike the CLI fire-and-forget
+        # path, which drops bad metrics and keeps the interaction).
         iid = log_interaction(
             prompt=prompt,
             response=response,
@@ -74,12 +82,46 @@ def _run_mcp_server() -> None:
             tools_used=tools_used,
             session_id=session_id,
             interaction_id=interaction_id,
+            metrics=metrics,
         )
         # Fire-and-forget async judge eval
         asyncio.create_task(_async_judge_and_reflect(
-            iid, prompt, response, tools_used, group_folder
+            iid, prompt, response, tools_used, group_folder, metrics=metrics,
         ))
         return {"id": iid, "status": "logged"}
+
+    @mcp.tool()
+    def log_metrics_tool(
+        interaction_id: str,
+        metrics: dict,
+        merge: bool = True,
+    ) -> dict:
+        """
+        Attach metrics to an already-logged interaction (post-hoc path).
+        With merge=True (default), new keys are merged over stored metrics;
+        merge=False replaces the payload wholesale. Returns the final dict.
+        """
+        from .metrics import update_metrics
+        try:
+            final = update_metrics(interaction_id, metrics, merge=merge)
+        except ValueError as exc:
+            return {"status": "error", "error": str(exc)}
+        return {"status": "ok", "metrics": final}
+
+    @mcp.tool()
+    def get_metrics_summary_tool(
+        group_folder: Optional[str] = None,
+        days: int = 30,
+        key: Optional[str] = None,
+    ) -> dict:
+        """
+        Summarize task metrics over the last N days, optionally filtered by
+        group_folder and/or restricted to one metric key. Returns per-key
+        numeric stats (count/mean/min/max/sum) or categorical value counts.
+        """
+        from .metrics import fetch_metrics_rows, summarize_metrics
+        rows = fetch_metrics_rows(group_folder=group_folder, days=days)
+        return summarize_metrics(rows, key=key)
 
     @mcp.tool()
     def get_reflections_tool(
@@ -138,8 +180,13 @@ async def _async_judge_and_reflect(
     response: str,
     tools_used: Optional[list[str]],
     group_folder: str,
+    metrics: Optional[dict] = None,
 ) -> None:
-    """Judge the interaction and generate reflections if score is low."""
+    """Judge the interaction and generate reflections if score is low.
+
+    metrics are passed to reflection generation only — the judge stays blind
+    to them so self-reported numbers can't inflate scores (anti-gaming).
+    """
     from .config import REFLECTION_THRESHOLD, MAX_REFLECTIONS_TO_GENERATE
     from .persona import digest_for_group
     try:
@@ -168,6 +215,7 @@ async def _async_judge_and_reflect(
                     dims=dims,
                     rationale=result.rationale,
                     tools_used=tools_used,
+                    metrics=metrics,
                 )
                 if content in generated_contents:
                     break  # LLM returned identical text; stop early

--- a/evolution/metrics.py
+++ b/evolution/metrics.py
@@ -1,0 +1,278 @@
+"""
+Generic per-task metrics for the evolution loop.
+
+Metrics are schemaless JSON attached to interactions: flat dicts whose values
+are scalars or lists of scalars. A soft registry (WELL_KNOWN_METRICS) warns on
+unknown keys but never rejects them — callers can track anything. The judge
+stays blind to metrics (anti-gaming); reflection generation sees them.
+
+Analysis functions are pure: they take rows as returned by
+StorageProvider.get_metrics_rows() so they can be tested without a database.
+Use fetch_metrics_rows() to get rows from the active storage provider.
+"""
+import json
+import logging
+from collections import Counter, defaultdict
+from typing import Any, Optional
+
+from .storage import get_storage
+
+log = logging.getLogger(__name__)
+
+# Hard cap on the serialized metrics payload per interaction. Prevents a
+# runaway caller from bloating the interactions table (prompt compaction
+# exists precisely because rows get re-read in bulk).
+MAX_METRICS_BYTES = 16384
+
+# Soft registry: documented keys with expected shapes. validate_metrics()
+# warns on keys missing from this registry but never rejects them.
+WELL_KNOWN_METRICS = {
+    "tests_passed": "int — tests passing after the task",
+    "tests_failed": "int — tests failing after the task",
+    "tests_added": "int — new tests written for the task",
+    "breaks": "list[str] — break categories observed (regression|expected|suspicious|integration)",
+    "confidence": "float 0-1 — agent's stated confidence in the result",
+    "warden_rounds": "int — review rounds before SHIP",
+    "regressions_caught": "int — regressions caught before merge",
+    "files_changed": "int — files touched by the task",
+    "duration_minutes": "float — wall-clock task duration",
+    "task_type": "str — free-form task classification",
+}
+
+BREAK_CATEGORIES = ("regression", "expected", "suspicious", "integration")
+
+_SCALAR_TYPES = (str, int, float, bool)
+
+
+def _is_scalar(value: Any) -> bool:
+    return isinstance(value, _SCALAR_TYPES)
+
+
+def validate_metrics(metrics: dict) -> dict:
+    """Validate a metrics dict. Returns it unchanged on success.
+
+    Raises ValueError on: non-dict input, non-string keys, nested objects,
+    lists containing non-scalars, None values, or serialized size above
+    MAX_METRICS_BYTES. Unknown keys only log a warning (soft registry).
+    """
+    if not isinstance(metrics, dict):
+        raise ValueError(f"metrics must be a dict, got {type(metrics).__name__}")
+    for key, value in metrics.items():
+        if not isinstance(key, str):
+            raise ValueError(f"metric keys must be strings, got {key!r}")
+        if isinstance(value, list):
+            if not all(_is_scalar(v) for v in value):
+                raise ValueError(
+                    f"metric {key!r}: lists may only contain scalars "
+                    "(str/int/float/bool)"
+                )
+        elif not _is_scalar(value):
+            raise ValueError(
+                f"metric {key!r}: value must be a scalar or a list of scalars, "
+                f"got {type(value).__name__}"
+            )
+        if key not in WELL_KNOWN_METRICS:
+            log.warning(
+                "metric %r is not in WELL_KNOWN_METRICS — accepted, but "
+                "consider a registered key for cross-task aggregation", key,
+            )
+    raw = json.dumps(metrics).encode("utf-8")
+    if len(raw) > MAX_METRICS_BYTES:
+        raise ValueError(
+            f"metrics payload is {len(raw)} bytes; max is {MAX_METRICS_BYTES}"
+        )
+    return metrics
+
+
+def parse_metrics(raw: Optional[str]) -> Optional[dict]:
+    """Parse a stored metrics JSON string. Returns None on missing/invalid."""
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        log.warning("unparseable metrics payload skipped: %.80r", raw)
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def update_metrics(
+    interaction_id: str,
+    metrics: dict,
+    *,
+    merge: bool = True,
+) -> dict:
+    """Attach or update metrics on an existing interaction (post-hoc path).
+
+    With merge=True (default), new keys are merged over any previously stored
+    metrics. With merge=False, the stored payload is replaced wholesale.
+    Returns the final stored dict. Raises ValueError if the interaction does
+    not exist or validation fails.
+    """
+    validate_metrics(metrics)
+    store = get_storage()
+    row = store.get_interaction(interaction_id)
+    if row is None:
+        raise ValueError(f"interaction {interaction_id!r} not found")
+    if merge:
+        existing = parse_metrics(row.get("metrics")) or {}
+        final = {**existing, **metrics}
+    else:
+        final = metrics
+    validate_metrics(final)  # merged payload must also respect the size cap
+    store.update_interaction(interaction_id, metrics=json.dumps(final))
+    return final
+
+
+def fetch_metrics_rows(
+    *,
+    group_folder: Optional[str] = None,
+    days: int = 30,
+    limit: int = 1000,
+) -> list[dict]:
+    """Fetch metrics-bearing interaction rows from the active storage provider."""
+    return get_storage().get_metrics_rows(
+        group_folder=group_folder, days=days, limit=limit,
+    )
+
+
+# ── Analysis (pure functions over get_metrics_rows() output) ─────────────────
+
+
+def _parsed_rows(rows: list[dict]) -> list[tuple[dict, dict]]:
+    """Yield (row, parsed_metrics) pairs, skipping unparseable payloads."""
+    out = []
+    for row in rows:
+        parsed = parse_metrics(row.get("metrics"))
+        if parsed:
+            out.append((row, parsed))
+    return out
+
+
+def _is_numeric(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def summarize_metrics(rows: list[dict], key: Optional[str] = None) -> dict:
+    """Per-key summary across rows.
+
+    Numeric values get count/mean/min/max/sum; strings, bools, and list
+    elements get categorical value counts. Pass key to restrict the summary
+    to a single metric.
+    """
+    numeric: dict[str, list[float]] = defaultdict(list)
+    categorical: dict[str, Counter] = defaultdict(Counter)
+    parsed = _parsed_rows(rows)
+
+    for _, metrics in parsed:
+        for k, v in metrics.items():
+            if key is not None and k != key:
+                continue
+            if _is_numeric(v):
+                numeric[k].append(v)
+            elif isinstance(v, list):
+                categorical[k].update(str(e) for e in v)
+            else:
+                categorical[k][str(v)] += 1
+
+    keys: dict[str, dict] = {}
+    for k, values in numeric.items():
+        keys[k] = {
+            "type": "numeric",
+            "count": len(values),
+            "mean": sum(values) / len(values),
+            "min": min(values),
+            "max": max(values),
+            "sum": sum(values),
+        }
+    for k, counter in categorical.items():
+        entry = keys.setdefault(k, {"type": "categorical", "count": 0})
+        entry["values"] = dict(counter.most_common())
+        entry["count"] = entry.get("count", 0) + sum(counter.values())
+
+    return {"interactions": len(parsed), "keys": keys}
+
+
+def metric_trend(rows: list[dict], key: str) -> list[dict]:
+    """Daily average of a numeric metric. Non-numeric values are skipped.
+
+    Returns [{"day", "avg", "count"}, ...] ordered by day ascending.
+    """
+    by_day: dict[str, list[float]] = defaultdict(list)
+    for row, metrics in _parsed_rows(rows):
+        value = metrics.get(key)
+        if _is_numeric(value):
+            by_day[str(row.get("timestamp", ""))[:10]].append(value)
+    return [
+        {"day": day, "avg": sum(vals) / len(vals), "count": len(vals)}
+        for day, vals in sorted(by_day.items())
+    ]
+
+
+# Confidence bands for calibration: (label, inclusive lo, exclusive hi).
+_CONFIDENCE_BANDS = (
+    ("low", 0.0, 0.5),
+    ("medium", 0.5, 0.8),
+    ("high", 0.8, 1.0 + 1e-9),  # epsilon so confidence == 1.0 lands in "high"
+)
+
+
+def confidence_calibration(rows: list[dict], key: str = "confidence") -> dict:
+    """Compare self-reported confidence against judge scores.
+
+    Only rows carrying both a numeric confidence metric and a judge_score
+    participate. gap = avg_confidence - avg_judge_score per band; a positive
+    gap means overconfidence.
+    """
+    pairs: list[tuple[float, float]] = []
+    for row, metrics in _parsed_rows(rows):
+        confidence = metrics.get(key)
+        score = row.get("judge_score")
+        if _is_numeric(confidence) and _is_numeric(score):
+            pairs.append((confidence, score))
+
+    buckets = []
+    for label, lo, hi in _CONFIDENCE_BANDS:
+        band = [(c, s) for c, s in pairs if lo <= c < hi]
+        if not band:
+            continue
+        avg_c = sum(c for c, _ in band) / len(band)
+        avg_s = sum(s for _, s in band) / len(band)
+        buckets.append({
+            "band": label,
+            "n": len(band),
+            "avg_confidence": avg_c,
+            "avg_judge_score": avg_s,
+            "gap": avg_c - avg_s,
+        })
+
+    overall_gap = (
+        sum(c - s for c, s in pairs) / len(pairs) if pairs else None
+    )
+    return {"n": len(pairs), "buckets": buckets, "overall_gap": overall_gap}
+
+
+def break_report(rows: list[dict]) -> dict:
+    """Aggregate the 'breaks' metric (list of break-category strings).
+
+    A bare string value is treated as a single-category list. Categories
+    outside BREAK_CATEGORIES are counted too (soft registry philosophy) —
+    they show up alongside the known ones.
+    """
+    by_category: Counter = Counter()
+    interactions_with_breaks = 0
+    parsed = _parsed_rows(rows)
+    for _, metrics in parsed:
+        breaks = metrics.get("breaks")
+        if isinstance(breaks, str):
+            breaks = [breaks]
+        if not isinstance(breaks, list) or not breaks:
+            continue
+        interactions_with_breaks += 1
+        by_category.update(str(b) for b in breaks)
+    return {
+        "interactions": len(parsed),
+        "interactions_with_breaks": interactions_with_breaks,
+        "total_breaks": sum(by_category.values()),
+        "by_category": dict(by_category.most_common()),
+    }

--- a/evolution/reflexion/generator.py
+++ b/evolution/reflexion/generator.py
@@ -17,7 +17,7 @@ User: {prompt}
 Assistant: {response}
 Tools: {tools}
 Score: {score:.2f}/1.0 | Breakdown: {dims} | Rationale: {rationale}
-
+{metrics_section}
 Style issues to look for: naming conventions (camelCase vs snake_case), import ordering, \
 library/framework preferences, function structure (flat vs nested, early returns), \
 comment verbosity, error handling patterns, type annotation density, response formatting.
@@ -30,6 +30,17 @@ Reply in this exact format (under 100 words, agent-fixable issues only):
 """
 
 
+def _format_metrics_section(metrics: Optional[dict]) -> str:
+    """One-line metrics anchor for the reflection prompts; empty when absent."""
+    if not metrics:
+        return ""
+    return (
+        f"Task metrics: {json.dumps(metrics)}\n"
+        "Use measured outcomes (tests, breaks, confidence, review rounds) "
+        "as evidence for the lesson.\n"
+    )
+
+
 def generate_reflection(
     prompt: str,
     response: str,
@@ -38,6 +49,7 @@ def generate_reflection(
     rationale: str = "",
     tools_used: Optional[list[str]] = None,
     model: str = JUDGE_MODEL,
+    metrics: Optional[dict] = None,
 ) -> tuple[str, str]:
     """
     Generate a reflection for a low-scoring interaction.
@@ -50,6 +62,7 @@ def generate_reflection(
         score=score,
         dims=json.dumps(dims or {}),
         rationale=rationale or "no rationale provided",
+        metrics_section=_format_metrics_section(metrics),
     )
 
     text = generate(formatted, model=model)
@@ -63,7 +76,7 @@ User: {prompt}
 Assistant: {response}
 Tools: {tools}
 Score: {score:.2f}/1.0 | Breakdown: {dims} | Rationale: {rationale}
-
+{metrics_section}
 Style patterns to look for: naming conventions, code structure preferences, \
 library/framework choices, response formatting and tone, comment style, \
 error handling approach, type usage patterns.
@@ -84,6 +97,7 @@ def generate_positive_reflection(
     rationale: str = "",
     tools_used: Optional[list[str]] = None,
     model: str = JUDGE_MODEL,
+    metrics: Optional[dict] = None,
 ) -> tuple[str, str]:
     """
     Generate a positive pattern reflection for a high-scoring interaction.
@@ -96,6 +110,7 @@ def generate_positive_reflection(
         score=score,
         dims=json.dumps(dims or {}),
         rationale=rationale or "no rationale provided",
+        metrics_section=_format_metrics_section(metrics),
     )
 
     text = generate(formatted, model=model)

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -59,8 +59,14 @@ class StorageProvider(ABC):
         has_code: Optional[int] = None,
         tool_calls: Optional[str] = None,
         available_tools: Optional[str] = None,
+        metrics: Optional[str] = None,
     ) -> str:
-        """Persist one agent interaction. Returns the interaction ID."""
+        """Persist one agent interaction. Returns the interaction ID.
+
+        When a row with the same ID already exists, all fields are overwritten
+        EXCEPT metrics: a None metrics value preserves any previously stored
+        metrics (COALESCE upsert), so post-hoc metric updates survive re-logging.
+        """
         ...
 
     @abstractmethod
@@ -97,6 +103,22 @@ class StorageProvider(ABC):
     @abstractmethod
     def count_interactions(self, **filters) -> int:
         """Count interactions matching the given filters."""
+        ...
+
+    @abstractmethod
+    def get_metrics_rows(
+        self,
+        *,
+        group_folder: Optional[str] = None,
+        days: int = 30,
+        limit: int = 1000,
+    ) -> list[dict]:
+        """Fetch interactions that have non-null metrics within the last N days.
+
+        Returns rows with keys: id, timestamp, group_folder, metrics (raw JSON
+        string), judge_score. Ordered by timestamp ascending so trend consumers
+        can iterate chronologically.
+        """
         ...
 
     # ── Score trend ──────────────────────────────────────────────────────────

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -44,6 +44,7 @@ _UPDATABLE_INTERACTION_COLS = frozenset({
     "user_signal",
     "correction_mined_at",
     "judge_schema_version",
+    "metrics",
 })
 
 # Guard against concurrent schema migrations from multiple threads
@@ -270,6 +271,7 @@ class SQLiteStorageProvider(StorageProvider):
             # JSON array of the OFFERED tool manifest per dispatch (LIA-154
             # observability; no live consumer — unblocks LIA-151 ground truth).
             ("available_tools", "TEXT"),
+            ("metrics", "TEXT"),  # JSON: generic per-task metrics (added in v1.7)
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list
@@ -333,21 +335,42 @@ class SQLiteStorageProvider(StorageProvider):
         has_code: Optional[int] = None,
         tool_calls: Optional[str] = None,
         available_tools: Optional[str] = None,
+        metrics: Optional[str] = None,
     ) -> str:
         db = self._connect()
+        # Upsert instead of INSERT OR REPLACE: REPLACE deletes the existing row
+        # (clobbering judge_score/judge_dims and firing ON DELETE CASCADE on
+        # reflections). DO UPDATE keeps unlisted columns intact, and metrics
+        # uses COALESCE so a None re-log preserves post-hoc metric updates.
         db.execute(
             """
-            INSERT OR REPLACE INTO interactions
+            INSERT INTO interactions
                 (id, timestamp, group_folder, prompt, response, tools_used,
                  latency_ms, eval_suite, session_id, domain_presets, user_signal,
-                 context_tokens, has_code, tool_calls, available_tools)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 context_tokens, has_code, tool_calls, available_tools, metrics)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                timestamp       = excluded.timestamp,
+                group_folder    = excluded.group_folder,
+                prompt          = excluded.prompt,
+                response        = excluded.response,
+                tools_used      = excluded.tools_used,
+                latency_ms      = excluded.latency_ms,
+                eval_suite      = excluded.eval_suite,
+                session_id      = excluded.session_id,
+                domain_presets  = excluded.domain_presets,
+                user_signal     = excluded.user_signal,
+                context_tokens  = excluded.context_tokens,
+                has_code        = excluded.has_code,
+                tool_calls      = excluded.tool_calls,
+                available_tools = excluded.available_tools,
+                metrics         = COALESCE(excluded.metrics, interactions.metrics)
             """,
             (
                 interaction_id, timestamp, group_folder, prompt, response,
                 tools_used, latency_ms, eval_suite, session_id,
                 domain_presets, user_signal, context_tokens, has_code,
-                tool_calls, available_tools,
+                tool_calls, available_tools, metrics,
             ),
         )
         db.commit()
@@ -463,6 +486,38 @@ class SQLiteStorageProvider(StorageProvider):
         ).fetchone()[0]
         db.close()
         return count
+
+    def get_metrics_rows(
+        self,
+        *,
+        group_folder: Optional[str] = None,
+        days: int = 30,
+        limit: int = 1000,
+    ) -> list[dict]:
+        db = self._connect()
+        params: list = []
+        extra_clauses = ""
+        if group_folder:
+            extra_clauses += " AND group_folder = ?"
+            params.append(group_folder)
+        # See score_trend for the same int-coerce + clamp rationale.
+        days_clamped = max(1, int(days))
+        # safe: days_clamped is a clamped int; extra_clauses built from
+        # local literal strings above. User values bound via params.
+        rows = db.execute(
+            f"""
+            SELECT id, timestamp, group_folder, metrics, judge_score
+            FROM interactions
+            WHERE metrics IS NOT NULL
+              AND timestamp >= DATETIME('now', '-{days_clamped} days')
+              {extra_clauses}
+            ORDER BY timestamp ASC
+            LIMIT ?
+            """,
+            params + [limit],
+        ).fetchall()
+        db.close()
+        return [dict(r) for r in rows]
 
     # ── Score trend ──────────────────────────────────────────────────────────
 

--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -679,6 +679,165 @@ def test_cmd_log_interaction_outputs_error_json_on_invalid_input(capsys):
     assert "error" in output
 
 
+# ── Metrics commands ──────────────────────────────────────────────────────────
+
+
+def test_cmd_log_interaction_stores_metrics(mock_judge, mock_embed, mock_reflection_generator):
+    """A metrics dict in the payload should be persisted as JSON."""
+    from evolution.cli import cmd_log_interaction
+
+    iid = "test-iid-metrics"
+    payload = json.dumps({
+        "id": iid,
+        "prompt": "Run tests",
+        "response": "12 passed",
+        "group_folder": "g",
+        "metrics": {"tests_passed": 12, "breaks": ["expected"]},
+    })
+    cmd_log_interaction(payload)
+
+    conn = open_db()
+    row = conn.execute("SELECT metrics FROM interactions WHERE id = ?", [iid]).fetchone()
+    conn.close()
+    assert json.loads(row["metrics"]) == {"tests_passed": 12, "breaks": ["expected"]}
+
+
+def test_cmd_log_interaction_invalid_metrics_dropped_not_fatal(
+    mock_judge, mock_embed, mock_reflection_generator
+):
+    """Malformed metrics must not lose the interaction (fire-and-forget path)."""
+    from evolution.cli import cmd_log_interaction
+
+    iid = "test-iid-bad-metrics"
+    payload = json.dumps({
+        "id": iid,
+        "prompt": "p",
+        "response": "r",
+        "group_folder": "g",
+        "metrics": {"nested": {"a": 1}},
+    })
+    cmd_log_interaction(payload)
+
+    conn = open_db()
+    row = conn.execute(
+        "SELECT id, metrics FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row is not None, "interaction must survive an invalid metrics payload"
+    assert row["metrics"] is None
+
+
+def test_cmd_log_metrics_posthoc_merge(mock_judge, mock_embed, mock_reflection_generator, capsys):
+    """cmd_log_metrics merges over previously stored metrics."""
+    from evolution.cli import cmd_log_interaction, cmd_log_metrics
+
+    iid = "test-iid-posthoc"
+    cmd_log_interaction(json.dumps({
+        "id": iid, "prompt": "p", "response": "r", "group_folder": "g",
+        "metrics": {"tests_passed": 3},
+    }))
+    capsys.readouterr()  # discard log_interaction output
+
+    cmd_log_metrics(json.dumps({
+        "interaction_id": iid,
+        "metrics": {"warden_rounds": 2},
+    }))
+    output = json.loads(capsys.readouterr().out.strip().split("\n")[-1])
+    assert output["status"] == "ok"
+    assert output["metrics"] == {"tests_passed": 3, "warden_rounds": 2}
+
+
+def test_cmd_log_metrics_missing_interaction_errors(capsys):
+    from evolution.cli import cmd_log_metrics
+
+    cmd_log_metrics(json.dumps({"interaction_id": "nope", "metrics": {"tests_passed": 1}}))
+    output = json.loads(capsys.readouterr().out.strip())
+    assert "error" in output
+
+
+def test_cmd_log_metrics_invalid_json_errors(capsys):
+    from evolution.cli import cmd_log_metrics
+
+    cmd_log_metrics("{broken")
+    output = json.loads(capsys.readouterr().out.strip())
+    assert output["error"] == "Invalid JSON"
+
+
+def _seed_metrics_interaction(iid, metrics, judge_score=None, group_folder="g"):
+    """Insert a metrics-bearing interaction with a current timestamp."""
+    from datetime import datetime, timezone
+    from evolution.storage import get_storage
+
+    store = get_storage()
+    store.log_interaction(
+        prompt="p", response="r", group_folder=group_folder,
+        timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        interaction_id=iid, metrics=json.dumps(metrics),
+    )
+    if judge_score is not None:
+        store.update_interaction(iid, judge_score=judge_score)
+
+
+def test_cmd_metrics_summary_json(capsys):
+    from evolution.cli import cmd_metrics
+
+    _seed_metrics_interaction("ms1", {"tests_passed": 2})
+    _seed_metrics_interaction("ms2", {"tests_passed": 4})
+    cmd_metrics("summary", as_json=True)
+    result = json.loads(capsys.readouterr().out)
+    assert result["interactions"] == 2
+    assert result["keys"]["tests_passed"]["mean"] == 3
+
+
+def test_cmd_metrics_trend_requires_key(capsys):
+    from evolution.cli import cmd_metrics
+
+    with pytest.raises(SystemExit):
+        cmd_metrics("trend")
+    output = json.loads(capsys.readouterr().out.strip())
+    assert "error" in output
+
+
+def test_cmd_metrics_trend_json(capsys):
+    from evolution.cli import cmd_metrics
+
+    _seed_metrics_interaction("mt1", {"tests_passed": 6})
+    cmd_metrics("trend", key="tests_passed", as_json=True)
+    result = json.loads(capsys.readouterr().out)
+    assert len(result) == 1
+    assert result[0]["avg"] == 6
+
+
+def test_cmd_metrics_calibration_json(capsys):
+    from evolution.cli import cmd_metrics
+
+    _seed_metrics_interaction("mc1", {"confidence": 0.9}, judge_score=0.7)
+    cmd_metrics("calibration", as_json=True)
+    result = json.loads(capsys.readouterr().out)
+    assert result["n"] == 1
+    assert result["buckets"][0]["band"] == "high"
+
+
+def test_cmd_metrics_breaks_json(capsys):
+    from evolution.cli import cmd_metrics
+
+    _seed_metrics_interaction("mb1", {"breaks": ["regression", "expected"]})
+    cmd_metrics("breaks", as_json=True)
+    result = json.loads(capsys.readouterr().out)
+    assert result["by_category"] == {"regression": 1, "expected": 1}
+
+
+def test_cmd_metrics_human_readable_output(capsys):
+    from evolution.cli import cmd_metrics
+
+    _seed_metrics_interaction("mh1", {"tests_passed": 5, "task_type": "feature"})
+    cmd_metrics("summary")
+    out = capsys.readouterr().out
+    assert "Metrics Summary" in out
+    assert "tests_passed" in out
+    assert "feature" in out
+
+
 # ── main() dispatch tests ─────────────────────────────────────────────────────
 
 

--- a/evolution/tests/test_interaction_log.py
+++ b/evolution/tests/test_interaction_log.py
@@ -96,6 +96,39 @@ def test_log_interaction_stores_user_signal():
     assert row["user_signal"] == "positive"
 
 
+def test_log_interaction_stores_metrics():
+    iid = log_interaction(
+        prompt="Run the tests",
+        response="12 passed",
+        group_folder="g",
+        metrics={"tests_passed": 12, "breaks": ["expected"]},
+    )
+    conn = open_db()
+    row = conn.execute(
+        "SELECT metrics FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert json.loads(row["metrics"]) == {"tests_passed": 12, "breaks": ["expected"]}
+
+
+def test_log_interaction_without_metrics_stores_null():
+    iid = log_interaction(prompt="p", response="r", group_folder="g")
+    conn = open_db()
+    row = conn.execute(
+        "SELECT metrics FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row["metrics"] is None
+
+
+def test_log_interaction_rejects_invalid_metrics():
+    with pytest.raises(ValueError, match="scalar"):
+        log_interaction(
+            prompt="p", response="r", group_folder="g",
+            metrics={"nested": {"a": 1}},
+        )
+
+
 def test_update_score_writes_score_and_dims():
     iid = log_interaction(prompt="Test", response="Resp", group_folder="g")
     dims = {"quality": 0.9, "safety": 1.0, "tool_use": 0.8, "personalization": 0.7}

--- a/evolution/tests/test_metrics.py
+++ b/evolution/tests/test_metrics.py
@@ -1,0 +1,317 @@
+"""Tests for evolution.metrics — validation, post-hoc updates, and analysis."""
+import json
+import logging
+
+import pytest
+
+import evolution.config as config_mod
+import evolution.db as db_mod
+import evolution.metrics as metrics_mod
+from evolution.metrics import (
+    MAX_METRICS_BYTES,
+    break_report,
+    confidence_calibration,
+    fetch_metrics_rows,
+    metric_trend,
+    parse_metrics,
+    summarize_metrics,
+    update_metrics,
+    validate_metrics,
+)
+from evolution.storage.provider import StorageRegistry
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sqlite_store(tmp_path, monkeypatch):
+    """Point the default sqlite provider at a temp DB and return it."""
+    test_db = tmp_path / "test_metrics.db"
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(db_mod, "EVOLUTION_DB_PATH", test_db)
+    monkeypatch.setattr(config_mod, "DB_PATH", tmp_path / "nonexistent_legacy.db")
+    from evolution.storage import get_storage
+    return get_storage("sqlite")
+
+
+def _row(metrics=None, judge_score=None, timestamp="2026-06-10T10:00:00Z",
+         group_folder="g", iid="i1"):
+    """Row shaped like get_metrics_rows() output, for the PURE analysis
+    functions only — these never hit the DB time-window filter, so the fixed
+    timestamp keeps trend-day assertions deterministic. DB-backed tests that
+    go through get_metrics_rows must seed with datetime.now() timestamps."""
+    return {
+        "id": iid,
+        "timestamp": timestamp,
+        "group_folder": group_folder,
+        "metrics": json.dumps(metrics) if metrics is not None else None,
+        "judge_score": judge_score,
+    }
+
+
+# ── validate_metrics ──────────────────────────────────────────────────────────
+
+
+class TestValidateMetrics:
+    def test_accepts_scalars(self):
+        m = {"tests_passed": 3, "confidence": 0.8, "task_type": "feature"}
+        assert validate_metrics(m) is m
+
+    def test_accepts_list_of_scalars(self):
+        m = {"breaks": ["regression", "expected"]}
+        assert validate_metrics(m) is m
+
+    def test_accepts_empty_dict(self):
+        assert validate_metrics({}) == {}
+
+    def test_rejects_non_dict(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            validate_metrics([1, 2])
+
+    def test_rejects_non_string_key(self):
+        with pytest.raises(ValueError, match="keys must be strings"):
+            validate_metrics({3: "x"})
+
+    def test_rejects_nested_object(self):
+        with pytest.raises(ValueError, match="scalar"):
+            validate_metrics({"tests_passed": {"unit": 3}})
+
+    def test_rejects_list_of_objects(self):
+        with pytest.raises(ValueError, match="lists may only contain scalars"):
+            validate_metrics({"breaks": [{"category": "regression"}]})
+
+    def test_rejects_none_value(self):
+        with pytest.raises(ValueError, match="scalar"):
+            validate_metrics({"tests_passed": None})
+
+    def test_rejects_oversized_payload(self):
+        m = {"task_type": "x" * MAX_METRICS_BYTES}
+        with pytest.raises(ValueError, match="max is"):
+            validate_metrics(m)
+
+    def test_unknown_key_warns_but_accepts(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="evolution.metrics"):
+            validate_metrics({"my_custom_metric": 1})
+        assert "WELL_KNOWN_METRICS" in caplog.text
+
+    def test_known_key_does_not_warn(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="evolution.metrics"):
+            validate_metrics({"tests_passed": 1})
+        assert caplog.text == ""
+
+
+# ── parse_metrics ─────────────────────────────────────────────────────────────
+
+
+class TestParseMetrics:
+    def test_parses_valid_json(self):
+        assert parse_metrics('{"x": 1}') == {"x": 1}
+
+    def test_none_and_empty_return_none(self):
+        assert parse_metrics(None) is None
+        assert parse_metrics("") is None
+
+    def test_invalid_json_returns_none(self):
+        assert parse_metrics("{not json") is None
+
+    def test_non_object_json_returns_none(self):
+        assert parse_metrics("[1, 2]") is None
+
+
+# ── update_metrics (post-hoc path, sqlite-backed) ─────────────────────────────
+
+
+class TestUpdateMetrics:
+    def test_merge_over_existing(self, sqlite_store):
+        sqlite_store.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2026-06-10T10:00:00Z", interaction_id="u1",
+            metrics='{"tests_passed": 3}',
+        )
+        final = update_metrics("u1", {"warden_rounds": 2})
+        assert final == {"tests_passed": 3, "warden_rounds": 2}
+        row = sqlite_store.get_interaction("u1")
+        assert json.loads(row["metrics"]) == final
+
+    def test_merge_new_key_wins(self, sqlite_store):
+        sqlite_store.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2026-06-10T10:00:00Z", interaction_id="u2",
+            metrics='{"confidence": 0.5}',
+        )
+        final = update_metrics("u2", {"confidence": 0.9})
+        assert final == {"confidence": 0.9}
+
+    def test_replace_mode(self, sqlite_store):
+        sqlite_store.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2026-06-10T10:00:00Z", interaction_id="u3",
+            metrics='{"tests_passed": 3}',
+        )
+        final = update_metrics("u3", {"warden_rounds": 1}, merge=False)
+        assert final == {"warden_rounds": 1}
+        row = sqlite_store.get_interaction("u3")
+        assert json.loads(row["metrics"]) == {"warden_rounds": 1}
+
+    def test_on_interaction_without_metrics(self, sqlite_store):
+        sqlite_store.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2026-06-10T10:00:00Z", interaction_id="u4",
+        )
+        final = update_metrics("u4", {"tests_passed": 1})
+        assert final == {"tests_passed": 1}
+
+    def test_missing_interaction_raises(self, sqlite_store):
+        with pytest.raises(ValueError, match="not found"):
+            update_metrics("nope", {"tests_passed": 1})
+
+    def test_invalid_metrics_raise_before_write(self, sqlite_store):
+        with pytest.raises(ValueError):
+            update_metrics("irrelevant", {"nested": {"a": 1}})
+
+    def test_merged_payload_size_enforced(self, sqlite_store):
+        big = "x" * (MAX_METRICS_BYTES // 2)
+        sqlite_store.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp="2026-06-10T10:00:00Z", interaction_id="u5",
+            metrics=json.dumps({"task_type": big}),
+        )
+        with pytest.raises(ValueError, match="max is"):
+            update_metrics("u5", {"my_other_blob": "y" * (MAX_METRICS_BYTES // 2 + 100)})
+
+    def test_fetch_metrics_rows_roundtrip(self, sqlite_store):
+        from datetime import datetime, timezone
+        sqlite_store.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            interaction_id="u6", metrics='{"tests_passed": 5}',
+        )
+        rows = fetch_metrics_rows(days=7)
+        assert [r["id"] for r in rows] == ["u6"]
+
+
+# ── summarize_metrics ─────────────────────────────────────────────────────────
+
+
+class TestSummarizeMetrics:
+    def test_numeric_summary(self):
+        rows = [
+            _row({"tests_passed": 2}, iid="a"),
+            _row({"tests_passed": 4}, iid="b"),
+        ]
+        result = summarize_metrics(rows)
+        assert result["interactions"] == 2
+        tp = result["keys"]["tests_passed"]
+        assert tp["type"] == "numeric"
+        assert tp["count"] == 2
+        assert tp["mean"] == 3
+        assert tp["min"] == 2
+        assert tp["max"] == 4
+        assert tp["sum"] == 6
+
+    def test_categorical_and_list_values(self):
+        rows = [
+            _row({"task_type": "feature", "breaks": ["regression", "expected"]}, iid="a"),
+            _row({"task_type": "feature", "breaks": ["regression"]}, iid="b"),
+        ]
+        result = summarize_metrics(rows)
+        assert result["keys"]["task_type"]["values"] == {"feature": 2}
+        assert result["keys"]["breaks"]["values"] == {"regression": 2, "expected": 1}
+
+    def test_bool_is_categorical(self):
+        result = summarize_metrics([_row({"my_flag": True})])
+        assert result["keys"]["my_flag"]["type"] == "categorical"
+
+    def test_key_filter(self):
+        rows = [_row({"tests_passed": 1, "confidence": 0.5})]
+        result = summarize_metrics(rows, key="confidence")
+        assert list(result["keys"]) == ["confidence"]
+
+    def test_unparseable_rows_skipped(self):
+        rows = [{"id": "x", "timestamp": "t", "group_folder": "g",
+                 "metrics": "{broken", "judge_score": None}]
+        result = summarize_metrics(rows)
+        assert result["interactions"] == 0
+        assert result["keys"] == {}
+
+
+# ── metric_trend ──────────────────────────────────────────────────────────────
+
+
+class TestMetricTrend:
+    def test_daily_averages_sorted(self):
+        rows = [
+            _row({"tests_passed": 2}, timestamp="2026-06-09T08:00:00Z", iid="a"),
+            _row({"tests_passed": 4}, timestamp="2026-06-09T18:00:00Z", iid="b"),
+            _row({"tests_passed": 6}, timestamp="2026-06-10T08:00:00Z", iid="c"),
+        ]
+        trend = metric_trend(rows, "tests_passed")
+        assert trend == [
+            {"day": "2026-06-09", "avg": 3, "count": 2},
+            {"day": "2026-06-10", "avg": 6, "count": 1},
+        ]
+
+    def test_non_numeric_values_skipped(self):
+        rows = [_row({"tests_passed": "lots"})]
+        assert metric_trend(rows, "tests_passed") == []
+
+    def test_missing_key_yields_empty(self):
+        rows = [_row({"confidence": 0.5})]
+        assert metric_trend(rows, "tests_passed") == []
+
+
+# ── confidence_calibration ────────────────────────────────────────────────────
+
+
+class TestConfidenceCalibration:
+    def test_bands_and_gap(self):
+        rows = [
+            _row({"confidence": 0.9}, judge_score=0.7, iid="a"),
+            _row({"confidence": 1.0}, judge_score=0.8, iid="b"),
+            _row({"confidence": 0.3}, judge_score=0.6, iid="c"),
+        ]
+        result = confidence_calibration(rows)
+        assert result["n"] == 3
+        bands = {b["band"]: b for b in result["buckets"]}
+        assert bands["high"]["n"] == 2  # 1.0 lands in "high" via epsilon
+        assert bands["high"]["gap"] == pytest.approx(0.95 - 0.75)
+        assert bands["low"]["n"] == 1
+        assert bands["low"]["gap"] == pytest.approx(0.3 - 0.6)
+        assert result["overall_gap"] == pytest.approx((0.2 + 0.2 - 0.3) / 3)
+
+    def test_rows_without_judge_score_excluded(self):
+        rows = [_row({"confidence": 0.9}, judge_score=None)]
+        result = confidence_calibration(rows)
+        assert result["n"] == 0
+        assert result["overall_gap"] is None
+        assert result["buckets"] == []
+
+
+# ── break_report ──────────────────────────────────────────────────────────────
+
+
+class TestBreakReport:
+    def test_counts_by_category(self):
+        rows = [
+            _row({"breaks": ["regression", "expected"]}, iid="a"),
+            _row({"breaks": ["regression"]}, iid="b"),
+            _row({"tests_passed": 3}, iid="c"),
+        ]
+        result = break_report(rows)
+        assert result["interactions"] == 3
+        assert result["interactions_with_breaks"] == 2
+        assert result["total_breaks"] == 3
+        assert result["by_category"] == {"regression": 2, "expected": 1}
+
+    def test_bare_string_treated_as_single_category(self):
+        result = break_report([_row({"breaks": "suspicious"})])
+        assert result["by_category"] == {"suspicious": 1}
+
+    def test_unknown_categories_still_counted(self):
+        result = break_report([_row({"breaks": ["flaky-env"]})])
+        assert result["by_category"] == {"flaky-env": 1}
+
+    def test_empty_breaks_list_not_counted(self):
+        result = break_report([_row({"breaks": []})])
+        assert result["interactions_with_breaks"] == 0

--- a/evolution/tests/test_reflexion_generator.py
+++ b/evolution/tests/test_reflexion_generator.py
@@ -52,3 +52,46 @@ def test_extract_category(text: str, expected: str) -> None:
 )
 def test_extract_positive_category(text: str, expected: str) -> None:
     assert _extract_positive_category(text) == expected
+
+
+# ── Metrics in the prompt template ────────────────────────────────────────────
+
+
+@pytest.fixture
+def capture_prompt(monkeypatch):
+    """Replace the LLM call with a capture that returns a fixed reflection."""
+    captured = []
+
+    def fake_generate(prompt, **kwargs):
+        captured.append(prompt)
+        return "- What went wrong: x\n- Next time: y\n- Category: reasoning"
+
+    monkeypatch.setattr("evolution.reflexion.generator.generate", fake_generate)
+    return captured
+
+
+def test_generate_reflection_includes_metrics(capture_prompt):
+    from evolution.reflexion.generator import generate_reflection
+
+    generate_reflection(
+        prompt="p", response="r", score=0.3,
+        metrics={"tests_failed": 2, "breaks": ["regression"]},
+    )
+    assert 'Task metrics: {"tests_failed": 2, "breaks": ["regression"]}' in capture_prompt[0]
+
+
+def test_generate_reflection_without_metrics_has_no_section(capture_prompt):
+    from evolution.reflexion.generator import generate_reflection
+
+    generate_reflection(prompt="p", response="r", score=0.3)
+    assert "Task metrics" not in capture_prompt[0]
+
+
+def test_generate_positive_reflection_includes_metrics(capture_prompt):
+    from evolution.reflexion.generator import generate_positive_reflection
+
+    generate_positive_reflection(
+        prompt="p", response="r", score=0.9,
+        metrics={"tests_passed": 12},
+    )
+    assert 'Task metrics: {"tests_passed": 12}' in capture_prompt[0]

--- a/evolution/tests/test_storage_provider.py
+++ b/evolution/tests/test_storage_provider.py
@@ -1,6 +1,7 @@
 """Tests for the StorageProvider / StorageRegistry pattern and SQLite implementation."""
 import os
 import struct
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from unittest.mock import patch
 
@@ -43,6 +44,7 @@ class FakeStorageProvider(StorageProvider):
     def update_interaction(self, *a, **kw): ...
     def get_interaction(self, *a): ...
     def get_recent_interactions(self, **kw): return []
+    def get_metrics_rows(self, **kw): return []
     def get_previous_in_session(self, *a): ...
     def count_interactions(self, **kw): return 0
     def score_trend(self, **kw): return []
@@ -321,6 +323,123 @@ class TestSQLiteInteractionCRUD:
         )
         assert sqlite_provider.count_interactions(eval_suite="runtime") == 1
         assert sqlite_provider.count_interactions(eval_suite="backfill") == 0
+
+
+class TestSQLiteMetrics:
+    @staticmethod
+    def _ts(days_ago: int = 0) -> str:
+        return (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    def test_log_interaction_persists_metrics(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m1",
+            metrics='{"tests_passed": 12}',
+        )
+        row = sqlite_provider.get_interaction("m1")
+        assert row["metrics"] == '{"tests_passed": 12}'
+
+    def test_relog_without_metrics_preserves_existing(self, sqlite_provider):
+        """COALESCE upsert: a None re-log must not clobber post-hoc metrics."""
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m2",
+            metrics='{"breaks": 2}',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p2", response="r2", group_folder="g",
+            timestamp=self._ts(), interaction_id="m2",
+        )
+        row = sqlite_provider.get_interaction("m2")
+        assert row["metrics"] == '{"breaks": 2}'
+        assert row["prompt"] == "p2"  # non-metrics columns still overwritten
+
+    def test_relog_with_metrics_overwrites(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m3",
+            metrics='{"v": 1}',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m3",
+            metrics='{"v": 2}',
+        )
+        row = sqlite_provider.get_interaction("m3")
+        assert row["metrics"] == '{"v": 2}'
+
+    def test_relog_preserves_judge_score(self, sqlite_provider):
+        """DO UPDATE (unlike INSERT OR REPLACE) keeps columns absent from the upsert."""
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m4",
+        )
+        sqlite_provider.update_interaction("m4", judge_score=0.9)
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m4",
+        )
+        row = sqlite_provider.get_interaction("m4")
+        assert row["judge_score"] is not None
+        assert abs(row["judge_score"] - 0.9) < 1e-5
+
+    def test_update_interaction_accepts_metrics(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m5",
+        )
+        sqlite_provider.update_interaction("m5", metrics='{"confidence": 0.8}')
+        row = sqlite_provider.get_interaction("m5")
+        assert row["metrics"] == '{"confidence": 0.8}'
+
+    def test_get_metrics_rows_skips_null_metrics(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m6",
+            metrics='{"x": 1}',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="m7",
+        )
+        rows = sqlite_provider.get_metrics_rows()
+        assert [r["id"] for r in rows] == ["m6"]
+        assert set(rows[0]) == {"id", "timestamp", "group_folder", "metrics", "judge_score"}
+
+    def test_get_metrics_rows_filters_group_and_days(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="a",
+            timestamp=self._ts(), interaction_id="m8",
+            metrics='{"x": 1}',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="b",
+            timestamp=self._ts(), interaction_id="m9",
+            metrics='{"x": 2}',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="a",
+            timestamp=self._ts(days_ago=60), interaction_id="m10",
+            metrics='{"x": 3}',
+        )
+        rows = sqlite_provider.get_metrics_rows(group_folder="a", days=30)
+        assert [r["id"] for r in rows] == ["m8"]
+
+    def test_get_metrics_rows_ordered_ascending(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(days_ago=2), interaction_id="m11",
+            metrics='{"x": 1}',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(days_ago=1), interaction_id="m12",
+            metrics='{"x": 2}',
+        )
+        rows = sqlite_provider.get_metrics_rows(days=7)
+        assert [r["id"] for r in rows] == ["m11", "m12"]
 
 
 class TestSQLiteReflectionCRUD:

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-09" # auto-bump @1780997087 (re-verified: LIA-154 available_tools)
+last_verified: "2026-06-10"
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-09" # auto-bump @1781032993 (re-verified: LIA-197 odysseus channel)
+last_verified: "2026-06-10"
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary

Adds a generic, schemaless metrics tracking layer to the evolution system so any task can attach measured outcomes (test counts, break categories, confidence, review rounds) to logged interactions — and the reflection loop can learn from them.

Plan was warden-approved (plan-reviewer SHIP after 3 rounds); implementation reviewed by code-reviewer (SHIP). Rebased onto current main — integrates cleanly with the LIA-154 tool-call observability columns (`log_interaction` upsert now covers `tool_calls` / `available_tools` too).

## Changes

- **Storage** (`sqlite.py`, `provider.py`): new `metrics TEXT` column via the established ALTER TABLE pattern; `INSERT OR REPLACE` replaced with `ON CONFLICT(id) DO UPDATE` using `COALESCE(excluded.metrics, interactions.metrics)` — a None re-log preserves post-hoc metrics, and (unlike REPLACE) re-logging no longer clobbers `judge_score` or cascade-deletes reflections. `"metrics"` added to the `_UPDATABLE_INTERACTION_COLS` allow-list. New `get_metrics_rows()`.
- **New `evolution/metrics.py`**: `validate_metrics` (flat dicts only — scalars or lists of scalars, 16KB cap), soft `WELL_KNOWN_METRICS` registry (warns on unknown keys, never rejects), `update_metrics(merge=True)` post-hoc path, and pure analysis functions: `summarize_metrics`, `metric_trend`, `confidence_calibration`, `break_report`.
- **Pipeline**: `interaction_log.py` validates + serializes; `cli.py` adds metrics passthrough (invalid metrics are dropped with a warning on the fire-and-forget host path — never lose the interaction), plus `log_metrics` and `metrics summary|trend|calibration|breaks` subcommands; `mcp_server.py` adds the metrics param plus `log_metrics_tool` and `get_metrics_summary_tool`.
- **Reflections see metrics, judge does not** (anti-gaming): `generator.py` prompt templates get a `Task metrics:` evidence section; wired through both `mcp_server._async_judge_and_reflect` and `maintenance._reflect_single`. `_score_single` and the judge path are untouched.
- `backfill.py` / `cc_backfill.py` intentionally unchanged — historical interactions have no metrics (default None).

## Tests

54 new tests (storage upsert semantics incl. judge-score preservation regression test, validation, merge, all four analysis functions, CLI commands, prompt injection). Full evolution suite after rebase: **569 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)