### PR TITLE
feat(cli): repurpose `deus web` to launch the Open WebUI

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -647,16 +647,104 @@ sys.exit(1)
         ;;
     esac
     ;;
-  home|web|"")
-    # `deus web` launches with --chrome for Claude-in-Chrome browser integration.
-    # Otherwise identical to bare `deus` / `deus home`.
+  web)
+    # Launch the Deus web UI (Open WebUI), the GUI for the Odysseus web channel.
+    # Container-state dispatch: inspect running state -> skip / start / create.
+    FRONTEND_PORT=3000
+    WEBUI_URL="http://localhost:$FRONTEND_PORT"
+
+    # Resolve the Odysseus backend port (first non-empty wins):
+    #   exported env -> .env -> macOS launchd plist -> default 3005.
+    # NOTE (LIA-301): 3005 is the documented config.ts / .env.example default but
+    # collides with the Linear-webhook default. This host's plist sets it to 3007.
+    BACKEND_PORT="$ODYSSEUS_HTTP_PORT"
+    if [ -z "$BACKEND_PORT" ] && [ -f "$SCRIPT_DIR/.env" ]; then
+      BACKEND_PORT=$(grep '^ODYSSEUS_HTTP_PORT=' "$SCRIPT_DIR/.env" | head -1 | cut -d= -f2-)
+    fi
+    if [ -z "$BACKEND_PORT" ] && [ -f "$PLIST" ] && [ -x /usr/libexec/PlistBuddy ]; then
+      BACKEND_PORT=$(/usr/libexec/PlistBuddy -c "Print :EnvironmentVariables:ODYSSEUS_HTTP_PORT" "$PLIST" 2>/dev/null)
+    fi
+    if [ -z "$BACKEND_PORT" ]; then
+      BACKEND_PORT=3005
+      echo "  Note: backend port not set; defaulting to 3005. Set ODYSSEUS_HTTP_PORT in .env to be explicit."
+    fi
+
+    # Docker preflight.
+    if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+      echo "Docker is required for the Deus web UI. Start Docker Desktop and retry."
+      exit 1
+    fi
+
+    _webui_wait_budget=90  # default; first-run create overrides to 120 below
+    _webui_running=$(docker inspect -f '{{.State.Running}}' open-webui 2>/dev/null)
+    if [ "$_webui_running" = "true" ]; then
+      echo "  Open WebUI already running."
+    elif [ "$_webui_running" = "false" ]; then
+      echo "  Starting Open WebUI container..."
+      docker start open-webui >/dev/null || { echo "Failed to start the Open WebUI container."; exit 1; }
+    else
+      # Container does not exist -> first-run create.
+      echo "  First run: creating the Open WebUI container (pulls the image on a clean host)..."
+      TOKEN=""
+      [ -f "$SCRIPT_DIR/.env" ] && TOKEN=$(grep '^ODYSSEUS_HTTP_TOKEN=' "$SCRIPT_DIR/.env" | head -1 | cut -d= -f2-)
+      if [ -z "$TOKEN" ]; then
+        echo "  Warning: ODYSSEUS_HTTP_TOKEN not found in .env — the UI won't reach the backend until it is set."
+      fi
+      # host.docker.internal is native on Docker Desktop (Mac/Win); only Linux
+      # needs the explicit host-gateway mapping (mirrors hostGatewayArgs() in
+      # src/platform.ts).
+      _add_host=()
+      [ "$(uname)" = "Linux" ] && _add_host=(--add-host=host.docker.internal:host-gateway)
+      docker run -d \
+        --name open-webui \
+        -p "$FRONTEND_PORT:8080" \
+        --restart unless-stopped \
+        "${_add_host[@]}" \
+        -e OPENAI_API_BASE_URL="http://host.docker.internal:$BACKEND_PORT/v1" \
+        -e OPENAI_API_KEY="$TOKEN" \
+        -e WEBUI_NAME="Deus" \
+        -v open-webui:/app/backend/data \
+        ghcr.io/open-webui/open-webui:main >/dev/null || {
+          echo "Failed to create the Open WebUI container."; exit 1; }
+      _webui_wait_budget=120
+    fi
+
+    # Non-fatal backend reachability check (401/405 = alive but gated).
+    _be_code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$BACKEND_PORT/v1/models" --max-time 4 2>/dev/null)
+    case "$_be_code" in
+      200|401|405) ;;
+      *) echo "  Warning: Deus backend not reachable on port $BACKEND_PORT (HTTP '$_be_code'). The service may be down — check 'deus logs'." ;;
+    esac
+
+    # Wait for the UI to answer, then open the browser.
+    printf "  Waiting for Open WebUI"
+    _elapsed=0
+    while [ "$_elapsed" -lt "$_webui_wait_budget" ]; do
+      if [ "$(curl -s -o /dev/null -w '%{http_code}' "$WEBUI_URL/health" --max-time 3 2>/dev/null)" = "200" ]; then
+        break
+      fi
+      printf "."
+      sleep 2
+      _elapsed=$((_elapsed + 2))
+    done
+    echo ""
+    if [ "$_elapsed" -ge "$_webui_wait_budget" ]; then
+      echo "  Open WebUI is still starting — give it a moment, then open: $WEBUI_URL"
+    else
+      echo "  Open WebUI ready: $WEBUI_URL"
+    fi
+    echo "  (First-ever use: create a local admin account, then pick the 'deus' model.)"
+    ( sleep 1; python3 -m webbrowser "$WEBUI_URL" >/dev/null 2>&1 ) &
+    ;;
+  home|"")
+    # Bare `deus` / `deus home`. Optional --chrome / TUI via config keys.
     CHROME_FLAG=""
     TUI_DEFAULT="false"
     AGENTS_MODE="false"
