### PR TITLE
fix(security): scope workflow token perms + drop shell in 2 setup calls (CodeQL)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,9 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   merge_group:
 
+permissions:
+  contents: read
+  pull-requests: read # dorny/paths-filter reads the PR changed-file list via the API on pull_request runs
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: "smoke"
 
+permissions:
+  contents: read
+
 jobs:
   eval:
     runs-on: ubuntu-latest

--- a/.github/workflows/setup-test.yml
+++ b/.github/workflows/setup-test.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/setup-test.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   setup-smoke:
     timeout-minutes: 10

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read # amannn/action-semantic-pull-request reads the PR title
+
 jobs:
   pr-title:
     name: PR title follows Conventional Commits

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-16" # auto-bump @1781558131
+last_verified: "2026-06-18" # auto-bump @1781735768
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-17" # auto-bump @1781705304
+last_verified: "2026-06-18" # auto-bump @1781735768
 governs:
   - src/
   - evolution/

--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -4,7 +4,7 @@
  * Other channels discover group names at runtime — this step auto-skips for them.
  * Replaces 05-sync-groups.sh + 05b-list-groups.sh
  */
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -204,7 +204,7 @@ await connect();
     const tmpScript = path.join(projectRoot, '.tmp-group-sync.mjs');
     fs.writeFileSync(tmpScript, syncScript, 'utf-8');
     try {
-      const output = execSync(`node ${tmpScript}`, {
+      const output = execFileSync('node', [tmpScript], {
         cwd: projectRoot,
         encoding: 'utf-8',
         timeout: 45000,

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -4,7 +4,7 @@
  *
  * Fixes: Root→system systemd, WSL nohup fallback, no `|| true` swallowing errors.
  */
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -959,8 +959,27 @@ function setupMaintenanceWindows(projectRoot: string, _homeDir: string): void {
   }
 
   try {
-    execSync(
-      `schtasks /Create /TN "${taskName}" /TR "${pythonPath} ${projectRoot}\\scripts\\maintenance.py" /SC DAILY /ST 04:30 /F`,
+    // execFileSync drops the cmd.exe shell; /TR keeps inner quotes because
+    // schtasks re-parses it as a command line (so paths with spaces survive).
+    const maintScript = path.win32.join(
+      projectRoot,
+      'scripts',
+      'maintenance.py',
+    );
+    execFileSync(
+      'schtasks',
+      [
+        '/Create',
+        '/TN',
+        taskName,
+        '/TR',
+        `"${pythonPath}" "${maintScript}"`,
+        '/SC',
+        'DAILY',
+        '/ST',
+        '04:30',
+        '/F',
+      ],
       { stdio: 'pipe' },
     );
     logger.info('Windows Task Scheduler: maintenance scheduled (daily 04:30)');


### PR DESCRIPTION
## Summary

Triages all 22 open CodeQL code-scanning alerts. **10 dismissed** as false positives (with per-alert justifications on GitHub); **12 fixed** here.

### Fixed

**Workflow `GITHUB_TOKEN` permissions** (`actions/missing-workflow-permissions`, 10 alerts) — add a top-level least-privilege `permissions:` block to 5 workflows:
| Workflow | Grant | Why |
|----------|-------|-----|
| `ci.yml` | `contents:read` + `pull-requests:read` | `dorny/paths-filter@v4` (L113/L184) reads the PR changed-file list via the API on `pull_request` runs |
| `validate-pr.yml` | `contents:read` + `pull-requests:read` | `amannn/action-semantic-pull-request@v6` reads the PR title (verified: needs `pull-requests:read`, not write) |
| `eval.yml`, `benchmark.yml`, `setup-test.yml` | `contents:read` | checkout + test only |

**Shell command injection from environment** (`js/shell-command-injection-from-environment`, 2 alerts) — convert two string-based `execSync` shell calls to `execFileSync` array-arg form. Removes the shell sink entirely **and** fixes a real path-with-spaces correctness bug:
- `setup/groups.ts`: `execSync(\`node ${tmpScript}\`)` → `execFileSync('node', [tmpScript])`
- `setup/service.ts`: `schtasks /Create` via `execFileSync`; `maintenance.py` path built with `path.win32.join`. The sibling `/Delete` call (hardcoded task name, no injection surface, no CodeQL alert) is intentionally left as-is.

### Dismissed (false positives, 10)

Clear-text logging of a non-secret Linear user-object ID / internal UUID PKs; ReDoS on anchored/base64-bounded regexes; stack-trace exposure where only `err.message` (never `.stack`) reaches a 127.0.0.1-only server; incomplete sanitization where inputs structurally cannot carry the missing escape; `<script` strip on a JSON-to-LLM sink (no HTML render); `Math.random()` for a session-slot label (not a security token); `process.cwd()` already single-quoted in a trusted-env shell call.

## Verification

- `npm run build` clean
- Full `vitest` suite: **1665 passing**
- YAML valid on all 5 workflows; permission grants verified minimal against each action's README
- Reviewed by plan + code co-gates (Claude + GPT)

No hook scripts touched (no hook smoke test required). The `ci.yml` / `validate-pr.yml` permission changes are self-validated by CI running on this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)