### PR TITLE
fix(evolution): self-calibrating optimizer abstain floor (LIA-209)

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -714,6 +714,16 @@ def main() -> None:
                              help="Embedding provider (default: auto-detect)")
     p_optparams.add_argument("--db", help="Path to memory_tree.db (default: ~/.deus/memory_tree.db)")
     p_optparams.add_argument("--force", action="store_true", help="Save artifact even if score regressed")
+    p_optparams.add_argument(
+        "--min-abstain", type=float, default=None,
+        help="Reject trials whose abstain accuracy regresses below this floor. "
+             "Default: self-calibrate to the baseline's own abstain accuracy (LIA-209).",
+    )
+    p_optparams.add_argument(
+        "--dry-run", action="store_true",
+        help="Compute and print the best params as JSON WITHOUT saving an artifact "
+             "(no live retrieval impact — the saved artifact is consumed live by memory_tree).",
+    )
 
     # taste
     p_taste = sub.add_parser("taste", help="Generate taste/style hypothesis profile")
@@ -789,14 +799,26 @@ def main() -> None:
     elif args.cmd == "dismiss_warden_finding":
         cmd_dismiss_warden_finding(args.json_str)
     elif args.cmd == "optimize-params":
-        from .optimizer.param_optimizer import optimize_and_save
         provider = args.provider if args.provider != "auto" else None
-        aid = optimize_and_save(
-            db_path=args.db, trials=args.trials, provider=provider,
-            force=args.force,
-        )
-        if not aid:
-            sys.exit(1)
+        if args.dry_run:
+            # Compute-only: never touches the active artifact (LIA-209 verification
+            # path). memory_tree consumes the saved artifact live, so a real save
+            # is a separate, sweep-gated go-live step.
+            from .optimizer.param_optimizer import optimize_params
+            result = optimize_params(
+                db_path=args.db, trials=args.trials, min_abstain=args.min_abstain,
+            )
+            if result is None:
+                sys.exit(1)
+            print(json.dumps(result, indent=2))
+        else:
+            from .optimizer.param_optimizer import optimize_and_save
+            aid = optimize_and_save(
+                db_path=args.db, trials=args.trials, provider=provider,
+                force=args.force, min_abstain=args.min_abstain,
+            )
+            if not aid:
+                sys.exit(1)
     elif args.cmd == "taste":
         cmd_taste(force=args.force, min_interactions=args.min_interactions)
     elif args.cmd == "consolidate-style":

--- a/evolution/optimizer/param_optimizer.py
+++ b/evolution/optimizer/param_optimizer.py
@@ -223,13 +223,21 @@ def optimize_params(
     db_path: Optional[str] = None,
     trials: int = DEFAULT_TRIALS,
     seed: int = 42,
-    min_abstain: float = 0.8,
+    min_abstain: Optional[float] = None,
     verbose: bool = True,
 ) -> Optional[dict[str, Any]]:
     """Run parameter optimization against the labeled benchmark.
 
     Returns dict with best params, scores, and metadata. None if benchmark
     data is missing or no valid trial found.
+
+    min_abstain is the floor below which a trial's abstain accuracy is treated
+    as a regression and the trial rejected. When None (default) it
+    self-calibrates to the baseline candidate's OWN abstain accuracy at i==0
+    ("don't regress abstain below current production"); pass a float to override.
+    LIA-209: a hardcoded 0.8 floor sat ABOVE the live baseline abstain (~0.727),
+    so every trial — including the baseline defaults — was rejected, best_score
+    stayed -1, and the run always reported "No valid trial found."
     """
     if not BENCH_LABELS.exists():
         print(f"[param-optimizer] Benchmark labels not found: {BENCH_LABELS}")
