### PR TITLE
fix(credential-proxy): key memory-bridge rate limit per authenticated group (LIA-244)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-13" # auto-bump @1781381986
+last_verified: "2026-06-14" # auto-bump @1781410461
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-06-13" # auto-bump @1781365126
+last_verified: "2026-06-14" # auto-bump @1781410461
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -66,9 +66,15 @@ const MEMORY_QUERY_SCRIPT = path.join(
 );
 const MEMORY_QUERY_TIMEOUT_MS = 4_000;
 
-/* ── Rate limiter (in-process, per-source) ─────────────────────────── */
+/* ── Rate limiter (in-process, keyed per authenticated group) ──────── */
 
-const RATE_LIMIT_MAX = 5;
+// 20/min per group: the /memory/query bucket is keyed on the authenticated
+// groupFolder (LIA-244), so this is a per-group budget — roughly a chatty
+// conversation's few requests per turn across a burst of turns. The old global
+// 5/min was shared across every group/container, so a single active chat
+// silently lost memory context (the container maps a 429 to empty context with
+// no telemetry).
+const RATE_LIMIT_MAX = 20;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
 interface RateBucket {
@@ -260,9 +266,12 @@ export function startCredentialProxy(
         if (bodyTooLarge) return; // already responded 413 above
         const body = Buffer.concat(chunks);
 
+        // Also keys the /memory/query rate limiter per authenticated group;
+        // null when auth is off (falls back to the socket address). (LIA-244)
+        let groupFolder: string | null = null;
         if (DEUS_PROXY_AUTH_ENABLED) {
           const token = req.headers['x-deus-proxy-token'] as string | undefined;
-          const groupFolder = token ? validateGroupToken(token) : null;
+          groupFolder = token ? validateGroupToken(token) : null;
           if (!groupFolder) {
             logger.error(
               { statusCode: 401, url: req.url, hasToken: !!token },
@@ -284,12 +293,18 @@ export function startCredentialProxy(
 
         /* ── Memory bridge route: POST /memory/query ───────────── */
         if (req.method === 'POST' && req.url === '/memory/query') {
-          const sourceKey =
-            (req.headers['x-deus-source'] as string) ||
-            req.socket.remoteAddress ||
-            'unknown';
+          // Rate-limit per AUTHENTICATED group, not the client-supplied
+          // x-deus-source header — that header is the constant 'container-claude'
+          // for every Claude container, so it collapsed all groups into one shared
+          // global bucket, and it is spoofable. Fall back to the socket address
+          // when proxy auth is disabled. (LIA-244)
+          const rateKey = groupFolder ?? req.socket.remoteAddress ?? 'unknown';
 
-          if (isRateLimited(sourceKey)) {
+          if (isRateLimited(rateKey)) {
+            logger.warn(
+              { group: rateKey },
+              'Memory bridge rate limit exceeded',
+            );
             res.writeHead(429, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'Rate limit exceeded' }));
             return;

--- a/src/memory-bridge.test.ts
+++ b/src/memory-bridge.test.ts
@@ -10,7 +10,11 @@ vi.mock('./config.js', () => ({
 
 vi.mock('./group-tokens.js', () => ({
   validateGroupToken: (token: string) =>
-    token === 'test-proxy-token-abc123' ? 'test-group' : null,
+    token === 'test-proxy-token-abc123'
+      ? 'test-group'
+      : token === 'test-proxy-token-group-b'
+        ? 'test-group-b'
+        : null,
 }));
 
 vi.mock('./env.js', () => ({
@@ -277,21 +281,58 @@ describe('memory bridge — POST /memory/query', () => {
     expect(json.error).toMatch(/timed out/i);
   });
 
-  it('returns 429 when rate limit is exceeded (6 rapid requests)', async () => {
-    const results: number[] = [];
-
-    for (let i = 0; i < 6; i++) {
+  it('returns 429 for a group after RATE_LIMIT_MAX (20) requests/min (LIA-244)', async () => {
+    for (let i = 0; i < 20; i++) {
       const res = await memoryRequest(
         proxyPort,
         JSON.stringify({ query: `query ${i}` }),
-        { 'x-deus-source': 'rate-limit-test' },
       );
-      results.push(res.statusCode);
+      expect(res.statusCode).toBe(200);
     }
+    const blocked = await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'one too many' }),
+    );
+    expect(blocked.statusCode).toBe(429);
+  });
 
-    // First 5 should succeed, 6th should be rate limited
-    expect(results.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
-    expect(results[5]).toBe(429);
+  it('keys the limit per authenticated group, not globally (LIA-244)', async () => {
+    // Exhaust group A's bucket. Under the old x-deus-source keying this was one
+    // global bucket, so group B would have been wrongly blocked too.
+    for (let i = 0; i < 20; i++) {
+      await memoryRequest(proxyPort, JSON.stringify({ query: `a ${i}` }));
+    }
+    expect(
+      (await memoryRequest(proxyPort, JSON.stringify({ query: 'a blocked' })))
+        .statusCode,
+    ).toBe(429);
+
+    // Group B (different proxy token → different group) has its own bucket.
+    const bFirst = await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'b first' }),
+      { 'x-deus-proxy-token': 'test-proxy-token-group-b' },
+    );
+    expect(bFirst.statusCode).toBe(200);
+  });
+
+  it('ignores the spoofable x-deus-source header for keying (LIA-244)', async () => {
+    // The old code keyed on x-deus-source, so rotating it dodged the limit.
+    // Now the same group shares one bucket regardless of the header.
+    for (let i = 0; i < 20; i++) {
+      const res = await memoryRequest(
+        proxyPort,
+        JSON.stringify({ query: `q ${i}` }),
+        { 'x-deus-source': `rotating-source-${i}` },
+      );
+      expect(res.statusCode).toBe(200);
+    }
+    const blocked = await memoryRequest(
+      proxyPort,
+      JSON.stringify({ query: 'still blocked' }),
+      { 'x-deus-source': 'a-fresh-source' },
+    );
+    expect(blocked.statusCode).toBe(429);
   });
 
   it('passes custom k and source to the script', async () => {


### PR DESCRIPTION
## Summary

The `/memory/query` rate limiter in `src/credential-proxy.ts` keyed the bucket on the client-supplied `x-deus-source` header — which is the constant `'container-claude'` for every Claude container. So `RATE_LIMIT_MAX` was **one global bucket shared across all groups and concurrent containers**, not per group. A single chatty conversation (or two groups at once) started getting 429s; the container maps `!res.ok` to `''` and **silently loses memory context** for those turns, with no telemetry (the 429 short-circuits before `memory_query.py` runs). The header key is also client-controlled (spoofable).

Closes LIA-244.

## Change

- Lift `groupFolder` (resolved from the authenticated proxy token) out of the `if (DEUS_PROXY_AUTH_ENABLED)` block so the rate limiter can use it.
- Key the bucket on `groupFolder ?? req.socket.remoteAddress ?? 'unknown'` — the authenticated group identity, falling back to the socket address only when proxy auth is disabled. The `x-deus-source` dependency is dropped (it was used only here; the body carries its own `source`).
- Raise `RATE_LIMIT_MAX` 5 → 20 (now a per-group budget).
- `logger.warn({ group }, ...)` on the 429 so drops are visible.

## Tests (`src/memory-bridge.test.ts`)

The pre-existing "6 rapid requests" test (which assumed the old global limit of 5) is replaced, and per-group behavior is now covered:
- a group is limited only after **20** req/min;
- **per-group isolation** — group B is unaffected by group A exhausting its bucket (the core fix);
- rotating `x-deus-source` no longer dodges the limit (one bucket per group).

**Verification:** targeted run 41 passed; **full suite 1601 passed, 0 failed** (the full run is what caught the stale 6-request test — now fixed). Code-reviewer SHIP + verification-gate SHIP.

## Scope

Rate-limit keying only. The audit's secondary "uncapped bridge-response size" asymmetry is a separate concern (a shared context budget in `memory_query.py`) and is intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)