### PR TITLE
fix(compress): never delete the CLAUDE.md body on pending-sync

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -119,11 +119,17 @@ After saving the session log:
       - **Sync pending tasks from Linear** (preferred) or merge from session log (fallback):
 
         **Linear sync path** (preferred):
-        Run: `python3 ~/deus/scripts/sync_linear_pending.py`
-        The script handles caching, staleness detection, GraphQL query, sorting, and formatting.
-        Capture its stdout. Keep the `pending:` key line itself, replace everything below it with the script's stdout.
-        Prepend nothing -- the script includes the `# Source of truth` comment.
-        **Replace** the entire `pending:` block with the script output. Linear IS the source of truth.
+        Run: `python3 ~/deus/scripts/sync_linear_pending.py --write`
+        The `--write` flag makes the script splice the fresh block into vault CLAUDE.md
+        **in place, safely**: it replaces ONLY the indented lines under `pending:` and aborts
+        rather than ever dropping a column-0 rule key. Linear IS the source of truth.
+
+        NEVER hand-splice with a "replace everything below `pending:`" / slice-to-EOF
+        operation: vault CLAUDE.md has an opening `---` but NO closing `---`, so the rule body
+        (`project:` … `index:`) is bare column-0 keys right after the pending list, and such a
+        replace deletes the whole body. Use `--write`; if you must edit by hand, replace only
+        the `- [ ]` lines and STOP at the first column-0 key.
+
         If any `[x]` items from the session log reference a Linear identifier that is still in the active list, log a note but do NOT remove it -- the issue's state in Linear is authoritative.
         If the script exits non-zero, read `branches/fallback-merge.md` for the manual merge path.
 

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-17" # auto-bump @1781704080
+last_verified: "2026-06-18" # auto-bump @1781781306
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/linear_pending_hook.py
+++ b/scripts/linear_pending_hook.py
@@ -19,12 +19,17 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent
+
+# Reuse the single safe pending-splice helper (indented-only replace + column-0
+# body-key guard). Importing sync_linear_pending as a library is safe: its work
+# is under main()/__main__. Do not add module-level side effects there.
+sys.path.insert(0, str(_SCRIPTS_DIR))
+from sync_linear_pending import _safe_replace_pending  # noqa: E402
 
 
 def _load_config() -> dict:
@@ -64,17 +69,14 @@ def _update_vault_pending(vault: "Path", pending_stdout: str) -> None:
 
     content = claude_md.read_text(encoding="utf-8", errors="replace")
 
-    # Prepend header to body lines; ensure trailing newline before next key
-    new_block = "pending:\n" + pending_stdout.rstrip() + "\n"
-
-    # Match 'pending:' followed by all indented lines (stops at next top-level key)
-    new_content = re.sub(
-        r"^pending:\n(?:[ \t][^\n]*\n)*",
-        new_block,
-        content,
-        count=1,
-        flags=re.MULTILINE,
-    )
+    # Shared safe splice: replaces only the indented pending block and ABORTS
+    # (ValueError) rather than ever dropping a column-0 rule key. On no-match or
+    # guard violation, leave the file unchanged (same as the prior no-match path).
+    try:
+        new_content = _safe_replace_pending(content, pending_stdout)
+    except ValueError as e:
+        sys.stderr.write(f"[linear-pending-hook] skipped pending update: {e}\n")
+        return
 
     if new_content != content:
         claude_md.write_text(new_content, encoding="utf-8")

