### PR TITLE
fix(container-runner): bound the streaming parse buffer (LIA-234)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-13" # auto-bump @1781356611
+last_verified: "2026-06-13" # auto-bump @1781361508
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-13" # auto-bump @1781356611
+last_verified: "2026-06-13" # auto-bump @1781361508
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-13" # auto-bump @1781356611
+last_verified: "2026-06-13" # auto-bump @1781361508
 governs:
   - src/
   - evolution/

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -163,6 +163,7 @@ import {
   ContainerOutput,
   readToolCalls,
   readAvailableTools,
+  boundParseBuffer,
 } from './container-runner.js';
 import {
   getActivePrompt,
@@ -309,6 +310,115 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBuffer must stay bounded (LIA-234). stdout/stderr accumulators are
+// capped at CONTAINER_MAX_OUTPUT_SIZE, but the stream parser's buffer was not:
+// a torn frame (START, never an END) or marker-free stdout noise could grow
+// the host heap for the container's full lifetime.
+// ---------------------------------------------------------------------------
+describe('boundParseBuffer (LIA-234)', () => {
+  // OUTPUT_START_MARKER = '---DEUS_OUTPUT_START---' (23 chars) → keep tail 22.
+  const KEEP = OUTPUT_START_MARKER.length - 1; // 22
+
+  it('trims marker-free noise to the last markerLen-1 bytes', () => {
+    const out = boundParseBuffer('x'.repeat(100), 50);
+    expect(out.droppedTornFrame).toBe(false);
+    expect(out.buffer).toBe('x'.repeat(KEEP));
+  });
+
+  it('returns a buffer shorter than the marker unchanged (boundary)', () => {
+    const buf = 'y'.repeat(KEEP); // exactly 22 < markerLen → cannot hold a START
+    const out = boundParseBuffer(buf, 50);
+    expect(out.droppedTornFrame).toBe(false);
+    expect(out.buffer).toBe(buf);
+  });
+
+  it('preserves a partial START prefix split across a chunk boundary', () => {
+    const partial = '---DEUS_OUTPUT_ST'; // 17-char prefix, not a full START
+    const buf = 'a'.repeat(20) + partial; // 37 bytes, no full START present
+    const out = boundParseBuffer(buf, 50);
+    expect(out.droppedTornFrame).toBe(false);
+    expect(out.buffer.length).toBe(KEEP);
+    expect(out.buffer.endsWith(partial)).toBe(true);
+  });
+
+  it('drops a torn frame (START with no END) once it exceeds the cap', () => {
+    const buf = OUTPUT_START_MARKER + 'x'.repeat(100); // START, no END
+    const out = boundParseBuffer(buf, 50);
+    expect(out.droppedTornFrame).toBe(true);
+    expect(out.buffer).toBe('');
+  });
+
+  it('leaves a legit pending frame under the cap unchanged', () => {
+    const buf = OUTPUT_START_MARKER + '{"partial'; // START, no END, small
+    const out = boundParseBuffer(buf, 1000);
+    expect(out.droppedTornFrame).toBe(false);
+    expect(out.buffer).toBe(buf);
+  });
+});
+
+describe('streaming parse resilience to noise + split frames (LIA-234)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('still parses a valid frame after marker-free stdout noise', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    fakeProc.stdout.push('random stdout noise with no markers\n');
+    emitOutputMarker(fakeProc, { status: 'success', result: 'hello' });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'hello' }),
+    );
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+  });
+
+  it('still parses a frame split across two chunks (mid-marker)', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    const json = JSON.stringify({ status: 'success', result: 'split' });
+    const full = `${OUTPUT_START_MARKER}\n${json}\n${OUTPUT_END_MARKER}\n`;
+    // Split inside the START marker so the first chunk holds only a partial
+    // START — exercises the marker-free trim's prefix-preservation path.
+    fakeProc.stdout.push(full.slice(0, 10));
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.stdout.push(full.slice(10));
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(onOutput).toHaveBeenCalledTimes(1);
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'split' }),
+    );
+
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
   });
 });
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -280,6 +280,40 @@ export function readAvailableTools(
   return [];
 }
 
