### PR TITLE
fix(agent-runner): make SendMessage unconditional in allowedTools (LIA-307)

### DIFF
--- a/container/agent-runner/src/allowed-tools.test.ts
+++ b/container/agent-runner/src/allowed-tools.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAllowedTools,
+  computeTeamsNeeded,
+  SWARM_SIGNALS,
+} from './allowed-tools.js';
+
+describe('buildAllowedTools', () => {
+  const base = { hasGcalMcp: false, hasLinearMcp: false };
+
+  it('always includes SendMessage — it pairs with the always-present Task tool (LIA-307)', () => {
+    expect(buildAllowedTools({ ...base, teamsNeeded: false })).toContain(
+      'SendMessage',
+    );
+    expect(buildAllowedTools({ ...base, teamsNeeded: true })).toContain(
+      'SendMessage',
+    );
+  });
+
+  it('always includes the Task tools regardless of teamsNeeded', () => {
+    for (const teamsNeeded of [false, true]) {
+      const tools = buildAllowedTools({ ...base, teamsNeeded });
+      expect(tools).toEqual(
+        expect.arrayContaining(['Task', 'TaskOutput', 'TaskStop']),
+      );
+    }
+  });
+
+  it('gates TeamCreate/TeamDelete behind teamsNeeded', () => {
+    const off = buildAllowedTools({ ...base, teamsNeeded: false });
+    expect(off).not.toContain('TeamCreate');
+    expect(off).not.toContain('TeamDelete');
+
+    const on = buildAllowedTools({ ...base, teamsNeeded: true });
+    expect(on).toContain('TeamCreate');
+    expect(on).toContain('TeamDelete');
+  });
+
+  it('gates the gcal/linear MCP wildcards by their flags', () => {
+    const none = buildAllowedTools({ ...base, teamsNeeded: false });
+    expect(none).not.toContain('mcp__gcal__*');
+    expect(none).not.toContain('mcp__linear__*');
+
+    const both = buildAllowedTools({
+      teamsNeeded: false,
+      hasGcalMcp: true,
+      hasLinearMcp: true,
+    });
+    expect(both).toContain('mcp__gcal__*');
+    expect(both).toContain('mcp__linear__*');
+  });
+
+  it('always includes the core + deus MCP tools', () => {
+    const tools = buildAllowedTools({ ...base, teamsNeeded: false });
+    expect(tools).toEqual(
+      expect.arrayContaining([
+        'Bash',
+        'Read',
+        'Write',
+        'Edit',
+        'Glob',
+        'Grep',
+        'WebSearch',
+        'WebFetch',
+        'TodoWrite',
+        'ToolSearch',
+        'Skill',
+        'NotebookEdit',
+        'mcp__deus__*',
+      ]),
+    );
+  });
+});
+
+describe('computeTeamsNeeded', () => {
+  it('is true when an external project is mounted, even with a plain prompt', () => {
+    expect(computeTeamsNeeded('what time is it?', true)).toBe(true);
+  });
+
+  it('is true when the prompt contains any swarm signal (case-insensitive)', () => {
+    for (const kw of SWARM_SIGNALS) {
+      expect(computeTeamsNeeded(`please ${kw.toUpperCase()} this`, false)).toBe(
+        true,
+      );
+    }
+  });
+
+  it('is false for a plain query with no project and no swarm signal', () => {
+    expect(computeTeamsNeeded('remind me to buy milk', false)).toBe(false);
+  });
+});

