### PR TITLE
fix(scheduler): reject blank cron on the host side (GH #788)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-18" # auto-bump @1781735768
+last_verified: "2026-06-18" # auto-bump @1781770135
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-06-14" # auto-bump @1781449539
+last_verified: "2026-06-18" # auto-bump @1781770135
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCronExpression } from './cron.js';
+
+describe('parseCronExpression', () => {
+  it('throws on an empty string', () => {
+    // The real cron-parser >= 5.5.0 gap: "" is silently parsed as "* * * * *"
+    // (every minute). The .trim() guard plugs this so it throws instead (GH #788).
+    expect(() => parseCronExpression('', 'UTC')).toThrow(/Invalid cron/);
+  });
+
+  it('throws on whitespace-only input', () => {
+    // Caught by the .trim() guard. (The parser would also reject these — the guard
+    // is belt-and-suspenders here; the only case the parser silently accepts is "".)
+    expect(() => parseCronExpression('   ', 'UTC')).toThrow(/Invalid cron/);
+    expect(() => parseCronExpression('\t', 'UTC')).toThrow(/Invalid cron/);
+  });
+
+  it('parses a valid cron and yields a usable next() time', () => {
+    const expr = parseCronExpression('0 9 * * *', 'UTC');
+    const next = expr.next().toISOString();
+    expect(typeof next).toBe('string');
+    expect(next).toMatch(/T09:00:00/);
+  });
+
+  it('still throws on other malformed input (delegates to the parser)', () => {
+    expect(() => parseCronExpression('not a cron', 'UTC')).toThrow();
+  });
+});

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,0 +1,18 @@
+import { CronExpressionParser, type CronExpression } from 'cron-parser';
+
+/**
+ * Parse a cron expression, rejecting blank input first. cron-parser >= 5.5.0
+ * silently parses the zero-length string `""` as `* * * * *` (every minute)
+ * instead of throwing, which would create a runaway job (GH #788). Single
+ * source of truth for host-side cron parsing so this guard can't be skipped.
+ *
+ * @throws {Error} when `value` is blank or not a valid cron expression.
+ */
+export function parseCronExpression(value: string, tz: string): CronExpression {
+  if (!value || !value.trim()) {
+    throw new Error(
+      `Invalid cron: "${value}". Use format like "0 9 * * *" or "*/5 * * * *".`,
+    );
+  }
+  return CronExpressionParser.parse(value, { tz });
+}

--- a/src/doc-gardener-seed.ts
+++ b/src/doc-gardener-seed.ts
@@ -1,6 +1,5 @@
-import { CronExpressionParser } from 'cron-parser';
-
 import { TIMEZONE } from './config.js';
+import { parseCronExpression } from './cron.js';
 import { createTask, getTaskById } from './db.js';
 
 const GARDENER_ID = 'doc-gardener-weekly';
