### PR TITLE
feat(arch): save/restore named views in the explorer (LIA-296)

### DIFF
--- a/tools/architecture-explorer/README.md
+++ b/tools/architecture-explorer/README.md
@@ -46,6 +46,17 @@ cd tools/architecture-explorer && python3 -m http.server 8000
   a file before you touch it), plus its connections light up (focus + context).
 - **Directional particles** flow along edges to show import/call direction.
 - **Search** → locate a file, fly the camera to it, expand its layer.
+- **Save a view** → the **Views** toolbar button opens a panel: name the current
+  view and **Save current** to bookmark it; **Restore** flies you back to it later;
+  **×** deletes it. A saved view captures **both navigation and appearance** —
+  expanded layers, camera position, layout mode (layered/tree), isolation, and
+  selection, plus the full theme (shape/color/edges/scene/labels/camera control).
+  Views are stored in `localStorage` **per repo** (keyed by the repo name in the
+  graph data), so opening the explorer on a different project shows only that
+  project's views. Persistence is scoped to the serving **origin** — views saved at
+  the default `deus arch` port persist across runs; a custom `--port` is a different
+  origin with its own list (same as saved themes). Under `file://` (no http server)
+  the browser may block `localStorage`, in which case saving is a graceful no-op.
 
 ## Customize the look (live)
 
@@ -87,10 +98,12 @@ A one-command `deus arch <project>` wrapper is still planned (Phase 2).
 |---|---|
 | `build.py` | generator: codegraph DB + layers (curated `layers.json` or directory-derived) → `graph-data.js` (`window.GRAPH`) |
 | `layers.json` | ordered path-glob → layer rules for *this* repo; auto-derived from directories on a poor fit |
-| `index.html` | page shell; loads vendor + `graph-data.js` + `theme.js` + `app.js` |
-| `app.js` | 3D graph structure + behavior (pinned-z layers, expand/collapse, detail panel, search, camera) |
-| `theme.js` | live appearance system (lil-gui panel; shape/color/edges/scene; localStorage) |
-| `style.css` | dark UI chrome (topbar, detail panel, legend) |
+| `index.html` | page shell; loads vendor + `graph-data.js` + `theme.js` + `sidebar.js` + `views.js` + `app.js` |
+| `app.js` | 3D graph structure + behavior (pinned-z layers, expand/collapse, detail panel, search, camera); exposes `snapshot`/`restore` for saved views |
+| `theme.js` | live appearance system (lil-gui panel; shape/color/edges/scene; localStorage); `getTheme`/`applyTheme` for saved views |
+| `sidebar.js` | IDE-style file-tree navigator + layer key |
+| `views.js` | save / restore / delete named views (per-repo `localStorage`; navigation + appearance) |
+| `style.css` | dark UI chrome (topbar, detail panel, legend, saved-views panel) |
 | `vendor/3d-force-graph.min.js` | 3D renderer (bundles Three.js; offline — see `vendor/README.md`) |
 | `vendor/lil-gui.umd.min.js` | live control panel |
 | `tests/test_build.py` | pytest for the generator |
@@ -105,7 +118,10 @@ long-tail merge, root-file handling, the palette, fit-detection, and the
 no-file-lost invariant across config↔auto. The **UI is verified manually** — run `build.py`, open `index.html`,
 confirm the 3D scene renders (layers as depth planes), fly/orbit work, click-a-layer
 expands its files, the detail panel shows Affects/Affected-by, and the appearance
-panel changes the look live.
+panel changes the look live. For **saved views**: open **Views**, save a named view,
+reload the page, confirm the name persists and **Restore** reapplies both the
+camera/expansion and the theme; the `archexplorer.views.v1::<repo>` key is visible in
+DevTools → Application → localStorage.
 
 ## Roadmap
 

--- a/tools/architecture-explorer/app.js
+++ b/tools/architecture-explorer/app.js
@@ -1090,8 +1090,17 @@
     graph: Graph, AE: AE, GRAPH: G,
     buildData: buildData, toggleLayer: toggleLayer, focusFile: focusFile,
     setControlType: setControlType,