@@ -242,6 +250,24 @@ def optimize_params(
 
     db = _open_db(db_path)
 
+    # Self-calibration (min_abstain is None) anchors the abstain floor to the
+    # BASELINE production defaults, which must be candidates[0]. If
+    # _seed_from_defaults() could not import them (ImportError -> []),
+    # candidates[0] would be a random sample and the floor meaningless — refuse
+    # rather than silently set a bogus production floor that a real (non-dry-run)
+    # run could promote into live retrieval (LIA-209 ai-eng review). Fail fast,
+    # before the expensive embedding step. An explicit --min-abstain has no such
+    # dependency, so it is allowed to proceed without the seed.
+    seeded = _seed_from_defaults()
+    if min_abstain is None and not seeded:
+        print(
+            "[param-optimizer] Cannot self-calibrate abstain floor: production "
+            "defaults unavailable (memory_tree import failed). "
+            "Pass --min-abstain explicitly to override."
+        )
+        db.close()
+        return None
+
     # Pre-embed all queries once (the expensive step)
     queries = list({item["query"] for item in dataset})
     if verbose:
@@ -253,7 +279,7 @@ def optimize_params(
 
     rng = random.Random(seed)
 
-    candidates = _seed_from_defaults()
+    candidates = list(seeded)
     for _ in range(trials - len(candidates)):
         candidates.append(_sample_params(rng))
 
@@ -261,22 +287,42 @@ def optimize_params(
     best_params: dict[str, float | int] = {}
     best_result: dict[str, Any] = {}
     baseline_score: float = -1.0
+    # LIA-209: the abstain floor actually applied. Stays None until the baseline
+    # (i==0) calibrates it to its own abstain accuracy, unless the caller pinned
+    # an explicit min_abstain. The baseline candidate is candidates[0]
+    # (_seed_from_defaults), so it is always scored first.
+    effective_floor: Optional[float] = min_abstain
 
     t_start = time.monotonic()
     for i, params in enumerate(candidates):
         result = _run_trial(db, dataset, params, vec_cache)
-        score = _score_result(result, min_abstain=min_abstain)
 
         if i == 0:
+            # candidates[0] is the production defaults on the self-calibrate path
+            # (the guard above guarantees `seeded` is non-empty there). On the
+            # explicit-floor path with no seed, it is a random sample, so
+            # baseline_score (and the reported delta) is measured against that
+            # random baseline — tolerated because the delta<=0 save guard still
+            # blocks a non-improving artifact, and the caller pinned the floor.
             recall = result.get("recall_at_k", 0.0)
             mrr = result.get("mrr_at_k", 0.0)
             baseline_score = recall * 0.8 + mrr * 0.2
+            if effective_floor is None:
+                baseline_abstain = result.get("abstain_accuracy")
+                # No abstain signal → 0.0 (no constraint); else the baseline's own
+                # accuracy. _score_result uses strict `<`, so the baseline passes
+                # its own floor (baseline_abstain < baseline_abstain is False).
+                effective_floor = (
+                    baseline_abstain if baseline_abstain is not None else 0.0
+                )
             if verbose:
                 print(
                     f"[param-optimizer] Baseline: recall={recall:.3f} "
                     f"abstain={result.get('abstain_accuracy', 'N/A')} "
-                    f"score={baseline_score:.4f}"
+                    f"score={baseline_score:.4f} (abstain floor={effective_floor:.3f})"
                 )
+
+        score = _score_result(result, min_abstain=effective_floor)
 
         if score is not None and score > best_score:
             best_score = score
@@ -331,17 +377,25 @@ def optimize_and_save(
     provider: Optional[str] = None,
     verbose: bool = True,
     force: bool = False,
+    min_abstain: Optional[float] = None,
 ) -> Optional[str]:
     """Run optimization and save result as an evolution artifact.
 
-    Refuses to save if optimized score is worse than baseline (unless force=True).
-    Returns artifact ID on success, None on failure or regression.
+    Refuses to save unless the optimized score strictly beats baseline (delta>0;
+    unless force=True). Returns artifact ID on success, None on failure or
+    no-improvement. min_abstain is forwarded to optimize_params (None =
+    self-calibrate to baseline abstain, LIA-209).
     """
-    result = optimize_params(db_path=db_path, trials=trials, verbose=verbose)
+    result = optimize_params(
+        db_path=db_path, trials=trials, min_abstain=min_abstain, verbose=verbose
+    )
     if result is None:
         return None
 
-    if result["delta"] < 0 and not force:
+    # LIA-209: <= 0, not < 0. A no-op run (best == baseline, delta == 0) now
+    # saves nothing — a delta-0 artifact would needlessly churn the active
+    # artifact (which memory_tree consumes live) without any measured gain.
+    if result["delta"] <= 0 and not force:
         if verbose:
             print(
                 f"[param-optimizer] No improvement found "

--- a/evolution/tests/test_param_optimizer.py
+++ b/evolution/tests/test_param_optimizer.py
@@ -13,6 +13,8 @@ from evolution.optimizer.param_optimizer import (
     _load_labels,
     _sample_params,
     _score_result,
+    optimize_and_save,
+    optimize_params,
 )
 
 
@@ -97,3 +99,130 @@ def test_score_result_no_abstain():
     score = _score_result(result)
     assert score is not None
     assert score == pytest.approx(0.8 * 0.8 + 0.7 * 0.2)
+
+
+# ── LIA-209: self-calibrating abstain floor ──────────────────────────────────
+
+
+@patch("evolution.optimizer.param_optimizer._open_db")
+@patch("evolution.optimizer.param_optimizer._precompute_embeddings")
+@patch("evolution.optimizer.param_optimizer._run_trial")
+@patch("evolution.optimizer.param_optimizer._load_labels")
+def test_optimize_params_self_calibrates_floor(mock_labels, mock_trial, mock_embed, mock_db):
+    """With min_abstain=None the floor calibrates to the baseline's own abstain
+    (0.727), so the baseline is no longer rejected by a fixed 0.8 — returns a
+    result where the old hardcoded floor returned None."""
+    mock_labels.return_value = [{"query": "q1", "tag": "t"}]
+    mock_embed.return_value = {}
+    mock_db.return_value = MagicMock()
+    # Every trial (incl. baseline at i==0) reports abstain 0.727 < the old 0.8.
+    mock_trial.return_value = {
+        "recall_at_k": 0.6, "mrr_at_k": 0.5, "abstain_accuracy": 0.727,
+    }
+
+    # verbose=True also exercises the `abstain floor={effective_floor:.3f}`
+    # log line (the float-formatting path).
+    result = optimize_params(trials=3, min_abstain=None, verbose=True)
+    assert result is not None, "self-calibrated floor should accept the baseline"
+    assert result["score"] >= 0
+    assert result["abstain_accuracy"] == pytest.approx(0.727)
+
+
+@patch("evolution.optimizer.param_optimizer._seed_from_defaults", return_value=[])
+@patch("evolution.optimizer.param_optimizer._open_db")
+@patch("evolution.optimizer.param_optimizer._load_labels")
+def test_optimize_params_refuses_self_calibration_without_defaults(
+    mock_labels, mock_db, mock_seed
+):
+    """When production defaults can't be imported (_seed_from_defaults() == []),
+    self-calibration (min_abstain=None) refuses — it must not anchor the floor to
+    a random sample. Fails fast before the embedding step (LIA-209 ai-eng review)."""
+    mock_labels.return_value = [{"query": "q1", "tag": "t"}]
+    mock_db.return_value = MagicMock()
+    assert optimize_params(trials=3, min_abstain=None, verbose=False) is None
+
+
+@patch("evolution.optimizer.param_optimizer._run_trial")
+@patch("evolution.optimizer.param_optimizer._precompute_embeddings")
+@patch("evolution.optimizer.param_optimizer._open_db")
+@patch("evolution.optimizer.param_optimizer._seed_from_defaults", return_value=[])
+@patch("evolution.optimizer.param_optimizer._load_labels")
+def test_optimize_params_explicit_floor_runs_without_defaults(
+    mock_labels, mock_seed, mock_db, mock_embed, mock_trial
+):
+    """An explicit min_abstain has no dependency on the production defaults, so it
+    proceeds even when _seed_from_defaults() is empty."""
+    mock_labels.return_value = [{"query": "q1", "tag": "t"}]
+    mock_db.return_value = MagicMock()
+    mock_embed.return_value = {}
+    mock_trial.return_value = {
+        "recall_at_k": 0.6, "mrr_at_k": 0.5, "abstain_accuracy": 0.9,
+    }
+    result = optimize_params(trials=3, min_abstain=0.8, verbose=False)
+    assert result is not None  # 0.9 >= 0.8 floor, runs fine without a seed
+
+
+@patch("evolution.optimizer.param_optimizer._open_db")
+@patch("evolution.optimizer.param_optimizer._precompute_embeddings")
+@patch("evolution.optimizer.param_optimizer._run_trial")
+@patch("evolution.optimizer.param_optimizer._load_labels")
+def test_optimize_params_explicit_min_abstain_overrides(mock_labels, mock_trial, mock_embed, mock_db):
+    """An explicit min_abstain above the trials' abstain rejects every trial
+    (the pre-LIA-209 'No valid trial found' behavior, now opt-in)."""
+    mock_labels.return_value = [{"query": "q1", "tag": "t"}]
+    mock_embed.return_value = {}
+    mock_db.return_value = MagicMock()
+    mock_trial.return_value = {
+        "recall_at_k": 0.6, "mrr_at_k": 0.5, "abstain_accuracy": 0.727,
+    }
+
+    result = optimize_params(trials=3, min_abstain=0.8, verbose=False)
+    assert result is None, "explicit floor of 0.8 must reject all 0.727 trials"
+
+
+@patch("evolution.optimizer.param_optimizer.optimize_params")
+def test_optimize_and_save_skips_on_zero_delta(mock_opt):
+    """LIA-209: delta == 0 (no improvement) must NOT save — tightened from < 0."""
+    mock_opt.return_value = {
+        "delta": 0.0, "params": {}, "baseline_score": 0.5, "score": 0.5, "trials": 3,
+    }
+    assert optimize_and_save(verbose=False) is None
+
+
+@patch("evolution.optimizer.artifacts.save_artifact", return_value="aid-xyz")
+@patch("evolution.optimizer.param_optimizer._detect_provider", return_value="ollama")
+@patch("evolution.optimizer.param_optimizer.optimize_params")
+def test_optimize_and_save_saves_on_positive_delta(mock_opt, mock_prov, mock_save):
+    """A strictly-positive delta still saves an artifact."""
+    mock_opt.return_value = {
+        "delta": 0.05, "params": {"a": 1}, "baseline_score": 0.5, "score": 0.55, "trials": 3,
+    }
+    aid = optimize_and_save(verbose=False)
+    assert aid == "aid-xyz"
+    mock_save.assert_called_once()
+
+
+def test_cli_optimize_params_dry_run_does_not_save(monkeypatch, capsys):
+    """The optimize-params --dry-run CLI path computes via optimize_params and
+    never calls optimize_and_save (so no artifact reaches live retrieval)."""
+    from evolution import cli
+
+    calls = {"params": 0, "save": 0}
+
+    def fake_params(**kw):
+        calls["params"] += 1
+        return {"params": {"a": 1}, "score": 0.5, "baseline_score": 0.5, "delta": 0.0, "trials": 1}
+
+    def fake_save(**kw):
+        calls["save"] += 1
+        return "should-not-be-saved"
+
+    monkeypatch.setattr("evolution.optimizer.param_optimizer.optimize_params", fake_params)
+    monkeypatch.setattr("evolution.optimizer.param_optimizer.optimize_and_save", fake_save)
+    monkeypatch.setattr("sys.argv", ["cli", "optimize-params", "--dry-run", "--trials", "1"])
+
+    cli.main()
+
+    assert calls["params"] == 1
+    assert calls["save"] == 0, "--dry-run must never save an artifact"
+    assert '"params"' in capsys.readouterr().out

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-12" # auto-bump @1781288969
+last_verified: "2026-06-12" # auto-bump @1781291092
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781288969
+last_verified: "2026-06-12" # auto-bump @1781291092
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Problem (LIA-209)

`evolution/optimizer/param_optimizer.py::optimize_params` rejects any benchmark
trial whose **abstain accuracy** regresses below `min_abstain`, which was
hardcoded at **0.8** — above even the live baseline abstain accuracy (measured
**0.591** on the real labeled benchmark). So *every* trial, including the
baseline defaults (`candidates[0]`), was rejected, `best_score` stayed at its
`-1` sentinel, and the run always printed **"No valid trial found"**. The
optimizer was a dead no-op.

## Fix

- `optimize_params(min_abstain: Optional[float] = None)`: when `None` (new
  default), the floor **self-calibrates** to the baseline candidate's own abstain
  accuracy at `i==0` ("don't regress below current production"). An explicit
  float overrides. `_score_result` uses strict `<`, so the baseline passes its
  own floor.
- **Fail-safe** (from ai-eng review): when the production defaults can't be
  imported (`_seed_from_defaults() == []`), self-calibration **refuses** (returns
  None) rather than anchoring the floor to a random sample that a non-dry-run
  could promote into live retrieval. An explicit `--min-abstain` is unaffected.
- `optimize_and_save` save-guard tightened `delta < 0` → `delta <= 0`: a no-op
  run (best == baseline) no longer churns the live-consumed active artifact.
- CLI: added `--min-abstain` and `--dry-run` (compute-only via `optimize_params`,
  prints JSON, **never saves**) to `optimize-params`.

## Live verification (compute-only, no artifact saved)

`optimize-params --dry-run` on the real benchmark:
```
Baseline: recall=0.735 abstain=0.591 score=0.7136 (abstain floor=0.591)
Done. baseline=0.7136 -> best=0.7136 (+0.0000)
```
The floor self-calibrates to 0.591, the baseline passes, `best_score=0.7136` (≥0)
— where the old hardcoded 0.8 floor returned `None`. No artifact written.

**Out of scope** (separate sweep-gated go-live): producing/promoting a real
artifact (run `deus sweep`, require neutral-or-better, then save).

## Tests

+5 tests (self-calibrate, explicit-override-rejects-all, refuse-without-defaults,
explicit-floor-runs-without-defaults, delta<=0 no-save, delta>0 saves, dry-run
never saves). Full `evolution/tests/` suite: **658 passed**.

## Reviews

code-reviewer (Opus) + ai-eng-warden both **SHIP** (ai-eng's REVISE on the
`_seed_from_defaults` edge was resolved by the fail-safe above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)