--- a/scripts/sync_linear_pending.py
+++ b/scripts/sync_linear_pending.py
@@ -220,14 +220,88 @@ def _format_pending(issues: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def main() -> int:
+# Matches the `pending:` key line plus ONLY its indented child lines (the
+# `# Source of truth` comment + `- [ ]` items). The rule body (project:..index:)
+# lives at column 0 directly after the pending list — vault CLAUDE.md has NO
+# closing `---` — so this pattern stops at the first column-0 key and never
+# touches the body. Same pattern used by linear_pending_hook / linear_vault_sync.
+_PENDING_BLOCK_RE = re.compile(r"^pending:\n(?:[ \t][^\n]*\n)*", re.MULTILINE)
+_COL0_KEY_RE = re.compile(r"^([a-z][a-z0-9-]*):", re.MULTILINE)
+
+
+def _resolve_vault() -> "Path | None":
+    """Vault path: DEUS_VAULT_PATH env → ~/.config/deus/config.json vault_path."""
+    env = os.environ.get("DEUS_VAULT_PATH")
+    if env:
+        return Path(os.path.expanduser(env))
+    try:
+        cfg = json.loads(Path("~/.config/deus/config.json").expanduser().read_text())
+    except (OSError, ValueError):
+        return None
+    vp = cfg.get("vault_path", "")
+    return Path(os.path.expanduser(vp)) if vp else None
+
+
+def _safe_replace_pending(content: str, pending_body: str) -> str:
+    """Replace ONLY the indented pending block, never the column-0 rule body.
+
+    `pending_body` is the indented child lines (comment + `- [ ]` items) WITHOUT
+    the `pending:` header — i.e. exactly this script's stdout. Raises ValueError
+    if there is no pending block, or if the replacement would drop any column-0
+    key. That guard is the fail-safe the agent-manual /compress path lacked: a
+    "replace everything below pending:" slice deleted the CLAUDE.md body twice on
+    2026-06-18 because the body is bare keys after pending (no closing `---`).
+    """
+    new_block = "pending:\n" + pending_body.rstrip("\n") + "\n"
+    new_content, n = _PENDING_BLOCK_RE.subn(new_block, content, count=1)
+    if n == 0:
+        raise ValueError("no `pending:` block found in CLAUDE.md")
+    # The key-set guard is fail-safe only because pending_body is trusted-internal
+    # (always _format_pending() output). A caller that fed attacker-controlled body
+    # with a column-0 `key:` could mask a real key's loss — do not widen the surface.
+    lost = sorted(set(_COL0_KEY_RE.findall(content)) - set(_COL0_KEY_RE.findall(new_content)))
+    if lost:
+        raise ValueError(f"refusing to write: replacement would drop body keys {lost}")
+    return new_content
+
+
+def _emit(output: str, write: bool) -> int:
+    """Print the pending block to stdout, or (--write) safely splice it into the
+    vault CLAUDE.md in place. On any write failure, fall back to stdout so the
+    caller never loses the data, and return INTERNAL_ERROR."""
+    if not write:
+        print(output, end="")
+        return SUCCESS
+    vault = _resolve_vault()
+    claude_md = (vault / "CLAUDE.md") if vault else None
+    if claude_md is None or not claude_md.exists():
+        print("--write: cannot resolve vault CLAUDE.md; printing to stdout", file=sys.stderr)
+        print(output, end="")
+        return INTERNAL_ERROR
+    try:
+        content = claude_md.read_text(encoding="utf-8", errors="replace")
+        new_content = _safe_replace_pending(content, output)
+    except ValueError as e:
+        print(f"--write: {e}; printing to stdout (file unchanged)", file=sys.stderr)
+        print(output, end="")
+        return INTERNAL_ERROR
+    if new_content != content:
+        claude_md.write_text(new_content, encoding="utf-8")
+        print(f"--write: updated {claude_md}", file=sys.stderr)
+    else:
+        print("--write: pending block already current", file=sys.stderr)
+    return SUCCESS
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    write = "--write" in args
     cache = _cache_path()
     db = _db_path()
 
     if _cache_is_fresh(cache, db):
-        print(cache.read_text(), end="")
         print("cache fresh", file=sys.stderr)
-        return SUCCESS
+        return _emit(cache.read_text(), write)
 
     token = _get_api_token()
     if not token:
@@ -318,8 +392,7 @@ def main() -> int:
             os.unlink(tmp_path)
         except OSError:
             pass
-    print(output, end="")
-    return SUCCESS
+    return _emit(output, write)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_sync_linear_pending.py
+++ b/scripts/tests/test_sync_linear_pending.py
@@ -244,3 +244,69 @@ def test_fetch_team_issues_respects_page_cap(monkeypatch, capsys):
         f"(MAX_PAGES_PER_TEAM={mod.MAX_PAGES_PER_TEAM}); results may be truncated"
         in err
     )
