### PR TITLE
fix(startup): abort on ODYSSEUS_HTTP_PORT / LINEAR_WEBHOOK_PORT collision (LIA-301)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,8 @@ CREDENTIAL_PROXY_HOST_UNSAFE=
 # (Bash, edits, MCP, memory). Generate a strong token (>= 32 chars):
 #   openssl rand -hex 32
 ODYSSEUS_HTTP_ENABLED=
+# Must DIFFER from LINEAR_WEBHOOK_PORT if both are enabled — they both default
+# to 3005, and a shared port aborts startup (fatal "Port configuration" check).
 ODYSSEUS_HTTP_PORT=3005
 ODYSSEUS_HTTP_TOKEN=
 # Char budget for the conversation history folded into each web turn's prompt
@@ -136,7 +138,8 @@ LINEAR_API_TOKEN=
 # LINEAR_TEAM_IDS=
 # Webhook secret for Linear event verification (HMAC-SHA256)
 # LINEAR_WEBHOOK_SECRET=
-# Port for webhook server (default: 3005)
+# Port for webhook server (default: 3005). MUST differ from ODYSSEUS_HTTP_PORT
+# if both are enabled — the two servers cannot bind the same port (startup aborts).
 # LINEAR_WEBHOOK_PORT=3005
 # Dedicated bot user ID for pipeline loop-prevention. Leave UNSET unless the
 # pipeline runs under a SEPARATE Linear account — setting it to your OWN user id

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-15" # auto-bump @1781519451
+last_verified: "2026-06-16" # auto-bump @1781558184
 governs:
   - src/
   - evolution/

--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -53,6 +53,7 @@ import {
   hasAnyChannelAuth,
   countRegisteredGroups,
   readDeusConfig,
+  detectPortCollision,
 } from './checks.js';
 
 const mockReadEnvFile = vi.mocked(readEnvFile);
@@ -326,5 +327,95 @@ describe('countRegisteredGroups', () => {
     // The source spawns node -e with better-sqlite3 and prints the count
     mockExecFileSync.mockReturnValue('3\n' as unknown as string);
     expect(countRegisteredGroups()).toBe(3);
+  });
+});
+
+// ── detectPortCollision (LIA-301) ─────────────────────────────────────────
+
+describe('detectPortCollision', () => {
+  const PORT_VARS = [
+    'ODYSSEUS_HTTP_ENABLED',
+    'ODYSSEUS_HTTP_PORT',
+    'LINEAR_WEBHOOK_PORT',
+    'LINEAR_WEBHOOK_SECRET',
+    'LINEAR_API_KEY',
+    'LINEAR_API_TOKEN',
+  ];
+  beforeEach(() => {
+    for (const k of PORT_VARS) delete process.env[k];
+  });
+
+  it('flags a collision on the fresh-install default (both 3005, ports unset)', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({ collision: true, port: 3005 });
+  });
+
+  it('no collision when the ports differ', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: '3007',
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+  });
+
+  it('no collision when Odysseus is disabled (even on equal ports)', () => {
+    mockReadEnvFile.mockReturnValue({
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+  });
+
+  it('no collision when the webhook secret is absent (webhook would not start)', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: 'true',
+      LINEAR_API_KEY: 'lin_x',
+    });
+    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+  });
+
+  it('flags a collision when only LINEAR_API_TOKEN (not LINEAR_API_KEY) is set', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      LINEAR_API_TOKEN: 'lin_tok',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({ collision: true, port: 3005 });
+  });
+
+  it('no collision when no Linear API key/token (webhook would not start)', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+  });
+
+  it('treats a non-numeric port as the 3005 default (NaN guard)', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: 'not-a-port',
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({ collision: true, port: 3005 });
+  });
+
+  it('lets process.env win over .env (mirrors index.ts merge order)', () => {
+    process.env.ODYSSEUS_HTTP_PORT = '4000';
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: '3005',
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    // process.env says 4000, .env says 3005 → resolves 4000 ≠ 3005 → no collision
+    expect(detectPortCollision()).toEqual({ collision: false, port: null });
   });
 });

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -77,6 +77,61 @@ export function hasApiCredentials(): boolean {
   );
 }
 
