### PR TITLE
fix(skills): expand ~ in /handoff vault path resolution

### DIFF
--- a/.claude/skills/handoff/skill.md
+++ b/.claude/skills/handoff/skill.md
@@ -14,7 +14,8 @@ This skill runs **host-side** (like `/compress` and `/resume`), so it resolves t
 
 1. **Resolve vault path** — read `vault_path` from `~/.config/deus/config.json`; if the env var `DEUS_VAULT_PATH` is set, it overrides. `$VAULT` means this resolved path. Fail loudly if neither is set — never write to a guessed path:
    ```bash
-   VAULT="${DEUS_VAULT_PATH:-$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.config/deus/config.json'))).get('vault_path',''))" 2>/dev/null)}"
+   VAULT="${DEUS_VAULT_PATH:-$(python3 -c "import json,os;print(os.path.expanduser(json.load(open(os.path.expanduser('~/.config/deus/config.json'))).get('vault_path','')))" 2>/dev/null)}"
+   VAULT="${VAULT/#\~/$HOME}"  # expand a leading ~ (e.g. from DEUS_VAULT_PATH); expanduser already handled the config value
    [ -z "$VAULT" ] && { echo "handoff: cannot resolve vault path — set DEUS_VAULT_PATH or config.json vault_path"; exit 1; }
    ```
 


### PR DESCRIPTION
## Problem

`/handoff` called `os.path.expanduser` on the config file path but not on the `vault_path` value read from it. When `~/.config/deus/config.json` stores `vault_path` with a leading `~` (e.g. `~/Documents/Obsidian Vaults/deus`), `$VAULT` became a literal `~`-prefixed string, and the subsequent `mkdir -p "$(dirname "$HANDOFF_FILE")"` created a literal `~` directory inside the current working directory instead of writing into the vault.

## Solution

- Wrap the read `vault_path` value in `os.path.expanduser(...)`.
- Add a bash-native leading-`~` expansion (`${VAULT/#\~/$HOME}`) so a tilde in `DEUS_VAULT_PATH` is handled too.

## Verification

Before: snippet output = `~/Documents/Obsidian Vaults/deus` (literal tilde).
After: `/Users/<user>/Documents/Obsidian Vaults/deus` — resolves to the real vault dir.

## Scope

Only `.claude/skills/handoff/skill.md` has this mechanical one-liner. The sibling skills (compress / resume / checkpoint / preserve) resolve the vault via prose and rely on the agent to expand, so they are not mechanically affected — noted as a follow-up in the issue.

Fixes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)