### PR TITLE
fix(memory): WAL + busy_timeout on the shared memory DBs (LIA-242)

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-12" # auto-bump @1781291092
+last_verified: "2026-06-13" # auto-bump @1781384217
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -308,6 +308,18 @@ def _backfill_fts(db: sqlite3.Connection) -> None:
 def open_db() -> sqlite3.Connection:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     db = sqlite3.connect(DB_PATH)
+    # WAL lets the fire-and-forget auto-compress indexer write concurrently with
+    # reads instead of racing on a single rollback-journal lock; busy_timeout
+    # makes a contended open wait instead of raising SQLITE_BUSY immediately.
+    # busy_timeout is set FIRST so the journal_mode=WAL write itself (a header
+    # change that takes a lock) waits rather than raising on a contended open.
+    # 30s absorbs the long writers (e.g. reenrich_embeddings holds a txn across
+    # many embed calls). Mirrors scripts/code_search.py (post-LIA-189).
+    # Safe here: DB lives under ~/.deus/ (local fs). WAL needs shared memory and
+    # would fail on a network mount. (LIA-242)
+    db.execute("PRAGMA busy_timeout=30000")
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA synchronous=NORMAL")
     db.enable_load_extension(True)
     sqlite_vec.load(db)
     db.enable_load_extension(False)

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -639,6 +639,17 @@ def open_db(db_path: Path = None) -> sqlite3.Connection:
     path = Path(db_path) if db_path else DB_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     db = sqlite3.connect(path)
+    # WAL allows concurrent readers/writer (the tree is read by hooks while the
+    # indexer writes); busy_timeout waits on contention instead of raising
+    # SQLITE_BUSY. busy_timeout is set FIRST so the journal_mode=WAL write itself
+    # (a header change that takes a lock) waits rather than raising on a contended
+    # open. 30s absorbs the long writers (e.g. reenrich_embeddings holds a txn
+    # across many embed calls). Mirrors scripts/code_search.py (post-LIA-189).
+    # Safe here: DB lives under ~/.deus/ (local fs). WAL needs shared memory and
+    # would fail on a network mount. (LIA-242)
+    db.execute("PRAGMA busy_timeout=30000")
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA synchronous=NORMAL")
     if sqlite_vec is not None:
         db.enable_load_extension(True)
         sqlite_vec.load(db)

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -332,6 +332,18 @@ def test_open_db_creates_entries_table(mi):
     assert "entries" in tables
 
 
+def test_open_db_enables_wal_and_busy_timeout(mi):
+    """open_db must set WAL journal mode and a busy_timeout so the fire-and-forget
+    auto-compress indexer can write concurrently with reads instead of racing on a
+    single rollback-journal lock (LIA-242). Use the read form of each PRAGMA."""
+    db = mi.open_db()
+    journal_mode = db.execute("PRAGMA journal_mode").fetchone()[0]
+    busy_timeout = db.execute("PRAGMA busy_timeout").fetchone()[0]
+    db.close()
+    assert journal_mode.lower() == "wal"
+    assert busy_timeout == 30000
+
+
 def test_entry_exists_false_for_new_db(mi):
     db = mi.open_db()
     result = mi.entry_exists(db, "/nonexistent/path.md")

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -252,6 +252,23 @@ class TestFrontmatter:
 # ── DB schema ─────────────────────────────────────────────────────────────────
 
 class TestDb:
+    def test_open_db_enables_wal_and_busy_timeout(self, tmp_db):
+        """open_db must set WAL + busy_timeout so hook reads and indexer writes
+        don't race on a single rollback-journal lock (LIA-242). Read form."""
+        assert tmp_db.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        assert tmp_db.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+
+    def test_open_db_default_path_enables_wal(self):
+        """The production call form open_db() (db_path=None → DB_PATH) must also
+        get WAL + busy_timeout. DB_PATH is redirected to a temp file by the
+        autouse isolate_memory_tree_paths conftest fixture."""
+        db = mt.open_db()
+        try:
+            assert db.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+            assert db.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+        finally:
+            db.close()
+
     def test_creates_all_tables(self, tmp_db):
         tables = {
             r[0]


### PR DESCRIPTION
## Summary

`memory_tree.open_db()` and `memory_indexer.open_db()` opened the two shared SQLite DBs with bare `sqlite3.connect()` — no WAL journal mode, no explicit `busy_timeout`. Those files are hit concurrently by per-prompt hooks, the container memory bridge, fire-and-forget auto-compress indexer spawns, and optimizer sweeps (~100k retrievals/2 days). Because every `retrieve()` also writes (`queries_log`), concurrent writes could hit `SQLITE_BUSY`; all failure paths are silent, and a locked-DB indexer `--add` leaves a session saved to the vault but never indexed with no retry.

Closes LIA-242.

## Change

In both `open_db()`s, immediately after `sqlite3.connect(...)`:
```python
db.execute("PRAGMA busy_timeout=30000")   # set FIRST so the WAL header write itself waits
db.execute("PRAGMA journal_mode=WAL")      # readers proceed during writes
db.execute("PRAGMA synchronous=NORMAL")
```

This mirrors the established precedent in `scripts/code_search.py:541-546` (post-LIA-189, the same multi-process-one-DB situation). `busy_timeout` is set **before** `journal_mode=WAL` because the WAL switch is itself a header write that takes a lock — it must wait, not raise, on a contended open. 30s absorbs the long writers (e.g. `reenrich_embeddings` holding a transaction across many embed calls).

WAL is local-fs only (needs shared memory); the DBs live under `~/.deus/`, so this is safe. WAL is forward/backward compatible — existing readers are unaffected.

## Tests

New tests assert both `open_db()`s report `journal_mode=wal` and `busy_timeout=30000`, including the production default-path form. Full `test_memory_tree.py` + `test_memory_indexer.py` suite: **409 passed** locally.

## Scope

Pragmas only. The auto-compress `--add` catch-up (a follow-up reliability improvement) is intentionally out of scope — WAL + 30s busy_timeout makes the lock failure that motivates it extremely unlikely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)