### PR TITLE
fix(linear-webhook): treat no-verdict-marker gate output as malfunction (LIA-241)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-13" # auto-bump @1781365126
+last_verified: "2026-06-13" # auto-bump @1781381986
 governs:
   - src/
   - evolution/

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -14,6 +14,7 @@ import { extractFrontmatter } from './linear-dispatcher.js';
 import {
   parseEnrichment,
   parseVerdict,
+  classifyGateOutcome,
   gateTransitionAction,
   parkErroredGateIssue,
   gateOutcomeEventType,
@@ -366,6 +367,28 @@ Needs work.`),
 
   it('returns null when no verdict', () => {
     expect(parseVerdict('No verdict here.')).toBeNull();
+  });
+});
+
+describe('classifyGateOutcome (LIA-241)', () => {
+  it('no verdict + failure signal → error', () => {
+    expect(classifyGateOutcome(null, 'exit 137')).toBe('error');
+  });
+
+  it('no verdict + clean exit → malfunction', () => {
+    expect(classifyGateOutcome(null, '')).toBe('malfunction');
+  });
+
+  it('parseable SHIP → verdict', () => {
+    expect(classifyGateOutcome('SHIP', '')).toBe('verdict');
+  });
+
+  it('parseable REVISE → verdict', () => {
+    expect(classifyGateOutcome('REVISE', '')).toBe('verdict');
+  });
+
+  it('parseable verdict takes precedence over a non-empty error', () => {
+    expect(classifyGateOutcome('SHIP', 'exit 137')).toBe('verdict');
   });
 });
 

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -236,6 +236,26 @@ export function gateTransitionAction(
   return 'none';
 }
 
+/**
+ * LIA-241: Classify a gate run's raw output so a clean-exit-without-verdict is
+ * never mistaken for a real verdict (LIA-169 only handled the non-empty-error path).
+ *
+ * - 'error'       = no parseable verdict AND a failure signal is present.
+ * - 'malfunction' = clean exit but no parseable verdict (gate produced nothing usable).
+ * - 'verdict'     = a parseable verdict — non-null parsedVerdict ALWAYS maps here,
+ *                   even on a non-zero exit (honor a verdict the gate managed to emit).
+ *
+ * Both 'error' and 'malfunction' callers MUST set the gate-errored flag so the
+ * outcome halts (parks to Manual Review Required) instead of reverting/escalating.
+ */
+export function classifyGateOutcome(
+  parsedVerdict: 'SHIP' | 'REVISE' | 'BLOCK' | null,
+  error: string,
+): 'error' | 'malfunction' | 'verdict' {
+  if (parsedVerdict) return 'verdict';
+  return error ? 'error' : 'malfunction';
+}
+
 /** LIA-169: an errored gate logs `gate_error`, not the misleading `gate_revise`. */
 export function gateOutcomeEventType(
   verdict: 'SHIP' | 'REVISE' | 'BLOCK',
@@ -1112,7 +1132,8 @@ async function handleIssueUpdate(
     let commentBody: string;
     let verdictText = '';
 
-    if (!parsedVerdict && error) {
+    const gateOutcome = classifyGateOutcome(parsedVerdict, error);
+    if (gateOutcome === 'error') {
       gateDidError = true;
       verdict = gateSpec.fallback;
       logger.warn(
@@ -1129,21 +1150,38 @@ async function handleIssueUpdate(
         `Gate agent error:\n\`\`\`\n${error}\n\`\`\``,
         gateSpec.mode,
       );
