### PR TITLE
chore(wardens): drop inert (?s: DOTALL flag from _glob_to_regex

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -2409,7 +2409,9 @@ def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
         else:
             out.append(re.escape(c))
             i += 1
-    return re.compile("(?s:" + "".join(out) + r")\Z")
+    # No DOTALL: matched inputs are file paths (an ``as_posix()``), which never contain a
+    # newline, so the ``.*`` emitted for ``**`` has nothing to span — the flag was inert.
+    return re.compile("".join(out) + r"\Z")
 
 
 def _glob_match(rel_posix: str, pattern: str) -> bool:


### PR DESCRIPTION
## What

Removes the inline `(?s:...)` DOTALL wrapper from `_glob_to_regex` in `scripts/codex_warden_hooks.py`, replacing it with a plain `re.compile(...)` plus a 2-line comment stating the *correct* reason it was inert.

This is the cosmetic follow-up explicitly noted when LIA-308 landed (#870).

## Why it's safe

`_glob_to_regex` emits `.*` for trailing/bare `**`. DOTALL only changes whether `.` matches `\n`. The matched inputs are always a file's `as_posix()` (`path.relative_to(worktree).as_posix()`) — a POSIX path that never contains a newline component — so the `.*` has nothing to span and the flag was inert.

- No behavior change for any **reachable** input.
- 264 hook tests pass, including the 26-case `full_match` regression matrix (`test_glob_match_full_match_semantics_all_pythons`).
- Co-gate: code-reviewer **SHIP** ([claude, gpt]).

## One nuance (declined an advisory test)

A reviewer suggested adding `("src/foo\nbar", "src/**", False)` to lock the invariant. I verified that `PurePosixPath("src/foo\nbar").full_match("src/**")` actually returns **True** — so that assertion would *contradict* the matrix's stated "expectations equal `PurePath.full_match`" contract. The newline-component case is unreachable through any current caller, so I left the matrix consistent with full_match rather than document a contradiction. The behavioral difference is real but gated by the no-newlines-in-paths invariant, which the new comment documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)