### PR TITLE
refactor(memory-tree): gate freshness automation on DB presence, async re-embed

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -21,22 +21,6 @@ _resolve_script_dir() {
 }
 SCRIPT_DIR="$(_resolve_script_dir)"
 
-# LIA-243: auto-enable the memory-tree freshness automation (PostToolUse
-# re-embed via scripts/memory_tree_hook.py, Stop drift scan via
-# scripts/stop_hook.py, and the resume nav-index injection below) when the tree
-# DB already exists — i.e. a configured machine. deus-cmd.sh launches the claude
-# session, so an export here is inherited by claude AND its hooks. We do NOT flip
-# the default on for bare clones (no ~/.deus/memory_tree.db → stays inert), since
-# the automation needs Ollama + embeddinggemma. An explicit DEUS_MEMORY_TREE
-# (0 or 1) always wins.
-if [ -z "${DEUS_MEMORY_TREE:-}" ]; then
-  _mt_db="${DEUS_MEMORY_TREE_DB:-$HOME/.deus/memory_tree.db}"
-  # handle a literal tilde if DEUS_MEMORY_TREE_DB was set as '~/...' (e.g. from a
-  # config file) and so never went through shell tilde expansion.
-  case "$_mt_db" in "~"/*) _mt_db="$HOME/${_mt_db#\~/}" ;; esac
-  [ -f "$_mt_db" ] && export DEUS_MEMORY_TREE=1
-fi
-
 # Prefix selection changes both the foreground CLI and runtime backend for this
 # invocation. Plain `deus` still defaults to Claude unless env/config says
 # otherwise.
@@ -964,8 +948,11 @@ for f in c.get('vault_autoload', ['CLAUDE.md']):
 	        fi
 	      done <<< "$VAULT_AUTOLOAD"
 
-	      # Memory tree (Phase 4, gated by DEUS_MEMORY_TREE=1 during dogfood).
-	      if [ "${DEUS_MEMORY_TREE:-0}" = "1" ]; then
+	      # Memory tree (Phase 4): inject the nav index when the tree DB exists
+	      # (opt out with DEUS_MEMORY_TREE=0).
+	      _mt_db="${DEUS_MEMORY_TREE_DB:-$HOME/.deus/memory_tree.db}"
+	      case "$_mt_db" in "~"/*) _mt_db="$HOME/${_mt_db#\~/}" ;; esac
+	      if [ "${DEUS_MEMORY_TREE:-}" != "0" ] && [ -f "$_mt_db" ]; then
 	        MEMORY_TREE_MD=$(cat "$VAULT/MEMORY_TREE.md" 2>/dev/null)
 	        if [ -n "$MEMORY_TREE_MD" ]; then
 	          CONTEXT="$CONTEXT\n\n=== VAULT: MEMORY_TREE.md ===\n$MEMORY_TREE_MD\n\n=== MEMORY TREE USAGE ===\nFor factual personal questions (identity, household, preferences, cross-branch), call:\n  python3 \$HOME/deus/scripts/memory_tree.py query \"<question>\"\nThe top result's path is the vault file to Read. On abstained:true or low confidence, fall back to Persona/INDEX.md. Prefer this over guessing from CLAUDE.md hints."

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -59,6 +59,21 @@ DB_PATH = Path(os.environ.get(
 )).expanduser()
 VAULT_PATH_ENV = "DEUS_VAULT_PATH"
 
+
+def tree_automation_enabled() -> bool:
+    """Whether the memory-tree freshness automation (PostToolUse re-embed, Stop
+    drift scan, resume nav-index injection) should run.
+
+    Gates on the real precondition — the tree DB existing — rather than a manual
+    enable flag: ON by default once ~/.deus/memory_tree.db is present, OFF only on
+    explicit opt-out (DEUS_MEMORY_TREE=0) or when no DB exists (a bare clone with
+    no Ollama/embeddings configured stays inert). The env var is read at call time
+    and DB_PATH is the module constant tests monkeypatch.
+    """
+    if os.environ.get("DEUS_MEMORY_TREE") == "0":
+        return False
+    return DB_PATH.exists()
+
 # Thresholds are provider-specific: Gemini embeddings produce higher absolute
 # cosine scores (~0.55-0.73 in-domain, ~0.45-0.53 OOD) vs Ollama embeddinggemma
 # (~0.30-0.66 in-domain, ~0.25-0.39 OOD). Env vars always override.

--- a/scripts/memory_tree_hook.py
+++ b/scripts/memory_tree_hook.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """
 Memory-tree PostToolUse hook. Re-embeds a vault node when Write/Edit/MultiEdit
-touches a tracked markdown file. Silent; gated by DEUS_MEMORY_TREE=1.
+touches a tracked markdown file. Silent; runs when the memory-tree DB exists
+(opt out with DEUS_MEMORY_TREE=0). The re-embed runs in a detached worker so the
+edit never blocks on an embedding round-trip — only the vector (ranking) is
+briefly stale, never the served text (read fresh from disk), and the Stop-hook
+drift scan reconciles anything a worker misses.
 
 Input: Claude Code hook JSON on stdin, e.g.
   {"hook_event_name": "PostToolUse", "tool_name": "Edit",
@@ -54,7 +58,13 @@ def dispatch(data: dict) -> str:
               no_description | missing | skipped_dir | already_tracked |
               embed_failed | import_failed | ext_reembedded | ext_not_in_tree
     """
-    if os.environ.get("DEUS_MEMORY_TREE", "0") != "1":
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        import memory_tree as mt
+    except ImportError:
+        return "import_failed"
+
+    if not mt.tree_automation_enabled():
         return "gate_off"
     fp = _file_path_from_hook(data)
     if not fp:
@@ -63,12 +73,6 @@ def dispatch(data: dict) -> str:
     abs_path = Path(fp).expanduser().resolve()
     if abs_path.suffix != ".md":
         return "not_markdown"
-
-    sys.path.insert(0, str(Path(__file__).parent))
-    try:
-        import memory_tree as mt
-    except ImportError:
-        return "import_failed"
 
     # Check auto-memory dir first (external population).
     ext_root = _auto_memory_root()
@@ -108,18 +112,80 @@ def dispatch(data: dict) -> str:
         return "embed_failed"
 
 
+def _precheck_db_path() -> Path:
+    """Cheap parent-side DB-path resolution (no memory_tree import) — keep this
+    byte-for-byte in sync with memory_tree.DB_PATH's env/default
+    (DEUS_MEMORY_TREE_DB, fallback ~/.deus/memory_tree.db) so the parent's spawn
+    pre-check and the worker's authoritative mt.tree_automation_enabled() agree."""
+    return Path(
+        os.environ.get("DEUS_MEMORY_TREE_DB", "~/.deus/memory_tree.db")
+    ).expanduser()
+
+
+def _reembed_timeout() -> float:
+    """Wall-clock ceiling for the detached worker (LIA-235: bound the child)."""
+    try:
+        v = float(os.environ.get("DEUS_MEMORY_TREE_REEMBED_TIMEOUT", "120"))
+        return v if v > 0 else 120.0
+    except (TypeError, ValueError):
+        return 120.0
+
+
 def main():
+    """Fire-and-forget: spawn a detached worker to re-embed, then return at once
+    so the edit never blocks. Cheap parent gate (no memory_tree import) skips the
+    spawn on opt-out or when no tree DB exists."""
     try:
         data = json.loads(sys.stdin.read() or "{}")
     except (json.JSONDecodeError, OSError):
         return
-    dispatch(data)
+    fp = _file_path_from_hook(data)
+    if not fp:
+        return
+    if os.environ.get("DEUS_MEMORY_TREE") == "0":
+        return
+    if not _precheck_db_path().exists():
+        return
+    import subprocess
+
+    subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), "--worker", fp],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _run_worker(file_path: str) -> None:
+    """Detached worker: run the synchronous dispatch() under a wall-clock timer so
+    a hung embed can't leave an orphan. Cross-platform (threading.Timer + os._exit,
+    no POSIX-only signal.alarm). A timeout is an EXPECTED slow-embed condition the
+    Stop-scan reconciles, so it exits 0 silently."""
+    import threading
+
+    # os._exit (not sys.exit) is intentional: a hard exit from the timer thread
+    # to kill a hung embed without waiting on interpreter teardown.
+    timer = threading.Timer(_reembed_timeout(), os._exit, args=(0,))
+    timer.daemon = True
+    timer.start()
+    try:
+        dispatch({"tool_input": {"file_path": file_path}})
+    finally:
+        timer.cancel()
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        # Never crash Claude Code, but surface the failure on stderr instead of
-        # vanishing silently (LIA-246).
-        sys.stderr.write(f"[memory-tree-hook] {type(e).__name__}: {e}\n")
+    if "--worker" in sys.argv:
+        try:
+            _run_worker(sys.argv[sys.argv.index("--worker") + 1])
+        except Exception:
+            # Worker is silent — the Stop-hook drift scan reconciles misses.
+            pass
+    else:
+        try:
+            main()
+        except Exception as e:
+            # Never crash Claude Code, but surface the failure on stderr instead
+            # of vanishing silently (LIA-246).
+            sys.stderr.write(f"[memory-tree-hook] {type(e).__name__}: {e}\n")

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -168,14 +168,15 @@ status: auto
 def _scan_vault_drift(vault: Path, limit: int = 5) -> int:
     """Re-embed up to `limit` tracked files whose mtime exceeds the last node
     update, then discover up to `limit` new vault files not yet in the tree.
-    Both paths are hash-gated and silent on errors. Gated by
-    DEUS_MEMORY_TREE=1. Returns total files attempted (reembed + discover)."""
-    if os.environ.get("DEUS_MEMORY_TREE", "0") != "1":
-        return 0
+    Both paths are hash-gated and silent on errors. Runs when the memory-tree DB
+    exists (opt out with DEUS_MEMORY_TREE=0). Returns total files attempted
+    (reembed + discover)."""
     try:
         sys.path.insert(0, str(Path(__file__).parent))
         import memory_tree as mt  # type: ignore
     except ImportError:
+        return 0
+    if not mt.tree_automation_enabled():
         return 0
     try:
         db = mt.open_db()

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -68,4 +68,14 @@ def isolate_memory_tree_paths(tmp_path, monkeypatch):
         monkeypatch.setattr(mod, "DB_PATH", tmp_db, raising=False)
         monkeypatch.setattr(mod, "_LOG_PATH", tmp_log, raising=False)
         monkeypatch.setattr(mod, "_AUDIT_PATH", tmp_audit, raising=False)
+    # The memory-tree freshness automation gates on the DB existing (LIA-243
+    # follow-up). Pin DEUS_MEMORY_TREE_DB to the same tmp path so the hook's
+    # parent-side pre-check (which reads the env, not the patched constant) agrees
+    # with mt.DB_PATH — otherwise memory_tree_hook.main() would spawn a real
+    # worker against ~/.deus/memory_tree.db. Clear DEUS_MEMORY_TREE so the only
+    # gate control in tests is DB presence + an explicit "0" opt-out; tmp_db is
+    # NOT created here, so automation is OFF by default (tests needing it on
+    # create the DB).
+    monkeypatch.setenv("DEUS_MEMORY_TREE_DB", str(tmp_db))
+    monkeypatch.delenv("DEUS_MEMORY_TREE", raising=False)
     yield

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -251,6 +251,34 @@ class TestFrontmatter:
 
 # ── DB schema ─────────────────────────────────────────────────────────────────
 
+class TestTreeAutomationEnabled:
+    """LIA-243 follow-up: the freshness automation gates on the DB existing, with
+    DEUS_MEMORY_TREE=0 as an explicit opt-out (DB_PATH is redirected to a tmp file
+    by the autouse conftest; DEUS_MEMORY_TREE is cleared there)."""
+
+    def test_off_when_no_db(self):
+        assert not mt.DB_PATH.exists()
+        assert mt.tree_automation_enabled() is False
+
+    def test_on_when_db_present(self):
+        mt.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        mt.DB_PATH.touch()
+        assert mt.tree_automation_enabled() is True
+
+    def test_off_on_explicit_opt_out_even_with_db(self, monkeypatch):
+        mt.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        mt.DB_PATH.touch()
+        monkeypatch.setenv("DEUS_MEMORY_TREE", "0")
+        assert mt.tree_automation_enabled() is False
+
+    def test_on_when_flag_non_zero_and_db_present(self, monkeypatch):
+        # Any non-"0" value (incl. legacy "1") with a DB present → enabled.
+        mt.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        mt.DB_PATH.touch()
+        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+        assert mt.tree_automation_enabled() is True
+
+
 class TestDb:
     def test_open_db_enables_wal_and_busy_timeout(self, tmp_db):
         """open_db must set WAL + busy_timeout so hook reads and indexer writes

--- a/scripts/tests/test_memory_tree_hook.py
+++ b/scripts/tests/test_memory_tree_hook.py
@@ -85,22 +85,36 @@ def built_db(fake_vault, stub_embed):
     return db
 
 
+@pytest.fixture
+def tree_db():
+    """Open the gate without a full tree: tree_automation_enabled() only needs
+    the DB file to exist (LIA-243 follow-up — automation gates on DB presence)."""
+    mt.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    mt.DB_PATH.touch()
+    yield
+
+
 # ── memory_tree_hook.dispatch ─────────────────────────────────────────────────
 
 class TestHookDispatch:
-    def test_gate_off_noop(self, fake_vault, monkeypatch):
-        monkeypatch.delenv("DEUS_MEMORY_TREE", raising=False)
+    def test_gate_off_no_db(self, fake_vault, monkeypatch):
+        # No DB present (conftest points DB_PATH at a non-existent tmp file) →
+        # automation is off even with a configured vault.
         result = hook.dispatch({"tool_input": {"file_path": str(fake_vault / "MEMORY_TREE.md")}})
         assert result == "gate_off"
 
-    def test_bad_input(self, fake_vault, monkeypatch):
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+    def test_gate_off_opt_out(self, fake_vault, tree_db, monkeypatch):
+        # DB present but explicit opt-out wins.
+        monkeypatch.setenv("DEUS_MEMORY_TREE", "0")
+        result = hook.dispatch({"tool_input": {"file_path": str(fake_vault / "MEMORY_TREE.md")}})
+        assert result == "gate_off"
+
+    def test_bad_input(self, fake_vault, tree_db, monkeypatch):
         assert hook.dispatch({}) == "bad_input"
         assert hook.dispatch({"tool_input": {}}) == "bad_input"
         assert hook.dispatch({"tool_input": {"file_path": ""}}) == "bad_input"
 
-    def test_no_vault(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+    def test_no_vault(self, tree_db, monkeypatch, tmp_path):
         monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
         # Point config lookup at a non-existent file so fallback returns None
         monkeypatch.setattr(
@@ -109,15 +123,13 @@ class TestHookDispatch:
         result = hook.dispatch({"tool_input": {"file_path": str(tmp_path / "x.md")}})
         assert result == "no_vault"
 
-    def test_file_outside_vault(self, fake_vault, tmp_path, monkeypatch):
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+    def test_file_outside_vault(self, fake_vault, tree_db, tmp_path, monkeypatch):
         outside = tmp_path / "outside.md"
         outside.write_text("# outside")
         result = hook.dispatch({"tool_input": {"file_path": str(outside)}})
         assert result == "not_vault_file"
 
-    def test_non_markdown(self, fake_vault, monkeypatch):
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+    def test_non_markdown(self, fake_vault, tree_db, monkeypatch):
         txt = fake_vault / "notes.txt"
         txt.write_text("hello")
         result = hook.dispatch({"tool_input": {"file_path": str(txt)}})
@@ -184,13 +196,13 @@ class TestDriftScan:
         attempted = stop_hook._scan_vault_drift(fake_vault, limit=1)
         assert attempted == 1
 
-    def test_missing_db_recovers_via_discovery(self, fake_vault, stub_embed, monkeypatch, tmp_path):
-        """If DB doesn't exist, scan rebuilds it via discovery on the next pass."""
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+    def test_missing_db_is_noop(self, fake_vault, stub_embed, monkeypatch, tmp_path):
+        """LIA-243 follow-up: the scan gates on the DB existing, so a missing DB
+        is a no-op (the DB is created by `deus init` / `memory_tree.py build`, not
+        bootstrapped by the stop-hook)."""
         monkeypatch.setattr(mt, "DB_PATH", tmp_path / "nonexistent.db")
         attempted = stop_hook._scan_vault_drift(fake_vault, limit=5)
-        # Both fixture files (MEMORY_TREE.md + household.md) should be discovered.
-        assert attempted == 2
+        assert attempted == 0
 
 
 class TestMainHandlerSurfacesErrors:
@@ -211,15 +223,77 @@ class TestMainHandlerSurfacesErrors:
         assert "AttributeError" in proc.stderr
 
     def test_memory_tree_hook_surfaces_crash_on_stderr(self):
-        env = {**os.environ, "DEUS_MEMORY_TREE": "1"}
+        # `[]` slips past json.loads then raises AttributeError in
+        # _file_path_from_hook (before any gate); the raise propagates to the
+        # __main__ `except Exception` block (not dispatch), exercising the
+        # stderr-surfacing path (LIA-246).
         proc = subprocess.run(
             [sys.executable, str(_ROOT / "scripts" / "memory_tree_hook.py")],
             input="[]",
             capture_output=True,
             text=True,
             timeout=30,
-            env=env,
         )
         assert proc.returncode == 0  # never block Claude Code
         assert "[memory-tree-hook]" in proc.stderr
         assert "AttributeError" in proc.stderr
+
+
+# ── memory_tree_hook.main — async fire-and-forget ─────────────────────────────
+
+class TestMainAsync:
+    """main() never re-embeds inline — it spawns a detached worker so the edit
+    doesn't block, and only when the automation is enabled (DB present, not
+    opted out)."""
+
+    def _run_main(self, monkeypatch, fp="/tmp/x.md"):
+        import io
+        import subprocess
+
+        calls = []
+        monkeypatch.setattr(
+            subprocess, "Popen", lambda *a, **k: calls.append((a, k))
+        )
+        monkeypatch.setattr(
+            "sys.stdin",
+            io.StringIO(json.dumps({"tool_input": {"file_path": fp}})),
+        )
+        hook.main()
+        return calls
+
+    def test_spawns_detached_worker_when_enabled(self, tree_db, monkeypatch):
+        import subprocess
+
+        calls = self._run_main(monkeypatch)
+        assert len(calls) == 1
+        args, kwargs = calls[0]
+        argv = args[0]
+        assert argv[0] == sys.executable
+        assert argv[1].endswith("memory_tree_hook.py")
+        assert argv[2] == "--worker"
+        assert argv[3] == "/tmp/x.md"
+        assert kwargs.get("start_new_session") is True
+        # stdout/stderr all silenced
+        assert kwargs.get("stdout") == subprocess.DEVNULL
+        assert kwargs.get("stderr") == subprocess.DEVNULL
+
+    def test_no_spawn_on_opt_out(self, tree_db, monkeypatch):
+        monkeypatch.setenv("DEUS_MEMORY_TREE", "0")
+        assert self._run_main(monkeypatch) == []
+
+    def test_no_spawn_when_no_db(self, monkeypatch):
+        # conftest leaves the DB absent by default → automation off.
+        assert self._run_main(monkeypatch) == []
+
+    def test_no_spawn_when_no_file_path(self, tree_db, monkeypatch):
+        import io
+
+        import subprocess
+
+        calls = []
+        monkeypatch.setattr(
+            subprocess, "Popen", lambda *a, **k: calls.append((a, k))
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_input": {}})))
+        hook.main()
+        assert calls == []

--- a/scripts/tests/test_memory_tree_phase3.py
+++ b/scripts/tests/test_memory_tree_phase3.py
@@ -580,7 +580,8 @@ class TestHookEdges:
 
     def test_tool_input_with_no_file_path(self, monkeypatch):
         """tool_input present but missing file_path → bad_input."""
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
+        mt.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        mt.DB_PATH.touch()  # open the gate (automation gates on DB presence)
         result = hook.dispatch({"tool_input": {"some_other_key": "v"}})
         assert result == "bad_input"
 
@@ -774,6 +775,7 @@ class TestHookDiscovery:
         monkeypatch.setattr(mt, "DB_PATH", db_path)
         real_open_db = mt.open_db
         monkeypatch.setattr(mt, "open_db", lambda path=None: real_open_db(db_path))
+        real_open_db(db_path).close()  # materialize so the gate (DB-exists) opens
         monkeypatch.setattr(hook, "_vault_root", lambda: v)
         status = hook.dispatch({"tool_input": {"file_path": str(v / "fresh.md")}})
         assert status == "discovered"
@@ -788,10 +790,11 @@ class TestHookDiscovery:
             "description: already in tree.\n---\n"
         )
         db_path = tmp_path / "t.db"
+        monkeypatch.setattr(mt, "DB_PATH", db_path)
         real_open_db = mt.open_db
         monkeypatch.setattr(mt, "open_db", lambda path=None: real_open_db(db_path))
         monkeypatch.setattr(hook, "_vault_root", lambda: v)
-        # Discover once so the node exists.
+        # Discover once so the node exists (also materializes db_path → gate open).
         db = real_open_db(db_path)
         mt.discover_node(v, "exists.md", db)
         db.close()
@@ -805,8 +808,10 @@ class TestHookDiscovery:
         v.mkdir()
         (v / "bare.md").write_text("---\ntitle: Bare\ndescription: no id.\n---\n")
         db_path = tmp_path / "t.db"
+        monkeypatch.setattr(mt, "DB_PATH", db_path)
         real_open_db = mt.open_db
         monkeypatch.setattr(mt, "open_db", lambda path=None: real_open_db(db_path))
+        real_open_db(db_path).close()  # materialize so the gate (DB-exists) opens
         monkeypatch.setattr(hook, "_vault_root", lambda: v)
         status = hook.dispatch({"tool_input": {"file_path": str(v / "bare.md")}})
         assert status == "no_id"
@@ -825,13 +830,14 @@ else:
 
 class TestStopHookDiscovery:
     def _setup(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("DEUS_MEMORY_TREE", "1")
         monkeypatch.setattr(mt, "embed_text", _stub_embed)
         v = tmp_path / "vault"
         v.mkdir()
         db_path = tmp_path / "t.db"
+        monkeypatch.setattr(mt, "DB_PATH", db_path)
         real_open_db = mt.open_db
         monkeypatch.setattr(mt, "open_db", lambda path=None: real_open_db(db_path))
+        real_open_db(db_path).close()  # materialize so the gate (DB-exists) opens
         return v, db_path, real_open_db
 
     def test_drift_scan_discovers_new_files(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up to **LIA-243** (#811). Two cohesive changes to the memory-tree freshness automation (PostToolUse re-embed, Stop drift scan, resume nav-index injection), both prompted by review discussion.

## 1. Self-gate on the real precondition (drop the redundant flag)

#811 gated on `DEUS_MEMORY_TREE=1` and then *auto-set that flag whenever the DB existed* — the flag and the DB-check were the same information twice. Replaced with a single shared helper:

```python
def tree_automation_enabled() -> bool:
    if os.environ.get("DEUS_MEMORY_TREE") == "0":
        return False
    return DB_PATH.exists()
```

- **ON by default** once the tree DB exists (a configured machine).
- **OFF** on a bare clone (no DB) or explicit **`DEUS_MEMORY_TREE=0`** opt-out.
- Converts both Python gate readers (`memory_tree_hook.dispatch`, `stop_hook._scan_vault_drift`) + the `deus-cmd.sh` Phase-4 gate; **removes the #811 auto-enable block**.

**Intentional behavior change:** a *missing* DB is now a no-op rather than being bootstrapped by the Stop scan. The DB is created by `deus init` / `memory_tree.py build` (both call `open_db`, which auto-creates it), so recovering a deleted DB is an explicit re-init, not a silent stop-hook side effect. The bootstrap test was updated to assert the new semantics.

## 2. Non-blocking re-embed

`memory_tree_hook.main()` is now fire-and-forget: it spawns a **detached worker** (`start_new_session`, `std* = DEVNULL`) and returns immediately, so a vault `.md` edit never waits on an embedding round-trip. The worker runs the unchanged synchronous `dispatch()` under a **cross-platform wall-clock bound** (`threading.Timer` + `os._exit`, default 120s via `DEUS_MEMORY_TREE_REEMBED_TIMEOUT`) so a hung embed can't orphan.

**Why it's safe:** served content is read fresh from disk at serve time (`memory_query._format_context`) — only the *vector/ranking* is briefly stale, never the text — and the Stop drift scan reconciles misses. A quickly deleted/moved file → `reembed_file` returns `"missing"` (no-op). A timeout exits 0 silently (a slow embed is expected, not an error).

## Verification
- **Real-binary smoke** (the actual hook, live DB + vault + Ollama): `main()` returned in **0.02s** (non-blocking) and the detached worker re-embedded (node `content_hash` changed, committed). Non-blocking re-confirmed at 0.047s with a no-DB precheck (no spawn).
- **220** memory-tree tests pass (incl. new `tree_automation_enabled` + async-spawn coverage); **239** warden-hook tests unaffected; `zsh -n` clean; no stale `==1` enable semantics remain.
- conftest pins `DEUS_MEMORY_TREE_DB` to the tmp DB so `main()` can never spawn a worker against `~/.deus` during tests.

> Companion local change (not in this PR): once merged + deployed, the `DEUS_MEMORY_TREE=1` key in `~/.claude/settings.json` becomes redundant and can be removed (the hooks self-gate on the DB).

## Wardens
plan-reviewer SHIP (r2) · code-reviewer SHIP (real-binary smoke + cleanups, re-reviewed) · verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)