### PR TITLE
feat(scripts): vetted CI-wait poll helper replacing gh pr checks --watch

### DIFF
--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI helper scripts (flag-lint excluded; see scripts/ci/flag_lint.py)."""

--- a/scripts/ci/wait_for_checks.py
+++ b/scripts/ci/wait_for_checks.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Vetted poller for a PR's REQUIRED CI checks — a safe replacement for
+``gh pr checks <pr> --required --watch``.
+
+Why this exists: several call sites piped ``gh pr checks --watch`` through
+``tail``/``grep``, which masks gh's non-zero exit and can wave a failing PR
+through a merge gate. This helper owns the poll loop, parses the checks JSON
+explicitly, and returns an authoritative ``(green: bool, detail: str)`` — never
+a masked exit. The zero-registered-checks case (gh can report exit 0 + ``[]``)
+is disambiguated against an unfiltered query so "no required checks" is never
+mistaken for "all green" (fail-closed).
+
+Poll cadence/ceiling are env-overridable (``DEUS_CI_POLL_INTERVAL`` /
+``DEUS_CI_POLL_TIMEOUT`` / ``DEUS_CI_POLL_RETRIES``) — operational tuning knobs
+with safe defaults, not feature gates (and ``scripts/ci/`` is flag-lint
+excluded). Cross-platform: arg-list subprocess, no shell.
+
+Exit codes: 0 = required checks green; 5 = not green / timeout / unreadable;
+2 = usage error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from _exit_codes import INTERNAL_ERROR, SUCCESS, USAGE_ERROR  # noqa: E402
+
+# Buckets gh assigns a check. "pending" keeps us polling. Green is a POSITIVE
+# allowlist — only pass/skipping count (a skipped required check is not a
+# failure). Anything else terminal (fail, cancel, OR an unrecognized bucket from
+# gh output drift) is NOT green: this gate must fail closed.
+_PENDING = "pending"
+_PASSING = frozenset({"pass", "skipping"})
+
+
+def _run(argv: list[str], timeout: int = 60):
+    """Arg-list subprocess (no shell). Returns the CompletedProcess, or None on
+    timeout/OSError so the caller can treat it as a transient read failure."""
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _query_checks(pr: int, *, required: bool):
+    """Return the parsed checks list for a PR, or None if gh produced no JSON.
+
+    None is deliberately ambiguous — a transient gh failure OR a "no checks"
+    message — and is disambiguated by the caller via the required/unfiltered
+    pair plus the retry budget.
+    """
+    argv = ["gh", "pr", "checks", str(pr), "--json", "name,state,bucket"]
+    if required:
+        argv.append("--required")
+    proc = _run(argv)
+    if proc is None:
+        return None
+    out = (proc.stdout or "").strip()
+    if not out.startswith("["):
+        return None  # "no checks" message / error text, not a JSON array
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def _bucket(check: dict) -> str:
+    return str(check.get("bucket") or check.get("state") or "").lower()
+
+
+def wait_for_required_checks(
+    pr: int,
+    *,
+    interval: int = 30,
+    timeout: int = 1800,
+    retries: int = 5,
+) -> tuple[bool, str]:
+    """Poll a PR's required checks until they settle. Returns ``(green, detail)``.
+
+    ``green`` is True only when every required check is in a passing/skipping
+    bucket. A PR with zero required checks is NEVER reported green (fail-closed):
+    if other checks exist, none are *required* (definitive False); if no checks
+    exist at all it is treated as not-yet-registered and retried until timeout.
+    """
+    deadline = time.monotonic() + timeout
+    transient = 0
+    while True:
+        required = _query_checks(pr, required=True)
+
+        if required is None:
+            # No JSON from the required query — transient error or "no checks".
+            if time.monotonic() >= deadline:
+                return False, f"timed out after {timeout}s (gh unreadable)"
+            transient += 1
+            if transient > retries:
+                return False, f"gh pr checks unreadable after {retries} retries"
+            time.sleep(interval)
+            continue
+        transient = 0
+
+        if not required:
+            # Zero required checks. Disambiguate against an unfiltered query so
+            # an empty `[]` is never mistaken for "all green".
+            allchecks = _query_checks(pr, required=False)
+            if allchecks:
+                return False, "no required checks configured (checks exist but none required)"
+            if time.monotonic() >= deadline:
+                return False, f"no checks registered after {timeout}s"
+            time.sleep(interval)
+            continue
+
+        buckets = [_bucket(c) for c in required]
+        if _PENDING in buckets:
+            if time.monotonic() >= deadline:
+                pend = [c.get("name") for c in required if _bucket(c) == _PENDING]
+                return False, f"timed out after {timeout}s; still pending: {pend}"
+            time.sleep(interval)
+            continue
+
+        # Positive allowlist: green only if EVERY required check passed/skipped.
+        # fail/cancel and any unrecognized bucket are surfaced as not-green.
+        not_green = [
+            f"{c.get('name')}({_bucket(c) or '?'})"
+            for c in required
+            if _bucket(c) not in _PASSING
+        ]
+        if not_green:
+            return False, f"required checks not green: {not_green}"
+        return True, f"all {len(required)} required checks green"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Wait for a PR's required CI checks to settle; authoritative exit."
+    )
+    ap.add_argument("pr", type=int, help="PR number")
+    ap.add_argument(
+        "--interval", type=int,
+        default=int(os.environ.get("DEUS_CI_POLL_INTERVAL", "30")),
+        help="Seconds between polls (env: DEUS_CI_POLL_INTERVAL; default 30).",
+    )
+    ap.add_argument(
+        "--timeout", type=int,
+        default=int(os.environ.get("DEUS_CI_POLL_TIMEOUT", "1800")),
+        help="Overall ceiling in seconds (env: DEUS_CI_POLL_TIMEOUT; default 1800).",
+    )
+    ap.add_argument(
+        "--retries", type=int,
+        default=int(os.environ.get("DEUS_CI_POLL_RETRIES", "5")),
+        help="Consecutive gh read failures tolerated (env: DEUS_CI_POLL_RETRIES; default 5).",
+    )
+    ap.add_argument("--json", action="store_true", help="Emit JSON (agent-native).")
+    ap.add_argument("--compact", action="store_true", help="Compact JSON (implies --json).")
+    args = ap.parse_args(argv)
+
+    if args.interval < 1 or args.timeout < 1:
+        print("wait_for_checks: --interval and --timeout must be >= 1", file=sys.stderr)
+        return USAGE_ERROR
+
+    green, detail = wait_for_required_checks(
+        args.pr, interval=args.interval, timeout=args.timeout, retries=args.retries
+    )
+    payload = {"pr": args.pr, "green": green, "detail": detail}
+    if args.json or args.compact:
+        print(
+            json.dumps(payload, separators=(",", ":"))
+            if args.compact
+            else json.dumps(payload, indent=2)
+        )
+    else:
+        print(f"PR #{args.pr}: {'GREEN' if green else 'NOT GREEN'} — {detail}")
+    return SUCCESS if green else INTERNAL_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_train.py
+++ b/scripts/merge_train.py
@@ -149,14 +149,16 @@ def _rebase_and_push(wt: Path, branch: str) -> tuple[bool, str]:
 
 
 def _wait_required_ci(pr: int, interval: int) -> tuple[bool, str]:
-    """Block on ``gh pr checks --required --watch``; green iff exit 0."""
-    result = _run(
-        ["gh", "pr", "checks", str(pr), "--required", "--watch", "--interval", str(interval)],
-        timeout=_CI_WATCH_TIMEOUT,
-    )
-    if result.returncode == 0:
-        return True, "required checks green"
-    return False, f"required CI not green (exit {result.returncode}): {_tail(result)}"
+    """Poll required checks via the vetted ci.wait_for_checks helper.
+
+    Replaces the old blocking ``gh pr checks --required --watch`` (whose exit
+    code several call sites masked by piping through tail/grep). The helper owns
+    the poll loop, parses the checks JSON authoritatively, and fail-closes on
+    the zero-required-checks ambiguity — returning a definite (green, detail).
+    """
+    from ci.wait_for_checks import wait_for_required_checks
+
+    return wait_for_required_checks(pr, interval=interval, timeout=_CI_WATCH_TIMEOUT)
 
 
 def _verify_mergeable(pr: int, *, retries: int = 6, delay: int = 3) -> tuple[bool, str]:

--- a/scripts/tests/test_merge_train.py
+++ b/scripts/tests/test_merge_train.py
@@ -298,14 +298,22 @@ def test_verify_mergeable_gives_up_after_persistent_unknown(mt, monkeypatch):
     assert "did not settle" in detail
 
 
-def test_wait_required_ci_uses_required_and_watch(mt, monkeypatch):
+def test_wait_required_ci_delegates_to_helper(mt, monkeypatch):
+    """_wait_required_ci now delegates to ci.wait_for_checks.wait_for_required_checks,
+    forwarding the PR and poll interval (no more `gh ... --watch`)."""
+    import ci.wait_for_checks as wfc
+
     captured = {}
 
-    def responder(argv):
-        captured["argv"] = list(argv)
-        return 0, "", ""
+    def fake_wait(pr, *, interval, timeout, retries=5):
+        captured["pr"] = pr
+        captured["interval"] = interval
+        captured["timeout"] = timeout
+        return True, "all 6 required checks green"
 
-    monkeypatch.setattr(mt, "_run", _fake_run(responder))
-    ok, _ = mt._wait_required_ci(709, interval=30)
+    monkeypatch.setattr(wfc, "wait_for_required_checks", fake_wait)
+    ok, detail = mt._wait_required_ci(709, interval=30)
     assert ok is True
-    assert "--required" in captured["argv"] and "--watch" in captured["argv"]
+    assert captured["pr"] == 709
+    assert captured["interval"] == 30
+    assert captured["timeout"] == mt._CI_WATCH_TIMEOUT

--- a/scripts/tests/test_wait_for_checks.py
+++ b/scripts/tests/test_wait_for_checks.py
@@ -1,0 +1,172 @@
+"""Unit tests for scripts/ci/wait_for_checks.py.
+
+The poll loop is exercised by faking `_query_checks` (the gh-checks JSON
+parser) and no-op'ing `time.sleep`; timeout paths drive a fake monotonic clock.
+No real subprocess or wall-clock waits.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_CI_DIR = Path(__file__).resolve().parents[1] / "ci"
+
+
+def load_wfc():
+    if "wait_for_checks" in sys.modules:
+        return sys.modules["wait_for_checks"]
+    spec = importlib.util.spec_from_file_location(
+        "wait_for_checks", _CI_DIR / "wait_for_checks.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["wait_for_checks"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def wfc():
+    return load_wfc()
+
+
+def _advancing_clock(step=5.0):
+    state = {"v": 0.0}
+
+    def clock():
+        state["v"] += step
+        return state["v"]
+
+    return clock
+
+
+def _sequence(*values):
+    """Fake _query_checks that yields each value once, then repeats the last."""
+    calls = {"i": 0}
+
+    def fake(pr, *, required):
+        v = values[min(calls["i"], len(values) - 1)]
+        calls["i"] += 1
+        return v
+
+    return fake
+
+
+# ── terminal states ──────────────────────────────────────────────────────────
+
+
+def test_all_required_green(wfc, monkeypatch):
+    monkeypatch.setattr(
+        wfc, "_query_checks",
+        lambda pr, *, required: [
+            {"name": "ci", "bucket": "pass"},
+            {"name": "lint", "bucket": "skipping"},  # skipped == pass
+        ],
+    )
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=10)
+    assert green is True
+    assert "green" in detail
+
+
+def test_required_failure_is_not_green(wfc, monkeypatch):
+    monkeypatch.setattr(
+        wfc, "_query_checks",
+        lambda pr, *, required: [
+            {"name": "ci", "bucket": "pass"},
+            {"name": "test-windows", "bucket": "fail"},
+        ],
+    )
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=10)
+    assert green is False
+    assert "not green" in detail
+    assert "test-windows" in detail
+
+
+def test_unknown_bucket_fails_closed(wfc, monkeypatch):
+    """An unrecognized terminal bucket (gh output drift) must NOT be green —
+    green is a positive pass/skipping allowlist, not a fail/cancel blocklist."""
+    monkeypatch.setattr(
+        wfc, "_query_checks",
+        lambda pr, *, required: [{"name": "ci", "bucket": "neutral"}],
+    )
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=10)
+    assert green is False
+    assert "ci" in detail
+
+
+def test_pending_then_green(wfc, monkeypatch):
+    monkeypatch.setattr(
+        wfc, "_query_checks",
+        _sequence([{"name": "ci", "bucket": "pending"}], [{"name": "ci", "bucket": "pass"}]),
+    )
+    monkeypatch.setattr(wfc.time, "sleep", lambda s: None)
+    green, _ = wfc.wait_for_required_checks(1, interval=0, timeout=10)
+    assert green is True
+
+
+# ── zero-registered-checks disambiguation ────────────────────────────────────
+
+
+def test_no_checks_registered_is_not_green(wfc, monkeypatch):
+    """Required `[]` + unfiltered `[]` → checks not registered yet → retried to
+    timeout, never reported green."""
+    monkeypatch.setattr(wfc, "_query_checks", lambda pr, *, required: [])
+    monkeypatch.setattr(wfc.time, "sleep", lambda s: None)
+    monkeypatch.setattr(wfc.time, "monotonic", _advancing_clock())
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=1)
+    assert green is False
+    assert "no checks registered" in detail
+
+
+def test_checks_exist_but_none_required_fails_closed(wfc, monkeypatch):
+    """Required `[]` while unfiltered has checks → none are *required* → False."""
+
+    def fake(pr, *, required):
+        return [] if required else [{"name": "advisory", "bucket": "pass"}]
+
+    monkeypatch.setattr(wfc, "_query_checks", fake)
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=10)
+    assert green is False
+    assert "none required" in detail
+
+
+# ── timeout & retry ──────────────────────────────────────────────────────────
+
+
+def test_timeout_while_pending(wfc, monkeypatch):
+    monkeypatch.setattr(
+        wfc, "_query_checks", lambda pr, *, required: [{"name": "ci", "bucket": "pending"}]
+    )
+    monkeypatch.setattr(wfc.time, "sleep", lambda s: None)
+    monkeypatch.setattr(wfc.time, "monotonic", _advancing_clock())
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=1)
+    assert green is False
+    assert "still pending" in detail
+
+
+def test_transient_read_failure_recovers(wfc, monkeypatch):
+    """Two unreadable polls (None) then a green list → recovers (retries reset)."""
+    monkeypatch.setattr(
+        wfc, "_query_checks",
+        _sequence(None, None, [{"name": "ci", "bucket": "pass"}]),
+    )
+    monkeypatch.setattr(wfc.time, "sleep", lambda s: None)
+    green, _ = wfc.wait_for_required_checks(1, interval=0, timeout=600, retries=5)
+    assert green is True
+
+
+def test_retries_exhausted(wfc, monkeypatch):
+    monkeypatch.setattr(wfc, "_query_checks", lambda pr, *, required: None)
+    monkeypatch.setattr(wfc.time, "sleep", lambda s: None)
+    green, detail = wfc.wait_for_required_checks(1, interval=0, timeout=600, retries=3)
+    assert green is False
+    assert "unreadable" in detail
+
+
+# ── bucket parsing helper ────────────────────────────────────────────────────
+
+
+def test_bucket_prefers_bucket_then_state(wfc):
+    assert wfc._bucket({"bucket": "PASS"}) == "pass"
+    assert wfc._bucket({"state": "FAILURE"}) == "failure"
+    assert wfc._bucket({}) == ""


