### PR TITLE
feat(odysseus): auto-consolidate Web UI conversations into vault memory (LIA-295)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,12 @@ ODYSSEUS_HTTP_TOKEN=
 # Char budget for the conversation history folded into each web turn's prompt
 # (LIA-294). Oldest messages are dropped first. Default 24000.
 ODYSSEUS_MAX_HISTORY_CHARS=24000
+# Auto-consolidate Web UI conversations into vault memory (LIA-295). ON by
+# default; set to 0 (or false) to disable. A conversation is saved + indexed
+# once it reaches MIN_TURNS user messages OR MIN_CHARS of transcript.
+DEUS_WEBUI_CONSOLIDATE=1
+DEUS_WEBUI_CONSOLIDATE_MIN_TURNS=3
+DEUS_WEBUI_CONSOLIDATE_MIN_CHARS=200
 
 # === Evolution / Eval ===
 EMBEDDING_PROVIDER=auto

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-16" # auto-bump @1781558184
+last_verified: "2026-06-16" # auto-bump @1781603212
 governs:
   - src/
   - evolution/

--- a/src/auto-compress.ts
+++ b/src/auto-compress.ts
@@ -1,20 +1,11 @@
-import { spawn } from 'child_process';
-import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
 
-import { fireAndForget } from './async/index.js';
-import { ASSISTANT_NAME, PROJECT_ROOT } from './config.js';
+import { ASSISTANT_NAME } from './config.js';
 import { getMessagesSince } from './db.js';
 import { logger } from './logger.js';
-import { PYTHON_BIN } from './platform.js';
+import { writeSessionLogAndIndex } from './memory-session-log.js';
 import { resolveVaultPath } from './solutions/index.js';
 import type { RegisteredGroup } from './types.js';
-
-const MEMORY_INDEXER_PATH = path.join(
-  PROJECT_ROOT,
-  'scripts',
-  'memory_indexer.py',
-);
 
 /**
  * Save the current session's conversation to the vault before an idle reset
@@ -85,26 +76,7 @@ tldr: |
 ${body}
 `;
 
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(savedPath, content, 'utf-8');
-
-  fireAndForget(
-    () =>
-      new Promise<void>((resolve, reject) => {
-        const child = spawn(
-          PYTHON_BIN,
-          [MEMORY_INDEXER_PATH, '--add', savedPath],
-          {
-            stdio: ['ignore', 'ignore', 'pipe'],
-          },
-        );
-        child.on('close', (code) =>
-          code === 0 ? resolve() : reject(new Error(`indexer exit ${code}`)),
-        );
-        child.on('error', reject);
-      }),
-    { name: 'auto-compress-index' },
-  );
+  writeSessionLogAndIndex(savedPath, content, 'auto-compress-index');
 
   logger.info(
     { group: group.name, path: savedPath },

--- a/src/memory-session-log.ts
+++ b/src/memory-session-log.ts
@@ -1,0 +1,57 @@
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+
+import { fireAndForget } from './async/index.js';
+import { PROJECT_ROOT } from './config.js';
+import { PYTHON_BIN } from './platform.js';
+
+const MEMORY_INDEXER_PATH = path.join(
+  PROJECT_ROOT,
+  'scripts',
+  'memory_indexer.py',
+);
+
+/**
+ * Write a markdown session log to the vault and fire-and-forget index it into
+ * long-term memory via `memory_indexer.py --add` (atom extraction + embedding
+ * dedup happen inside the indexer). Shared by the idle auto-compress path
+ * (auto-compress.ts) and the Web UI conversation consolidation path
+ * (webui-consolidation.ts, LIA-295) so the spawn + cross-platform PYTHON_BIN
+ * wiring lives in exactly one place.
+ *
+ * `onSettle` (optional) fires when the indexer child closes or errors — callers
+ * that hold an in-flight guard use it to release the guard once the detached
+ * `--add` actually finishes, not merely when the spawn is launched.
+ */
+export function writeSessionLogAndIndex(
+  savedPath: string,
+  content: string,
+  spawnLabel: string,
+  onSettle?: () => void,
+): void {
+  mkdirSync(path.dirname(savedPath), { recursive: true });
+  writeFileSync(savedPath, content, 'utf-8');
+
+  fireAndForget(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const child = spawn(
+          PYTHON_BIN,
+          [MEMORY_INDEXER_PATH, '--add', savedPath],
+          { stdio: ['ignore', 'ignore', 'pipe'] },
+        );
+        // onSettle is idempotent at the call site (a Set.delete), so firing on
+        // both 'error' and a subsequent 'close' is harmless.
+        child.on('close', (code) => {
+          onSettle?.();
+          code === 0 ? resolve() : reject(new Error(`indexer exit ${code}`));
+        });
+        child.on('error', (err) => {
+          onSettle?.();
+          reject(err);
+        });
+      }),
+    { name: spawnLabel },
+  );
+}