+    } else if (gateOutcome === 'malfunction') {
+      // LIA-241: clean exit but no parseable `## Verdict:` line. Treat as a gate
+      // malfunction (not a genuine REVISE) — byte-symmetric with the 'error'
+      // branch: gateDidError halts/parks, applies Warden: Error, skips the
+      // bounced label + attempt escalation, and never merges the raw output into
+      // the issue description (finalEnrichment stays undefined). verdictText also
+      // stays '' so the pipeline detail reads '(no detail)', never raw output.
+      gateDidError = true;
+      verdict = gateSpec.fallback;
+      const preview = output.length > 500 ? `${output.slice(0, 500)}…` : output;
+      logger.warn(
+        {
+          issueId: data.id,
+          gate: gateSpec.name,
+          outputLen: output.length,
+        },
+        'linear-webhook: gate agent exited cleanly but produced no ## Verdict marker — treating as gate malfunction',
+      );
+      commentBody = formatGateComment(
+        gateSpec.name,
+        'ERROR',
+        `Gate agent exited cleanly but produced no \`## Verdict:\` marker (malfunction).\n\nOutput preview:\n\`\`\`\n${preview}\n\`\`\``,
+        gateSpec.mode,
+      );
     } else {
+      // gateOutcome === 'verdict' here, so parsedVerdict is non-null (the
+      // ?? fallback only satisfies the type checker). LIA-241 removed the old
+      // "no markers → use full output as enrichment" path: it is now structurally
+      // unreachable (a marker-less clean exit routes to 'malfunction' above), and
+      // it was the vector that merged raw malformed output into the description.
       verdict = parsedVerdict ?? gateSpec.fallback;
-      let enrichmentBody = parseEnrichment(output);
-
-      if (!enrichmentBody && !parsedVerdict && output.length > 100) {
-        logger.warn(
-          {
-            issueId: data.id,
-            gate: gateSpec.name,
-            outputLen: output.length,
-          },
-          'linear-webhook: agent output missing ## Enrichment/## Verdict markers, using full output as enrichment',
-        );
-        enrichmentBody = output;
-      }
+      const enrichmentBody = parseEnrichment(output);
 
       finalEnrichment = enrichmentBody ?? undefined;
 
@@ -1547,13 +1585,36 @@ async function runGateForIssue(
     let commentBody: string;
     let verdictText = '';
 
-    if (!parsedVerdict && error) {
+    const sweepOutcome = classifyGateOutcome(parsedVerdict, error);
+    if (sweepOutcome === 'error') {
       verdict = 'REVISE';
       gateAgentError = true;
       commentBody = formatGateComment(
         gateSpec.name,
         'ERROR',
         `Gate agent error (startup sweep):\n\`\`\`\n${error}\n\`\`\``,
+        gateSpec.mode,
+      );
+    } else if (sweepOutcome === 'malfunction') {
+      // LIA-241: clean exit, no parseable `## Verdict:` line — same malfunction
+      // handling as handleIssueUpdate. gateAgentError halts/parks; finalEnrichment
+      // and verdictText stay unset so no raw output reaches the description or
+      // pipeline detail.
+      verdict = 'REVISE';
+      gateAgentError = true;
+      const preview = output.length > 500 ? `${output.slice(0, 500)}…` : output;
+      logger.warn(
+        {
+          issueId: issue.id,
+          gate: gateSpec.name,
+          outputLen: output.length,
+        },
+        'startup-sweep: gate agent exited cleanly but produced no ## Verdict marker — treating as gate malfunction',
+      );
+      commentBody = formatGateComment(
+        gateSpec.name,
+        'ERROR',
+        `Gate agent exited cleanly but produced no \`## Verdict:\` marker (malfunction, startup sweep).\n\nOutput preview:\n\`\`\`\n${preview}\n\`\`\``,
         gateSpec.mode,
       );
     } else {


### PR DESCRIPTION
## What

Closes **LIA-241**. A gate agent that exits cleanly (`error === ''`) but emits no parseable `## Verdict:` line previously fell through to the genuine-verdict path — its fallback REVISE drove **real** side effects (bounced:unscoped label, `gate_revise` event, attempt-count escalation toward `warden:blocked` / Manual Review Required), and when the output was >100 chars the **raw malformed output was merged into the issue description** as enrichment. This violated `orchestration-rules.md` "Gate fallbacks are errors, not approvals." LIA-169 fixed only the non-empty-`error` and exception paths and left this clean-exit-no-marker case classified as a genuine REVISE.

## Fix

- New exported pure helper `classifyGateOutcome(parsedVerdict, error)` → `'error' | 'malfunction' | 'verdict'` (mirrors the existing tested `gateTransitionAction` idiom). `parsedVerdict` non-null always maps to `'verdict'`, even on a non-zero exit.
- The clean-exit-no-marker case routes to a new **`malfunction`** branch that is byte-symmetric with the existing `error` branch: sets the gate-errored flag (→ `halt`/park via `gateTransitionAction`, Warden: Error label, bounced label + attempt escalation skipped), posts an ERROR comment with a 500-char-capped output preview, and leaves `finalEnrichment` + `verdictText` unset so **no raw output reaches the description or pipeline detail**.
- Applied to **both** gate-output sites — `handleIssueUpdate` and the startup-sweep path — via the shared helper (DRY).
- The old "no markers → use full output as enrichment" block is now **structurally unreachable** (a marker-less clean exit routes to `malfunction`) and was removed, eliminating the description-pollution vector entirely.

## Tests

- `describe('classifyGateOutcome')` — 5 cases: error / malfunction / verdict (SHIP, REVISE) / verdict-over-error precedence.
- Full suite green: **1604 passed**. Build clean.

## Wardens

plan-reviewer SHIP · code-reviewer SHIP (cleanups applied + re-reviewed) · verification-gate SHIP (evidence: build 0, 1604 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)