### PR TITLE
fix(compress): restore 3 dangling branches/*.md helper files (LIA-203)

### DIFF
--- a/.claude/skills/compress/branches/external-mode.md
+++ b/.claude/skills/compress/branches/external-mode.md
@@ -1,0 +1,70 @@
+# External Project Mode — Memory Level Gate, Scope, and Redaction
+
+This file is read by `/compress` when the current working directory is **not** `~/deus`
+(External Project Mode). It covers three responsibilities called out in skill.md:
+
+1. Memory level gate (whether to proceed at all)
+2. Step 0 — Preserve permanent memories: scope rules
+3. Session log redaction rules (post-save)
+
+---
+
+## Memory level gate
+
+Compute the MD5 hash of the current working directory and read
+`~/.config/deus/projects/<hash>.json`.
+
+```bash
+# macOS
+dir_hash=$(echo -n "$(pwd)" | md5 -q)
+# Linux
+dir_hash=$(echo -n "$(pwd)" | md5sum | cut -d' ' -f1)
+config_file="$HOME/.config/deus/projects/${dir_hash}.json"
+```
+
+Read `memory_level` and `save_summaries` from that file.
+
+- If `memory_level` is **restricted**: tell the user:
+  > "Session saving is disabled for restricted projects. Your work is preserved in git
+  > commits and Claude Code's native session transcript. Use /project-settings to change this."
+  >
+  > Then **stop**.
+- If `save_summaries` is **false**: tell the user the same message and **stop**.
+- If `memory_level` is **standard** or **full** with summaries enabled: **proceed**.
+
+---
+
+## Step 0 scope — what to preserve in `$VAULT/CLAUDE.md`
+
+`$VAULT` is resolved per the vault-path resolution logic in skill.md (not re-derived here).
+
+**standard memory level:** Only preserve USER preferences and behavioral corrections — things
+about the user, not the project. Skip project-specific architecture decisions or code patterns.
+
+**full memory level:** Preserve both user preferences AND project-relevant decisions. No
+restriction on scope.
+
+---
+
+## Session log redaction (standard memory level only)
+
+After saving the session log, run the redaction script to strip any code snippets or file
+contents that leaked through:
+
+```bash
+python3 ~/deus/scripts/redact_session.py "<full path to saved log>"
+```
+
+Only run this step when `memory_level` is `standard` (not `full` or `restricted`).
+If the script exits non-zero, skip silently — the log is still saved; instruct the user
+to review it manually. On success the script writes a `.pre-redact.md` backup of the
+original alongside the log; that file appearing is expected, not an error.
+
+**Session log field guidance (standard memory level):**
+
+- Do NOT include specific file paths, function names, or code snippets in the session log
+- Focus on decisions, architecture, and what was tried/learned
+- `## Files Modified` should use descriptions ("updated the auth middleware") not paths
+- Goal: the log captures WHAT was decided and WHY, without leaking code details
+
+**Full memory level:** No redaction — include full details as in home mode.

--- a/.claude/skills/compress/branches/fallback-merge.md
+++ b/.claude/skills/compress/branches/fallback-merge.md
@@ -1,0 +1,44 @@
+# Fallback Merge — Manual Pending Sync When sync_linear_pending.py Exits Non-Zero
+
+This file is read by `/compress` when `python3 ~/deus/scripts/sync_linear_pending.py`
+exits with a non-zero code (auth error, internal error, rate limit, or any other non-zero
+exit). It describes the manual merge path for updating `pending:` in vault `CLAUDE.md` from
+the session log instead.
+
+Do NOT use this path if the script succeeded (exit 0) — Linear is the source of truth when
+the script runs cleanly.
+
+---
+
+## Manual merge procedure
+
+1. **Read the current `pending:` block** from vault `CLAUDE.md`. If the block is missing,
+   treat it as an empty list.
+
+2. **Remove completed items**: for each `[x]` item from the `## Pending Tasks` section of the
+   session log just saved, find its match in the pending list and remove it:
+   - **Match on core identifiers** (file names, feature names, PR numbers, tool names),
+     ignoring parenthetical annotations like `(closed: ...)`, `(done)`, `(PR #N)` and minor
+     wording differences.
+   - **Compound items** (`A + B`): if a pending item has sub-tasks joined by ` + `, match each
+     part independently. All parts matched → remove the whole item. Some parts matched →
+     rewrite to keep only the unmatched parts.
+   - **Dedup pass**: after removals, check each remaining `[ ]` item — if it is semantically
+     covered by any `[x]` (same feature/identifier, different wording), remove it.
+
+3. **Add new items**: add any new `[ ]` items from the session log that don't already exist in
+   the pending list and aren't already covered by a `[x]` from this session (avoid duplicates).
+
+4. **Write the merged list back** to the `pending:` block in vault `CLAUDE.md`.
+
+---
+
+## Notes
+
+- No hard item cap on `pending:`. Total CLAUDE.md file size is the governor (see the archive
+  trigger step in skill.md).
+- Do NOT drop a live `[ ]` item solely to hit a count limit.
+- This fallback does NOT cross-check `[x]` items against Linear active issues — that check is
+  only meaningful when the Linear script runs successfully. In fallback mode, the session log
+  is the only signal available.
+- Log the script's stderr (if any) in your completion confirmation so the failure is visible.

--- a/.claude/skills/compress/branches/retrospective.md
+++ b/.claude/skills/compress/branches/retrospective.md
@@ -1,0 +1,60 @@
+# Session Retrospective — Conditions and Dispatch
+
+This file is read by `/compress` for the "Trigger session retrospective" step. It is only
+relevant in **home mode** (`~/deus`). Skip silently if any check fails.
+
+---
+
+## Conditions (all must be true)
+
+a. Current mode is **home mode** (`~/deus`).
+
+b. The `$VAULT/Retrospectives/` directory exists. This is the **opt-in gate** — if the
+   directory is absent, never trigger. Do not create the directory.
+
+c. No retrospective file for today exists:
+   ```bash
+   ! test -f "$VAULT/Retrospectives/$(date +%Y-%m-%d)-retrospective.md"
+   ```
+
+d. The number of session log files newer than the most recent retrospective meets or exceeds
+   the `session_window` threshold:
+   ```bash
+   LATEST_RETRO=$(ls -t "$VAULT/Retrospectives"/*.md 2>/dev/null | head -1)
+   if [ -n "$LATEST_RETRO" ]; then
+     NEW_COUNT=$(find "$VAULT/Session-Logs" -name "*.md" -newer "$LATEST_RETRO" | wc -l | tr -d ' ')
+   else
+     NEW_COUNT=$(find "$VAULT/Session-Logs" -name "*.md" | wc -l | tr -d ' ')
+   fi
+   ```
+   Read `session_window` from `~/deus/.claude/wardens/retrospective-schema.md` (default: 20).
+   Proceed only if `NEW_COUNT >= session_window`. (Here `session_window` is used as a
+   trigger threshold — fire only at/above this count — not as the schema's "reading window".)
+
+`$VAULT` is resolved per the vault-path resolution logic in skill.md (not re-derived here).
+
+---
+
+## Dispatch
+
+When all four conditions are met, dispatch via the Agent tool (in-session, background):
+
+- `subagent_type`: `"session-retrospective"`
+- `run_in_background`: `true`
+- `prompt`: `"Run a session retrospective. SESSION_LOG_ROOT=<resolved $VAULT>"`
+  (substitute the actual resolved `$VAULT` path, not the literal string `$VAULT`)
+
+This avoids `claude -p`, which draws from the Agent SDK credit on subscription plans.
+
+If the Agent tool is unavailable (e.g. a non–Claude Code backend), skip silently.
+
+---
+
+## Reporting
+
+In your completion confirmation, report:
+
+- `"retrospective triggered (background)"` — if dispatched
+- `"retrospective skipped: <reason>"` — if any check failed, naming the specific condition that
+  was false (e.g. `"skipped: Retrospectives/ dir absent"`, `"skipped: already run today"`,
+  `"skipped: only 12/20 sessions since last retro"`)

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-11" # auto-bump @1781171415
+last_verified: "2026-06-11" # auto-bump @1781175456
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Problem

`.claude/skills/compress/skill.md` references three helper files that **never existed** (dangling since #520 — `git log --all --full-history -- .claude/skills/compress/branches/` is empty):

- `branches/external-mode.md` (skill.md L27/44/92/135)
- `branches/fallback-merge.md` (skill.md L128)
- `branches/retrospective.md` (skill.md L152)

Impact: home-mode `/compress` degrades gracefully, but **external-project-mode at `standard` memory level lost its redaction guidance** (privacy-adjacent — redaction strips code paths/snippets before they land in a session log), and the retrospective step silently skipped (confirmed live last session).

## Fix

Restore the three files (option B1 — keeps the lean-skill + on-demand-load design the committed skill already assumes). Content recovered from git history (`bc994bc8`, the pre-#520 self-contained skill), **adapted to the current skill**:

- `external-mode.md` — memory-level gate (`~/.config/deus/projects/<hash>.json`), Step 0 scope rules, standard-level redaction (`redact_session.py`)
- `fallback-merge.md` — manual pending-sync path when `sync_linear_pending.py` exits non-zero (reframed from the obsolete MCP-direct flow to the current script-first design)
- `retrospective.md` — opt-in trigger conditions + `session-retrospective` agent dispatch

## Verification

- `grep -rn 'branches/' .claude/skills/compress/skill.md` → all refs now resolve to existing files.
- plan-reviewer **SHIP**; code-reviewer **SHIP** — every factual claim independently verified against the real sources (`redact_session.py:171-175`, `project-settings/skill.md`, `retrospective-schema.md` `session_window: 20`, `sync_linear_pending.py` exit codes, `session-retrospective` agent).
- The global `~/.claude/skills/compress` is a directory symlink to this repo dir (same inode) → the restored files resolve automatically post-merge; no `~/.claude` change bundled.

Closes LIA-203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)