### PR TITLE
fix(evolution): credit retrieved reflections at scoring time (LIA-214)

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -269,6 +269,10 @@ def cmd_log_interaction(json_str: str) -> None:
         tool_calls=tool_calls,
         available_tools=available_tools,
         metrics=metrics,
+        # LIA-214: persist the retrieved IDs so update_score can credit them
+        # once the judge score is known (deferred from this fire-and-forget path,
+        # where the score is still NULL).
+        retrieved_reflection_ids=retrieved_reflection_ids or None,
     )
 
     # Batch judge: check if we've accumulated enough unjudged interactions
@@ -296,15 +300,10 @@ def cmd_log_interaction(json_str: str) -> None:
         except Exception as exc:
             log.warning('evolution: user_signal handling failed — %s: %s', type(exc).__name__, exc)
 
-    # Feedback loop — increment helpful counts when current interaction scored well.
-    if retrieved_reflection_ids:
-        try:
-            _handle_retrieved_reflections(
-                current_iid=iid,
-                retrieved_reflection_ids=retrieved_reflection_ids,
-            )
-        except Exception as exc:
-            log.warning('evolution: retrieved_reflection increment failed — %s: %s', type(exc).__name__, exc)
+    # Retrieved-reflection crediting (LIA-214) now happens in update_score, gated
+    # on the judge score being known and >= POSITIVE_THRESHOLD. The previous
+    # synchronous credit here saw a still-NULL score on this fire-and-forget path
+    # ~97% of the time and silently skipped — that block was removed.
 
     print(json.dumps({"id": iid, "status": "ok"}))
 
@@ -351,30 +350,6 @@ def _handle_user_signal(
         interaction_id=prev["id"],
         group_folder=prev.get("group_folder"),
     )
-
-
-def _handle_retrieved_reflections(
-    *,
-    current_iid: str,
-    retrieved_reflection_ids: list,
-) -> None:
-    """Increment helpful count for retrieved reflections when current interaction scored high."""
-    from .config import POSITIVE_THRESHOLD
-    from .reflexion.store import increment_helpful
-    from .storage import get_storage
-
-    store = get_storage()
-    row = store.get_interaction(current_iid)
-    if row is None:
-        return
-
-    judge_score = row.get("judge_score")
-    # Only reward retrievals for responses we know scored well NOW; skip if unjudged
-    if judge_score is None or judge_score < POSITIVE_THRESHOLD:
-        return
-
-    for rid in retrieved_reflection_ids:
-        increment_helpful(rid)
 
 
 def cmd_log_metrics(json_str: str) -> None:

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -28,6 +28,7 @@ def log_interaction(
     tool_calls: Optional[list[dict]] = None,
     available_tools: Optional[list[str]] = None,
     metrics: Optional[dict] = None,
+    retrieved_reflection_ids: Optional[list[str]] = None,
 ) -> str:
     """
     Persist one agent interaction.  Returns the interaction ID.
@@ -35,6 +36,12 @@ def log_interaction(
 
     metrics is a flat dict of task metrics (see evolution.metrics) — validated
     here so a malformed payload fails loudly at log time, not at analysis time.
+
+    retrieved_reflection_ids are the reflections retrieved for this prompt;
+    they are persisted now and credited (times_helpful++) at scoring time by
+    update_score, once the judge score is known and >= POSITIVE_THRESHOLD
+    (LIA-214 — crediting at log time saw a still-NULL judge score ~97% of the
+    time and silently skipped).
     """
     # Canonical validation gate: the MCP path calls this directly with no
     # other check (errors propagate to the caller by design). cli.py
@@ -64,6 +71,12 @@ def log_interaction(
         # LIA-154: offered tool manifest (observability only; unblocks LIA-151).
         available_tools=json.dumps(available_tools or []),
         metrics=json.dumps(metrics) if metrics is not None else None,
+        # LIA-214: persisted now, credited at scoring time (see update_score).
+        retrieved_reflection_ids=(
+            json.dumps(retrieved_reflection_ids)
+            if retrieved_reflection_ids
+            else None
+        ),
     )
     return iid
 
