### PR TITLE
refactor(env): migrate remaining || env-parse sites to envPositiveInt (LIA-297)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781449539
+last_verified: "2026-06-15" # auto-bump @1781509379
 governs:
   - src/
   - evolution/

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -23,6 +23,7 @@ import { logger } from './logger.js';
 import { extractPrUrl } from './pr-url-extractor.js';
 import { notifyPipelineStep } from './linear-notifications.js';
 import { fireAndForget } from './async/index.js';
+import { envPositiveInt } from './env-utils.js';
 import type { LinearContext } from './linear-dispatcher.js';
 
 const execFileAsync = promisify(execFile);
@@ -363,7 +364,7 @@ async function pollUntilMergeable(
   // Max CI-poll cycles before parking a still-pending PR (LIA-215). 20 × 60s ≈
   // 20 min — generous headroom over this repo's ~3-min CI. Read at call time so
   // it's env-overridable (and test-tunable) without a restart.
-  const maxAttempts = Number(process.env.AUTO_MERGE_POLL_MAX_ATTEMPTS) || 20;
+  const maxAttempts = envPositiveInt('AUTO_MERGE_POLL_MAX_ATTEMPTS', 20);
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     await new Promise<void>((resolve) =>
       setTimeout(resolve, CI_POLL_INTERVAL_MS),

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -37,6 +37,7 @@ import { defaultSession } from './agent-runtimes/types.js';
 import { CONTAINER_TIMEOUT_ERROR_PREFIX } from './container-runner.js';
 import { resolveGroupIpcPath } from './group-folder.js';
 import { getBus } from './events/bus.js';
+import { envPositiveInt } from './env-utils.js';
 import type {
   RunContext,
   RuntimeEventSink,
@@ -53,8 +54,10 @@ const DEFAULT_POLL_MS = 30_000;
 // Deadline ceiling for a single Linear poll fetch (env-overridable). The effective
 // per-poll timeout (_fetchTimeoutMs) is derived from the active poll interval so it
 // is always < the interval — a hung fetch can never overlap the next tick.
-const LINEAR_FETCH_TIMEOUT_MS =
-  Number(process.env.LINEAR_FETCH_TIMEOUT_MS) || 15_000;
+const LINEAR_FETCH_TIMEOUT_MS = envPositiveInt(
+  'LINEAR_FETCH_TIMEOUT_MS',
+  15_000,
+);
 // Effective per-poll fetch deadline. Recomputed by startLinearDispatcher and
 // setPollInterval (which co-manage _timer) so it tracks the live poll interval.
 let _fetchTimeoutMs = LINEAR_FETCH_TIMEOUT_MS;


### PR DESCRIPTION
## What

Migrates the two inline `Number(process.env.X) || default` env-parse sites left unmigrated by LIA-293 (#823) to the shared `envPositiveInt(name, fallback)` helper in `src/env-utils.ts`:

- `src/linear-dispatcher.ts` — `LINEAR_FETCH_TIMEOUT_MS` (per-poll Linear fetch deadline ceiling; const name preserved, RHS swap)
- `src/linear-auto-merge.ts` — `AUTO_MERGE_POLL_MAX_ATTEMPTS` → `maxAttempts` (CI-poll cycle cap in `pollUntilMergeable`)

## Why

The `Number(env) || default` form silently falls back when the value is `0` (`0 || default === default`) — precisely the trap `envPositiveInt` was created to prevent. The helper's `Number.isFinite(n) && n > 0` guard **preserves that behavior exactly** and additionally rejects negative/NaN values.

## Safety

- `0` is never a legitimate value at either site (a 0ms timeout / 0 poll-attempts is a misconfiguration), so semantics are unchanged.
- No test sets either var to `0`; `linear-auto-merge.test.ts` uses `'2'` (positive, unaffected) and the delete path (fallback, unaffected).
- Neither var is `DEUS_*`-prefixed, so flag_lint is uninvolved.

## Testing

- `npm run build` clean
- Targeted: `linear-dispatcher.test.ts` + `linear-auto-merge.test.ts` — 111/111 pass
- Full suite: `npx vitest run` — **1614/1614 pass**

Reviews: plan-reviewer SHIP, code-reviewer SHIP, ai-eng-warden SHIP.

Closes LIA-297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)