### PR TITLE
fix(memory): stop hooks hardcoding the abstain threshold

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -2631,10 +2631,11 @@ def run_memory_retrieval(event: dict[str, Any], repo_root: Path) -> int:
     if not tree.exists():
         return 0
 
-    abstain = os.environ.get("DEUS_TREE_ABSTAIN", "0.45")
+    # No --abstain: the child inherits DEUS_TREE_ABSTAIN and resolves its
+    # own threshold chain (env -> learned artifact -> provider default).
     try:
         result = subprocess.run(
-            [sys.executable, str(tree), "query", prompt, "--json", "-k", "3", "--abstain", abstain],
+            [sys.executable, str(tree), "query", prompt, "--json", "-k", "3"],
             cwd=repo_root,
             text=True,
             stdout=subprocess.PIPE,

--- a/scripts/memory_retrieval_hook.py
+++ b/scripts/memory_retrieval_hook.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -13,7 +12,6 @@ if str(_SCRIPTS_DIR) not in sys.path:
 
 MIN_PROMPT_LEN = 10
 TOP_K = 3
-DEFAULT_ABSTAIN = "0.45"
 MAX_CONTEXT_CHARS = 4096
 
 
@@ -38,12 +36,13 @@ def main() -> None:
         new_terms = sc.extract_terms(prompt)
         concepts = sc.update_concepts(session_id, new_terms) or None
 
-    abstain = float(os.environ.get("DEUS_TREE_ABSTAIN", DEFAULT_ABSTAIN))
-
+    # Threshold resolution belongs to the library: memory_query falls back to
+    # mt.DEFAULT_ABSTAIN_THRESHOLD (env var -> learned artifact -> provider
+    # default). A hook-level default would override learned artifacts and
+    # provider-aware calibration.
     result = mq.recall(
         prompt,
         k=TOP_K,
-        abstain_threshold=abstain,
         source="repo-hook",
         concepts=concepts,
     )

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -862,6 +862,28 @@ def test_memory_retrieval_injects_vault_result(monkeypatch, tmp_path, capsys):
     assert "Brain Dump" not in context
 
 
+def test_memory_retrieval_omits_abstain_flag(monkeypatch, tmp_path):
+    """Threshold resolution belongs to the memory_tree CLI (env -> learned
+    artifact -> provider default); the hook must not shadow it."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "memory_tree.py").write_text("", encoding="utf-8")
+
+    captured: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):
+        captured.append(args[0])
+        return subprocess.CompletedProcess(args[0], 0, stdout="")
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+
+    assert hooks.run_memory_retrieval(prompt_event(repo, "remember this"), repo) == 0
+
+    assert len(captured) == 1
+    assert "--abstain" not in captured[0]
+
+
 def test_memory_retrieval_blocks_vault_path_traversal(monkeypatch, tmp_path, capsys):
     hooks = load_hooks()
     repo = git_repo(tmp_path)

--- a/scripts/tests/test_memory_retrieval_hook.py
+++ b/scripts/tests/test_memory_retrieval_hook.py
@@ -1,0 +1,84 @@
+"""Tests for memory_retrieval_hook.py — UserPromptSubmit auto-retrieval.
+
+The hook must not resolve the abstain threshold itself: memory_query.recall
+falls back to memory_tree.DEFAULT_ABSTAIN_THRESHOLD, which is the single
+source of truth (env var -> learned artifact -> provider-aware default).
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load_hook(monkeypatch, recall_calls: list[dict]):
+    """Load the hook module with stubbed memory_query / session_concepts."""
+    fake_mq = types.ModuleType("memory_query")
+
+    def fake_recall(prompt, **kwargs):
+        recall_calls.append(kwargs)
+        return {"context": "stubbed context"}
+
+    fake_mq.recall = fake_recall
+
+    fake_sc = types.ModuleType("session_concepts")
+    fake_sc.extract_terms = lambda prompt: []
+    fake_sc.update_concepts = lambda session_id, terms: None
+
+    monkeypatch.setitem(sys.modules, "memory_query", fake_mq)
+    monkeypatch.setitem(sys.modules, "session_concepts", fake_sc)
+
+    spec = importlib.util.spec_from_file_location(
+        "memory_retrieval_hook_under_test",
+        SCRIPTS_DIR / "memory_retrieval_hook.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_recall_called_without_abstain_override(monkeypatch, capsys):
+    calls: list[dict] = []
+    hook = _load_hook(monkeypatch, calls)
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"prompt": "what do you know about my style"})),
+    )
+
+    hook.main()
+
+    assert len(calls) == 1
+    assert "abstain_threshold" not in calls[0]
+    output = json.loads(capsys.readouterr().out)
+    assert output["hookSpecificOutput"]["additionalContext"] == "stubbed context"
+
+
+def test_short_prompt_bails_before_recall(monkeypatch, capsys):
+    calls: list[dict] = []
+    hook = _load_hook(monkeypatch, calls)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"prompt": "hi"})))
+
+    hook.main()
+
+    assert calls == []
+    assert capsys.readouterr().out == ""
+
+def test_session_concepts_passed_to_recall(monkeypatch, capsys):
+    calls: list[dict] = []
+    hook = _load_hook(monkeypatch, calls)
+    sys.modules["session_concepts"].update_concepts = lambda sid, terms: ["drums", "music"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"prompt": "what instruments do I play", "session_id": "s1"})),
+    )
+
+    hook.main()
+
+    assert len(calls) == 1
+    assert calls[0]["concepts"] == ["drums", "music"]
+    assert "abstain_threshold" not in calls[0]


