### PR TITLE
fix(linear-auto-merge): --admin poll-to-green for the autonomous auto-merge (LIA-215)

### DIFF
--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -17,7 +17,7 @@
 - Never proceed while a review agent is running. Wait for its verdict.
 - REVISE from any warden means re-run after fixes until SHIP. Never touch markers, commit, or proceed on REVISE — no exceptions, no "close enough," no time-pressure rationalization.
 - Quality over speed by default. Never shortcut a warden loop, skip a review round, or rationalize lower standards because of time pressure, autonomy grants, or late-session fatigue. Only skip when the user explicitly says to prioritize speed.
-- Never merge failing CI. Never use --admin/direct push except emergencies.
+- Never merge failing or pending CI. --admin is the accepted solo-dev landing path once all REQUIRED checks are green (+ fresh per-command approval interactively, or pipeline gates autonomously) — not emergency-only (LIA-147). Never --admin over red/pending CI.
 
 ## Verification & Honesty
 - Never speculate. Only state verified facts. If unsure, say so.

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781291092
+last_verified: "2026-06-12" # auto-bump @1781293105
 governs:
   - src/
   - evolution/

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -488,201 +488,164 @@ function makeAutoMergeCtx() {
   } as unknown as import('./linear-dispatcher.js').LinearContext;
 }
 
-describe('attemptAutoMerge — auto flag passed to gh pr merge', () => {
+describe('attemptAutoMerge — --admin poll-to-green (LIA-215)', () => {
+  const PR = 'https://github.com/test-owner/test-repo/pull/200';
+  const checks = (bucket: 'pass' | 'pending' | 'fail') => ({
+    stdout: JSON.stringify([{ bucket, name: 'ci' }]),
+  });
+
   beforeEach(() => {
     process.env.LINEAR_AUTO_MERGE = '1';
   });
   afterEach(() => {
     delete process.env.LINEAR_AUTO_MERGE;
+    delete process.env.AUTO_MERGE_POLL_MAX_ATTEMPTS;
+    vi.useRealTimers();
   });
 
-  it('passes --auto flag when queuing GitHub auto-merge', async () => {
-    // First call: gh pr checks (preCheck inside mergePr with {auto:true}) → pending
-    // Second call: gh pr merge --auto → success (autoQueued)
-    execFileMock
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
-      })
-      .mockReturnValueOnce({ stdout: '' }); // merge --auto succeeds
-
-    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
-    const ctx = makeAutoMergeCtx();
-    upsertIssuePr(
-      'am-issue-1',
-      'https://github.com/test-owner/test-repo/pull/99',
-    );
-    updatePrAutoMergeState('am-issue-1', 'pending');
-
-    await attemptAutoMerge(
-      ctx,
-      'am-issue-1',
-      'https://github.com/test-owner/test-repo/pull/99',
-      'LIA-99',
-    );
-
-    // Verify --auto was in the merge call args
-    const mergeCall = execFileMock.mock.calls.find(
+  function mergeCallArgs(): string[] | undefined {
+    const call = execFileMock.mock.calls.find(
       (c: unknown[]) =>
         Array.isArray(c[1]) && (c[1] as string[]).includes('merge'),
     );
-    expect(mergeCall).toBeDefined();
-    expect(mergeCall![1]).toContain('--auto');
-  });
+    return call ? (call[1] as string[]) : undefined;
+  }
 
-  it('returns immediately when GitHub auto-merge is successfully queued', async () => {
-    // preCheck → pending; merge --auto → success
+  it('CI already green → --admin merge (never --auto) → Done', async () => {
+    // initial checks → pass; mergePr precheck → pass; gh pr merge → ok
     execFileMock
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
-      })
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'))
       .mockReturnValueOnce({ stdout: '' });
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr(
-      'am-issue-2',
-      'https://github.com/test-owner/test-repo/pull/100',
-    );
-    updatePrAutoMergeState('am-issue-2', 'pending');
+    upsertIssuePr('am-pass', PR);
+    updatePrAutoMergeState('am-pass', 'pending');
 
-    await attemptAutoMerge(
-      ctx,
-      'am-issue-2',
-      'https://github.com/test-owner/test-repo/pull/100',
-      'LIA-100',
-    );
+    await attemptAutoMerge(ctx, 'am-pass', PR, 'LIA-200');
 
-    // No issue state update yet — GitHub handles the merge asynchronously
-    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
-    expect(ctx.client.createComment).not.toHaveBeenCalled();
-  });
-
-  it('falls back to direct merge when --auto fails, and merges if CI passes', async () => {
-    vi.useFakeTimers();
-
-    // Call sequence:
-    //  1. gh pr checks (preCheck for --auto) → pending
-    //  2. gh pr merge --auto → error (branch protection not set)
-    //  3. gh pr checks (fallback poll) → pass
-    //  4. gh pr checks (preCheck for direct merge) → pass
-    //  5. gh pr merge (direct) → success
-    const autoError = new Error(
-      'auto-merge not allowed: branch protection not configured',
-    );
-    execFileMock
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
-      })
-      .mockReturnValueOnce({ error: autoError })
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'pass', name: 'ci' }]),
-      })
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'pass', name: 'ci' }]),
-      })
-      .mockReturnValueOnce({ stdout: '' });
-
-    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
-    const ctx = makeAutoMergeCtx();
-    upsertIssuePr(
-      'am-issue-3',
-      'https://github.com/test-owner/test-repo/pull/101',
-    );
-    updatePrAutoMergeState('am-issue-3', 'pending');
-
-    const promise = attemptAutoMerge(
-      ctx,
-      'am-issue-3',
-      'https://github.com/test-owner/test-repo/pull/101',
-      'LIA-101',
-    );
-    // Advance past the CI_POLL_INTERVAL_MS wait
-    await vi.runAllTimersAsync();
-    await promise;
-
-    // Direct merge succeeded → issue moved to Done
+    const args = mergeCallArgs();
+    expect(args).toBeDefined();
+    expect(args).toContain('--admin');
+    expect(args).not.toContain('--auto');
     expect(ctx.client.updateIssue).toHaveBeenCalledWith(
-      'am-issue-3',
+      'am-pass',
       expect.objectContaining({ stateId: 'done-id' }),
     );
