### PR TITLE
fix(scheduler): reject empty/whitespace cron expressions (LIA-201)

### DIFF
--- a/container/agent-runner/src/schedule-validator.ts
+++ b/container/agent-runner/src/schedule-validator.ts
@@ -23,13 +23,15 @@ export function validateSchedule(
   const { schedule_type, schedule_value, target_group_jid } = input;
 
   if (schedule_type === 'cron') {
+    // cron-parser silently accepts empty/whitespace strings; guard before parse.
+    const invalidCron = `Invalid cron: "${schedule_value}". Use format like "0 9 * * *" or "*/5 * * * *".`;
+    if (!schedule_value.trim()) {
+      return { ok: false, error: invalidCron };
+    }
     try {
       CronExpressionParser.parse(schedule_value);
     } catch {
-      return {
-        ok: false,
-        error: `Invalid cron: "${schedule_value}". Use format like "0 9 * * *" or "*/5 * * * *".`,
-      };
+      return { ok: false, error: invalidCron };
     }
   } else if (schedule_type === 'interval') {
     const ms = parseInt(schedule_value, 10);


### PR DESCRIPTION
## Problem

`validateSchedule` in `container/agent-runner/src/schedule-validator.ts` called `CronExpressionParser.parse(schedule_value)` to validate cron schedules — but `cron-parser` does **not** throw on an empty or whitespace-only string. So a `schedule_type: 'cron'` with `schedule_value: ''` passed validation and would produce a broken schedule entry at runtime.

## Fix

An explicit `if (!schedule_value.trim())` guard before the parse, returning the same `Invalid cron` error (extracted to a shared `invalidCron` const so the guard and the parse-failure path can't drift).

## Tests / verification
- The pre-existing test `schedule-validator.test.ts` → `rejects an empty cron expression` was **RED** before this fix (confirmed: `expect(result.ok).toBe(false)` failed) and is **green** after.
- Full suite: 13/13 (verification-gate independently confirmed).

Note: this is a `container/agent-runner` change — picked up on the next container rebuild.

Closes LIA-201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)