### PR TITLE
feat(memory): extract shared consolidateSessionLog core (LIA-302 Phase 1)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-16" # auto-bump @1781614772
+last_verified: "2026-06-16" # auto-bump @1781640462
 governs:
   - src/
   - evolution/

--- a/src/auto-compress.ts
+++ b/src/auto-compress.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 
 import { ASSISTANT_NAME } from './config.js';
+import { consolidateSessionLog } from './consolidation-core.js';
 import { getMessagesSince } from './db.js';
 import { logger } from './logger.js';
-import { writeSessionLogAndIndex } from './memory-session-log.js';
 import { resolveVaultPath } from './solutions/index.js';
 import type { RegisteredGroup } from './types.js';
 
@@ -11,14 +11,20 @@ import type { RegisteredGroup } from './types.js';
  * Save the current session's conversation to the vault before an idle reset
  * clears it. Lightweight: no LLM calls, no atom extraction — just raw
  * conversation as a session log + fire-and-forget embedding indexing.
+ *
+ * Path/envelope assembly + index dispatch live in the shared consolidation
+ * core (LIA-302); this surface owns the trigger, the message source, the
+ * empty-guard, and the `type: session` format. It also short-circuits on a
+ * missing vault BEFORE the (non-trivial) message query — the core re-checks
+ * the vault as the authoritative write gate.
  */
 export async function autoCompressSession(
   group: RegisteredGroup,
   chatJid: string,
   effectiveIdleHours: number,
 ): Promise<void> {
-  const vaultPath = resolveVaultPath();
-  if (!vaultPath) {
+  // Short-circuit before the DB query when there is nowhere to write.
+  if (!resolveVaultPath()) {
     logger.debug('Auto-compress skipped: no vault configured');
     return;
   }
@@ -44,9 +50,6 @@ export async function autoCompressSession(
   const dateStr = now.toISOString().slice(0, 10);
   const timeStr = now.toISOString().slice(11, 16).replace(':', '');
   const safeFolder = path.basename(group.folder);
-  const fileName = `auto-${safeFolder}-${timeStr}.md`;
-  const dir = path.join(vaultPath, 'Session-Logs', dateStr);
-  const savedPath = path.join(dir, fileName);
 
   const firstUserMsg = messages.find((m) => !m.is_from_me);
   const tldr = firstUserMsg
@@ -65,21 +68,24 @@ export async function autoCompressSession(
     })
     .join('\n\n');
 
-  const content = `---
-type: session
+  const frontmatter = `type: session
 date: ${dateStr}
 topics: [auto-compress]
 tldr: |
-  ${tldr}
----
+  ${tldr}`;
 
-${body}
-`;
+  const savedPath = consolidateSessionLog({
+    dateStr,
+    fileStem: `auto-${safeFolder}-${timeStr}`,
+    frontmatter,
+    body,
+    spawnLabel: 'auto-compress-index',
+  });
 
-  writeSessionLogAndIndex(savedPath, content, 'auto-compress-index');
-
-  logger.info(
-    { group: group.name, path: savedPath },
-    'Auto-compress: session saved',
-  );
+  if (savedPath) {
+    logger.info(
+      { group: group.name, path: savedPath },
+      'Auto-compress: session saved',
+    );
+  }
 }

--- a/src/consolidation-core.ts
+++ b/src/consolidation-core.ts
@@ -1,0 +1,66 @@
+import path from 'path';
+
+import { logger } from './logger.js';
+import { writeSessionLogAndIndex } from './memory-session-log.js';
+import { resolveVaultPath } from './solutions/index.js';
+
+/**
+ * Shared session-log consolidation envelope for the two surfaces that persist a
+ * conversation to the vault (auto-compress.ts; webui-consolidation.ts, LIA-295).
+ * The core owns only the structural tail they shared byte-for-byte: vault
+ * resolution, the `Session-Logs/<date>/<stem>.md` path, the
+ * `---\n<fm>\n---\n\n<body>\n` envelope, and dispatch to writeSessionLogAndIndex
+ * (the seam to the unchanged `memory_indexer.py --add` heart). Each surface
+ * keeps its own format, empty-guard, kill-switch, and in-flight-key lifecycle.
+ *
+ * Throw-transparency: NO try/catch here — a synchronous write failure propagates
+ * unchanged, so auto-compress still rejects (its orchestrator catches it) and
+ * webui still catches it in its own try/catch to release its in-flight key.
+ */
+export interface ConsolidationSpec {
+  /** Log date `YYYY-MM-DD`. The surface owns the clock read. */
+  dateStr: string;
+  /** File name without extension, e.g. `auto-whatsapp_main-1000` or `webui-<key>`. */
+  fileStem: string;
+  /** Pre-rendered YAML frontmatter block — NO `---` delimiters. */
+  frontmatter: string;
+  /** Pre-rendered markdown body. */
+  body: string;
+  /** fireAndForget label for the detached indexer spawn. */
+  spawnLabel: string;
+  /**
+   * Optional callback fired when the attempt concludes: either synchronously on
+   * a no-vault skip (below), or — via writeSessionLogAndIndex — when the
+   * detached indexer child settles. webui uses it to release its in-flight
+   * guard, so a skip MUST still fire it or the guard would stick. It may fire
+   * more than once (the indexer settles on both 'close' and 'error'); callers
+   * must keep it idempotent (webui's is a `Set.delete`).
+   */
+  onSettle?: () => void;
+}
+
+/**
+ * Persist a pre-rendered session log to the vault and fire-and-forget index it.
+ * Returns the written path, or null when skipped (no vault configured).
+ */
+export function consolidateSessionLog(spec: ConsolidationSpec): string | null {
+  const vaultPath = resolveVaultPath();
+  if (!vaultPath) {
+    logger.debug('Consolidation skipped: no vault configured');
+    // Release the caller's in-flight guard even though nothing was written —
+    // the spawn (which would otherwise fire onSettle) never launches.
+    spec.onSettle?.();
+    return null;
+  }
+
+  const savedPath = path.join(
+    vaultPath,
+    'Session-Logs',
+    spec.dateStr,
+    `${spec.fileStem}.md`,
+  );
+  const content = `---\n${spec.frontmatter}\n---\n\n${spec.body}\n`;
+
+  writeSessionLogAndIndex(savedPath, content, spec.spawnLabel, spec.onSettle);
+  return savedPath;
+}

--- a/src/consolidation-golden.test.ts
+++ b/src/consolidation-golden.test.ts
@@ -208,6 +208,31 @@ describe('@oracle skip contracts', () => {
     });
     expect(mockWrite).not.toHaveBeenCalled();
   });
