### PR TITLE
fix(container): route entrypoint tsc output to stderr, not stdout (LIA-226)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -71,7 +71,9 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Container input (prompt, group info) is passed via stdin JSON.
 # Credentials are injected by the host's credential proxy — never passed here.
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && ./node_modules/.bin/tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+# tsc stdout → stderr (1>&2) keeps stdout clean for the OUTPUT_START/OUTPUT_END
+# protocol. Do NOT use `2>&1 >&2` — bash L-to-R sends BOTH streams to stdout.
+RUN printf '#!/bin/bash\nset -e\ncd /app && ./node_modules/.bin/tsc --outDir /tmp/dist 1>&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-13" # auto-bump @1781369195
+last_verified: "2026-06-16" # auto-bump @1781558131
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
## Problem (LIA-226)

The container entrypoint ran `tsc --outDir /tmp/dist 2>&1 >&2`. Bash applies redirects **left-to-right**: fd2 is duplicated onto stdout first, then fd1 onto the now-stdout fd2 — net effect, **both streams go to stdout**. Consequences:
- Pollutes the `OUTPUT_START`/`OUTPUT_END` JSON protocol channel the host parses (`src/container-runner.ts`).
- On compile failure, stderr is empty, so the host error path `Container exited with code N: ${stderr.slice(-200)}` (`container-runner.ts:824`) reports a **blank tail** — the real tsc error is lost.

## Fix

`2>&1 >&2` → `1>&2`: routes tsc's stdout diagnostics to stderr in one op. stdout stays clean for the protocol, and compile errors now surface on the host error path.

## Verification

The Dockerfile entrypoint string is not unit-testable and CI does not rebuild the container, so this rests on the empirical redirect proof:

```
OLD  bash -c '{ echo OUT; echo ERR >&2; } 2>&1 >&2'  -> stdout=[OUT,ERR]  stderr=[]
NEW  bash -c '{ echo OUT; echo ERR >&2; } 1>&2'      -> stdout=[]         stderr=[OUT,ERR]
```

Scope is **redirect-only** — the buffer-cap hardening the issue also mentions is deferred as a separate concern (the issue's own adversarial verifier called it a narrow case).

> [!NOTE]
> Runtime change: rebuild the agent container (`./container/build.sh`) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)