@@ -75,7 +88,14 @@ def update_score(
     parse_error: bool = False,
     schema_version: int = 1,
 ) -> None:
-    """Attach judge score and dimension breakdown to a logged interaction."""
+    """Attach judge score and dimension breakdown to a logged interaction.
+
+    Once the score is known, credit any reflections retrieved for this
+    interaction's prompt (LIA-214). This is the single score seam — batch judge
+    (maintenance), async MCP, and backfill all route through here — so crediting
+    here, gated on an atomic one-shot claim, fixes the log-time temporal race
+    (the judge score was still NULL ~97% of the time) without double-crediting.
+    """
     store = get_storage()
     store.update_interaction(
         interaction_id,
@@ -84,6 +104,52 @@ def update_score(
         parse_error=int(parse_error),
         judge_schema_version=schema_version,
     )
+    _credit_retrieved_reflections(store, interaction_id, score)
+
+
+def _credit_retrieved_reflections(store, interaction_id: str, score: float) -> None:
+    """Credit (times_helpful++) reflections retrieved for a positively-scored
+    interaction, exactly once.
+
+    Gated three ways: score >= POSITIVE_THRESHOLD, the interaction actually had
+    retrieved reflections, and an atomic claim_interaction_credit() that only one
+    writer can win — so concurrent score writers and judge re-scores credit a
+    reflection at most once.
+    """
+    from ..config import POSITIVE_THRESHOLD
+
+    if score < POSITIVE_THRESHOLD:
+        return
+    row = store.get_interaction(interaction_id)
+    if not row:
+        return
+    raw = row.get("retrieved_reflection_ids")
+    # This early-return is load-bearing: the backfill/cc_backfill paths call
+    # update_score WITHOUT wrapping it in try/except and log rows with NULL
+    # retrieved_reflection_ids, so returning here (before any raise-capable call)
+    # keeps those paths safe.
+    if not raw:
+        return
+    try:
+        ids = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not ids:
+        return
+    # Atomic one-shot: only the writer that flips credited_at NULL->now credits.
+    # The claim is consumed BEFORE the increment loop ON PURPOSE: under concurrent
+    # score writers (batch judge + async MCP) claiming after the loop would let
+    # both writers increment before either claims = double-credit. Claiming first
+    # bounds credit to exactly once; the cost is that a mid-loop failure leaves
+    # partial credit (acceptable — these are monotonic counters, not user data).
+    if not store.claim_interaction_credit(interaction_id):
+        return
+    # Routed through reflexion.store.increment_helpful (the single "mark helpful"
+    # chokepoint) rather than store.increment_reflection_helpful directly.
+    from ..reflexion.store import increment_helpful
+
+    for rid in ids:
+        increment_helpful(rid)
 
 
 def get_recent(

--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -60,18 +60,33 @@ class StorageProvider(ABC):
         tool_calls: Optional[str] = None,
         available_tools: Optional[str] = None,
         metrics: Optional[str] = None,
+        retrieved_reflection_ids: Optional[str] = None,
     ) -> str:
         """Persist one agent interaction. Returns the interaction ID.
 
         When a row with the same ID already exists, all fields are overwritten
-        EXCEPT metrics: a None metrics value preserves any previously stored
-        metrics (COALESCE upsert), so post-hoc metric updates survive re-logging.
+        EXCEPT metrics and retrieved_reflection_ids: a None value for either
+        preserves the previously stored value (COALESCE upsert), so post-hoc
+        metric updates and the retrieved-reflection IDs (needed at scoring time)
+        survive re-logging. credited_at is never written here — see
+        claim_interaction_credit (LIA-214).
         """
         ...
 
     @abstractmethod
     def update_interaction(self, interaction_id: str, **fields) -> None:
         """Update fields on an existing interaction (e.g. judge_score, judge_dims)."""
+        ...
+
+    @abstractmethod
+    def claim_interaction_credit(self, interaction_id: str) -> bool:
+        """Atomically claim the one-shot reflection-credit slot for an interaction.
+
+        Sets credited_at if currently NULL. Returns True for the single writer
+        that won the claim, False if already claimed or the row is missing.
+        Makes LIA-214 retrieved-reflection crediting idempotent under concurrent
+        score writers and judge re-scores.
+        """
         ...
 
     @abstractmethod

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -272,6 +272,15 @@ class SQLiteStorageProvider(StorageProvider):
             # observability; no live consumer — unblocks LIA-151 ground truth).
             ("available_tools", "TEXT"),
             ("metrics", "TEXT"),  # JSON: generic per-task metrics (added in v1.7)
+            # LIA-214: IDs of reflections retrieved for this interaction's prompt,
+            # credited (times_helpful++) once the judge scores it >= POSITIVE_THRESHOLD.
+            ("retrieved_reflection_ids", "TEXT"),  # JSON array of reflection ids
+            # LIA-214: one-shot credit guard. Set atomically via
+            # claim_interaction_credit() so concurrent score writers / re-scores
+            # credit each retrieved reflection exactly once. Kept OUT of the
+            # log_interaction upsert (like judge_score) so a NULL re-log cannot
+            # clobber the guard back to NULL.
+            ("credited_at", "TEXT"),
         ]:
             try:
                 # safe: col + coltype come from the literal tuple-list
