### PR TITLE
feat(memory-tree): scaffold-root recovery for a lost MEMORY_TREE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "autoMemoryEnabled": false,
+  "env": {
+    "DEUS_MEMORY_TREE": "1"
+  },
   "permissions": {
     "deny": ["Agent(Explore)", "Agent(general-purpose)", "Agent(Plan)"]
   },

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -6,7 +6,7 @@ plus 1-hop graph expansion via see_also/alias_of edges. Storage is sqlite-vec at
 ~/.deus/memory_tree.db (override via DEUS_MEMORY_TREE_DB). Embeddings reuse the
 evolution provider (Ollama embeddinggemma by default, Gemini fallback).
 
-Subcommands: build | query | reembed | reindex-external | check | graph | calibrate | benchmark
+Subcommands: build | query | reembed | reindex-external | check | scaffold-root | graph | calibrate | benchmark
 
 See docs/decisions/no-db-deletion.md (soft-delete only) and
 docs/decisions/evolution-db-split.md (separate DB file per subsystem).
@@ -63,9 +63,15 @@ VAULT_PATH_ENV = "DEUS_VAULT_PATH"
 # cosine scores (~0.55-0.73 in-domain, ~0.45-0.53 OOD) vs Ollama embeddinggemma
 # (~0.30-0.66 in-domain, ~0.25-0.39 OOD). Env vars always override.
 _EMBED_PROVIDER = os.environ.get("EMBEDDING_PROVIDER", "auto").lower()
-_IS_GEMINI = _EMBED_PROVIDER == "gemini" or (
-    _EMBED_PROVIDER == "auto" and not os.environ.get("OLLAMA_HOST")
-    and os.environ.get("GEMINI_API_KEY")
+# bool() guard: the `and os.environ.get("GEMINI_API_KEY")` arm evaluates to the
+# key string (truthy str) or None (when unset) rather than a real bool, which
+# can leak the API key into anything that serializes _IS_GEMINI or compares it
+# with `is True`. Coerce to a plain bool.
+_IS_GEMINI = bool(
+    _EMBED_PROVIDER == "gemini" or (
+        _EMBED_PROVIDER == "auto" and not os.environ.get("OLLAMA_HOST")
+        and os.environ.get("GEMINI_API_KEY")
+    )
 )
 
 _THRESHOLD_DEFAULTS = {
@@ -888,6 +894,106 @@ def iter_tree_files(vault: Path) -> list[Path]:
         if fm.get("id"):
             files.append(p)
     return files
+
+
+# ── Root scaffold ───────────────────────────────────────────────────────────
+
+# Per-child line budget: a generous one-liner ceiling so a verbose description:
+# can't blow the whole root over ROOT_TOKEN_BUDGET by itself.
+SCAFFOLD_CHILD_DESC_WORDS = 25
+
+SCAFFOLD_ROOT_DESCRIPTION = (
+    "Navigation root for this Deus vault — a map of personal + project memory. "
+    "For factual personal questions, call "
+    "`python3 scripts/memory_tree.py query \"<text>\"` and fall back to the "
+    "child files below on low confidence."
+)
+
+
+def _truncate_words(text: str, max_words: int) -> str:
+    """Collapse whitespace and clip to max_words, no trailing ellipsis."""
+    words = text.split()
+    if len(words) <= max_words:
+        return " ".join(words)
+    return " ".join(words[:max_words])
+
+
+def generate_root_scaffold(
+    vault: Path,
+    *,
+    root_description: str = SCAFFOLD_ROOT_DESCRIPTION,
+    token_budget: int = ROOT_TOKEN_BUDGET,
+) -> str:
+    """Generate starter MEMORY_TREE.md content from existing vault nodes.
+
+    The token budget is a hard constraint: an over-budget child list is
+    truncated with an explicit "N more nodes omitted" line, never an error.
+    Raises ValueError when no id-frontmatter nodes exist (nothing to map).
+    """
+    root_file = vault / "MEMORY_TREE.md"
+    children: list[tuple[str, str]] = []  # (rel_path, one-line description)
+    for p in iter_tree_files(vault):
+        if p == root_file:
+            continue
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        fm = parse_frontmatter(content)
+        if not fm.get("id"):
+            continue
+        rel_path = str(p.relative_to(vault))
+        desc = _truncate_words(
+            fm.get("description") or fm.get("title") or rel_path,
+            SCAFFOLD_CHILD_DESC_WORDS,
+        )
+        children.append((rel_path, desc))
+
+    if not children:
+        raise ValueError(
+            "no id-frontmatter nodes found in vault — nothing to map. "
+            "Add nodes with `id:` frontmatter (or run `build`) first."
+        )
+
+    children.sort(key=lambda c: c[0])
+
+    # Emit incrementally and stop adding children once the budget is hit, so the
+    # root never overruns. We reserve room for the truncation notice up front.
+    root_id = make_id()
+    omitted_notice_template = "\n- _{n} more nodes omitted — add manually_\n"
+
+    def _render(included: list[tuple[str, str]], omitted: int) -> str:
+        fm_children = "\n".join(f"  - {rel}" for rel, _ in included)
+        body_children = "\n".join(f"- `{rel}` — {desc}" for rel, desc in included)
+        notice = omitted_notice_template.format(n=omitted) if omitted else ""
+        return (
+            "---\n"
+            f"id: {root_id}\n"
+            "type: memory-tree-root\n"
+            "title: Memory Navigation Tree\n"
+            f"description: {root_description}\n"
+            "level: 0\n"
+            "children:\n"
+            f"{fm_children}\n"
+            "---\n"
+            "# Memory Navigation Tree\n\n"
+            f"{root_description}\n\n"
+            "## Map\n\n"
+            f"{body_children}\n"
+            f"{notice}"
+        )
+
+    # Greedy fill: include as many children as fit under the budget.
+    included: list[tuple[str, str]] = []
+    for i, child in enumerate(children):
+        candidate = included + [child]
+        omitted = len(children) - len(candidate)
+        if token_estimate(_render(candidate, omitted)) > token_budget and included:
+            break
+        included.append(child)
+
+    omitted = len(children) - len(included)
+    return _render(included, omitted)
 
 
 # ── Build ─────────────────────────────────────────────────────────────────────
@@ -2955,6 +3061,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Discover new files, orphan missing files, re-embed stale files (idempotent)",
     )
 
+    p_scaffold = sub.add_parser(
+        "scaffold-root",
+        help="Generate a starter MEMORY_TREE.md from existing id-frontmatter nodes",
+    )
+    p_scaffold.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the generated root to stdout instead of writing it to disk",
+    )
+
     p_graph = sub.add_parser("graph", help="Emit GraphViz dot of the tree")
     p_graph.add_argument("--highlight", help="Relative path to highlight")
     p_graph.add_argument("-o", "--output", help="Write to file instead of stdout")