### PR DESCRIPTION
## Problem

Several merge-gate call sites ran `gh pr checks <pr> --required --watch` piped
through `tail`/`grep`, which **masks gh's non-zero exit** and can wave a failing
PR through a merge (the exact hazard the CI Gate Safety rule warns about).

## Fix

New **`scripts/ci/wait_for_checks.py`** owns the poll loop, parses the checks JSON
explicitly, and returns an authoritative `(green: bool, detail: str)` — never a
masked exit.

- **Green is a positive `pass`/`skipping` allowlist.** `fail`/`cancel` and any
  unrecognized bucket (gh output drift) **fail closed**.
- **Zero required checks is never reported green.** Disambiguated against an
  unfiltered query: *checks-exist-but-none-required* is a definitive failure;
  *no-checks-yet* is retried until timeout.
- Transient gh read failures retried (`retries`, deadline-checked first).
- Poll cadence/ceiling env-overridable: `DEUS_CI_POLL_INTERVAL` /
  `DEUS_CI_POLL_TIMEOUT` / `DEUS_CI_POLL_RETRIES` (operational knobs;
  `scripts/ci/` is flag-lint-excluded).
- Cross-platform (arg-list `subprocess`, no shell), typed exit codes
  (`scripts/_exit_codes.py`), agent-native `--json`/`--compact`.

`scripts/merge_train.py::_wait_required_ci` now delegates to the helper.

## Tests

New `scripts/tests/test_wait_for_checks.py` — 10 tests: green, fail,
unknown-bucket-fails-closed, pending→green, both zero-checks branches, timeout,
transient-recovers, retries-exhausted, bucket parsing. `test_merge_train.py`
delegation test updated. **27 local tests pass** (helper + merge_train).

## Reviews

code-reviewer (Opus) **SHIP** (its fail-open-on-unknown-bucket Warning was
folded into the positive allowlist above). ai-eng N/A (no `evolution/` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)