### PR TITLE
feat(tools): auto-derive arch-explorer layers so it works on any repo

### DIFF
--- a/tools/architecture-explorer/README.md
+++ b/tools/architecture-explorer/README.md
@@ -24,7 +24,8 @@ codegraph index            # run from the repo root if the DB is stale
 
 # 2. generate the graph data
 python3 tools/architecture-explorer/build.py
-#    or against an explicit DB / another repo:
+#    or against an explicit DB / another repo (layers auto-derive if the bundled
+#    layers.json doesn't fit that repo — see "other projects" below):
 python3 tools/architecture-explorer/build.py --db /path/to/.codegraph/codegraph.db
 
 # 3. open it (serving over http is recommended — gives full localStorage for saved themes)
@@ -58,20 +59,34 @@ The control panel (top-right) changes appearance instantly, no code:
 - **Presets** (Blueprint / Galaxy / Minimal) + **Reset**. Your look is saved to
   `localStorage` and restored on reload.
 
-## Reusing / re-layering (and other projects)
+## Other projects (it works on any repo)
 
 It's a **self-contained, portable tool** — copy `tools/architecture-explorer/` into
-any codegraph-indexed repo and run `build.py --db <that repo>/.codegraph/codegraph.db`.
-To change the layers (or adapt to a different repo's structure), edit **`layers.json`**
-— ordered rules, first matching glob wins, no code change. `build.py` is standard-library
-only (no third-party deps). A one-command `deus arch <project>` wrapper is planned (Phase 2).
+any codegraph-indexed repo, or point it at one: `build.py --db <repo>/.codegraph/codegraph.db`.
+`build.py` is standard-library only (no third-party deps).
+
+**Layering is automatic.** The bundled `layers.json` describes *this* repo's
+architecture. On any other repo those rules won't match, so `build.py` detects the
+poor fit and **derives layers from the directory structure instead** — each top-level
+directory (e.g. `src`, `lib`, `api`) becomes a colored layer, with a generated palette.
+You get a meaningful map out of the box, not one undifferentiated blob. No config, no
+code change.
+
+| Want | Do |
+|---|---|
+| Auto-derived layers (default on a foreign repo) | just run `build.py --db <repo>/.codegraph/codegraph.db` |
+| Force directory-derived layers anywhere | `--auto` |
+| Group two levels deep (`src/memory`, `src/api`) | `--layers-depth 2` (applies under `--auto` or when auto-fallback triggers; default auto-selects 1, or 2 when one dir dominates) |
+| Curate the layers by hand | edit `layers.json` (ordered rules, first matching glob wins) or pass `--layers my.json` (always trusted, never auto-overridden) |
+
+A one-command `deus arch <project>` wrapper is still planned (Phase 2).
 
 ## Files
 
 | File | Responsibility |
 |---|---|
-| `build.py` | generator: codegraph DB + `layers.json` → `graph-data.js` (`window.GRAPH`) |
-| `layers.json` | ordered path-glob → layer rules |
+| `build.py` | generator: codegraph DB + layers (curated `layers.json` or directory-derived) → `graph-data.js` (`window.GRAPH`) |
+| `layers.json` | ordered path-glob → layer rules for *this* repo; auto-derived from directories on a poor fit |
 | `index.html` | page shell; loads vendor + `graph-data.js` + `theme.js` + `app.js` |
 | `app.js` | 3D graph structure + behavior (pinned-z layers, expand/collapse, detail panel, search, camera) |
 | `theme.js` | live appearance system (lil-gui panel; shape/color/edges/scene; localStorage) |
@@ -85,7 +100,9 @@ only (no third-party deps). A one-command `deus arch <project>` wrapper is plann
 
 `tests/test_build.py` (`python3 -m pytest tools/architecture-explorer/tests/`)
 covers the generator: layer assignment, edge aggregation, filtering, schema,
-determinism. The **UI is verified manually** — run `build.py`, open `index.html`,
+determinism, and directory-derived (auto) layering — depth selection, the cap +
+long-tail merge, root-file handling, the palette, fit-detection, and the
+no-file-lost invariant across config↔auto. The **UI is verified manually** — run `build.py`, open `index.html`,
 confirm the 3D scene renders (layers as depth planes), fly/orbit work, click-a-layer
 expands its files, the detail panel shows Affects/Affected-by, and the appearance
 panel changes the look live.
@@ -94,6 +111,8 @@ panel changes the look live.
 
 - **Phase 2 — chat panel:** ask "where does X happen / what does Y affect" answered
   from the graph data + codegraph FTS (grounded, not hallucinated).
-- **`deus arch <project>`** — one-command portable invocation for any indexed repo.
+- ✅ **Works on any repo** — layers auto-derive from the directory structure when the
+  curated `layers.json` doesn't fit (done).
+- **`deus arch <project>`** — one-command portable invocation (index if needed → build → open).
 - Theme export/import; git-churn coloring; a semantic-coupling layer (e.g. the shared
   judge RUBRIC → its 4 dimensions) so the map doubles as a change-awareness instrument.

--- a/tools/architecture-explorer/build.py
+++ b/tools/architecture-explorer/build.py
@@ -8,12 +8,18 @@ architectural layer, and emits `graph-data.js` (a `window.GRAPH = {...}` global)
 that the static `index.html` renders with no server and no network.
 
 Self-contained: standard library only (sqlite3, json, argparse, fnmatch,
-pathlib). Portable — copy this directory into any codegraph-indexed repo and
-run it; edit `layers.json` to re-layer.
+colorsys, pathlib). Portable — copy this directory into any codegraph-indexed
+repo and run it. Layering is automatic on any project: if the bundled
+`layers.json` rules don't fit the repo (few/no files match), layers are derived
+from the directory structure instead. Edit `layers.json` (or pass `--layers`) to
+curate; pass `--auto` to force directory-derived layers.
 
 Usage:
   python3 build.py                       # uses ../../.codegraph/codegraph.db
