### PR TITLE
ci: pin windows runner to windows-2022 (node-gyp VS18 break)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,10 @@ jobs:
         run: cargo test
 
   test-windows:
-    runs-on: windows-latest
+    # Pinned: windows-latest moved to a VS 18 image that node-gyp 10.x cannot
+    # detect, breaking the better-sqlite3 native build at `npm ci`. windows-2022
+    # ships VS 2022 (recognized). Revert to windows-latest once node-gyp supports VS 18.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem

`windows-latest` rolled to a **Visual Studio 18** image that `node-gyp` 10.x reports as `unknown version "undefined"`. This breaks the `better-sqlite3` native build at `npm ci`, so the **required `test-windows`** check fails on **every** PR.

Diagnosed on #773:
- Reproduced on a re-run (same `find VS` / `could not find a version of Visual Studio 2017 or newer` signature).
- `test-windows` was **green on branches built ~1h before** the image rollout, then failed on every run after.
- Failure is in `npm ci` (dependency native build) — independent of any PR's source changes.

## Fix

Pin the `test-windows` job to `windows-2022` (ships VS 2022, which `node-gyp` recognizes). One line + an explanatory comment. Trivially reversible — revert to `windows-latest` once `node-gyp` supports VS 18.

This unblocks `test-windows` for **all** open and future PRs, including #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)