### PR TITLE
feat(linear): sort pending block by priority, fix webhook multi-team clobber

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,9 @@ LINEAR_API_TOKEN=
 # LINEAR_FETCH_TIMEOUT_MS=15000
 # Optional: Linear team ID override (auto-discovered if only one team)
 # LINEAR_TEAM_ID=
+# Optional: comma-separated team IDs for the multi-team pending/home block.
+# Takes precedence over LINEAR_TEAM_ID. Unset = discover all teams.
+# LINEAR_TEAM_IDS=
 # Webhook secret for Linear event verification (HMAC-SHA256)
 # LINEAR_WEBHOOK_SECRET=
 # Port for webhook server (default: 3005)

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781449539
+last_verified: "2026-06-15" # auto-bump @1781502755
 governs:
   - src/
   - evolution/

--- a/scripts/sync_linear_pending.py
+++ b/scripts/sync_linear_pending.py
@@ -39,6 +39,11 @@ STATE_PRIORITY = {
     "Backlog": 5,
 }
 
+# Linear issue priority: 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low.
+# Remap so Urgent sorts first and "No priority" sorts last.
+# Keep in sync with PRIORITY_RANK in src/linear-vault-sync.ts.
+PRIORITY_RANK = {1: 0, 2: 1, 3: 2, 4: 3, 0: 4}
+
 EXCLUDED_STATES = {"Done", "Canceled", "Duplicate"}
 
 QUERY = """
@@ -53,6 +58,7 @@ query($teamId: ID!) {
     nodes {
       title
       identifier
+      priority
       state { name type }
     }
   }
@@ -160,6 +166,7 @@ def _cache_is_fresh(cache: Path, db: Path) -> bool:
 
 def _format_pending(issues: list[dict]) -> str:
     issues.sort(key=lambda i: (
+        PRIORITY_RANK.get(i.get("priority", 0), 4),
         STATE_PRIORITY.get(i.get("state", {}).get("name", ""), 99),
         int(re.sub(r"\D", "", i.get("identifier", "0")) or "0"),
     ))

--- a/src/linear-vault-sync.test.ts
+++ b/src/linear-vault-sync.test.ts
@@ -11,6 +11,7 @@ function mockLinearClient(
     url: string;
     stateName: string;
     stateType: string;
+    priority?: number;
   }>,
 ) {
   // Only .issues() is exercised; full LinearClient has ~40 methods
@@ -20,6 +21,7 @@ function mockLinearClient(
         title: i.title,
         identifier: i.identifier,
         url: i.url,
+        priority: i.priority,
         state: Promise.resolve({ name: i.stateName, type: i.stateType }),
       })),
     }),
@@ -108,6 +110,91 @@ describe('fetchActiveIssues', () => {
       'LIA-8',
       'LIA-10',
     ]);
+  });
+
+  it('sorts by issue priority first: Urgent before High before None', async () => {
+    // Same state (Backlog) so only priority distinguishes them.
+    // Linear priority: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low.
+    const client = mockLinearClient([
+      {
+        title: 'No priority',
+        identifier: 'LIA-1',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        priority: 0,
+      },
+      {
+        title: 'High',
+        identifier: 'LIA-2',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        priority: 2,
+      },
+      {
+        title: 'Urgent',
+        identifier: 'LIA-3',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        priority: 1,
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result.map((i) => i.identifier)).toEqual([
+      'LIA-3', // Urgent
+      'LIA-2', // High
+      'LIA-1', // None (last)
+    ]);
+  });
+
+  it('priority outranks state and identifier (frozen LIA-9/LIA-10 case)', async () => {
+    // Urgent LIA-9 must sort before Medium LIA-10 even though both are Backlog
+    // and LIA-9 has the higher number.
+    const client = mockLinearClient([
+      {
+        title: 'Medium task',
+        identifier: 'LIA-10',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        priority: 3,
+      },
+      {
+        title: 'Urgent task',
+        identifier: 'LIA-9',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        priority: 1,
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result.map((i) => i.identifier)).toEqual(['LIA-9', 'LIA-10']);
+  });
+
+  it('treats missing priority as No priority (sorts last)', async () => {
+    const client = mockLinearClient([
+      {
+        title: 'Unset priority',
+        identifier: 'LIA-1',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        // priority omitted -> undefined -> 0 -> rank last
+      },
+      {
+        title: 'Urgent',
+        identifier: 'LIA-2',
+        url: '',
+        stateName: 'Backlog',
+        stateType: 'backlog',
+        priority: 1,
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result.map((i) => i.identifier)).toEqual(['LIA-2', 'LIA-1']);
   });
 });
 

--- a/src/linear-vault-sync.ts
+++ b/src/linear-vault-sync.ts
@@ -15,10 +15,16 @@ const STATE_PRIORITY: Record<string, number> = {
 
 const EXCLUDED_STATE_TYPES = new Set(['completed', 'canceled']);
 
+// Linear issue priority: 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low.
+// Remap so Urgent sorts first and "No priority" sorts last. Mirrors
+// PRIORITY_RANK in scripts/sync_linear_pending.py — keep the two in lockstep.
+const PRIORITY_RANK: Record<number, number> = { 1: 0, 2: 1, 3: 2, 4: 3, 0: 4 };
+
 interface LinearIssueNode {
   title: string;
   identifier: string;
   url: string;
+  priority: number;
   state: { name: string; type: string };
 }
 
@@ -47,11 +53,15 @@ export async function fetchActiveIssues(
       title: node.title,
       identifier: node.identifier,
       url: node.url,
+      priority: node.priority ?? 0,
       state: { name: state.name, type: state.type },
     });
   }
 
   issues.sort((a, b) => {
+    const ra = PRIORITY_RANK[a.priority] ?? 4;
+    const rb = PRIORITY_RANK[b.priority] ?? 4;
+    if (ra !== rb) return ra - rb;
     const pa = STATE_PRIORITY[a.state.name] ?? 99;
     const pb = STATE_PRIORITY[b.state.name] ?? 99;
     if (pa !== pb) return pa - pb;

--- a/src/linear-webhook.test.ts
+++ b/src/linear-webhook.test.ts
@@ -28,6 +28,7 @@ import {
   retryWithBackoff,
   _setSleepFnForTests,
   runInlineCompletionCheck,
+  shouldSyncVaultForTeam,
 } from './linear-webhook.js';
 import { RetryableError, UserError, FatalError } from './errors/index.js';
 
@@ -1139,5 +1140,43 @@ describe('computeScopeLabelChanges – gate-error guard', () => {
       gateLabels,
     );
     expect(result.addIds).toContain('label-revise');
+  });
+});
+
+describe('shouldSyncVaultForTeam', () => {
+  const ORIG_IDS = process.env.LINEAR_TEAM_IDS;
+  const ORIG_ID = process.env.LINEAR_TEAM_ID;
+
+  afterEach(() => {
+    if (ORIG_IDS === undefined) delete process.env.LINEAR_TEAM_IDS;
+    else process.env.LINEAR_TEAM_IDS = ORIG_IDS;
+    if (ORIG_ID === undefined) delete process.env.LINEAR_TEAM_ID;
+    else process.env.LINEAR_TEAM_ID = ORIG_ID;
+  });
+
+  it('stands down when LINEAR_TEAM_IDS (multi-team view) is set', () => {
+    process.env.LINEAR_TEAM_IDS = 'team-a,team-b';
+    process.env.LINEAR_TEAM_ID = 'team-a';
+    expect(shouldSyncVaultForTeam('team-a')).toBe(false);
+  });
+
+  it('syncs when single LINEAR_TEAM_ID equals the event team', () => {
+    delete process.env.LINEAR_TEAM_IDS;
+    process.env.LINEAR_TEAM_ID = 'team-a';
+    expect(shouldSyncVaultForTeam('team-a')).toBe(true);
+  });
+
+  it('stands down when single LINEAR_TEAM_ID differs from the event team', () => {
+    delete process.env.LINEAR_TEAM_IDS;
+    process.env.LINEAR_TEAM_ID = 'team-a';
+    expect(shouldSyncVaultForTeam('team-b')).toBe(false);
+  });
+
+  it('stands down when neither var is set (discover-all is multi-team)', () => {
+    // Consequence: real-time vault refresh is disabled in discover-all mode;
+    // the SessionStart hook (+ TTL) maintains the block instead.
+    delete process.env.LINEAR_TEAM_IDS;
+    delete process.env.LINEAR_TEAM_ID;
+    expect(shouldSyncVaultForTeam('team-a')).toBe(false);
   });
 });

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -202,12 +202,29 @@ function isNonRetryableHttpError(err: unknown): boolean {
 
 let _syncTimer: ReturnType<typeof setTimeout> | null = null;
 
-function debouncedVaultSync(ctx: LinearContext, vaultPath: string): void {
+// A webhook carries one team's event and can't rebuild a multi-team pending
+// block, so it does its real-time refresh ONLY in the unambiguous single-team
+// case; otherwise it stands down and lets the SessionStart hook own the block.
+// `eventTeamId` MUST be the webhook payload's team, not ctx.teamId (which is
+// derived from LINEAR_TEAM_ID, making the comparison a tautology).
+export function shouldSyncVaultForTeam(eventTeamId: string): boolean {
+  if (process.env.LINEAR_TEAM_IDS) return false;
+  const single = process.env.LINEAR_TEAM_ID;
+  return !!single && single === eventTeamId;
+}
+
+function debouncedVaultSync(
+  ctx: LinearContext,
+  vaultPath: string,
+  eventTeamId: string,
+): void {
+  if (!shouldSyncVaultForTeam(eventTeamId)) return;
+
   if (_syncTimer) clearTimeout(_syncTimer);
   _syncTimer = setTimeout(async () => {
     _syncTimer = null;
     try {
-      await syncVaultPending(ctx.client, ctx.teamId, vaultPath);
+      await syncVaultPending(ctx.client, eventTeamId, vaultPath);
     } catch (err) {
       logger.debug({ err }, 'vault-sync: failed to sync pending block');
     }
@@ -1984,7 +2001,7 @@ export function startLinearWebhookServer(
     }
 
     if (ctx.vaultPath) {
-      debouncedVaultSync(ctx, ctx.vaultPath);
+      debouncedVaultSync(ctx, ctx.vaultPath, d.teamId);
     }
 
     handleIssueUpdate(raw, ctx, gateSpecs).catch((err) => {


### PR DESCRIPTION
## Summary

Builds on #824 (multi-team pending block). Fixes two things #824 left open.

### 1. Priority sort
Neither the SessionStart path (`sync_linear_pending.py`) nor the webhook path (`linear-vault-sync.ts`) considered Linear issue **priority** — an Urgent issue sorted by workflow state and could land mid-list. Both now sort by priority first (Urgent > High > Medium > Low > None), then state, then issue number. `PRIORITY_RANK` is duplicated across the two runtimes by necessity and cross-referenced in both.

Because issues are pooled across teams before sorting, an Urgent issue from any team sorts above lower-priority in-progress items. This is intended — it matches Linear's own priority view.

### 2. Webhook multi-team clobber
#824 made the pending block multi-team, but the live webhook still overwrote it with **only the single dispatch team's** issues on every event. New pure predicate `shouldSyncVaultForTeam`:

- `LINEAR_TEAM_IDS` set (multi-team view) → stand down (SessionStart hook + 60min TTL owns the block).
- else `LINEAR_TEAM_ID` set and equal to the event's team → real-time sync.
- else → stand down.

The guard keys off the **event's** team id, not `ctx.teamId` (which is derived from `LINEAR_TEAM_ID`, so that comparison would be a tautology). Trade-off: in multi-team mode the webhook no longer refreshes the block in real time, deferring to the SessionStart path — acceptable, since a webhook only carries one team's event and can't rebuild a complete multi-team block anyway.

Also documents `LINEAR_TEAM_IDS` in `.env.example` (omitted by #824).

## Test plan
- `npm run build` clean; 98 tests pass across `linear-vault-sync.test.ts` + `linear-webhook.test.ts`.
- New tests: priority-sort ordering (Urgent-first, missing-priority-last, frozen LIA-9-before-LIA-10), and all four `shouldSyncVaultForTeam` branches.
- Python sort verified standalone against a frozen prediction; live run with `LINEAR_TEAM_IDS=<team>` fetched that team's issues with the Urgent issue sorted first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)