### PR TITLE
feat(wardens): co-gate ai-eng-warden + plan-reviewer; verification→Opus (LIA-303 Phase 3)

### DIFF
--- a/.claude/agents/verification-gate.md
+++ b/.claude/agents/verification-gate.md
@@ -1,7 +1,10 @@
 ---
 name: verification-gate
 description: Evidence-before-claims gate. Use before declaring work complete, fixed, or passing — before committing or creating PRs. Requires running verification commands and confirming output before any success claims. Adapted from Superpowers' verification-before-completion pattern. <example>Context: Just finished implementing a feature. user: "Done, all tests pass." assistant: "Running verification-gate before claiming completion." <commentary>Any completion claim triggers this.</commentary></example>
-model: sonnet
+# opus (not sonnet): this gate synthesizes tool output across multiple claims in one turn and
+# must catch contradictions between a "done" claim and the actual command output — the failure
+# mode is a missed contradiction, where deeper reasoning earns its cost (LIA-303).
+model: opus
 color: red
 ---
 

--- a/scripts/codex_warden.py
+++ b/scripts/codex_warden.py
@@ -71,6 +71,9 @@ def main(argv: list[str] | None = None) -> int:
     src = ap.add_mutually_exclusive_group()
     src.add_argument("--rev-range", help="commit sha or a..b range (default: working tree)")
     src.add_argument("--diff-file", help="path to a unified diff file to review")
+    src.add_argument("--content-file",
+                     help="path to a file read verbatim as the review target (non-diff roles, "
+                          "e.g. plan-reviewer reviewing a plan file)")
     ap.add_argument("--model", help="backend model id (default: backend/config default)")
     ap.add_argument("--timeout", type=float, default=cr.DEFAULT_TIMEOUT,
                     help=f"per-call timeout seconds (default {cr.DEFAULT_TIMEOUT:.0f})")
@@ -99,7 +102,9 @@ def main(argv: list[str] | None = None) -> int:
         return USAGE_ERROR
 
     try:
-        content = spec.gather(str(root), args.rev_range, args.diff_file)
+        # --content-file (non-diff roles) and --diff-file are mutually exclusive; route whichever
+        # was supplied into the gatherer's diff_file slot (_gather_diff ignores it; _gather_file reads it).
+        content = spec.gather(str(root), args.rev_range, args.content_file or args.diff_file)
     except cr.ReviewError as exc:
         sys.stderr.write(f"[codex-warden] {exc.message}\n")
         return exc.code

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -1271,6 +1271,13 @@ def run_session_init(repo_root: Path) -> int:
         *(cross_review_file(r) for r in _WIRED_ROLES),
     ):
         _marker(repo_root, name).unlink(missing_ok=True)
+    # plan-reviewer co-gate asymmetry (Phase 3): unlike code-reviewer (store-based, persists across
+    # sessions), plan-reviewer's Claude signal is the .plan-reviewed MARKER, cleared above on every
+    # session start. Its model-backend verdicts must match — clear plan-reviewer@<backend> so a fresh
+    # session needs fresh model review, else a stale GPT SHIP + a re-marked plan bypasses the gate
+    # (oracle O2). Other roles' stores intentionally persist (the comment above).
+    for _b in KNOWN_MODEL_BACKENDS:
+        _clear_verdict(store_key("plan-reviewer", _b), repo_root)
     _PATTERN_ROUTES_CACHE = None
     _INJECTED_DOCS.clear()
     _sync_atom_kinds_on_init(repo_root)
@@ -1552,6 +1559,12 @@ def run_plan_mode_invalidator(event: dict[str, Any], repo_root: Path) -> int:
     if should_clear:
         _marker(repo_root, ".plan-reviewed").unlink(missing_ok=True)
         _marker(repo_root, ".warden-memo.md").unlink(missing_ok=True)
+        # Co-gate (Phase 3): a new plan invalidates the model-backend review too — clear the
+        # plan-reviewer@<backend> verdicts + cross-review, else a stale GPT SHIP from the prior
+        # plan lets a re-marked .plan-reviewed bypass the gate without fresh model review (oracle O1).
+        for _b in KNOWN_MODEL_BACKENDS:
+            _clear_verdict(store_key("plan-reviewer", _b), repo_root)
+        _marker(repo_root, cross_review_file("plan-reviewer")).unlink(missing_ok=True)
     return 0
 
 
@@ -1566,9 +1579,17 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     ):
         return 0
 
-    # Marker check first — cheapest, satisfies the gate before any
-    # subprocess work in `_managed_paths`.
+    # Claude side = the .plan-reviewed marker (its lifecycle is unchanged: SessionStart and /plan
+    # both clear it to force re-review). Phase 3 (LIA-303) layers the co-gate ON TOP: when the
+    # marker is present, every configured MODEL backend (e.g. gpt) must also be SHIP. Marker-absent
+    # paths below are byte-unchanged. _evaluate_backends(skip_claude=True) reads only model verdicts
+    # from the store; the invalidators clear plan-reviewer@<backend> so a fresh plan needs fresh
+    # model review (no stale-SHIP bypass — oracle O1/O2). Pure JSON read: no added subprocess cost.
     if _marker(repo_root, ".plan-reviewed").exists():
+        model_blocking = _evaluate_backends("plan-reviewer", config, repo_root, skip_claude=True)
+        if not model_blocking:
+            return 0
+        _block_pre_tool(_warden_backends_block_message("plan-reviewer", model_blocking, repo_root))
         return 0
 
     # ExitPlanMode has no file paths — skip _managed_paths (which would