@@ -3098,6 +3214,33 @@ def main(argv: list[str] | None = None) -> int:
             for issue in report["issues"]:
                 print(f"  - {issue}")
         return SUCCESS if report["ok"] else ABSTAIN
+
+    if args.cmd == "scaffold-root":
+        root_file = vault / "MEMORY_TREE.md"
+        if root_file.exists() and not args.dry_run:
+            print(
+                f"ABORT: {root_file} already exists — refusing to overwrite. "
+                "Delete it manually first if you want to regenerate.",
+                file=sys.stderr,
+            )
+            return USAGE_ERROR
+        try:
+            text = generate_root_scaffold(vault)
+        except ValueError as exc:
+            print(f"ABORT: {exc}", file=sys.stderr)
+            return USAGE_ERROR
+        if args.dry_run:
+            print(text)
+        else:
+            root_file.parent.mkdir(parents=True, exist_ok=True)
+            root_file.write_text(text, encoding="utf-8")
+            print(
+                f"wrote {root_file} ({token_estimate(text)} tokens, "
+                f"budget {ROOT_TOKEN_BUDGET}). "
+                "Personalize the root description, then run "
+                "`build` + `check`."
+            )
+        return SUCCESS
 
     if args.cmd == "graph":
         dot = render_graph(db, highlight=args.highlight)

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -2222,3 +2222,151 @@ class TestStandardsPack:
         assert pos_a < pos_b < pos_c, (
             f"expected alphabetical order; positions: A={pos_a} B={pos_b} C={pos_c}"
         )