@@ -336,19 +345,24 @@ class SQLiteStorageProvider(StorageProvider):
         tool_calls: Optional[str] = None,
         available_tools: Optional[str] = None,
         metrics: Optional[str] = None,
+        retrieved_reflection_ids: Optional[str] = None,
     ) -> str:
         db = self._connect()
         # Upsert instead of INSERT OR REPLACE: REPLACE deletes the existing row
         # (clobbering judge_score/judge_dims and firing ON DELETE CASCADE on
-        # reflections). DO UPDATE keeps unlisted columns intact, and metrics
-        # uses COALESCE so a None re-log preserves post-hoc metric updates.
+        # reflections). DO UPDATE keeps unlisted columns intact. metrics and
+        # retrieved_reflection_ids use COALESCE so a None re-log preserves a
+        # previously-stored value (post-hoc metrics; the IDs needed at scoring
+        # time). credited_at is intentionally absent — written only via
+        # claim_interaction_credit (LIA-214).
         db.execute(
             """
             INSERT INTO interactions
                 (id, timestamp, group_folder, prompt, response, tools_used,
                  latency_ms, eval_suite, session_id, domain_presets, user_signal,
-                 context_tokens, has_code, tool_calls, available_tools, metrics)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 context_tokens, has_code, tool_calls, available_tools, metrics,
+                 retrieved_reflection_ids)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 timestamp       = excluded.timestamp,
                 group_folder    = excluded.group_folder,
@@ -364,13 +378,18 @@ class SQLiteStorageProvider(StorageProvider):
                 has_code        = excluded.has_code,
                 tool_calls      = excluded.tool_calls,
                 available_tools = excluded.available_tools,
-                metrics         = COALESCE(excluded.metrics, interactions.metrics)
+                metrics         = COALESCE(excluded.metrics, interactions.metrics),
+                retrieved_reflection_ids = COALESCE(
+                    excluded.retrieved_reflection_ids,
+                    interactions.retrieved_reflection_ids
+                )
             """,
             (
                 interaction_id, timestamp, group_folder, prompt, response,
                 tools_used, latency_ms, eval_suite, session_id,
                 domain_presets, user_signal, context_tokens, has_code,
                 tool_calls, available_tools, metrics,
+                retrieved_reflection_ids,
             ),
         )
         db.commit()
@@ -396,6 +415,27 @@ class SQLiteStorageProvider(StorageProvider):
         )
         db.commit()
         db.close()
+
+    def claim_interaction_credit(self, interaction_id: str) -> bool:
+        """Atomically claim the one-shot reflection-credit slot for an interaction.
+
+        Sets credited_at = now only if it is currently NULL. Returns True for the
+        single writer that won the claim, False if already claimed (or the row is
+        missing). Makes LIA-214 crediting idempotent under concurrent score
+        writers (batch judge + async MCP path) and judge re-scores.
+        """
+        db = self._connect()
+        # datetime('now') mirrors archive_reflection_by_id's lifecycle marker;
+        # the value is only ever read as NULL vs non-NULL (the claim guard).
+        cur = db.execute(
+            "UPDATE interactions SET credited_at = datetime('now') "
+            "WHERE id = ? AND credited_at IS NULL",
+            [interaction_id],
+        )
+        db.commit()
+        claimed = cur.rowcount == 1
+        db.close()
+        return claimed
 
     def get_interaction(self, interaction_id: str) -> Optional[dict]:
         db = self._connect()

