### PR TITLE
fix(container-runner): prevent a rejected onOutput from wedging the group (LIA-212)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-09" # auto-bump @1781026737
+last_verified: "2026-06-12" # auto-bump @1781278494
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-09" # auto-bump @1781026737
+last_verified: "2026-06-12" # auto-bump @1781278494
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781277819
+last_verified: "2026-06-12" # auto-bump @1781278494
 governs:
   - src/
   - evolution/

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -313,6 +313,115 @@ describe('container-runner timeout behavior', () => {
 });
 
 // ---------------------------------------------------------------------------
+// A rejected onOutput must NOT wedge the group (LIA-212).
+//
+// onOutput rejection is reachable in production: container-backend.ts's onOutput
+// awaits eventSink with no try/catch, and the orchestrator's eventSink awaits
+// channel.sendMessage — a transient WhatsApp/Telegram send failure rejects.
+// Before the fix, that poisoned outputChain: (1) later streamed outputs were
+// silently dropped, and (2) every streaming close seam gated its only resolve()
+// behind outputChain.then(...), so on a rejected chain the dispatch promise
+// never settled — the group died and leaked a concurrency slot until restart.
+// ---------------------------------------------------------------------------
+
+describe('rejected onOutput resilience (LIA-212)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a rejected onOutput still lets the dispatch promise settle (no wedge)', async () => {
+    // Rejects on the (only) marker — mimics a transient channel.sendMessage
+    // failure bubbling up through the eventSink.
+    const onOutput = vi.fn(async (output: ContainerOutput) => {
+      if (output.result === 'boom') {
+        throw new Error('transient channel.sendMessage failure');
+      }
+    });
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // Capture settlement WITHOUT awaiting: pre-fix the promise never settles,
+    // so `await resultPromise` would hang the suite instead of failing the
+    // assertion. The .then tap lets us assert settlement and fail fast.
+    let settled: Awaited<ReturnType<typeof runContainerAgent>> | undefined;
+    void resultPromise.then((r) => {
+      settled = r;
+    });
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'boom',
+      newSessionId: 'session-wedge',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Normal exit → the streaming-success close seam waits on outputChain.
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Pre-fix: the rejected chain gates the only resolve() → never settles.
+    expect(settled).toBeDefined();
+    expect(settled!.status).toBe('success');
+    expect(onOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it('a rejected onOutput does not drop subsequent streamed outputs', async () => {
+    const seen: Array<string | null> = [];
+    const onOutput = vi.fn(async (output: ContainerOutput) => {
+      seen.push(output.result);
+      if (output.result === 'first') {
+        throw new Error('transient channel.sendMessage failure');
+      }
+    });
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+    let settled = false;
+    void resultPromise.then(() => {
+      settled = true;
+    });
+
+    // First marker rejects (poisons the chain pre-fix) ...
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'first',
+      newSessionId: 'session-drop',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    // ... the second marker must still reach onOutput.
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'second',
+      newSessionId: 'session-drop',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Pre-fix: chain poisoned by the 'first' rejection → onOutput('second')
+    // never runs and the dispatch never settles.
+    expect(seen).toContain('second');
+    expect(settled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // logInteraction fires on EVERY output-producing completion path (LIA-196).
 // Before LIA-196 the idle-after-output and non-zero-after-output paths resolved
 // success but never logged. These tests pin logInteraction to all four close

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -468,7 +468,17 @@ export async function runContainerAgent(
             resetTimeout();
             // Call onOutput for all markers (including null results)
             // so idle timers start even for "silent" query completions.
-            outputChain = outputChain.then(() => onOutput(parsed));
+            // .catch keeps outputChain non-poisoning (LIA-212): a rejected
+            // onOutput (e.g. a transient send failure) must not drop later
+            // outputs or block the close-time resolve — log and continue.
+            outputChain = outputChain
+              .then(() => onOutput(parsed))
+              .catch((err) => {
+                logger.error(
+                  { group: group.name, err },
+                  'onOutput handler rejected; continuing stream',
+                );
+              });
           } catch (err) {
             logger.error(
               { group: group.name, err },
@@ -602,7 +612,10 @@ export async function runContainerAgent(
             { group: group.name, containerName, duration, code },
             'Container timed out after output (idle cleanup)',
           );
-          outputChain.then(() => {
+          // .then(settle, settle): settle the dispatch promise whether the
+          // output chain fulfilled or rejected (LIA-212 defense-in-depth) —
+          // this is the only resolve() on this path, so settle unconditionally.
+          const settle = () => {
             // Produced output -> still log for the evolution loop (LIA-196).
             logDispatch(null, input.sessionRef?.session_id, reapedLatencyMs());
             resolve({
@@ -615,7 +628,8 @@ export async function runContainerAgent(
                   : undefined),
               newSessionId,
             });
-          });
+          };
+          outputChain.then(settle, settle);
           return;
         }
 
@@ -707,7 +721,9 @@ export async function runContainerAgent(
             { group: group.name, code, duration },
             'Container exited non-zero after output (treating as success)',
           );
-          outputChain.then(() => {
+          // .then(settle, settle): settle whether the output chain fulfilled or
+          // rejected (LIA-212 defense-in-depth) — see the idle-cleanup seam.
+          const settle = () => {
             // Produced output -> still log for the evolution loop (LIA-196).
             logDispatch(null, input.sessionRef?.session_id, reapedLatencyMs());
             resolve({
@@ -720,7 +736,8 @@ export async function runContainerAgent(
                   : undefined),
               newSessionId,
             });
-          });
+          };
+          outputChain.then(settle, settle);
           return;
         }
 
@@ -746,7 +763,9 @@ export async function runContainerAgent(
 
       // Streaming mode: wait for output chain to settle, return completion marker
       if (onOutput) {
-        outputChain.then(() => {
+        // .then(settle, settle): settle whether the output chain fulfilled or
+        // rejected (LIA-212 defense-in-depth) — see the idle-cleanup seam.
+        const settle = () => {
           logger.info(
             { group: group.name, duration, newSessionId },
             'Container completed (streaming mode)',
@@ -763,7 +782,8 @@ export async function runContainerAgent(
                 : undefined),
             newSessionId,
           });
-        });
+        };
+        outputChain.then(settle, settle);
         return;
       }
 


### PR DESCRIPTION
## Problem (LIA-212, high severity — 2026-06-12 deep quality audit)

A rejected `onOutput` callback **permanently wedged a group**. The rejection is reachable in production: `container-backend.ts`'s `onOutput` awaits the eventSink with no try/catch, and the orchestrator's eventSink awaits `channel.sendMessage` — a transient WhatsApp/Telegram send failure rejects.

Once `outputChain` was rejected:
1. **Outputs dropped** — later markers' `outputChain.then(() => onOutput(parsed))` skip `onFulfilled` on a rejected chain, silently losing subsequent streamed outputs.
2. **Promise never settles** — all three streaming close seams (`:605`/`:710`/`:749`) gate their **only** `resolve()` behind `outputChain.then(...)`. On a rejected chain the callback never runs → the `runContainerAgent` promise never settles → `runTurn` never returns → `GroupQueue`'s `finally` never executes → `state.active` stays `true`, a `MAX_CONCURRENT_CONTAINERS` slot leaks, and the group is dead (future messages pile into `pendingMessages`) until process restart. Only trace: one `unhandledRejection` log via `index.ts:157`.

## Fix (`src/container-runner.ts` only)

1. The `onOutput` chaining now has a `.catch` that logs and continues, so a rejected `onOutput` can no longer poison `outputChain`.
2. The three close seams settle via `const settle = …; outputChain.then(settle, settle)` (not `.finally`, which would re-reject) so the dispatch promise settles regardless of chain outcome — keeping the settlement guarantee local to the catastrophic non-settlement site.

**Scope:** container-runner only. The orchestrator `:404` `sendMessage` try/catch (graceful per-send delivery handling) is a separate message-delivery-resilience concern, tracked as a follow-up — the wedge is fully fixed without it, and the `.catch` preserves the underlying send error in the log.

## Tests

New `describe('rejected onOutput resilience (LIA-212)')`:
- the dispatch promise still settles when `onOutput` rejects (no wedge);
- a subsequent streamed output is not dropped after a rejection.

Both **fail without the fix** (`2 failed` + unhandled rejection at `:471`, the production symptom) and **pass with it** (`65 passed`).

## Verification

- `npx vitest run src/container-runner.test.ts` → 65/65.
- `npx tsc --noEmit` → exit 0; `prettier --check` → clean; `eslint` → 0 errors.
- Reproduction proven: stashed only the source fix → 2 new tests fail + unhandled rejections at `container-runner.ts:471`.

**Deploy:** host-only (no container rebuild — `runContainerAgent` runs host-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)