### PR TITLE
fix(orchestrator): guard onOutput channel sends with try/catch + fallback (LIA-286)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781283773
+last_verified: "2026-06-13" # auto-bump @1781356611
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-12" # auto-bump @1781283773
+last_verified: "2026-06-13" # auto-bump @1781356611
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-12" # auto-bump @1781293105
+last_verified: "2026-06-13" # auto-bump @1781356611
 governs:
   - src/
   - evolution/

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -613,6 +613,146 @@ describe('processGroupMessages', () => {
       'Visible reply',
     );
   });
+
+  // ── Send-failure resilience (LIA-286) ───────────────────────────────────────
+
+  const FALLBACK_TEXT =
+    'I generated a reply but could not deliver it — please ask again.';
+
+  it('swallows a send failure and continues without throwing (LIA-286)', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    // Both the primary send and the fallback send fail.
+    channel.sendMessage.mockRejectedValue(new Error('channel down'));
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'Hello user!' });
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'Hello user!' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    // Agent succeeded, so the turn still reports success even though delivery
+    // failed — the failure must not propagate as a rejection.
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    expect(result).toBe(true);
+    // Primary send + fallback send both attempted.
+    expect(channel.sendMessage).toHaveBeenCalledTimes(2);
+    const { logger } = await import('./logger.js');
+    expect(vi.mocked(logger.warn)).toHaveBeenCalled();
+  });
+
+  it('sends a user-facing fallback notice when the primary send fails (LIA-286)', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    // Primary send fails, fallback send succeeds.
+    channel.sendMessage
+      .mockRejectedValueOnce(new Error('rejected'))
+      .mockResolvedValue(undefined);
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'Hello user!' });
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'Hello user!' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    await orchestrator.processGroupMessages('group@g.us');
+    expect(channel.sendMessage).toHaveBeenCalledTimes(2);
+    expect(channel.sendMessage).toHaveBeenNthCalledWith(
+      1,
+      'group@g.us',
+      'Hello user!',
+    );
+    expect(channel.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      'group@g.us',
+      FALLBACK_TEXT,
+    );
+  });
+
+  it('rolls back the cursor when both sends fail and the agent errors (LIA-286)', async () => {
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    // Primary + fallback both fail: the user received nothing.
+    channel.sendMessage.mockRejectedValue(new Error('channel down'));
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'Partial response' });
+      return { status: 'error', result: null, error: 'crashed after output' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    // Nothing delivered + agent error → roll back so the message re-processes.
+    expect(result).toBe(false);
+    expect(state.setLastAgentTimestamp).toHaveBeenNthCalledWith(
+      1,
+      'group@g.us',
+      'ts-1',
+    );
+    expect(state.setLastAgentTimestamp).toHaveBeenNthCalledWith(
+      2,
+      'group@g.us',
+      'ts-prev',
+    );
+  });
+
+  it('does NOT roll back when the fallback was delivered even if the agent errors (LIA-286)', async () => {
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    // Primary fails, fallback succeeds → a user-visible delivery happened.
+    channel.sendMessage
+      .mockRejectedValueOnce(new Error('rejected'))
+      .mockResolvedValue(undefined);
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'Partial response' });
+      return { status: 'error', result: null, error: 'crashed after output' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+    // Fallback delivered → no rollback, no re-send of the fallback next poll.
+    expect(result).toBe(true);
+    expect(state.setLastAgentTimestamp).toHaveBeenCalledTimes(1);
+    expect(state.setLastAgentTimestamp).toHaveBeenCalledWith(
+      'group@g.us',
+      'ts-1',
+    );
+  });
 });
 
 // ── Injection scanner integration ────────────────────────────────────────────

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -381,6 +381,22 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
     let hadError = false;
     let outputSentToUser = false;
 
