### PR TITLE
fix(linear-webhook): disable bot-actor guard when no dedicated bot id is set (LIA-240)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,7 +130,10 @@ LINEAR_API_TOKEN=
 # LINEAR_WEBHOOK_SECRET=
 # Port for webhook server (default: 3005)
 # LINEAR_WEBHOOK_PORT=3005
-# Override bot user ID for webhook loopback detection (auto-discovered via viewer())
+# Dedicated bot user ID for pipeline loop-prevention. Leave UNSET unless the
+# pipeline runs under a SEPARATE Linear account — setting it to your OWN user id
+# makes the webhook guard swallow your CLI-initiated transitions (move/rerun/
+# start), since the CLI and dispatcher share one API key. Unset = guard off.
 # LINEAR_BOT_USER_ID=
 # Auto-merge agent PRs after CI passes (0=off, 1=on)
 # LINEAR_AUTO_MERGE=0

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -262,7 +262,7 @@ const effectiveMode = data.labels.some((l) => l.name === 'warden:strict')
 | `LINEAR_POLL_INTERVAL_MS` | 30000 | How often the dispatcher polls |
 | `LINEAR_TEAM_ID` | auto-discovered | Override if account has multiple teams |
 | `LINEAR_WEBHOOK_PORT` | 3005 | Port the webhook server binds to |
-| `LINEAR_BOT_USER_ID` | authenticated viewer ID | Override to match a dedicated bot account |
+| `LINEAR_BOT_USER_ID` | none (loop-guard disabled) | Set to a dedicated bot account's user ID to enable pipeline loop-prevention. Do NOT set it to your own user id — the guard would swallow your CLI-initiated transitions (move/rerun/start), since the CLI and dispatcher share one API key. |
 
 **Adding a gate:** create `.claude/agents/wardens/{name}.md` with `gate_to` frontmatter pointing to the target workflow state. Restart Deus. No code change required.
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-13" # auto-bump @1781365126
+last_verified: "2026-06-14" # auto-bump @1781411201
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781410738
+last_verified: "2026-06-14" # auto-bump @1781411201
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -127,6 +127,7 @@ import {
   validateLinearIdentifier,
   classifyRunFailure,
   executeAgentRun,
+  resolveBotUserId,
 } from './linear-dispatcher.js';
 import type {
   LinearContext,
@@ -190,6 +191,28 @@ function makeMockCtx(overrides: Partial<LinearContext> = {}): LinearContext {
     ...overrides,
   };
 }
