### PR TITLE
feat(LIA-281): add --diff mode for the true KV-cache reuse ceiling

### DIFF
--- a/scripts/cache_prefix_detector.py
+++ b/scripts/cache_prefix_detector.py
@@ -21,10 +21,18 @@ Not wired to CI or the fcc proxy by design (the proxy is a third-party uv
 tool); that wiring is deferred and tracked in LIA-205. The parser core is kept
 reusable so a future interceptor can import it.
 
+The single-prefix scan flags volatile *shape*, not confirmed *change*: a
+hex-shaped permanent-memory ULID is correctly flagged yet never churns, so it
+does not actually bust the cache. The `--diff` mode closes that gap -- it diffs
+two real assembled prefixes (earlier vs later request) and reports the offset of
+the first char that ACTUALLY differs, the true reuse ceiling; the shaped-token
+core becomes a secondary attribution signal.
+
 Usage:
     cache_prefix_detector.py <file>        # analyze a file's content
     cache_prefix_detector.py --stdin       # analyze stdin
     cache_prefix_detector.py <file> --json  # structured output
+    cache_prefix_detector.py --diff A B    # true reuse ceiling = first real diff
 """
 
 from __future__ import annotations
@@ -34,6 +42,8 @@ import base64
 import json
 import string
 import sys
+import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -52,6 +62,13 @@ _JWT_CHARS = frozenset(string.ascii_letters + string.digits + "-_.")
 
 _SAMPLE_MAX = 16  # never emit full content -- truncate the sample
 
+# Sanitized-window bounds for `--diff` attribution. `context_before` is the
+# shared tail right before the split (identical in both files); a_after/b_after
+# are the first differing chars from each side. Same "never echo full content"
+# philosophy as _SAMPLE_MAX -- callers pre-slice to these char counts.
+_CONTEXT_BEFORE = 48
+_CONTEXT_AFTER = 24
+
 
 @dataclass(frozen=True)
 class VolatileToken:
@@ -59,11 +76,16 @@ class VolatileToken:
 
     `sample` is truncated (<= _SAMPLE_MAX chars) so we never echo full content
     (a prefix can contain secrets); `offset` is the char index in the prefix.
+    `length` is the token's full (un-truncated) char span -- kept so `--diff`
+    can test whether a divergence offset falls INSIDE a token's span (e.g. a
+    date whose last digit changed). It is deliberately NOT serialized by
+    `as_dict`, so the existing single-prefix JSON contract is unchanged.
     """
 
     offset: int
     kind: str  # "uuid" | "iso8601" | "jwt" | "hex"
     sample: str
+    length: int
 
     def as_dict(self) -> dict:
         return {"offset": self.offset, "kind": self.kind, "sample": self.sample}
@@ -200,7 +222,7 @@ def detect_volatile_tokens(text: str) -> list[VolatileToken]:
     for off, length, kind, raw in candidates:
         if off < cursor:
             continue
-        kept.append(VolatileToken(off, kind, _sample(raw)))
+        kept.append(VolatileToken(off, kind, _sample(raw), length))
         cursor = off + length
     return kept
 
