### PR TITLE
fix(wardens): version-independent glob match + hermetic hook tests in CI (LIA-308)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,10 @@ jobs:
         # Regression-protect the provider-agnostic warden co-gate engine: the gpt +
         # openai_compat backends, the role specs, the strict-AND gate / loop guard / HITL
         # override (test_warden_review), the driver (test_codex_warden), the codex engine
-        # (test_codex_review), and the Phase 3 co-gate oracle. All hermetic — the model
-        # seams are mocked, so no codex CLI / network is touched.
-        # NOT included: test_codex_warden_hooks.py — several admin-merge-gate tests invoke
-        # the real `gh` CLI (gh pr checks), which needs GH_TOKEN + network and is not
-        # hermetic in CI. Making them mock `gh` so the full hook engine joins this step is
-        # tracked in LIA-308.
-        run: python3 -m pytest scripts/tests/test_warden_review.py scripts/tests/test_codex_warden.py scripts/tests/test_codex_review.py scripts/tests/test_phase3_cogate_oracle.py -v
+        # (test_codex_review), the Phase 3 co-gate oracle, and the full hook engine incl.
+        # the admin-merge + structural-check gates (test_codex_warden_hooks). All hermetic —
+        # the gh CLI and model seams are mocked, so no codex CLI / gh / network is touched.
+        run: python3 -m pytest scripts/tests/test_warden_review.py scripts/tests/test_codex_warden.py scripts/tests/test_codex_review.py scripts/tests/test_phase3_cogate_oracle.py scripts/tests/test_codex_warden_hooks.py -v
 
       - name: Session type contract tests
         run: python3 -m pytest tests/test_session_type_contract.py -v

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -7,6 +7,7 @@ import argparse
 import contextlib
 import dataclasses
 import datetime as dt
+import functools
 import hashlib
 import json
 import os
@@ -2352,11 +2353,69 @@ def run_cold_memory_injector(event: dict[str, Any], repo_root: Path) -> int:
     return 0
 
 