### PR DESCRIPTION
## Problem

Both retrieval hooks pinned the abstain-threshold fallback to **0.45**:

- `scripts/memory_retrieval_hook.py:16` — `DEFAULT_ABSTAIN = "0.45"`
- `scripts/codex_warden_hooks.py` `run_memory_retrieval` — `os.environ.get("DEUS_TREE_ABSTAIN", "0.45")`

This overrode the library's calibrated provider-aware defaults (`memory_tree._THRESHOLD_DEFAULTS`: ollama **0.30**, gemini **0.54**) and silently bypassed the learned-artifact chain (`evolution.optimizer.artifacts`). `docs/ENVIRONMENT.md` documents the default as 0.30 — docs and hooks contradicted each other.

## Changes

- `memory_retrieval_hook.py`: `recall()` is called without `abstain_threshold`; `memory_query` falls back to `mt.DEFAULT_ABSTAIN_THRESHOLD` (env var → learned artifact → provider-aware default). Unused `import os` removed.
- `codex_warden_hooks.py`: the `--abstain` flag is dropped from the spawned `memory_tree.py query` — the child inherits `DEUS_TREE_ABSTAIN` and its argparse default is already `DEFAULT_ABSTAIN_THRESHOLD`, so forwarding was pure duplication.
- Tests: hook invokes recall without the override (+ session-concepts pass-through); warden-hook spawned command carries no `--abstain`.

`DEUS_TREE_ABSTAIN` still works as the explicit override — read by the library, the single source of truth.

## Sweep evidence (per `docs/decisions/threshold-calibration-sweep.md`)

1,440-combo calibrate-sweep, 74-query fixture (as refreshed in #764), ollama/embeddinggemma:

| Operating point | Recall | Abstain accuracy |
|---|---|---|
| Hook today (0.45) | 0.351 | 0.909 |
| Library default (0.30) | **0.649** | 0.318 |
| Sweep best (0.31/gap .06/cov .40/cap .30/eo 1) | 0.649 | 0.591 |

The 0.45 override rejected ~65% of answerable queries. Prior research (`memory-tree-benchmark-robustness.md`) independently measured 0.45 as "too aggressive" (59% recall) on a larger vault. Library default values deliberately unchanged — per-machine tuning is the learned-artifact mechanism's job.

## Live smoke (hook paths, real tree, Ollama)

Both entry points verified injecting retrieved memory end-to-end; example flip: `"how should you phrase requests to me"` → `Persona/work-style/communication.md` at score 0.411 — abstained at 0.45, correctly returned at the library default.

## Verification

- Against this branch's base: 264 tests pass across the three affected test files; `evolution/tests` green on the origin equivalent.
- Cherry-pick of liam-cyberpro/Deus#8.

Wardens: plan-reviewer SHIP, code-reviewer SHIP, verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)