-    if [ "$1" = "web" ] || [ "$(_read_config_key chrome_default)" = "true" ]; then
+    if [ "$(_read_config_key chrome_default)" = "true" ]; then
       CHROME_FLAG="--chrome"
     fi
-    if [ "$1" != "web" ] && [ "$(_read_config_key tui_default)" = "true" ]; then
+    if [ "$(_read_config_key tui_default)" = "true" ]; then
       TUI_DEFAULT="true"
     fi
     for _arg in "$@"; do
@@ -1458,7 +1546,8 @@ $STARTUP_INSTRUCTION"
     echo "  deus auth       Validate credentials and rebuild+restart"
     echo "  deus auth refresh [--dry-run]  Proactive OAuth token refresh (scheduled every 30 min by launchd)"
     echo "  deus build      Compile TypeScript and restart the service (--no-restart, --quiet)"
-    echo "  deus web        Same as 'deus' but launches claude with --chrome (Claude-in-Chrome integration)"
+    echo "  deus web        Launch the Deus web UI (Open WebUI): start/create the container and open the browser"
+    echo "                    (Claude-in-Chrome is now opt-in via the chrome_default config key)"
     echo "  deus backend    Manage default AI backend and model (show|set|model|list)"
     echo "  deus gcal       Google Calendar token management (status|auth|ping)"
     echo "  deus listen     Record from mic, transcribe, and copy to clipboard"


### PR DESCRIPTION
## What

Repurposes the `deus web` subcommand to launch the **Open WebUI** — the browser GUI that fronts the always-on Odysseus OpenAI-compatible web channel — instead of launching `claude --chrome` (Claude-in-Chrome).

The Claude-in-Chrome behavior is **not lost**: it's already reachable via the existing `chrome_default` config key, which the `home|""` arm still honors.

## The new `web)` arm

- **Backend port resolution** (first non-empty wins): `$ODYSSEUS_HTTP_PORT` → `.env` → macOS launchd plist (PlistBuddy, guarded) → default `3005`.
  - Note (LIA-301): `3005` mirrors the `config.ts` / `.env.example` default but collides with the Linear-webhook default; this host's plist sets `3007`. A hint is printed when the port falls through to the default.
- **Docker preflight**: clear message + `exit 1` if Docker is unavailable.
- **Container-state dispatch** via `docker inspect -f '{{.State.Running}}'`:
  - running → skip, stopped → `docker start`, missing → `docker run -d` wired to `host.docker.internal:<backend_port>/v1` with `OPENAI_API_KEY` read from `.env` at runtime.
- **Non-fatal backend reachability check**, then a health poll on `:3000/health` (90s budget; 120s on first-run create), then opens the browser via `python3 -m webbrowser`.
- Help text updated.

## Cross-platform

- `--add-host=host.docker.internal:host-gateway` is gated to **Linux only** (Docker Desktop on Mac/Win injects `host.docker.internal` natively); mirrors `hostGatewayArgs()` in `src/platform.ts`.
- PlistBuddy/plist read is macOS-only and guarded; non-macOS falls through to `.env` / default.

## Security

- Token read from `.env` at runtime, passed only via `docker run -e`, **never echoed** to stdout/logs. It is visible to local `docker inspect` (inherent Docker `-e` limitation) — localhost-scoped, same trust level as reading `.env`.

## Verification

- `zsh -n deus-cmd.sh` passes.
- All three lifecycle paths run live: already-running, stopped→start, missing→create.
- On recreate, the container reaches the backend: `/v1/models` → HTTP 200, model `deus`.
- plan-reviewer SHIP (after one REVISE round) and code-reviewer SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)