-    isExpanded: function (layerId) { return !!expanded[layerId]; }
+    isExpanded: function (layerId) { return !!expanded[layerId]; },
+    // Saved-view (ArchViews) hooks: snapshot() captures the navigation memento
+    // {expanded, selectedId, isolated, layoutMode, cam}; restore(state, animMs)
+    // reapplies it (rebuilds graphData → reseeds node positions; animates the
+    // camera). These already power the in-memory Back history; views.js persists
+    // them by name. Exposed read/write so an external module owns no graph state.
+    snapshot: snapshot,
+    restore: restore
   };
   // let the file-tree panel (sidebar.js) mount once everything is ready
   if (window.ArchSidebar && window.ArchSidebar.init) window.ArchSidebar.init(window.ArchExplorer);
+  // let the saved-views panel (views.js) mount once everything is ready
+  if (window.ArchViews && window.ArchViews.init) window.ArchViews.init(window.ArchExplorer);
 })();

--- a/tools/architecture-explorer/index.html
+++ b/tools/architecture-explorer/index.html
@@ -19,6 +19,7 @@
       <button id="btn-back" title="Go back to the previous view" disabled>&larr; Back</button>
       <button id="btn-expand-all">Expand all</button>
       <button id="btn-collapse-all">Collapse all</button>
+      <button id="btn-views" title="Save / restore named views">Views</button>
       <button id="btn-reset-cam">Reset</button>
     </div>
   </header>
@@ -50,6 +51,7 @@
   <script src="graph-data.js"></script>
   <script src="theme.js"></script>
   <script src="sidebar.js"></script>
