### PR TITLE
fix(container-mounter): shadow real credentials from the control-group project mount (LIA-210)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781261347
+last_verified: "2026-06-12" # auto-bump @1781262829
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-06-02" # auto-bump @1780407086
+last_verified: "2026-06-12" # auto-bump @1780407086
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/container-mounter.test.ts
+++ b/src/container-mounter.test.ts
@@ -181,6 +181,87 @@ describe('buildVolumeMounts: control group', () => {
   });
 });
 
+// ── Control group credential lockdown (LIA-210) ─────────────────────────
+
+describe('buildVolumeMounts: control group credential lockdown (LIA-210)', () => {
+  it('shadows runtime-state dirs (data/store/groups/logs) under the project root', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    mockReaddirSync.mockReturnValue([]);
+    const group = makeGroup({ isControlGroup: true });
+    const mounts = buildVolumeMounts(group, true);
+    for (const name of ['data', 'store', 'groups', 'logs']) {
+      const shadow = findMount(mounts, `/workspace/project/${name}`);
+      expect(shadow, `${name} should be shadowed`).toBeDefined();
+      expect(shadow!.readonly).toBe(true);
+      // Shadow source is an empty dir under DATA_DIR/control-shadows, not the
+      // real runtime dir — so the container cannot read the real content.
+      expect(shadow!.hostPath).toContain('control-shadows');
+      expect(shadow!.hostPath).not.toContain(`${path.sep}${name}${path.sep}`);
+    }
+  });
+
+  it('shadows non-gcal integrations children but preserves gcal', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    mockReaddirSync.mockImplementation((p) =>
+      String(p).endsWith('integrations')
+        ? (['gcal', 'odysseus'] as unknown as ReturnType<typeof fs.readdirSync>)
+        : ([] as unknown as ReturnType<typeof fs.readdirSync>),
+    );
+    const group = makeGroup({ isControlGroup: true });
+    const mounts = buildVolumeMounts(group, true);
+    // odysseus shadowed
+    const odysseus = findMount(
+      mounts,
+      '/workspace/project/integrations/odysseus',
+    );
+    expect(odysseus).toBeDefined();
+    expect(odysseus!.readonly).toBe(true);
+    expect(odysseus!.hostPath).toContain('control-shadows');
+    // gcal preserved (NOT shadowed) — its MCP reads creds in-container by
+    // design; it stays visible through the parent /workspace/project mount.
+    const gcal = findMount(mounts, '/workspace/project/integrations/gcal');
+    expect(gcal).toBeUndefined();
+  });
+
+  it('does not shadow runtime dirs that do not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const group = makeGroup({ isControlGroup: true });
+    const mounts = buildVolumeMounts(group, true);
+    for (const name of ['data', 'store', 'groups', 'logs']) {
+      expect(findMount(mounts, `/workspace/project/${name}`)).toBeUndefined();
+    }
+  });
+});
+
+// ── Worktree mount shadowing (LIA-210 shared-helper coverage) ───────────
+
+describe('buildVolumeMounts: worktree mount shadowing', () => {
+  it('shadows sensitive files/dirs in a worktree mount via the shared helper', () => {
+    const worktreePath = path.join(TMP_BASE, 'wt', 'feature-x');
+    mockExistsSync.mockReturnValue(true);
+    mockRealpathSync.mockImplementation((p) => String(p));
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    mockReaddirSync.mockReturnValue([]);
+    const group = makeGroup({ isControlGroup: true });
+    const mounts = buildVolumeMounts(group, true, worktreePath);
+    // Worktree mounted writable at /workspace/project (project override).
+    const proj = findMount(mounts, '/workspace/project');
+    expect(proj).toBeDefined();
+    expect(proj!.readonly).toBe(false);
+    expect(proj!.hostPath).toBe(worktreePath);
+    // .env shadowed via the shared helper.
+    const envShadow = findMount(mounts, '/workspace/project/.env');
+    expect(envShadow).toBeDefined();
+    expect(envShadow!.hostPath).toBe(os.devNull);
+    // credentials/ dir shadowed under worktree-shadows.
+    const credShadow = findMount(mounts, '/workspace/project/credentials');
+    expect(credShadow).toBeDefined();
+    expect(credShadow!.hostPath).toContain('worktree-shadows');
+  });
+});
+
 // ── Non-control group basic mounts ──────────────────────────────────────
 
 describe('buildVolumeMounts: non-control group', () => {

--- a/src/container-mounter.test.ts
+++ b/src/container-mounter.test.ts
@@ -239,7 +239,11 @@ describe('buildVolumeMounts: control group credential lockdown (LIA-210)', () =>
 
 describe('buildVolumeMounts: worktree mount shadowing', () => {
   it('shadows sensitive files/dirs in a worktree mount via the shared helper', () => {
-    const worktreePath = path.join(TMP_BASE, 'wt', 'feature-x');
+    // path.resolve (not path.join) so the path is drive-absolute on Windows:
+    // the worktree branch guards on `realWorktree !== path.resolve(worktreePath)`,
+    // and a drive-relative path (\tmp\...) would gain a drive letter under
+    // path.resolve and fail that equality, skipping the mount.
+    const worktreePath = path.resolve(TMP_BASE, 'wt', 'feature-x');
     mockExistsSync.mockReturnValue(true);
     mockRealpathSync.mockImplementation((p) => String(p));
     mockStatSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -66,6 +66,41 @@ function resolveVaultPath(): string | null {
   return null;
 }
 
+/**
+ * Shadow sensitive files (devNull) and dirs (empty dir under `dirShadowBase`)
+ * inside a `/workspace/project` mount. Single-sourced across every project-root
+ * mount branch: divergence here is a credential-exposure bug — it was exactly
+ * that (the control branch shadowed only `.env` while the others ran these
+ * loops; LIA-210).
+ */
+function pushProjectShadows(
+  mounts: VolumeMount[],
+  hostDir: string,
+  dirShadowBase: string,
+): void {
+  for (const pattern of SENSITIVE_FILE_PATTERNS) {
+    if (fs.existsSync(path.join(hostDir, pattern))) {
+      mounts.push({
+        hostPath: os.devNull,
+        containerPath: `/workspace/project/${pattern}`,
+        readonly: true,
+      });
+    }
+  }
+  for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
+    const dirPath = path.join(hostDir, dirPattern);
+    if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+      const shadowDir = path.join(dirShadowBase, dirPattern);
+      fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
+      mounts.push({
+        hostPath: shadowDir,
+        containerPath: `/workspace/project/${dirPattern}`,
+        readonly: true,
+      });
+    }
+  }
+}
+
 export function buildVolumeMounts(
   group: RegisteredGroup,
   isControlGroup: boolean,
@@ -85,13 +120,61 @@ export function buildVolumeMounts(
         containerPath: '/workspace/project',
         readonly: true,
       });
-      const envFile = path.join(projectRoot, '.env');
-      if (fs.existsSync(envFile)) {
+      // Credential shadowing (LIA-210): the whole repo is mounted read-only for
+      // the control/dev agent, but read-only is still `cat`-able — every path
+      // holding real secrets or PII must be shadowed. Three layers:
+      // (1) shared patterns (.env*, credentials/, secrets/):
+      pushProjectShadows(
+        mounts,
+        projectRoot,
+        path.join(DATA_DIR, 'control-shadows'),
+      );
+      // (2) Deus runtime-state dirs (live creds in data/env/env + store/auth,
+      // message DBs, logs). Denylist, not allowlist: the agent needs broad code
+      // access, so an allowlist would break unknown/future code dirs. DENYLIST:
+      // any new runtime/cred dir under the project root MUST be added here.
+      for (const name of ['data', 'store', 'groups', 'logs']) {
+        if (!fs.existsSync(path.join(projectRoot, name))) continue;
+        const shadowDir = path.join(DATA_DIR, 'control-shadows', name);
+        fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
         mounts.push({
-          hostPath: os.devNull,
-          containerPath: '/workspace/project/.env',
+          hostPath: shadowDir,
+          containerPath: `/workspace/project/${name}`,
           readonly: true,
         });
+      }
+      // (3) integrations/: shadow every child EXCEPT gcal, whose MCP reads its
+      // OAuth creds in-container by design (agent-runner reads
+      // /workspace/project/integrations/gcal/*). gcal stays visible through the
+      // parent mount; enumerating keeps new integrations hidden by default.
+      // Residual in-container gcal-token exposure: follow-up LIA-282.
+      const integrationsDir = path.join(projectRoot, 'integrations');
+      if (fs.existsSync(integrationsDir)) {
+        for (const child of fs.readdirSync(integrationsDir)) {
+          if (child === 'gcal') continue;
+          const childPath = path.join(integrationsDir, child);
+          const containerChild = `/workspace/project/integrations/${child}`;
+          if (fs.statSync(childPath).isDirectory()) {
+            const shadowDir = path.join(
+              DATA_DIR,
+              'control-shadows',
+              'integrations',
+              child,
+            );
+            fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
+            mounts.push({
+              hostPath: shadowDir,
+              containerPath: containerChild,
+              readonly: true,
+            });
+          } else {
+            mounts.push({
+              hostPath: os.devNull,
+              containerPath: containerChild,
+              readonly: true,
+            });
+          }
+        }
       }
     }
 
@@ -137,33 +220,11 @@ export function buildVolumeMounts(
         containerPath: '/workspace/project',
         readonly: false,
       });
-      for (const pattern of SENSITIVE_FILE_PATTERNS) {
-        const filePath = path.join(worktreePath, pattern);
-        if (fs.existsSync(filePath)) {
-          mounts.push({
-            hostPath: os.devNull,
-            containerPath: `/workspace/project/${pattern}`,
-            readonly: true,
-          });
-        }
-      }
-      for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
-        const dirPath = path.join(worktreePath, dirPattern);
-        if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
-          const shadowDir = path.join(
-            DATA_DIR,
-            'worktree-shadows',
-            path.basename(worktreePath),
-            dirPattern,
-          );
-          fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
-          mounts.push({
-            hostPath: shadowDir,
-            containerPath: `/workspace/project/${dirPattern}`,
-            readonly: true,
-          });
-        }
-      }
+      pushProjectShadows(
+        mounts,
+        worktreePath,
+        path.join(DATA_DIR, 'worktree-shadows', path.basename(worktreePath)),
+      );
     }
   } else if (group.projectId) {
     // External project mount: when a group has an associated project,
@@ -197,39 +258,13 @@ export function buildVolumeMounts(
           readonly: effectiveReadonly,
         });
 
