### PR TITLE
feat(odysseus): stream Web UI chat output incrementally + Thinking indicator

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -64,6 +64,10 @@ interface ContainerInput {
   imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
   projectHint?: string;
   effort?: 'low' | 'medium' | 'high' | 'max';
+  // Streaming consumer flag (Odysseus Web UI). Claude-only: enables SDK partial
+  // messages so answer text + tool activity stream incrementally. See host
+  // ContainerInputSchema in src/ipc-protocol.ts.
+  stream?: boolean;
 }
 
 interface ImageContentBlock {
@@ -78,9 +82,15 @@ type ContentBlock = ImageContentBlock | TextContentBlock;
 
 // SYNC-REQUIRED: Must match ContainerOutputSchema in src/ipc-protocol.ts (host side).
 // Cannot import from there — this package runs inside an isolated container.
+// Discriminated-union streaming protocol: 'success'|'error' are terminal;
+// 'partial' (carries `delta`) and 'activity' (carries `text`) are transient
+// streaming side-events, emitted Claude-only when the per-turn stream flag is set.
 interface ContainerOutput {
-  status: 'success' | 'error';
-  result: string | null;
+  status: 'success' | 'error' | 'partial' | 'activity';
+  result?: string | null;
+  delta?: string; // status:'partial' — incremental answer text.
+  text?: string; // status:'activity' — a thinking/tool-progress line.
+  streamed?: boolean; // status:'success' — true iff ≥1 partial was streamed.
   newSessionRef?: RuntimeSession;
   newSessionId?: string;
   error?: string;
@@ -868,9 +878,55 @@ async function runQuery(
     writeAvailableTools(process.env.DEUS_INTERACTION_ID, allowedTools);
   }
 
+  // ── Streaming (Web UI live output) ──────────────────────────────────────────
+  // runQuery is the CLAUDE path only (main() returns for openai/llama-cpp before
+  // calling it), so enabling partial messages here is structurally Claude-only.
+  // Gated by the per-turn stream flag → off for WhatsApp/scheduler (unchanged).
+  const wantsStreaming =
+    !!containerInput.stream &&
+    (containerInput.backend ?? 'claude') === 'claude';
+  // Coalesce token deltas into ~40-char / 50ms chunks (hard cap 512) so partial
+  // markers don't flood the IPC channel one-per-token. `didStreamPartials` tells
+  // the terminal result marker to set `streamed` so the host suppresses the
+  // duplicate final emission.
+  let partialBuf = '';
+  let lastPartialFlush = Date.now();
+  let didStreamPartials = false;
+  const PARTIAL_FLUSH_CHARS = 40;
+  const PARTIAL_FLUSH_MS = 50;
+  const PARTIAL_HARD_CAP = 512;
+  const flushPartial = (): void => {
+    if (!partialBuf) return;
+    writeOutput({ status: 'partial', delta: partialBuf });
+    partialBuf = '';
+    lastPartialFlush = Date.now();
+    didStreamPartials = true;
+  };
+  const pushPartial = (textDelta: string): void => {
+    partialBuf += textDelta;
+    // Emit in hard-cap-sized chunks if a single delta is unusually large, so one
+    // marker can never approach the host parse-buffer bound.
+    while (partialBuf.length >= PARTIAL_HARD_CAP) {
+      writeOutput({
+        status: 'partial',
+        delta: partialBuf.slice(0, PARTIAL_HARD_CAP),
+      });
+      partialBuf = partialBuf.slice(PARTIAL_HARD_CAP);
+      lastPartialFlush = Date.now();
+      didStreamPartials = true;
+    }
+    if (
+      partialBuf.length >= PARTIAL_FLUSH_CHARS ||
+      Date.now() - lastPartialFlush >= PARTIAL_FLUSH_MS
+    ) {
+      flushPartial();
+    }
+  };
+
   for await (const message of query({
     prompt: stream,
     options: {
+      includePartialMessages: wantsStreaming,
       cwd,
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
@@ -989,6 +1045,41 @@ async function runQuery(
       lastAssistantUuid = (message as { uuid: string }).uuid;
     }
 
+    // Web UI streaming: surface answer token deltas (→ partial) and tool-use
+    // starts (→ activity) as they happen. Only present when includePartialMessages
+    // is on (wantsStreaming). Defensive: a malformed event must never break a turn.
+    if (wantsStreaming && message.type === 'stream_event') {
+      try {
+        // The SDKMessage union types `event` as the broad BetaRawMessageStreamEvent;
+        // its content_block_delta/start members aren't narrowed on the union, so we
+        // structurally probe the fields we need rather than import the beta subtypes.
+        const ev = (message as { event?: Record<string, unknown> }).event;
+        const evType = ev?.type as string | undefined;
+        if (evType === 'content_block_delta') {
+          const delta = ev?.delta as
+            | { type?: string; text?: string }
+            | undefined;
+          if (delta?.type === 'text_delta' && delta.text)
+            pushPartial(delta.text);
+        } else if (evType === 'content_block_start') {
+          const block = (
+            ev as { content_block?: { type?: string; name?: string } }
+          ).content_block;
+          if (block?.type === 'tool_use' && block.name) {
+            flushPartial(); // keep streamed answer text ordered before the activity
+            writeOutput({ status: 'activity', text: `Running ${block.name}…` });
+          }
+        }
+      } catch (err) {
+        // Never break a turn on a malformed event, but log so SDK wire drift
+        // (a changed content_block_delta shape silently killing streaming) is
+        // observable instead of resurfacing as dead-air with no trace.
+        log(
+          `malformed stream_event ignored: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     if (message.type === 'system' && message.subtype === 'init') {
       newSessionId = message.session_id;
       if (newSessionId !== _trackedSessionId) {
@@ -1019,6 +1110,7 @@ async function runQuery(
     }
 
     if (message.type === 'result') {
+      flushPartial(); // emit any buffered streamed tail before the terminal marker
       resultCount++;
       const textResult =
         'result' in message ? (message as { result?: string }).result : null;
@@ -1029,6 +1121,10 @@ async function runQuery(
       writeOutput({
         status: 'success',
         result: textResult || null,
+        // When the answer already streamed as partials, tell the host to suppress
+        // re-emitting `result` (avoids duplication). Absent when not streaming →
+        // byte-identical to current behavior for WhatsApp/scheduler.
+        ...(didStreamPartials ? { streamed: true } : {}),
         newSessionRef: defaultSession(newSessionId),
         newSessionId,
         contextStats: _lastContextStats,

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781447481
+last_verified: "2026-06-16" # auto-bump @1781614772
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-14" # auto-bump @1781447481
+last_verified: "2026-06-16" # auto-bump @1781614772
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-14" # auto-bump @1781447481
+last_verified: "2026-06-16" # auto-bump @1781614461
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-14" # auto-bump @1781447481
+last_verified: "2026-06-16" # auto-bump @1781614461
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-16" # auto-bump @1781603212
+last_verified: "2026-06-16" # auto-bump @1781614772
 governs:
   - src/
   - evolution/

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-15" # auto-bump @1781519451
+last_verified: "2026-06-16" # auto-bump @1781614461
 governs:
   - src/
   - evolution/

--- a/src/agent-runtimes/container-backend.test.ts
+++ b/src/agent-runtimes/container-backend.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { RuntimeEvent, RuntimeEventSink } from './types.js';
+import { defaultSession } from './types.js';
+import type { ContainerOutput } from '../container-runner.js';
+
+// Mock runContainerAgent so we can drive onOutput with an arbitrary marker
+// sequence and observe the RuntimeEvents the backend maps them to.
+const { runContainerAgentMock } = vi.hoisted(() => ({
+  runContainerAgentMock: vi.fn(),
+}));
+vi.mock('../container-runner.js', () => ({
+  runContainerAgent: runContainerAgentMock,
+}));
+
+const { ContainerRuntime } = await import('./container-backend.js');
+
+function makeRuntime() {
+  return new ContainerRuntime('claude', {} as never, {
+    resolveGroup: () => ({ folder: 'main', name: 'Main' }) as never,
+    assistantName: 'Deus',
+    registerProcess: () => {},
+  });
+}
+
+const baseCtx = {
+  prompt: 'hi',
+  groupFolder: 'main',
+  chatJid: 'c@g.us',
+  isControlGroup: true,
+  effort: 'low' as const, // avoids resolveAgentEffort needing a full group
+};
+
+beforeEach(() => {
+  runContainerAgentMock.mockReset();
+});
+
+describe('ContainerRuntime onOutput → eventSink mapping', () => {
+  it('streams partial→output_text + activity→activity, and suppresses the final result when streamed', async () => {
+    runContainerAgentMock.mockImplementation(
+      async (
+        _g: unknown,
+        _i: unknown,
+        _onProc: unknown,
+        onOutput: (o: ContainerOutput) => Promise<void>,
+      ) => {
+        await onOutput({ status: 'activity', text: 'Running grep' });
+        await onOutput({ status: 'partial', delta: 'Hel' });
+        await onOutput({ status: 'partial', delta: 'lo' });
+        await onOutput({
+          status: 'success',
+          result: 'Hello',
+          streamed: true,
+          newSessionId: 's1',
+        });
+        return { status: 'success', result: 'Hello', newSessionId: 's1' };
+      },
+    );
+
+    const events: RuntimeEvent[] = [];
+    const sink: RuntimeEventSink = (e) => {
+      events.push(e);
+    };
+    await makeRuntime().runTurn(
+      { ...baseCtx, stream: true },
+      defaultSession('', 'claude'),
+      sink,
+    );
+
+    const text = (t: RuntimeEvent['type']) =>
+      events
+        .filter((e) => e.type === t)
+        .map((e) => (e as { text: string }).text);
+
+    // Answer arrived as deltas; the final 'Hello' is NOT re-emitted (no dup).
+    expect(text('output_text')).toEqual(['Hel', 'lo']);
+    expect(text('activity')).toEqual(['Running grep']);
+    expect(events.some((e) => e.type === 'turn_complete')).toBe(true);
+  });
+
+  it('emits the final result as output_text when NOT streamed (buffered/WhatsApp path)', async () => {
+    runContainerAgentMock.mockImplementation(
+      async (
+        _g: unknown,
+        _i: unknown,
+        _onProc: unknown,
+        onOutput: (o: ContainerOutput) => Promise<void>,
+      ) => {
+        await onOutput({
+          status: 'success',
+          result: 'Hello',
+          newSessionId: 's1',
+        });
+        return { status: 'success', result: 'Hello', newSessionId: 's1' };
+      },
+    );
+
+    const events: RuntimeEvent[] = [];
+    await makeRuntime().runTurn(baseCtx, defaultSession('', 'claude'), (e) => {
+      events.push(e);
+    });
+
+    expect(
+      events
+        .filter((e) => e.type === 'output_text')
+        .map((e) => (e as { text: string }).text),
+    ).toEqual(['Hello']);
+  });
+});

--- a/src/agent-runtimes/container-backend.ts
+++ b/src/agent-runtimes/container-backend.ts
@@ -62,7 +62,21 @@ export class ContainerRuntime implements AgentRuntime {
     }
 
     const onOutput = async (output: ContainerOutput) => {
-      if (output.result) {
+      // Transient streaming variants (Claude backend + stream flag only). These
+      // are fire-and-forget side events; they carry no terminal/session state.
+      if (output.status === 'partial') {
+        if (output.delta)
+          await eventSink({ type: 'output_text', text: output.delta });
+        return;
+      }
+      if (output.status === 'activity') {
+        if (output.text)
+          await eventSink({ type: 'activity', text: output.text });
+        return;
+      }
+      // Terminal markers (success/error). Suppress the final answer emission when
+      // it already went out as `partial` deltas (`streamed`), to avoid duplication.
+      if (output.result && !output.streamed) {
         await eventSink({ type: 'output_text', text: output.result });
       }
       if (
@@ -106,6 +120,7 @@ export class ContainerRuntime implements AgentRuntime {
         ...(runContext.ipcRunKey && {
           ipcRunKey: runContext.ipcRunKey,
         }),
+        ...(runContext.stream && { stream: true }),
       },
       (proc, containerName) =>
         this.deps.registerProcess(
@@ -119,7 +134,7 @@ export class ContainerRuntime implements AgentRuntime {
 
     return {
       status: output.status === 'error' ? 'error' : 'success',
-      result: output.result,
+      result: output.result ?? null,
       sessionRef:
         output.newSessionRef ??
         (output.newSessionId

--- a/src/agent-runtimes/types.ts
+++ b/src/agent-runtimes/types.ts
@@ -42,6 +42,13 @@ export interface RunContext {
   toolBroker?: ToolBroker;
   worktreePath?: string;
   /**
+   * Streaming consumer flag. When true (set by the Odysseus Web UI channel), the
+   * Claude backend enables SDK partial messages so answer text and tool/thinking
+   * activity stream incrementally as `output_text`/`activity` events instead of one
+   * terminal blob. Absent for WhatsApp/scheduler → unchanged buffered behavior.
+   */
+  stream?: boolean;
+  /**
    * Per-run IPC namespace key (LIA-211). When set, the container's IPC dir is
    * keyed `ipc/<groupFolder>/<runKey>` instead of `ipc/<groupFolder>`, so
    * concurrent runs that share a groupFolder (Linear dispatches/gates, each
@@ -53,6 +60,9 @@ export interface RunContext {
 
 export type RuntimeEvent =
   | { type: 'output_text'; text: string }
+  // Transient thinking/tool-progress line surfaced separately from the answer
+  // (Web UI renders it as a reasoning block). Sinks without a handler ignore it.
+  | { type: 'activity'; text: string }
   | { type: 'tool_call'; name: string; arguments: Record<string, unknown> }
   | { type: 'session'; sessionRef: RuntimeSession }
   | { type: 'turn_complete' }

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -488,7 +488,7 @@ describe('rejected onOutput resilience (LIA-212)', () => {
   it('a rejected onOutput does not drop subsequent streamed outputs', async () => {
     const seen: Array<string | null> = [];
     const onOutput = vi.fn(async (output: ContainerOutput) => {
-      seen.push(output.result);
+      seen.push(output.result ?? null);
       if (output.result === 'first') {
         throw new Error('transient channel.sendMessage failure');
       }
@@ -528,6 +528,62 @@ describe('rejected onOutput resilience (LIA-212)', () => {
     // never runs and the dispatch never settles.
     expect(seen).toContain('second');
     expect(settled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming-variant markers (Web UI live output): the parse loop must accept the
+// transient 'partial'/'activity' variants and surface their payloads to onOutput,
+// without disturbing the terminal 'success'/'streamed' handling.
+// ---------------------------------------------------------------------------
+
+describe('streaming variant markers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('parses partial + activity markers and a streamed terminal in order', async () => {
+    const seen: ContainerOutput[] = [];
+    const onOutput = vi.fn(async (o: ContainerOutput) => {
+      seen.push(o);
+    });
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+    void resultPromise.then(() => {});
+
+    emitOutputMarker(fakeProc, { status: 'activity', text: 'Running grep' });
+    emitOutputMarker(fakeProc, { status: 'partial', delta: 'Hel' });
+    emitOutputMarker(fakeProc, { status: 'partial', delta: 'lo' });
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'Hello',
+      streamed: true,
+      newSessionId: 'session-stream',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(seen.map((o) => o.status)).toEqual([
+      'activity',
+      'partial',
+      'partial',
+      'success',
+    ]);
+    expect(seen[0].text).toBe('Running grep');
+    expect(seen[1].delta).toBe('Hel');
+    expect(seen[2].delta).toBe('lo');
+    expect(seen[3].streamed).toBe(true);
+    expect(seen[3].result).toBe('Hello');
   });
 });
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -883,7 +883,7 @@ export async function runContainerAgent(
 
         // Post-dispatch: log interaction for evolution loop (fire-and-forget)
         logDispatch(
-          output.result,
+          output.result ?? null,
           input.sessionRef?.session_id ??
             output.newSessionRef?.session_id ??
             output.newSessionId,

--- a/src/ipc-protocol.ts
+++ b/src/ipc-protocol.ts
@@ -53,9 +53,22 @@ export const CompactionEventSchema = z.object({
 // ── ContainerOutput ─────────────────────────────────────────────────────────
 
 export const ContainerOutputSchema = z.object({
-  // Load-bearing fields stay strict — a marker missing these is genuinely unusable.
-  status: z.enum(['success', 'error']),
-  result: z.string().nullable(),
+  // Discriminated-union streaming protocol over the single marker channel:
+  //   'success' | 'error'  — terminal, authoritative (carry result/error).
+  //   'partial'            — transient answer chunk (carries `delta`), Phase 2.
+  //   'activity'           — transient thinking/tool-progress (carries `text`), Phase 1.
+  // Transient variants are fire-and-forget side events emitted DURING a turn and
+  // never set session/PR/context fields. Streaming is Claude-only and gated by the
+  // per-turn `stream` flag, so WhatsApp/scheduler/OpenAI/llama turns never see them.
+  status: z.enum(['success', 'error', 'partial', 'activity']),
+  // `result` required-nullable for terminal markers; optional for transient ones.
+  result: z.string().nullable().optional(),
+  // Transient payloads (mutually exclusive with each other).
+  delta: z.string().optional(), // status:'partial' — incremental answer text.
+  text: z.string().optional(), // status:'activity' — a thinking/progress line.
+  // Terminal-`success` flag: true iff ≥1 `partial` was streamed this turn, so the
+  // host suppresses re-emitting `result` (the text already went out as deltas).
+  streamed: z.boolean().optional(),
   newSessionRef: RuntimeSessionSchema.optional(),
   newSessionId: z.string().optional(),
   error: z.string().optional(),
@@ -99,6 +112,10 @@ export const ContainerInputSchema = z.object({
     .optional(),
   projectHint: z.string().optional(),
   effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
+  // Streaming consumers (Odysseus Web UI) set this so the Claude backend enables
+  // SDK partial messages and emits `partial`/`activity` markers. Off for WhatsApp/
+  // scheduler → byte-for-byte unchanged behavior.
+  stream: z.boolean().optional(),
   worktreePath: z.string().optional(),
   // Per-run IPC namespace key (LIA-211). Carried into the mounter so the
   // container's IPC dir is keyed per run for collision-prone shared folders.

--- a/src/odysseus-server.test.ts
+++ b/src/odysseus-server.test.ts
@@ -569,6 +569,87 @@ describe('SSE streaming', () => {
   });
 });
 
+// ── Incremental streaming (Web UI live output) ──────────────────────────────
+describe('SSE streaming — incremental', () => {
+  const post = () =>
+    request(
+      { method: 'POST', path: '/v1/chat/completions', headers: authHeaders },
+      chatBody(),
+    );
+
+  it('streams each output_text as its own ordered content delta (none empty)', async () => {
+    const turn: TurnDriver = async (sink) => {
+      await sink({ type: 'output_text', text: 'Hel' });
+      await sink({ type: 'output_text', text: 'lo ' });
+      await sink({ type: 'output_text', text: 'world' });
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'Hello world' };
+    };
+    await listen(makeDeps({ turn }));
+    const r = await post();
+    const contents = [...r.body.matchAll(/"content":"([^"]*)"/g)].map(
+      (m) => m[1],
+    );
+    expect(contents).toEqual(['Hel', 'lo ', 'world']);
+    expect(contents.every((c) => c.length > 0)).toBe(true);
+  });
+
+  it('maps an activity event to reasoning_content, never to answer content', async () => {
+    const turn: TurnDriver = async (sink) => {
+      await sink({ type: 'activity', text: 'Running grep' });
+      await sink({ type: 'output_text', text: 'done' });
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'done' };
+    };
+    await listen(makeDeps({ turn }));
+    const r = await post();
+    expect(r.body).toContain('"reasoning_content":"Running grep"');
+    expect(r.body).not.toContain('"content":"Running grep"');
+    expect(r.body).toContain('"content":"done"');
+  });
+
+  it('threads stream=true onto RunContext for a streaming request', async () => {
+    let captured: { stream?: boolean } | undefined;
+    await listen(
+      makeDeps({ onTurn: (ctx) => (captured = ctx as { stream?: boolean }) }),
+    );
+    await request(
+      { method: 'POST', path: '/v1/chat/completions', headers: authHeaders },
+      chatBody('hi', true),
+    );
+    expect(captured?.stream).toBe(true);
+  });
+
+  it('leaves RunContext.stream unset for a non-streaming request', async () => {
+    let captured: { stream?: boolean } | undefined;
+    await listen(
+      makeDeps({ onTurn: (ctx) => (captured = ctx as { stream?: boolean }) }),
+    );
+    await request(
+      { method: 'POST', path: '/v1/chat/completions', headers: authHeaders },
+      chatBody('hi', false),
+    );
+    expect(captured?.stream).toBeFalsy();
+  });
+
+  it('drops activity events on the non-streaming buffered path', async () => {
+    const turn: TurnDriver = async (sink) => {
+      await sink({ type: 'activity', text: 'Running grep' });
+      await sink({ type: 'output_text', text: 'answer' });
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'answer' };
+    };
+    await listen(makeDeps({ turn }));
+    const r = await request(
+      { method: 'POST', path: '/v1/chat/completions', headers: authHeaders },
+      chatBody('hi', false),
+    );
+    const parsed = JSON.parse(r.body);
+    expect(parsed.choices[0].message.content).toBe('answer');
+    expect(r.body).not.toContain('Running grep');
+  });
+});
+
 // ── Non-streaming ───────────────────────────────────────────────────────────
 describe('non-streaming', () => {
   beforeEach(() => listen(makeDeps()));

--- a/src/odysseus-server.test.ts
+++ b/src/odysseus-server.test.ts
@@ -594,6 +594,31 @@ describe('SSE streaming — incremental', () => {
     expect(contents.every((c) => c.length > 0)).toBe(true);
   });
 
+  it('emits an immediate turn-start "Thinking…" reasoning frame before any content', async () => {
+    // Slow first token: assert the thinking indicator is already on the wire.
+    const turn: TurnDriver = async (sink) => {
+      await sink({ type: 'output_text', text: 'late answer' });
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'late answer' };
+    };
+    await listen(makeDeps({ turn }));
+    const r = await post();
+    const thinkIdx = r.body.indexOf('"reasoning_content":"Thinking');
+    const contentIdx = r.body.indexOf('"content":"late answer"');
+    expect(thinkIdx).toBeGreaterThan(-1);
+    // Thinking frame precedes the first answer content frame.
+    expect(thinkIdx).toBeLessThan(contentIdx);
+  });
+
+  it('does not emit the turn-start thinking frame on the non-streaming path', async () => {
+    await listen(makeDeps());
+    const r = await request(
+      { method: 'POST', path: '/v1/chat/completions', headers: authHeaders },
+      chatBody('hi', false),
+    );
+    expect(r.body).not.toContain('Thinking');
+  });
+
   it('maps an activity event to reasoning_content, never to answer content', async () => {
     const turn: TurnDriver = async (sink) => {
       await sink({ type: 'activity', text: 'Running grep' });

--- a/src/odysseus-server.ts
+++ b/src/odysseus-server.ts
@@ -578,6 +578,13 @@ function handleChatCompletion(
     });
     // Early role delta — satisfies the time-to-first-token window immediately.
     writeSse(res, chunkFrame(turnNonce, { role: 'assistant' }, null));
+    // Immediate thinking indicator — covers container cold-start dead-air on
+    // no-tool turns (see commit msg). reasoning_content is Open WebUI-specific —
+    // it renders as a collapsible thinking block; standard clients ignore it.
+    writeSse(
+      res,
+      chunkFrame(turnNonce, { reasoning_content: 'Thinking…' }, null),
+    );
     activeSse++;
     sseCounted = true;
     keepalive = setInterval(() => {

--- a/src/odysseus-server.ts
+++ b/src/odysseus-server.ts
@@ -632,6 +632,10 @@ function handleChatCompletion(
     groupFolder: mainGroup.folder,
     chatJid: mainJid,
     isControlGroup: true,
+    // Streaming consumers only: enables the Claude backend's incremental
+    // partial/activity events so the answer renders live instead of one terminal
+    // blob. Buffered (stream:false) turns leave it off and assemble the result.
+    ...(stream && { stream: true }),
   };
 
   const sink: RuntimeEventSink = async (event) => {
@@ -642,6 +646,17 @@ function handleChatCompletion(
       if (stream && res.writable)
         writeSse(res, chunkFrame(turnNonce, { content: event.text }, null));
       else if (!stream) buffered.push(event.text);
+      scheduleClose();
+    } else if (event.type === 'activity') {
+      // Transient thinking/tool-progress — surfaced on `reasoning_content` (Open
+      // WebUI renders it as a collapsible thinking block, keeping the answer clean).
+      // Streaming-only and never buffered into the final result.
+      firstTokenSeen = true;
+      if (stream && res.writable)
+        writeSse(
+          res,
+          chunkFrame(turnNonce, { reasoning_content: event.text }, null),
+        );
       scheduleClose();
     } else if (event.type === 'turn_complete') {
       deps.queue.notifyIdle(mainJid);

--- a/src/session-commands.ts
+++ b/src/session-commands.ts
@@ -270,9 +270,12 @@ export function isSessionCommandAllowed(
   return isMainGroup || isFromMe;
 }
 
-/** Minimal agent result interface — matches the subset of ContainerOutput used here. */
+/** Minimal agent result interface — matches the subset of ContainerOutput used here.
+ * status mirrors ContainerOutput (incl. transient 'partial'/'activity' streaming
+ * variants) so an onOutput handler typed against this stays assignable; consumers
+ * here only act on 'success'/'error' and ignore the transient ones. */
 export interface AgentResult {
-  status: 'success' | 'error';
+  status: 'success' | 'error' | 'partial' | 'activity';
   result?: string | object | null;
 }
 


### PR DESCRIPTION
## What

Live token-streaming for the Odysseus Web UI (Open WebUI), plus a turn-start "Thinking…" indicator that covers container cold-start. Previously the Web UI showed nothing until the full turn completed; now output streams incrementally and a reasoning block appears immediately.

This is prior local work that was committed to `main` but never pushed — re-homed onto a dedicated branch for proper review.

## How

- **Streaming via the SDK**, not a protocol rewrite: uses `includePartialMessages` and surfaces incremental chunks through the existing IPC path.
- **Gated on a per-turn `stream` flag** (`ipc-protocol.ts` / `types.ts`): only the Web UI channel opts in, so WhatsApp / scheduler / OpenAI / llama.cpp paths are unchanged.
- **Thinking indicator** = a `reasoning_content` SSE frame emitted at turn start; Open WebUI renders it as a collapsible thinking block, keeping the final answer clean.

## Files

`src/odysseus-server.ts`, `src/agent-runtimes/container-backend.ts`, `src/agent-runtimes/types.ts`, `src/ipc-protocol.ts`, `src/container-runner.ts`, `src/session-commands.ts`, `container/agent-runner/src/index.ts` + tests (`odysseus-server.test.ts`, `container-backend.test.ts`, `container-runner.test.ts`).

## Notes

- Branch head `a8f218a3` is the local integration merge; its merge-base with `main` is `197e8092`, so the diff is exactly the streaming feature (10 files). Intended to land as a squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)