+  <script src="views.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/tools/architecture-explorer/style.css
+++ b/tools/architecture-explorer/style.css
@@ -350,6 +350,44 @@ html, body {
 /* END SIDEBAR */
 
 /* ============================================================
+   Saved views panel (views.js) — top-center dropdown. Sidebar
+   owns the left, detail + appearance panels own the right, so
+   center-top is the clear zone.
+   ============================================================ */
+#btn-views.active { background: #1c2438; border-color: #3a4568; color: #7fb2ff; }
+.av-panel {
+  position: fixed; top: 52px; left: 50%; transform: translateX(-50%);
+  width: 300px; max-height: calc(100vh - 96px); z-index: 12;
+  display: flex; flex-direction: column; gap: 8px;
+  background: #0b0f1a; border: 1px solid #222b42; border-radius: 10px;
+  padding: 12px; box-shadow: 0 10px 40px #000a;
+  pointer-events: auto;
+}
+.av-panel.hidden { display: none; }
+.av-head { font-weight: 600; font-size: 13px; color: #e6e9ef; }
+.av-save-row { display: flex; gap: 6px; }
+.av-input {
+  flex: 1; min-width: 0; background: #11182b; color: #e6e9ef;
+  border: 1px solid #2a3450; border-radius: 6px; padding: 5px 8px; font-size: 12px;
+}
+.av-input:focus { outline: none; border-color: #4a90d9; }
+.av-panel button {
+  background: #141c30; color: #cdd5e6; border: 1px solid #2a3450;
+  border-radius: 6px; padding: 5px 9px; font-size: 12px; cursor: pointer; white-space: nowrap;
+}
+.av-panel button:hover { background: #1c2438; border-color: #3a4568; }
+.av-status { color: #e0a04a; font-size: 11px; }
+.av-empty { color: #7a8499; font-size: 12px; padding: 4px 2px; }
+.av-list { display: flex; flex-direction: column; gap: 4px; overflow-y: auto; }
+.av-row { display: flex; align-items: center; gap: 6px; }
+.av-name {
+  flex: 1; min-width: 0; font-size: 12px; color: #e6e9ef;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.av-del { color: #c97a7a; padding: 4px 8px; line-height: 1; }
+.av-del:hover { background: #2a1c1c; border-color: #5a3a3a; color: #ff9b9b; }
+
+/* ============================================================
    NAV PAD — on-screen camera navigation (app.js buildNavPad)
    ============================================================ */
 #navpad {

--- a/tools/architecture-explorer/theme.js
+++ b/tools/architecture-explorer/theme.js
@@ -648,7 +648,39 @@
       if (dagModeController) { try { dagModeController.updateDisplay(); } catch (e) { /* graceful */ } }
     }
 
-    return { init: init, refresh: refresh, onSelect: onSelect, rebind: rebind, syncControlType: syncControlType, syncDagMode: syncDagMode, shapeForLayerOrder: shapeForLayerOrder };
+    // Snapshot the live appearance for a saved view (ArchViews). Returns a shallow
+    // copy so callers can't mutate the internal theme. `dagMode` is DELIBERATELY
+    // excluded: it tracks the live layout (may be 'td' after a tree toggle) but a
+    // saved view drives the dag from its OWN nav.layoutMode via restore()+syncDagMode,
+    // so carrying dagMode here would desync the dropdown on restore (same reasoning as
+    // syncDagMode's no-saveTheme note above).
+    function getTheme() {
+      var copy = Object.assign({}, theme);
+      delete copy.dagMode;
+      return copy;
+    }
+
+    // Re-apply a saved appearance blob (ArchViews restore). Mirrors applyPreset:
+    // merge over the live theme, persist, sync the GUI controls, re-apply visuals.
+    // applyAll()→applyCamera() handles a controlType change by rebuilding the graph
+    // (controlType is construction-only); the rebind `rebinding` guard prevents
+    // re-entry. Node positions are NOT carried here — the caller restores nav state
+    // AFTER this (app.js restore() regenerates graphData), so positions reseed there.
+    function applyTheme(obj) {
+      if (!obj) return;
+      Object.keys(obj).forEach(function (k) {
+        if (k === 'dagMode') return;            // never let a saved blob drive the dag
+        theme[k] = obj[k];
+      });
+      saveTheme(theme);
+      if (gui) {
+        try { gui.controllersRecursive().forEach(function (c) { c.updateDisplay(); }); }
+        catch (e) { /* graceful */ }
+      }
+      applyAll();
+    }
+
+    return { init: init, refresh: refresh, onSelect: onSelect, rebind: rebind, syncControlType: syncControlType, syncDagMode: syncDagMode, shapeForLayerOrder: shapeForLayerOrder, getTheme: getTheme, applyTheme: applyTheme };
   })();
 
 })();

--- a/tools/architecture-explorer/views.js
+++ b/tools/architecture-explorer/views.js
@@ -1,0 +1,193 @@
+/* =============================================================
+   ArchViews — save / restore / delete NAMED views.
+   Wired by app.js via: window.ArchViews.init(window.ArchExplorer)
+
+   A "view" bundles NAVIGATION + APPEARANCE:
+     nav   = ArchExplorer.snapshot()  -> {expanded, selectedId, isolated, layoutMode, cam}
+     theme = ArchTheme.getTheme()     -> node/edge/scene/camera/label appearance (no dagMode)
+
+   Persistence: localStorage, PER-REPO (keyed by GRAPH.meta.repo) so the same
+   explorer origin reused across `deus arch <repo>` runs keeps each repo's views
+   separate (deus-cmd.sh reuses one URL across projects). All storage access is
+   wrapped in try/catch -> graceful no-op when localStorage is unavailable
+   (private mode / quota), mirroring theme.js saveTheme/loadTheme.
+
+   Pattern: a Registry (view-name -> {nav, theme}) rendered as a re-render-on-change
+   DOM list. The named, persisted views extend app.js's in-memory Memento
+   (snapshot/restore). No external dependencies. Vanilla JS only.
+   ============================================================= */
+
+window.ArchViews = (function () {
+  'use strict';
+
+  /* ---- state ---- */
+  var _api = null;          // window.ArchExplorer
+  var _panel = null;
+  var _listEl = null;
+  var _nameInput = null;
+  var _btn = null;
+  var STORAGE_PREFIX = 'archexplorer.views.v1::';
+
+  /* ---- helpers ---- */
+  function el(tag, cls, attrs) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (attrs) Object.keys(attrs).forEach(function (k) { e.setAttribute(k, attrs[k]); });
+    return e;
+  }
+
+  /* ---- per-repo store (Registry: name -> {nav, theme, savedAt}) ---- */
+  var _warnedNoRepo = false;
+  function repoKey() {
+    var repo = '';
+    try { repo = (window.GRAPH && window.GRAPH.meta && window.GRAPH.meta.repo) || ''; } catch (e) { /* noop */ }
+    if (!repo && !_warnedNoRepo) {
+      // A repo-less graph-data.js means every such session shares one key — flag it
+      // once so a misconfigured build is debuggable, without polluting normal runs.
+      _warnedNoRepo = true;
+      try { console.warn('[ArchViews] GRAPH.meta.repo missing — saved views share a single unscoped key.'); } catch (e) { /* noop */ }
+    }
+    return STORAGE_PREFIX + repo;
+  }
+  function loadAll() {
+    try {
+      var raw = localStorage.getItem(repoKey());
+      if (!raw) return {};
+      var o = JSON.parse(raw);
+      return (o && typeof o === 'object') ? o : {};
+    } catch (e) { return {}; }
+  }
+  function saveAll(obj) {
+    try { localStorage.setItem(repoKey(), JSON.stringify(obj)); return true; }
+    catch (e) { return false; }   // file:// SecurityError / quota exceeded
+  }
+
+  /* ---- actions ---- */
+  function saveCurrent() {
+    var name = (_nameInput.value || '').trim();
+    if (!name) { _nameInput.focus(); return; }
+    var all = loadAll();
+    if (Object.prototype.hasOwnProperty.call(all, name) &&
+        !window.confirm("Overwrite view '" + name + "'?")) return;
+    var view;
+    try {
+      view = {
+        nav: (_api && _api.snapshot) ? _api.snapshot() : null,
+        theme: (window.ArchTheme && window.ArchTheme.getTheme) ? window.ArchTheme.getTheme() : null,
+        savedAt: Date.now()
+      };
+    } catch (e) { showStatus('Could not capture the current view.'); return; }   // snapshot/getTheme threw — abort cleanly
+    all[name] = view;
+    if (!saveAll(all)) { showStatus('Storage unavailable — view not saved.'); return; }
+    _nameInput.value = '';
+    renderList();
+  }
+
+  function restoreView(name) {
+    var v = loadAll()[name];
+    if (!v) return;
+    // Appearance FIRST: applyTheme may rebuild the graph (controlType is
+    // construction-only); the rebind guard prevents re-entry. Navigation LAST:
+    // restore() regenerates graphData (reseeds node positions deterministically in
+    // layered mode / re-settles+frames in tree mode) and animates the camera to the
+    // saved viewpoint, so it lands correctly even across a controlType rebuild.
+    if (v.theme && window.ArchTheme && window.ArchTheme.applyTheme) window.ArchTheme.applyTheme(v.theme);
+    if (v.nav && _api && _api.restore) _api.restore(v.nav, 700);
+  }
+
+  function deleteView(name) {
+    var all = loadAll();
+    if (!Object.prototype.hasOwnProperty.call(all, name)) return;
+    delete all[name];
+    if (!saveAll(all)) { showStatus('Storage unavailable — could not delete view.'); return; }
+    renderList();
+  }
+
+  /* ---- UI ---- */
+  function showStatus(msg) {
+    var s = _panel && _panel.querySelector('.av-status');
+    if (!s) return;
+    s.textContent = msg;          // textContent: never interpret as HTML
+    s.style.display = msg ? 'block' : 'none';
+  }
+
+  function renderList() {
+    if (!_listEl) return;
+    _listEl.innerHTML = '';
+    var all = loadAll();
+    var names = Object.keys(all).sort(function (a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; });
+    if (!names.length) {
+      var empty = el('div', 'av-empty');
+      empty.textContent = 'No saved views for this repo.';
+      _listEl.appendChild(empty);
+      return;
+    }
+    names.forEach(function (name) {
+      var row = el('div', 'av-row');
+      var label = el('span', 'av-name');
+      label.textContent = name;             // user input -> textContent, XSS-safe
+      label.title = name;
+      var restoreBtn = el('button', 'av-restore', { title: 'Restore this view' });
+      restoreBtn.textContent = 'Restore';
+      restoreBtn.addEventListener('click', function () { restoreView(name); });
+      var delBtn = el('button', 'av-del', { title: 'Delete this view (no undo)' });
+      delBtn.textContent = '×';        // ×
+      delBtn.addEventListener('click', function () { deleteView(name); });
+      row.appendChild(label);
+      row.appendChild(restoreBtn);
+      row.appendChild(delBtn);
+      _listEl.appendChild(row);
+    });
+  }
+
+  function buildPanel() {
+    _panel = el('div', 'av-panel hidden', { id: 'views-panel' });
+
+    var head = el('div', 'av-head');
+    head.textContent = 'Saved views';
+    _panel.appendChild(head);
+
+    var saveRow = el('div', 'av-save-row');
+    _nameInput = el('input', 'av-input', { type: 'text', placeholder: 'View name…', maxlength: '80' });
+    _nameInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); saveCurrent(); }
+    });
+    var saveBtn = el('button', 'av-save', { title: 'Save the current view' });
+    saveBtn.textContent = 'Save current';
+    saveBtn.addEventListener('click', saveCurrent);
+    saveRow.appendChild(_nameInput);
+    saveRow.appendChild(saveBtn);
+    _panel.appendChild(saveRow);
+
+    var status = el('div', 'av-status');
+    status.style.display = 'none';
+    _panel.appendChild(status);
+
+    _listEl = el('div', 'av-list');
+    _panel.appendChild(_listEl);
+
+    document.body.appendChild(_panel);
+    renderList();
+  }
+
+  function togglePanel() {
+    if (!_panel) return;
+    var hidden = _panel.classList.toggle('hidden');
+    if (_btn) _btn.classList.toggle('active', !hidden);
+    if (!hidden) {
+      showStatus('');             // clear any stale status
+      renderList();               // reflect any external changes
+      if (_nameInput) _nameInput.focus();
+    }
+  }
+
+  /* ---- public API ---- */
+  function init(api) {
+    _api = api;
+    buildPanel();
+    _btn = document.getElementById('btn-views');
+    if (_btn) _btn.addEventListener('click', togglePanel);
+  }
+
+  return { init: init };
+}());