-        // Shadow sensitive files to prevent credential leakage.
-        // The container will see the null device instead of the real file.
-        for (const pattern of SENSITIVE_FILE_PATTERNS) {
-          const filePath = path.join(realProjectPath, pattern);
-          if (fs.existsSync(filePath)) {
-            mounts.push({
-              hostPath: os.devNull,
-              containerPath: `/workspace/project/${pattern}`,
-              readonly: true,
-            });
-          }
-        }
-
-        // Shadow sensitive directories
-        for (const dirPattern of SENSITIVE_DIR_PATTERNS) {
-          const dirPath = path.join(realProjectPath, dirPattern);
-          if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
-            // Can't shadow a directory with /dev/null — use an empty tmpdir instead.
-            // Create a project-specific empty dir that persists across runs.
-            const shadowDir = path.join(
-              DATA_DIR,
-              'project-shadows',
-              group.projectId!,
-              dirPattern,
-            );
-            fs.mkdirSync(shadowDir, { recursive: true, mode: 0o700 });
-            mounts.push({
-              hostPath: shadowDir,
-              containerPath: `/workspace/project/${dirPattern}`,
-              readonly: true,
-            });
-          }
-        }
+        // Shadow sensitive files/dirs (.env*, credentials/, secrets/) so the
+        // container sees /dev/null / an empty dir instead of real content.
+        pushProjectShadows(
+          mounts,
+          realProjectPath,
+          path.join(DATA_DIR, 'project-shadows', group.projectId!),
+        );
 
         // Security note: symlinks WITHIN the mounted project can escape the
         // project boundary (e.g., project/data -> /etc/passwd). Docker/Apple