@@ -9,7 +8,7 @@ const CRON_EXPR = '0 3 * * 1'; // Monday 03:00 local — low-traffic window
 export function seedDocGardener(jid: string, folder: string): void {
   if (!jid || !folder) return;
   if (getTaskById(GARDENER_ID)) return;
-  const interval = CronExpressionParser.parse(CRON_EXPR, { tz: TIMEZONE });
+  const interval = parseCronExpression(CRON_EXPR, TIMEZONE);
   createTask({
     id: GARDENER_ID,
     chat_jid: jid,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,9 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-import { CronExpressionParser } from 'cron-parser';
-
 import { fireAndForget } from './async/index.js';
+import { parseCronExpression } from './cron.js';
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { getSkillIpcHandlers } from './skills/registry.js';
 import { AvailableGroup } from './container-runner.js';
@@ -273,9 +272,7 @@ export async function processTaskIpc(
         let nextRun: string | null = null;
         if (scheduleType === 'cron') {
           try {
-            const interval = CronExpressionParser.parse(data.schedule_value, {
-              tz: TIMEZONE,
-            });
+            const interval = parseCronExpression(data.schedule_value, TIMEZONE);
             nextRun = interval.next().toISOString();
           } catch {
             logger.warn(
@@ -441,9 +438,9 @@ export async function processTaskIpc(
           };
           if (updatedTask.schedule_type === 'cron') {
             try {
-              const interval = CronExpressionParser.parse(
+              const interval = parseCronExpression(
                 updatedTask.schedule_value,
-                { tz: TIMEZONE },
+                TIMEZONE,
               );
               updates.next_run = interval.next().toISOString();
             } catch {

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -143,6 +143,25 @@ describe('task scheduler', () => {
     expect(new Date(nextRun!).getTime()).toBe(expected);
   });
 
+  it('computeNextRun throws on a blank cron value (GH #788)', () => {
+    const task = {
+      id: 'blank-cron',
+      group_folder: 'test',
+      chat_jid: 'test@g.us',
+      prompt: 'test',
+      schedule_type: 'cron' as const,
+      schedule_value: '', // empty — cron-parser >= 5.5.0 would treat as every-minute
+      context_mode: 'isolated' as const,
+      next_run: new Date(Date.now() - 1000).toISOString(),
+      last_run: null,
+      last_result: null,
+      status: 'active' as const,
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+
+    expect(() => computeNextRun(task)).toThrow(/Invalid cron/);
+  });
+
   it('computeNextRun returns null for once-tasks', () => {
     const task = {
       id: 'once-test',
@@ -392,6 +411,34 @@ describe('startSchedulerLoop execution path', () => {
       expect.any(String), // nextRun (ISO string for interval task)
       expect.stringContaining('task output'),
     );
+  });
+
+  // 6b. Blank cron in a stored row → run is recorded, then the task is paused
+  //     (not marked 'completed') so it stops churning. Guards the computeNextRun
+  //     call site against updateTaskAfterRun's null-next_run → 'completed' CASE (GH #788).
+  it('pauses (does not complete) a due task whose stored cron is blank', async () => {
+    createTask(
+      makeTask({
+        id: 'task-blank-cron',
+        schedule_type: 'cron',
+        schedule_value: '',
+        next_run: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    );
+
+    const updateTaskAfterRunSpy = vi.spyOn(
+      await import('./db.js'),
+      'updateTaskAfterRun',
+    );
+
+    startSchedulerLoop(makeDeps());
+    await vi.advanceTimersByTimeAsync(10);
+
+    const task = getTaskById('task-blank-cron');
+    expect(task?.status).toBe('paused');
+    expect(task?.next_run).toBeNull();
+    // The 'completed'-forcing path must be bypassed entirely.
+    expect(updateTaskAfterRunSpy).not.toHaveBeenCalled();
   });
 
   // 7. Guard — second call to startSchedulerLoop returns early

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -1,5 +1,6 @@
-import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
+
+import { parseCronExpression } from './cron.js';
 
 // Iterate by code point to avoid splitting UTF-16 surrogate pairs (emoji crash on Anthropic API).
 export function safeSlice(str: string, maxCodePoints: number): string {
@@ -50,9 +51,7 @@ export function computeNextRun(task: ScheduledTask): string | null {
   const now = Date.now();
 
   if (task.schedule_type === 'cron') {
-    const interval = CronExpressionParser.parse(task.schedule_value, {
-      tz: TIMEZONE,
-    });
+    const interval = parseCronExpression(task.schedule_value, TIMEZONE);
     return interval.next().toISOString();
   }
 
@@ -263,7 +262,25 @@ async function runTask(
     error,
   });
 
-  const nextRun = computeNextRun(task);
+  let nextRun: string | null;
+  try {
+    nextRun = computeNextRun(task);
+  } catch (cronErr) {
+    // A malformed cron in a stored row (e.g. a legacy/blank value that bypassed
+    // create-time validation) must not be routed through updateTaskAfterRun: with
+    // a null next_run its `CASE WHEN ? IS NULL THEN 'completed'` branch would mark
+    // the task completed, hiding the problem. Pause it instead to stop churn, the
+    // same way the invalid-group-folder path above does. logTaskRun already
+    // recorded this run, so we don't re-log here.
+    const cronMsg =
+      cronErr instanceof Error ? cronErr.message : String(cronErr);
+    logger.error(
+      { taskId: task.id, value: task.schedule_value, error: cronMsg },
+      'Invalid cron in stored task — pausing to stop churn',
+    );
+    updateTask(task.id, { status: 'paused', next_run: null });
+    return;
+  }
   const resultSummary = error
     ? `Error: ${error}`
     : result


### PR DESCRIPTION
Fixes #788.

## Problem
`cron-parser` >= 5.5.0 (resolved by the declared `^5.0.0`) silently parses the empty string `""` as `* * * * *` (every minute) instead of throwing. The container-side `validateSchedule` was already fixed (its `!schedule_value.trim()` guard), but the **host process** parses `schedule_value` directly at three sites with no blank guard, so a blank cron from a model tool-call or user input creates a runaway every-minute job.

## Fix
- **New `src/cron.ts`** — `parseCronExpression(value, tz)` rejects blank input (`!value || !value.trim()`) before delegating to `CronExpressionParser.parse`. Single source of truth for host-side cron parsing.
- **`src/task-scheduler.ts`** — `computeNextRun` routes through the helper. Its call site in `runTask` was **outside** the function's try/catch: a throw there skipped `updateTaskAfterRun`, leaving the row half-updated (run logged, `next_run` never set) and breaking recurrence silently. It now catches → logs → pauses the task (mirroring the existing invalid-group-folder path) rather than letting `updateTaskAfterRun`'s `CASE WHEN ? IS NULL THEN 'completed'` mark a malformed-cron task as completed. This also fixes a **pre-existing latent bug** for any garbage cron in a stored row.
- **`src/ipc.ts`** — CREATE (`schedule_task`) and UPDATE handlers use the helper inside their existing `try/catch` + `break` (blank rejected before storage).
- **`src/doc-gardener-seed.ts`** — migrated to the helper so the single-source-of-truth invariant holds (its expression is a hardcoded literal, so it was never affected by the bug; this is consistency only).

## Tests
- `src/cron.test.ts` — blank/whitespace throw; valid parses; garbage still throws.
- `src/task-scheduler.test.ts` — `computeNextRun` throws on blank cron; a due blank-cron stored task ends `status: 'paused'`, `next_run: null`, and `updateTaskAfterRun` is **not** called (the 'completed'-forcing path is bypassed).
- Full suite: **1671 passed**. `tsc --noEmit` clean; eslint clean on changed files.

## Credit
Reported and container-fixed by @Yonatan1203 (credited via `Co-authored-by`); this PR closes the host-side half they identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)