### PR TITLE
fix(container-runner): escalate to runtime kill when graceful stop fails

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-13" # auto-bump @1781361508
+last_verified: "2026-06-14" # auto-bump @1781447481
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-13" # auto-bump @1781361508
+last_verified: "2026-06-14" # auto-bump @1781447481
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781411201
+last_verified: "2026-06-14" # auto-bump @1781447481
 governs:
   - src/
   - evolution/

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -586,9 +586,24 @@ export async function runContainerAgent(
           if (err) {
             logger.warn(
               { group: group.name, containerName, err },
-              'Graceful stop failed, force killing',
+              'Graceful stop failed, force killing container',
             );
-            forceKillProcess(container.pid!);
+            // `docker kill` targets the runtime container; forceKillProcess only
+            // reaps the orphaned `docker stop` CLI client, not the container.
+            execFile(
+              CONTAINER_RUNTIME_BIN,
+              ['kill', containerName],
+              { timeout: 15000 },
+              (killErr) => {
+                if (killErr) {
+                  logger.error(
+                    { group: group.name, containerName, err: killErr },
+                    'Force kill failed — container may still be running',
+                  );
+                }
+                if (container.pid != null) forceKillProcess(container.pid);
+              },
+            );
           }
         },
       );


### PR DESCRIPTION
## LIA-228

The container hard-timeout fallback called `forceKillProcess(container.pid)` on a failed `docker stop`, which kills the **CLI client** — not the container, which keeps running.

**Fix:** escalate to `<runtime> kill <containerName>` (runtime SIGKILL), then reap the client pid. Clear log when the kill itself fails (container may still be running) + a `pid != null` guard.

**Verify:** `tsc --noEmit` clean; code-reviewer SHIP.