### PR DESCRIPTION
## Summary

Closes **LIA-210** (high-severity security). The control/main group's container mount (`src/container-mounter.ts` `buildVolumeMounts`, control-group fallback) bind-mounted the **entire** Deus project root read-only at `/workspace/project` and shadowed **only `.env`**. `DATA_DIR`/`STORE_DIR`/`GROUPS_DIR` and `integrations/` all live under the project root, so a prompt-injected control agent (Bash + `web_fetch`; container egress is open, no `--network` restriction) could `cat` real credentials straight out of the read-only mount, **defeating the credential-proxy guarantee**:

| Path | Secret exposed |
|------|----------------|
| `data/env/env` | live `CLAUDE_CODE_OAUTH_TOKEN` + `TELEGRAM_BOT_TOKEN` |
| `store/auth/` | WhatsApp Baileys session keys |
| `integrations/gcal/*` | Google OAuth credentials/tokens |
| `data/*.db`, `store/messages.db`, `groups/*` | all channel message history |

The worktree and external-project branches already shadowed via `SENSITIVE_*_PATTERNS`; the control branch had **drifted** and didn't. (The audit issue listed `data`/`groups`/`integrations` but missed `store/` — found during re-derivation; all 28 top-level dirs were enumerated to bound the sensitive set.)

## Fix

- **Extract `pushProjectShadows()`** and use it in all three project-mount branches (control / worktree / external) — single-sourcing the security-critical shadow logic whose duplication is the root cause of this drift.
- **Control-group fallback** now shadows, in three layers:
  1. shared patterns (`.env*`, `credentials/`, `secrets/`) via the helper;
  2. Deus runtime-state dirs `data`/`store`/`groups`/`logs` (denylist — documented why not allowlist: the control/dev agent needs broad code access, so an allowlist would silently break unknown/future code dirs);
  3. every `integrations/` child **except `gcal`** (enumerate-non-gcal — gcal's MCP reads its OAuth creds in-container *by design*, so it stays readable through the parent mount; secure-by-default for new integrations).
- All shadows are **2-level child-over-parent** bind mounts — the same depth the existing `.env`/`credentials` shadows use. Verified on Docker (a child empty-dir mount hides the real parent content while a sibling parent file stays readable).

## Deliberate residual (tracked: LIA-282)

gcal's Google OAuth token is still readable in-container — this is the **existing** design (the MCP reads it there) and a much narrower exposure than the closed ones. Per the chosen approach, the proper fix (proxy gcal through the host) is deferred to **LIA-282**.

## Verification
- `npx vitest run src/container-mounter.test.ts` → 39/39 (was 35; +4: runtime-dir shadowing, integrations non-gcal + gcal preserved, non-existent dirs, worktree-branch helper coverage).
- `npx tsc --noEmit` → exit 0.

## Deploy
Host-only — `buildVolumeMounts` runs host-side per dispatch. `ff-merge + npm run build + kickstart`. **No container image rebuild** (the mount logic isn't in the container); takes effect on the next dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)