--- a/container/agent-runner/src/allowed-tools.ts
+++ b/container/agent-runner/src/allowed-tools.ts
@@ -1,0 +1,84 @@
+// Tool-allowlist construction for the CLAUDE-backend container run.
+//
+// Extracted from index.ts so the gating logic is unit-testable: index.ts runs
+// `bootstrap(main, ...)` at module load, so importing helpers from it would
+// execute the agent during tests. Pure functions only — no side effects — which
+// also matches the existing helper-module pattern (doom-loop-detector.ts,
+// context-registry.ts).
+
+// Keywords that signal the prompt requires multi-agent *team* orchestration.
+// When none are present and no external project is mounted, the team tools
+// (TeamCreate, TeamDelete) are excluded from allowedTools to save ~200 tokens
+// per call on personal-assistant queries.
+//
+// NOTE: SendMessage is deliberately NOT gated here. It pairs with the Task tool
+// (always allowed) — the Task tool's own description advertises SendMessage as
+// the way to continue a previously-spawned subagent (SDK sdk-tools.d.ts:297,
+// "addressable via SendMessage({to: name})"). Gating it while Task stays
+// unconditional made plain queries that spawned a Task subagent hit
+// "SendMessage tool isn't available" (LIA-307).
+export const SWARM_SIGNALS = [
+  'parallel agent',
+  'subagent',
+  'agent team',
+  'agent swarm',
+  'orchestrate',
+  'in parallel',
+  'multiple agents',
+  'spawn agent',
+];
+
+/**
+ * Whether multi-agent *team* tools (TeamCreate/TeamDelete) should be offered.
+ * True when an external project is mounted (engineering context) or the prompt
+ * explicitly signals multi-agent intent via a SWARM_SIGNALS keyword.
+ */
+export function computeTeamsNeeded(
+  prompt: string,
+  hasProject: boolean,
+): boolean {
+  return (
+    hasProject || SWARM_SIGNALS.some((kw) => prompt.toLowerCase().includes(kw))
+  );
+}
+
+export interface AllowedToolsOpts {
+  /** Result of computeTeamsNeeded — gates TeamCreate/TeamDelete only. */
+  teamsNeeded: boolean;
+  /** Google Calendar MCP server is available for this run. */
+  hasGcalMcp: boolean;
+  /** Linear MCP server is available for this run. */
+  hasLinearMcp: boolean;
+}
+
+/**
+ * Build the allowedTools manifest for a CLAUDE-backend run.
+ *
+ * SendMessage is unconditional (pairs with the always-present Task tool).
+ * Only TeamCreate/TeamDelete are gated behind `teamsNeeded`.
+ */
+export function buildAllowedTools(opts: AllowedToolsOpts): string[] {
+  const { teamsNeeded, hasGcalMcp, hasLinearMcp } = opts;
+  return [
+    'Bash',
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'WebSearch',
+    'WebFetch',
+    'Task',
+    'TaskOutput',
+    'TaskStop',
+    'SendMessage',
+    ...(teamsNeeded ? ['TeamCreate', 'TeamDelete'] : []),
+    'TodoWrite',
+    'ToolSearch',
+    'Skill',
+    'NotebookEdit',
+    'mcp__deus__*',
+    ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
+    ...(hasLinearMcp ? ['mcp__linear__*'] : []),
+  ];
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -36,6 +36,7 @@ import { DoomLoopDetector, createDoomLoopHook } from './doom-loop-detector.js';
 import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 import { createToolCallLogHook } from './tool-call-log.js';
 import { writeAvailableTools } from './available-tools-log.js';
+import { buildAllowedTools, computeTeamsNeeded } from './allowed-tools.js';
 import type { AgentRuntimeId } from './tool-broker.js';
 import { resolveGroupAttachmentPath } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
@@ -138,21 +139,6 @@ interface SDKUserMessage {
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
-
-// Keywords that signal the prompt requires multi-agent orchestration.
-// When none are present and no external project is mounted, swarm tools
-// (TeamCreate, TeamDelete, SendMessage) are excluded from allowedTools,
-// saving ~300 tokens per call on personal-assistant queries.
-const SWARM_SIGNALS = [
-  'parallel agent',
-  'subagent',
-  'agent team',
-  'agent swarm',
-  'orchestrate',
-  'in parallel',
-  'multiple agents',
-  'spawn agent',
-];
 
 // Module-level state is safe: container runs one session per process lifecycle.
 let _lastContextStats: ContextStats | undefined;
@@ -802,14 +788,14 @@ async function runQuery(
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
 
-  // Swarm tools are only needed for multi-agent orchestration.
-  // Exclude them for plain personal-assistant queries to save ~300 tokens.
-  // Always include when an external project is mounted (engineering context)
-  // or the prompt explicitly signals multi-agent intent.
-  const teamsNeeded =
-    hasProject || SWARM_SIGNALS.some((kw) => prompt.toLowerCase().includes(kw));
+  // Team tools (TeamCreate/TeamDelete) are only needed for multi-agent team
+  // orchestration. Exclude them for plain personal-assistant queries to save
+  // ~200 tokens. Always include when an external project is mounted (engineering
+  // context) or the prompt explicitly signals multi-agent intent. SendMessage is
+  // NOT gated here — see allowed-tools.ts (it pairs with the always-present Task).
+  const teamsNeeded = computeTeamsNeeded(prompt, hasProject);
   log(
-    `Swarm tools: ${teamsNeeded ? 'included' : 'excluded (~300 tokens saved)'}`,
+    `Team tools: ${teamsNeeded ? 'included' : 'excluded (~200 tokens saved)'}`,
   );
 
   // Google Calendar MCP: available when the host project is mounted and gcal
@@ -852,27 +838,11 @@ async function runQuery(
   // LIA-151's tool_selection ground truth. The openai/llama-cpp backends branch
   // out earlier (index.ts ~1104/1119) and never reach here, so available_tools
   // is intentionally empty for them in v1.
-  const allowedTools = [
-    'Bash',
-    'Read',
-    'Write',
-    'Edit',
-    'Glob',
-    'Grep',
-    'WebSearch',
-    'WebFetch',
-    'Task',
-    'TaskOutput',
-    'TaskStop',
-    ...(teamsNeeded ? ['TeamCreate', 'TeamDelete', 'SendMessage'] : []),
-    'TodoWrite',
-    'ToolSearch',
-    'Skill',
-    'NotebookEdit',
-    'mcp__deus__*',
-    ...(hasGcalMcp ? ['mcp__gcal__*'] : []),
-    ...(hasLinearMcp ? ['mcp__linear__*'] : []),
-  ];
+  const allowedTools = buildAllowedTools({
+    teamsNeeded,
+    hasGcalMcp,
+    hasLinearMcp,
+  });
   // LIA-154: capture the offered manifest (default-on; DEUS_AVAILABLE_TOOLS_LOG=0 opts out).
   if (process.env.DEUS_AVAILABLE_TOOLS_LOG !== '0') {
     writeAvailableTools(process.env.DEUS_INTERACTION_ID, allowedTools);


### PR DESCRIPTION
## Problem
`container/agent-runner/src/index.ts` gated `SendMessage` behind `teamsNeeded` while `Task`/`TaskOutput`/`TaskStop` were always present. The `Task` tool's own description advertises `SendMessage` as the way to continue a previously-spawned subagent (SDK `sdk-tools.d.ts:297`). So on a plain personal-assistant query (no project mounted, no swarm keyword) the model could spawn a `Task` subagent and then try to continue it via `SendMessage` — which was filtered out → SDK returns **"SendMessage tool isn't available"**, occasionally leaking into a user-visible reply.

## Fix
- Make `SendMessage` **unconditional** (it pairs with the always-present `Task`).
- Keep `TeamCreate`/`TeamDelete` (true multi-agent team orchestration) behind `teamsNeeded`.
- Extract a pure `container/agent-runner/src/allowed-tools.ts` module (`buildAllowedTools` + `computeTeamsNeeded` + `SWARM_SIGNALS`) so the gate is unit-testable — `index.ts` runs `bootstrap(main)` at import, so the logic can't be tested in place (matches the `doom-loop-detector.ts` / `context-registry.ts` pattern).
- Add `allowed-tools.test.ts` (8 vitest tests).

Token impact: the excluded-path saving drops from ~300 to ~200 tokens (SendMessage schema ~100).

## Scope / blast radius
- `allowedTools` is built **only** in `container/agent-runner` (host backends and the openai/llama-cpp paths don't reach this construction).
- Strictly **more permissive** (SendMessage now always allowed) → cannot break existing swarm/project runs, which already had it.

## Testing
- `npx vitest run` in `container/agent-runner`: **178/178 passing** (incl. 8 new).
- `tsc` build clean; `prettier --check` clean on all changed files.

## Deploy
Container-only; `dist/` is gitignored. After merge, rebuild the agent image (`./container/build.sh` → `deus-agent:latest`) and restart for the change to take effect. No host `kickstart` needed.

## Reviews
- plan-reviewer (Claude): **SHIP**
- code-reviewer (Claude **+** GPT co-gate): **SHIP / SHIP**

## Follow-up
GPT plan-review co-gate hit `COULD_NOT_RUN` on the content-file plan (counts diff-files → 0 dropped). Failed open by design, but the content-file→GPT plan-review path may need a fix so the co-gate actually runs on plans (tracked in LIA-307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)