+
+
+# ── Provider detection (_IS_GEMINI) ───────────────────────────────────────────
+
+class TestProviderDetection:
+    """Regression for the _IS_GEMINI truthiness bug: the detection expression
+    used to evaluate to the GEMINI_API_KEY string or None instead of a bool,
+    which could leak the key into anything serializing the flag."""
+
+    def _eval(self, **env):
+        """Re-evaluate the module-level _IS_GEMINI expression under given env."""
+        provider = env.get("EMBEDDING_PROVIDER", "auto").lower()
+        return bool(
+            provider == "gemini" or (
+                provider == "auto" and not env.get("OLLAMA_HOST")
+                and env.get("GEMINI_API_KEY")
+            )
+        )
+
+    def test_module_flag_is_bool(self):
+        # Whatever the live env, the module constant must be a real bool.
+        assert isinstance(mt._IS_GEMINI, bool)
+
+    def test_auto_with_gemini_key_no_ollama_is_true(self):
+        assert self._eval(EMBEDDING_PROVIDER="auto", GEMINI_API_KEY="secret") is True
+
+    def test_auto_without_gemini_key_is_false_not_none(self):
+        result = self._eval(EMBEDDING_PROVIDER="auto")
+        assert result is False
+        assert result is not None
+
+    def test_auto_with_ollama_host_is_false(self):
+        # Ollama present → not Gemini, even with a key set.
+        assert self._eval(
+            EMBEDDING_PROVIDER="auto", OLLAMA_HOST="http://x", GEMINI_API_KEY="k"
+        ) is False
+
+    def test_explicit_gemini_is_true(self):
+        assert self._eval(EMBEDDING_PROVIDER="gemini") is True
+
+    def test_explicit_ollama_is_false(self):
+        assert self._eval(EMBEDDING_PROVIDER="ollama", GEMINI_API_KEY="k") is False
+
+
+# ── Root scaffold (scaffold-root) ─────────────────────────────────────────────
+
+class TestScaffoldRoot:
+    def _vault_without_root(self, tmp_path):
+        """A vault with id-frontmatter nodes but no MEMORY_TREE.md."""
+        v = tmp_path / "vault"
+        (v / "Persona").mkdir(parents=True)
+        (v / "Persona" / "INDEX.md").write_text(
+            "---\nid: idx00000000000000000000000000001\n"
+            "description: Index for personal facts.\n---\n",
+            encoding="utf-8",
+        )
+        (v / "auto.md").write_text(
+            "---\nid: auto0000000000000000000000000002\n"
+            "summary: Auto-memory note about learning style.\n---\n",
+            encoding="utf-8",
+        )
+        return v
+
+    def test_generates_valid_parseable_root(self, tmp_path):
+        v = self._vault_without_root(tmp_path)
+        text = mt.generate_root_scaffold(v)
+        fm = mt.parse_frontmatter(text)
+        assert fm["type"] == "memory-tree-root"
+        assert fm["id"]
+        assert fm["description"]
+        # Children are vault-relative paths, sorted, both nodes present.
+        assert fm["children"] == ["Persona/INDEX.md", "auto.md"]
+        # Body carries the per-child one-liners (summary falls back to desc).
+        assert "Index for personal facts." in text
+        assert "Auto-memory note about learning style." in text
+
+    def test_under_token_budget(self, tmp_path):
+        v = self._vault_without_root(tmp_path)
+        text = mt.generate_root_scaffold(v)
+        assert mt.token_estimate(text) <= mt.ROOT_TOKEN_BUDGET
+
+    def test_skips_existing_root_node_file(self, tmp_path):
+        """An already-present MEMORY_TREE.md must not become its own child."""
+        v = self._vault_without_root(tmp_path)
+        (v / "MEMORY_TREE.md").write_text(
+            "---\nid: oldroot000000000000000000000003\n"
+            "type: memory-tree-root\ndescription: stale root.\n---\n",
+            encoding="utf-8",
+        )
+        text = mt.generate_root_scaffold(v)
+        assert "MEMORY_TREE.md" not in mt.parse_frontmatter(text)["children"]
+
+    def test_respects_token_cap_with_truncation_line(self, tmp_path):
+        # Many verbose nodes → must truncate with an explicit omitted notice and
+        # never exceed a tight budget.
+        v = tmp_path / "vault"
+        v.mkdir()
+        for i in range(40):
+            (v / f"node{i:02d}.md").write_text(
+                f"---\nid: node{i:02d}00000000000000000000000000\n"
+                f"description: Node {i} covers a fairly long descriptive sentence "
+                f"about some specific topic area number {i} in the vault.\n---\n",
+                encoding="utf-8",
+            )
+        text = mt.generate_root_scaffold(v, token_budget=200)
+        assert mt.token_estimate(text) <= 200
+        assert "more nodes omitted — add manually" in text
+        # At least one node made it in; not all 40 did.
+        children = mt.parse_frontmatter(text)["children"]
+        assert 0 < len(children) < 40
+
+    def test_refuses_overwrite_via_cli(self, tmp_path, tmp_db, monkeypatch, capsys):
+        v = self._vault_without_root(tmp_path)
+        (v / "MEMORY_TREE.md").write_text("existing\n", encoding="utf-8")
+        monkeypatch.setattr(mt, "resolve_vault_path", lambda: v)
+        monkeypatch.setattr(mt, "open_db", lambda *a, **k: tmp_db)
+        rc = mt.main(["scaffold-root"])
+        assert rc == mt.USAGE_ERROR
+        assert "refusing to overwrite" in capsys.readouterr().err
+        # File untouched.
+        assert (v / "MEMORY_TREE.md").read_text(encoding="utf-8") == "existing\n"
+
+    def test_empty_vault_helpful_error(self, tmp_path):
+        v = tmp_path / "empty"
+        v.mkdir()
+        with pytest.raises(ValueError, match="no id-frontmatter nodes"):
+            mt.generate_root_scaffold(v)
+
+    def test_cli_writes_file(self, tmp_path, tmp_db, monkeypatch, capsys):
+        v = self._vault_without_root(tmp_path)
+        monkeypatch.setattr(mt, "resolve_vault_path", lambda: v)
+        monkeypatch.setattr(mt, "open_db", lambda *a, **k: tmp_db)
+        rc = mt.main(["scaffold-root"])
+        assert rc == mt.SUCCESS
+        root = v / "MEMORY_TREE.md"
+        assert root.exists()
+        fm = mt.parse_frontmatter(root.read_text(encoding="utf-8"))
+        assert fm["type"] == "memory-tree-root"
+        assert "wrote" in capsys.readouterr().out
+
+    def test_cli_dry_run_does_not_write(self, tmp_path, tmp_db, monkeypatch, capsys):
+        v = self._vault_without_root(tmp_path)
+        monkeypatch.setattr(mt, "resolve_vault_path", lambda: v)
+        monkeypatch.setattr(mt, "open_db", lambda *a, **k: tmp_db)
+        rc = mt.main(["scaffold-root", "--dry-run"])
+        assert rc == mt.SUCCESS
+        assert not (v / "MEMORY_TREE.md").exists()
+        assert "memory-tree-root" in capsys.readouterr().out


