### PR TITLE
test(scripts): cover config.json vault resolution tier

### DIFF
--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1114,6 +1114,86 @@ class TestCheckBenchLabels:
         rc = drift_check.check_bench_labels(repo_root)
         assert rc == 0, "Benchmark labels have drifted from vault — run drift_check.py --bench-labels"
 
+    # Existing tests all set DEUS_VAULT_PATH, bypassing the config.json tier.
+    # These exercise it directly via the expanduser-redirect pattern.
+
+    @staticmethod
+    def _redirect_config(monkeypatch, cfg_path):
+        original_expanduser = Path.expanduser
+
+        def fake_expand(self):
+            if str(self) == "~/.config/deus/config.json":
+                return cfg_path
+            return original_expanduser(self)
+
+        monkeypatch.setattr(Path, "expanduser", fake_expand)
+
+    def test_config_json_vault_used_when_env_unset(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "INFRA.md").write_text("---\ndescription: tools\n---\n")
+        cfg_dir = tmp_path / ".config" / "deus"
+        cfg_dir.mkdir(parents=True)
+        cfg_path = cfg_dir / "config.json"
+        cfg_path.write_text(json.dumps({"vault_path": str(vault)}))
+        self._redirect_config(monkeypatch, cfg_path)
+        # Isolate from real auto-memory so all_known derives only from the config vault.
+        monkeypatch.setattr(drift_check, "_AUTO_MEMORY_GLOBS", (tmp_path / "no-auto",))
+
+        root = self._make_bench(tmp_path, [
+            {"query": "test", "expected_path": "INFRA.md", "expected_paths": ["INFRA.md"]},
+        ])
+        assert drift_check.check_bench_labels(root) == 0
+        assert "OK" in capsys.readouterr().out
+
+    def test_malformed_config_json_falls_back(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        cfg_dir = tmp_path / ".config" / "deus"
+        cfg_dir.mkdir(parents=True)
+        cfg_path = cfg_dir / "config.json"
+        cfg_path.write_text("{not valid json")
+        self._redirect_config(monkeypatch, cfg_path)
+        # Hermetic: malformed config → fall through to legacy path. Patch out
+        # auto-memory AND vault enumeration so the result is deterministic
+        # regardless of whether the legacy fallback happens to exist here.
+        monkeypatch.setattr(drift_check, "_AUTO_MEMORY_GLOBS", (tmp_path / "no-auto",))
+        monkeypatch.setattr(drift_check, "_collect_vault_paths", lambda v: set())
+
+        root = self._make_bench(tmp_path, [
+            {"query": "test", "expected_path": "X.md", "expected_paths": ["X.md"]},
+        ])
+        # Must not raise on malformed JSON; no known paths → skipped, rc 0.
+        assert drift_check.check_bench_labels(root) == 0
+        assert "skipped" in capsys.readouterr().out.lower()
+
+    def test_env_var_takes_precedence_over_config(self, tmp_path, monkeypatch, capsys):
+        env_vault = tmp_path / "env_vault"
+        env_vault.mkdir()
+        (env_vault / "INFRA.md").write_text("---\ndescription: tools\n---\n")
+        monkeypatch.setenv("DEUS_VAULT_PATH", str(env_vault))
+        # Config points at a different, NON-empty vault lacking INFRA.md. If it
+        # were wrongly used, validation would find OTHER.md but not INFRA.md →
+        # "Stale"/rc 1, distinguishable from the env vault's full-pass "OK".
+        cfg_dir = tmp_path / ".config" / "deus"
+        cfg_dir.mkdir(parents=True)
+        cfg_path = cfg_dir / "config.json"
+        bad_vault = tmp_path / "cfg_vault"
+        bad_vault.mkdir()
+        (bad_vault / "OTHER.md").write_text("---\ndescription: other\n---\n")
+        cfg_path.write_text(json.dumps({"vault_path": str(bad_vault)}))
+        self._redirect_config(monkeypatch, cfg_path)
+        monkeypatch.setattr(drift_check, "_AUTO_MEMORY_GLOBS", (tmp_path / "no-auto",))
+
+        root = self._make_bench(tmp_path, [
+            {"query": "test", "expected_path": "INFRA.md", "expected_paths": ["INFRA.md"]},
+        ])
+        rc = drift_check.check_bench_labels(root)
+        # "OK" proves the env vault was validated in full, not the config vault's
+        # skip/stale path — i.e. the env var won.
+        assert rc == 0
+        assert "OK" in capsys.readouterr().out
+
 
 # ── worktree merge-base auto-default (LIA-146) ──────────────────────────────────
 

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -2267,3 +2267,85 @@ class TestStandardsPack:
         assert pos_a < pos_b < pos_c, (
             f"expected alphabetical order; positions: A={pos_a} B={pos_b} C={pos_c}"
         )
+
+
+# ── resolve_vault_path — env var → config.json → legacy fallback ───────────────
+
+
+class TestResolveVaultPath:
+    """Cover resolve_vault_path's three tiers; redirect only the config.json
+    expanduser to a tmp file (pattern from test_memory_tree_phase3.py).
+    Fallback assertions are structural to stay user-agnostic for the public repo.
+    """
+
+    @staticmethod
+    def _redirect_config(monkeypatch, cfg_path):
+        original_expanduser = Path.expanduser
+
+        def fake_expand(self):
+            if str(self) == "~/.config/deus/config.json":
+                return cfg_path
+            return original_expanduser(self)
+
+        monkeypatch.setattr(Path, "expanduser", fake_expand)
+
+    @staticmethod
+    def _write_config(tmp_path, body):
+        cfg_dir = tmp_path / ".config" / "deus"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        cfg_path = cfg_dir / "config.json"
+        cfg_path.write_text(body)
+        return cfg_path
+
+    def test_env_var_takes_precedence(self, tmp_path, monkeypatch):
+        env_vault = tmp_path / "env_vault"
+        monkeypatch.setenv("DEUS_VAULT_PATH", str(env_vault))
+        # Config present but must be ignored when the env var is set.
+        cfg_path = self._write_config(
+            tmp_path, json.dumps({"vault_path": str(tmp_path / "cfg_vault")})
+        )
+        self._redirect_config(monkeypatch, cfg_path)
+        assert mt.resolve_vault_path() == Path(str(env_vault))
+
+    def test_config_json_used_when_env_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        cfg_vault = tmp_path / "cfg_vault"
+        cfg_path = self._write_config(
+            tmp_path, json.dumps({"vault_path": str(cfg_vault)})
+        )
+        self._redirect_config(monkeypatch, cfg_path)
+        assert mt.resolve_vault_path() == Path(str(cfg_vault))
+
+    def test_missing_config_falls_back(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        # Point at a config path that does not exist (file never written).
+        cfg_path = tmp_path / ".config" / "deus" / "config.json"
+        self._redirect_config(monkeypatch, cfg_path)
+        result = mt.resolve_vault_path()
+        assert isinstance(result, Path)
+        assert str(result).endswith("Deus")  # legacy fallback (user-agnostic)
+
+    def test_malformed_config_falls_back(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        cfg_path = self._write_config(tmp_path, "{not valid json")
+        self._redirect_config(monkeypatch, cfg_path)
+        result = mt.resolve_vault_path()  # must not raise
+        assert isinstance(result, Path)
+        assert result != cfg_path
+        assert str(result).endswith("Deus")
+
+    def test_empty_vault_path_falls_back(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        cfg_path = self._write_config(tmp_path, json.dumps({"vault_path": ""}))
+        self._redirect_config(monkeypatch, cfg_path)
+        result = mt.resolve_vault_path()
+        assert isinstance(result, Path)
+        assert str(result).endswith("Deus")
+
+    def test_non_string_vault_path_falls_back(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+        cfg_path = self._write_config(tmp_path, json.dumps({"vault_path": 42}))
+        self._redirect_config(monkeypatch, cfg_path)
+        result = mt.resolve_vault_path()
+        assert isinstance(result, Path)
+        assert str(result).endswith("Deus")


### PR DESCRIPTION
## Summary
PR #702 added a config.json vault-resolution tier (`DEUS_VAULT_PATH` env → `~/.config/deus/config.json` `vault_path` → legacy fallback) to `resolve_vault_path()` (`scripts/memory_tree.py`) and `check_bench_labels()` (`scripts/drift_check.py`), but merged **without test coverage**. This adds it.

## What's covered
- **`scripts/tests/test_memory_tree.py`** — new `TestResolveVaultPath` (6 cases): env-var precedence, config.json used when env unset, and fallback on missing / malformed-JSON / empty / non-string `vault_path`. `resolve_vault_path()` previously had **zero** tests despite 3 live callers (`memory_query.py`, `memory_tree.py`, `memory_tree_hook.py`).
- **`scripts/tests/test_drift_check.py`** — 3 cases on `TestCheckBenchLabels`: config.json vault used when env unset, malformed-config fallback (hermetic), and env-var precedence. The existing tests all set `DEUS_VAULT_PATH`, bypassing the config tier.

## Notes
- Fallback assertions are structural (`str(result).endswith("Deus")`) instead of hardcoding the personal fallback path — keeps the public-repo tests user-agnostic.
- The 3 `test_drift_check.py` cases are **CI-gated** (ci.yml runs `test_drift_check.py`). `test_memory_tree.py` is **not** in CI, so its 6 cases gate locally only. **Follow-up:** add `test_memory_tree.py` to CI.

## Test plan
- [x] `pytest scripts/tests/test_drift_check.py scripts/tests/test_memory_tree.py` → 250 passed
- [x] New classes: `TestResolveVaultPath` (6) + `TestCheckBenchLabels` config cases (3) pass
- [x] `python3 scripts/drift_check.py --bench-labels` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