+@functools.lru_cache(maxsize=512)  # patterns come from a small static config; 512 never evicts in practice
+def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Compile a pathlib-style glob to a regex with ``full_match`` semantics on every Python.
+
+    Version-INDEPENDENT by design: ``PurePath.full_match`` (3.13+) treats ``**`` as "zero or
+    more path segments" but the pre-3.13 ``PurePath.match`` fallback does not, so a
+    version-split implementation silently under-matched ``**`` globs on Python < 3.13. Arms:
+    ``**/`` -> zero+ segments; ``**`` -> anything; ``*`` -> within a segment; ``?`` -> one
+    char; ``[seq]``/``[!seq]`` -> char class (``!`` mapped to ``^``); unterminated ``[`` ->
+    literal; everything else escaped. (Regression matrix: test_glob_match_full_match_semantics.)
+    """
+    i, n = 0, len(pattern)
+    out: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if pattern[i:i + 2] == "**":
+                i += 2
+                if i < n and pattern[i] == "/":
+                    out.append("(?:[^/]*/)*")  # ** + / -> zero or more whole segments
+                    i += 1
+                else:
+                    out.append(".*")            # trailing/bare ** -> anything incl. '/'
+            else:
+                out.append("[^/]*")             # * -> within a segment (never crosses '/')
+                i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c == "[":
+            j = i + 1
+            if j < n and pattern[j] == "!":       # ONLY '!' negates (glob/pathlib convention)
+                j += 1
+            if j < n and pattern[j] == "]":      # a literal ']' as the first class member
+                j += 1
+            while j < n and pattern[j] != "]":
+                j += 1
+            if j >= n:                            # unterminated '[' -> literal
+                out.append(r"\[")
+                i += 1
+            else:
+                body = pattern[i + 1:j]
+                neg = body.startswith("!")
+                if neg:
+                    body = body[1:]
+                # Escape for a regex char class: '\' and ']' always; a LEADING '^' is a glob
+                # literal (only '!' negates) so escape it lest regex read it as negation. Ranges
+                # like 'a-z' pass through unchanged.
+                body = body.replace("\\", "\\\\").replace("]", r"\]")
+                if body.startswith("^"):
+                    body = "\\" + body
+                out.append("[" + ("^" if neg else "") + body + "]")
+                i = j + 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return re.compile("(?s:" + "".join(out) + r")\Z")
+
+
 def _glob_match(rel_posix: str, pattern: str) -> bool:
-    p = PurePosixPath(rel_posix)
-    if hasattr(p, "full_match"):
-        return p.full_match(pattern)
-    return p.match(pattern)
+    # Inputs are always a FILE's ``as_posix()`` (no trailing slash); rstrip defensively so a
+    # trailing '/' can't diverge from pathlib's path normalization.
+    return _glob_to_regex(pattern).match(rel_posix.rstrip("/")) is not None
 
 
 def run_structural_check(event: dict[str, Any], repo_root: Path) -> int:

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -313,9 +313,10 @@ def test_code_review_gate_blocks_git_commit_without_marker(tmp_path, capsys):
     assert "code-reviewer" in reason
 
 
-def test_admin_merge_gate_blocks_without_exact_approval(tmp_path, capsys):
+def test_admin_merge_gate_blocks_without_exact_approval(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # CI check is incidental; this gates approval-marker logic
 
     rc = hooks.run_admin_merge_gate(
         bash_event(repo, "gh pr merge 294 --squash --admin"),
@@ -329,9 +330,10 @@ def test_admin_merge_gate_blocks_without_exact_approval(tmp_path, capsys):
     assert "approve-admin-merge" in reason
 
 
-def test_admin_merge_gate_blocks_with_gh_global_repo_flag(tmp_path, capsys):
+def test_admin_merge_gate_blocks_with_gh_global_repo_flag(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # CI check is incidental; this gates approval-marker logic
 
     rc = hooks.run_admin_merge_gate(
         bash_event(repo, "gh --repo owner/repo pr merge 294 --squash --admin"),
@@ -344,9 +346,10 @@ def test_admin_merge_gate_blocks_with_gh_global_repo_flag(tmp_path, capsys):
     assert "fresh explicit approval" in reason
 
 
-def test_admin_merge_gate_blocks_with_gh_short_repo_flag(tmp_path, capsys):
+def test_admin_merge_gate_blocks_with_gh_short_repo_flag(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # CI check is incidental; this gates admin-command detection
 
     rc = hooks.run_admin_merge_gate(
         bash_event(repo, "gh -R owner/repo pr merge 294 --squash --admin"),
@@ -358,9 +361,10 @@ def test_admin_merge_gate_blocks_with_gh_short_repo_flag(tmp_path, capsys):
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
-def test_admin_merge_gate_blocks_equals_form_admin_flag(tmp_path, capsys):
+def test_admin_merge_gate_blocks_equals_form_admin_flag(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # CI check is incidental; this gates admin-command detection
 
     rc = hooks.run_admin_merge_gate(
         bash_event(repo, "gh pr merge 294 --squash --admin=true"),
@@ -372,9 +376,10 @@ def test_admin_merge_gate_blocks_equals_form_admin_flag(tmp_path, capsys):
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
-def test_admin_merge_gate_blocks_absolute_gh_path(tmp_path, capsys):
+def test_admin_merge_gate_blocks_absolute_gh_path(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # CI check is incidental; this gates admin-command detection
 
     rc = hooks.run_admin_merge_gate(
         bash_event(repo, "/opt/homebrew/bin/gh pr merge 294 --squash --admin=true"),
@@ -386,9 +391,10 @@ def test_admin_merge_gate_blocks_absolute_gh_path(tmp_path, capsys):
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
-def test_admin_merge_gate_blocks_windows_gh_exe_path(tmp_path, capsys):
+def test_admin_merge_gate_blocks_windows_gh_exe_path(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # CI check is incidental; this gates admin-command detection
 
     rc = hooks.run_admin_merge_gate(
         bash_event(
@@ -413,10 +419,11 @@ def test_admin_merge_detection_handles_windows_shell_tokenization(monkeypatch):
 
 
 def test_admin_merge_gate_allows_exact_approved_command_and_consumes_marker(
-    tmp_path, capsys
+    tmp_path, capsys, monkeypatch
 ):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # approve_admin_merge + gate both check CI; mock it green
     command = "gh pr merge 294 --squash --admin"
 
     assert hooks.approve_admin_merge(command, repo) == 0
@@ -430,9 +437,10 @@ def test_admin_merge_gate_allows_exact_approved_command_and_consumes_marker(
     assert "permissionDecision" not in output
 
 
-def test_admin_merge_gate_rejects_stale_marker_for_different_command(tmp_path, capsys):
+def test_admin_merge_gate_rejects_stale_marker_for_different_command(tmp_path, capsys, monkeypatch):
     hooks = load_hooks()
     repo = git_repo(tmp_path)
+    _green_ci(hooks, monkeypatch)  # approve_admin_merge + gate both check CI; mock it green
 
     assert hooks.approve_admin_merge("gh pr merge 294 --squash --admin", repo) == 0
     rc = hooks.run_admin_merge_gate(
@@ -2416,6 +2424,53 @@ def _structural_config(repo: Path, checks: list[dict]) -> None:
     (cold_dir / "structural-checks.json").write_text(
         json.dumps({"checks": checks}), encoding="utf-8"
     )
+
+
+@pytest.mark.parametrize(
+    "rel,pattern,expected",
+    [
+        # ``**`` matches zero or more whole segments — the cross-version bug (LIA-308):
+        # full_match (3.13+) returns True for all of these; the old 3.12 ``.match`` fallback
+        # returned False for the zero-segment case, silently under-matching ``**`` globs.
+        ("src/main.ts", "src/**/*.ts", True),       # ** matches ZERO segments
+        ("src/a/main.ts", "src/**/*.ts", True),     # ** matches one
+        ("src/a/b/c/d.ts", "src/**/*.ts", True),    # ** matches many
+        ("src/foo.js", "src/**/*.ts", False),       # wrong extension
+        ("docs/readme.md", "src/**/*.ts", False),   # wrong root
+        ("packages/mcp-foo/src/a/b.ts", "packages/mcp-*/src/**/*.ts", True),  # real config glob
+        # ``*`` never crosses a path separator:
+        ("main.ts", "*.ts", True),
+        ("a/main.ts", "*.ts", False),
+        ("src/a/main.ts", "src/*.ts", False),
+        # ``**/`` zero-or-more at the root:
+        ("main.ts", "**/*.ts", True),
+        ("a/b/c.ts", "**/*.ts", True),
+        # trailing ``**`` (zero/one/many segments):
+        ("src", "src/**", False),
+        ("src/a", "src/**", True),
+        ("src/a/b/c", "src/**", True),
+        # character classes (incl. negation) — handled, not corrupted by re.escape:
+        ("src/a.ts", "src/[abc].ts", True),
+        ("src/d.ts", "src/[abc].ts", False),
+        ("src/x.ts", "src/[!abc].ts", True),
+        ("src/a.ts", "src/[!abc].ts", False),
+        ("file1.txt", "file[0-9].txt", True),
+        ("fileA.txt", "file[0-9].txt", False),
+        # a LEADING '^' is a glob LITERAL (only '!' negates) — must NOT act as regex negation:
+        ("a.ts", "[^abc].ts", True),    # 'a' is a member of the literal class {^,a,b,c}
+        ("x.ts", "[^abc].ts", False),   # 'x' is not a member
+        ("^.ts", "[^abc].ts", True),    # '^' itself is a member
+        # unterminated '[' is treated as a literal (no crash, no over-match):
+        ("a[b.ts", "a[b.ts", True),
+        ("axb.ts", "a[b.ts", False),
+    ],
+)
+def test_glob_match_full_match_semantics_all_pythons(rel, pattern, expected):
+    """Regression guard for LIA-308: _glob_match must give full_match `**` semantics on
+    EVERY Python (the old impl under-matched `**` on < 3.13). These expectations equal
+    PurePath.full_match's verified output and must hold regardless of the runtime version."""
+    hooks = load_hooks()
+    assert hooks._glob_match(rel, pattern) is expected
 
 
 def test_structural_check_warns_on_pattern_match(tmp_path, capsys):


### PR DESCRIPTION
## What

Gets the 4000-line warden hook-engine test suite (`test_codex_warden_hooks.py`) into CI — it was excluded in LIA-305 for two reasons, both fixed here. Closes LIA-308.

## Two fixes

### 1. Production bug: `_glob_match` under-matched `**` on Python < 3.13
`_glob_match` used `PurePath.full_match` on 3.13+ (where `**` matches zero-or-more path segments) but fell back to `PurePath.match` on 3.12, which does **not** treat `**` recursively. So the **structural-check warden silently under-matched `**` globs** (e.g. `src/**/*.ts` vs `src/main.ts`) on Python < 3.13 — missing real violations on those runtimes. This surfaced as a `structural_check` test failure on CI's Python 3.12.

Replaced the version-split with a single **version-independent `_glob_to_regex`** translator used on every Python: `**/`→zero+ segments, `**`→anything, `*`→within-segment, `?`→one char, `[seq]`/`[!seq]`→char class (only `!` negates; a leading `^` is a literal), unterminated `[`→literal, else escaped. **0 mismatches vs `PurePosixPath.full_match` across a 25-case matrix** (`**` depth, segment boundaries, trailing-`**`, char classes incl. `[^abc]` literal-`^` / `[!abc]` negation / `[a-z]` ranges, unterminated `[`).

### 2. Hermeticity: admin-merge tests called the real `gh` CLI
Several admin-merge-gate tests reached `_check_ci_status` → real `gh pr checks`, which has no `GH_TOKEN`/network in the CI sandbox. They now mock it via the existing `_green_ci` helper (the CI check is incidental — these tests cover admin-command detection + approval-marker logic; the section-2 suite owns CI-status coverage).

## CI

Adds `test_codex_warden_hooks.py` to the "Warden review tests" step.

## Verification

- **264 tests pass on both Python 3.12.13 (CI's version, failed pre-fix) and 3.14.5**, under CI-equivalent conditions (no `GH_TOKEN`, `gh` off `PATH`), repeatedly.
- `_glob_to_regex` verified to **0 mismatches vs `full_match`** across the full matrix.
- **Real-invocation hook smoke test** (the rule for hook-script changes) — live `python3 codex_warden_hooks.py run structural-check` with hook JSON on stdin, the exact settings.json path:
  - **Happy path** (`src/**/*.ts` matches `src/main.ts`) → emits the warning JSON, exit 0 — on **both 3.12 and 3.14**:
    ```
    {"systemMessage":"[structural-check] WARNING: pattern violations found:\n\n  [no-private-import] src/main.ts: No private imports"}
    ```
  - **Silent path** (clean file, no match) → no output, exit 0.

## Reviews

plan-reviewer SHIP (expanded scope) · code-reviewer SHIP (clean rebased diff + a bracket-handling correctness re-review) · code-reviewer GPT co-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)