+/**
+ * Bound the streaming parse buffer (LIA-234). Exported for testing.
+ *
+ * Called once per stdout data event on the post-while-loop remainder, which is
+ * at most ONE partial frame: the marker loop already consumed every complete
+ * START..END pair, so a "multiple STARTs" remainder cannot occur. Without this,
+ * sibling stdout/stderr accumulators are capped at CONTAINER_MAX_OUTPUT_SIZE but
+ * parseBuffer was not — a torn frame (START, no END) or marker-free stdout noise
+ * could grow the host heap for the container's full (idle-extendable) lifetime.
+ *
+ * No START present: keep only the last markerLen-1 bytes (the longest possible
+ * split-START prefix), discarding marker-free noise. START present but over the
+ * cap: torn frame, drop it — the cap is a strict `>` so the END can still arrive
+ * in the same chunk as the boundary byte. Stateless, O(n) per call.
+ */
+export function boundParseBuffer(
+  buffer: string,
+  maxSize: number,
+): { buffer: string; droppedTornFrame: boolean } {
+  if (buffer.indexOf(OUTPUT_START_MARKER) === -1) {
+    return {
+      buffer:
+        buffer.length >= OUTPUT_START_MARKER.length
+          ? buffer.slice(-(OUTPUT_START_MARKER.length - 1))
+          : buffer,
+      droppedTornFrame: false,
+    };
+  }
+  if (buffer.length > maxSize) {
+    return { buffer: '', droppedTornFrame: true };
+  }
+  return { buffer, droppedTornFrame: false };
+}
+
 export async function runContainerAgent(
   group: RegisteredGroup,
   input: ContainerInput,
@@ -486,6 +520,21 @@ export async function runContainerAgent(
               'Failed to parse streamed output chunk',
             );
           }
+        }
+
+        // Bound the remainder so a torn frame or marker-free noise can't grow
+        // the host heap unbounded over the container's lifetime (LIA-234).
+        const beforeLen = parseBuffer.length;
+        const bounded = boundParseBuffer(
+          parseBuffer,
+          CONTAINER_MAX_OUTPUT_SIZE,
+        );
+        parseBuffer = bounded.buffer;
+        if (bounded.droppedTornFrame) {
+          logger.warn(
+            { group: group.name, parseBufferSize: beforeLen },
+            'Container output parse buffer exceeded size limit; dropping torn frame',
+          );
         }
       }
     });


### PR DESCRIPTION
## What

The host-side stdout stream parser in `src/container-runner.ts` did `parseBuffer += chunk` on every data event and trimmed it **only** when a complete `OUTPUT_START..OUTPUT_END` marker pair was consumed. Two unbounded-growth modes:

1. **Torn frame** — a START with no END (`if (endIdx === -1) break`) keeps everything buffered for the container's full (idle-extendable, 30+ min) lifetime.
2. **Marker-free noise** — stdout with no START at all never enters the trim loop, so it's never discarded.

The sibling `stdout`/`stderr` accumulators are already capped at `CONTAINER_MAX_OUTPUT_SIZE` (10MB); `parseBuffer` was the missed one. A buggy or compromised agent catting a large file to stdout could pin host heap per concurrent container, on a permanent launchd service.

## Fix

Exported pure helper `boundParseBuffer(buffer, maxSize)`, called once per data event on the **post-while-loop remainder** (at most one partial frame — the loop already consumed every complete pair):

| Remainder | Action |
|-----------|--------|
| No START present | keep only the last `markerLen-1` bytes (longest possible split-START prefix); discard marker-free noise |
| START present, over cap | torn frame → drop, `logger.warn` |
| Otherwise | unchanged (legit pending frame under cap) |

A single legit output message > 10MB is dropped as torn, but `stdout` truncates at that size anyway so such a frame is already corrupted — acceptable.

## Tests

7 new: 5 pure-unit covering every branch (marker-free trim, sub-marker boundary unchanged, split-START prefix preserved, torn-frame drop, legit pending unchanged) + 2 integration via the fake-proc harness (valid frame after marker-free noise still parses; frame split mid-marker across two chunks still parses — regression guard). Build clean, 72/72 tests pass.

## Wardens

plan-reviewer SHIP (after 1 REVISE), code-reviewer SHIP, verification-gate SHIP.

Closes LIA-234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)