-    expect(ctx.client.createComment).toHaveBeenCalledWith(
-      expect.objectContaining({ issueId: 'am-issue-3' }),
-    );
-
-    vi.useRealTimers();
   });
 
-  it('allows pending CI state for --auto preCheck (does not block on pending)', async () => {
-    // preCheck → pending; merge --auto → success (autoQueued)
+  it('CI failing → requeue to Ready for Agent, no merge call', async () => {
+    execFileMock.mockReturnValueOnce(checks('fail'));
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-fail', PR);
+    updatePrAutoMergeState('am-fail', 'pending');
+
+    await attemptAutoMerge(ctx, 'am-fail', PR, 'LIA-201');
+
+    expect(mergeCallArgs()).toBeUndefined();
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'am-fail',
+      expect.objectContaining({ stateId: 'ready-id' }),
+    );
+  });
+
+  it('CI pending → schedules background poll, no synchronous merge/requeue', async () => {
+    vi.useFakeTimers();
+    execFileMock.mockReturnValueOnce(checks('pending'));
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-pend', PR);
+    updatePrAutoMergeState('am-pend', 'pending');
+
+    await attemptAutoMerge(ctx, 'am-pend', PR, 'LIA-202');
+
+    // Nothing decided synchronously — the detached poll's timer is not advanced.
+    expect(mergeCallArgs()).toBeUndefined();
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+    // Still pending (not failed, not requeued).
+    expect(getPendingAutoMerges().some((p) => p.issue_id === 'am-pend')).toBe(
+      true,
+    );
+  });
+
+  it('CI pending then green → MERGED via the background poll (the LIA-215 regression)', async () => {
+    vi.useFakeTimers();
+    // initial → pending; poll#1 → pending; poll#2 → pass; mergePr precheck → pass; merge → ok
     execFileMock
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'pending', name: 'ci' }]),
-      })
+      .mockReturnValueOnce(checks('pending'))
+      .mockReturnValueOnce(checks('pending'))
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'))
       .mockReturnValueOnce({ stdout: '' });
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr(
-      'am-issue-4',
-      'https://github.com/test-owner/test-repo/pull/102',
+    upsertIssuePr('am-slow', PR);
+    updatePrAutoMergeState('am-slow', 'pending');
+
+    await attemptAutoMerge(ctx, 'am-slow', PR, 'LIA-203');
+    await vi.runAllTimersAsync(); // drive the detached poll to completion
+
+    const args = mergeCallArgs();
+    expect(args).toContain('--admin');
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'am-slow',
+      expect.objectContaining({ stateId: 'done-id' }),
     );