+
+  it('webui does NOT write when no vault is configured AND releases the in-flight key', () => {
+    // Phase 1 moves vault resolution into the shared core, so webui now adds its
+    // in-flight key BEFORE the core call. The core MUST release that key on the
+    // no-vault skip (via onSettle), or this conversation could never consolidate
+    // again — a silent, permanent suppression. This pins that contract.
+    const fixture = {
+      messages: [
+        { role: 'user', content: 'no-vault skip-path first message' },
+        { role: 'assistant', content: 'a1' },
+        { role: 'user', content: 'q2' },
+        { role: 'assistant', content: 'a2' },
+        { role: 'user', content: 'q3' },
+      ],
+    };
+
+    mockResolveVault.mockReturnValue(null);
+    consolidateWebConversation(fixture);
+    expect(mockWrite).not.toHaveBeenCalled();
+
+    // Key released → once a vault is configured, an identical retry writes.
+    mockResolveVault.mockReturnValue('/vault');
+    consolidateWebConversation(fixture);
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ── Behavior goldens (per-surface throw/await contracts the core must preserve) ─

--- a/src/consolidation-golden.test.ts
+++ b/src/consolidation-golden.test.ts
@@ -1,0 +1,251 @@
+/**
+ * LIA-302 Phase 0 — @oracle golden capture (regression net for the unification).
+ *
+ * These snapshots are CAPTURED FROM THE LIVE PRE-REFACTOR code by running the two
+ * consolidation surfaces against fixed fixtures, NOT hand-composed. They pin the
+ * EXACT bytes each surface hands to writeSessionLogAndIndex (the stable seam below
+ * both the current and the future unified core), plus the per-surface throw/await
+ * contracts. Phase 1 (extracting consolidateSessionLog) MUST keep every snapshot
+ * byte-identical — that is the proof the envelope refactor changed nothing.
+ *
+ * Determinism: system time is frozen; the auto-compress body time token `(HH:MM)`
+ * is the only runtime-TZ-variant fragment, so it is normalized to `(HH:MM)` — the
+ * envelope refactor cannot affect it (body rendering stays in each surface), and
+ * the surrounding `**sender** (HH:MM): text` structure is still pinned.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NewMessage, RegisteredGroup } from './types.js';
+
+const mockWrite =
+  vi.fn<
+    (p: string, content: string, label: string, onSettle?: () => void) => void
+  >();
+vi.mock('./memory-session-log.js', () => ({
+  writeSessionLogAndIndex: mockWrite,
+}));
+
+const mockResolveVault = vi.fn<() => string | null>();
+vi.mock('./solutions/index.js', () => ({
+  resolveVaultPath: mockResolveVault,
+}));
+
+const mockGetMessagesSince = vi.fn<() => NewMessage[]>();
+vi.mock('./db.js', async (orig) => ({
+  ...((await orig()) as Record<string, unknown>),
+  getMessagesSince: mockGetMessagesSince,
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { autoCompressSession } = await import('./auto-compress.js');
+const { consolidateWebConversation } = await import('./webui-consolidation.js');
+
+/** The exact (path, content, label) handed to writeSessionLogAndIndex, normalized. */
+function captured(): { savedPath: string; content: string; label: string } {
+  const [savedPath, content, label] = mockWrite.mock.calls[0];
+  return {
+    savedPath: savedPath.replace(/\\/g, '/'), // cross-platform separator
+    // Normalize the only runtime-TZ-variant token. It fires solely on
+    // auto-compress output; webui bodies carry no `(HH:MM)`, so this is a no-op
+    // there. The surrounding `**sender** (HH:MM): text` structure stays pinned.
+    content: content.replace(/\((\d{2}):(\d{2})\)/g, '(HH:MM)'),
+    label,
+  };
+}
+
+function msg(o: Partial<NewMessage>): NewMessage {
+  return {
+    id: '1',
+    chat_jid: 'c@jid',
+    sender: 'sender',
+    sender_name: 'Alice',
+    content: 'hi',
+    timestamp: '2026-05-12T10:00:00.000Z',
+    is_from_me: false,
+    ...o,
+  } as NewMessage;
+}
+
+function makeGroup(): RegisteredGroup {
+  return {
+    name: 'Test Group',
+    folder: 'whatsapp_main',
+    channels: [],
+    isControlGroup: false,
+  } as unknown as RegisteredGroup;
+}
+
+const WEBUI_FIXTURE = {
+  messages: [
+    { role: 'user', content: 'How do I configure X?' },
+    { role: 'assistant', content: 'Set X in config.' },
+    { role: 'user', content: 'And Y?' },
+    { role: 'assistant', content: 'Set Y too.' },
+    { role: 'user', content: 'Thanks.' },
+  ],
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-12T10:00:00.000Z'));
+  mockWrite.mockReset();
+  mockResolveVault.mockReset().mockReturnValue('/vault');
+  mockGetMessagesSince.mockReset();
+  delete process.env.DEUS_WEBUI_CONSOLIDATE;
+  delete process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS;
+  delete process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS;
+});
+
+afterEach(() => {
+  // Release EVERY webui in-flight guard a test left held (not just the last),
+  // then restore the clock. Belt-and-suspenders: each webui test also uses a
+  // unique first-user message, so keys never collide across tests regardless.
+  for (const call of mockWrite.mock.calls) call[3]?.();
+  vi.useRealTimers();
+});
+
+// ── Byte goldens (the envelope + frontmatter + body each surface emits) ───────
+
+describe('@oracle auto-compress output', () => {
+  it('byte-stable session-log envelope handed to writeSessionLogAndIndex', async () => {
+    mockGetMessagesSince.mockReturnValue([
+      msg({
+        sender_name: 'Alice',
+        content: 'How do I configure X?',
+        is_from_me: false,
+        timestamp: '2026-05-12T10:00:00.000Z',
+      }),
+      msg({
+        sender_name: 'Deus',
+        content: 'Set X in config.',
+        is_from_me: true,
+        timestamp: '2026-05-12T10:01:00.000Z',
+      }),
+    ]);
+
+    await autoCompressSession(makeGroup(), 'c@jid', 8);
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(captured()).toMatchInlineSnapshot(`
+      {
+        "content": "---
+      type: session
+      date: 2026-05-12
+      topics: [auto-compress]
+      tldr: |
+        How do I configure X?
+      ---
+
+      **Alice** (HH:MM): How do I configure X?
+
+      **Deus** (HH:MM): Set X in config.
+      ",
+        "label": "auto-compress-index",
+        "savedPath": "/vault/Session-Logs/2026-05-12/auto-whatsapp_main-1000.md",
+      }
+    `);
+  });
+});
+
+describe('@oracle webui-consolidation output', () => {
+  it('byte-stable web-session envelope handed to writeSessionLogAndIndex', () => {
+    consolidateWebConversation(WEBUI_FIXTURE);
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(captured()).toMatchInlineSnapshot(`
+      {
+        "content": "---
+      type: web-session
+      date: 2026-05-12
+      topics: [webui, auto-consolidate]
+      tldr: "How do I configure X?"
+      ---
+
+      **User**: How do I configure X?
+
+      **Assistant**: Set X in config.
+
+      **User**: And Y?
+
+      **Assistant**: Set Y too.
+
+      **User**: Thanks.
+      ",
+        "label": "webui-consolidation-index",
+        "savedPath": "/vault/Session-Logs/2026-05-12/webui-db1753a7f3b3f129.md",
+      }
+    `);
+  });
+});
+
+// ── Skip contracts (the "must NOT write" guards the core will OWN) ─────────────
+// As load-bearing as the byte content: Phase 1 moves the vault-gate + empty-skip
+// into the shared core, so the oracle must pin that each still short-circuits.
+
+describe('@oracle skip contracts', () => {
+  it('auto-compress does NOT write when no vault is configured', async () => {
+    mockResolveVault.mockReturnValue(null);
+    mockGetMessagesSince.mockReturnValue([msg({})]);
+    await autoCompressSession(makeGroup(), 'c@jid', 8);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('auto-compress does NOT write when there are no messages', async () => {
+    mockGetMessagesSince.mockReturnValue([]);
+    await autoCompressSession(makeGroup(), 'c@jid', 8);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('webui does NOT write below the consolidation threshold', () => {
+    // Pin thresholds so the skip branch is exercised regardless of default drift.
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS = '3';
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS = '200';
+    consolidateWebConversation({
+      messages: [{ role: 'user', content: 'one short turn, skip-threshold' }],
+    });
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+});
+
+// ── Behavior goldens (per-surface throw/await contracts the core must preserve) ─
+
+describe('@oracle throw/await contracts', () => {
+  it('auto-compress PROPAGATES a synchronous write failure (orchestrator catches it)', async () => {
+    mockGetMessagesSince.mockReturnValue([msg({})]);
+    mockWrite.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    await expect(autoCompressSession(makeGroup(), 'c@jid', 8)).rejects.toThrow(
+      'EACCES: permission denied',
+    );
+  });
+
+  it('webui SWALLOWS a synchronous write failure and releases the in-flight key (void contract)', () => {
+    // Distinct first-user message → a unique conversation key (no collision with
+    // the byte-golden webui test, which holds its own key until afterEach).
+    const throwFixture = {
+      messages: [
+        { role: 'user', content: 'throw-path conversation first message' },
+        { role: 'assistant', content: 'a1' },
+        { role: 'user', content: 'q2' },
+        { role: 'assistant', content: 'a2' },
+        { role: 'user', content: 'q3' },
+      ],
+    };
+    mockWrite.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    // Fire-and-forget contract: must NOT throw out to the sink.
+    expect(() => consolidateWebConversation(throwFixture)).not.toThrow();
+
+    // The catch released the conversation key → an identical retry writes again.
+    mockWrite.mockReset();
+    consolidateWebConversation(throwFixture);
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/webui-consolidation.ts
+++ b/src/webui-consolidation.ts
@@ -1,11 +1,9 @@
 import crypto from 'crypto';
-import path from 'path';
 
+import { consolidateSessionLog } from './consolidation-core.js';
 import { envPositiveInt } from './env-utils.js';
 import { logger } from './logger.js';
-import { writeSessionLogAndIndex } from './memory-session-log.js';
 import { messageText } from './openai-messages.js';
-import { resolveVaultPath } from './solutions/index.js';
 
 /**
  * Web UI conversation auto-consolidation into vault memory (LIA-295).
@@ -100,12 +98,6 @@ export function consolidateWebConversation(body: unknown): void {
     return;
   }
 
-  const vaultPath = resolveVaultPath();
-  if (!vaultPath) {
-    logger.debug('Web UI consolidation skipped: no vault configured');
-    return;
-  }
-
   const key = crypto
     .createHash('sha256')
     .update(firstUserText)
@@ -113,7 +105,9 @@ export function consolidateWebConversation(body: unknown): void {
     .slice(0, 16);
 
   // Drop re-entrant consolidations for the same conversation while a prior
-  // --add is still running (released in onSettle below).
+  // --add is still running (released via onSettle below — which fires on the
+  // detached spawn settling AND on the core's no-vault skip, so the key can
+  // never get permanently stuck).
   if (inFlightConsolidation.has(key)) {
     logger.debug({ key }, 'Web UI consolidation: already in-flight, skipped');
     return;
@@ -121,13 +115,6 @@ export function consolidateWebConversation(body: unknown): void {
 
   const now = new Date();
   const dateStr = now.toISOString().slice(0, 10);
-  // One file per conversation, overwritten as it grows — re-index re-dedups.
-  const savedPath = path.join(
-    vaultPath,
-    'Session-Logs',
-    dateStr,
-    `webui-${key}.md`,
-  );
 
   // JSON.stringify yields a valid double-quoted YAML scalar (YAML ⊇ JSON), so
   // untrusted first-message text (leading spaces, colons, quotes) can't corrupt
@@ -135,32 +122,39 @@ export function consolidateWebConversation(body: unknown): void {
   const tldr = JSON.stringify(
     firstUserText.replace(/\s+/g, ' ').trim().slice(0, 120),
   );
-  const content = `---
-type: web-session
+  const frontmatter = `type: web-session
 date: ${dateStr}
 topics: [webui, auto-consolidate]
-tldr: ${tldr}
----
+tldr: ${tldr}`;
 
-${transcript}
-`;
-
+  // One file per conversation (`webui-<key>.md`), overwritten as it grows —
+  // re-index re-dedups. Vault resolution + path/envelope assembly happen in the
+  // shared consolidation core (LIA-302).
   inFlightConsolidation.add(key);
+  let savedPath: string | null;
   try {
-    writeSessionLogAndIndex(
-      savedPath,
-      content,
-      'webui-consolidation-index',
-      () => inFlightConsolidation.delete(key),
-    );
+    savedPath = consolidateSessionLog({
+      dateStr,
+      fileStem: `webui-${key}`,
+      frontmatter,
+      body: transcript,
+      spawnLabel: 'webui-consolidation-index',
+      onSettle: () => inFlightConsolidation.delete(key),
+    });
   } catch (err) {
     // Synchronous mkdir/write failure throws BEFORE the indexer spawn launches,
     // so the onSettle release never fires — drop the guard here so the key isn't
-    // stuck. (Success path releases via onSettle when the spawn settles.)
+    // stuck. (Success path releases via onSettle when the spawn settles; a
+    // no-vault skip releases it synchronously inside the core.)
     inFlightConsolidation.delete(key);
     logger.warn({ err }, 'Web UI consolidation: vault write failed');
     return;
   }
 
-  logger.info({ path: savedPath }, 'Web UI conversation consolidated to vault');
+  if (savedPath) {
+    logger.info(
+      { path: savedPath },
+      'Web UI conversation consolidated to vault',
+    );
+  }
 }


### PR DESCRIPTION
## What

Unify the byte-for-byte structural tail that the two session-log consolidation surfaces — idle **auto-compress** and **Web UI conversation consolidation** (LIA-295) — duplicated: vault resolution, the `Session-Logs/<date>/<stem>.md` path, the `---\n<fm>\n---\n\n<body>\n` envelope, and dispatch to `writeSessionLogAndIndex`.

## How

- **New `src/consolidation-core.ts`** — `consolidateSessionLog(spec)`: Parameter Object + Extract Function facade. Resolves the vault (skips + fires `onSettle` so an in-flight key can't stick), builds the path, assembles the envelope, delegates to `writeSessionLogAndIndex`. No `try/catch` (throw-transparency preserved).
- **`auto-compress.ts` + `webui-consolidation.ts`** adopt the core; each keeps its own trigger, source, format, empty-guard, kill-switch, and in-flight-key lifecycle. auto-compress keeps an early vault short-circuit before its (non-trivial) DB query; the core re-checks as the authoritative write gate.
- **`memory_indexer.py`** (the atom-extract / dedup / entity-graph memory-write heart) is **untouched by design** — the unified core only reshuffles the TS envelope feeding `--add`, so the indexer provably does the same thing.

## Verification

- The **7 Phase-0 `@oracle` byte snapshots are unchanged** — proof the envelope bytes are identical for both surfaces after the refactor.
- Adds **1 oracle** pinning the webui no-vault key-release contract (the path is now load-bearing: a stuck key would silently suppress consolidation forever).
- Full `npx vitest run`: **1655/1655 green** (88 files). `npm run build` clean.
- plan-reviewer SHIP + code-reviewer SHIP (re-reviewed after restoring auto-compress's early vault check).

## Scope notes

- `/compress` (a host skill, not TS) and format convergence between the two surfaces are **out of scope** (deferred — converging formats risks the indexer's body chunker).
- Phase 2 (this ticket): confirm `test-windows` green in CI; optional `docs/consolidation-contract.md`.

Linear: **LIA-302**

🤖 Generated with [Claude Code](https://claude.com/claude-code)