+
+describe('resolveBotUserId (LIA-240)', () => {
+  it('returns empty string when unset (guard disabled)', () => {
+    expect(resolveBotUserId(undefined)).toBe('');
+  });
+
+  it('returns empty string for an empty value', () => {
+    expect(resolveBotUserId('')).toBe('');
+  });
+
+  it('returns empty string for whitespace-only (guard disabled)', () => {
+    expect(resolveBotUserId('   ')).toBe('');
+  });
+
+  it('returns a configured bot id verbatim', () => {
+    expect(resolveBotUserId('bot-1')).toBe('bot-1');
+  });
+
+  it('trims surrounding whitespace on a configured id', () => {
+    expect(resolveBotUserId('  bot-1  ')).toBe('bot-1');
+  });
+});
 
 describe('loadRoleSpecs', () => {
   const tmpDir = path.join(process.cwd(), '.test-agents-tmp');

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -154,7 +154,7 @@ export interface LinearContext {
   bus: EventBus; // app-wide event hub; same singleton at emit- and register-side
   stateByName: Map<string, WorkflowState>;
   stateById: Map<string, WorkflowState>;
-  botUserId: string;
+  botUserId: string; // empty = loop-guard disabled (no dedicated bot); see resolveBotUserId
   viewerId: string; // human operator ID, used to assign issues on In Review
   deps: LinearDispatcherDependencies;
   dispatchGroup: RegisteredGroup;
@@ -164,6 +164,19 @@ export interface LinearContext {
   teamId: string;
   repoSlug?: string;
   vaultPath: string | null;
+}
+
+/**
+ * LIA-240: resolve the pipeline's bot identity for the webhook loop-guard.
+ * Returns '' (guard disabled) when no DEDICATED bot id is configured. The old
+ * `|| viewer.id` fallback made the guard match the human operator — because the
+ * CLI and dispatcher share one API key, Linear records the same actor for a
+ * human CLI action (move/rerun/start) and a pipeline self-write, so the guard
+ * silently swallowed CLI-initiated transitions. Only enable the guard when the
+ * pipeline runs under a separate Linear account (an explicit, distinct user id).
+ */
+export function resolveBotUserId(envValue: string | undefined): string {
+  return (envValue ?? '').trim();
 }
 
 let _timer: ReturnType<typeof setInterval> | null = null;
@@ -1680,7 +1693,18 @@ export async function initLinearContext(
     }
 
     const viewer = await client.viewer;
-    const botUserId = process.env.LINEAR_BOT_USER_ID || viewer.id;
+    const botUserId = resolveBotUserId(process.env.LINEAR_BOT_USER_ID);
+    if (botUserId) {
+      logger.info(
+        { botUserId },
+        'linear-dispatcher: actor loop-guard active (dedicated bot identity configured)',
+      );
+    } else {
+      logger.info(
+        {},
+        'linear-dispatcher: actor loop-guard disabled — no LINEAR_BOT_USER_ID set; CLI-initiated transitions are honored',
+      );
+    }
 
     const existing = Object.values(deps.registeredGroups()).find(
       (g) => g.folder === DISPATCH_GROUP_JID,

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -14,6 +14,7 @@ import { extractFrontmatter } from './linear-dispatcher.js';
 import {
   parseEnrichment,
   parseVerdict,
+  shouldSkipBotTransition,
   gateTransitionAction,
   parkErroredGateIssue,
   gateOutcomeEventType,
@@ -366,6 +367,30 @@ Needs work.`),
 
   it('returns null when no verdict', () => {
     expect(parseVerdict('No verdict here.')).toBeNull();
+  });
+});
+
+describe('shouldSkipBotTransition (LIA-240)', () => {
+  it('does not skip when no bot id is configured (guard disabled)', () => {
+    // The exact LIA-240 regression: a human CLI actor with no dedicated bot id
+    // configured must NOT be treated as the pipeline's own write.
+    expect(shouldSkipBotTransition('human-actor', '')).toBe(false);
+  });
+
+  it('does not skip when the actor differs from the bot', () => {
+    expect(shouldSkipBotTransition('human-actor', 'bot-1')).toBe(false);
+  });
+
+  it('skips when the actor matches the configured bot (own write)', () => {
+    expect(shouldSkipBotTransition('bot-1', 'bot-1')).toBe(true);
+  });
+
+  it('does not skip when the actor id is missing', () => {
+    expect(shouldSkipBotTransition(undefined, 'bot-1')).toBe(false);
+  });
+
+  it('does not skip when both are empty', () => {
+    expect(shouldSkipBotTransition('', '')).toBe(false);
   });
 });
 

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -222,6 +222,20 @@ export function parseVerdict(
 }
 
 /**
+ * LIA-240: whether to skip a transition because the pipeline's own bot triggered
+ * it (loop-prevention). Skips ONLY when a dedicated bot id is configured AND the
+ * webhook actor matches it. An empty botUserId (no dedicated bot — see
+ * resolveBotUserId) never skips, so CLI-initiated transitions made under the
+ * shared operator identity are honored instead of being silently swallowed.
+ */
+export function shouldSkipBotTransition(
+  actorId: string | undefined,
+  botUserId: string,
+): boolean {
+  return Boolean(actorId) && Boolean(botUserId) && actorId === botUserId;
+}
+
+/**
  * LIA-169: An errored gate halts regardless of mode/verdict — its fallback
  * 'REVISE' would otherwise drive the strict revert and re-dispatch loop.
  * 'halt' = park (quiescent state); 'revert' = legit strict non-SHIP; 'none' = leave.
@@ -685,7 +699,7 @@ async function handleIssueUpdate(
   if (!toState || !fromState) return;
 
   const actorId = payload.actor?.id;
-  if (actorId && actorId === ctx.botUserId) {
+  if (shouldSkipBotTransition(actorId, ctx.botUserId)) {
     logger.info(
       { issueId: data.id, gate: toState.name, actorId },
       'linear-webhook: skipping bot-triggered transition',


### PR DESCRIPTION
Closes **LIA-240**.

## Problem

The webhook bot-actor loop-guard (`linear-webhook.ts`) silently swallowed **CLI-initiated** pipeline transitions (`:move`, `r` rerun, `s` start). Root cause in `linear-dispatcher.ts`:

```ts
const botUserId = process.env.LINEAR_BOT_USER_ID || viewer.id;
```

When no dedicated bot id is configured, the `|| viewer.id` fallback makes `botUserId` the **human operator**. Because the CLI and the dispatcher share one Linear API key, Linear records the *same* actor id for a human CLI action and a pipeline self-write — so the guard (meant to stop the pipeline reacting to its *own* writes) matched the operator and dropped their CLI actions.

Dormant today only because `.env` carries a non-matching sentinel; a fresh clone following `.env.example` (var commented out) would hit it on every manual intervention.

## Fix

- `resolveBotUserId(env) → (env ?? '').trim()` — resolves to `''` (loop-guard **disabled**) when no dedicated bot id is set, instead of falling back to `viewer.id`. The guard only engages when the pipeline runs under a **separate** Linear account (an explicit, distinct id).
- `shouldSkipBotTransition(actorId, botUserId)` extracts the guard condition; an empty `botUserId` never skips ⇒ CLI transitions are honored.
- Loop-prevention is **fully preserved** for configured-bot setups.

**Zero-impact** on any machine that sets `LINEAR_BOT_USER_ID` (sentinel or real) — old and new code both yield that value. Only the *unset* case changes (`viewer.id` → `''`).

## Docs
`.env.example` + the pipeline ADR now state unset = guard off and warn against setting it to your own user id.

## Verification
- Two pure helpers, 10 unit tests (incl. the exact regression case: human actor + no bot id ⇒ not skipped).
- Full suite **1609 passed**; build clean.
- `botUserId` confirmed consumed only by the guard; `viewerId` (In-Review assignment) unchanged.

## Wardens
plan-reviewer SHIP (r2) · code-reviewer SHIP · ai-eng-warden SHIP (no LLM surface) · verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)