@@ -233,6 +255,118 @@ def analyze_prefix(text: str) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# `--diff` mode: the AUTHORITATIVE reuse-ceiling signal. The single-prefix scan
+# above flags shape; this diffs two real prefixes for the first char that
+# actually CHANGES. Read-only -- compares, never mutates.
+# ---------------------------------------------------------------------------
+
+
+def _first_divergence(a: str, b: str) -> int | None:
+    """Index of the first differing char between `a` and `b` (= the longest
+    common prefix length), or None if neither diverges within the shared length.
+
+    None covers two cases the caller separates via the lengths: identical
+    strings, and one being a strict prefix of the other (no mismatch in
+    [0, min(len)), so the common prefix is the whole shorter string). Single
+    O(min(len)) scan; never allocates the prefix string."""
+    n = min(len(a), len(b))
+    for i in range(n):
+        if a[i] != b[i]:
+            return i
+    return None
+
+
+def _window(raw: str) -> str:
+    """Escape control chars in a short context slice so a newline/tab cannot
+    corrupt single-line human output. Printable non-ASCII (e.g. Hebrew in the
+    vault prefix) is kept as-is -- `unicode_escape` would obscure it. Callers
+    pre-slice `raw` to a bounded length (never echo full content, same intent
+    as `_sample`)."""
+    out = []
+    for ch in raw:
+        if ch == "\n":
+            out.append("\\n")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\r":
+            out.append("\\r")
+        elif unicodedata.category(ch)[0] == "C":
+            out.append(f"\\x{ord(ch):02x}")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def diff_prefixes(a: str, b: str) -> dict:
+    """Diff two assembled prefixes (FILE_A = earlier/reference, FILE_B =
+    later/current) and report the offset of the first char that ACTUALLY
+    differs -- the true local KV-cache reuse ceiling, the signal the
+    single-prefix `analyze_prefix` heuristic can only approximate by shape.
+
+    `prefixes_identical` is ALWAYS present and authoritative: `compact_json`
+    strips the nullable `reuse_ceiling`, so callers must key off the bool.
+    Offsets are char indices -- a tight upper bound on the token-level ceiling
+    (the token holding the first differing char is the first non-reusable one).
+
+    Attribution is secondary. `detect_volatile_tokens` runs on FILE_A; the
+    pre-ceiling region is byte-identical in both files, so the choice of side is
+    immaterial. `shaped_false_alarms` counts shaped tokens lying ENTIRELY before
+    the divergence -- shaped-but-stable tokens the single-prefix heuristic would
+    have flagged but the diff proves reusable (the load-bearing LIA-281 point).
+    The divergence is `shaped` iff a token's span covers the offset. Read-only.
+    """
+    a_len, b_len = len(a), len(b)
+    div = _first_divergence(a, b)
+
+    if div is None and a_len == b_len:
+        # Identical: the whole prefix is reusable, so EVERY shaped token in it
+        # is a false alarm (none of them change).
+        false_alarms = sum(1 for t in detect_volatile_tokens(a) if t.offset < a_len)
+        return {
+            "prefixes_identical": True,
+            "a_len": a_len,
+            "b_len": b_len,
+            "reuse_ceiling": None,
+            # b_len==0 guard wins over the identical->1.0 rule: two empty
+            # strings reuse nothing meaningful.
+            "reuse_ceiling_fraction": 1.0 if b_len else 0.0,
+            "one_is_prefix_of_other": False,
+            "shaped_false_alarms": false_alarms,
+        }
+
+    one_prefix = div is None  # no mismatch within shared length, unequal lengths
+    ceiling = min(a_len, b_len) if one_prefix else div
+
+    tokens = detect_volatile_tokens(a)
+    # Entirely before the divergence -> reusable -> the heuristic over-counted.
+    false_alarms = sum(1 for t in tokens if t.offset + t.length <= ceiling)
+    # The shaped token (if any) whose span COVERS the divergence -- the
+    # heuristic's correct hit (e.g. a date whose last digit changed).
+    hit = next(
+        (t for t in tokens if t.offset <= ceiling < t.offset + t.length),
+        None,
+    )
+
+    return {
+        "prefixes_identical": False,
+        "a_len": a_len,
+        "b_len": b_len,
+        "reuse_ceiling": ceiling,
+        "reuse_ceiling_fraction": round(ceiling / b_len, 4) if b_len else 0.0,
+        "one_is_prefix_of_other": one_prefix,
+        "shaped_false_alarms": false_alarms,
+        "divergence": {
+            "offset": ceiling,
+            "shaped": hit is not None,
+            "kind": hit.kind if hit else None,
+            "context_before": _window(a[max(0, ceiling - _CONTEXT_BEFORE) : ceiling]),
+            "a_after": _window(a[ceiling : ceiling + _CONTEXT_AFTER]),
+            "b_after": _window(b[ceiling : ceiling + _CONTEXT_AFTER]),
+        },
+    }
+
+
 def _print_human(report: dict) -> None:
     if report["prefix_stable"]:
         print(
@@ -250,6 +384,56 @@ def _print_human(report: dict) -> None:
         print(f"  @{t['offset']:>7}  {t['kind']:<8}  {t['sample']}")
 
 
+def _print_diff_human(report: dict) -> None:
+    if report["prefixes_identical"]:
+        print(
+            f"prefixes identical: full {report['b_len']} chars KV-reusable "
+            "(no divergence)"
+        )
+        return
+    ceiling = report["reuse_ceiling"]
+    pct = report["reuse_ceiling_fraction"] * 100
+    div = report["divergence"]
+    kind = div["kind"] or "unstructured"
+    # When one prefix is a strict prefix of the other there is no differing char
+    # -- the shorter just ran out. Tag it so the empty A/B next line doesn't read
+    # like a bug.
+    tail = " (one prefix is a prefix of the other)" if report["one_is_prefix_of_other"] else ""
+    print(
+        f"reuse ceiling = {ceiling}/{report['b_len']} chars "
+        f"({pct:.1f}% of FILE_B reusable from FILE_A); "
+        f"first real divergence at offset {ceiling} [{kind}]{tail}"
+    )
+    print(f"  before: {div['context_before']}")
+    print(f"  A next: {div['a_after']}")
+    print(f"  B next: {div['b_after']}")
+    print(
+        "  shaped-but-stable tokens before divergence: "
+        f"{report['shaped_false_alarms']}"
+    )
+
+
+def _emit(
+    report: dict,
+    args: argparse.Namespace,
+    long_fields: tuple,
+    human: Callable[[dict], None],
+) -> int:
+    """Shared output plumbing for both modes: JSON (with --compact/--select) in
+    agent context, else the given human printer. `long_fields` names the fields
+    `--compact` may truncate (differs per mode)."""
+    if args.json or is_agent_context():
+        output = report
+        if args.compact:
+            output = compact_json(output, long_fields=long_fields)
+        if args.select:
+            output = select_fields(output, args.select)
+        print(json.dumps(output))
+    else:
+        human(report)
+    return SUCCESS
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="cache_prefix_detector",
@@ -261,6 +445,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--stdin", action="store_true", help="Read the prefix from stdin instead of a file"
     )
