### PR TITLE
docs(readme): correct co-gate backend-config wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ cooldown_minutes: 60
 Your gate prompt here...
 ```
 
-Select review wardens (`plan-reviewer`, `code-reviewer`, `ai-eng-warden`) can run on Claude or GPT — or both at once as a cross-model **co-gate**, where each provider reviews independently and the change ships only when both agree. Configure backends per warden via `/wardens`.
+Select review wardens (`plan-reviewer`, `code-reviewer`, `ai-eng-warden`) can run on Claude or GPT — or both at once as a cross-model **co-gate**, where each provider reviews independently and the change ships only when both agree. Per-warden backends are set in `.claude/wardens/config.json` (`/wardens` manages the gates themselves).
 
 ---
 


### PR DESCRIPTION
Follow-up to #874. The code-reviewer's rec#3 accuracy fix was reviewed and approved but did not land in the merged commit — the merged README still says "Configure backends per warden via \`/wardens\`", which overclaims (the \`/wardens\` TUI has no backend-selection field today; per-warden backends are JSON-config-driven).

This one-line fix corrects it to: "Per-warden backends are set in \`.claude/wardens/config.json\` (\`/wardens\` manages the gates themselves)."

🤖 Generated with [Claude Code](https://claude.com/claude-code)