-  python3 build.py --db path/to.db       # explicit DB
+  python3 build.py --db path/to.db       # explicit DB (auto-layers if layers.json doesn't fit)
+  python3 build.py --auto                # force directory-derived layers
+  python3 build.py --layers-depth 2      # group by two path levels (src/memory) under --auto
+  python3 build.py --layers my.json      # explicit curated layer rules (always trusted)
   python3 build.py --include-tests       # keep *.test.* / test_* / tests/ files
   python3 build.py --json                # print a machine-readable summary
 
@@ -23,11 +29,13 @@ from __future__ import annotations
 
 import argparse
 import ast
+import colorsys
 import fnmatch
 import json
 import sqlite3
 import sys
 import time
+from collections import Counter
 from pathlib import Path
 
 # ── Minimal typed exit codes (self-contained; mirrors scripts/_exit_codes.py
@@ -73,6 +81,154 @@ def _assign_layer(path: str, layers: list[dict]) -> str:
             if fnmatch.fnmatch(norm, glob):
                 return layer["id"]
     return layers[-1]["id"]
+
+
+# ── Auto-layering (directory-derived) ─────────────────────────────────────────
+# When the curated layers.json doesn't fit a repo, layers are derived from the
+# directory structure so the explorer is useful on ANY codegraph-indexed project.
+_OTHER_ID = "other"          # catch-all: root files + the tail beyond the cap
+_AUTO_MAX_LAYERS = 16        # cap on distinct directory groups (palette + clarity)
+_AUTO_MIN_GROUPS = 4         # below this many depth-1 dirs, descend to depth 2
+_AUTO_DOMINANT_FRAC = 0.70   # if one depth-1 dir holds more than this share, descend
+# Min fraction of files that must land OUTSIDE a config's catch-all/fallback layer
+# for the config to count as a "fit". Measured: Deus's own layers.json scores
+# 279/389 = 0.72 on the Deus repo (fits → stays curated); the same rules score ~0
+# on any other repo (nothing matches → auto-derive). 0.40 cleanly separates them.
+_FIT_THRESHOLD = 0.40
+
+
+def _hsl_to_hex(hue: float, sat: float = 0.55, light: float = 0.55) -> str:
+    """Palette color for an evenly-spaced `hue` in [0, 360).
+
+    NOTE: stdlib `colorsys` uses HLS argument order (hue, LIGHTNESS, SATURATION),
+    NOT HSL — so saturation is passed LAST. Getting this wrong silently yields
+    desaturated colors.
+    """
+    r, g, b = colorsys.hls_to_rgb(hue / 360.0, light, sat)
+    return "#%02x%02x%02x" % (round(r * 255), round(g * 255), round(b * 255))
+
+
+def _sanitize_layer_id(name: str) -> str:
+    """Layer ids must be whitespace-free.
+
+    app.js encodes edge-aggregation keys as ``src_layer + ' ' + tgt_layer + ' ' +
+    kind`` and splits on the SPACE, so a space inside a layer id corrupts parsing
+    (see app.js, buildData). Directory names can contain spaces, so collapse any
+    run of whitespace to a single '_'. The human-facing label keeps the original
+    name. ('/' is safe — it is not the delimiter.)
+    """
+    return "_".join(name.split()) or _OTHER_ID
+
+
+def _dir_prefix(path: str, depth: int) -> str | None:
+    """Directory prefix of `path` at `depth` segments; None for a root file.
+
+    A file with fewer directory levels than `depth` uses all it has
+    ('src/foo.ts' at depth 2 -> 'src'); a file with no directory -> None.
+    """
+    dirs = path.replace("\\", "/").split("/")[:-1]   # drop the filename
+    if not dirs:
+        return None
+    return "/".join(dirs[:depth])
+
+
+def _auto_layers(paths: list[str], depth: int | None = None) -> tuple[list[dict], dict, int]:
+    """Derive layers + a direct {path -> layer_id} map from directory structure.
+
+    No globs: assignment is exact (a path's layer is its directory prefix), so
+    fnmatch metacharacters, prefix-substring collisions, and shallow/deep glob
+    ordering are all non-issues.
+
+    `depth`: 1 = top-level dir, 2 = two levels. When None, auto-select: start at
+    depth 1 and descend to 2 if depth 1 is too coarse (< _AUTO_MIN_GROUPS distinct
+    dirs, or one dir holds > _AUTO_DOMINANT_FRAC of files). The largest
+    _AUTO_MAX_LAYERS groups are kept; the smaller tail and all root files merge
+    into a trailing catch-all 'other' layer.
+
+    Returns ``(layers, assign, depth)``.
+    """
+    total = len(paths)
+
+    def counts_at(d: int) -> Counter:
+        c: Counter = Counter()
+        for p in paths:
+            g = _dir_prefix(p, d)
+            if g is not None:
+                c[g] += 1
+        return c
+
+    if depth is None:
+        depth = 1
+        d1 = counts_at(1)
+        dominant = (max(d1.values()) / total) if (d1 and total) else 1.0
+        if len(d1) < _AUTO_MIN_GROUPS or dominant > _AUTO_DOMINANT_FRAC:
+            depth = 2
+
+    counts = counts_at(depth)
+    # Largest groups first; ties broken by first-occurrence order in `paths`
+    # (Counter.most_common + CPython 3.7+ dict ordering = deterministic). The tail
+    # beyond the cap falls through to 'other'.
+    top = [g for g, _ in counts.most_common(_AUTO_MAX_LAYERS)]
+    top_id = {g: _sanitize_layer_id(g) for g in top}
+    kept = set(top)
+
+    assign: dict = {}
+    for p in paths:
+        g = _dir_prefix(p, depth)
+        assign[p] = top_id[g] if (g in kept) else _OTHER_ID
+
+    has_other = any(v == _OTHER_ID for v in assign.values())
+    palette_n = max(len(top) + (1 if has_other else 0), 1)
+    layers = [
+        {
+            "id": top_id[g],
+            "label": g,
+            "color": _hsl_to_hex(360.0 * i / palette_n),
+            "globs": [],   # auto mode assigns via the returned map, not globs
+        }
+        for i, g in enumerate(top)
+    ]
+    if has_other:
+        layers.append({"id": _OTHER_ID, "label": "Other", "color": "#566573", "globs": []})
+    return layers, assign, depth
+
+
+def _resolve_layers(
+    kept_paths: list[str],
+    layers_path: Path | None,
+    auto: bool,
+    layers_depth: int | None,
+    allow_auto_fallback: bool,
+) -> tuple[list[dict], dict, str, int | None]:
+    """Decide the layer set + a {path -> layer_id} assignment for `kept_paths`.
+
+    - ``auto`` True: derive layers from directory structure (ignores layers_path).
+    - else: load `layers_path` (a curated config). If ``allow_auto_fallback`` and
+      the config is a POOR FIT for this repo (< _FIT_THRESHOLD of files land
+      outside its catch-all/fallback layer), auto-derive instead. This is what
+      lets the bundled Deus layers.json act as a curated default on the Deus repo
+      yet auto-derive on any other repo (copy-in or ``--db``). An EXPLICIT
+      ``--layers`` is always trusted (the caller passes allow_auto_fallback=False).
+
+    Returns ``(layers, assign, mode, depth)``; mode in {'auto', 'config'}; depth is
+    the auto depth (None for config mode).
+    """
+    if auto:
+        layers, assign, depth = _auto_layers(kept_paths, layers_depth)
+        return layers, assign, "auto", depth
+    cfg = _load_layers(layers_path)
+    assign = {p: _assign_layer(p, cfg) for p in kept_paths}
+    if allow_auto_fallback and kept_paths:
+        # Fit = fraction of files matched to a NON-fallback layer. Assumes the
+        # config's LAST layer is its catch-all (the bundled layers.json ends with a
+        # '*' glob; _assign_layer also returns it for no-match) — which holds for
+        # the only config this fallback ever runs on (the bundled default).
+        fallback_id = cfg[-1]["id"]
+        outside = sum(1 for p in kept_paths if assign[p] != fallback_id)
+        if (outside / len(kept_paths)) < _FIT_THRESHOLD:
+            layers, assign, depth = _auto_layers(kept_paths, layers_depth)
+            return layers, assign, "auto", depth
+    return cfg, assign, "config", None
 
 
 def _py_doc_maps(repo_root: Path, rel_path: str, cache: dict) -> tuple[dict, dict]:
