### PR TITLE
fix(skills): load x-integration host handler in the compiled prod service (LIA-191)

### DIFF
--- a/.claude/skills/x-integration/host.ts
+++ b/.claude/skills/x-integration/host.ts
@@ -157,3 +157,24 @@ export async function handleXIpc(
   }
   return true;
 }
+
+// Structural copy of SkillIpcHandler (src/skills/registry.ts) — keeps host.ts
+// free of any src/ import so tsconfig.skills.json compiles it standalone.
+// `deps` is `unknown` because x-integration uses no IpcDeps method.
+type RegisterFn = (
+  name: string,
+  handler: (
+    data: Record<string, unknown>,
+    sourceGroup: string,
+    isControlGroup: boolean,
+    deps: unknown,
+  ) => Promise<boolean>,
+) => void;
+
+export function register(reg: RegisterFn): void {
+  // dataDir mirrors src/config.ts:55 DATA_DIR (= path.resolve(process.cwd(), 'data')).
+  const dataDir = path.resolve(process.cwd(), 'data');
+  reg('x-integration', (data, sourceGroup, isControlGroup, _deps) =>
+    handleXIpc(data, sourceGroup, isControlGroup, dataDir),
+  );
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
 
+      - name: Typecheck skill hosts
+        run: npx tsc -p tsconfig.skills.json --noEmit
+
       - name: Tests
         run: npx vitest run
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p packages/mcp-channel-core && for d in packages/*/; do [ \"$d\" != 'packages/mcp-channel-core/' ] && [ -f \"$d/tsconfig.json\" ] && tsc -p \"$d\"; done && tsc",
+    "build": "tsc -p packages/mcp-channel-core && for d in packages/*/; do [ \"$d\" != 'packages/mcp-channel-core/' ] && [ -f \"$d/tsconfig.json\" ] && tsc -p \"$d\"; done && tsc && tsc -p tsconfig.skills.json",
     "postbuild": "python3 scripts/codebase_map.py --output .claude/codebase_map.md",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-08" # auto-bump @1780941703
+last_verified: "2026-06-11" # auto-bump @1781178220
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-11" # auto-bump @1781176077
+last_verified: "2026-06-11" # auto-bump @1781178220
 governs:
   - src/
   - evolution/

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-11" # auto-bump @1781175456
+last_verified: "2026-06-11" # auto-bump @1781178220
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/src/skills/index.test.ts
+++ b/src/skills/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { loadSkillIpcHandlers } from './index.js';
+import { logger } from '../logger.js';
 
 // Mock fs and logger
 vi.mock('fs');
@@ -54,5 +55,43 @@ describe('loadSkillIpcHandlers', () => {
     expect(fs.readdirSync).toHaveBeenCalledWith(skillsDir, {
       withFileTypes: true,
     });
+  });
+
+  it('warns loudly when a skill has host.ts but no compiled host.js', async () => {
+    const skillsDir = path.join(process.cwd(), '.claude', 'skills');
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s === skillsDir) return true; // skills dir exists
+      if (s.endsWith('host.js')) return false; // not compiled
+      if (s.endsWith('host.ts')) return true; // source present
+      return false;
+    });
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      { name: 'x-integration', isDirectory: () => true },
+    ] as never);
+
+    await loadSkillIpcHandlers();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ skill: 'x-integration' }),
+      expect.stringContaining('no compiled host.js'),
+    );
+  });
+
+  it('does not warn when a compiled host.js is present', async () => {
+    const skillsDir = path.join(process.cwd(), '.claude', 'skills');
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s === skillsDir) return true;
+      if (s.endsWith('host.js')) return true; // compiled present
+      return false;
+    });
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      { name: 'x-integration', isDirectory: () => true },
+    ] as never);
+
+    await loadSkillIpcHandlers();
+
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -36,11 +36,22 @@ export async function loadSkillIpcHandlers(): Promise<void> {
     const hostJs = path.join(SKILLS_DIR, entry.name, 'host.js');
     const hostTs = path.join(SKILLS_DIR, entry.name, 'host.ts');
 
-    const resolvedPath = fs.existsSync(hostJs)
-      ? hostJs
-      : fs.existsSync(hostTs)
-        ? hostTs
-        : null;
+    const hasJs = fs.existsSync(hostJs);
+    const hasTs = fs.existsSync(hostTs);
+    if (!hasJs && hasTs) {
+      // The compiled production service (node dist/) has no TS loader, so a
+      // direct import() of host.ts throws ERR_UNKNOWN_FILE_EXTENSION and the
+      // handler silently never registers. Make that misconfig LOUD. Run
+      // `npm run build` (tsconfig.skills.json) to emit host.js; the .ts
+      // fallback below only works under tsx/dev.
+      logger.warn(
+        { skill: entry.name, hostTs },
+        'Skill ships host.ts but no compiled host.js — it will NOT load in the ' +
+          'compiled production service. Run `npm run build` to generate host.js.',
+      );
+    }
+
+    const resolvedPath = hasJs ? hostJs : hasTs ? hostTs : null;
     if (!resolvedPath) continue;
 
     try {

--- a/tsconfig.skills.json
+++ b/tsconfig.skills.json
@@ -1,0 +1,16 @@
+{
+  "//": "Compiles skill host.ts files (e.g. .claude/skills/*/host.ts) to host.js IN PLACE so the compiled production service (node dist/, no TS loader) can load them. Standalone (no extends) to avoid the base tsconfig's outDir:./dist + rootDir:./src, which would misdirect emit and reject files outside src/. host.js is gitignored (.gitignore:101); npm run build regenerates it.",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ES2022",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "declarationMap": false,
+    "noEmit": false
+  },
+  "include": [".claude/skills/*/host.ts"]
+}


### PR DESCRIPTION
## Problem

The `x-integration` skill's host IPC handlers (post/like/reply/retweet/quote) **never register in the compiled production service** (`node dist/index.js`). They work only under `npm run dev` (tsx). Three layers, all real:

1. **Availability** — `.claude/skills/x-integration/` ships only `host.ts`; prod has no TS loader, so `import('host.ts')` throws `ERR_UNKNOWN_FILE_EXTENSION` (caught → silent degradation).
2. **No `register` export** — `src/skills/index.ts:48-50` calls `mod.register(registerSkillIpcHandler)`, but `host.ts` exported only `handleXIpc`.
3. **Signature mismatch** — the dispatch (`src/ipc.ts:660`) passes `deps: IpcDeps`, but `handleXIpc`'s 4th param was `dataDir: string`, and `IpcDeps` has no data-dir field. The handler was never wired to the current contract.

## Fix

- **`host.ts`** — add `register()` with a structural-typed adapter that conforms to the registry's `SkillIpcHandler` and resolves the data dir itself (`path.resolve(process.cwd(),'data')`, mirroring `config.ts:55` DATA_DIR). Uses a **local structural type** (`deps: unknown`) so `host.ts` has zero `src/` dependency and compiles standalone. `handleXIpc` unchanged.
- **`tsconfig.skills.json`** (new) + **`npm run build`** wiring — compile `.claude/skills/*/host.ts` → `host.js` **in place** (no `outDir`); `declaration`/`sourceMap` off (no stray `.d.ts`/`.map`). `host.js` is already gitignored → regenerated each build, never stale.
- **`ci.yml`** — `Typecheck skill hosts` step (`tsc -p tsconfig.skills.json --noEmit`) in the required `ci` job, so a broken skills tsconfig/host fails CI.
- **`src/skills/index.ts`** — loud warning when a skill ships `host.ts` with no compiled `host.js` (makes the latent prod-fail trap visible for any future skill); preserves the `.ts` dev fallback.
- **`src/skills/index.test.ts`** — 2 loader tests for the warning behavior.

## Verification

- plan-reviewer **SHIP** (v4); code-reviewer **SHIP**.
- `tsc --noEmit -p tsconfig.json` → **0 errors**; `tsc -p tsconfig.skills.json --noEmit` → **0 errors**.
- `npm run build` emits `.claude/skills/x-integration/host.js` (no stray artifacts); `vitest` loader suite **5/5 pass**.
- **End-to-end**: a compiled `node` process (no TS loader) ran `loadSkillIpcHandlers()` → `getRegisteredSkillNames()` returned `["x-integration"]` — the bug is fixed in a prod-style load, not just compiling.

Closes LIA-191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)