### PR TITLE
feat(linear-sync): exclude Icebox state from the pending-block sync

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-15" # auto-bump @1781511586
+last_verified: "2026-06-15" # auto-bump @1781519451
 governs:
   - src/
   - evolution/

--- a/scripts/sync_linear_pending.py
+++ b/scripts/sync_linear_pending.py
@@ -44,7 +44,11 @@ STATE_PRIORITY = {
 # Keep in sync with PRIORITY_RANK in src/linear-vault-sync.ts.
 PRIORITY_RANK = {1: 0, 2: 1, 3: 2, 4: 3, 0: 4}
 
-EXCLUDED_STATES = {"Done", "Canceled", "Duplicate"}
+# "Icebox" = someday/maybe ideas: kept in Linear but excluded from the
+# auto-loaded pending block (move back to Backlog to reactivate). It's a
+# backlog-type state, so it survives the GraphQL type filter and is dropped
+# here by name, same as Duplicate.
+EXCLUDED_STATES = {"Done", "Canceled", "Duplicate", "Icebox"}
 
 # Linear's max page size is 250; we paginate so a team with more open issues
 # is never silently truncated.

--- a/scripts/tests/test_sync_linear_pending.py
+++ b/scripts/tests/test_sync_linear_pending.py
@@ -155,6 +155,16 @@ def test_main_excluded_states_filtered(run_main):
     assert "LIA-2" in out and "LIA-1" not in out
 
 
+def test_main_icebox_state_filtered(run_main):
+    # Icebox = someday/maybe ideas; kept in Linear but excluded from the block.
+    code, out = run_main(
+        ["t1"],
+        {"t1": [_issue("LIA-1", state="Icebox"), _issue("LIA-2", state="Todo")]},
+    )
+    assert code == mod.SUCCESS
+    assert "LIA-2" in out and "LIA-1" not in out
+
+
 def test_main_single_team_output_stays_flat(run_main):
     # Back-compat: a single-team workspace renders exactly as before — header
     # line + one issue line, no per-project sub-headers.

--- a/src/linear-vault-sync.test.ts
+++ b/src/linear-vault-sync.test.ts
@@ -82,6 +82,27 @@ describe('fetchActiveIssues', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('filters out Icebox state (someday/maybe, backlog-type)', async () => {
+    const client = mockLinearClient([
+      {
+        title: 'Iced idea',
+        identifier: 'LIA-5',
+        url: '',
+        stateName: 'Icebox',
+        stateType: 'backlog',
+      },
+      {
+        title: 'Active',
+        identifier: 'LIA-6',
+        url: '',
+        stateName: 'Todo',
+        stateType: 'unstarted',
+      },
+    ]);
+    const result = await fetchActiveIssues(client, 'team-1');
+    expect(result.map((i) => i.identifier)).toEqual(['LIA-6']);
+  });
+
   it('sorts by state priority then identifier number', async () => {
     const client = mockLinearClient([
       {

--- a/src/linear-vault-sync.ts
+++ b/src/linear-vault-sync.ts
@@ -14,6 +14,9 @@ const STATE_PRIORITY: Record<string, number> = {
 };
 
 const EXCLUDED_STATE_TYPES = new Set(['completed', 'canceled']);
+// Excluded by state NAME (these survive the type filter): Duplicate, plus
+// Icebox — someday/maybe ideas kept in Linear but out of the pending block.
+const EXCLUDED_STATE_NAMES = new Set(['Duplicate', 'Icebox']);
 
 // Linear issue priority: 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low.
 // Remap so Urgent sorts first and "No priority" sorts last. Mirrors
@@ -69,7 +72,7 @@ export async function fetchActiveIssues(
     const node = result.nodes[i];
     const state = states[i];
     if (!state || EXCLUDED_STATE_TYPES.has(state.type)) continue;
-    if (state.name === 'Duplicate') continue;
+    if (EXCLUDED_STATE_NAMES.has(state.name)) continue;
     issues.push({
       title: node.title,
       identifier: node.identifier,


### PR DESCRIPTION
## Why

Follow-up to #834 (LIA-298). The auto-loaded CLAUDE.md `pending:` block was dominated by ~27 speculative `idea/*` + `research/*` issues (LIA-250–276, 283) filed in a brainstorm batch — they load every turn but aren't active work.

Solution (user-chosen): an **Icebox** Linear state (type=backlog) for someday/maybe ideas. The 27 issues were moved there — **kept in Linear, reversible per-issue** (move back to Backlog to reactivate), zero idea loss. This PR teaches both sync paths to exclude it.

## Change

Icebox is backlog-type, so it survives the GraphQL `type nin [completed, canceled]` filter and must be dropped **by name** — exactly like the existing `Duplicate` handling:
- `scripts/sync_linear_pending.py`: add `"Icebox"` to `EXCLUDED_STATES`.
- `src/linear-vault-sync.ts`: new `EXCLUDED_STATE_NAMES = {Duplicate, Icebox}` set, replacing the inline `Duplicate` check.

## Tests
- Python (+1): `test_main_icebox_state_filtered` → **16 passed**.
- TS (+1): `filters out Icebox state` → **14 passed**.
- Full `npx vitest run` → **1625 passed**. `npm run build` → clean.

## Effect
Pending block drops from ~100 → ~73 active items. No Linear issue filed for this change — the workspace hit its free issue limit (which is itself a reason iceboxing alone won't fix the *count*; see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)