@@ -132,11 +288,27 @@ def _resolve_doc(repo_root: Path, fp: str, name: str, start_line, raw_doc: str, 
     return raw_doc[:600]
 
 
-def build(db_path: Path, layers_path: Path, include_tests: bool) -> dict:
+def build(
+    db_path: Path,
+    layers_path: Path | None = None,
+    include_tests: bool = False,
+    *,
+    auto: bool = False,
+    layers_depth: int | None = None,
+    allow_auto_fallback: bool = False,
+) -> dict:
+    """Build the architecture graph from a codegraph DB.
+
+    Layer assignment: with ``auto`` (or when ``allow_auto_fallback`` is set and the
+    config is a poor fit for the repo) layers are derived from the directory
+    structure; otherwise the curated ``layers_path`` rules are used. ``layers_path``
+    may be None ONLY with ``auto=True`` — every non-auto caller must supply a config
+    path (the CLI defaults it to the bundled layers.json). See _resolve_layers.
+    """
     if not db_path.exists():
         raise FileNotFoundError(f"codegraph DB not found: {db_path}")
-    layers = _load_layers(layers_path)
-    layer_ids = {l["id"] for l in layers}
+    if not auto and layers_path is None:
+        raise ValueError("layers_path is required unless auto=True")
     # Repo root = the directory holding `.codegraph/` — used to resolve source
     # files for Python docstring recovery (see _py_doc_maps) and editor deep-links.
     repo_root = db_path.resolve().parent.parent
@@ -188,20 +360,25 @@ def build(db_path: Path, layers_path: Path, include_tests: bool) -> dict:
             if r["is_exported"]:
                 exported.setdefault(fp, []).append(r["name"])
 
-        # ── Nodes (files), filtered + layer-assigned ──────────────────────────
+        # ── Layer resolution ──────────────────────────────────────────────────
+        # Files surviving the test filter, then layered (curated config or, when it
+        # doesn't fit / --auto, derived from the directory structure).
+        kept_list = sorted(p for p in files if include_tests or not _is_test_path(p))
+        layers, assign, layer_mode, layer_depth = _resolve_layers(
+            kept_list, layers_path, auto, layers_depth, allow_auto_fallback
+        )
+        kept = set(kept_list)
+
+        # ── Nodes (files), layer-assigned ─────────────────────────────────────
         nodes = []
-        kept: set[str] = set()
-        for path, info in files.items():
-            if not include_tests and _is_test_path(path):
-                continue
-            layer = _assign_layer(path, layers)
-            kept.add(path)
+        for path in kept_list:
+            info = files[path]
             nodes.append(
                 {
                     "id": path,
                     "label": path.replace("\\", "/").rsplit("/", 1)[-1],
                     "file_path": path,
-                    "layer": layer,
+                    "layer": assign[path],
                     "language": info["language"],
                     "loc": int(loc.get(path, 0) or 0),
                     "n_symbols": int(info["n_symbols"] or 0),
@@ -252,6 +429,8 @@ def build(db_path: Path, layers_path: Path, include_tests: bool) -> dict:
                 "n_files": len(nodes),
                 "n_edges": len(edges),
                 "include_tests": include_tests,
+                "layer_mode": layer_mode,     # 'config' (curated) | 'auto' (directory-derived)
+                "layer_depth": layer_depth,   # auto grouping depth (None in config mode)
             },
             "layers": out_layers,
             "nodes": sorted(nodes, key=lambda n: (n["layer"], n["id"])),
@@ -264,16 +443,39 @@ def build(db_path: Path, layers_path: Path, include_tests: bool) -> dict:
 def main(argv: list[str] | None = None) -> int:
     here = Path(__file__).resolve().parent
     repo_root = here.parent.parent  # tools/architecture-explorer -> repo root
+    bundled_layers = here / "layers.json"
     ap = argparse.ArgumentParser(description="Generate the architecture-explorer graph data.")
     ap.add_argument("--db", type=Path, default=repo_root / ".codegraph" / "codegraph.db")
-    ap.add_argument("--layers", type=Path, default=here / "layers.json")
+    ap.add_argument("--layers", type=Path, default=None,
+                    help="curated layer rules (JSON); always trusted. Default: the bundled "
+                         "layers.json, used only if it fits the repo (else auto-derived).")
+    ap.add_argument("--auto", action="store_true",
+                    help="force directory-derived layers (ignore layers.json)")
+    ap.add_argument("--layers-depth", type=int, default=None, dest="layers_depth",
+                    help="auto-layer grouping depth (1=top-level dir, 2=two levels); default: auto-select")
     ap.add_argument("--out", type=Path, default=here / "graph-data.js")
     ap.add_argument("--include-tests", action="store_true", help="keep test files")
     ap.add_argument("--json", action="store_true", help="print a machine-readable summary")
     args = ap.parse_args(argv)
 
+    # Resolve the layering mode:
+    #   --auto            -> directory-derived (no config).
+    #   --layers PATH     -> explicit curated config, always trusted.
+    #   (neither)         -> the bundled layers.json, but allow auto-fallback if it
+    #                        doesn't fit this repo (makes it work on external repos).
+    if args.auto:
+        layers_path, auto, allow_auto_fallback = None, True, False
+    elif args.layers is not None:
+        layers_path, auto, allow_auto_fallback = args.layers, False, False
+    else:
+        layers_path, auto, allow_auto_fallback = bundled_layers, False, True
+
     try:
-        graph = build(args.db, args.layers, args.include_tests)
+        graph = build(
+            args.db, layers_path, args.include_tests,
+            auto=auto, layers_depth=args.layers_depth,
+            allow_auto_fallback=allow_auto_fallback,
+        )
     except FileNotFoundError as e:
         print(f"error: {e}", file=sys.stderr)
         return NOT_FOUND
@@ -287,17 +489,22 @@ def main(argv: list[str] | None = None) -> int:
     payload = "window.GRAPH = " + json.dumps(graph, separators=(",", ":")) + ";\n"
     args.out.write_text(payload, encoding="utf-8")
 
+    mode = graph["meta"]["layer_mode"]
+    depth = graph["meta"]["layer_depth"]
     summary = {
         "out": str(args.out),
         "n_files": graph["meta"]["n_files"],
         "n_edges": graph["meta"]["n_edges"],
+        "layer_mode": mode,
+        "layer_depth": depth,
         "layers": [l["id"] for l in graph["layers"]],
     }
     if args.json:
         print(json.dumps(summary))
     else:
+        mode_note = f"auto (depth {depth})" if mode == "auto" else "config"
         print(f"wrote {args.out}")
-        print(f"  files: {summary['n_files']}  edges: {summary['n_edges']}")
+        print(f"  files: {summary['n_files']}  edges: {summary['n_edges']}  layers: {mode_note}")
         print(f"  layers: {', '.join(summary['layers'])}")
         print("  open it:  python3 -m webbrowser " + str(here / "index.html"))
     return SUCCESS

--- a/tools/architecture-explorer/tests/test_build.py
+++ b/tools/architecture-explorer/tests/test_build.py
@@ -303,3 +303,210 @@ class TestPythonDocstring:
         graph = build.build(db, LAYERS, include_tests=False)
         node = next(n for n in graph["nodes"] if n["file_path"] == "ghost.py")
         assert node["top_symbols"][0]["doc"] == "fallback doc"
+
+
+# ── External-project support: directory-derived (auto) layers ─────────────────
+
+_SCHEMA = """
+    CREATE TABLE files (path TEXT PRIMARY KEY, content_hash TEXT, language TEXT,
+                        size INTEGER, modified_at INTEGER, indexed_at INTEGER, node_count INTEGER);
+    CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, name TEXT, qualified_name TEXT,
+                        file_path TEXT, language TEXT, start_line INTEGER, end_line INTEGER,
+                        start_column INTEGER, end_column INTEGER, docstring TEXT, signature TEXT,
+                        visibility TEXT, is_exported INTEGER, is_async INTEGER, is_static INTEGER,
+                        is_abstract INTEGER, decorators TEXT, type_parameters TEXT, updated_at INTEGER);
+    CREATE TABLE edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT, target TEXT,
+                        kind TEXT, metadata TEXT, line INTEGER, col INTEGER, provenance TEXT);
+"""
+
+
+def _make_simple_db(tmp_path: Path, paths: list[str]) -> Path:
+    """Minimal codegraph DB at <tmp>/.codegraph/codegraph.db: one `files` row + one
+    `nodes` row per path (paths must be DISTINCT — `path` is PRIMARY KEY). Enough to
+    exercise layer resolution; no edges."""
+    cg = tmp_path / ".codegraph"
+    cg.mkdir(parents=True, exist_ok=True)
+    db = cg / "codegraph.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(_SCHEMA)
+    for i, p in enumerate(paths):
+        lang = "py" if p.endswith(".py") else "ts"
+        conn.execute("INSERT INTO files VALUES (?,?,?,?,?,?,?)", (p, "h", lang, 50, 0, 0, 1))
+        conn.execute(
+            "INSERT INTO nodes (id, kind, name, qualified_name, file_path, language, start_line, "
+            "end_line, start_column, end_column, is_exported, updated_at) VALUES (?,?,?,?,?,?,?,?,0,0,1,0)",
+            (f"n{i}", "function", f"fn{i}", f"fn{i}", p, lang, 1, 10),
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _grp(prefix: str, n: int) -> list[str]:
+    """n distinct file paths under `prefix`."""
+    return [f"{prefix}/f{i}.ts" for i in range(n)]
+
+
+class TestPalette:
+    def test_hex_format(self):
+        for h in (0, 90, 180, 270, 359):
+            c = build._hsl_to_hex(h)
+            assert len(c) == 7 and c[0] == "#"
+            int(c[1:], 16)  # parses as hex (raises otherwise)
+
+    def test_known_hue_red_dominant(self):
+        # H=0 (red), L=0.5, S=0.7 -> red channel clearly dominant. Guards the
+        # colorsys HLS argument order (lightness before saturation): a swap here
+        # silently desaturates and this assertion fails.
+        c = build._hsl_to_hex(0, sat=0.7, light=0.5)
+        r, g, b = int(c[1:3], 16), int(c[3:5], 16), int(c[5:7], 16)
+        assert r > g and r > b and r >= 178  # 0.7*255 ~= 178
+
+    def test_distinct_colors(self):
+        cols = [build._hsl_to_hex(360.0 * i / 12) for i in range(12)]
+        assert len(set(cols)) == 12
+
+
+class TestSanitizeAndPrefix:
+    def test_sanitize_whitespace_to_underscore(self):
+        assert build._sanitize_layer_id("my dir") == "my_dir"
+        assert build._sanitize_layer_id("a\tb  c") == "a_b_c"
+
+    def test_sanitize_keeps_slash(self):
+        # '/' is NOT the app.js edge-key delimiter (space is) -> kept for depth-2 ids
+        assert build._sanitize_layer_id("src/memory") == "src/memory"
+
+    def test_sanitize_blank_falls_to_other(self):
+        assert build._sanitize_layer_id("   ") == build._OTHER_ID
+
+    def test_dir_prefix_depths(self):
+        assert build._dir_prefix("src/memory/foo.ts", 1) == "src"
+        assert build._dir_prefix("src/memory/foo.ts", 2) == "src/memory"
+        assert build._dir_prefix("src/foo.ts", 2) == "src"   # fewer levels than depth
+        assert build._dir_prefix("README.md", 1) is None     # root file (no directory)
+
+
+class TestAutoLayers:
+    def test_depth1_groups_by_top_dir(self):
+        paths = _grp("src", 5) + _grp("lib", 5) + _grp("docs", 5) + _grp("test_x", 5)
+        layers, assign, depth = build._auto_layers(paths)
+        assert depth == 1
+        assert {"src", "lib", "docs", "test_x"} <= {l["id"] for l in layers}
+        assert set(assign) == set(paths)
+
+    def test_descend_to_depth2_when_one_dir_dominant(self):
+        paths = _grp("src/api", 8) + _grp("src/web", 8) + _grp("lib", 2)  # src = 16/18 > 70%
+        layers, _, depth = build._auto_layers(paths)
+        assert depth == 2
+        assert "src/api" in {l["label"] for l in layers}
+
+    def test_descend_when_too_few_top_dirs(self):
+        paths = _grp("src/api", 3) + _grp("src/web", 3)  # only 1 top-level dir (<4)
+        _, _, depth = build._auto_layers(paths)
+        assert depth == 2
+
+    def test_root_files_go_to_other(self):
+        paths = _grp("src", 5) + _grp("lib", 5) + _grp("docs", 5) + _grp("x", 5) + ["README.md", "setup.py"]
+        _, assign, _ = build._auto_layers(paths, depth=1)
+        assert assign["README.md"] == build._OTHER_ID
+        assert assign["setup.py"] == build._OTHER_ID
+
+    def test_cap_and_long_tail_merge_into_other(self):
+        # 20 top-level dirs (d00 biggest .. d19 smallest) -> capped at 16 + "other"
+        paths = [p for i in range(20) for p in _grp(f"d{i:02d}", 20 - i)]
+        layers, assign, _ = build._auto_layers(paths, depth=1)
+        non_other = [l for l in layers if l["id"] != build._OTHER_ID]
+        assert len(non_other) == build._AUTO_MAX_LAYERS  # 16
+        assert any(l["id"] == build._OTHER_ID for l in layers)
+        assert assign["d19/f0.ts"] == build._OTHER_ID    # smallest -> tail -> other
+        assert assign["d00/f0.ts"] != build._OTHER_ID    # biggest -> kept
+
+    def test_layers_ordered_by_file_count(self):
+        paths = _grp("big", 10) + _grp("mid", 5) + _grp("small", 2)
+        layers, _, _ = build._auto_layers(paths, depth=1)
+        non_other = [l["id"] for l in layers if l["id"] != build._OTHER_ID]
+        assert non_other[:3] == ["big", "mid", "small"]
+
+    def test_every_path_assigned_exactly_once(self):
+        paths = ["src/a.ts", "lib/b.ts", "c.md", "src/d/e.ts"]
+        _, assign, _ = build._auto_layers(paths)
+        assert set(assign) == set(paths)
+
+    def test_whitespace_dir_id_sanitized_label_preserved(self):
+        paths = _grp("my src", 5) + _grp("lib", 5) + _grp("x", 5) + _grp("y", 5)
+        layers, assign, _ = build._auto_layers(paths, depth=1)
+        msrc = next(l for l in layers if l["label"] == "my src")
+        assert msrc["id"] == "my_src" and " " not in msrc["id"]   # protects app.js space-delim edge keys
+        assert assign["my src/f0.ts"] == "my_src"
+
+    def test_deterministic(self):
+        paths = _grp("src", 5) + _grp("lib", 3) + _grp("x", 4) + _grp("y", 2)
+        assert build._auto_layers(paths, depth=1) == build._auto_layers(paths, depth=1)
+
+    def test_deterministic_with_ties(self):
+        # equal counts -> ties broken by first-occurrence order in `paths` (stable)
+        paths = _grp("x", 4) + _grp("y", 4) + _grp("z", 4)
+        a = build._auto_layers(paths, depth=1)
+        assert a == build._auto_layers(paths, depth=1)
+        assert [l["id"] for l in a[0]] == ["x", "y", "z"]
+
+    def test_distinct_colors_per_layer_including_other(self):
+        # root files force an 'other' layer too; its grey must not collide with the palette
+        paths = _grp("a", 5) + _grp("b", 4) + _grp("c", 3) + _grp("d", 2) + ["README.md", "x.py"]
+        layers, _, _ = build._auto_layers(paths, depth=1)
+        assert any(l["id"] == build._OTHER_ID for l in layers)
+        colors = [l["color"] for l in layers]
+        assert len(set(colors)) == len(colors)
+
+
+class TestLayerResolution:
+    def test_build_auto_mode(self, tmp_path):
+        paths = _grp("src", 4) + _grp("lib", 4) + _grp("api", 4) + _grp("web", 4)
+        g = build.build(_make_simple_db(tmp_path, paths), None, include_tests=False, auto=True)
+        assert g["meta"]["layer_mode"] == "auto" and g["meta"]["layer_depth"] == 1
+        assert g["meta"]["n_files"] == 16
+        assert {"src", "lib", "api", "web"} <= {n["layer"] for n in g["nodes"]}
+
+    def test_none_layers_without_auto_raises(self, tmp_path):
+        db = _make_simple_db(tmp_path, ["src/a.ts"])
+        with pytest.raises(ValueError):
+            build.build(db, None, include_tests=False)  # auto=False + no config
+
+    def test_foreign_repo_auto_fallback(self, tmp_path):
+        # none of Deus's globs match -> with fallback allowed, auto-derive (not 1 blob)
+        paths = _grp("app/api", 5) + _grp("app/web", 5) + _grp("server", 5) + _grp("client", 5)
+        g = build.build(_make_simple_db(tmp_path, paths), LAYERS, include_tests=False,
+                        allow_auto_fallback=True)
+        assert g["meta"]["layer_mode"] == "auto"
+        used = {n["layer"] for n in g["nodes"]}
+        assert "channels" not in used and len(used) > 1
+
+    def test_fitting_repo_keeps_curated_config(self, tmp_path):
+        # Deus-matching paths -> curated config kept even with fallback allowed
+        paths = _grp("src/channels", 5) + _grp("evolution", 5) + _grp("container", 5) + _grp("tui", 5)
+        g = build.build(_make_simple_db(tmp_path, paths), LAYERS, include_tests=False,
+                        allow_auto_fallback=True)
+        assert g["meta"]["layer_mode"] == "config"
+
+    def test_explicit_layers_never_auto_fallback(self, tmp_path):
+        # allow_auto_fallback=False (an explicit --layers) -> config even on a poor fit
+        paths = _grp("app", 5) + _grp("web", 5)
+        g = build.build(_make_simple_db(tmp_path, paths), LAYERS, include_tests=False,
+                        allow_auto_fallback=False)
+        assert g["meta"]["layer_mode"] == "config"
+
+    def test_invariant_same_files_and_edges_across_modes(self, tmp_path):
+        # config vs auto must layer the SAME file set (none lost/duplicated) + same edges
+        paths = _grp("src/channels", 4) + _grp("evolution", 4) + _grp("tui", 4)
+        db = _make_simple_db(tmp_path, paths)
+        cfg = build.build(db, LAYERS, include_tests=False)
+        aut = build.build(db, None, include_tests=False, auto=True)
+        assert cfg["meta"]["n_files"] == aut["meta"]["n_files"]
+        assert cfg["meta"]["n_edges"] == aut["meta"]["n_edges"]
+        assert {n["id"] for n in cfg["nodes"]} == {n["id"] for n in aut["nodes"]}
+
+    def test_auto_layers_all_present_in_out(self, tmp_path):
+        # every auto layer with files is emitted (out_layers filters to used)
+        paths = _grp("src", 4) + _grp("lib", 4) + _grp("docs", 4) + _grp("api", 4)
+        g = build.build(_make_simple_db(tmp_path, paths), None, include_tests=False, auto=True)
+        assert {n["layer"] for n in g["nodes"]} == {l["id"] for l in g["layers"]}


### PR DESCRIPTION
## What

Makes the 3D **architecture explorer** usable on **any** codegraph-indexed repo, not just Deus.

Today the explorer only works here: `layers.json` hardcodes Deus-specific path globs, so on any other repo every file collapses into the catch-all `other` layer — one undifferentiated blob. This PR adds **directory-derived ("auto") layers** that kick in when the curated config doesn't fit the repo.

## How

- **`_auto_layers(paths, depth)`** — groups files by directory prefix into ordered, colored layers (generated HSL palette), returning a **direct `path → layer_id` map** (no globs, so no fnmatch-metachar / prefix-collision / depth-ordering pitfalls). Depth auto-selects: 1, descending to 2 when one dir holds >70% of files or there are <4 top-level dirs. Capped at 16 groups; the smaller tail + root files merge into `other`. Layer ids are whitespace-sanitized (app.js space-delimits its edge-aggregation keys).
- **`_resolve_layers` / fit-detection** — an explicit `--layers` is always trusted; the bundled `layers.json` is used only if it **fits** the repo (≥40% of files land outside its catch-all), otherwise layers auto-derive. So the Deus repo keeps its curated 11 layers, while any other repo (copy-in or `--db`) gets a meaningful directory map out of the box. `--auto` forces it; `--layers-depth N` overrides depth.
- **`build()`** gains keyword-only `auto` / `layers_depth` / `allow_auto_fallback`; the 23 pre-existing (positional) tests are behaviorally unchanged. `meta` gains `layer_mode` + `layer_depth`.

Generator-only change — **no viewer changes** (`app.js`/`theme.js`/`index.html` untouched).

## Tests

+24 tests (48 total): palette incl. the `colorsys` HLS arg-order, prefix/sanitize, depth selection, the 16-cap + tail/root merge, ordering, determinism (incl. ties), fit-detection both ways, and a **no-file-lost invariant** across config↔auto.

## Verified

| Case | Result |
|---|---|
| Deus default (`build.py`) | `config` mode, 11 curated layers (unchanged) |
| Deus `--auto` | `auto` depth-1, 14 directory layers |
| both Deus modes | 389 files / 693 edges (no file lost or duplicated) |
| nanoclaw-oai-adapter, sec-filing-monitor (foreign repos) | auto-derive — not a single blob |
| in-browser (Deus `--auto`) | 14 layers render with distinct palette colors, dir labels, no app console errors |

## Note

**Stacked on #797** (the architecture-explorer branch, not yet merged to main), so this PR's diff currently includes #797's commits too. Once #797 lands, this reduces to just the auto-layer change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)