### PR TITLE
fix(linear): sync pending from all teams, grouped by project

### DIFF
--- a/scripts/sync_linear_pending.py
+++ b/scripts/sync_linear_pending.py
@@ -41,6 +41,10 @@ STATE_PRIORITY = {
 
 EXCLUDED_STATES = {"Done", "Canceled", "Duplicate"}
 
+# Intentionally per-team (one $teamId per call). main() fans out across all
+# teams and merges the results (Scatter-Gather), which keeps the partial-success
+# loop working when one team's fetch fails. Do NOT collapse this into a bulk
+# multi-team query.
 QUERY = """
 query($teamId: ID!) {
   issues(
@@ -54,6 +58,7 @@ query($teamId: ID!) {
       title
       identifier
       state { name type }
+      team { name }
     }
   }
 }
@@ -104,12 +109,29 @@ def _get_api_token() -> str | None:
     return env_file.get("LINEAR_API_TOKEN") or env_file.get("LINEAR_API_KEY")
 
 
-def _get_team_id() -> str | None:
-    tid = os.environ.get("LINEAR_TEAM_ID")
-    if tid:
-        return tid
+def _get_team_ids() -> list[str]:
+    """Resolve explicit team IDs from config, or [] to signal discover-all.
+
+    Precedence:
+      1. LINEAR_TEAM_IDS (comma-separated) -- restrict to a subset.
+      2. LINEAR_TEAM_ID (single) -- legacy back-compat, one-element list.
+      3. [] -- caller falls back to discovering every team the token sees.
+
+    Env vars win over the .env file for both keys.
+    """
     env_file = _read_env_file()
-    return env_file.get("LINEAR_TEAM_ID")
+
+    multi = os.environ.get("LINEAR_TEAM_IDS") or env_file.get("LINEAR_TEAM_IDS")
+    if multi:
+        ids = [t.strip() for t in multi.split(",") if t.strip()]
+        if ids:
+            return ids
+
+    single = os.environ.get("LINEAR_TEAM_ID") or env_file.get("LINEAR_TEAM_ID")
+    if single and single.strip():
+        return [single.strip()]
+
+    return []
 
 
 def _graphql(token: str, query: str, variables: dict | None = None) -> dict:
@@ -126,12 +148,11 @@ def _graphql(token: str, query: str, variables: dict | None = None) -> dict:
         return json.loads(resp.read())
 
 
-def _discover_team_id(token: str) -> str | None:
+def _discover_team_ids(token: str) -> list[str]:
+    """Return every team ID the token can see (all teams, not just the first)."""
     result = _graphql(token, "{ teams { nodes { id name } } }")
     nodes = result.get("data", {}).get("teams", {}).get("nodes", [])
-    if not nodes:
-        return None
-    return nodes[0]["id"]
+    return [n["id"] for n in nodes if n.get("id")]
 
 
 def _cache_is_fresh(cache: Path, db: Path) -> bool:
@@ -146,18 +167,46 @@ def _cache_is_fresh(cache: Path, db: Path) -> bool:
     return True
 
 
+def _issue_sort_key(issue: dict) -> tuple[int, int]:
+    """Intra-group order: most-urgent state first, then numeric id."""
+    return (
+        STATE_PRIORITY.get(issue.get("state", {}).get("name", ""), 99),
+        int(re.sub(r"\D", "", issue.get("identifier", "0")) or "0"),
+    )
+
+
 def _format_pending(issues: list[dict]) -> str:
-    issues.sort(key=lambda i: (
-        STATE_PRIORITY.get(i.get("state", {}).get("name", ""), 99),
-        int(re.sub(r"\D", "", i.get("identifier", "0")) or "0"),
-    ))
-    lines = ["  # Source of truth: Linear. Synced by SessionStart hook (/compress as fallback)."]
+    """Render the pending block, grouped by project (team) — never interleaved.
+
+    Group key is the identifier alpha-prefix (e.g. "FOR", "LIA"), the authoritative
+    project tag (nodes without one are skipped below). Groups are ordered alphabetically by prefix (stable
+    across syncs — diff-quiet), issues within a group keep the urgency sort. A
+    `  # <project>` sub-header is emitted only when >=2 groups exist, so a
+    single-team block stays byte-identical to the pre-grouping output.
+    """
+    groups: dict[str, list[dict]] = {}
+    labels: dict[str, str] = {}
     for issue in issues:
-        title = issue.get("title", "")
-        if len(title) > 80:
-            title = title[:77] + "..."
         identifier = issue.get("identifier", "")
-        lines.append(f"  - [ ] {title} ({identifier})")
+        m = re.match(r"[A-Za-z]+", identifier)
+        if not m:  # no identifier / no alpha prefix -> malformed, skip (no crash)
+            continue
+        prefix = m.group(0)
+        groups.setdefault(prefix, []).append(issue)
+        # Header label: friendly team name when present, else the prefix itself.
+        if prefix not in labels:
+            labels[prefix] = (issue.get("team") or {}).get("name") or prefix
+
+    lines = ["  # Source of truth: Linear. Synced by SessionStart hook (/compress as fallback)."]
+    multi = len(groups) > 1
+    for prefix in sorted(groups):
+        if multi:
+            lines.append(f"  # {labels[prefix]}")
+        for issue in sorted(groups[prefix], key=_issue_sort_key):
+            title = issue.get("title", "")
+            if len(title) > 80:
+                title = title[:77] + "..."
+            lines.append(f"  - [ ] {title} ({issue.get('identifier', '')})")
     return "\n".join(lines)
 
 
@@ -175,38 +224,79 @@ def main() -> int:
         print("LINEAR_API_TOKEN not found", file=sys.stderr)
         return AUTH_ERROR
 
-    team_id = _get_team_id()
-    if not team_id:
-        team_id = _discover_team_id(token)
-    if not team_id:
-        print("could not determine team ID", file=sys.stderr)
+    team_ids = _get_team_ids()
+    if not team_ids:
+        # Discovery is fail-loud: an auth/rate error here aborts the whole sync.
+        try:
+            team_ids = _discover_team_ids(token)
+        except HTTPError as e:
+            if e.code == 401:
+                print(f"auth error (discovery): {e}", file=sys.stderr)
+                return AUTH_ERROR
+            if e.code == 429:
+                print(f"rate limited (discovery): {e}", file=sys.stderr)
+                return RATE_LIMIT
+            print(f"HTTP error (discovery): {e}", file=sys.stderr)
+            return INTERNAL_ERROR
+        except (URLError, OSError) as e:
+            print(f"network error (discovery): {e}", file=sys.stderr)
+            return INTERNAL_ERROR
+    if not team_ids:
+        print("could not determine any team ID", file=sys.stderr)
         return INTERNAL_ERROR
 
+    # Scatter-Gather: fetch each team independently, merge the results.
+    # Auth/rate errors are fail-loud (abort); other per-team errors are
+    # partial-succeed (warn + skip that team) so one flaky team doesn't nuke
+    # the whole sync. Total failure (zero successes) returns INTERNAL_ERROR so
+    # the hook leaves the existing pending block untouched instead of wiping it.
     t0 = time.time()
-    try:
-        result = _graphql(token, QUERY, {"teamId": team_id})
-    except HTTPError as e:
-        if e.code == 401:
-            print(f"auth error: {e}", file=sys.stderr)
-            return AUTH_ERROR
-        if e.code == 429:
-            print(f"rate limited: {e}", file=sys.stderr)
-            return RATE_LIMIT
-        print(f"HTTP error: {e}", file=sys.stderr)
-        return INTERNAL_ERROR
-    except (URLError, OSError) as e:
-        print(f"network error: {e}", file=sys.stderr)
+    all_nodes: list[dict] = []
+    successes = 0
+    for tid in team_ids:
+        try:
+            result = _graphql(token, QUERY, {"teamId": tid})
+        except HTTPError as e:
+            if e.code == 401:
+                print(f"auth error (team {tid}): {e}", file=sys.stderr)
+                return AUTH_ERROR
+            if e.code == 429:
+                print(f"rate limited (team {tid}): {e}", file=sys.stderr)
+                return RATE_LIMIT
+            print(f"HTTP error (team {tid}, skipped): {e}", file=sys.stderr)
+            continue
+        except (URLError, OSError) as e:
+            print(f"network error (team {tid}, skipped): {e}", file=sys.stderr)
+            continue
+        successes += 1
+        all_nodes.extend(result.get("data", {}).get("issues", {}).get("nodes", []))
+
+    if successes == 0:
+        print("all team fetches failed", file=sys.stderr)
         return INTERNAL_ERROR
 
-    nodes = result.get("data", {}).get("issues", {}).get("nodes", [])
-    issues = [
-        n for n in nodes
-        if n.get("state", {}).get("name") not in EXCLUDED_STATES
-    ]
+    # Dedup by identifier (defensive against a repeated team id in the override;
+    # Linear identifiers are globally unique across teams).
+    seen: set[str] = set()
+    issues = []
+    for n in all_nodes:
+        if n.get("state", {}).get("name") in EXCLUDED_STATES:
+            continue
+        ident = n.get("identifier", "")
+        if not ident:  # malformed node without an identifier -- skip, don't dedup-collapse
+            continue
+        if ident in seen:
+            continue
+        seen.add(ident)
+        issues.append(n)
 
     output = _format_pending(issues)
     elapsed = time.time() - t0
-    print(f"fetched {len(issues)} issues in {elapsed:.1f}s", file=sys.stderr)
+    print(
+        f"fetched {len(issues)} issues from {successes}/{len(team_ids)} teams "
+        f"in {elapsed:.1f}s",
+        file=sys.stderr,
+    )
 
     tmp_fd, tmp_path = tempfile.mkstemp(dir=str(cache.parent), prefix=".cache.")
     closed = False

--- a/scripts/tests/test_sync_linear_pending.py
+++ b/scripts/tests/test_sync_linear_pending.py
@@ -1,0 +1,283 @@
+"""Tests for scripts/sync_linear_pending.py.
+
+The GraphQL layer is fully mocked -- no network, no Linear creds (CI has none).
+Covers the multi-team Scatter-Gather fetch, partial-success handling, and the
+fail-loud auth/rate paths.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+# Ensure scripts/ is importable
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import sync_linear_pending as slp
+from _exit_codes import AUTH_ERROR, INTERNAL_ERROR, RATE_LIMIT, SUCCESS
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _issue(title: str, identifier: str, state: str = "Todo", team: str | None = None) -> dict:
+    node = {"title": title, "identifier": identifier, "state": {"name": state, "type": "x"}}
+    if team is not None:
+        node["team"] = {"name": team}
+    return node
+
+
+def _http_error(code: int) -> HTTPError:
+    return HTTPError("https://api.linear.app/graphql", code, "err", {}, None)
+
+
+def _is_discovery(query: str) -> bool:
+    return "teams {" in query
+
+
+def _make_graphql(per_team: dict[str, list[dict]],
+                  discover: list[str] | None = None,
+                  raise_for: dict[str, BaseException] | None = None):
+    """Build a fake _graphql.
+
+    per_team   : teamId -> list of issue nodes the issues query returns.
+    discover   : team ids the discovery query returns (defaults to per_team keys).
+    raise_for  : teamId -> exception to raise instead of returning issues;
+                 key "__discover__" raises on the discovery query.
+    """
+    raise_for = raise_for or {}
+    discover_ids = discover if discover is not None else list(per_team.keys())
+
+    def _fake(token, query, variables=None):
+        if _is_discovery(query):
+            if "__discover__" in raise_for:
+                raise raise_for["__discover__"]
+            return {"data": {"teams": {"nodes": [{"id": t, "name": t} for t in discover_ids]}}}
+        tid = (variables or {}).get("teamId")
+        if tid in raise_for:
+            raise raise_for[tid]
+        return {"data": {"issues": {"nodes": per_team.get(tid, [])}}}
+
+    return _fake
+
+
+@pytest.fixture
+def run_main(monkeypatch, tmp_path):
+    """Run slp.main() with cache disabled, a tmp cache dir, and a fake token."""
+    cache_file = tmp_path / "linear-pending-cache.md"
+    monkeypatch.setattr(slp, "_cache_is_fresh", lambda *a, **k: False)
+    monkeypatch.setattr(slp, "_cache_path", lambda: cache_file)
+    monkeypatch.setattr(slp, "_get_api_token", lambda: "fake-token")
+    # Default: no explicit team ids -> exercise discovery unless a test overrides.
+    monkeypatch.setattr(slp, "_get_team_ids", lambda: [])
+
+    def _run():
+        return slp.main()
+
+    return _run
+
+
+# ── _get_team_ids parsing ───────────────────────────────────────────────────
+
+class TestGetTeamIds:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        # Isolate from real env + ~/deus/.env
+        monkeypatch.delenv("LINEAR_TEAM_IDS", raising=False)
+        monkeypatch.delenv("LINEAR_TEAM_ID", raising=False)
+        monkeypatch.setattr(slp, "_read_env_file", lambda: {})
+
+    def test_parses_comma_list(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_TEAM_IDS", "a, b ,c")
+        assert slp._get_team_ids() == ["a", "b", "c"]
+
+    def test_drops_empty_entries(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_TEAM_IDS", "a,,  ,b")
+        assert slp._get_team_ids() == ["a", "b"]
+
+    def test_falls_back_to_single(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_TEAM_ID", "solo")
+        assert slp._get_team_ids() == ["solo"]
+
+    def test_multi_wins_over_single(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_TEAM_IDS", "a,b")
+        monkeypatch.setenv("LINEAR_TEAM_ID", "solo")
+        assert slp._get_team_ids() == ["a", "b"]
+
+    def test_empty_when_unset(self):
+        assert slp._get_team_ids() == []
+
+    def test_empty_multi_falls_back_to_single(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_TEAM_IDS", "  ,  ")
+        monkeypatch.setenv("LINEAR_TEAM_ID", "solo")
+        assert slp._get_team_ids() == ["solo"]
+
+    def test_reads_from_env_file(self, monkeypatch):
+        monkeypatch.setattr(slp, "_read_env_file", lambda: {"LINEAR_TEAM_IDS": "x,y"})
+        assert slp._get_team_ids() == ["x", "y"]
+
+
+# ── multi-team merge ────────────────────────────────────────────────────────
+
+class TestMultiTeamMerge:
+    def test_both_teams_appear(self, run_main, monkeypatch, capsys):
+        per_team = {
+            "T1": [_issue("Team-A task", "ACME-9", "Todo", team="Acme")],
+            "T2": [_issue("Team-B task", "BETA-5", "In Progress", team="Beta")],
+        }
+        monkeypatch.setattr(slp, "_graphql", _make_graphql(per_team, discover=["T1", "T2"]))
+        assert run_main() == SUCCESS
+        out = capsys.readouterr().out
+        assert "ACME-9" in out
+        assert "BETA-5" in out
+
+    def test_excluded_states_dropped(self, run_main, monkeypatch, capsys):
+        per_team = {
+            "T1": [_issue("Open", "ACME-1", "Todo"), _issue("Closed", "ACME-2", "Done")],
+        }
+        monkeypatch.setattr(slp, "_graphql", _make_graphql(per_team, discover=["T1"]))
+        assert run_main() == SUCCESS
+        out = capsys.readouterr().out
+        assert "ACME-1" in out
+        assert "ACME-2" not in out
+
+    def test_dedup_by_identifier(self, run_main, monkeypatch, capsys):
+        # Same id discovered twice (e.g. repeated team) -> appears once.
+        per_team = {"T1": [_issue("Dup", "ACME-3", "Todo")]}
+        monkeypatch.setattr(slp, "_graphql", _make_graphql(per_team, discover=["T1", "T1"]))
+        assert run_main() == SUCCESS
+        out = capsys.readouterr().out
+        assert out.count("ACME-3") == 1
+
+    def test_explicit_team_ids_skip_discovery(self, run_main, monkeypatch, capsys):
+        monkeypatch.setattr(slp, "_get_team_ids", lambda: ["T2"])
+        per_team = {"T1": [_issue("a", "ACME-1")], "T2": [_issue("b", "BETA-5")]}
+        monkeypatch.setattr(slp, "_graphql", _make_graphql(per_team, discover=["T1", "T2"]))
+        assert run_main() == SUCCESS
+        out = capsys.readouterr().out
+        assert "BETA-5" in out
+        assert "ACME-1" not in out
+
+
+# ── grouping by project ──────────────────────────────────────────────────────
+
+class TestGrouping:
+    def _item_lines(self, out: str) -> list[str]:
+        return [ln for ln in out.splitlines() if ln.strip().startswith("- [ ]")]
+
+    def _header_lines(self, out: str) -> list[str]:
+        # group headers are indented "# X" comments, excluding the source-of-truth line
+        return [
+            ln for ln in out.splitlines()
+            if ln.strip().startswith("#") and "Source of truth" not in ln
+        ]
+
+    def test_groups_contiguous_and_alpha_ordered(self):
+        issues = [
+            _issue("b1", "BETA-5", "In Progress", team="Beta"),
+            _issue("a1", "ACME-9", "Todo", team="Acme"),
+            _issue("a2", "ACME-1", "Todo", team="Acme"),
+            _issue("b2", "BETA-2", "Todo", team="Beta"),
+        ]
+        out = slp._format_pending(issues)
+        items = self._item_lines(out)
+        # All ACME items precede all BETA items (alpha group order), no interleaving.
+        prefixes = ["ACME" if "ACME-" in ln else "BETA" for ln in items]
+        assert prefixes == ["ACME", "ACME", "BETA", "BETA"]
+
+    def test_intra_group_urgency_sort(self):
+        issues = [
+            _issue("low", "ACME-2", "Todo", team="Acme"),
+            _issue("high", "ACME-9", "In Progress", team="Acme"),
+        ]
+        out = slp._format_pending(issues)
+        # In Progress (priority 0) sorts before Todo (priority 4) within the group.
+        assert out.index("ACME-9") < out.index("ACME-2")
+
+    def test_single_group_no_header(self):
+        issues = [
+            _issue("a", "ACME-1", "Todo", team="Acme"),
+            _issue("b", "ACME-2", "Todo", team="Acme"),
+        ]
+        out = slp._format_pending(issues)
+        # Back-compat: a single project emits no group header.
+        assert self._header_lines(out) == []
+
+    def test_group_header_format(self):
+        issues = [
+            _issue("a", "ACME-1", "Todo", team="Acme Corp"),
+            _issue("b", "BETA-1", "Todo", team="Beta Team"),
+        ]
+        out = slp._format_pending(issues)
+        lines = out.splitlines()
+        assert "  # Acme Corp" in lines
+        assert "  # Beta Team" in lines
+        # No blank lines between groups (would break the consumer hook regex).
+        assert "" not in lines
+
+    def test_header_falls_back_to_prefix_when_team_missing(self):
+        issues = [
+            _issue("a", "ACME-1", "Todo"),   # no team field
+            _issue("b", "BETA-1", "Todo"),
+        ]
+        out = slp._format_pending(issues)
+        lines = out.splitlines()
+        assert "  # ACME" in lines
+        assert "  # BETA" in lines
+
+    def test_node_missing_identifier_skipped(self):
+        issues = [
+            _issue("ghost", "", "Todo", team="Acme"),
+            _issue("real", "ACME-1", "Todo", team="Acme"),
+        ]
+        out = slp._format_pending(issues)  # must not raise
+        items = self._item_lines(out)
+        assert len(items) == 1
+        assert "ACME-1" in out
+        assert "ghost" not in out
+
+
+# ── partial success & failure ───────────────────────────────────────────────
+
+class TestPartialAndFailure:
+    def test_partial_success_on_transient_error(self, run_main, monkeypatch, capsys):
+        per_team = {"T1": [_issue("ok", "ACME-1")], "T2": [_issue("never", "BETA-5")]}
+        gql = _make_graphql(per_team, discover=["T1", "T2"],
+                            raise_for={"T2": URLError("boom")})
+        monkeypatch.setattr(slp, "_graphql", gql)
+        assert run_main() == SUCCESS
+        out = capsys.readouterr().out
+        assert "ACME-1" in out
+        assert "BETA-5" not in out
+
+    def test_all_teams_fail_is_internal_error(self, run_main, monkeypatch):
+        per_team = {"T1": [], "T2": []}
+        gql = _make_graphql(per_team, discover=["T1", "T2"],
+                            raise_for={"T1": URLError("a"), "T2": URLError("b")})
+        monkeypatch.setattr(slp, "_graphql", gql)
+        assert run_main() == INTERNAL_ERROR
+
+    def test_auth_error_during_fetch(self, run_main, monkeypatch):
+        per_team = {"T1": [_issue("x", "ACME-1")]}
+        gql = _make_graphql(per_team, discover=["T1"], raise_for={"T1": _http_error(401)})
+        monkeypatch.setattr(slp, "_graphql", gql)
+        assert run_main() == AUTH_ERROR
+
+    def test_rate_limit_during_fetch(self, run_main, monkeypatch):
+        per_team = {"T1": [_issue("x", "ACME-1")]}
+        gql = _make_graphql(per_team, discover=["T1"], raise_for={"T1": _http_error(429)})
+        monkeypatch.setattr(slp, "_graphql", gql)
+        assert run_main() == RATE_LIMIT
+
+    def test_auth_error_during_discovery(self, run_main, monkeypatch):
+        gql = _make_graphql({}, raise_for={"__discover__": _http_error(401)})
+        monkeypatch.setattr(slp, "_graphql", gql)
+        assert run_main() == AUTH_ERROR
+
+    def test_no_teams_discovered_is_internal_error(self, run_main, monkeypatch):
+        gql = _make_graphql({}, discover=[])
+        monkeypatch.setattr(slp, "_graphql", gql)
+        assert run_main() == INTERNAL_ERROR


### PR DESCRIPTION
## Problem

`sync_linear_pending.py` produces the `pending:` block consumed by `/compress` and the SessionStart hook. It fetched issues from a **single** Linear team: with `LINEAR_TEAM_ID` unset, `_discover_team_id` returned `nodes[0]` (whichever team Linear listed first). Any pending task in another team never surfaced in catch-ups — the tasks were safe in Linear, but the "remind me" intent was defeated.

## Fix

Fetch every team the token can see, then render the block grouped by project.

- `_get_team_ids()` — optional `LINEAR_TEAM_IDS` (comma-separated) override → legacy single `LINEAR_TEAM_ID` → `[]` (discover all). Back-compat preserved.
- `_discover_team_ids()` — returns all team ids, not just the first.
- `main()` — Scatter-Gather over teams, merge + dedup by identifier. Auth (401) / rate (429) fail loud; other per-team errors warn + skip (partial-succeed); zero successes → `INTERNAL_ERROR` so the consumer hook leaves the existing block intact rather than wiping it.
- `_format_pending()` — group by identifier prefix, groups ordered alphabetically (stable/diff-quiet), urgency sort within each group, a `# <project>` header per group. **Single-group output is byte-identical to before** (no UX delta for single-team users). `QUERY` gains `team { name }` for the header label only; grouping never depends on it.

## Notes

- No hardcoded team IDs (public repo): discovery + env override only; test fixtures use generic `ACME-`/`BETA-` prefixes.
- No `.env` changes (`LINEAR_TEAM_ID` stays commented; the new default is all-teams).

## Verification

- `python3 -m pytest scripts/tests/test_sync_linear_pending.py` → **23/23 pass** (GraphQL layer mocked; CI has no Linear creds).
- Manual run: `fetched 13 issues from 2/2 teams`, with `FOR-*` under `# Force` and `LIA-*` under `# Liam Steiner`, no interleaving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
