### PR TITLE
chore(deps): bump starlette from 1.0.1 to 1.3.1 in /evolution

### DIFF
--- a/evolution/requirements.txt
+++ b/evolution/requirements.txt
@@ -9,7 +9,7 @@ sentence-transformers>=3.0.0
 
 # MCP server (optional — for external agent integration)
 mcp==1.27.1
-starlette==1.0.1                # CVE-2026-48710 fix — MCP's >=0.27 constraint is too loose
+starlette==1.3.1                # CVE-2026-48710 fix — MCP's >=0.27 constraint is too loose
 
 # DSPy optimizer (optional — install when running `evolve optimize`)
 # dspy>=3.2.0

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-14" # auto-bump @1781410171
+last_verified: "2026-06-17" # auto-bump @1781705304
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-16" # auto-bump @1781640462
+last_verified: "2026-06-17" # auto-bump @1781705304
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
Rebased replacement for #856 (dependabot) with the `eval-change.md` pattern-drift bump regenerated — dependabot doesn't run the pre-push bump hook, so the original PR's required `ci` failed on `evolution/` drift.

Same dependency bump as #856; closing that in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)