### PR TITLE
fix(wardens): driver records verdicts into the gate's per-worktree bucket

### DIFF
--- a/scripts/codex_warden.py
+++ b/scripts/codex_warden.py
@@ -94,6 +94,13 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"[codex-warden] {exc.message}\n")
         return exc.code
 
+    # `root` (the worktree toplevel) is for gathering the diff + the codex sandbox cwd.
+    # Warden state (verdict store, cross-review files, loop counter) is namespaced under
+    # the PRIMARY repo's per-worktree bucket — the same one the commit gate reads (it uses
+    # warden-shim.sh's git-common-dir REPO_ROOT). So state I/O uses `marker_root` + an
+    # explicit `worktree_override(root)`, making the bucket independent of the process cwd.
+    marker_root = whooks.primary_repo_root(root)
+
     if not registry.is_registered(args.backend):
         sys.stderr.write(
             f"[codex-warden] unknown backend '{args.backend}'. Registered: "
@@ -113,16 +120,20 @@ def main(argv: list[str] | None = None) -> int:
     if not content.strip():
         sys.stderr.write("[codex-warden] empty change — nothing to review (abstain).\n")
         if args.warden_mark:
-            whooks.record_script_verdict(root, skey, "SHIP",
-                                         "abstain: no reviewable content")
-            whooks.note_model_review_round(root, args.role, args.backend, "SHIP",
-                                           whooks.read_claude_verdict(root, args.role))
+            with whooks.worktree_override(root):
+                whooks.record_script_verdict(marker_root, skey, "SHIP",
+                                             "abstain: no reviewable content")
+                whooks.note_model_review_round(marker_root, args.role, args.backend, "SHIP",
+                                               whooks.read_claude_verdict(marker_root, args.role))
         return ABSTAIN
 
     rules_path = Path(spec.rules_path)
     if not rules_path.is_absolute():
         rules_path = root / rules_path
-    cross_context = whooks.read_cross_context(root, args.role, for_backend=args.backend)
+    # Narrowly scoped — only the cross-context read needs the worktree override; the
+    # backend.review() call below is cwd-agnostic (it reviews in-memory content).
+    with whooks.worktree_override(root):
+        cross_context = whooks.read_cross_context(marker_root, args.role, for_backend=args.backend)
 
     backend = registry.get_backend(args.backend)
     verdict = backend.review(ReviewRequest(
@@ -147,11 +158,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.warden_mark:
         reason = (verdict.error if verdict.could_not_run
                   else verdict.summary or f"{args.backend} {verdict.verdict}")
-        whooks.record_script_verdict(root, skey, verdict.verdict, reason)
-        whooks.write_model_cross_review(root, args.role, args.backend, verdict.verdict,
-                                        verdict.findings, verdict.summary)
-        whooks.note_model_review_round(root, args.role, args.backend, verdict.verdict,
-                                       whooks.read_claude_verdict(root, args.role))
+        with whooks.worktree_override(root):
+            whooks.record_script_verdict(marker_root, skey, verdict.verdict, reason)
+            whooks.write_model_cross_review(marker_root, args.role, args.backend, verdict.verdict,
+                                            verdict.findings, verdict.summary)
+            whooks.note_model_review_round(marker_root, args.role, args.backend, verdict.verdict,
+                                           whooks.read_claude_verdict(marker_root, args.role))
 
     if verdict.could_not_run:
         return _CODE_FROM_CATEGORY.get(verdict.category, INTERNAL_ERROR)

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import dataclasses
 import datetime as dt
 import hashlib
@@ -391,10 +392,47 @@ _PER_WORKTREE_MARKERS = frozenset({
 #: fresh, single-threaded process, so a plain dict is safe).
 _WORKTREE_CACHE: dict[tuple[str, str], Path] = {}
 
-#: CLI override: the `mark`/`mark-batch` actions run from a terminal whose cwd
-#: is not guaranteed to be the worktree, so main() sets this (try/finally) to
-#: inject the target worktree. Hooks never set it -> they auto-derive from cwd.
+#: Explicit-worktree override, mutated only via the `worktree_override` context manager
+#: (stack-safe). Callers whose cwd is not guaranteed to be the target worktree set it: the
+#: `mark`/`mark-batch` CLI actions, and the out-of-band model driver (codex_warden.py),
+#: which records verdicts into a worktree's bucket from any cwd. Hooks never set it ->
+#: they auto-derive from cwd.
 _WORKTREE_OVERRIDE: Path | None = None
+
+
+def primary_repo_root(start: Path) -> Path:
+    """The shared/main repo root for ``start``, even from a linked worktree.
+
+    Resolves the parent of ``git rev-parse --git-common-dir`` (the shared ``.git``),
+    mirroring warden-shim.sh's REPO_ROOT. This is the root under which per-worktree
+    marker buckets live, so a driver that records verdicts must use THIS root (not the
+    worktree's own ``--show-toplevel``) to land in the bucket the gate reads. For a
+    non-worktree repo the common dir is ``<top>/.git`` so this equals the toplevel.
+    Falls back to the toplevel, then ``start``, when git can't resolve a common dir.
+    """
+    common = _git(start, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if common:
+        return Path(common).resolve(strict=False).parent
+    top = _git(start, "rev-parse", "--show-toplevel")
+    return Path(top).resolve(strict=False) if top else start.resolve(strict=False)
+
+
+@contextlib.contextmanager
+def worktree_override(worktree: Path):
+    """Pin marker/verdict resolution to an EXPLICIT worktree for the duration of the
+    block, independent of ``os.getcwd()``. Restores the prior value on exit (nesting and
+    direct test calls are safe). Writes go through ``_claude_marker_dir(repo_root)``,
+    which reads ``_WORKTREE_OVERRIDE`` — so under this block a driver running from any cwd
+    targets ``repo_root/.claude/worktree-markers/<sha(worktree)>`` deterministically, the
+    same bucket the gate reads via ``_verdicts_path_for_worktree``.
+    """
+    global _WORKTREE_OVERRIDE
+    prev = _WORKTREE_OVERRIDE
+    _WORKTREE_OVERRIDE = worktree
+    try:
+        yield
+    finally:
+        _WORKTREE_OVERRIDE = prev
 
 
 def _current_worktree(repo_root: Path) -> Path:
@@ -4057,11 +4095,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _with_cli_worktree(repo_root: Path, worktree_root_arg: str | None, fn):
-    """Run a CLI mark action with ``_WORKTREE_OVERRIDE`` set so marker + verdict
+    """Run a CLI mark action with the worktree override set so marker + verdict
     writes land in the correct per-worktree bucket regardless of the process cwd.
-    Restores the previous value on exit so direct test calls don't leak state.
     """
-    global _WORKTREE_OVERRIDE
     if worktree_root_arg:
         wt = Path(worktree_root_arg).resolve(strict=False)
     else:
@@ -4074,12 +4110,8 @@ def _with_cli_worktree(repo_root: Path, worktree_root_arg: str | None, fn):
                 file=sys.stderr,
             )
             wt = repo_root
-    prev = _WORKTREE_OVERRIDE  # nested calls are safe: prev is restored on exit
-    _WORKTREE_OVERRIDE = wt
-    try:
+    with worktree_override(wt):
         return fn()
-    finally:
-        _WORKTREE_OVERRIDE = prev
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/tests/test_warden_review.py
+++ b/scripts/tests/test_warden_review.py
@@ -370,3 +370,68 @@ def test_invalidator_clears_gpt_verdict(repo, monkeypatch):
     h.run_code_review_invalidator(ev, repo)
     assert h._read_verdict(_GPT_KEY, repo) is None
     assert not h._marker(repo, h.cross_review_file(_ROLE)).exists()
+
+
+# ── Driver records into the gate's per-worktree bucket (worktree-marker-root fix) ──
+
+def test_primary_repo_root_normal_repo_returns_toplevel(monkeypatch):
+    # Non-worktree repo: git-common-dir is <top>/.git, so its parent is <top>.
+    monkeypatch.setattr(h, "_git",
+                        lambda cwd, *a: "/repo/.git" if a[-1] == "--git-common-dir" else None)
+    assert h.primary_repo_root(Path("/repo")) == Path("/repo")
+
+
+def test_primary_repo_root_worktree_returns_common_dir_parent(monkeypatch):
+    # A linked worktree's git-common-dir points at the PRIMARY repo's .git, not its own.
+    monkeypatch.setattr(h, "_git",
+                        lambda cwd, *a: "/primary/.git" if a[-1] == "--git-common-dir" else None)
+    assert h.primary_repo_root(Path("/primary/wt-feature")) == Path("/primary")
+
+
+def test_primary_repo_root_falls_back_to_toplevel(monkeypatch):
+    def fake_git(cwd, *a):
+        if a[-1] == "--show-toplevel":
+            return "/fallback/top"
+        return None  # no common dir
+    monkeypatch.setattr(h, "_git", fake_git)
+    assert h.primary_repo_root(Path("/whatever")) == Path("/fallback/top")
+
+
+def test_worktree_override_makes_write_path_equal_gate_read_path(tmp_path):
+    # Frozen invariant: under worktree_override(wt) with repo_root=primary, the driver's
+    # WRITE path (_verdicts_path) equals the gate's deterministic READ path
+    # (_verdicts_path_for_worktree) — independent of os.getcwd().
+    primary, wt = tmp_path / "primary", tmp_path / "wt-feature"
+    prev = h._WORKTREE_OVERRIDE
+    with h.worktree_override(wt):
+        assert h._verdicts_path(primary) == h._verdicts_path_for_worktree(primary, wt)
+    assert h._WORKTREE_OVERRIDE is prev  # restored on exit, no leak
+
+
+def test_worktree_override_main_repo_is_flat(tmp_path):
+    # Back-compat: when the worktree IS the repo root, resolution stays flat.
+    primary = tmp_path / "primary"
+    with h.worktree_override(primary):
+        assert h._verdicts_path(primary) == primary / ".claude" / ".warden-verdicts.json"
+
+
+def test_worktree_override_restores_prior_value():
+    prev = h._WORKTREE_OVERRIDE
+    h._WORKTREE_OVERRIDE = Path("/prev/override")
+    try:
+        with h.worktree_override(Path("/new/wt")):
+            assert h._WORKTREE_OVERRIDE == Path("/new/wt")
+        assert h._WORKTREE_OVERRIDE == Path("/prev/override")
+    finally:
+        h._WORKTREE_OVERRIDE = prev
+
+
+def test_worktree_override_nesting_is_stack_safe():
+    # Outer sets /a, inner sets /b; inner exit restores /a, outer exit restores the original.
+    prev = h._WORKTREE_OVERRIDE
+    with h.worktree_override(Path("/a")):
+        assert h._WORKTREE_OVERRIDE == Path("/a")
+        with h.worktree_override(Path("/b")):
+            assert h._WORKTREE_OVERRIDE == Path("/b")
+        assert h._WORKTREE_OVERRIDE == Path("/a")
+    assert h._WORKTREE_OVERRIDE is prev


### PR DESCRIPTION
## Problem

The out-of-band model-reviewer driver (`scripts/codex_warden.py`) records warden verdicts into a **different marker bucket** than the commit-time co-gate reads, so a worktree's GPT verdict recorded via `--warden-mark` is invisible to the gate -> the commit is blocked with `gpt: not run yet` despite a real SHIP. (Hit live while shipping #858 from a worktree; flagged in #859's "Related observation".)

Root cause: the driver sets `root = cfr.repo_root()` = `git rev-parse --show-toplevel` = the **worktree**, and uses that single root for both gathering the diff and all verdict/state writes. `_claude_marker_dir(worktree)` resolves to the worktree's flat `.claude/`. But `warden-shim.sh` feeds the gate `REPO_ROOT` = `git --git-common-dir` parent = the **primary** repo, so the gate reads `_verdicts_path_for_worktree(primary, worktree)` = `<primary>/.claude/worktree-markers/<sha>/.warden-verdicts.json`. Different base and bucket.

## Fix

Separate the two roots in the driver:
- **`codex_warden_hooks.py`**: add `primary_repo_root(start)` (parent of `git --git-common-dir`, mirroring `warden-shim.sh`'s `REPO_ROOT`); extract a public `worktree_override(wt)` context manager from `_with_cli_worktree`'s inline try/finally and have `_with_cli_worktree` delegate to it (DRY, behavior-preserving).
- **`codex_warden.py`**: keep `root` (worktree) for `spec.gather` and `ReviewRequest.cwd`; add `marker_root = primary_repo_root(root)`; wrap every `whooks.*` verdict/state call in `worktree_override(root)` passing `marker_root`. Writes now resolve to `<primary>/.claude/worktree-markers/<sha>` -- exactly the bucket the gate reads -- independent of process cwd.

Non-worktree repos are unchanged (common-dir parent == toplevel -> flat `.claude`).

## Verification

- Unit test freezes the invariant: under `worktree_override(wt)` with `repo_root=primary`, `_verdicts_path(primary) == _verdicts_path_for_worktree(primary, wt)` (driver write path == gate read path), cwd-independent. Plus `primary_repo_root` (normal/worktree/fallback), back-compat flat, and override restore + nesting.
- Integration: running the driver from a worktree recorded `code-reviewer@gpt` SHIP into `<primary>/.claude/worktree-markers/<sha>/.warden-verdicts.json` (the gate's bucket), not the worktree-flat path.
- 63 tests pass; source files ruff-clean.

Relates to #859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
