### PR TITLE
fix(code-search): re-tune confidence abstain threshold to 0.25 (LIA-204)

### DIFF
--- a/scripts/code_search.py
+++ b/scripts/code_search.py
@@ -141,6 +141,14 @@ def _migrate_legacy_if_match(root: Path | None, dbp: Path) -> None:
 DEFAULT_TOP_K = 10
 DEFAULT_RRF_K = int(os.environ.get("DEUS_CODE_SEARCH_RRF_K", "60"))
 
+# Retrieval-confidence threshold below which a query is flagged as likely
+# outside the indexed codebase (search() warning) and counted as a correct
+# abstain (benchmark()). Re-tuned for the generic-NL calibration from #717: a
+# sweep over scripts/tests/fixtures/code_search_bench.jsonl found 0.25 is the
+# lowest threshold reaching the 0.85 abstain-accuracy plateau while minimizing
+# in-domain false-flags (LIA-204).
+CONFIDENCE_ABSTAIN_THRESHOLD = 0.25
+
 # Calibration query set for retrieval_confidence (GH #717).
 # Built from NL-shaped queries, not symbol-name self-lookups: querying
 # `chunk_name.replace("_"," ")` matches its own chunk at artificially tight
@@ -876,7 +884,7 @@ def search(
     Returns results with retrieval_confidence (0-1): query-level signal
     indicating how well the query matches the indexed codebase. Computed
     via percentile rank against a stored calibration distribution. Below
-    0.3 = likely out-of-domain.
+    0.25 = likely out-of-domain.
     """
     dbp = _resolve_db_path()
     _migrate_legacy_if_match(_project_root(), dbp)
@@ -1004,7 +1012,7 @@ def search(
             }
             if top_vec_distance >= 2.0:
                 entry["low_confidence_warning"] = "embedding unavailable — confidence unreliable"
-            elif retrieval_confidence < 0.3:
+            elif retrieval_confidence < CONFIDENCE_ABSTAIN_THRESHOLD:
                 entry["low_confidence_warning"] = "query may be outside indexed codebase"
             results.append(entry)
 
@@ -1295,7 +1303,7 @@ def benchmark(
 
         if expect_abstain:
             abstain_total += 1
-            if ret_conf < 0.3:
+            if ret_conf < CONFIDENCE_ABSTAIN_THRESHOLD:
                 abstain_correct += 1
                 bucket.setdefault("abstain_correct", 0)
                 bucket["abstain_correct"] += 1

--- a/scripts/code_search_mcp.py
+++ b/scripts/code_search_mcp.py
@@ -60,7 +60,7 @@ def _run_mcp_server() -> None:
         Each result includes two confidence scores:
         - confidence (0-1): per-result ranking quality (RRF score normalized).
         - retrieval_confidence (0-1): query-level signal indicating how well the
-          query matches the indexed codebase. Below 0.3 = likely out-of-domain.
+          query matches the indexed codebase. Below 0.25 = likely out-of-domain.
           This value is identical across all results for the same query.
 
         Args:

--- a/scripts/tests/test_code_search_calibration.py
+++ b/scripts/tests/test_code_search_calibration.py
@@ -59,3 +59,22 @@ def test_717_nl_calibration_beats_symbol_self_lookup():
     assert rc(nl_query_dist, nl_cal, True) > rc(nl_query_dist, symbol_cal, True)
     # Genuinely out-of-domain queries still rank far -> low confidence.
     assert rc(0.70, nl_cal, True) <= 0.1
+
+
+def test_lia204_abstain_threshold_value():
+    # LIA-204 re-tuned the shared abstain/warning threshold off the old 0.3.
+    # Guard against accidental drift back.
+    assert code_search.CONFIDENCE_ABSTAIN_THRESHOLD == 0.25
+
+
+def test_lia204_threshold_separates_indomain_from_ood():
+    """The 0.25 threshold keeps in-domain NL matches above the warning line
+    while still flagging far out-of-domain queries (LIA-204 sweep choice)."""
+    # Generic-NL calibration shape (post-#717).
+    cal = [0.38, 0.42, 0.43, 0.44, 0.46, 0.48, 0.50, 0.53, 0.55, 0.57]
+    thr = code_search.CONFIDENCE_ABSTAIN_THRESHOLD
+    # An in-domain match (low NN distance) scores well above threshold ->
+    # no false "outside indexed codebase" warning.
+    assert rc(0.40, cal, True) >= thr
+    # A far out-of-domain match scores below threshold -> correctly flagged.
+    assert rc(0.95, cal, True) < thr


### PR DESCRIPTION
## Context

#717 replaced the symbol-name self-lookup calibration with a generic-NL one (in-domain NL confidence docstring 0.471→0.874, git-history 0.13→0.592). Side effect: out-of-domain confidence also rose, so the hardcoded `0.3` abstain threshold — tuned for the old over-tight distribution — now mis-scores. It was duplicated in two shared sites:

- `search()` — the `retrieval_confidence < 0.3` → "query may be outside indexed codebase" warning.
- `benchmark()` — the `ret_conf < 0.3` abstain-accuracy check.

## Sweep (measure-first)

170 fixtures, run once against the **live recalibrated** index, then swept offline:

| thr | abstain_acc | abst_far | abst_near | in-domain false-flags |
|----|----|----|----|----|
| 0.20 | 0.800 | 0.800 | 0.800 | 10/150 |
| **0.25** | **0.850** | 0.800 | 0.900 | 14/150 |
| 0.30 (old) | 0.850 | 0.800 | 0.900 | 15/150 |
| 0.35 | 0.850 | 0.800 | 0.900 | 17/150 |
| 0.45 | 0.850 | 0.800 | 0.900 | 24/150 |

Confidence by tag: `abstain-far` med 0.157 / **max 0.571**; `abstain-near` med 0.071 / **max 0.571**; `docstring` med 0.971; `git-history` med 0.686.

**Reading:** abstain_accuracy **plateaus at 0.85** — 3/20 abstain fixtures carry confidence up to 0.571, an inherent ceiling no usable threshold clears (the old "1.0" was an artifact of the over-tight calibration that also false-flagged real git-history queries at 0.13 < 0.3 — the bug #717 fixed). In-domain false-flags grow monotonically with threshold. **0.25 strictly dominates 0.30** (identical 0.85 abstain, fewer in-domain false-flags) and is the lowest threshold at the plateau. The production-warning optimum (0.20) and benchmark-abstain optimum (0.25) are one sweep step apart → **single constant**.

## Change

- `scripts/code_search.py` — `CONFIDENCE_ABSTAIN_THRESHOLD = 0.25` (module constant), both `0.3` call sites, and the `search()` docstring.
- `scripts/code_search_mcp.py` — the tool-description text ("Below 0.25 = likely out-of-domain").
- `scripts/tests/test_code_search_calibration.py` — assert the constant + a CI-safe `_retrieval_confidence` test that an in-domain distance (0.40 → 0.900) clears the threshold and a far-OOD distance (0.95 → 0.000) does not.

## Verification

plan-reviewer **SHIP** (v2, with this sweep); code-reviewer **SHIP**. `pytest scripts/tests/test_code_search_calibration.py` → **6 passed**.

## Deploy note

Recalibration/threshold changes do **not** invalidate a running code-search server's in-memory `_cal_cache` / module constants — the per-session MCP servers pick this up on restart. (Filing a follow-up to add cache invalidation on `reindex()` + a `code_search_queries.jsonl` production log so future tuning has real-usage coverage.)

Closes LIA-204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)