--- a/src/odysseus-server.test.ts
+++ b/src/odysseus-server.test.ts
@@ -8,6 +8,8 @@ vi.mock('./config.js', () => ({
   ODYSSEUS_HTTP_ENABLED: true,
   ODYSSEUS_HTTP_PORT: 0,
   INJECTION_SCANNER_CONFIG: { enabled: false, threshold: 0.7, logOnly: true },
+  // Pulled in transitively via webui-consolidation → memory-session-log (LIA-295).
+  PROJECT_ROOT: '/tmp/deus-test',
 }));
 
 vi.mock('./container-runner.js', () => ({

--- a/src/odysseus-server.ts
+++ b/src/odysseus-server.ts
@@ -42,8 +42,10 @@ import { readEnvFile } from './env.js';
 import { GroupQueue } from './group-queue.js';
 import { scanForInjection } from './guardrails/injection-scanner.js';
 import { logger } from './logger.js';
+import { messageText } from './openai-messages.js';
 import { getAvailableGroups } from './router-state.js';
 import { RegisteredGroup } from './types.js';
+import { consolidateWebConversation } from './webui-consolidation.js';
 
 const ODYSSEUS_BIND_HOST = '127.0.0.1'; // localhost only — never 0.0.0.0
 const MIN_TOKEN_LEN = 32;
@@ -181,22 +183,6 @@ function completionFrame(id: string, content: string): Record<string, unknown> {
     ],
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
   };
-}
-
-/** Flatten an OpenAI message `content` (string or multi-part array) to text. */
-function messageText(content: unknown): string {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    // OpenAI multi-part content: concatenate text parts.
-    return content
-      .map((p: unknown) =>
-        typeof (p as { text?: unknown })?.text === 'string'
-          ? (p as { text: string }).text
-          : '',
-      )
-      .join('');
-  }
-  return '';
 }
 
 /** Extract the last user message from an OpenAI chat body. */
@@ -647,6 +633,11 @@ function handleChatCompletion(
       deps.queue.notifyIdle(mainJid);
       scheduleClose();
       finalize();
+      // Consolidate this conversation into vault memory (LIA-295). Called AFTER
+      // finalize() so the SSE response is already closed; it is fire-and-forget
+      // (returns void, never await it) and touches no `res`, so it cannot run
+      // against an ended response. `body` carries the full replayed history.
+      consolidateWebConversation(body);
     } else if (event.type === 'error') {
       finalize(event.error);
     }

--- a/src/openai-messages.ts
+++ b/src/openai-messages.ts
@@ -1,0 +1,22 @@
+/**
+ * Helpers for the OpenAI chat-completions `messages` shape that the Web UI
+ * (Odysseus /v1) replays on every request. Shared by odysseus-server.ts (prompt
+ * building) and webui-consolidation.ts (LIA-295) so neither duplicates the
+ * multi-part content walker — and so they don't import each other (cycle-free).
+ */
+
+/** Flatten an OpenAI message `content` (string or multi-part array) to text. */
+export function messageText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    // OpenAI multi-part content: concatenate text parts.
+    return content
+      .map((p: unknown) =>
+        typeof (p as { text?: unknown })?.text === 'string'
+          ? (p as { text: string }).text
+          : '',
+      )
+      .join('');
+  }
+  return '';
+}

