### PR TITLE
fix(linear-sync): fetch pending issues from all teams, not just the first

### DIFF
--- a/scripts/sync_linear_pending.py
+++ b/scripts/sync_linear_pending.py
@@ -104,12 +104,25 @@ def _get_api_token() -> str | None:
     return env_file.get("LINEAR_API_TOKEN") or env_file.get("LINEAR_API_KEY")
 
 
-def _get_team_id() -> str | None:
-    tid = os.environ.get("LINEAR_TEAM_ID")
-    if tid:
-        return tid
+def _get_team_ids() -> list[str]:
+    """Explicit team IDs from config, or [] to signal 'discover every team'.
+
+    Precedence: LINEAR_TEAM_IDS (comma-separated subset) > legacy single
+    LINEAR_TEAM_ID > [] (discover all). Env vars win over the .env file.
+    """
     env_file = _read_env_file()
-    return env_file.get("LINEAR_TEAM_ID")
+
+    multi = os.environ.get("LINEAR_TEAM_IDS") or env_file.get("LINEAR_TEAM_IDS")
+    if multi:
+        ids = [t.strip() for t in multi.split(",") if t.strip()]
+        if ids:
+            return ids
+
+    single = os.environ.get("LINEAR_TEAM_ID") or env_file.get("LINEAR_TEAM_ID")
+    if single and single.strip():
+        return [single.strip()]
+
+    return []
 
 
 def _graphql(token: str, query: str, variables: dict | None = None) -> dict:
@@ -126,12 +139,11 @@ def _graphql(token: str, query: str, variables: dict | None = None) -> dict:
         return json.loads(resp.read())
 
 
-def _discover_team_id(token: str) -> str | None:
+def _discover_team_ids(token: str) -> list[str]:
+    """Every team id visible to this token (not just the first)."""
     result = _graphql(token, "{ teams { nodes { id name } } }")
     nodes = result.get("data", {}).get("teams", {}).get("nodes", [])
-    if not nodes:
-        return None
-    return nodes[0]["id"]
+    return [n["id"] for n in nodes if n.get("id")]
 
 
 def _cache_is_fresh(cache: Path, db: Path) -> bool:
@@ -175,38 +187,77 @@ def main() -> int:
         print("LINEAR_API_TOKEN not found", file=sys.stderr)
         return AUTH_ERROR
 
-    team_id = _get_team_id()
-    if not team_id:
-        team_id = _discover_team_id(token)
-    if not team_id:
-        print("could not determine team ID", file=sys.stderr)
+    team_ids = _get_team_ids()
+    if not team_ids:
+        # Discovery is fail-loud: an auth/rate error here aborts the whole sync,
+        # returning the same exit code a per-team failure would.
+        try:
+            team_ids = _discover_team_ids(token)
+        except HTTPError as e:
+            if e.code == 401:
+                print(f"auth error (discovery): {e}", file=sys.stderr)
+                return AUTH_ERROR
+            if e.code == 429:
+                print(f"rate limited (discovery): {e}", file=sys.stderr)
+                return RATE_LIMIT
+            print(f"HTTP error (discovery): {e}", file=sys.stderr)
+            return INTERNAL_ERROR
+        except (URLError, OSError) as e:
+            print(f"network error (discovery): {e}", file=sys.stderr)
+            return INTERNAL_ERROR
+    if not team_ids:
+        print("could not determine any team ID", file=sys.stderr)
         return INTERNAL_ERROR
 
+    # Scatter-Gather across teams: auth/rate errors abort (fail-loud); any other
+    # per-team error is warn + skip (partial-succeed). Zero successes returns
+    # INTERNAL_ERROR so the caller keeps its existing pending block.
     t0 = time.time()
-    try:
-        result = _graphql(token, QUERY, {"teamId": team_id})
-    except HTTPError as e:
-        if e.code == 401:
-            print(f"auth error: {e}", file=sys.stderr)
-            return AUTH_ERROR
-        if e.code == 429:
-            print(f"rate limited: {e}", file=sys.stderr)
-            return RATE_LIMIT
-        print(f"HTTP error: {e}", file=sys.stderr)
-        return INTERNAL_ERROR
-    except (URLError, OSError) as e:
-        print(f"network error: {e}", file=sys.stderr)
+    raw_nodes: list[dict] = []
+    successes = 0
+    for tid in team_ids:
+        try:
+            result = _graphql(token, QUERY, {"teamId": tid})
+        except HTTPError as e:
+            if e.code == 401:
+                print(f"auth error (team {tid}): {e}", file=sys.stderr)
+                return AUTH_ERROR
+            if e.code == 429:
+                print(f"rate limited (team {tid}): {e}", file=sys.stderr)
+                return RATE_LIMIT
+            print(f"HTTP error (team {tid}, skipped): {e}", file=sys.stderr)
+            continue
+        except (URLError, OSError) as e:
+            print(f"network error (team {tid}, skipped): {e}", file=sys.stderr)
+            continue
+        successes += 1
+        raw_nodes.extend(
+            result.get("data", {}).get("issues", {}).get("nodes", [])
+        )
+
+    if successes == 0:
+        print("all team fetches failed", file=sys.stderr)
         return INTERNAL_ERROR
 