+
+
+# ---------------------------------------------------------------------------
+# Safe pending splice + body-key guard (regression for the 2026-06-18
+# /compress body-deletion bug: vault CLAUDE.md has no closing `---`, so the
+# rule body is bare column-0 keys directly after the pending list).
+# ---------------------------------------------------------------------------
+
+_CLAUDE_FIXTURE = """\
+---
+critical:
+  - project
+previous:
+  - "prior session note"
+pending:
+  # Source of truth: Linear.
+  - [ ] old item (LIA-1)
+project: Deus | path: ~/deus
+style: concise, direct
+index: see Persona/INDEX.md
+"""
+
+
+def test_safe_replace_preserves_body_keys():
+    new_body = "  # Source of truth: Linear.\n  - [ ] fresh (LIA-2)\n"
+    out = mod._safe_replace_pending(_CLAUDE_FIXTURE, new_body)
+    assert "LIA-2" in out and "old item" not in out  # pending swapped
+    for key in ("project:", "style:", "index:"):  # body survives
+        assert f"\n{key}" in out
+    assert "Deus | path: ~/deus" in out
+
+
+def test_safe_replace_raises_without_pending_block():
+    with pytest.raises(ValueError):
+        mod._safe_replace_pending("project: Deus\nstyle: x\n", "  - [ ] a\n")
+
+
+def test_safe_replace_guard_fires_on_body_loss(monkeypatch):
+    # Simulate a regex regression that greedily eats to EOF; the column-0
+    # key-preservation guard MUST refuse to return a body-dropping result.
+    import re as _re
+
+    monkeypatch.setattr(
+        mod, "_PENDING_BLOCK_RE", _re.compile(r"^pending:\n[\s\S]*", _re.MULTILINE)
+    )
+    with pytest.raises(ValueError, match="drop body keys"):
+        mod._safe_replace_pending(_CLAUDE_FIXTURE, "  - [ ] fresh (LIA-2)\n")
+
+
+def test_main_write_splices_in_place_preserving_body(tmp_path, monkeypatch):
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text(_CLAUDE_FIXTURE, encoding="utf-8")
+    cache = tmp_path / "cache.md"
+    cache.write_text(
+        "  # Source of truth: Linear.\n  - [ ] fresh (LIA-2)\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(mod, "_cache_path", lambda: cache)
+    monkeypatch.setattr(mod, "_db_path", lambda: tmp_path / "messages.db")
+    monkeypatch.setattr(mod, "_cache_is_fresh", lambda c, d: True)  # no network
+    monkeypatch.setattr(mod, "_resolve_vault", lambda: tmp_path)
+    code = mod.main(["--write"])
+    assert code == mod.SUCCESS
+    out = claude_md.read_text()
+    assert "LIA-2" in out and "old item" not in out
+    for key in ("project:", "style:", "index:"):
+        assert f"\n{key}" in out


### PR DESCRIPTION
## Problem

The `/compress` skill told the agent to "replace everything below \`pending:\`" in vault `CLAUDE.md`. That file has an opening `---` but **no closing `---`**, so the rule body (`project:` … `index:`) is bare column-0 keys directly after the pending list. Executed as a slice-to-EOF, the instruction **deletes the entire rule body**. It happened twice on 2026-06-18 (once caught + recovered mid-session).

The two automated writers (`linear_pending_hook.py`, `linear_vault_sync.py`) were already safe — they use an indented-only regex. The bug existed only on the agent-manual path the skill prescribed.

## Fix (defense in depth)

- **`sync_linear_pending.py`** — new `--write` that splices the fresh block in place via `_safe_replace_pending`: an indented-only regex replace **plus a column-0 body-key preservation guard that aborts** rather than ever returning a body-dropping result. New `_resolve_vault` + `_emit`; `main()` funnels both the cache-fresh and fresh-fetch paths through `_emit`. On write failure → stdout fallback + `INTERNAL_ERROR`.
- **`linear_pending_hook.py`** — routes through the shared `_safe_replace_pending` (removes the duplicated regex, gains the guard).
- **compress skill** — calls `sync_linear_pending.py --write`; forbids the unsafe hand-edit.
- **tests** — 4 regression tests: body keys survive a splice, guard fires on body loss, raises on missing block, `--write` round-trip preserves the body.

## Verification

- 20/20 tests pass (`scripts/tests/test_sync_linear_pending.py`).
- A `--write` round-trip against a copy of the live 138-line `CLAUDE.md` preserved all 31 column-0 keys.
- The no-`--write` stdout path is byte-identical for existing callers.

## Deferred (separate change)

Give `CLAUDE.md` a real closing `---` so frontmatter/body is structurally unambiguous (higher blast radius: `memory_tree.parse_frontmatter`, archive logic, `vault_context_hook`).

## Review

- plan-reviewer: SHIP (Claude + GPT co-gate, after one REVISE round)
- code-reviewer: SHIP (Claude + GPT co-gate); warnings applied (skill prose trimmed, guard trusted-input comment added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)