### PR TITLE
fix(pipeline): park errored gate's issue even when an exception is thrown (LIA-175)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-10"
+last_verified: "2026-06-10" # auto-bump @1781084247
 governs:
   - src/
   - evolution/

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -15,6 +15,7 @@ import {
   parseEnrichment,
   parseVerdict,
   gateTransitionAction,
+  parkErroredGateIssue,
   gateOutcomeEventType,
   parseRatings,
   mergeEnrichment,
@@ -365,6 +366,63 @@ Needs work.`),
 
   it('returns null when no verdict', () => {
     expect(parseVerdict('No verdict here.')).toBeNull();
+  });
+});
+
+describe('parkErroredGateIssue (LIA-175)', () => {
+  // Minimal LinearContext mock — the helper only touches stateByName + client.updateIssue.
+  function makeCtx(
+    updateIssue: ReturnType<typeof vi.fn>,
+    hasManualState = true,
+  ): Parameters<typeof parkErroredGateIssue>[0] {
+    const stateByName = new Map<string, { id: string; name: string }>();
+    if (hasManualState) {
+      stateByName.set('Manual Review Required', {
+        id: 'mrr-state-id',
+        name: 'Manual Review Required',
+      });
+    }
+    return {
+      stateByName,
+      client: { updateIssue },
+    } as unknown as Parameters<typeof parkErroredGateIssue>[0];
+  }
+
+  it('parks the issue in Manual Review Required when the state exists', async () => {
+    const updateIssue = vi.fn().mockResolvedValue(undefined);
+    await parkErroredGateIssue(
+      makeCtx(updateIssue),
+      'issue-1',
+      'bouncer-gate',
+      'test',
+    );
+    expect(updateIssue).toHaveBeenCalledWith('issue-1', {
+      stateId: 'mrr-state-id',
+    });
+  });
+
+  it('does NOT call updateIssue when the Manual Review Required state is absent', async () => {
+    const updateIssue = vi.fn().mockResolvedValue(undefined);
+    await parkErroredGateIssue(
+      makeCtx(updateIssue, false),
+      'issue-1',
+      'bouncer-gate',
+      'test',
+    );
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('swallows an updateIssue rejection without throwing (never masks the gate error)', async () => {
+    const updateIssue = vi.fn().mockRejectedValue(new Error('Linear 500'));
+    await expect(
+      parkErroredGateIssue(
+        makeCtx(updateIssue),
+        'issue-1',
+        'bouncer-gate',
+        'test',
+      ),
+    ).resolves.toBeUndefined();
+    expect(updateIssue).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -244,6 +244,40 @@ export function gateOutcomeEventType(
   return verdict === 'SHIP' ? 'gate_ship' : 'gate_revise';
 }
 
+/**
+ * Park an errored gate's issue in "Manual Review Required" (quiescent; nothing
+ * polls it). Must be called from a finally, not the try, so a thrown exception
+ * doesn't bypass it (LIA-175). Swallows its own errors — never rethrows over the
+ * original gate error.
+ */
+export async function parkErroredGateIssue(
+  ctx: LinearContext,
+  issueId: string,
+  gateName: string,
+  logPrefix: string,
+): Promise<void> {
+  try {
+    const manualState = ctx.stateByName.get('Manual Review Required');
+    if (manualState) {
+      await ctx.client.updateIssue(issueId, { stateId: manualState.id });
+      logger.info(
+        { issueId, gate: gateName },
+        `${logPrefix}: gate errored — moved to Manual Review Required`,
+      );
+    } else {
+      logger.warn(
+        { issueId, gate: gateName },
+        `${logPrefix}: Manual Review Required state not found — leaving issue in place`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      { issueId, err },
+      `${logPrefix}: failed to park errored gate issue in Manual Review Required`,
+    );
+  }
+}
+
 export function parseEnrichment(output: string): string | null {
   const match = output.match(/^## Enrichment\s*\n([\s\S]*?)(?=^## Verdict)/m);
   return match ? match[1].trim() : null;
@@ -1174,32 +1208,11 @@ async function handleIssueUpdate(
       verdict,
       gateDidError,
     );
-    if (transitionAction === 'halt') {
-      // LIA-169: gate errored — park in a quiescent state so no poller re-picks
-      // it (leaving it in "In Review" exposes it to sweepStaleInReview; "Manual
-      // Review Required" is polled by nothing). Warden: Error label is applied
-      // in the finally block.
-      try {
-        const manualState = ctx.stateByName.get('Manual Review Required');
-        if (manualState) {
-          await ctx.client.updateIssue(data.id, { stateId: manualState.id });
-          logger.info(
-            { issueId: data.id, gate: gateSpec.name },
-            'linear-webhook: gate errored — moved to Manual Review Required (halt)',
-          );
-        } else {
-          logger.warn(
-            { issueId: data.id, gate: gateSpec.name },
-            'linear-webhook: Manual Review Required state not found — leaving issue in place',
-          );
-        }
-      } catch (err) {
-        logger.warn(
-          { issueId: data.id, err },
-          'linear-webhook: failed to park errored gate issue in Manual Review Required',
-        );
-      }
-    } else if (transitionAction === 'revert') {
+    // LIA-175: the 'halt' (gate-errored) park now lives in the finally block,
+    // keyed on gateDidError, so it ALSO fires when an exception is caught below
+    // (gateTransitionAction returns 'halt' iff gateErrored, so this is
+    // behaviorally equivalent for the verdict-error case).
+    if (transitionAction === 'revert') {
       try {
         let revertStateId = fromStateId;
         let revertStateName = fromState.name;
@@ -1363,6 +1376,15 @@ async function handleIssueUpdate(
       if (safeRemoveIds.length > 0) update.removedLabelIds = safeRemoveIds;
       if (addIds.length > 0) update.addedLabelIds = addIds;
       retryLabelUpdate(ctx.client, data.id, update);
+    }
+
+    // LIA-175: park an errored gate's issue in a quiescent state. The inline
+    // halt-park only ran for verdict-errors inside the try; an EXCEPTION caught
+    // above skipped it, leaving the issue in "In Review" exposed to
+    // sweepStaleInReview. Runs concurrently with the fire-and-forget label
+    // update above — independent Linear calls, no ordering requirement.
+    if (gateDidError) {
+      await parkErroredGateIssue(ctx, data.id, gateSpec.name, 'linear-webhook');
     }
 
     // LIA-169: skip on gate error — the outer catch sets finalVerdict=REVISE +
@@ -1594,30 +1616,10 @@ async function runGateForIssue(
       verdict,
       gateAgentError,
     );
-    if (transitionAction === 'halt') {
-      // LIA-169: gate errored — park in Manual Review Required (quiescent; no
-      // poller re-picks it). Warden: Error label is applied in the finally block.
-      try {
-        const manualState = ctx.stateByName.get('Manual Review Required');
-        if (manualState) {
-          await ctx.client.updateIssue(issue.id, { stateId: manualState.id });
-          logger.info(
-            { issueId: issue.id, gate: gateSpec.name },
-            'startup-sweep: gate errored — moved to Manual Review Required (halt)',
-          );
-        } else {
-          logger.warn(
-            { issueId: issue.id, gate: gateSpec.name },
-            'startup-sweep: Manual Review Required state not found — leaving issue in place',
-          );
-        }
-      } catch (err) {
-        logger.warn(
-          { issueId: issue.id, err },
-          'startup-sweep: failed to park errored gate issue in Manual Review Required',
-        );
-      }
-    } else if (transitionAction === 'revert') {
+    // LIA-175: the 'halt' (gate-errored) park now lives in the finally block,
+    // keyed on gateAgentError, so it also covers the exception path. See
+    // handleIssueUpdate for the rationale.
+    if (transitionAction === 'revert') {
       if (gateSpec.revertTo) {
         const revertState = ctx.stateByName.get(gateSpec.revertTo);
         if (revertState) {
@@ -1742,6 +1744,12 @@ async function runGateForIssue(
       if (safeRemoveIds.length > 0) update.removedLabelIds = safeRemoveIds;
       if (addIds.length > 0) update.addedLabelIds = addIds;
       retryLabelUpdate(ctx.client, issue.id, update);
+    }
+
+    // LIA-175: park an errored gate's issue so an exception caught above doesn't
+    // leave it in "In Review". See handleIssueUpdate for the rationale.
+    if (gateAgentError) {
+      await parkErroredGateIssue(ctx, issue.id, gateSpec.name, 'startup-sweep');
     }
 
     // LIA-169: skip on gate error — see handleIssueUpdate; the outer catch sets


### PR DESCRIPTION
## Problem (safety)

When a gate evaluation **throws an exception**, the issue was left in **"In Review"** with only an error label — never parked in "Manual Review Required". `sweepStaleInReview` only skips `warden:skip` (confirmed `linear-auto-merge.ts:410-456`), so an errored-but-stuck issue is exposed to re-dispatch / auto-merge (phantom retry loops on infra failures).

Root cause: the inline park lived inside the `try` (`if (transitionAction === 'halt')`), so an exception jumped straight to the outer `catch` (which sets the error flag) and then the `finally` (which only applied the error label) — bypassing the park entirely. The same pattern existed in **both** gate functions (`handleIssueUpdate` and the startup-sweep gate).

## Fix

- Extract an exported `parkErroredGateIssue(ctx, issueId, gateName, logPrefix)` helper (gets the "Manual Review Required" state, `updateIssue`, logs; **swallows its own errors** so a park failure can never mask the original gate error).
- Remove the inline `transitionAction === 'halt'` park at both sites (the `revert` branch is preserved).
- Add a guarded `if (gateDidError)` / `if (gateAgentError)` park in **each `finally`**, after the label update.

**Why this is behaviorally equivalent + a strict superset:** `gateTransitionAction(mode, verdict, gateErrored)` returns `'halt'` **iff** `gateErrored` (src/linear-webhook.ts:228). So the finally-park fires exactly when the old inline halt-park did (verdict-error case) **plus** the previously-uncovered exception case. The `revert` path keeps `gateErrored=false`, so it is unaffected; the success path is unaffected.

## Tests / verification
- 3 new unit tests for `parkErroredGateIssue` (parks when state present; no-op + warn when absent; swallows an `updateIssue` rejection without throwing).
- `npm run build` clean; `npx vitest run src/linear-webhook.test.ts` 74/74. Verification-gate independently confirmed zero remaining `transitionAction === 'halt'` park blocks and that the pre-merge-check gate (~line 577) is untouched.
- ai-eng-warden: SHIP — pure state-transition control-flow, zero LLM surface.

Closes LIA-175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)