### PR DESCRIPTION
## What

Adds a **Views** toolbar control to the `deus arch` 3D explorer: save the current state as a **named view**, restore it, or delete it. Closes LIA-296.

A saved view bundles **navigation + appearance**:
- **Navigation** — expanded layers, camera position, layout mode (layered/tree), isolation, selection (the existing `snapshot()`).
- **Appearance** — the full theme (node shape/color/size, edges, scene, bloom, labels, camera control).

Views persist in `localStorage` **per-repo** (key `archexplorer.views.v1::<repo>`), so the explorer origin reused across `deus arch <repo>` runs keeps each project's views separate (deus-cmd.sh reuses one URL across projects).

## How

- **`views.js`** (new, `window.ArchViews`) — per-repo localStorage Registry (`name → {nav, theme, savedAt}`) + a top-center panel UI (name input + Save current; list of Restore/× rows). All storage access wrapped in try/catch → graceful no-op when localStorage is unavailable (private mode / quota). User-entered names rendered via `textContent` (XSS-safe). Mounts via `app.js` calling `ArchViews.init`.
- **`app.js`** — exposes the existing `snapshot`/`restore` on `window.ArchExplorer`; adds the `ArchViews.init` mount.
- **`theme.js`** — adds `getTheme()` (shallow copy, `dagMode` excluded) and `applyTheme(obj)` to the `ArchTheme` public API. `dagMode` is excluded because `nav.layoutMode` drives the dag on restore — carrying it in the saved theme would desync the dropdown (mirrors the existing localStorage-save decision).
- **`index.html` / `style.css`** — `#btn-views` button + `.av-*` panel styling.
- **`README.md`** — feature docs + per-repo / per-origin persistence caveat.

**Restore ordering:** apply the theme first (its `controlType` change may rebuild the graph; bounded by the `rebinding` guard), then animate the nav `restore()` last — `restore()` regenerates `graphData` (reseeds positions deterministically in layered mode / re-settles+frames in tree) and flies the camera to the saved viewpoint, so it lands correctly even across a controlType rebuild.

Client-side only. No host/CLI/TypeScript changes, no new deps. Pattern: extends app.js's in-memory **Memento** (snapshot/restore) to named, persisted mementos.

## Verification

No JS test harness exists for the explorer (README: UI verified manually). Verified live over `python3 -m http.server` against a real DOM:
- Save persists to the per-repo key and **survives a page reload**.
- Restore reapplies expanded layers **and** theme (scheme/shape/monoColor).
- Delete removes the correct entry; delete-under-quota-failure shows a visible status message.
- Empty name rejected; duplicate name overwrites to a single entry (confirm()).
- **Per-repo isolation** confirmed; a malicious view name renders as `textContent` (no `<img>` element created).
- Zero console errors from the feature; single panel in production.

Reviewed by plan-reviewer (SHIP after revisions) and code-reviewer (SHIP; 2 error-handling fixes + 1 UX status-message rec applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)