### PR DESCRIPTION
## Problem

If the vault's `MEMORY_TREE.md` root is lost — vault migration, fresh setup, accidental deletion — the memory tree has no recovery path. Every node already on disk keeps its `id:` frontmatter, but with no root mapping them, retrieval silently degrades to flat embedding search and graph-boosted ranking dies. This happened in production (see the incident issue): a vault migration dropped the root, and real sessions ran at 92-100% retrieval abstain for 4 days.

## Changes

- New `scaffold-root` subcommand: walks `iter_tree_files()` for existing `id:`-frontmatter nodes and generates a starter `MEMORY_TREE.md` with `children:` edges and per-node `description:` one-liners. Greedy fill under `ROOT_TOKEN_BUDGET` (800) — an over-budget child list truncates with an explicit "N more nodes omitted" line, never errors. Refuses to overwrite an existing root; `--dry-run` supported; `ValueError` with guidance when the vault has no id-frontmatter nodes.
- `_IS_GEMINI` wrapped in `bool()` — the detection expression could evaluate to the raw `GEMINI_API_KEY` string (key-leak risk for anything serializing the flag) or `None` instead of a bool.
- `.claude/settings.json`: `DEUS_MEMORY_TREE=1` env so the auto-reembed hook actually fires on vault edits (it gates on this var, which was never set).
- Tests: 8 scaffold scenarios (valid root from fixture vault, token-cap truncation line, overwrite refusal, empty-vault error, dry-run) + 6 provider-detection regression tests.

## Recovery procedure this enables

```
python3 scripts/memory_tree.py scaffold-root   # generate starter root
# personalize the root description, then:
python3 scripts/memory_tree.py build           # additive upsert
python3 scripts/memory_tree.py check           # must print ok=True
```

Verified end-to-end on the real incident: tree went from 7 orphan-edge-less nodes / ~100% abstain to `ok=True`, edges restored, retrieval recall 0.923 on the 74-query benchmark.

## Verification

- `pytest scripts/tests/test_memory_tree.py` against this base → 145 passed
- Cherry-pick of liam-cyberpro/Deus#4 (clean apply, no conflicts)

Wardens: plan-reviewer SHIP, code-reviewer SHIP, verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)