-    nodes = result.get("data", {}).get("issues", {}).get("nodes", [])
-    issues = [
-        n for n in nodes
-        if n.get("state", {}).get("name") not in EXCLUDED_STATES
-    ]
+    # Filter excluded states + dedup by identifier (globally unique in Linear).
+    seen: set[str] = set()
+    issues = []
+    for n in raw_nodes:
+        if n.get("state", {}).get("name") in EXCLUDED_STATES:
+            continue
+        ident = n.get("identifier", "")
+        if not ident or ident in seen:
+            continue
+        seen.add(ident)
+        issues.append(n)
 
     output = _format_pending(issues)
     elapsed = time.time() - t0
-    print(f"fetched {len(issues)} issues in {elapsed:.1f}s", file=sys.stderr)
+    print(
+        f"fetched {len(issues)} issues from {successes}/{len(team_ids)} teams "
+        f"in {elapsed:.1f}s",
+        file=sys.stderr,
+    )
 
     tmp_fd, tmp_path = tempfile.mkstemp(dir=str(cache.parent), prefix=".cache.")
     closed = False

--- a/scripts/tests/test_sync_linear_pending.py
+++ b/scripts/tests/test_sync_linear_pending.py
@@ -1,0 +1,165 @@
+"""Tests for scripts/sync_linear_pending.py — multi-team Scatter-Gather fetch.
+
+The GraphQL layer is fully mocked: no network, no Linear credentials (CI has
+none). Covers the all-teams discovery, per-team merge + identifier dedup, the
+partial-success path (one flaky team must not blank the block), the fail-loud
+auth/rate paths, and the zero-success → INTERNAL_ERROR contract that tells the
+caller to KEEP its existing pending block.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "sync_linear_pending", _SCRIPTS / "sync_linear_pending.py"
+)
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)
+
+
+def _issue(identifier: str, title: str = "t", state: str = "Todo") -> dict:
+    return {
+        "title": title,
+        "identifier": identifier,
+        "state": {"name": state, "type": "unstarted"},
+    }
+
+
+def _make_graphql(teams: list[str], per_team: dict):
+    """Fake _graphql: the teams-discovery query returns `teams`; each per-team
+    issues query returns per_team[teamId] (a node list) or raises it if it is
+    an Exception instance."""
+
+    def fake(token, query, variables=None):
+        if "teams" in query and "issues" not in query:
+            return {"data": {"teams": {"nodes": [{"id": t, "name": t} for t in teams]}}}
+        tid = (variables or {}).get("teamId")
+        val = per_team.get(tid, [])
+        if isinstance(val, Exception):
+            raise val
+        return {"data": {"issues": {"nodes": val}}}
+
+    return fake
+
+
+def _http_error(code: int) -> HTTPError:
+    return HTTPError("https://api.linear.app/graphql", code, "err", None, None)
+
+
+# ── _get_team_ids precedence ──────────────────────────────────────────────
+
+
+def test_get_team_ids_csv_override(monkeypatch):
+    monkeypatch.setattr(mod, "_read_env_file", lambda: {})
+    monkeypatch.setenv("LINEAR_TEAM_IDS", "a, b ,c")
+    monkeypatch.delenv("LINEAR_TEAM_ID", raising=False)
+    assert mod._get_team_ids() == ["a", "b", "c"]
+
+
+def test_get_team_ids_legacy_single(monkeypatch):
+    monkeypatch.setattr(mod, "_read_env_file", lambda: {})
+    monkeypatch.delenv("LINEAR_TEAM_IDS", raising=False)
+    monkeypatch.setenv("LINEAR_TEAM_ID", "solo")
+    assert mod._get_team_ids() == ["solo"]
+
+
+def test_get_team_ids_empty_signals_discover_all(monkeypatch):
+    monkeypatch.setattr(mod, "_read_env_file", lambda: {})
+    monkeypatch.delenv("LINEAR_TEAM_IDS", raising=False)
+    monkeypatch.delenv("LINEAR_TEAM_ID", raising=False)
+    assert mod._get_team_ids() == []
+
+
+def test_discover_team_ids_returns_all(monkeypatch):
+    monkeypatch.setattr(mod, "_graphql", _make_graphql(["t1", "t2", "t3"], {}))
+    assert mod._discover_team_ids("tok") == ["t1", "t2", "t3"]
+
+
+# ── main() Scatter-Gather ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def run_main(tmp_path, monkeypatch):
+    cache = tmp_path / "cache.md"
+    db = tmp_path / "messages.db"  # absent → cache never counts as fresh
+    monkeypatch.setattr(mod, "_cache_path", lambda: cache)
+    monkeypatch.setattr(mod, "_db_path", lambda: db)
+    monkeypatch.setattr(mod, "_read_env_file", lambda: {})
+    monkeypatch.setenv("LINEAR_API_TOKEN", "tok")
+    monkeypatch.delenv("LINEAR_TEAM_ID", raising=False)
+    monkeypatch.delenv("LINEAR_TEAM_IDS", raising=False)
+
+    def _run(teams, per_team):
+        monkeypatch.setattr(mod, "_graphql", _make_graphql(teams, per_team))
+        code = mod.main()
+        out = cache.read_text() if cache.exists() else None
+        return code, out
+
+    return _run
+
+
+def test_main_merges_multiple_teams(run_main):
+    code, out = run_main(["t1", "t2"], {"t1": [_issue("LIA-1")], "t2": [_issue("FOR-9")]})
+    assert code == mod.SUCCESS
+    assert "LIA-1" in out and "FOR-9" in out
+
+
+def test_main_dedups_identifier_across_teams(run_main):
+    code, out = run_main(["t1", "t2"], {"t1": [_issue("LIA-1")], "t2": [_issue("LIA-1")]})
+    assert code == mod.SUCCESS
+    assert out.count("LIA-1") == 1
+
+
+def test_main_partial_success_skips_flaky_team(run_main):
+    # One team errors with a transient network failure — the other still lands.
+    code, out = run_main(
+        ["t1", "t2"], {"t1": [_issue("LIA-1")], "t2": URLError("boom")}
+    )
+    assert code == mod.SUCCESS
+    assert "LIA-1" in out
+
+
+def test_main_auth_error_is_fail_loud(run_main):
+    code, out = run_main(
+        ["t1", "t2"], {"t1": _http_error(401), "t2": [_issue("LIA-1")]}
+    )
+    assert code == mod.AUTH_ERROR
+    assert out is None  # cache untouched → caller keeps existing block
+
+
+def test_main_rate_limit_is_fail_loud(run_main):
+    code, out = run_main(["t1"], {"t1": _http_error(429)})
+    assert code == mod.RATE_LIMIT
+
+
+def test_main_zero_success_preserves_block(run_main):
+    code, out = run_main(["t1", "t2"], {"t1": URLError("x"), "t2": URLError("y")})
+    assert code == mod.INTERNAL_ERROR
+    assert out is None  # nothing written, existing pending block survives
+
+
+def test_main_excluded_states_filtered(run_main):
+    code, out = run_main(
+        ["t1"], {"t1": [_issue("LIA-1", state="Done"), _issue("LIA-2", state="Todo")]}
+    )
+    assert code == mod.SUCCESS
+    assert "LIA-2" in out and "LIA-1" not in out
+
+
+def test_main_single_team_output_stays_flat(run_main):
+    # Back-compat: a single-team workspace renders exactly as before — header
+    # line + one issue line, no per-project sub-headers.
+    code, out = run_main(["t1"], {"t1": [_issue("LIA-2", title="hello")]})
+    assert code == mod.SUCCESS
+    lines = out.splitlines()
+    assert len(lines) == 2
+    assert lines[1] == "  - [ ] hello (LIA-2)"


### PR DESCRIPTION
## Supersedes #816 (native reimplementation)

`_discover_team_id` returned `nodes[0]`, so a multi-team workspace silently dropped pending issues from every other team. Reimplemented natively (not a copy of the work-fork PR #816):

- `_discover_team_ids` returns **all** teams; `_get_team_ids` honors `LINEAR_TEAM_IDS` (csv) > legacy `LINEAR_TEAM_ID` > discover-all.
- Scatter-Gather: auth(401)/rate(429) **fail-loud**; other per-team errors **warn+skip** (partial-success); dedup by identifier; **zero-success → INTERNAL_ERROR** so the caller keeps its existing pending block.
- `_format_pending` unchanged → single-team output **byte-identical**.

**Premise (plan-review):** canonical workspace is currently single-team (LIA only, no `LINEAR_TEAM_ID` override), so this is a **latent robustness fix** — no active data loss today.

**Verify:** `pytest scripts/tests/test_sync_linear_pending.py` 12/12 pass; code-reviewer SHIP.