### PR TITLE
fix(agent-runner): guard image-attachment path traversal in default Claude backend (LIA-220)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -37,6 +37,7 @@ import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 import { createToolCallLogHook } from './tool-call-log.js';
 import { writeAvailableTools } from './available-tools-log.js';
 import type { AgentRuntimeId } from './tool-broker.js';
+import { resolveGroupAttachmentPath } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
 import { createPreToolUseHook, dispatchHost } from './pre-tool-use-hook.js';
 import { createBlockingPreToolUseObserver } from './pre-tool-use-gate-observer.js';
@@ -667,15 +668,20 @@ async function runQuery(
   if (containerInput.imageAttachments?.length) {
     const blocks: ContentBlock[] = [];
     for (const img of containerInput.imageAttachments) {
-      const imgPath = path.join('/workspace/group', img.relativePath);
       try {
+        // Guard against path traversal (e.g. '../../proc/self/environ'), the
+        // same guard the openai/llama backends use. DELIBERATE divergence: those
+        // call it outside the try, so a traversal aborts the whole query; we keep
+        // it inside so one malicious [Image: ...] tag is skipped + logged and the
+        // run continues (any group member could otherwise wedge a query).
+        const imgPath = resolveGroupAttachmentPath(img.relativePath);
         const data = fs.readFileSync(imgPath).toString('base64');
         blocks.push({
           type: 'image',
           source: { type: 'base64', media_type: img.mediaType, data },
         });
       } catch (err) {
-        log(`Failed to load image: ${imgPath}`);
+        log(`Failed to load image: ${img.relativePath}`);
       }
     }
     if (blocks.length > 0) {

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-11" # auto-bump @1781178220
+last_verified: "2026-06-12" # auto-bump @1781218365
 governs:
   - src/
   - evolution/

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -100,6 +100,30 @@ describe('image processing', () => {
       const messages = [{ content: 'just text' }];
       expect(parseImageReferences(messages as any)).toEqual([]);
     });
+
+    it('drops path-traversal references that escape the attachments dir', () => {
+      const messages = [
+        { content: '[Image: attachments/img-123.jpg] ok' },
+        {
+          content:
+            '[Image: attachments/../../../../proc/self/environ] exfil attempt',
+        },
+        { content: '[Image: attachments/../vault/CLAUDE.md]' },
+        { content: '[Image: attachments/sub/../img-789.jpg]' },
+      ];
+      const refs = parseImageReferences(messages as any);
+
+      // Escaping refs are dropped; in-tree paths survive. The 'sub/../' case is
+      // not realistic processImage output — it's a boundary check that the guard
+      // keys on actual escape, not on the mere presence of '..'.
+      expect(refs).toEqual([
+        { relativePath: 'attachments/img-123.jpg', mediaType: 'image/jpeg' },
+        {
+          relativePath: 'attachments/sub/../img-789.jpg',
+          mediaType: 'image/jpeg',
+        },
+      ]);
+    });
   });
 
   describe('host-side image flow', () => {

--- a/src/image.ts
+++ b/src/image.ts
@@ -53,6 +53,20 @@ export async function processImage(
   return { content, relativePath };
 }
 
+/**
+ * Host-side defense-in-depth: drop any `relativePath` that escapes the group's
+ * `attachments/` subtree before it reaches the container (the regex capture
+ * permits `..`, e.g. `attachments/../../proc/self/environ`). `processImage`
+ * only ever emits `attachments/img-*.jpg`, so no legitimate path is rejected.
+ * `path.posix` is deliberate — relativePaths are always POSIX container paths
+ * regardless of host OS.
+ */
+function isWithinAttachments(relativePath: string): boolean {
+  if (path.posix.isAbsolute(relativePath)) return false;
+  const normalized = path.posix.normalize(relativePath);
+  return normalized === 'attachments' || normalized.startsWith('attachments/');
+}
+
 export function parseImageReferences(
   messages: Array<{ content: string }>,
 ): ImageAttachment[] {
@@ -61,8 +75,10 @@ export function parseImageReferences(
     let match: RegExpExecArray | null;
     IMAGE_REF_PATTERN.lastIndex = 0;
     while ((match = IMAGE_REF_PATTERN.exec(msg.content)) !== null) {
+      const relativePath = match[1];
+      if (!isWithinAttachments(relativePath)) continue;
       // Always JPEG — processImage() normalizes all images to .jpg
-      refs.push({ relativePath: match[1], mediaType: 'image/jpeg' });
+      refs.push({ relativePath, mediaType: 'image/jpeg' });
     }
   }
   return refs;


### PR DESCRIPTION
## Summary

Closes **LIA-220** (high-severity security). The default Claude Code backend loaded image attachments via a raw `path.join('/workspace/group', img.relativePath)` with **no traversal guard**, while the opt-in openai/llama-cpp backends already call `resolveGroupAttachmentPath` (`container/agent-runner/src/tool-broker.ts:339`).

`img.relativePath` flows untrusted from channel message bodies: the host regex `IMAGE_REF_PATTERN` capture `[^\]]+` (`src/image.ts`) permits `..`. A message containing `[Image: attachments/../../../../proc/self/environ]` was read inside the container and base64-encoded into the LLM request — an **arbitrary in-container file-read / exfiltration primitive** on the default, most-used backend (e.g. reading `/proc/self/environ` or `/workspace/project` files). `parseImageReferences` runs over the whole missed-messages batch, so any group member (even non-allowlisted) can plant the tag; it fires when an allowed sender triggers a run.

## Fix (defense-in-depth, two layers)

| Layer | File | Change |
|---|---|---|
| Container sink | `container/agent-runner/src/index.ts` | Replace raw `path.join` with `resolveGroupAttachmentPath(img.relativePath)` — the same guard the other two backends use. |
| Host source | `src/image.ts` | `parseImageReferences` drops any ref that normalizes outside `attachments/` (new `isWithinAttachments` helper) before it crosses into the container. |
| Test | `src/image.test.ts` | Cover the host-side drop + intra-tree boundary. |

### Deliberate divergence from the sibling backends
The openai/llama-cpp backends call the guard **outside** their try-block, so a traversal attempt throws out of the image loop and aborts the entire query. This fix places the guard **inside** the try, so a malicious tag is skipped + logged and the run continues. Rationale: any group member could otherwise wedge every query by planting one bad `[Image: ...]` tag (a denial-of-service). This is intentional, not an oversight.

## Verification
- Host: `npx vitest run src/image.test.ts` → 11/11 pass (incl. new `drops path-traversal references…`).
- Container guard tests: `openai-backend.test.ts` + 2 gate tests → 20/20 pass (incl. `resolveGroupAttachmentPath('../vault/CLAUDE.md')` throws `/escapes/`).
- `tsc --noEmit`: host exit 0, container exit 0.

Note: the guard's canonical unit test lives in `tool-broker.ts`'s function but is currently asserted from `openai-backend.test.ts:34-41` (and the two `*.gate.test.ts`). If a future refactor moves it, keep that coverage.

## ⚠️ Deploy requirement
This touches the **container** image. `npm run build` does **not** rebuild it — run `./container/build.sh` and restart groups for the fix to reach running containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)