### PR TITLE
fix(logger): disable ANSI color when stdout is not a TTY

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-06-09" # auto-bump (re-verified: LIA-197 odysseus channel)
+last_verified: "2026-06-14" # auto-bump @1781448670
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781447510
+last_verified: "2026-06-14" # auto-bump @1781448670
 governs:
   - src/
   - evolution/

--- a/src/deus-listen.test.ts
+++ b/src/deus-listen.test.ts
@@ -24,6 +24,7 @@ vi.mock('./platform.js', () => ({
   IS_LINUX: false,
   IS_WINDOWS: false,
   killProcess: vi.fn(),
+  isInteractiveTerminal: () => false,
 }));
 
 vi.mock('./transcription.js', () => ({

--- a/src/evolution-client.test.ts
+++ b/src/evolution-client.test.ts
@@ -10,6 +10,7 @@ vi.mock('child_process', () => ({
 // without sending a real signal (SIGKILL is unsupported on Windows).
 vi.mock('./platform.js', () => ({
   forceKillProcess: vi.fn(),
+  isInteractiveTerminal: () => false,
 }));
 
 import { spawn } from 'child_process';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,14 @@
 import pino from 'pino';
+import { isInteractiveTerminal } from './platform.js';
 
 export const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } },
+  // Pretty, colorized output only for an interactive terminal. Under launchd
+  // (or any piped/redirected stdout) emit plain NDJSON so ANSI escape codes
+  // don't corrupt persisted log files (LIA-272).
+  transport: isInteractiveTerminal()
+    ? { target: 'pino-pretty', options: { colorize: true } }
+    : undefined,
 });
 
 // Route uncaught errors through pino so they get timestamps in stderr

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -22,6 +22,7 @@ import {
   containerBuildHint,
   detectProxyBindHost,
   hostGatewayArgs,
+  isInteractiveTerminal,
 } from './platform.js';
 
 const mockExecFileSync = vi.mocked(execFileSync);
@@ -107,5 +108,11 @@ describe('hostGatewayArgs', () => {
     } else {
       expect(args).toEqual([]);
     }
+  });
+});
+
+describe('isInteractiveTerminal', () => {
+  it('returns a boolean (never undefined, via the ?? false guard)', () => {
+    expect(typeof isInteractiveTerminal()).toBe('boolean');
   });
 });

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -196,3 +196,10 @@ export function openBrowser(url: string): boolean {
   spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref();
   return true;
 }
+
+// Gates human-only terminal formatting (e.g. ANSI color) so it never lands in a
+// redirected log file under launchd. Centralized per the platform-abstraction
+// ADR — no raw `process.stdout` outside this file.
+export function isInteractiveTerminal(): boolean {
+  return process.stdout.isTTY ?? false;
+}


### PR DESCRIPTION
## LIA-272

`pino-pretty` `colorize:true` wrote ANSI escapes into `logs/deus.log` under launchd (non-TTY). Gate the pretty transport on a new `isInteractiveTerminal()` in `platform.ts` (per the platform-abstraction ADR — no raw `process.stdout` outside that file); plain NDJSON under a service manager.

**Verify:** `tsc --noEmit` clean; `platform.test.ts` 13 pass; code-reviewer SHIP.