### PR TITLE
fix(bootstrap): log process-warning stacks for localization (GH #305)

### DIFF
--- a/container/agent-runner/src/bootstrap.ts
+++ b/container/agent-runner/src/bootstrap.ts
@@ -74,6 +74,15 @@ function installGlobalHandlers(
     if (exitOnUnhandledRejection) process.exit(1);
     // MIRROR-IGNORE-END
   });
+
+  // Node only emits a warning's stack frames under --trace-warnings (GH #305),
+  // so log the `warning` Error directly to capture its emit site. Does not
+  // suppress Node's default stderr print.
+  process.on('warning', (warning: Error) => {
+    // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
+    logError(name, 'process warning', warning);
+    // MIRROR-IGNORE-END
+  });
 }
 
 // MIRROR-IGNORE-START -- helpers for the console-based variant; src/ has only `serializeError` and uses pino at the call sites instead
@@ -97,4 +106,5 @@ export function __resetBootstrapForTesting(): void {
   globalHandlersInstalled = false;
   process.removeAllListeners('uncaughtException');
   process.removeAllListeners('unhandledRejection');
+  process.removeAllListeners('warning');
 }

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-18" # auto-bump @1781770135
+last_verified: "2026-06-18" # auto-bump @1781773309
 governs:
   - src/
   - evolution/

--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -131,6 +131,38 @@ describe('bootstrap', () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it('installs a warning handler that logs the warning with its stack (GH #305)', async () => {
+    bootstrap(async () => {}, { name: 'entry-warn' });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const listeners = process.listeners('warning');
+    expect(listeners.length).toBeGreaterThanOrEqual(1);
+
+    // Mirror the real signal: a MaxListenersExceededWarning Error with a stack.
+    const warning = new Error(
+      'Possible EventEmitter memory leak detected. 11 drain listeners added to [Socket].',
+    );
+    warning.name = 'MaxListenersExceededWarning';
+    (listeners[listeners.length - 1] as (w: Error) => void)(warning);
+
+    await waitForLog(() =>
+      logCalls.some((c) => c.level === 'warn' && c.msg === 'process warning'),
+    );
+    const logged = logCalls.find(
+      (c) => c.level === 'warn' && c.msg === 'process warning',
+    );
+    expect(logged).toBeDefined();
+    expect(logged!.ctx).toMatchObject({ entry: 'entry-warn' });
+    const ctx = logged!.ctx as {
+      warning: { name: string; message: string; stack?: string };
+    };
+    expect(ctx.warning.name).toBe('MaxListenersExceededWarning');
+    // The stack is the whole point — it carries the emit site we can't otherwise see.
+    expect(typeof ctx.warning.stack).toBe('string');
+    expect((ctx.warning.stack as string).length).toBeGreaterThan(0);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it('exitOnUnhandledRejection=true terminates the process', async () => {
     bootstrap(async () => {}, {
       name: 'entry-g',

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -101,6 +101,25 @@ function installGlobalHandlers(
     if (exitOnUnhandledRejection) process.exit(1);
     // MIRROR-IGNORE-END
   });
+
+  // Node only emits a warning's stack frames under --trace-warnings (GH #305),
+  // so log the `warning` Error directly to capture its emit site in structured
+  // logs. Does not suppress Node's default stderr print.
+  process.on('warning', (warning: Error) => {
+    // MIRROR-IGNORE-START -- intentional logger divergence (see file header)
+    logger.warn(
+      {
+        warning: {
+          name: warning.name,
+          message: warning.message,
+          stack: warning.stack,
+        },
+        entry: name,
+      },
+      'process warning',
+    );
+    // MIRROR-IGNORE-END
+  });
 }
 
 // MIRROR-IGNORE-START -- serializeError body diverges: src/ checks isDeusError; container/ has no DeusError dep so falls through to plain Error handling
@@ -123,4 +142,5 @@ export function __resetBootstrapForTesting(): void {
   globalHandlersInstalled = false;
   process.removeAllListeners('uncaughtException');
   process.removeAllListeners('unhandledRejection');
+  process.removeAllListeners('warning');
 }


### PR DESCRIPTION
Re: #305.

## Problem
A recurring `MaxListenersExceededWarning: 11 drain listeners added to [Socket]` (23 occurrences, last 2026-06-17) **cannot be localized**: Node only prints a warning's emit-site stack under `--trace-warnings`, so the host's auto-captured reports (`~/.config/deus/log_to_issue_details/<fp>.json`) have empty `top_frames` and the source socket is unknowable. The warning is benign (count stable at 11 = transient socket write-backpressure, not a growing leak). PR #705 backed off WhatsApp reconnects as the suspected cause, but the warning still recurs — so the residual source must be captured directly rather than guessed at.

## Change (instrumentation only)
Add a `process.on('warning')` handler to bootstrap's once-per-process `installGlobalHandlers` (alongside the existing `uncaughtException`/`unhandledRejection` handlers). It logs the warning's `name`/`message`/`stack` via pino with `entry` attribution. The `warning` object is an `Error` whose `.stack` carries the full emit site, so the **next occurrence self-localizes in `logs/deus.log`**. Node's default stderr print is unaffected (no signal loss for the existing capture).

This deliberately does **not** blind-fix a guessed socket (diagnosis before treatment). The actual leak fix — likely a one-line `setMaxListeners(N)` on the identified emitter — is a follow-up once the captured stack reveals it.

## Tests
- `src/bootstrap.test.ts`: new case asserts the handler logs `{ warning: { name, message, stack }, entry }` at `warn` with a **non-empty stack** when a `MaxListenersExceededWarning` is emitted.
- `__resetBootstrapForTesting` now clears the `'warning'` listener.
- Full suite: **1672 passed** (was 1671). tsc + eslint clean.

Reviewed: plan-reviewer (claude+gpt) SHIP; code-reviewer (claude+gpt) SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)