### PR TITLE
fix(memory-tree): patch the executing module in calibrate_sweep's embed cache

### DIFF
--- a/docs/decisions/threshold-calibration-sweep.md
+++ b/docs/decisions/threshold-calibration-sweep.md
@@ -35,8 +35,12 @@ Run `deus sweep` after any change to the retrieval pipeline:
 ### Implementation
 
 - Function: `calibrate_sweep()` in `scripts/memory_tree.py`
-- Pre-caches query embeddings before sweeping (~14s upfront) to avoid
-  redundant Ollama calls across ~108-480 combinations
+- Pre-caches query embeddings before sweeping (~5s upfront) to avoid
+  redundant Ollama calls across the grid. The cache monkeypatch targets
+  `sys.modules[__name__]` — under CLI invocation the executing module is
+  `__main__`, and patching via `import memory_tree` would hit a second
+  module copy, silently disabling the cache (observed: a 92s sweep ran
+  ~7h making one live embed call per query per combo)
 - CLI: `python3 scripts/memory_tree.py calibrate-sweep <dataset.jsonl> --json`
 - Wrapper: `deus sweep [optional-dataset-path]`
 - Output: best thresholds, top-5 Pareto frontier, current defaults for
@@ -46,6 +50,10 @@ Run `deus sweep` after any change to the retrieval pipeline:
 
 - Never blend recall and abstain_accuracy into one score (per
   benchmark-regression-gate.md §3)
-- Grid size bounded: 4-6 values per dimension × 4 dimensions = 108-480 combos
-- Pre-cached embeddings keep wall-clock under 60s for 108 combos
+- Grid size bounded: the grid has grown with the pipeline — a 5th
+  dimension (`min_entity_overlap`, added with the coherence gate) brought
+  it to 6×4×5×4×3 = 1,440 combos. Acceptable because per-combo cost with
+  an effective embed cache is ~0.1s
+- Pre-cached embeddings keep wall-clock ~90s for 1,440 combos
+  (measured 2026-06-10, 74-query dataset)
 - Thresholds are env-var tunable — the sweep recommends, the operator decides

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-10" # auto-bump @1781093014
+last_verified: "2026-06-11" # auto-bump @1781165037
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -2261,7 +2261,12 @@ def calibrate_sweep(
             return _cache[text]
         return _orig_embed(text)
 
-    import memory_tree as _self
+    # Patch the EXECUTING module: under CLI invocation __name__ is
+    # "__main__" and `import memory_tree` would load a second module copy,
+    # leaving benchmark() calling the unpatched embed_text (one live Ollama
+    # call per query per combo). sys.modules[__name__] resolves to the
+    # right module object in both invocation modes.
+    _self = sys.modules[__name__]
     _self.embed_text = _cached_embed
 
     abstain_vals = [round(x, 2) for x in _frange(0.25, 0.41, 0.03)]

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -2222,3 +2222,66 @@ class TestStandardsPack:
         assert pos_a < pos_b < pos_c, (
             f"expected alphabetical order; positions: A={pos_a} B={pos_b} C={pos_c}"
         )
+
+
+
+# ── calibrate_sweep embed cache ───────────────────────────────────────────────
+
+class TestCalibrateSweepCache:
+    def test_cache_effective_under_cli_module_identity(self, fake_vault, tmp_path, monkeypatch):
+        """Regression: calibrate_sweep must patch the EXECUTING module.
+
+        Under CLI invocation the module is named "__main__", and the old
+        `import memory_tree as _self` patched a second module copy — every
+        per-combo retrieval then hit the live embedder (~107k Ollama calls
+        for a full sweep). Simulate that identity split by loading the
+        script under a different module name and counting embed calls:
+        only the pre-cache pass may embed, once per unique query.
+        """
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "memory_tree_cli_sim", _ROOT / "scripts" / "memory_tree.py"
+        )
+        sim = importlib.util.module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, "memory_tree_cli_sim", sim)
+        spec.loader.exec_module(sim)
+
+        stub = StubEmbed()
+        calls: list[str] = []
+
+        def counting_embed(text: str) -> list[float]:
+            calls.append(text)
+            return stub(text)
+
+        monkeypatch.setattr(sim, "embed_text", counting_embed)
+        monkeypatch.setattr(sim, "embed_batch_text", lambda ts: [stub(t) for t in ts])
+        monkeypatch.setattr(
+            sim, "generate_approach_angles", lambda d, b: ["q one", "q two", "q three"]
+        )
+        # Shrink the grid: 1 value per float dim keeps the test fast while
+        # still exercising multiple combos via the entity-overlap dim.
+        monkeypatch.setattr(sim, "_frange", lambda start, stop, step: [start])
+
+        db = sim.open_db(tmp_path / "sweep.db")
+        try:
+            sim.build_tree(fake_vault, db)
+            calls.clear()
+
+            dataset = [
+                {"query": "background career history", "expected_path": "Persona/life/background.md"},
+                {"query": "totally unrelated nonsense", "abstain": True},
+            ]
+            result = sim.calibrate_sweep(db, dataset, k=3)
+
+            assert result["total_combos"] == 3  # 1*1*1*1 floats x 3 entity-overlap
+            unique_queries = {item["query"] for item in dataset}
+            assert set(calls) == unique_queries
+            assert len(calls) == len(unique_queries), (
+                "embed called per-combo — the pre-cache monkeypatch missed "
+                "the executing module"
+            )
+            # The finally-block must restore the original (our counting stub).
+            assert sim.embed_text is counting_embed
+        finally:
+            db.close()


### PR DESCRIPTION
## Problem

`calibrate_sweep()` pre-caches query embeddings by monkeypatching `embed_text` — via `import memory_tree as _self`. Under CLI invocation (`python3 scripts/memory_tree.py calibrate-sweep ...`) the executing module is `__main__`, so that import loads a **second module copy**: the patch landed on the copy while `benchmark()` ran in `__main__` with the live function. Every per-combo retrieval made a real Ollama embed call.

Observed: a sweep that takes **92s** with an effective cache ran **7+ hours** (1,440 combos × 74 queries ≈ 107k live embed calls) before being killed. Low CPU, all wall-clock waiting on Ollama — looked like a hang, was actually a silent cache bypass.

## Changes

- `calibrate_sweep`: `_self = sys.modules[__name__]` — resolves to the executing module in both invocation modes (imported: `"memory_tree"`; CLI: `"__main__"`). Comment documents the trap.
- Regression test (`TestCalibrateSweepCache`): loads `memory_tree.py` under a different module name via importlib — simulating the CLI identity split — stubs embed with a counter, shrinks the grid, asserts embeds == unique query count. **Verified failing against the old code** (8 calls vs 2 expected) and passing against the fix.
- ADR `threshold-calibration-sweep.md` corrected: grid is 1,440 combos since the `min_entity_overlap` dimension landed with the coherence gate (was documented 108-480); ~90s measured wall-clock; module-identity gotcha documented.
- `patterns/documentation.md` bumped (governs `docs/`).

## Verification

- `pytest scripts/tests/test_memory_tree.py` against this branch's base → 132 passed (includes the new regression test)
- Regression verified both directions via git-stash check
- Cherry-pick of liam-cyberpro/Deus#9 (test-file conflict resolved: only the new test class brought over; unrelated origin-only test classes excluded)

Wardens: plan-reviewer SHIP, code-reviewer SHIP, verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)