@@ -1714,37 +1735,14 @@ def run_ai_eng_gate(event: dict[str, Any], repo_root: Path) -> int:
     command = tool_input.get("command") if isinstance(tool_input, dict) else ""
     if not isinstance(command, str) or not GIT_COMMIT_RE.search(command):
         return 0
-    if _marker(repo_root, ".ai-eng-reviewed").exists():
-        return 0
-
     if not _diff_touches_llm_files(repo_root):
         return 0
 
-    mark_cmd = (
-        f"  python3 {shlex.quote(str(_active_script_path(repo_root)))} "
-        f"mark ai-eng-reviewed SHIP \"reason\""
-    )
-
-    if _last_verdict_is_blocking(repo_root, "ai-eng-warden"):
-        last = _last_verdict(repo_root, "ai-eng-warden")
-        reason = (
-            f"[ai-eng-gate] BLOCKED: last ai-eng-warden verdict was {last}.\n\n"
-            "Re-run the ai-eng-warden after fixing the issues. Trivial bypass is "
-            f"not permitted after {last} — no exceptions.\n\n"
-            f"After SHIP:\n{mark_cmd}"
-        )
-    else:
-        reason = (
-            "[ai-eng-gate] BLOCKED: no AI engineering review marker.\n\n"
-            "This commit touches LLM-related code. Run the ai-eng-warden and wait "
-            "for VERDICT: SHIP. Then run:\n\n"
-            f"{mark_cmd}\n\n"
-            "Trivial-commit bypass (non-LLM changes only):\n"
-            f"  python3 {shlex.quote(str(_active_script_path(repo_root)))} "
-            f"mark ai-eng-reviewed TRIVIAL \"reason\""
-        )
-    _block_pre_tool(reason)
-    return 0
+    # Co-gate across every configured backend (Phase 3, LIA-303). Mirrors code-reviewer:
+    # the Claude verdict is read from the store under "ai-eng-warden" and model backends via
+    # store_key. The diff-touches-LLM-files trigger above is ai-eng-specific, so it stays here;
+    # the generic gate handles the strict-AND verdict combination + block messaging.
+    return run_warden_backends_gate("ai-eng-warden", event, repo_root)
 
 
 def run_verification_gate(event: dict[str, Any], repo_root: Path) -> int:
@@ -2125,8 +2123,14 @@ def run_code_review_invalidator(event: dict[str, Any], repo_root: Path) -> int:
     for _b in KNOWN_MODEL_BACKENDS:
         _clear_verdict(store_key("code-reviewer", _b), repo_root)
     _marker(repo_root, cross_review_file("code-reviewer")).unlink(missing_ok=True)
-    # LLM code is a subset of all code — source edits invalidate both markers
+    # LLM code is a subset of all code — source edits invalidate ai-eng-warden too.
+    # Phase 3 made ai-eng store-based (like code-reviewer), so clear the Claude verdict store +
+    # model-backend verdicts + cross-review here, not just the marker, else a stale SHIP persists.
     _marker(repo_root, ".ai-eng-reviewed").unlink(missing_ok=True)
+    _clear_verdict("ai-eng-reviewed", repo_root)  # clears the "ai-eng-warden" JSON key via MARKER_NAMES
+    for _b in KNOWN_MODEL_BACKENDS:
+        _clear_verdict(store_key("ai-eng-warden", _b), repo_root)
+    _marker(repo_root, cross_review_file("ai-eng-warden")).unlink(missing_ok=True)
     return 0
 
 
