### PR TITLE
fix(memory,hooks): surface swallowed exceptions (LIA-245, LIA-246)

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-13" # auto-bump @1781384217
+last_verified: "2026-06-14" # auto-bump @1781410171
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -2446,8 +2446,6 @@ def detect_contradictions(db: sqlite3.Connection, new_atom_id: int,
             consecutive_failures = 0
             verdict = response.text.strip().upper().split()[0] if response.text else ""
             if verdict == "CONTRADICT":
-                conflicts.append({"older_id": existing_id, "newer_id": new_atom_id,
-                                  "older_text": existing_text})
                 # Log to pending_conflicts for user review — never auto-invalidate
                 today = local_now().strftime("%Y-%m-%d")
                 try:
@@ -2462,10 +2460,18 @@ def detect_contradictions(db: sqlite3.Connection, new_atom_id: int,
                     # the deferred transaction rolls back on connection close and the
                     # conflict is lost — making --resolve-conflicts permanently empty.
                     db.commit()
-                except Exception:
-                    pass
-                print(f"  CONFLICT DETECTED (pending review): atom {existing_id} "
-                      f"may be superseded by {new_atom_id} ({existing_text[:60]})")
+                except sqlite3.Error as e:
+                    # Surface the failed write instead of printing false success;
+                    # narrow so the outer guard still catches non-DB errors (LIA-245).
+                    print(f"  WARN: failed to record contradiction (atom {existing_id} "
+                          f"vs {new_atom_id}): {e}", file=sys.stderr)
+                else:
+                    # Count + announce only once persisted, so cmd_extract's
+                    # "N conflict(s) logged" count matches --resolve-conflicts (LIA-245).
+                    conflicts.append({"older_id": existing_id, "newer_id": new_atom_id,
+                                      "older_text": existing_text})
+                    print(f"  CONFLICT DETECTED (pending review): atom {existing_id} "
+                          f"may be superseded by {new_atom_id} ({existing_text[:60]})")
         except Exception as e:
             consecutive_failures += 1
             print(f"  WARN: contradiction check failed ({consecutive_failures}/3): {e}", file=sys.stderr)

--- a/scripts/memory_tree_hook.py
+++ b/scripts/memory_tree_hook.py
@@ -119,5 +119,7 @@ def main():
 if __name__ == "__main__":
     try:
         main()
-    except Exception:
-        pass
+    except Exception as e:
+        # Never crash Claude Code, but surface the failure on stderr instead of
+        # vanishing silently (LIA-246).
+        sys.stderr.write(f"[memory-tree-hook] {type(e).__name__}: {e}\n")

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -350,5 +350,8 @@ def main():
 if __name__ == "__main__":
     try:
         main()
-    except Exception:
-        pass  # Always silent
+    except Exception as e:
+        # Never crash Claude Code, but surface the failure instead of vanishing
+        # silently — a swallowed crash here can bypass the bg-compress gate and
+        # lose a session from the vault (LIA-246).
+        sys.stderr.write(f"[stop-hook] {type(e).__name__}: {e}\n")

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -6,6 +6,7 @@ We stub those imports before loading the module.
 """
 import importlib
 import os
+import sqlite3
 import sys
 import types
 from pathlib import Path
@@ -2069,6 +2070,64 @@ def test_detect_contradictions_invalidates_on_conflict(mi, fresh_vault, monkeypa
     assert pending[0] == old_id
     assert pending[1] == 999
     assert pending[2] == 0  # unresolved
+    db.close()
+
+
+def test_detect_contradictions_commit_failure_warns_not_false_success(
+    mi, fresh_vault, monkeypatch, capsys
+):
+    """If the pending_conflicts commit fails, we must WARN to stderr and NOT
+    print the 'CONFLICT DETECTED (pending review)' success line — the old code
+    swallowed the error and printed success unconditionally (LIA-245)."""
+    db = mi.open_db()
+    vec = [0.5] * mi.EMBED_DIM
+
+    cur = db.execute(
+        "INSERT INTO entries (path, date, chunk, type, confidence) "
+        "VALUES ('old.md', '2024-01-01', 'User lives in NYC', 'atom', 0.70)"
+    )
+    old_id = cur.lastrowid
+    db.execute("INSERT INTO embeddings(rowid, embedding) VALUES (?, ?)",
+               [old_id, mi.serialize(vec)])
+    db.commit()
+
+    class FakeResponse:
+        text = "CONTRADICT"
+
+    class FakeModels:
+        def generate_content(self, **kwargs):
+            return FakeResponse()
+
+    class FakeClient:
+        models = FakeModels()
+
+    monkeypatch.setattr(mi, "_client", FakeClient())
+
+    # Wrap the connection so commit() raises (sqlite3.Connection methods can't be
+    # monkeypatched directly); everything else proxies to the real db.
+    class FlakyCommitDB:
+        def __init__(self, real):
+            self._real = real
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def commit(self):
+            raise sqlite3.OperationalError("disk I/O error")
+
+    new_vec = [0.5] * mi.EMBED_DIM
+    new_vec[0] = 0.501
+    conflicts = mi.detect_contradictions(
+        FlakyCommitDB(db), 999, "User lives in Tel Aviv", new_vec
+    )
+
+    out, err = capsys.readouterr()
+    # Persistence failed → the conflict must NOT be counted as "logged for review"
+    # (it won't appear in --resolve-conflicts), so it is excluded from the returned
+    # list that feeds cmd_extract's count, and no false success line is printed.
+    assert len(conflicts) == 0
+    assert "CONFLICT DETECTED (pending review)" not in out
+    assert "WARN: failed to record contradiction" in err
     db.close()
 
 

--- a/scripts/tests/test_memory_tree_hook.py
+++ b/scripts/tests/test_memory_tree_hook.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -189,3 +191,35 @@ class TestDriftScan:
         attempted = stop_hook._scan_vault_drift(fake_vault, limit=5)
         # Both fixture files (MEMORY_TREE.md + household.md) should be discovered.
         assert attempted == 2
+
+
+class TestMainHandlerSurfacesErrors:
+    """LIA-246: a crash in the __main__ guard must surface on stderr, not vanish
+    silently, while still exiting 0. Feeding ``[]`` slips past the JSON parse
+    guard then raises AttributeError on ``[].get(...)`` — before any DB access."""
+
+    def test_stop_hook_surfaces_crash_on_stderr(self):
+        proc = subprocess.run(
+            [sys.executable, str(_ROOT / "scripts" / "stop_hook.py")],
+            input="[]",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0  # never block Claude Code
+        assert "[stop-hook]" in proc.stderr
+        assert "AttributeError" in proc.stderr
+
+    def test_memory_tree_hook_surfaces_crash_on_stderr(self):
+        env = {**os.environ, "DEUS_MEMORY_TREE": "1"}
+        proc = subprocess.run(
+            [sys.executable, str(_ROOT / "scripts" / "memory_tree_hook.py")],
+            input="[]",
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert proc.returncode == 0  # never block Claude Code
+        assert "[memory-tree-hook]" in proc.stderr
+        assert "AttributeError" in proc.stderr


### PR DESCRIPTION
Two batched observability / data-integrity fixes from the 2026-06-12 deep quality audit. No runtime behavior change on the happy path — both only make silent failures visible.

## LIA-245 — don't claim a contradiction is logged when its commit fails

`detect_contradictions` (`scripts/memory_indexer.py`) wrapped the `pending_conflicts` INSERT+commit in a blanket `except Exception: pass`, and **both** `conflicts.append(...)` and the `CONFLICT DETECTED (pending review)` print ran regardless of whether the commit persisted. On a rollback (e.g. a locked DB) the conflict was lost, yet the code printed success — and the unpersisted conflict still inflated `cmd_extract`'s "N conflict(s) logged for review" count (the sole consumer of the returned list). So `--resolve-conflicts` could be empty while the run claimed conflicts were logged.

- Narrow to `except sqlite3.Error as e` with a stderr `WARN` (the outer best-effort guard still catches non-DB errors, so extraction never aborts).
- Move **both** the append and the success print into the commit-succeeded (`else`) branch, so the count and `--resolve-conflicts` stay consistent.

The existing persistence regression test (`evolution/tests/test_memory_indexer_contradiction_commit.py`) still passes; a new test asserts a commit failure → stderr WARN, no false success print, and the conflict excluded from the returned list.

## LIA-246 — surface swallowed crashes in hook entry points

`stop_hook.py` and `memory_tree_hook.py` wrapped their `__main__` entry in `except Exception: pass` with zero trace. A silent crash in stop_hook's `main()` can bypass `_bg_compress_gate`, losing a background session from the vault with **no artifact anywhere to detect it** — contradicting the repo's own hook observability standard (`linear_pending_hook` / `vault_context_hook` / `memory_retrieval_hook` all write `[hook] {e}` to stderr).

- Keep the never-crash contract (still exit 0) but write `[stop-hook]`/`[memory-tree-hook] {type}: {e}` to stderr.

## Verification

Tests: **14 passed** (`test_memory_tree_hook.py` + contradiction-commit regression); contradiction tests in `test_memory_indexer.py`: **7 passed**. New subprocess tests feed each hook a valid-JSON list (slips past the parse guard → `AttributeError`) and assert the stderr marker appears with exit 0.

**Real-invocation hook smoke test** (exact Claude Code invocation `python3 <script>` + hook JSON on stdin + real env, against the modified scripts):

```
stop_hook.py        HAPPY (valid Stop payload)              -> exit 0, no stderr
stop_hook.py        ERROR ([] payload)                      -> exit 0, stderr: [stop-hook] AttributeError: 'list' object has no attribute 'get'
memory_tree_hook.py HAPPY (PostToolUse Edit, gate on)       -> exit 0, no stderr
memory_tree_hook.py ERROR ([] payload, gate on)             -> exit 0, stderr: [memory-tree-hook] AttributeError: 'list' object has no attribute 'get'
```

Confirms, under real CC invocation semantics, that both hooks still exit 0 (never block Claude Code), the happy path is clean, and the error path now surfaces the failure on stderr. (A literal `claude logs` excerpt of the modified code isn't available pre-merge — the live session runs `~/deus/scripts`, not the worktree, and the changed code is the `__main__` handler reachable only on a crash.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)