--- a/src/webui-consolidation.test.ts
+++ b/src/webui-consolidation.test.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockWriteSessionLogAndIndex =
@@ -115,9 +117,12 @@ describe('consolidateWebConversation — vault + content', () => {
   it('writes a stable per-conversation path keyed by the first user message', () => {
     consolidateWebConversation(conversation(3, 'stable-key-convo'));
     const savedPath = mockWriteSessionLogAndIndex.mock.calls[0][0];
-    expect(savedPath).toMatch(
-      /\/vault\/Session-Logs\/\d{4}-\d{2}-\d{2}\/webui-[0-9a-f]{16}\.md$/,
-    );
+    // Assert on path components, not raw separators — path.join yields '\' on
+    // Windows and '/' on POSIX, so a slash-literal regex is not cross-platform.
+    const parts = savedPath.split(/[/\\]/);
+    expect(path.basename(savedPath)).toMatch(/^webui-[0-9a-f]{16}\.md$/);
+    expect(parts).toContain('Session-Logs');
+    expect(parts.some((p) => /^\d{4}-\d{2}-\d{2}$/.test(p))).toBe(true);
   });
 
   it('builds web-session frontmatter with a user/assistant transcript', () => {

--- a/src/webui-consolidation.test.ts
+++ b/src/webui-consolidation.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockWriteSessionLogAndIndex =
+  vi.fn<
+    (
+      savedPath: string,
+      content: string,
+      label: string,
+      onSettle?: () => void,
+    ) => void
+  >();
+vi.mock('./memory-session-log.js', () => ({
+  writeSessionLogAndIndex: mockWriteSessionLogAndIndex,
+}));
+
+const mockResolveVaultPath = vi.fn<() => string | null>();
+vi.mock('./solutions/index.js', () => ({
+  resolveVaultPath: mockResolveVaultPath,
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { consolidateWebConversation } = await import('./webui-consolidation.js');
+
+interface Turn {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+/** Build an OpenAI-style request body with the given turns. */
+function body(turns: Turn[]): unknown {
+  return { messages: turns };
+}
+
+/** N user/assistant turn-pairs, first user message customizable for hashing. */
+function conversation(
+  userCount: number,
+  firstUser = 'first question',
+): unknown {
+  const turns: Turn[] = [];
+  for (let i = 0; i < userCount; i++) {
+    turns.push({ role: 'user', content: i === 0 ? firstUser : `q${i}` });
+    turns.push({ role: 'assistant', content: `a${i}` });
+  }
+  return body(turns);
+}
+
+beforeEach(() => {
+  mockWriteSessionLogAndIndex.mockReset();
+  mockResolveVaultPath.mockReset();
+  mockResolveVaultPath.mockReturnValue('/vault');
+  delete process.env.DEUS_WEBUI_CONSOLIDATE;
+  delete process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS;
+  delete process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS;
+});
+
+afterEach(() => {
+  // Release any guard a test left held so module-level state doesn't leak.
+  const settle = mockWriteSessionLogAndIndex.mock.calls.at(-1)?.[3];
+  settle?.();
+});
+
+describe('consolidateWebConversation — threshold', () => {
+  it('consolidates at the default 3-user-turn boundary (>=)', () => {
+    consolidateWebConversation(conversation(3, 'boundary-3-turns'));
+    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a short single-turn conversation (below both thresholds)', () => {
+    consolidateWebConversation(body([{ role: 'user', content: 'hi' }]));
+    expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
+  });
+
+  it('consolidates a 1-turn conversation that exceeds the char threshold', () => {
+    const long = 'x'.repeat(250);
+    consolidateWebConversation(
+      body([
+        { role: 'user', content: long },
+        { role: 'assistant', content: 'ok' },
+      ]),
+    );
+    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors env-overridden MIN_TURNS', () => {
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS = '2';
+    consolidateWebConversation(conversation(2, 'two-turn-override'));
+    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('consolidateWebConversation — kill switch', () => {
+  it('does nothing when DEUS_WEBUI_CONSOLIDATE=0', () => {
+    process.env.DEUS_WEBUI_CONSOLIDATE = '0';
+    consolidateWebConversation(conversation(5, 'disabled-flag'));
+    expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when DEUS_WEBUI_CONSOLIDATE=false', () => {
+    process.env.DEUS_WEBUI_CONSOLIDATE = 'false';
+    consolidateWebConversation(conversation(5, 'disabled-false'));
+    expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
+  });
+});
+
+describe('consolidateWebConversation — vault + content', () => {
+  it('skips when no vault is configured', () => {
+    mockResolveVaultPath.mockReturnValue(null);
+    consolidateWebConversation(conversation(3, 'no-vault'));
+    expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
+  });
+
+  it('writes a stable per-conversation path keyed by the first user message', () => {
+    consolidateWebConversation(conversation(3, 'stable-key-convo'));
+    const savedPath = mockWriteSessionLogAndIndex.mock.calls[0][0];
+    expect(savedPath).toMatch(
+      /\/vault\/Session-Logs\/\d{4}-\d{2}-\d{2}\/webui-[0-9a-f]{16}\.md$/,
+    );
+  });
+
+  it('builds web-session frontmatter with a user/assistant transcript', () => {
+    consolidateWebConversation(
+      body([
+        { role: 'user', content: 'what is X' },
+        { role: 'assistant', content: 'X is Y' },
+        { role: 'user', content: 'and Z?' },
+        { role: 'assistant', content: 'Z too' },
+        { role: 'user', content: 'thanks' },
+      ]),
+    );
+    const content = mockWriteSessionLogAndIndex.mock.calls[0][1];
+    expect(content).toContain('type: web-session');
+    expect(content).toContain('topics: [webui, auto-consolidate]');
+    expect(content).toContain('**User**: what is X');
+    expect(content).toContain('**Assistant**: X is Y');
+    // The spawn label is the 3rd arg, not part of the markdown content.
+    expect(mockWriteSessionLogAndIndex.mock.calls[0][2]).toBe(
+      'webui-consolidation-index',
+    );
+  });
+
+  it('emits a safe quoted YAML tldr for adversarial first-message text', () => {
+    // Leading spaces + a colon + quotes would corrupt a raw block scalar.
+    consolidateWebConversation(
+      conversation(3, '  weird: "key" value with: colons'),
+    );
+    const content = mockWriteSessionLogAndIndex.mock.calls[0][1];
+    // tldr is a JSON-stringified (double-quoted, escaped) single-line scalar.
+    expect(content).toMatch(/\ntldr: "(?:[^"\\]|\\.)*"\n/);
+    expect(content).not.toContain('tldr: |');
+  });
+
+  it('excludes system messages from the transcript', () => {
+    consolidateWebConversation(
+      body([
+        { role: 'system', content: 'SECRET SYSTEM PROMPT' },
+        { role: 'user', content: 'hello there friend' },
+        { role: 'assistant', content: 'hi' },
+        { role: 'user', content: 'more' },
+        { role: 'user', content: 'and more text to cross threshold' },
+      ]),
+    );
+    const content = mockWriteSessionLogAndIndex.mock.calls[0][1];
+    expect(content).not.toContain('SECRET SYSTEM PROMPT');
+  });
+});
+
+describe('consolidateWebConversation — in-flight idempotency guard', () => {
+  it('drops a re-entrant consolidation for the same conversation, then allows it after release', () => {
+    const convo = () => conversation(3, 'idempotency-guard-convo');
+
+    // 1st call: writes + holds the guard (mock does NOT invoke onSettle).
+    consolidateWebConversation(convo());
+    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
+
+    // 2nd call while in-flight: same first-message hash → no-op.
+    consolidateWebConversation(convo());
+    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
+
+    // Release the guard (simulate the indexer spawn settling).
+    const onSettle = mockWriteSessionLogAndIndex.mock.calls[0][3];
+    expect(onSettle).toBeTypeOf('function');
+    onSettle?.();
+
+    // 3rd call after release: allowed again.
+    consolidateWebConversation(convo());
+    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/webui-consolidation.ts
+++ b/src/webui-consolidation.ts
@@ -1,0 +1,166 @@
+import crypto from 'crypto';
+import path from 'path';
+
+import { envPositiveInt } from './env-utils.js';
+import { logger } from './logger.js';
+import { writeSessionLogAndIndex } from './memory-session-log.js';
+import { messageText } from './openai-messages.js';
+import { resolveVaultPath } from './solutions/index.js';
+
+/**
+ * Web UI conversation auto-consolidation into vault memory (LIA-295).
+ *
+ * The /compress and /handoff skills operate on a developer's host Claude Code
+ * session — they never see the container assistant's end-user conversations.
+ * Web UI (Odysseus /v1) turns run on fresh, non-persisted sessions (LIA-294)
+ * and never hit the DB, so nothing consolidates those conversations into
+ * long-term memory. This closes that gap: when a Web UI conversation grows past
+ * a threshold, write it to the vault as a session log and index it via
+ * `memory_indexer.py --add` (atom extraction + L2 dedup live inside the
+ * indexer, which is the pollution control). Reuses the auto-compress write+index
+ * tail (memory-session-log.ts).
+ *
+ * The Web UI control group is the operator themselves (isControlGroup) — these
+ * are the user's own chats into the user's own vault, the same trust model as
+ * /compress. So the real risk is vault pollution (handled by --add dedup), not
+ * third-party privacy.
+ */
+
+// Kill switch — ON by default. Set DEUS_WEBUI_CONSOLIDATE=0 (or false) to
+// disable Web UI consolidation without a code change (LIA-295).
+function consolidationEnabled(): boolean {
+  const raw = process.env.DEUS_WEBUI_CONSOLIDATE;
+  return raw !== '0' && raw !== 'false';
+}
+
+// Consolidate once the conversation reaches EITHER threshold (env-overridable;
+// envPositiveInt clamps a non-positive/NaN override back to the fallback).
+const MIN_TURNS = () => envPositiveInt('DEUS_WEBUI_CONSOLIDATE_MIN_TURNS', 3);
+const MIN_CHARS = () => envPositiveInt('DEUS_WEBUI_CONSOLIDATE_MIN_CHARS', 200);
+
+// In-flight guard keyed by conversation hash. A per-request boolean would not
+// survive across the queued turns GroupQueue serialises on the shared jid; this
+// module-level Set blocks a re-entrant consolidation for the same conversation
+// while a prior detached `--add` is still running (released on spawn settle).
+const inFlightConsolidation = new Set<string>();
+
+interface ChatMessage {
+  role?: unknown;
+  content?: unknown;
+}
+
+function extractMessages(body: unknown): ChatMessage[] {
+  const messages = (body as { messages?: unknown })?.messages;
+  return Array.isArray(messages) ? (messages as ChatMessage[]) : [];
+}
+
+function roleLabel(role: unknown): string {
+  if (role === 'user') return 'User';
+  if (role === 'assistant') return 'Assistant';
+  if (role === 'system') return 'System';
+  return typeof role === 'string' && role ? role : 'unknown';
+}
+
+/**
+ * Consolidate a completed Web UI turn's conversation into vault memory.
+ *
+ * Fully fire-and-forget: returns void (NOT a Promise) and must never be
+ * awaited — the SSE response (res.end via finalize) must not wait on a vault
+ * write or a detached indexer spawn. The spawn touches no `res` object, so it
+ * can never run after the response ends.
+ */
+export function consolidateWebConversation(body: unknown): void {
+  if (!consolidationEnabled()) return;
+
+  const messages = extractMessages(body);
+  if (messages.length === 0) return;
+
+  const userMessages = messages.filter((m) => m.role === 'user');
+  // Hash the RAW first user message (messages[], not the budget-pruned prompt
+  // transcript) so the key stays stable once long histories get truncated.
+  const firstUser = userMessages[0];
+  if (!firstUser) return;
+  const firstUserText = messageText(firstUser.content);
+  if (!firstUserText.trim()) return;
+
+  // Transcript = user + assistant turns (skip system/snapshot noise).
+  const transcriptLines: string[] = [];
+  for (const m of messages) {
+    if (m.role !== 'user' && m.role !== 'assistant') continue;
+    const text = messageText(m.content).trim();
+    if (!text) continue;
+    transcriptLines.push(`**${roleLabel(m.role)}**: ${text}`);
+  }
+  if (transcriptLines.length === 0) return;
+  const transcript = transcriptLines.join('\n\n');
+
+  // Threshold: consolidate once EITHER the user-turn count OR the total
+  // transcript length crosses its bound. Below both → not worth persisting yet.
+  if (userMessages.length < MIN_TURNS() && transcript.length < MIN_CHARS()) {
+    return;
+  }
+
+  const vaultPath = resolveVaultPath();
+  if (!vaultPath) {
+    logger.debug('Web UI consolidation skipped: no vault configured');
+    return;
+  }
+
+  const key = crypto
+    .createHash('sha256')
+    .update(firstUserText)
+    .digest('hex')
+    .slice(0, 16);
+
+  // Drop re-entrant consolidations for the same conversation while a prior
+  // --add is still running (released in onSettle below).
+  if (inFlightConsolidation.has(key)) {
+    logger.debug({ key }, 'Web UI consolidation: already in-flight, skipped');
+    return;
+  }
+
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10);
+  // One file per conversation, overwritten as it grows — re-index re-dedups.
+  const savedPath = path.join(
+    vaultPath,
+    'Session-Logs',
+    dateStr,
+    `webui-${key}.md`,
+  );
+
+  // JSON.stringify yields a valid double-quoted YAML scalar (YAML ⊇ JSON), so
+  // untrusted first-message text (leading spaces, colons, quotes) can't corrupt
+  // the frontmatter the indexer parses. Collapse whitespace + cap length first.
+  const tldr = JSON.stringify(
+    firstUserText.replace(/\s+/g, ' ').trim().slice(0, 120),
+  );
+  const content = `---
+type: web-session
+date: ${dateStr}
+topics: [webui, auto-consolidate]
+tldr: ${tldr}
+---
+
+${transcript}
+`;
+
+  inFlightConsolidation.add(key);
+  try {
+    writeSessionLogAndIndex(
+      savedPath,
+      content,
+      'webui-consolidation-index',
+      () => inFlightConsolidation.delete(key),
+    );
+  } catch (err) {
+    // Synchronous mkdir/write failure throws BEFORE the indexer spawn launches,
+    // so the onSettle release never fires — drop the guard here so the key isn't
+    // stuck. (Success path releases via onSettle when the spawn settles.)
+    inFlightConsolidation.delete(key);
+    logger.warn({ err }, 'Web UI consolidation: vault write failed');
+    return;
+  }
+
+  logger.info({ path: savedPath }, 'Web UI conversation consolidated to vault');
+}


### PR DESCRIPTION
## Problem (LIA-295)

`/compress` and `/handoff` operate on a developer's host Claude Code session — they never see the container assistant's **end-user** conversations. Web UI (Odysseus `/v1`) turns run on fresh, non-persisted sessions (LIA-294) and never hit the DB, so as the Web UI becomes the primary interface, those conversations are lost to long-term memory.

## Fix

Automatic consolidation, no user command. On `turn_complete`, once a conversation crosses a threshold (`>= MIN_TURNS` user messages **OR** `>= MIN_CHARS` transcript), it's written to the vault as a `web-session` log and indexed via `memory_indexer.py --add` — whose atom extraction + L2≈0.55 embedding dedup are the pollution control (the same machinery `/compress` trusts).

### Design
- **Hot-path safe:** `consolidateWebConversation()` is fully fire-and-forget — called *after* `finalize()`, never awaited, touches no `res`, so it cannot delay or break the SSE response.
- **Identity / idempotency:** `sha256(16)` of the **raw** first user message → one file per conversation (`webui-<hash>.md`), overwritten as it grows (re-index re-dedups). Hashing the raw `messages[0]` (not the budget-pruned prompt) keeps the key stable once long histories truncate. A module-level `Set` guards against re-entrant consolidation while a prior `--add` is still running (released on spawn settle; the sync-write-failure path releases in `catch`).
- **Robust frontmatter:** `tldr` is a `JSON.stringify`'d quoted YAML scalar (YAML ⊇ JSON), so untrusted text (leading spaces, colons, quotes) can't corrupt what the indexer parses.
- **Control:** gated by `DEUS_WEBUI_CONSOLIDATE` (default **ON**; set `0` to disable). `memoryPrivacy` is a *container read-access* field, not a host write-gate, so it is deliberately **not** the gate — the env flag is the real control. The Web UI control group is the operator themselves (own chats → own vault, same trust model as `/compress`); thresholds are env-overridable.
- **DRY:** extracts the shared write+`--add` tail into `memory-session-log.ts` and `messageText` into `openai-messages.ts` (cycle-free), reused by `auto-compress.ts` (behavior unchanged).

### Scope
Consolidation only. Handoff/thread-summary deferred. No change to LIA-294 stateless sessions (reads `messages`, never persists the session); `compactionEvent`/channel path untouched.

## Tests
11 new (threshold boundary, char threshold, env override, kill switch `0`/`false`, no-vault, stable path, frontmatter/transcript shape, system-message exclusion, adversarial-YAML safety, in-flight idempotency). `auto-compress.test.ts` stays green (refactor is behavior-preserving). Full suite **1637 passed / 0 failed**; flag_lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)