+/**
+ * Detect an ODYSSEUS_HTTP_PORT / LINEAR_WEBHOOK_PORT collision (LIA-301).
+ *
+ * Both default to 3005 (config.ts ODYSSEUS_HTTP_PORT and linear-webhook.ts
+ * DEFAULT_WEBHOOK_PORT), so a fresh install that enables the Web UI while the
+ * Linear webhook is also configured tries to bind the same port twice →
+ * EADDRINUSE deep in startup. Run as a fatal startup check (startup-gate.ts)
+ * BEFORE any server binds so the operator gets an actionable message instead.
+ *
+ * Resolves both sides via readEnvFile + process.env (process.env wins, matching
+ * the index.ts:390-392 merge order) instead of importing the config.ts
+ * constants — those are frozen at module load from process.env only and would
+ * miss .env-only values, which is exactly the fresh-install case this guards.
+ * Mirrors the actual webhook-start conditions (index.ts: linearApiKey + secret)
+ * so it never false-positives when the webhook would not start.
+ */
+export function detectPortCollision(): {
+  collision: boolean;
+  port: number | null;
+} {
+  const env = readEnvFile([
+    'ODYSSEUS_HTTP_ENABLED',
+    'ODYSSEUS_HTTP_PORT',
+    'LINEAR_WEBHOOK_PORT',
+    'LINEAR_WEBHOOK_SECRET',
+    'LINEAR_API_KEY',
+    'LINEAR_API_TOKEN',
+  ]);
+  // process.env wins unless unset/empty, then fall back to .env — mirrors the
+  // index.ts:390-392 merge (`if (v && !process.env[k]) process.env[k] = v`,
+  // which also treats an empty process.env value as "use .env"). `||` (not `??`)
+  // is deliberate so an empty-string env var doesn't shadow the .env value.
+  const resolve = (k: string): string | undefined => process.env[k] || env[k];
+
+  const enabledRaw = resolve('ODYSSEUS_HTTP_ENABLED');
+  const odysseusEnabled = enabledRaw === '1' || enabledRaw === 'true';
+  const webhookWillStart =
+    !!(resolve('LINEAR_API_KEY') || resolve('LINEAR_API_TOKEN')) &&
+    !!resolve('LINEAR_WEBHOOK_SECRET');
+  if (!odysseusEnabled || !webhookWillStart) {
+    return { collision: false, port: null };
+  }
+
+  // NaN → 3005, mirroring linear-webhook.ts's own DEFAULT_WEBHOOK_PORT guard.
+  const parsePort = (raw: string | undefined): number => {
+    const n = parseInt(raw || '3005', 10);
+    return Number.isNaN(n) ? 3005 : n;
+  };
+  const odysseusPort = parsePort(resolve('ODYSSEUS_HTTP_PORT'));
+  const webhookPort = parsePort(resolve('LINEAR_WEBHOOK_PORT'));
+
+  const collision = odysseusPort === webhookPort;
+  return { collision, port: collision ? odysseusPort : null };
+}
+
 /** Check if a Gemini API key is configured for memory embeddings. */
 export function hasGeminiApiKey(): boolean {
   const env = readEnvFile(['GEMINI_API_KEY']);

--- a/src/startup-gate.test.ts
+++ b/src/startup-gate.test.ts
@@ -9,6 +9,7 @@ vi.mock('./checks.js', () => ({
   hasAnyChannelAuth: vi.fn(() => false),
   hasContainerImage: vi.fn(() => false),
   countRegisteredGroups: vi.fn(() => 0),
+  detectPortCollision: vi.fn(() => ({ collision: false, port: null })),
 }));
 
 vi.mock('./logger.js', () => ({
@@ -23,6 +24,7 @@ import {
   hasAnyChannelAuth,
   hasContainerImage,
   countRegisteredGroups,
+  detectPortCollision,
 } from './checks.js';
 import {
   runStartupChecks,
@@ -45,6 +47,7 @@ const mockHasPythonDeps = vi.mocked(hasPythonDeps);
 const mockHasAnyChannelAuth = vi.mocked(hasAnyChannelAuth);
 const mockHasContainerImage = vi.mocked(hasContainerImage);
 const mockCountRegisteredGroups = vi.mocked(countRegisteredGroups);
+const mockDetectPortCollision = vi.mocked(detectPortCollision);
 
 beforeEach(() => {
   // Reset all check mocks to failing defaults
@@ -55,6 +58,7 @@ beforeEach(() => {
   mockHasAnyChannelAuth.mockReturnValue(false);
   mockHasContainerImage.mockReturnValue(false);
   mockCountRegisteredGroups.mockReturnValue(0);
+  mockDetectPortCollision.mockReturnValue({ collision: false, port: null });
 });
 
 // ── runStartupChecks ──────────────────────────────────────────────────────
@@ -141,6 +145,24 @@ describe('runStartupChecks', () => {
     expect(report.warnings).toHaveLength(0);
     expect(report.suggestions).toHaveLength(0);
     expect(report.passed.length).toBeGreaterThan(0);
+  });
+
+  it('returns fatal when the Odysseus/Linear webhook ports collide (LIA-301)', () => {
+    mockHasApiCredentials.mockReturnValue(true);
+    mockDetectPortCollision.mockReturnValue({ collision: true, port: 3005 });
+    const report = runStartupChecks();
+    const fatal = report.fatals.find((r) => r.name === 'Port configuration');
+    expect(fatal).toBeDefined();
+    expect(fatal!.hint).toContain('3005');
+    expect(fatal!.hint).toContain('ODYSSEUS_HTTP_PORT');
+    expect(fatal!.hint).toContain('LINEAR_WEBHOOK_PORT');
+  });
+
+  it('puts Port configuration in passed when there is no collision', () => {
+    mockHasApiCredentials.mockReturnValue(true);
+    const report = runStartupChecks();
+    const passedNames = report.passed.map((r) => r.name);
+    expect(passedNames).toContain('Port configuration');
   });
 });
 

--- a/src/startup-gate.ts
+++ b/src/startup-gate.ts
@@ -18,6 +18,7 @@ import {
   hasAnyChannelAuth,
   hasContainerImage,
   countRegisteredGroups,
+  detectPortCollision,
 } from './checks.js';
 import { DEFAULT_AGENT_RUNTIME } from './config.js';
 import { logger } from './logger.js';
@@ -55,6 +56,24 @@ registerStartupCheck({
     ok: hasApiCredentials(),
     hint: 'Set ANTHROPIC_API_KEY or run `claude login` for Claude; set OPENAI_API_KEY or run `codex login` for OpenAI',
   }),
+});
+
+registerStartupCheck({
+  name: 'Port configuration',
+  level: 'fatal',
+  run: () => {
+    const { collision, port } = detectPortCollision();
+    return {
+      name: 'Port configuration',
+      level: 'fatal',
+      ok: !collision,
+      // hint is only surfaced for non-ok results (formatResult), but keep it
+      // truthful on both paths rather than rendering "both null" on success.
+      hint: collision
+        ? `ODYSSEUS_HTTP_PORT and LINEAR_WEBHOOK_PORT are both ${port}. The Web UI and Linear webhook servers cannot share a port — set one to a different value in .env.`
+        : 'Web UI and Linear webhook ports are distinct.',
+    };
+  },
 });
 
 registerStartupCheck({


### PR DESCRIPTION
## Problem (LIA-301)

`ODYSSEUS_HTTP_PORT` (config.ts, default 3005) and `LINEAR_WEBHOOK_PORT` (linear-webhook.ts `DEFAULT_WEBHOOK_PORT`, default 3005) collide. On a fresh install with the Web UI enabled (`ODYSSEUS_HTTP_ENABLED=1`) and a Linear webhook configured, both servers try to bind 3005 → opaque `EADDRINUSE` deep in startup. This machine dodges it via an env-specific `ODYSSEUS_HTTP_PORT=3007`, but the defaults still collide for a new user.

## Fix

Fail fast with an actionable message instead of an opaque bind error:

- New pure helper `detectPortCollision()` in `src/checks.ts`.
- Registered as a `level:'fatal'` **"Port configuration"** check in `src/startup-gate.ts`, so `runStartupChecks()` aborts at `index.ts:80` — **before any server binds** (Odysseus binds at :370, webhook later) — naming both vars and the shared port.

Chose a fail-fast guard over changing the default: it doesn't silently change behavior for existing port-3005 single-server users, and surfaces the misconfig instead of a cryptic `EADDRINUSE`.

### Resolution details
- Resolves both sides via `readEnvFile` + `process.env` (`process.env` wins, mirroring the `index.ts:390-392` merge incl. its empty-string semantics) **instead of** importing the frozen `config.ts` constants — those are evaluated from `process.env` only at module load and would miss `.env`-only values, which is exactly the fresh-install case this guards.
- `webhookWillStart` mirrors the **actual** webhook-start conditions (`linearApiKey` at index.ts:393-394 **and** `LINEAR_WEBHOOK_SECRET` at :421), so it never false-positives when the webhook would not start.
- Non-numeric port → 3005, mirroring `linear-webhook.ts`'s own `DEFAULT_WEBHOOK_PORT` guard.

## Tests

10 new (build clean, full suite **1635 passed / 0 failed**):
- `checks.test.ts` (8): fresh-install default collision, ports-differ, odysseus-disabled, no-secret, token-only, no-key, NaN-guard, `process.env` precedence.
- `startup-gate.test.ts` (2): fatal-on-collision + passed-when-no-collision.

Live-safe: this host resolves 3007 vs 3005 (differ) → check stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)