### PR TITLE
docs: fix stale references in ADR, SPEC, and QUALITY_GRADES (#723, #724, #725)

### DIFF
--- a/docs/QUALITY_GRADES.md
+++ b/docs/QUALITY_GRADES.md
@@ -8,9 +8,9 @@ Per-subsystem health at a glance. Updated manually or by the doc-gardening agent
 |-----------|-------|-------------|----------|---------------|
 | Memory tree | B | 2026-05-16 | Atom fallback disabled pending benchmark | [atom-fallback-evaluation](decisions/atom-fallback-evaluation.md) |
 | Scheduler/cron | A | 2026-05-16 | -- | -- |
-| Warden gates | B | 2026-06-01 | No remediation instructions | -- |
-| Backends (Claude/OpenAI) | B | 2026-06-01 | Codex hook parity open | [AAG-010](agent-agnostic-debt.md) |
+| Warden gates | B | 2026-06-08 | No remediation instructions | -- |
+| Backends (Claude/OpenAI) | B | 2026-06-08 | Codex hook parity open | [AAG-010](agent-agnostic-debt.md) |
 | Eval/benchmarks | A | 2026-05-16 | -- | [benchmark-regression-gate](decisions/benchmark-regression-gate.md) |
-| Channel layer | B | 2026-05-16 | Agent-native migration WIP | -- |
+| Channel layer | B | 2026-06-08 | Agent-native migration WIP | -- |
 | TUI/CLI | C | 2026-05-16 | Visual verification deferred 6+ times | [tui-agent-orchestration](decisions/tui-agent-orchestration.md) |
 | Pattern verification | C | 2026-06-01 | 4/5 gaps open | [pattern-verification-deferred](decisions/pattern-verification-deferred.md) |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -71,10 +71,10 @@ graph LR
 
 Channels self-register using a barrel-import pattern:
 
-1. Each channel skill adds a file to `src/channels/` (e.g. `whatsapp.ts`, `telegram.ts`) that calls `registerChannel()` at module load time:
+1. Each channel skill adds a file to `src/channels/` (e.g. `mcp-whatsapp.ts`, `mcp-telegram.ts`) that calls `registerChannel()` at module load time:
 
    ```typescript
-   // src/channels/whatsapp.ts
+   // src/channels/mcp-whatsapp.ts
    import { registerChannel, ChannelOpts } from './registry.js';
 
    export class WhatsAppChannel implements Channel { /* ... */ }
@@ -89,8 +89,8 @@ Channels self-register using a barrel-import pattern:
 2. The barrel file `src/channels/index.ts` imports all channel modules, triggering registration:
 
    ```typescript
-   import './whatsapp.js';
-   import './telegram.js';
+   import './mcp-whatsapp.js';
+   import './mcp-telegram.js';
    // ... each skill adds its import here
    ```
 
@@ -138,7 +138,7 @@ interface Channel {
 
 To add a new channel, contribute a skill to `.claude/skills/add-<name>/` that:
 
-1. Adds a `src/channels/<name>.ts` file implementing the `Channel` interface
+1. Adds a `src/channels/mcp-<name>.ts` file implementing the `Channel` interface
 2. Calls `registerChannel(name, factory)` at module load
 3. Returns `null` from the factory if credentials are missing
 4. Adds an import line to `src/channels/index.ts`

--- a/docs/decisions/multi-agent-orchestration-research.md
+++ b/docs/decisions/multi-agent-orchestration-research.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-05-06
-**Scope:** `src/agent-backends/`, `src/message-orchestrator.ts`, `container/agent-runner/`, `.claude/wardens/`, memory atoms
+**Scope:** `src/agent-runtimes/`, `src/message-orchestrator.ts`, `container/agent-runner/`, `.claude/wardens/`, memory atoms
 **Related:**
 - `backend-neutral-agent-runtime.md` — defines the backend interface contract this ADR proposes renaming; that ADR already deferred agents-js adoption ("Full OpenAI Agents SDK sessions, handoffs, and tracing remain parity work") — this ADR formalizes that deferral as a skip with architectural justification
 - `parallel-agent-orchestration.md` — covers TUI-level parallel agent sessions (independent CLI sessions). This ADR covers container-level multi-agent coordination (subagents within a single request), a different scope

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-08" # auto-bump @1780918638
+last_verified: "2026-06-10" # auto-bump @1781093014
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
Fixes three doc-gardener-filed staleness issues. Docs-only; no code changes.

## Changes

| File | Fix | Issue |
|------|-----|-------|
| `docs/decisions/multi-agent-orchestration-research.md` | Scope `src/agent-backends/` -> `src/agent-runtimes/` (dir was renamed) | #723 |
| `docs/SPEC.md` | Channel example filenames `whatsapp.ts`/`telegram.ts` -> `mcp-whatsapp.ts`/`mcp-telegram.ts`; "Adding a New Channel" placeholder `<name>.ts` -> `mcp-<name>.ts` | #724 |
| `docs/QUALITY_GRADES.md` | "Last audited" -> 2026-06-08 for Warden gates, Backends (Claude/OpenAI), Channel layer | #725 |

## Verification

- `src/agent-backends/` no longer exists; `src/agent-runtimes/` confirmed present.
- `src/channels/` contains `mcp-*.ts`; barrel `src/channels/index.ts` imports `./mcp-*.js` — SPEC example now matches reality.
- No `agent-backends` references remain anywhere in `docs/`.
- code-reviewer warden: **SHIP** (all references factually verified against the filesystem; no blocking issues).

Closes #723
Closes #724
Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)