-    updatePrAutoMergeState('am-issue-4', 'pending');
-
-    // Should NOT throw or fail — pending CI is allowed for --auto
-    await expect(
-      attemptAutoMerge(
-        ctx,
-        'am-issue-4',
-        'https://github.com/test-owner/test-repo/pull/102',
-        'LIA-102',
-      ),
-    ).resolves.toBeUndefined();
-
-    // No error comment, no re-queue
-    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
   });
 
-  it('blocks --auto when CI is already failing', async () => {
+  it('CI pending then failing → requeue via the poll', async () => {
     vi.useFakeTimers();
-
-    // preCheck for --auto → fail (blocks auto-merge attempt)
-    // fallback poll → fail (CI still failing)
     execFileMock
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'fail', name: 'ci' }]),
-      })
-      // mergePr({auto:true}) returns early, no merge call
-      // fallback: preCheck returns fail immediately in mergePr({auto:false})
-      // but we hit the "auto failed" path first — need to wait for the timer
-      // then the fallback queryPrChecks call:
-      .mockReturnValueOnce({
-        stdout: JSON.stringify([{ bucket: 'fail', name: 'ci' }]),
-      });
+      .mockReturnValueOnce(checks('pending'))
+      .mockReturnValueOnce(checks('fail'));
 
     const { attemptAutoMerge } = await import('./linear-auto-merge.js');
     const ctx = makeAutoMergeCtx();
-    upsertIssuePr(
-      'am-issue-5',
-      'https://github.com/test-owner/test-repo/pull/103',
-    );
-    updatePrAutoMergeState('am-issue-5', 'pending');
+    upsertIssuePr('am-pf', PR);
+    updatePrAutoMergeState('am-pf', 'pending');
 
-    const promise = attemptAutoMerge(
-      ctx,
-      'am-issue-5',
-      'https://github.com/test-owner/test-repo/pull/103',
-      'LIA-103',
-    );
+    await attemptAutoMerge(ctx, 'am-pf', PR, 'LIA-204');
     await vi.runAllTimersAsync();
-    await promise;
 
-    // CI fail triggers re-queue to Ready for Agent
+    expect(mergeCallArgs()).toBeUndefined();
     expect(ctx.client.updateIssue).toHaveBeenCalledWith(
-      'am-issue-5',
+      'am-pf',
       expect.objectContaining({ stateId: 'ready-id' }),
     );
+  });
 
-    vi.useRealTimers();
+  it('CI pending past the cap → PARKED: stays pending, no requeue, no breaker', async () => {
+    vi.useFakeTimers();
+    process.env.AUTO_MERGE_POLL_MAX_ATTEMPTS = '2';
+    // initial → pending; poll#1 → pending; poll#2 → pending; cap reached → park.
+    execFileMock
+      .mockReturnValueOnce(checks('pending'))
+      .mockReturnValueOnce(checks('pending'))
+      .mockReturnValueOnce(checks('pending'));
+
+    const { attemptAutoMerge } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('am-cap', PR);
+    updatePrAutoMergeState('am-cap', 'pending');
+
+    await attemptAutoMerge(ctx, 'am-cap', PR, 'LIA-205');
+    await vi.runAllTimersAsync();
+
+    // Parked-but-visible: no merge, no requeue/state change, but a comment is
+    // posted and the issue stays 'pending' for the sweep.
+    expect(mergeCallArgs()).toBeUndefined();
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+    expect(ctx.client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId: 'am-cap' }),
+    );
+    expect(getPendingAutoMerges().some((p) => p.issue_id === 'am-cap')).toBe(
+      true,
+    );
   });
 });
 

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -21,7 +21,8 @@ import {
 } from './db.js';
 import { logger } from './logger.js';
 import { extractPrUrl } from './pr-url-extractor.js';
-import { macosNotify, notifyPipelineStep } from './linear-notifications.js';
+import { notifyPipelineStep } from './linear-notifications.js';
+import { fireAndForget } from './async/index.js';
 import type { LinearContext } from './linear-dispatcher.js';
 
 const execFileAsync = promisify(execFile);
@@ -140,10 +141,14 @@ export async function queryPrChecks(prUrl: string): Promise<PrChecksResult> {
   }
 }
 