--- a/evolution/tests/test_interaction_log.py
+++ b/evolution/tests/test_interaction_log.py
@@ -144,6 +144,117 @@ def test_update_score_writes_score_and_dims():
     assert parsed_dims["quality"] == 0.9
 
 
+# ── LIA-214: credit retrieved reflections at scoring time ────────────────────
+
+
+def test_update_score_credits_retrieved_reflections_once(monkeypatch):
+    """score >= POSITIVE_THRESHOLD credits each retrieved reflection exactly once,
+    even when update_score runs again (re-score)."""
+    credited: list[str] = []
+    monkeypatch.setattr(
+        "evolution.reflexion.store.increment_helpful",
+        lambda rid: credited.append(rid),
+    )
+    iid = log_interaction(
+        prompt="p", response="r", group_folder="g",
+        retrieved_reflection_ids=["ref-a", "ref-b"],
+    )
+    update_score(iid, 0.9, {})
+    assert sorted(credited) == ["ref-a", "ref-b"]
+
+    # Re-score (e.g. a later judge re-run): the one-shot guard blocks re-credit.
+    update_score(iid, 0.95, {})
+    assert sorted(credited) == ["ref-a", "ref-b"]
+
+
+def test_update_score_credits_at_exact_threshold(monkeypatch):
+    """Boundary: a score EXACTLY at POSITIVE_THRESHOLD (0.85) credits — the gate
+    is strict less-than, so the threshold value itself is positive."""
+    credited: list[str] = []
+    monkeypatch.setattr(
+        "evolution.reflexion.store.increment_helpful",
+        lambda rid: credited.append(rid),
+    )
+    iid = log_interaction(
+        prompt="p", response="r", group_folder="g",
+        retrieved_reflection_ids=["ref-edge"],
+    )
+    update_score(iid, config_mod.POSITIVE_THRESHOLD, {})
+    assert credited == ["ref-edge"]
+
+
+def test_update_score_no_credit_below_threshold(monkeypatch):
+    credited: list[str] = []
+    monkeypatch.setattr(
+        "evolution.reflexion.store.increment_helpful",
+        lambda rid: credited.append(rid),
+    )
+    iid = log_interaction(
+        prompt="p", response="r", group_folder="g",
+        retrieved_reflection_ids=["ref-low"],
+    )
+    update_score(iid, 0.5, {})
+    assert credited == []
+    # credited_at stays NULL so a later positive score can still credit.
+    conn = open_db()
+    row = conn.execute(
+        "SELECT credited_at FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row["credited_at"] is None
+
+
+def test_update_score_sub_then_super_threshold_credits_once(monkeypatch):
+    """A sub-threshold score followed by a >= threshold re-score credits once."""
+    credited: list[str] = []
+    monkeypatch.setattr(
+        "evolution.reflexion.store.increment_helpful",
+        lambda rid: credited.append(rid),
+    )
+    iid = log_interaction(
+        prompt="p", response="r", group_folder="g",
+        retrieved_reflection_ids=["ref-x"],
+    )
+    update_score(iid, 0.4, {})
+    assert credited == []  # below threshold — no claim, no credit
+    update_score(iid, 0.92, {})
+    assert credited == ["ref-x"]  # now credited
+    update_score(iid, 0.99, {})
+    assert credited == ["ref-x"]  # still exactly once
+
+
+def test_update_score_no_credit_when_no_retrieved_ids(monkeypatch):
+    """A high score with no retrieved reflections credits nothing and never crashes."""
+    credited: list[str] = []
+    monkeypatch.setattr(
+        "evolution.reflexion.store.increment_helpful",
+        lambda rid: credited.append(rid),
+    )
+    iid = log_interaction(prompt="p", response="r", group_folder="g")
+    update_score(iid, 0.95, {})
+    assert credited == []
+    # No retrieved IDs → credited_at remains NULL (no spurious claim write).
+    conn = open_db()
+    row = conn.execute(
+        "SELECT credited_at FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row["credited_at"] is None
+
+
+def test_log_interaction_persists_retrieved_reflection_ids():
+    iid = log_interaction(
+        prompt="p", response="r", group_folder="g",
+        retrieved_reflection_ids=["a", "b", "c"],
+    )
+    conn = open_db()
+    row = conn.execute(
+        "SELECT retrieved_reflection_ids FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert json.loads(row["retrieved_reflection_ids"]) == ["a", "b", "c"]
+
+
 def test_get_recent_returns_logged_interactions():
     log_interaction(prompt="First", response="A", group_folder="g1")
     log_interaction(prompt="Second", response="B", group_folder="g2")

--- a/evolution/tests/test_storage_provider.py
+++ b/evolution/tests/test_storage_provider.py
@@ -42,6 +42,7 @@ class FakeStorageProvider(StorageProvider):
     # Stubs — not exercised in registry tests
     def log_interaction(self, **kw): ...
     def update_interaction(self, *a, **kw): ...
+    def claim_interaction_credit(self, *a): return False
     def get_interaction(self, *a): ...
     def get_recent_interactions(self, **kw): return []
     def get_metrics_rows(self, **kw): return []
@@ -385,6 +386,93 @@ class TestSQLiteMetrics:
         row = sqlite_provider.get_interaction("m4")
         assert row["judge_score"] is not None
         assert abs(row["judge_score"] - 0.9) < 1e-5
+
+    # ── LIA-214: retrieved_reflection_ids + credit one-shot ──────────────────
+
+    def test_log_interaction_persists_retrieved_reflection_ids(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r1",
+            retrieved_reflection_ids='["a", "b"]',
+        )
+        row = sqlite_provider.get_interaction("r1")
+        assert row["retrieved_reflection_ids"] == '["a", "b"]'
+        # A fresh log leaves the credit guard NULL (back-compat / unclaimed).
+        assert row["credited_at"] is None
+
+    def test_log_interaction_defaults_retrieved_reflection_ids_null(self, sqlite_provider):
+        """Back-compat: omitting the IDs stores NULL, not a crash."""
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r2",
+        )
+        row = sqlite_provider.get_interaction("r2")
+        assert row["retrieved_reflection_ids"] is None
+
+    def test_relog_preserves_retrieved_reflection_ids(self, sqlite_provider):
+        """COALESCE upsert: a None re-log must not drop the IDs needed at scoring."""
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r3",
+            retrieved_reflection_ids='["x", "y"]',
+        )
+        # Re-log without IDs (the fire-and-forget re-log shape).
+        sqlite_provider.log_interaction(
+            prompt="p2", response="r2", group_folder="g",
+            timestamp=self._ts(), interaction_id="r3",
+        )
+        row = sqlite_provider.get_interaction("r3")
+        assert row["retrieved_reflection_ids"] == '["x", "y"]'
+        assert row["prompt"] == "p2"  # non-COALESCE columns still overwritten
+
+    def test_relog_with_retrieved_reflection_ids_overwrites(self, sqlite_provider):
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r4",
+            retrieved_reflection_ids='["a"]',
+        )
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r4",
+            retrieved_reflection_ids='["b", "c"]',
+        )
+        row = sqlite_provider.get_interaction("r4")
+        assert row["retrieved_reflection_ids"] == '["b", "c"]'
+
+    def test_claim_interaction_credit_is_one_shot(self, sqlite_provider):
+        """First claim wins (True); subsequent claims lose (False)."""
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r5",
+            retrieved_reflection_ids='["a"]',
+        )
+        assert sqlite_provider.claim_interaction_credit("r5") is True
+        assert sqlite_provider.claim_interaction_credit("r5") is False
+        row = sqlite_provider.get_interaction("r5")
+        assert row["credited_at"] is not None
+
+    def test_claim_interaction_credit_missing_row(self, sqlite_provider):
+        assert sqlite_provider.claim_interaction_credit("does-not-exist") is False
+
+    def test_relog_preserves_credited_at(self, sqlite_provider):
+        """credited_at is absent from the upsert (like judge_score), so a NULL
+        re-log cannot clobber the one-shot guard back to NULL and re-enable
+        double-credit."""
+        sqlite_provider.log_interaction(
+            prompt="p", response="r", group_folder="g",
+            timestamp=self._ts(), interaction_id="r6",
+            retrieved_reflection_ids='["a"]',
+        )
+        assert sqlite_provider.claim_interaction_credit("r6") is True
+        # Re-log without credited_at (it is never passed to log_interaction).
+        sqlite_provider.log_interaction(
+            prompt="p2", response="r2", group_folder="g",
+            timestamp=self._ts(), interaction_id="r6",
+        )
+        row = sqlite_provider.get_interaction("r6")
+        assert row["credited_at"] is not None
+        # A second claim must still lose — the guard survived the re-log.
+        assert sqlite_provider.claim_interaction_credit("r6") is False
 
     def test_update_interaction_accepts_metrics(self, sqlite_provider):
         sqlite_provider.log_interaction(

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-12" # auto-bump @1781285244
+last_verified: "2026-06-12" # auto-bump @1781288969
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781285244
+last_verified: "2026-06-12" # auto-bump @1781288969
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Problem (LIA-214)

Reflections retrieved for an agent prompt are supposed to get `times_helpful++`
when the interaction scores `>= POSITIVE_THRESHOLD` (0.85). Credit was attempted
**synchronously in `cmd_log_interaction`** right after logging — but at that point
the judge score is still async-`NULL` ~97% of the time, so the `>= 0.85` gate
returned early and credit was almost never granted (measured **3.1%** credit
rate). This is a temporal race that starves the reflection-quality signal the
evolution loop relies on to decide which reflections to keep and serve.

## Fix

- Persist `retrieved_reflection_ids` on the interaction row at log time (new TEXT
  column, JSON array).
- Move crediting into `update_score()` — the **single seam** every scoring path
  routes through (batch judge `maintenance.py`, async `mcp_server.py`,
  `backfill.py`, `cc_backfill.py`). Credit fires once the score is known.
- **Double-credit guard:** new `credited_at` column claimed via an **atomic
  one-shot** `claim_interaction_credit()` (`UPDATE … SET credited_at=datetime('now')
  WHERE id=? AND credited_at IS NULL`, win = `rowcount==1`). Concurrent score
  writers and judge re-scores credit each reflection **exactly once**.
- `retrieved_reflection_ids` is **COALESCE**-protected in the upsert (a NULL re-log
  preserves it). `credited_at` is deliberately kept **out** of the INSERT/upsert
  column list (like `judge_score`) so a NULL re-log can't clobber the one-shot
  guard back to NULL and re-enable double-credit.
- Removed the racy synchronous `_handle_retrieved_reflections` block **and** its
  now-dead function definition from `cli.py`.

## Why the claim precedes the increment loop

Claiming credit *before* the `increment_helpful` loop is intentional: claiming
*after* would let two concurrent score writers both pass the still-NULL claim
check and both run the loop = double-credit. Claiming first bounds credit to
exactly once (documented in-code).

## Tests

+13 tests (7 storage-provider, 6 interaction_log): COALESCE preservation,
`credited_at` survives re-log, atomic one-shot claim, credit at/above/below the
0.85 boundary, sub-then-super-threshold credits once, no-retrieved-IDs no-op,
back-compat NULL columns. Full `evolution/tests/` suite: **653 passed, 1 skipped**
(640 on main; +13 mine). flag-lint: pass (no new env gates). `py_compile`: OK.

## Deploy

Python-only (per-call subprocess) — **no `npm build` / `com.deus` restart** needed.

## Reviews

code-reviewer (Opus) and ai-eng-warden both returned **SHIP** on the final state;
the atomic-claim TOCTOU-freedom and the `credited_at`-out-of-upsert invariant were
independently confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)