### PR TITLE
fix(linear-webhook): bypass bouncer-gate for issues with an open/merged PR (LIA-119)

### DIFF
--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -215,6 +215,7 @@ The bouncer gate uses the enrichment hash for a fast-path: if the hash matches t
 5. **`allowedFrom` check** - illegal transitions (e.g., Backlog directly to Done) are immediately reverted without running a gate agent.
 6. **Cooldown** - if a gate ran for this issue within `cooldown_minutes`, the previous verdict is reused and no agent is spawned.
 7. **`inFlightGate`** - if a gate is already running for this issue, the new event is dropped. One gate run per issue at a time.
+8. **Bouncer open/merged PR bypass** (LIA-119) - if the issue has an open or merged PR in the DB, `queryPrState` confirms the live GitHub state and the bouncer skips without LLM eval. Prevents spurious REVISE on issues with completed work when a state transition re-enters the bouncer (e.g. In Review → Todo). CLOSED PRs fall through to normal eval.
 
 ## UX -- Advise vs Strict Mode
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-10" # auto-bump @1781093014
+last_verified: "2026-06-11" # auto-bump @1781176077
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-10" # auto-bump @1781084247
+last_verified: "2026-06-11" # auto-bump @1781176077
 governs:
   - src/
   - evolution/

--- a/src/linear-webhook-bouncer-pr-bypass.test.ts
+++ b/src/linear-webhook-bouncer-pr-bypass.test.ts
@@ -1,0 +1,225 @@
+/**
+ * LIA-119: Bouncer-gate open-PR bypass tests.
+ *
+ * Drives _handleIssueUpdateForTest (the real handleIssueUpdate entry) with
+ * module-level mocks so that:
+ *   - getIssuePr  returns a real PR record from the DB layer stub
+ *   - queryPrState returns a controlled live-GH state
+ *   - executeAgentRun (the LLM path) is spied — never called on OPEN/MERGED
+ *
+ * Intentional CLOSED-PR fall-through: a CLOSED (abandoned) PR must NOT be
+ * caught by this bypass. Work was abandoned; a fresh bouncer eval should
+ * decide whether to re-dispatch. The no-assertion on CLOSED below documents
+ * this: the bouncer LLM IS called (executeAgentRun spy is invoked).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { _initTestDatabase, insertWebhookEvent } from './db.js';
+import type { EntityWebhookPayloadWithIssueData } from '@linear/sdk/webhooks';
+import type { LinearContext } from './linear-dispatcher.js';
+import type { GateSpec } from './linear-gate-specs.js';
+
+// ── Module-level mocks ────────────────────────────────────────────────────────
+// Must be declared before any imports that consume these modules.
+
+vi.mock('./db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./db.js')>();
+  return {
+    ...actual,
+    // getIssuePr is overridden per-test via mockReturnValue
+    getIssuePr: vi.fn(),
+  };
+});
+
+vi.mock('./linear-auto-merge.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./linear-auto-merge.js')>();
+  return {
+    ...actual,
+    queryPrState: vi.fn(),
+    triggerAutoMerge: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('./linear-dispatcher.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./linear-dispatcher.js')>();
+  return {
+    ...actual,
+    executeAgentRun: vi.fn().mockResolvedValue({ text: '', error: '' }),
+  };
+});
+
+// ── Import units under test AFTER vi.mock declarations ────────────────────────
+
+const { getIssuePr } = await import('./db.js');
+const { queryPrState } = await import('./linear-auto-merge.js');
+const { executeAgentRun } = await import('./linear-dispatcher.js');
+const { _handleIssueUpdateForTest } = await import('./linear-webhook.js');
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const TO_STATE_ID = 'rfa-state-id';
+const FROM_STATE_ID = 'todo-state-id';
+const ISSUE_ID = 'issue-lia-119';
+const PR_URL = 'https://github.com/owner/repo/pull/613';
+
+function makeBouncerGateSpec(): GateSpec {
+  return {
+    name: 'bouncer-gate',
+    gateTo: 'Ready for Agent',
+    allowedFrom: [], // no restriction
+    mode: 'advise',
+    fallback: 'REVISE',
+    cooldownMinutes: 0, // disable cooldown so it doesn't interfere
+    content: 'gate content',
+  };
+}
+
+function makeCtx(): LinearContext {
+  const stateById = new Map([
+    [
+      TO_STATE_ID,
+      { id: TO_STATE_ID, name: 'Ready for Agent', type: 'unstarted' },
+    ],
+    [FROM_STATE_ID, { id: FROM_STATE_ID, name: 'In Review', type: 'started' }],
+  ]);
+  const stateByName = new Map([
+    [
+      'Ready for Agent',
+      { id: TO_STATE_ID, name: 'Ready for Agent', type: 'unstarted' },
+    ],
+    ['In Review', { id: FROM_STATE_ID, name: 'In Review', type: 'started' }],
+  ]);
+  return {
+    stateById,
+    stateByName,
+    botUserId: 'bot-user-id',
+    viewerId: 'human-user-id',
+    inFlightGate: new Set<string>(),
+    inFlightDispatch: new Set<string>(),
+    gateLabels: {
+      evaluating: null,
+      revise: null,
+      error: '',
+      bouncedUnscoped: null,
+      bouncedStale: null,
+      bouncedNoContext: null,
+      wardenSkip: null,
+      effort: {},
+      complexity: {},
+    },
+    teamId: 'team-1',
+    repoSlug: 'owner/repo',
+    vaultPath: null,
+    client: {
+      updateIssue: vi.fn().mockResolvedValue(undefined),
+      createComment: vi.fn().mockResolvedValue({ id: 'comment-1' }),
+    } as unknown as LinearContext['client'],
+    bus: { emit: vi.fn(), on: vi.fn() } as unknown as LinearContext['bus'],
+    deps: {} as LinearContext['deps'],
+    dispatchGroup: {} as LinearContext['dispatchGroup'],
+  } as unknown as LinearContext;
+}
+
+function makePayload(
+  issueId: string = ISSUE_ID,
+): EntityWebhookPayloadWithIssueData {
+  return {
+    action: 'update',
+    actor: { id: 'human-user-id' }, // not the bot
+    webhookTimestamp: Date.now(),
+    updatedFrom: { stateId: FROM_STATE_ID },
+    data: {
+      id: issueId,
+      identifier: 'LIA-119',
+      title: 'Test issue with open PR',
+      description: 'Some description',
+      stateId: TO_STATE_ID,
+      labels: [],
+    },
+  } as unknown as EntityWebhookPayloadWithIssueData;
+}
+
+function makeGateSpecs(): Map<string, GateSpec> {
+  return new Map([['Ready for Agent', makeBouncerGateSpec()]]);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  _initTestDatabase();
+  vi.clearAllMocks();
+});
+
+describe('bouncer-gate open-PR bypass (LIA-119)', () => {
+  it('calls queryPrState with the PR URL from getIssuePr, skips LLM on OPEN', async () => {
+    vi.mocked(getIssuePr).mockReturnValue({
+      pr_url: PR_URL,
+      branch: 'feat/lia-119',
+      auto_merge_state: 'none',
+    });
+    vi.mocked(queryPrState).mockResolvedValue({ state: 'OPEN' });
+
+    await _handleIssueUpdateForTest(makePayload(), makeCtx(), makeGateSpecs());
+
+    // (a) queryPrState was called with the URL from getIssuePr
+    expect(queryPrState).toHaveBeenCalledWith(PR_URL);
+    // (b) the LLM path was never invoked
+    expect(executeAgentRun).not.toHaveBeenCalled();
+  });
+
+  it('skips LLM eval on MERGED PR', async () => {
+    vi.mocked(getIssuePr).mockReturnValue({
+      pr_url: PR_URL,
+      branch: 'feat/lia-119',
+      auto_merge_state: 'merged',
+    });
+    vi.mocked(queryPrState).mockResolvedValue({ state: 'MERGED' });
+
+    await _handleIssueUpdateForTest(makePayload(), makeCtx(), makeGateSpecs());
+
+    expect(queryPrState).toHaveBeenCalledWith(PR_URL);
+    expect(executeAgentRun).not.toHaveBeenCalled();
+  });
+
+  it('falls through to normal eval when no PR record exists (regression: fresh issue)', async () => {
+    // No PR in DB — getIssuePr returns undefined
+    vi.mocked(getIssuePr).mockReturnValue(undefined);
+    // executeAgentRun would be called by the full gate path; mock it to avoid
+    // actually running an LLM or erroring on missing infra
+    vi.mocked(executeAgentRun).mockResolvedValue({
+      text: '## Verdict: SHIP\n',
+      error: '',
+    });
+
+    await _handleIssueUpdateForTest(makePayload(), makeCtx(), makeGateSpecs());
+
+    // queryPrState must NOT be called when there is no PR record
+    expect(queryPrState).not.toHaveBeenCalled();
+    // The LLM path WAS reached (normal bouncer eval runs on fresh issues)
+    expect(executeAgentRun).toHaveBeenCalled();
+  });
+
+  // Intentional CLOSED-PR fall-through: a closed (abandoned) PR means the
+  // previous work was superseded. The bouncer should re-evaluate whether the
+  // issue is ready for a fresh agent run — so the LLM path must still fire.
+  it('falls through to normal eval when PR state is CLOSED (abandoned work)', async () => {
+    vi.mocked(getIssuePr).mockReturnValue({
+      pr_url: PR_URL,
+      branch: 'feat/lia-119',
+      auto_merge_state: 'failed',
+    });
+    vi.mocked(queryPrState).mockResolvedValue({ state: 'CLOSED' });
+    vi.mocked(executeAgentRun).mockResolvedValue({
+      text: '## Verdict: SHIP\n',
+      error: '',
+    });
+
+    await _handleIssueUpdateForTest(makePayload(), makeCtx(), makeGateSpecs());
+
+    expect(queryPrState).toHaveBeenCalledWith(PR_URL);
+    // CLOSED → bypass did NOT fire → LLM path ran
+    expect(executeAgentRun).toHaveBeenCalled();
+  });
+});

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -23,8 +23,9 @@ import {
   incrementAttemptCount,
   appendReviseHistory,
   computeEnrichmentHash,
+  getIssuePr,
 } from './db.js';
-import { triggerAutoMerge } from './linear-auto-merge.js';
+import { triggerAutoMerge, queryPrState } from './linear-auto-merge.js';
 import { notifyPipelineStep } from './linear-notifications.js';
 import { syncVaultPending } from './linear-vault-sync.js';
 import { RetryableError, UserError, FatalError } from './errors/index.js';
@@ -917,6 +918,28 @@ async function handleIssueUpdate(
     );
     return;
   }
+
+  // LIA-119: skip bouncer eval when the issue already has an open or merged PR.
+  // Triage solves this on fresh agent dispatch (triage_skip_open_pr) but the
+  // bypass doesn't reach the bouncer when a state transition re-enters it (e.g.
+  // In Review → Todo). Inserting BEFORE inFlightGate.add keeps the fast-path
+  // clean — no lock to release on early return.
+  // CLOSED (abandoned) PRs fall through to normal eval so a fresh agent can run.
+  if (gateSpec.name === 'bouncer-gate') {
+    const prRec = getIssuePr(data.id);
+    if (prRec?.pr_url) {
+      const prState = await queryPrState(prRec.pr_url);
+      if (prState && (prState.state === 'OPEN' || prState.state === 'MERGED')) {
+        updateWebhookEventStatus(eventKey, 'done', { verdict: 'skipped' });
+        logger.info(
+          { issueId: data.id, pr: prRec.pr_url, prState: prState.state },
+          'linear-webhook: bouncer skip — open/merged PR',
+        );
+        return;
+      }
+    }
+  }
+
   ctx.inFlightGate.add(data.id);
 
   // --- Bouncer entry-path router: short-circuit on fresh enrichment hash ---
@@ -1924,3 +1947,7 @@ export function startLinearWebhookServer(
     });
   });
 }
+
+// Test-only export — allows unit tests to drive handleIssueUpdate directly
+// without starting the full webhook server. Pattern mirrors _setSleepFnForTests.
+export const _handleIssueUpdateForTest = handleIssueUpdate;


### PR DESCRIPTION
## Problem

The bouncer-gate entry-path router in `src/linear-webhook.ts` had no PR-state awareness. Any state transition that re-enters the bouncer (e.g. dragging In Review → Todo) ran a full LLM eval and could emit a spurious **REVISE** on an issue whose work is already done and PR'd — observed on LIA-73 (bouncer REVISE'd an issue with PR #613 open + output-quality-gate SHIP'd). Triage already solves this (`triage_skip_open_pr`) but its bypass never reached the bouncer.

## Fix

Add a PR fast-path **before** `ctx.inFlightGate.add(data.id)` (no in-flight lock to release on early return), **guarded to the bouncer gate only** (`gateSpec.name === 'bouncer-gate'` — other gates unaffected):

```
getIssuePr(data.id)            // sync SQLite read, no API cost; undefined for fresh issues
  → queryPrState(pr_url)       // gh CLI, only when a PR URL is on record
    → OPEN | MERGED            // mark event done({verdict:'skipped'}), return — no LLM call
    → CLOSED / none            // fall through to normal eval (abandoned work re-evaluates)
```

The `getIssuePr → queryPrState` chain (not `queryPrState(issueId)`, which takes a URL) was the correctness pivot caught in plan review.

## Tests (`src/linear-webhook-bouncer-pr-bypass.test.ts`, 4 cases)

Drive the **real** `handleIssueUpdate` and stub `getIssuePr` one layer up, asserting **outcome** (the LLM path `executeAgentRun` is/isn't called), not plumbing:

| Case | queryPrState called w/ PR_URL | LLM path |
|------|---|---|
| OPEN PR | yes | **not** called (bypass) |
| MERGED PR | yes | **not** called (bypass) |
| No PR (fresh) | no | called (regression) |
| CLOSED PR | yes | called (fall-through) |

## Verification

- plan-reviewer **SHIP** (v2); code-reviewer **SHIP** — guard, argument (`pr_url` not id), placement, and non-vacuous assertions all verified against primary source.
- `tsc --noEmit` clean — **0 errors** (main baseline 0; 2 test-file type errors found in my verification pass and fixed pre-commit), `vitest` **4/4 pass**.
- Adds the 8th loop-break mechanism to `docs/decisions/linear-webhook-pipeline.md`.

Closes LIA-119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)