+// --admin is the only viable merge path on this solo repo (LIA-215/LIA-147):
+// branch protection requires an approving review no second human can give, so
+// GitHub-native --auto can never complete (it sits BLOCKED forever) — and gh
+// rejects --admin+--auto together anyway. Require CI green first, then merge.
+// The "wait for CI" responsibility lives in pollUntilMergeable, not in gh.
 async function mergePr(
   prUrl: string,
-  options: { auto: boolean } = { auto: false },
-): Promise<{ merged: boolean; autoQueued?: boolean; error?: string }> {
+): Promise<{ merged: boolean; error?: string }> {
   const prNumber = prUrl.match(/\/pull\/(\d+)/)?.[1];
   const repoMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/);
   const repo = repoMatch?.[1];
@@ -152,21 +157,9 @@ async function mergePr(
     return { merged: false, error: 'Invalid PR URL' };
   }
 
-  // For direct merge (no --auto), CI must already be passing.
-  // For --auto, we only need CI to have started (pending or pass) — GitHub
-  // will wait for the required checks before completing the merge.
   const preCheck = await queryPrChecks(prUrl);
-  if (options.auto) {
-    if (preCheck.status === 'fail') {
-      return {
-        merged: false,
-        error: `CI already failing, not queuing auto-merge: ${preCheck.summary}`,
-      };
-    }
-  } else {
-    if (preCheck.status !== 'pass') {
-      return { merged: false, error: `CI not passing: ${preCheck.summary}` };
-    }
+  if (preCheck.status !== 'pass') {
+    return { merged: false, error: `CI not passing: ${preCheck.summary}` };
   }
 
   const args = [
@@ -179,17 +172,10 @@ async function mergePr(
     '--delete-branch',
     '--admin',
   ];
-  if (options.auto) {
-    args.push('--auto');
-  }
 
   try {
     await execFileAsync('gh', args, { timeout: MERGE_TIMEOUT_MS });
-    // With --auto, gh exits 0 meaning auto-merge was successfully *queued*;
-    // GitHub will complete the merge when CI passes.
-    return options.auto
-      ? { merged: false, autoQueued: true }
-      : { merged: true };
+    return { merged: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('already been merged') || msg.includes('MERGED')) {
@@ -284,72 +270,55 @@ export async function attemptAutoMerge(
   if (!isAutoMergeEnabled()) return;
   const ident = identifier ?? 'unknown';
 
-  // Step 1: Try to enable GitHub's native auto-merge.  --auto makes GitHub
-  // wait for all required status checks before completing the merge itself, so
-  // we don't need to poll here.
-  const autoResult = await mergePr(prUrl, { auto: true });
-  logger.info(
-    {
-      issueId,
-      prUrl,
-      autoQueued: autoResult.autoQueued,
-      error: autoResult.error,
-    },
-    'auto-merge: auto-merge attempt',
-  );
-
-  if (autoResult.merged) {
-    // Already merged (edge case: --auto succeeded immediately)
-    await handleMergeSuccess(ctx, issueId, prUrl, ident);
-    return;
-  }
-
-  if (autoResult.autoQueued) {
-    // GitHub accepted the auto-merge request — it will merge when CI passes.
-    // The sweepPendingAutoMerges cycle will detect the MERGED state later.
-    logger.info(
-      { issueId, prUrl },
-      'auto-merge: GitHub auto-merge queued, waiting for CI',
-    );
-    return;
-  }
-
-  // Step 2: --auto failed (branch protection not configured, or CI already
-  // failing).  Fall back to a single direct-merge attempt after one poll cycle.
-  logger.warn(
-    { issueId, prUrl, error: autoResult.error },
-    'auto-merge: --auto unavailable, falling back to direct merge after CI poll',
-  );
-
-  await new Promise<void>((resolve) =>
-    setTimeout(resolve, CI_POLL_INTERVAL_MS),
-  );
-
+  // Decide on the CURRENT CI state. GitHub-native --auto is dead on this repo
+  // (see mergePr), so we poll to green ourselves (LIA-215).
   const checks = await queryPrChecks(prUrl);
   logger.info(
     { issueId, prUrl, status: checks.status },
-    'auto-merge: CI status (fallback)',
+    'auto-merge: initial CI status',
   );
 
-  if (checks.status !== 'pass') {
-    const reason =
-      checks.status === 'pending'
-        ? `CI still pending after fallback wait: ${checks.summary}`
-        : `CI failed: ${checks.summary}`;
+  if (checks.status === 'fail') {
+    // A real CI failure — re-dispatch a fresh agent attempt.
     await handleMergeFailure(
       ctx,
       issueId,
       prUrl,
       ident,
-      reason,
+      `CI failed: ${checks.summary}`,
       'automerge_failed',
       true,
     );
     return;
   }
 
-  const directResult = await mergePr(prUrl, { auto: false });
-  if (directResult.merged) {
+  if (checks.status === 'pending') {
+    // CI still running — hand off to a detached bounded poll so the caller (an
+    // awaited webhook cooldown callback) returns immediately. The PR stays
+    // auto_merge_state='pending'; the startup sweep re-runs this on restart.
+    fireAndForget(() => pollUntilMergeable(ctx, issueId, prUrl, ident), {
+      name: 'auto-merge.poll',
+    });
+    return;
+  }
+
+  // CI already green — merge now.
+  await mergeOrFail(ctx, issueId, prUrl, ident);
+}
+
+/**
+ * --admin-merge a green PR and route the outcome. Shared by attemptAutoMerge
+ * and pollUntilMergeable. A merge-call failure here is NOT requeued (requeue
+ * false): the build was green, so a fresh agent attempt would not help.
+ */
+async function mergeOrFail(
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  ident: string,
+): Promise<void> {
+  const result = await mergePr(prUrl);
+  if (result.merged) {
     await handleMergeSuccess(ctx, issueId, prUrl, ident);
   } else {
     await handleMergeFailure(
@@ -357,11 +326,88 @@ export async function attemptAutoMerge(
       issueId,
       prUrl,
       ident,
-      directResult.error ?? 'unknown merge error',
+      result.error ?? 'unknown merge error',
       'automerge_failed',
       false,
     );
   }
+}
+
+/**
+ * Poll a PR's CI until it reaches a terminal state, then --admin-merge on pass.
+ * Detached via fireAndForget so it never blocks the dispatch path (LIA-215).
+ *
+ *  - pass    → --admin merge (mergeOrFail).
+ *  - fail    → failure(requeue): a broken build warrants a fresh agent attempt.
+ *  - pending → wait CI_POLL_INTERVAL_MS, retry, up to AUTO_MERGE_POLL_MAX_ATTEMPTS.
+ *  - exhausted (still pending past the cap) → PARK: leave auto_merge_state
+ *    'pending', no requeue, no circuit-breaker, but POST a comment so the parked
+ *    PR is visible, not dark. pending != failure, so we must NOT thrash the
+ *    agent. sweepPendingAutoMerges re-runs this on the next restart. NOTE: that
+ *    sweep is startup-only, so a parked PR waits until the next deploy/restart —
+ *    acceptable for a solo pipeline that restarts on every deploy; a periodic
+ *    sweep is a deferred option.
+ *
+ * CAVEAT: queryPrChecks maps a transient gh error (auth/network/rate-limit) to
+ * 'pending' (see its catch), so a SUSTAINED gh outage looks like slow CI and
+ * parks after the cap rather than alerting. A distinct 'error' status that
+ * requeues after K consecutive errors is a deferred improvement; the
+ * cap-exhaustion comment keeps such a PR visible in the meantime.
+ */
+async function pollUntilMergeable(
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  ident: string,
+): Promise<void> {
+  // Max CI-poll cycles before parking a still-pending PR (LIA-215). 20 × 60s ≈
+  // 20 min — generous headroom over this repo's ~3-min CI. Read at call time so
+  // it's env-overridable (and test-tunable) without a restart.
+  const maxAttempts = Number(process.env.AUTO_MERGE_POLL_MAX_ATTEMPTS) || 20;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, CI_POLL_INTERVAL_MS),
+    );
+
+    const checks = await queryPrChecks(prUrl);
+    logger.info(
+      { issueId, prUrl, status: checks.status, attempt: attempt + 1 },
+      'auto-merge: CI poll',
+    );
+
+    if (checks.status === 'pending') continue;
+
+    if (checks.status === 'fail') {
+      await handleMergeFailure(
+        ctx,
+        issueId,
+        prUrl,
+        ident,
+        `CI failed: ${checks.summary}`,
+        'automerge_failed',
+        true,
+      );
+      return;
+    }
+
+    // pass
+    await mergeOrFail(ctx, issueId, prUrl, ident);
+    return;
+  }
+
+  // Cap exhausted, CI still pending. PARK — do not requeue or trip the breaker
+  // (pending != failure), but post a comment so the parked PR is visible rather
+  // than going dark. The startup sweep re-runs this attempt on the next restart.
+  logger.warn(
+    { issueId, prUrl, attempts: maxAttempts },
+    'auto-merge: CI still pending after poll cap, leaving pending for the next startup sweep',
+  );
+  await ctx.client
+    .createComment({
+      issueId,
+      body: `**Auto-merge waiting** - CI still pending after ${maxAttempts} poll cycles. Left in pending (not failed); will retry on the next sweep. PR: ${prUrl}`,
+    })
+    .catch(() => {});
 }
 
 export async function sweepPendingAutoMerges(
@@ -388,8 +434,8 @@ export async function sweepPendingAutoMerges(
           );
           await handleMergeSuccess(ctx, issue_id, pr_url, ident || 'unknown');
         } else {
-          // Not yet merged — re-run the full attempt (will queue --auto again or
-          // fall through to the direct-merge fallback).
+          // Not yet merged — re-run the full attempt (re-checks CI and either
+          // --admin-merges now or schedules the poll, LIA-215).
           await attemptAutoMerge(ctx, issue_id, pr_url, ident || 'unknown');
         }
       })


### PR DESCRIPTION
## Problem (LIA-215, high severity — 2026-06-12 audit)

`attemptAutoMerge` (the unattended step that lands PRs after the output-quality-gate SHIPs) was **fundamentally broken**. `mergePr` always passed `--admin` and appended `--auto` for "Step 1" (queue GitHub-native auto-merge), but **`gh` rejects `--admin`+`--auto`** at flag validation (verified: the `gh` 2.92.0 binary contains `` specify only one of `--auto`, `--disable-auto`, or `--admin` ``). So Step 1 *always* errored → every auto-merge degraded to the fallback: one 60s wait, a single CI check, and if not yet green a **requeue-a-fresh-agent**. Since real CI takes >60s, healthy PRs got spuriously re-dispatched and the **circuit breaker** (threshold 3) parked good work in Manual Review.

**Why not the audit's "drop `--admin` from the `--auto` path":** GitHub-native `--auto` can **never complete** on this solo repo — branch protection requires an approving review no second human can give, so an `--auto`-queued PR sits `BLOCKED` forever. That would trade a fast-fail for a silent never-merge. `--admin` is the only viable landing path.

## Fix

- **`mergePr`** — drop `--auto`/`autoQueued`; always `--admin` after a CI-pass precheck.
- **`attemptAutoMerge`** — decide on the *current* CI: `pass` → `--admin` merge; `fail` → requeue (a broken build warrants a fresh attempt); `pending` → detached `fireAndForget(pollUntilMergeable)` so the awaited webhook cooldown callback returns immediately.
- **`pollUntilMergeable`** — bounded poll to a terminal state (`AUTO_MERGE_POLL_MAX_ATTEMPTS`, **default 20 × 60s ≈ 20 min**, env-overridable): `pass` → merge, `fail` → requeue, **cap-exhausted → PARK** (leave `pending`, no requeue/breaker) + a visible "Auto-merge waiting" comment; the startup `sweepPendingAutoMerges` re-runs it on restart. **`pending != failure`**, so a slow-but-healthy PR no longer thrashes the agent.

## LIA-147 (recorded, Option A)

`.claude/rules/core-behavioral-rules.md` — `--admin` is the accepted solo-dev landing path once all REQUIRED checks are green (+ interactive per-command approval / autonomous-pipeline gates), not emergency-only. Closes the 7-window "Lapsing" drift.

## Tests

Rewrote the auto-merge suite for the new flow (removed the 5 dead `--auto` cases); added: `mergePr` uses `--admin` never `--auto`; the synchronous pass/fail/pending decisions; and the poll cases — **pending-then-green → MERGED** (the regression), pending-then-fail → requeue, and **cap-exhaustion → PARKED-but-visible**. All 6 new tests **fail without the source fix** (verified by stashing it).

## Verification

`npx vitest run src/linear-auto-merge.test.ts` → 24/24. `tsc --noEmit` → 0. `prettier --check src/**/*.ts` → clean. `eslint` → 0 problems.

**Deploy:** host-only (no `container/agent-runner/` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)