+    // Swallow channel send failures so they never propagate as an onOutput
+    // rejection (LIA-286); logs with orchestrator-layer context. The boolean
+    // return gates cursor/rollback state on whether delivery actually happened.
+    const trySend = async (text: string, label: string): Promise<boolean> => {
+      try {
+        await channel.sendMessage(chatJid, text);
+        return true;
+      } catch (err) {
+        logger.warn(
+          { group: group.name, chatJid, label, err },
+          'channel.sendMessage failed',
+        );
+        return false;
+      }
+    };
+
     const output = await runAgent(
       group,
       prompt,
@@ -401,8 +417,19 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
             `Agent output: ${raw.length} chars`,
           );
           if (text) {
-            await channel.sendMessage(chatJid, text);
-            outputSentToUser = true;
+            if (await trySend(text, 'agent-output')) {
+              outputSentToUser = true;
+            } else if (
+              // Primary delivery failed — terse user-facing notice so the loss
+              // isn't silent. A delivered fallback sets the flag too, so the
+              // rollback path below won't re-send it next poll (LIA-286).
+              await trySend(
+                'I generated a reply but could not deliver it — please ask again.',
+                'agent-output-fallback',
+              )
+            ) {
+              outputSentToUser = true;
+            }
           }
           // Only reset idle timer on actual results, not session-update markers
           resetIdleTimer();
@@ -415,9 +442,10 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
           // s.tokens/s.pct from the null checks.
           const s = result.contextStats;
           if (s?.warn && s.tokens != null && s.pct != null) {
-            await channel.sendMessage(
-              chatJid,
+            // Best-effort advisory notice; swallow delivery failures.
+            await trySend(
               `Context at ${s.pct}% (${s.tokens.toLocaleString()} / ${s.limit.toLocaleString()} tokens). Use /compact to free space.`,
+              'context-notify',
             );
           }
 
@@ -426,9 +454,10 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
             const preInfo = e.preTokens
               ? ` (was ${e.preTokens.toLocaleString()} tokens)`
               : '';
-            await channel.sendMessage(
-              chatJid,
+            // Best-effort advisory notice; swallow delivery failures.
+            await trySend(
               `Context auto-compacted${preInfo}. Use /compact manually to control timing.`,
+              'auto-compact-notice',
             );
           }
         }


### PR DESCRIPTION
## What

Follow-up to LIA-212 (PR #790). The `onOutput` callback in `src/message-orchestrator.ts` had **three** unguarded `await channel.sendMessage(...)` sites — primary agent output (`:404`) plus two CONTEXT_NOTIFY advisory notices (`:418`, `:429`). A transient send failure threw out of `onOutput`. Post-LIA-212 that no longer wedges the group (`container-runner.ts`'s `outputChain.catch` is a non-poisoning backstop), but the failure surfaced only as a generic downstream log with no orchestrator-layer context.

## Change

Add a local `trySend(text, label): Promise<boolean>` helper inside `processGroupMessages` that wraps the send in try/catch, logs `logger.warn({ group, chatJid, label, err }, 'channel.sendMessage failed')`, and swallows the error — so it never propagates as an `onOutput` rejection. LIA-212's `.catch` becomes a pure backstop, exactly as the issue's architecture note requested.

Delivery semantics:

| # | Outcome | `outputSentToUser` | Effect |
|---|---------|--------------------|--------|
| 1 | Primary send OK | true | normal |
| 2 | Primary fails, fallback notice OK | true | no rollback / no re-send of the fallback |
| 3 | Both fail + agent error | false | existing rollback re-processes the message |
| 4 | Both fail, agent OK | false | message consumed, failure logged with context |

The two CONTEXT_NOTIFY sends route through `trySend` best-effort (return ignored).

## Deliberately not doing

- **No cursor-rollback on send-failure** as an auto-retry: it would re-run the *entire agent* every poll → unbounded token-burn loop on persistent / content-rejection failures (strictly worse than today).
- **No inline retry**: an immediate retry is pointless (socket still bad same-tick) and a short delay is too short to bridge a real channel re-auth gap (seconds).
- Host-command sends (`:280`, `:601`) are outside `onOutput` and out of scope.

## Tests

4 new cases in `message-orchestrator.test.ts` cover all four delivery-outcome combinations above. Build clean (tsc), 24/24 tests pass.

## Wardens

plan-reviewer SHIP (after one REVISE — caught the fallback double-send edge), code-reviewer SHIP, verification-gate SHIP.

Closes LIA-286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)