### PR TITLE
ci: gate the container/agent-runner vitest suite in CI (LIA-201 part 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,30 @@ jobs:
 
       - name: Tests
         run: npx vitest run
+
+  test-agent-runner:
+    runs-on: ubuntu-latest
+    # PR-only, mirroring test-packages (merge queue is not enabled on this repo).
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            agent-runner:
+              - 'container/agent-runner/**'
+      - uses: actions/setup-node@v6
+        if: steps.filter.outputs.agent-runner == 'true'
+        with:
+          node-version: 20
+      - name: Test agent-runner
+        if: steps.filter.outputs.agent-runner == 'true'
+        working-directory: container/agent-runner
+        run: |
+          npm ci
+          # vitest isn't a declared dep (the container Dockerfile installs devDeps
+          # into the runtime image), so declaring it would bloat the agent image.
+          # Install ephemerally, pinned to the root's version (see root package-lock).
+          npm install --no-save vitest@4.1.8
+          npx vitest run


### PR DESCRIPTION
## Problem (root cause of LIA-201)

The `container/agent-runner` package has its own `vitest.config.ts` and **170 tests** (15 files), but ran in **zero** CI workflows — the root `ci` job's `npx vitest run` uses the root vitest config (`include: ['src/**','setup/**']`), which never reaches `container/agent-runner/src/**`. So that suite was verified only by local discipline; a regression there was invisible to required CI. (This is exactly why part 1's empty-cron test — fixed in #760 — sat red on `main` unnoticed.)

## Fix

A new paths-filtered `test-agent-runner` job in `.github/workflows/ci.yml`, mirroring the existing `test-packages` required-check pattern: the job always runs (so it can become a required check) but gates the real work behind `dorny/paths-filter` on `container/agent-runner/**` (skipped steps still pass → safe as a required check; doesn't burn CI on unrelated PRs).

**Why vitest is installed ephemerally** (`npm install --no-save vitest@4.1.8`): vitest is not a declared dep of `container/agent-runner` (it resolves via monorepo-root hoisting locally). It can't simply be declared, because the agent `Dockerfile` installs devDeps into the **runtime** image (the entrypoint runs `tsc`), so adding vitest (+ ~100 transitive deps) would bloat the agent container. The ephemeral, root-pinned install keeps `package.json`/lock and the image untouched.

## Verification
- YAML parses (5 jobs); single additive 27-line job, no other files touched.
- The exact job command sequence was run locally from a **clean** install — `npm ci && npm install --no-save vitest@4.1.8 && npx vitest run` → **170/170 green** (verification-gate confirmed independently).
- Note: this PR only changes `.github/`, so the paths-filter skips the steps on its own PR; the job exercises for real on the next PR touching `container/agent-runner/**`.

## Follow-up (not in this PR)
Once merged, `test-agent-runner` should be added to branch-protection **required** checks (it gates the container the live agent runs). That's a repo-policy change applied post-merge so it doesn't block any open PR lacking the job.

Part 2 of LIA-201 (part 1 = the empty-cron bug, shipped #760). This closes the coverage gap; LIA-201 can close when this merges + the required-check is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)