+    parser.add_argument(
+        "--diff",
+        nargs=2,
+        metavar=("FILE_A", "FILE_B"),
+        help="Diff two prefixes (earlier vs later); report the offset of the "
+        "first char that ACTUALLY differs -- the true KV-cache reuse ceiling.",
+    )
     parser.add_argument("--json", action="store_true", help="Structured JSON output")
     parser.add_argument(
         "--compact", action="store_true", help="Strip nulls / truncate long fields"
@@ -270,12 +461,33 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if args.stdin and args.file:
-        print("error: pass either a file or --stdin, not both", file=sys.stderr)
+    # Exactly one input mode: a file, --stdin, or --diff A B.
+    if sum(bool(m) for m in (args.file, args.stdin, args.diff)) != 1:
+        print(
+            "error: provide exactly one of a file, --stdin, or --diff FILE_A FILE_B",
+            file=sys.stderr,
+        )
         return USAGE_ERROR
-    if not args.stdin and not args.file:
-        print("error: provide a file path or --stdin", file=sys.stderr)
-        return USAGE_ERROR
+
+    if args.diff:
+        try:
+            texts = []
+            for raw_path in args.diff:
+                path = Path(raw_path)
+                if not path.is_file():
+                    print(f"error: file not found: {raw_path}", file=sys.stderr)
+                    return NOT_FOUND
+                texts.append(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError as exc:
+            print(f"error: could not read input: {exc}", file=sys.stderr)
+            return INTERNAL_ERROR
+        report = diff_prefixes(texts[0], texts[1])
+        return _emit(
+            report,
+            args,
+            long_fields=("context_before", "a_after", "b_after"),
+            human=_print_diff_human,
+        )
 
     try:
         if args.stdin:
@@ -291,17 +503,7 @@ def main(argv: list[str] | None = None) -> int:
         return INTERNAL_ERROR
 
     report = analyze_prefix(text)
-
-    if args.json or is_agent_context():
-        output = report
-        if args.compact:
-            output = compact_json(output, long_fields=("sample",))
-        if args.select:
-            output = select_fields(output, args.select)
-        print(json.dumps(output))
-    else:
-        _print_human(report)
-    return SUCCESS
+    return _emit(report, args, long_fields=("sample",), human=_print_human)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_cache_prefix_detector.py
+++ b/scripts/tests/test_cache_prefix_detector.py
@@ -202,3 +202,162 @@ def test_mixed_input_sorted_by_offset():
     seq = [(t.offset, t.kind) for t in toks]
     assert seq == sorted(seq)  # strictly ascending by offset
     assert [t.kind for t in toks] == ["jwt", "iso8601", "hex"]
+
+
+# --- diff mode (the authoritative reuse-ceiling signal) ---------------------
+
+
+def test_diff_identical_fully_reusable():
+    rep = cpd.diff_prefixes("same prefix text", "same prefix text")
+    assert rep["prefixes_identical"] is True
+    assert rep["reuse_ceiling"] is None
+    assert rep["reuse_ceiling_fraction"] == 1.0
+    assert "divergence" not in rep
+
+
+def test_diff_first_divergence_offset():
+    rep = cpd.diff_prefixes("abcDEF", "abcXEF")
+    assert rep["prefixes_identical"] is False
+    assert rep["reuse_ceiling"] == 3
+    assert rep["divergence"]["offset"] == 3
+
+
+def test_diff_one_is_prefix_of_other():
+    rep = cpd.diff_prefixes("abc", "abcdef")
+    assert rep["prefixes_identical"] is False
+    assert rep["one_is_prefix_of_other"] is True
+    assert rep["reuse_ceiling"] == 3
+    assert rep["reuse_ceiling_fraction"] == round(3 / 6, 4)
+
+
+def test_diff_shaped_kind_at_divergence():
+    # The date's last digit changes -> the divergence is INSIDE the iso8601
+    # token's span (mid-token), so it must still be attributed to "iso8601".
+    rep = cpd.diff_prefixes("date: 2026-06-11 end", "date: 2026-06-12 end")
+    assert rep["divergence"]["shaped"] is True
+    assert rep["divergence"]["kind"] == "iso8601"
+    assert rep["reuse_ceiling"] == rep["divergence"]["offset"]
+
+
+def test_diff_unstructured_divergence():
+    # A bare digit count changing is not a shaped token -> kind None.
+    rep = cpd.diff_prefixes("x: 3 sessions", "x: 4 sessions")
+    assert rep["divergence"]["shaped"] is False
+    assert rep["divergence"]["kind"] is None
+    assert rep["shaped_false_alarms"] == 0
+
+
+def test_diff_shaped_false_alarms_counted():
+    # The LOAD-BEARING test: a stable UUID identical in both prefixes sits
+    # before the real (date) divergence. Shaped, but reusable -> a false alarm
+    # the single-prefix heuristic would wrongly flag. The diff proves the actual
+    # churn is the downstream date, not the UUID.
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    rep = cpd.diff_prefixes(f"id {uuid} d 2026-06-11", f"id {uuid} d 2026-06-12")
+    assert rep["shaped_false_alarms"] >= 1
+    assert rep["divergence"]["kind"] == "iso8601"  # the date is the real cause
+    assert rep["reuse_ceiling"] > 3 + len(uuid)  # past the stable UUID
+
+
+def test_diff_both_empty():
+    rep = cpd.diff_prefixes("", "")
+    assert rep["prefixes_identical"] is True
+    assert rep["reuse_ceiling"] is None
+    # b_len==0 guard wins over the identical->1.0 rule.
+    assert rep["reuse_ceiling_fraction"] == 0.0
+
+
+def test_diff_b_empty_a_nonempty():
+    rep = cpd.diff_prefixes("abc", "")
+    assert rep["prefixes_identical"] is False
+    assert rep["one_is_prefix_of_other"] is True
+    assert rep["reuse_ceiling"] == 0
+    assert rep["reuse_ceiling_fraction"] == 0.0
+
+
+def test_diff_a_empty_b_nonempty():
+    # Mirror of the above: empty FILE_A, non-empty FILE_B. b_len>0 so the
+    # fraction is the natural 0/3, not the b_len==0 guard.
+    rep = cpd.diff_prefixes("", "abc")
+    assert rep["prefixes_identical"] is False
+    assert rep["one_is_prefix_of_other"] is True
+    assert rep["reuse_ceiling"] == 0
+    assert rep["reuse_ceiling_fraction"] == 0.0
+
+
+def test_diff_window_escapes_newline():
+    # A newline inside the context window must be escaped so it cannot corrupt
+    # the single-line human output.
+    rep = cpd.diff_prefixes("x\nK: 2026-06-11", "x\nK: 2026-06-12")
+    ctx = rep["divergence"]["context_before"]
+    assert "\n" not in ctx
+    assert "\\n" in ctx
+
+
+# --- diff mode: agent-native CLI --------------------------------------------
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+def test_diff_cli_json(tmp_path, capsys):
+    a = _write(tmp_path, "a.txt", "date 2026-06-11")
+    b = _write(tmp_path, "b.txt", "date 2026-06-12")
+    rc = cpd.main(["--diff", a, b, "--json"])
+    assert rc == cpd.SUCCESS
+    obj = json.loads(capsys.readouterr().out)
+    expected = {
+        "prefixes_identical",
+        "a_len",
+        "b_len",
+        "reuse_ceiling",
+        "reuse_ceiling_fraction",
+        "one_is_prefix_of_other",
+        "shaped_false_alarms",
+    }
+    assert expected <= set(obj)
+    assert obj["prefixes_identical"] is False
+
+
+def test_diff_cli_missing_file_not_found(tmp_path):
+    a = _write(tmp_path, "a.txt", "present")
+    rc = cpd.main(["--diff", a, str(tmp_path / "nope.txt")])
+    assert rc == cpd.NOT_FOUND
+
+
+def test_diff_cli_conflicts_with_stdin(tmp_path):
+    a = _write(tmp_path, "a.txt", "x")
+    b = _write(tmp_path, "b.txt", "y")
+    # --diff + --stdin -> exactly-one-mode guard rejects before any file read.
+    assert cpd.main(["--diff", a, b, "--stdin"]) == cpd.USAGE_ERROR
+
+
+def test_diff_cli_conflicts_with_positional(tmp_path):
+    a = _write(tmp_path, "a.txt", "x")
+    b = _write(tmp_path, "b.txt", "y")
+    f = _write(tmp_path, "f.txt", "z")
+    assert cpd.main([f, "--diff", a, b]) == cpd.USAGE_ERROR
+
+
+def test_diff_cli_human(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("DEUS_AGENT_NATIVE", raising=False)
+    a = _write(tmp_path, "a.txt", "date 2026-06-11")
+    b = _write(tmp_path, "b.txt", "date 2026-06-12")
+    rc = cpd.main(["--diff", a, b])  # no --json -> human branch
+    assert rc == cpd.SUCCESS
+    assert "reuse ceiling" in capsys.readouterr().out
+
+
+def test_diff_cli_compact_keeps_identical_bool(tmp_path, capsys):
+    a = _write(tmp_path, "a.txt", "identical prefix")
+    rc = cpd.main(["--diff", a, a, "--json", "--compact"])
+    assert rc == cpd.SUCCESS
+    obj = json.loads(capsys.readouterr().out)
+    # compact_json strips the None reuse_ceiling; the authoritative bool survives
+    # and the divergence block is absent (never emitted when identical).
+    assert obj["prefixes_identical"] is True
+    assert "reuse_ceiling" not in obj
+    assert "divergence" not in obj


### PR DESCRIPTION
## Summary
Adds a `--diff FILE_A FILE_B` mode to the LIA-205 cache-prefix detector (`scripts/cache_prefix_detector.py`) — the actionable follow-up tracked as **LIA-281**.

The existing single-prefix scan flags volatile-**shaped** tokens (UUID/ISO-8601/JWT/hex), which over-counts: a hex-shaped permanent-memory ULID is correctly flagged yet never churns between requests, so it never busts the KV cache. `--diff` closes that gap — it diffs two real assembled prefixes (earlier vs later request) and reports the offset of the first char that **actually differs** = the true local `llama-server` KV-cache reuse ceiling. The shaped-token core is demoted to a secondary attribution signal.

## What it reports
- `reuse_ceiling` — first divergent char offset (the authoritative signal)
- `reuse_ceiling_fraction` — fraction of FILE_B reusable from FILE_A's cache
- `shaped_false_alarms` — shaped-but-stable tokens *before* the divergence (what the single-prefix heuristic would have wrongly flagged)
- `divergence.{kind, context_before, a_after, b_after}` — attribution: which token kind owns the split (or `unstructured`), with a sanitized, control-char-escaped context window

## Design notes
- **Read-only by construction** — compares, never mutates.
- **Agent-native** — typed exit codes, `--json`/`--compact`/`--select`, an always-present authoritative `prefixes_identical` bool that survives `compact_json`'s None-stripping.
- **Stdlib-only, no regex, no new deps.**
- Existing single-prefix JSON contract **unchanged**: a new internal `VolatileToken.length` field (deliberately not serialized by `as_dict`) lets the diff attribute a *mid-token* change — e.g. a date whose last digit flips — to its token instead of miscounting it as stable.
- **Value framing:** local-model prefill-latency / effective context only. Saves \$0 on the flat Claude subscription. Not wired to CI or the fcc proxy (standalone diagnostic).

## Tests
16 new tests (38 total): offset / identical / prefix-of, shaped-kind at a mid-token divergence, the load-bearing `shaped_false_alarms` case (stable UUID before a real date change), empty-input edges, CLI mode-conflict / missing-file / compact, and newline-escaping. `python3 -m pytest scripts/tests/test_cache_prefix_detector.py -q` → **38 passed**.

Closes LIA-281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)