@@ -3012,9 +3016,12 @@ def _warden_backends_block_message(
             lines.append(_claude_backend_block_message(role, marker, repo_root))
         else:
             state = verdict or "not run yet"
+            # Non-diff roles (plan-reviewer) need an explicit --content-file path; diff roles
+            # auto-gather the working-tree diff, so no source arg is shown for them.
+            src = " --content-file <path-to-plan>" if role in _CONTENT_FILE_ROLES else ""
             lines.append(
                 f"  - {backend}: {state} -- run:\n"
-                f"  python3 scripts/codex_warden.py --role {role} --backend {backend} --warden-mark"
+                f"  python3 scripts/codex_warden.py --role {role} --backend {backend}{src} --warden-mark"
             )
     if _co_gate_escalation_active(repo_root, role):
         loop = _read_loop(repo_root, role)
@@ -3032,6 +3039,54 @@ def _warden_backends_block_message(
             f"--role {role} --reason \"<justification>\"",
         ]
     return "\n".join(lines)
+
+
+def _evaluate_backends(
+    role: str, config: dict[str, Any], repo_root: Path, *, skip_claude: bool = False
+) -> list[tuple[str, str | None]]:
+    """Strict-AND verdict evaluation for a role's configured backends.
+
+    Returns the list of (backend, verdict) pairs that are NOT SHIP (the blocking set);
+    an empty list means every configured backend is SHIP (gate passes). COULD_NOT_RUN
+    fails OPEN (warn + skip, never blocks). Unknown backend ids are warned and skipped.
+
+    Trigger-agnostic by design: it reads only the verdict store, so commit-triggered gates
+    (code-reviewer/ai-eng-warden) and edit-triggered gates (plan-reviewer) can share it.
+    ``skip_claude=True`` evaluates only the model backends — used by plan-reviewer, whose
+    Claude signal is the ``.plan-reviewed`` marker (not the verdict store)."""
+    blocking: list[tuple[str, str | None]] = []
+    for backend in _role_backends(config, role):
+        if backend == BACKEND_CLAUDE:
+            if skip_claude:
+                continue
+            # Claude's verdict is stored under the role key (run_verdict_tracker writes the
+            # subagent type, which == the role). Read it directly — role-generic, no marker
+            # indirection — equivalent to the old _read_verdict("code-reviewed") for this role.
+            verdict = _last_verdict(repo_root, role)
+            # TRIVIAL is the human trivial-commit bypass (mark_warden accepts SHIP|TRIVIAL and
+            # writes the literal verdict). It satisfies the Claude side exactly like SHIP — the
+            # marker-only gates honored it, so the backends gate must too. Model backends never
+            # emit TRIVIAL (MODEL_VERDICTS), so this only applies to the Claude side.
+            if verdict == "TRIVIAL":
+                continue
+        elif backend in KNOWN_MODEL_BACKENDS:
+            verdict = _read_verdict(store_key(role, backend), repo_root)
+        else:
+            sys.stderr.write(
+                f"[warden-backends-gate] WARNING: unknown backend '{backend}' in "
+                f"{role}.backends -- skipped (not gating).\n"
+            )
+            continue
+        if verdict == VERDICT_SHIP:
+            continue
+        if verdict == VERDICT_COULD_NOT_RUN:
+            sys.stderr.write(
+                f"[warden-backends-gate] WARNING: {role}@{backend} could not run (infra) -- "
+                "gate FAIL-OPEN for this backend; commit allowed. Retry with --warden-mark.\n"
+            )
+            continue
+        blocking.append((backend, verdict))
+    return blocking
 
 
 def run_warden_backends_gate(role: str, event: dict[str, Any], repo_root: Path) -> int:
@@ -3054,31 +3109,7 @@ def run_warden_backends_gate(role: str, event: dict[str, Any], repo_root: Path) 
     if not isinstance(command, str) or not GIT_COMMIT_RE.search(command):
         return 0
 
-    blocking: list[tuple[str, str | None]] = []
-    for backend in _role_backends(config, role):
-        if backend == BACKEND_CLAUDE:
-            # Claude's verdict is stored under the role key (run_verdict_tracker writes the
-            # subagent type, which == the role). Read it directly — role-generic, no marker
-            # indirection — equivalent to the old _read_verdict("code-reviewed") for this role.
-            verdict = _last_verdict(repo_root, role)
-        elif backend in KNOWN_MODEL_BACKENDS:
-            verdict = _read_verdict(store_key(role, backend), repo_root)
-        else:
-            sys.stderr.write(
-                f"[warden-backends-gate] WARNING: unknown backend '{backend}' in "
-                f"{role}.backends -- skipped (not gating).\n"
-            )
-            continue
-        if verdict == VERDICT_SHIP:
-            continue
-        if verdict == VERDICT_COULD_NOT_RUN:
-            sys.stderr.write(
-                f"[warden-backends-gate] WARNING: {role}@{backend} could not run (infra) -- "
-                "gate FAIL-OPEN for this backend; commit allowed. Retry with --warden-mark.\n"
-            )
-            continue
-        blocking.append((backend, verdict))
-
+    blocking = _evaluate_backends(role, config, repo_root)
     if not blocking:
         return 0
     _block_pre_tool(_warden_backends_block_message(role, blocking, repo_root))
@@ -3385,7 +3416,13 @@ MARKER_NAMES.update({
 # backend's verdict via this marker, and model backends via the "<role>@<backend>" key.
 _ROLE_CLAUDE_MARKER = {
     "code-reviewer": "code-reviewed",
+    "ai-eng-warden": "ai-eng-reviewed",
+    "plan-reviewer": "plan-reviewed",
 }
+
+#: Roles whose model-backend review reads an explicit file (not a git diff) — the block
+#: message must instruct `--content-file`. Diff roles auto-gather the working-tree diff.
+_CONTENT_FILE_ROLES = frozenset({"plan-reviewer"})
 
 
 def mark_warden(marker_name: str, verdict: str, reason: str, repo_root: Path) -> int:

--- a/scripts/tests/test_codex_warden.py
+++ b/scripts/tests/test_codex_warden.py
@@ -71,6 +71,39 @@ def test_driver_unknown_backend_usage_error(git_repo, monkeypatch):
     assert rc == USAGE_ERROR
 
 
+# ── Phase 3 (LIA-303): plan-reviewer reviews a --content-file (no git diff) ────────
+
+def test_driver_plan_reviewer_content_file_records_verdict(git_repo, tmp_path, monkeypatch):
+    # plan-reviewer has no diff; the plan text is read verbatim from --content-file and the
+    # gpt verdict is recorded under plan-reviewer@gpt for the co-gate to read.
+    plan = tmp_path / "plan.md"
+    plan.write_text("## Plan\nDo the thing safely.", encoding="utf-8")
+    captured = {}
+    monkeypatch.setattr(cw.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cw.registry, "is_registered", lambda b: True)
+
+    def _backend(b):
+        def review(req):
+            captured["content"] = req.content      # prove the plan text reached the backend
+            return Verdict("SHIP", [], "plan looks sound")
+        return types.SimpleNamespace(review=review)
+    monkeypatch.setattr(cw.registry, "get_backend", _backend)
+
+    rc = cw.main(["--role", "plan-reviewer", "--content-file", str(plan), "--warden-mark"])
+    assert rc == 0
+    assert "Do the thing safely." in captured["content"]
+    assert cw.whooks._read_verdict("plan-reviewer@gpt", git_repo) == "SHIP"
+
+
+def test_driver_plan_reviewer_without_content_file_errors(git_repo, monkeypatch):
+    from _exit_codes import USAGE_ERROR
+    monkeypatch.setattr(cw.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cw.registry, "is_registered", lambda b: True)
+    # No --content-file → _gather_file raises ReviewError(USAGE_ERROR); driver maps to non-zero.
+    rc = cw.main(["--role", "plan-reviewer", "--warden-mark"])
+    assert rc == USAGE_ERROR
+
+
 def test_driver_out_writes_json(git_repo, tmp_path, monkeypatch):
     monkeypatch.setattr(cw.cr.cfr, "repo_root", lambda: str(git_repo))
     monkeypatch.setattr(cw.cr.cfr, "get_diff", lambda root, rr, df: _DIFF)

--- a/scripts/tests/test_phase3_cogate_oracle.py
+++ b/scripts/tests/test_phase3_cogate_oracle.py
@@ -1,0 +1,405 @@
+"""Oracle tests for LIA-303 Phase 3: plan-reviewer co-gate.
+
+Each test is derived FROM THE SPEC, blind to the implementation. They are RED
+against the current (pre-Phase-3) codebase and GREEN only on a correct
+implementation.
+
+Run:
+    python3 -m pytest scripts/tests/test_phase3_cogate_oracle.py -v
+
+Oracle tagging convention (oracle-rules.md § oracle-tagged):
+    # @oracle: <one-line spec reference>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import codex_warden_hooks as h
+from warden_review.constants import BACKEND_GPT, store_key
+
+_PLAN_ROLE = "plan-reviewer"
+_GPT_KEY = store_key(_PLAN_ROLE, BACKEND_GPT)   # "plan-reviewer@gpt"
+_CODE_ROLE = "code-reviewer"
+_CODE_GPT_KEY = store_key(_CODE_ROLE, BACKEND_GPT)   # "code-reviewer@gpt"
+
+
+# ── Fixtures (mirrors test_warden_review.py harness exactly) ──────────────────
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """Isolated repo-root with all gate state under tmp_path/.claude."""
+    cdir = tmp_path / ".claude"
+    (cdir / "wardens").mkdir(parents=True)
+    monkeypatch.setattr(h, "_claude_marker_dir", lambda root: cdir)
+    monkeypatch.setattr(h, "_worktree_for_cwd", lambda cwd, root: tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def blocks(monkeypatch):
+    """Capture _block_pre_tool calls so tests can assert ALLOW vs BLOCK."""
+    recorded: list[str] = []
+    monkeypatch.setattr(h, "_block_pre_tool", lambda reason: recorded.append(reason))
+    return recorded
+
+
+def _config(repo: Path, cfg: dict) -> None:
+    (repo / ".claude" / "wardens" / "config.json").write_text(json.dumps(cfg))
+
+
+def _set(repo: Path, key: str, verdict: str) -> None:
+    """Write a verdict into the store (same helper used by test_warden_review.py)."""
+    h.record_script_verdict(repo, key, verdict, "oracle-test")
+
+
+def _plan_edit_event(repo: Path) -> dict:
+    """A PreToolUse Edit event inside the repo worktree.
+
+    The hook reads ``tool_input["file_path"]`` (not ``path``) per _event_paths
+    in codex_warden_hooks.py:281.  Using the wrong key produces an empty path
+    list, which causes the gate to take the 'outside-worktree' early-return path
+    instead of blocking — masking the missing marker.
+    """
+    return {
+        "tool_name": "Edit",
+        "cwd": str(repo),
+        "tool_input": {
+            "file_path": str(repo / "src" / "main.py"),
+            "old_string": "a",
+            "new_string": "b",
+        },
+    }
+
+
+def _commit_event(repo: Path) -> dict:
+    return {"cwd": str(repo), "tool_input": {"command": "git commit -m x"}}
+
+
+def _plan_mode_event(repo: Path) -> dict:
+    """A UserPromptSubmit /plan event that should trigger the invalidator."""
+    return {
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": str(repo),
+        "prompt": "/plan redesign the auth module",
+    }
+
+
+def _exit_plan_mode_event(repo: Path) -> dict:
+    """ExitPlanMode tool event that should also trigger the invalidator."""
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "ExitPlanMode",
+        "cwd": str(repo),
+        "tool_input": {},
+    }
+
+
+# ── Contract A: plan-reviewer co-gate ─────────────────────────────────────────
+#
+# Gate allows ONLY when BOTH the .plan-reviewed marker exists AND the GPT
+# verdict is SHIP.  Missing or REVISE GPT verdict must block even when the
+# marker is present.
+
+def test_cogate_plan_marker_and_gpt_ship_allows(repo, blocks):
+    # @oracle: Contract A — BOTH marker present AND GPT SHIP → ALLOW
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+    assert blocks == [], (
+        "gate must ALLOW when both .plan-reviewed marker exists and GPT verdict is SHIP"
+    )
+
+
+def test_cogate_plan_marker_present_gpt_missing_blocks(repo, blocks):
+    # @oracle: Contract A — marker present but GPT verdict absent → BLOCK
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    # GPT verdict deliberately NOT written
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+    assert blocks, (
+        "gate must BLOCK when .plan-reviewed marker exists but GPT verdict is missing; "
+        "this fails on the current (pre-Phase-3) implementation where marker alone suffices"
+    )
+
+
+def test_cogate_plan_marker_present_gpt_revise_blocks(repo, blocks):
+    # @oracle: Contract A — marker present but GPT verdict is REVISE → BLOCK
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "REVISE")
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+    assert blocks, (
+        "gate must BLOCK when marker exists but GPT verdict is REVISE; "
+        "the pre-Phase-3 gate ignores GPT entirely and would ALLOW — that is the bug"
+    )
+
+
+def test_cogate_plan_marker_absent_blocks_regardless_of_gpt(repo, blocks):
+    # @oracle: Contract A — no marker → BLOCK even if GPT is SHIP (pre-existing behaviour)
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+    # Marker deliberately absent
+    _set(repo, _GPT_KEY, "SHIP")
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+    assert blocks, (
+        "gate must BLOCK when marker is absent, regardless of GPT verdict"
+    )
+
+
+def test_cogate_plan_gpt_could_not_run_fails_open(repo, blocks):
+    # @oracle: Contract A — COULD_NOT_RUN is infra failure → fail open (ALLOW when marker present)
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "COULD_NOT_RUN")
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+    assert blocks == [], (
+        "COULD_NOT_RUN is an infra failure — must fail open and ALLOW the edit"
+    )
+
+
+# ── Contract B: /plan invalidation clears BOTH marker AND GPT verdict ─────────
+#
+# The discriminating shape: seed marker-present + stale GPT SHIP, fire the
+# invalidator, re-create the marker (simulating a fresh Claude plan-review SHIP
+# on the new plan, but NO new GPT review), then assert the gate BLOCKS.
+#
+# A buggy impl that clears only the marker (not the GPT store) would re-use the
+# stale SHIP verdict after the marker is re-created → gate ALLOWS → test FAILS.
+
+def test_o1_plan_invalidation_clears_gpt_verdict(repo, blocks):
+    # @oracle: Contract B — /plan invalidator must clear plan-reviewer@gpt store key
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+
+    # Seed: stale state from a prior plan-review cycle
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")  # stale GPT SHIP from the OLD plan
+
+    # Fire the plan-mode invalidator (triggered by /plan prompt)
+    h.run_plan_mode_invalidator(_plan_mode_event(repo), repo)
+
+    # Simulate fresh Claude plan-review SHIP on the NEW plan (just the marker)
+    _marker_path.touch()
+
+    # Gate must now BLOCK: the new plan has no GPT review
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+
+    assert blocks, (
+        "after /plan invalidation + re-created marker, gate must BLOCK because "
+        "the stale plan-reviewer@gpt SHIP was cleared; "
+        "a buggy impl that clears only the marker leaves the stale GPT SHIP intact "
+        "and the gate would ALLOW — this test catches that bypass"
+    )
+
+
+def test_o1_exit_plan_mode_also_clears_gpt_verdict(repo, blocks):
+    # @oracle: Contract B (ExitPlanMode path) — ExitPlanMode invalidator must also clear plan-reviewer@gpt
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")  # stale GPT SHIP
+
+    # Fire via ExitPlanMode
+    h.run_plan_mode_invalidator(_exit_plan_mode_event(repo), repo)
+
+    # Re-create marker (fresh Claude SHIP on new plan, but no new GPT review)
+    _marker_path.touch()
+
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+
+    assert blocks, (
+        "ExitPlanMode invalidation path must also clear plan-reviewer@gpt verdict; "
+        "stale GPT SHIP + re-created marker must BLOCK, not ALLOW"
+    )
+
+
+def test_o1_gpt_verdict_is_absent_after_invalidation(repo):
+    # @oracle: Contract B — directly verify plan-reviewer@gpt is None after invalidator runs
+    #
+    # NOTE: This test correctly discriminates only once Phase 3 adds "plan-reviewer" to
+    # WIRED_ROLES in warden_review/constants.py (so that _read_verdict / _write_verdict
+    # route through MARKER_NAMES for "plan-reviewer@gpt").  On the pre-Phase-3 codebase,
+    # _read_verdict("plan-reviewer@gpt") returns None unconditionally (key not in
+    # MARKER_NAMES), so the test passes vacuously.  The compound end-to-end test
+    # test_o1_plan_invalidation_clears_gpt_verdict is the primary discriminator.
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")
+
+    h.run_plan_mode_invalidator(_plan_mode_event(repo), repo)
+
+    stored = h._read_verdict(_GPT_KEY, repo)
+    assert stored is None, (
+        f"plan-reviewer@gpt must be None after /plan invalidation, got {stored!r}; "
+        "a Phase-3 impl that adds plan-reviewer to WIRED_ROLES but forgets to clear "
+        "the verdict from the invalidator would fail this test"
+    )
+
+
+# ── Contract C: SessionStart invalidation clears BOTH marker AND GPT verdict ──
+#
+# Same discriminating shape as O1, but driven by run_session_init instead of
+# the plan-mode invalidator.
+
+def test_o2_session_init_clears_gpt_verdict(repo, blocks):
+    # @oracle: Contract C — run_session_init must clear plan-reviewer@gpt store key
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+
+    # Seed: stale state left over from the previous session
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")  # stale GPT SHIP from old session
+
+    # Session start fires
+    h.run_session_init(repo)
+
+    # Simulate fresh Claude plan-review SHIP on first plan of the new session
+    _marker_path.touch()
+
+    # Gate must BLOCK: new session's plan has no fresh GPT review
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+
+    assert blocks, (
+        "after run_session_init + re-created marker, gate must BLOCK because the "
+        "stale plan-reviewer@gpt SHIP was cleared by session init; "
+        "a buggy impl that does not clear the verdict store would carry the stale "
+        "SHIP forward and the gate would ALLOW — this test catches that bypass"
+    )
+
+
+def test_o2_gpt_verdict_is_absent_after_session_init(repo):
+    # @oracle: Contract C — directly verify plan-reviewer@gpt is None after run_session_init
+    #
+    # NOTE: same WIRED_ROLES caveat as test_o1_gpt_verdict_is_absent_after_invalidation.
+    # Discriminates correctly only once "plan-reviewer" is in WIRED_ROLES.  On the
+    # pre-Phase-3 codebase this passes vacuously.  The primary discriminator is
+    # test_o2_session_init_clears_gpt_verdict (end-to-end gate check).
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")
+
+    h.run_session_init(repo)
+
+    stored = h._read_verdict(_GPT_KEY, repo)
+    assert stored is None, (
+        f"plan-reviewer@gpt must be None after run_session_init, got {stored!r}; "
+        "a Phase-3 impl that adds plan-reviewer to WIRED_ROLES but forgets to clear "
+        "the verdict from session_init would fail this test"
+    )
+
+
+def test_o2_session_init_still_clears_plan_reviewed_marker(repo):
+    # @oracle: Contract C — run_session_init must still clear .plan-reviewed marker (regression guard)
+    _marker_path = h._marker(repo, ".plan-reviewed")
+    _marker_path.parent.mkdir(parents=True, exist_ok=True)
+    _marker_path.touch()
+
+    h.run_session_init(repo)
+
+    assert not _marker_path.exists(), (
+        ".plan-reviewed marker must be cleared by run_session_init (pre-existing behaviour)"
+    )
+
+
+# ── Contract A prerequisite: plan-reviewer must be in WIRED_ROLES ────────────
+#
+# The gate can only read and write "plan-reviewer@gpt" through the verdict store
+# if "plan-reviewer" is in WIRED_ROLES (warden_review/constants.py).  MARKER_NAMES
+# is built from WIRED_ROLES × KNOWN_MODEL_BACKENDS — if the role is absent, all
+# _read_verdict / _write_verdict calls for "plan-reviewer@gpt" silently no-op and
+# the gate can never read back a verdict it was supposed to check.
+
+def test_plan_reviewer_in_wired_roles(repo):
+    # @oracle: Contract A prerequisite — plan-reviewer must be wired so its GPT key is routable
+    from warden_review.constants import WIRED_ROLES
+    assert _PLAN_ROLE in WIRED_ROLES, (
+        f"'plan-reviewer' must be in WIRED_ROLES (warden_review/constants.py) so that "
+        f"'{_GPT_KEY}' is present in MARKER_NAMES and _read_verdict/_write_verdict can "
+        "route it; without this, all verdict reads for plan-reviewer@gpt return None "
+        "and the co-gate is a no-op regardless of what the invalidator does"
+    )
+
+
+def test_plan_reviewer_gpt_key_in_marker_names(repo):
+    # @oracle: Contract A prerequisite — plan-reviewer@gpt must be in MARKER_NAMES identity map
+    assert _GPT_KEY in h.MARKER_NAMES, (
+        f"'{_GPT_KEY}' must be in MARKER_NAMES so _read_verdict can look it up; "
+        "adding plan-reviewer to WIRED_ROLES generates this entry automatically"
+    )
+
+
+# ── Contract D: code-reviewer co-gate regression guard ────────────────────────
+#
+# The _evaluate_backends extraction in Phase 3 must not break the existing
+# code-reviewer co-gate. Mirror the key existing tests from test_warden_review.py.
+
+def test_o3_code_reviewer_both_ship_allows(repo, blocks):
+    # @oracle: Contract D — code-reviewer co-gate: both SHIP → ALLOW (regression)
+    _config(repo, {_CODE_ROLE: {"backends": ["claude", "gpt"]}})
+    _set(repo, _CODE_ROLE, "SHIP")
+    _set(repo, _CODE_GPT_KEY, "SHIP")
+    rc = h.run_warden_backends_gate(_CODE_ROLE, _commit_event(repo), repo)
+    assert rc == 0
+    assert blocks == [], (
+        "code-reviewer co-gate must ALLOW when both Claude and GPT verdict are SHIP"
+    )
+
+
+def test_o3_code_reviewer_gpt_revise_blocks(repo, blocks):
+    # @oracle: Contract D — code-reviewer co-gate: GPT REVISE → BLOCK (regression)
+    _config(repo, {_CODE_ROLE: {"backends": ["claude", "gpt"]}})
+    _set(repo, _CODE_ROLE, "SHIP")
+    _set(repo, _CODE_GPT_KEY, "REVISE")
+    h.run_warden_backends_gate(_CODE_ROLE, _commit_event(repo), repo)
+    assert blocks, (
+        "code-reviewer co-gate must BLOCK when GPT verdict is REVISE; "
+        "regression: _evaluate_backends extraction must not break this"
+    )
+
+
+def test_o3_code_reviewer_gpt_missing_blocks(repo, blocks):
+    # @oracle: Contract D — code-reviewer co-gate: GPT missing → BLOCK (regression)
+    _config(repo, {_CODE_ROLE: {"backends": ["claude", "gpt"]}})
+    _set(repo, _CODE_ROLE, "SHIP")
+    # GPT verdict not set
+    h.run_warden_backends_gate(_CODE_ROLE, _commit_event(repo), repo)
+    assert blocks, (
+        "code-reviewer co-gate must BLOCK when GPT verdict is absent"
+    )
+
+
+def test_o3_code_reviewer_gpt_could_not_run_fails_open(repo, blocks):
+    # @oracle: Contract D — code-reviewer co-gate: COULD_NOT_RUN → ALLOW (regression)
+    _config(repo, {_CODE_ROLE: {"backends": ["claude", "gpt"]}})
+    _set(repo, _CODE_ROLE, "SHIP")
+    _set(repo, _CODE_GPT_KEY, "COULD_NOT_RUN")
+    h.run_warden_backends_gate(_CODE_ROLE, _commit_event(repo), repo)
+    assert blocks == [], (
+        "COULD_NOT_RUN must fail open — infra failures must not block commits"
+    )

--- a/scripts/tests/test_warden_review.py
+++ b/scripts/tests/test_warden_review.py
@@ -89,6 +89,75 @@ def test_code_reviewer_role_gathers_diff(monkeypatch):
     assert spec.gather("/x", None, None) == "THE DIFF"
 
 
+# ── Phase 3 (LIA-303): ai-eng-warden + plan-reviewer role specs + gatherers ───────
+
+def test_ai_eng_warden_role_gathers_diff(monkeypatch):
+    monkeypatch.setattr(cr.cfr, "get_diff", lambda root, rr, df: "THE DIFF")
+    spec = ROLE_SPECS["ai-eng-warden"]
+    assert spec.claude_marker == "ai-eng-reviewed"
+    assert spec.rules_path == ".claude/wardens/ai-engineering-rules.md"
+    assert spec.gather("/x", None, None) == "THE DIFF"   # diff-based, like code-reviewer
+
+
+def test_plan_reviewer_role_gathers_content_file(tmp_path):
+    spec = ROLE_SPECS["plan-reviewer"]
+    assert spec.claude_marker == "plan-reviewed"
+    assert spec.rules_path == ".claude/wardens/plan-review-rules.md"
+    plan = tmp_path / "plan.md"
+    plan.write_text("THE PLAN TEXT", encoding="utf-8")
+    # The content-file path arrives in the diff_file slot (codex_warden routes --content-file there).
+    assert spec.gather("/x", None, str(plan)) == "THE PLAN TEXT"
+
+
+def test_plan_reviewer_gather_without_content_file_raises():
+    spec = ROLE_SPECS["plan-reviewer"]
+    with pytest.raises(cr.ReviewError):
+        spec.gather("/x", None, None)
+
+
+# ── _evaluate_backends / _evaluate_model_backends (the extracted, trigger-agnostic core) ──
+
+def test_evaluate_model_backends_skips_claude(tmp_path):
+    repo = tmp_path
+    cfg = {"plan-reviewer": {"backends": ["claude", BACKEND_GPT]}}
+    gpt_key = store_key("plan-reviewer", BACKEND_GPT)   # "plan-reviewer@gpt"
+    # Claude verdict deliberately absent; skip_claude must ignore it and judge only gpt.
+    h._write_verdict(repo, gpt_key, "SHIP", "ok")
+    assert h._evaluate_backends("plan-reviewer", cfg, repo, skip_claude=True) == []
+    # And with gpt REVISE it blocks (still ignoring the missing claude verdict):
+    h._write_verdict(repo, gpt_key, "REVISE", "no")
+    blocking = h._evaluate_backends("plan-reviewer", cfg, repo, skip_claude=True)
+    assert [b for b, _ in blocking] == [BACKEND_GPT]
+
+
+def test_evaluate_backends_is_pure_no_event(tmp_path):
+    """The extracted core takes no event/cwd/commit guard — callable standalone."""
+    repo = tmp_path
+    cfg = {"code-reviewer": {"backends": ["claude"]}}
+    # No claude verdict in the store → blocking (fail-closed), no exception.
+    assert h._evaluate_backends("code-reviewer", cfg, repo) == [("claude", None)]
+
+
+def test_claude_trivial_verdict_satisfies_gate(tmp_path):
+    """TRIVIAL is the human trivial-commit bypass — it must pass the Claude side like SHIP, for
+    every role on the backends gate (regression: the GPT co-gate caught that ai-eng's TRIVIAL
+    bypass broke when it moved onto _evaluate_backends; code-reviewer had the same latent bug)."""
+    repo = tmp_path
+    for role in ("code-reviewer", "ai-eng-warden"):
+        h._write_verdict(repo, role, "TRIVIAL", "trivial commit")
+        cfg = {role: {"backends": ["claude"]}}
+        assert h._evaluate_backends(role, cfg, repo) == [], f"{role} TRIVIAL must pass the gate"
+
+
+def test_model_backend_non_ship_still_blocks_under_trivial_claude(tmp_path):
+    """TRIVIAL only excuses the Claude side; a co-gated model backend that is not SHIP still blocks."""
+    repo = tmp_path
+    h._write_verdict(repo, "code-reviewer", "TRIVIAL", "trivial")
+    h._write_verdict(repo, store_key("code-reviewer", BACKEND_GPT), "REVISE", "gpt found a bug")
+    cfg = {"code-reviewer": {"backends": ["claude", BACKEND_GPT]}}
+    assert [b for b, _ in h._evaluate_backends("code-reviewer", cfg, repo)] == [BACKEND_GPT]
+
+
 # ── Codex backend: result mapping + fail-open ─────────────────────────────────────
 
 def test_backend_maps_success_to_verdict(monkeypatch):

--- a/scripts/warden_review/constants.py
+++ b/scripts/warden_review/constants.py
@@ -54,5 +54,7 @@ def cross_review_file(role: str) -> str:
     return f".{role}-cross-review.md"
 
 
-#: Roles wired into the provider-agnostic co-gate today (Phase 2). Phase 3 extends this.
-WIRED_ROLES = ("code-reviewer",)
+#: Roles wired into the provider-agnostic co-gate. Phase 2 wired code-reviewer; Phase 3
+#: (LIA-303) added ai-eng-warden + plan-reviewer. Adding a role here auto-registers its
+#: ``<role>@<backend>`` verdict keys into MARKER_NAMES and its loop/cross-review ephemera.
+WIRED_ROLES = ("code-reviewer", "ai-eng-warden", "plan-reviewer")

--- a/scripts/warden_review/roles.py
+++ b/scripts/warden_review/roles.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 import cross_family_review as cfr
 
@@ -25,11 +26,38 @@ def _gather_diff(root: str, rev_range: str | None, diff_file: str | None) -> str
     return cfr.get_diff(root, rev_range, diff_file)
 
 
+def _gather_file(root: str, rev_range: str | None, diff_file: str | None) -> str:
+    """Read review content verbatim from a file path (for non-diff roles, e.g. plan-reviewer).
+
+    The path arrives in the ``diff_file`` slot (codex_warden.py routes ``--content-file`` there).
+    Plain ``read_text`` — no shell, no diff parsing. Raises if the path is absent/unreadable so
+    the driver surfaces a clear usage error rather than reviewing empty content. Role-agnostic:
+    the message names no specific role so any future content-file role can reuse this gatherer."""
+    if not diff_file:
+        raise cfr.ReviewError(
+            cfr.USAGE_ERROR,
+            "this role requires --content-file <path> (no git diff to review)",
+        )
+    return Path(diff_file).read_text(encoding="utf-8")
+
+
 ROLE_SPECS: dict[str, RoleSpec] = {
     "code-reviewer": RoleSpec(
         role="code-reviewer",
         rules_path=".claude/wardens/code-review-rules.md",
         claude_marker="code-reviewed",
         gather=_gather_diff,
+    ),
+    "ai-eng-warden": RoleSpec(
+        role="ai-eng-warden",
+        rules_path=".claude/wardens/ai-engineering-rules.md",
+        claude_marker="ai-eng-reviewed",
+        gather=_gather_diff,
+    ),
+    "plan-reviewer": RoleSpec(
+        role="plan-reviewer",
+        rules_path=".claude/wardens/plan-review-rules.md",
+        claude_marker="plan-reviewed",
+        gather=_gather_file,
     ),
 }


### PR DESCRIPTION
Closes LIA-303. Phase 3 of the provider-agnostic warden co-gate (Phase 2 wired code-reviewer in #839).

## What

Extends the Claude+GPT co-gate to **ai-eng-warden** and **plan-reviewer**, and pins the **verification-gate to Claude Opus**. threat-modeler is deferred (LIA-303 follow-up — advisory-only today, no input path).

## How

- **`_evaluate_backends(role, config, repo, *, skip_claude=False)`** — extracted the strict-AND verdict loop from `run_warden_backends_gate` (behavior-preserving), so non-commit gates can reuse it. Claude-side **TRIVIAL** now satisfies the gate like SHIP (model backends never emit TRIVIAL).
- **ai-eng-warden** — commit-triggered, mirrors code-reviewer: `run_ai_eng_gate` keeps its `_diff_touches_llm_files` trigger, then delegates to `run_warden_backends_gate`. `run_code_review_invalidator` now clears the ai-eng Claude store + model verdicts on source edit.
- **plan-reviewer** — Edit/Write-triggered. Keeps the `.plan-reviewed` **marker** as the Claude signal (its SessionStart + `/plan` invalidation lifecycle is unchanged) and layers the GPT store-check on top via `_evaluate_backends(skip_claude=True)`. `run_plan_mode_invalidator` + `run_session_init` now clear `plan-reviewer@<backend>` so a stale GPT SHIP can't satisfy a re-marked plan.
- **verification-gate → Opus** — 1-line agent-spec model change + inline justification.
- **`codex_warden.py --content-file`** — feeds a plan file (verbatim `read_text`, no shell) to the GPT plan-reviewer; routed into the gatherer's `diff_file` slot.

## The co-gate caught a real bug (dogfooding)

Running the GPT backend on this very diff returned **REVISE**: moving ai-eng to the backends gate broke its **TRIVIAL bypass** (the marker-only gate honored TRIVIAL; `_evaluate_backends` only accepted SHIP). This was also a **latent Phase-2 bug** in code-reviewer. Fixed in `_evaluate_backends` (Claude-side TRIVIAL passes) + 2 regression-guard tests. GPT re-review then SHIP.

## Invalidation correctness (the keystone)

plan-reviewer's marker-based lifecycle differs from code-reviewer's store-based one. The two invalidators clear the model-backend verdict so neither `/plan` nor SessionStart leaves a stale GPT SHIP that bypasses the gate.

## Tests

- New **`test_phase3_cogate_oracle.py`** — independent red-green oracle authored from the spec (oracle-author, blind to impl): 17 tests, **7 were red** against pre-Phase-3 code (the GPT-check + both invalidation bypass discriminators), all green now.
- Role-spec / `--content-file` driver / TRIVIAL coverage added to `test_warden_review.py` + `test_codex_warden.py`.
- **73 warden+oracle tests pass**; CI pytest set 176 pass; full `scripts/tests` sweep green.
- **Real CLI hook smoke** (`python3 scripts/codex_warden_hooks.py run plan-review-gate|plan-mode-invalidator` + JSON stdin): marker-absent→deny; marker+gpt SHIP→allow; marker+gpt missing→deny with `--content-file`; `/plan` clears stale `plan-reviewer@gpt`.

## Reviews

plan-reviewer SHIP (1 REVISE), code-reviewer SHIP (Claude + **GPT co-gate**, 1 REVISE→fixed), ai-eng-warden SHIP. No TS touched (vitest unaffected).

## Activation

Per-role config (`config["<role>"].backends`) is opt-in and **not committed**; ai-eng-warden + plan-reviewer get turned on in the local `~/.config/deus/config.json` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)