### PR TITLE
refactor(wardens): extract verdict-store capsule from gate engine (LIA-306)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -16,7 +16,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 # Warden-review layer constants (zero-dependency leaf module — safe on the hot hook path).
@@ -46,6 +46,28 @@ from warden_hooks.command_parse import (  # noqa: E402
     _shell_tokens,
 )
 from warden_hooks.globs import _glob_match, _glob_to_regex  # noqa: E402
+from warden_hooks import verdict_store as _verdict_store  # noqa: E402
+from warden_hooks.verdict_store import (  # noqa: E402
+    _audit_log_path,
+    _bypass_log_path,
+    _clear_verdict,
+    _last_verdict,
+    _last_verdict_is_blocking,
+    _read_verdict,
+    _read_verdicts,
+    _read_verdicts_at,
+    _verdicts_path,
+    _verdicts_path_for_worktree,
+    _write_bypass_log,
+    _write_verdict,
+    record_script_verdict,
+)
+
+# Inject the entry module so the verdict-store capsule resolves entry-owned helpers
+# (_claude_marker_dir, _git, _write_atomic, _debug, _marker_dir_for_worktree,
+# MARKER_NAMES) through the LIVE module at call time — preserving test monkeypatches
+# without re-importing this file on the hot hook path. See warden_hooks/verdict_store.py.
+_verdict_store.bind_entry(sys.modules[__name__])
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2686,156 +2708,15 @@ def run_orchestrator_preflight(event: dict[str, Any], repo_root: Path) -> int:
     return 0
 
 
-def _verdicts_path(repo_root: Path) -> Path:
-    # Per-worktree: the code-review + verification gates decide on this store
-    # (not the marker files), so it must be isolated alongside the markers.
-    # Main repo resolves to the flat .claude/.warden-verdicts.json (back-compat).
-    return _claude_marker_dir(repo_root) / ".warden-verdicts.json"
-
-
-def _verdicts_path_for_worktree(repo_root: Path, worktree_root: Path) -> Path:
-    # Deterministic verdict store for an EXPLICIT worktree (the admin-merge
-    # standing gate resolves the cwd worktree itself rather than relying on
-    # _current_worktree()'s os.getcwd() derivation). Mirrors _verdicts_path.
-    return _marker_dir_for_worktree(repo_root, worktree_root) / ".warden-verdicts.json"
-
-
-def _audit_log_path(repo_root: Path) -> Path:
-    # Deliberately GLOBAL (flat), not per-worktree: this is an append-only audit
-    # trail that aggregates verdicts across every worktree. Do not namespace it.
-    return repo_root / ".claude" / ".warden-log"
-
-
-def _bypass_log_path() -> Path:
-    override = os.environ.get("DEUS_WARDEN_BYPASS_LOG")
-    if override:
-        return Path(override)
-    return Path.home() / ".claude" / ".warden-bypass-log"
-
-
-def _write_bypass_log(
-    warden: str,
-    verdict: str,
-    session_type: str,
-    reason: str,
-    cwd: Path,
-) -> None:
-    try:
-        diff_stats = _git(cwd, "diff", "--stat", "HEAD")
-        entry = {
-            "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "warden": warden,
-            "verdict": verdict,
-            "session_type": session_type,
-            "reason": reason,
-            "cwd": str(cwd),
-            "diff_stats": diff_stats,
-        }
-        path = _bypass_log_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
-    except OSError:
-        _debug("bypass log write failed")
-
-
 def _is_bg_session() -> bool:
     return bool(os.environ.get("CLAUDE_JOB_DIR"))
 
 
-def _read_verdicts_at(path: Path) -> dict[str, Any]:
-    """Read a .warden-verdicts.json at an EXPLICIT path (no cwd derivation)."""
-    if not path.exists():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def _read_verdicts(repo_root: Path) -> dict[str, Any]:
-    return _read_verdicts_at(_verdicts_path(repo_root))
-
-
-def _read_verdict(marker_name: str, repo_root: Path) -> str | None:
-    """Return the verdict string for *marker_name* from .warden-verdicts.json.
-
-    Maps the marker name (e.g. ``"code-reviewed"``) to the warden key used in
-    the JSON (e.g. ``"code-reviewer"``) via ``MARKER_NAMES``.  Returns ``None``
-    if the file is absent, malformed, or the entry is missing.
-    """
-    warden = MARKER_NAMES.get(marker_name)
-    if not warden:
-        return None
-    data = _read_verdicts(repo_root)
-    entry = data.get(warden)
-    if not isinstance(entry, dict):
-        return None
-    v = entry.get("verdict")
-    return v if isinstance(v, str) else None
-
-
-def _clear_verdict(marker_name: str, repo_root: Path) -> None:
-    """Remove the *marker_name* entry from .warden-verdicts.json.
-
-    Maps the marker name to the warden key via ``MARKER_NAMES``.  Silently
-    skips if the file is absent or the key is not present.
-    """
-    warden = MARKER_NAMES.get(marker_name)
-    if not warden:
-        return
-    path = _verdicts_path(repo_root)
-    data = _read_verdicts(repo_root)
-    if warden not in data:
-        return
-    del data[warden]
-    try:
-        _write_atomic(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
-    except OSError:
-        _debug(f"_clear_verdict: failed to write {path}")
-
-
-def _write_verdict(repo_root: Path, warden: str, verdict: str, reason: str, source: str = "manual") -> None:
-    path = _verdicts_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = _read_verdicts(repo_root)
-    stamp = dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    data[warden] = {"verdict": verdict, "ts": stamp, "reason": reason, "source": source}
-    _write_atomic(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
-
-    log = _audit_log_path(repo_root)
-    safe_reason = reason.replace("|", "/").replace("\n", " ").strip()
-    with log.open("a", encoding="utf-8") as f:
-        f.write(f"{stamp} | {warden:<15} | {verdict:<7} | {safe_reason}\n")
-
-
-def _last_verdict(repo_root: Path, warden: str) -> str | None:
-    data = _read_verdicts(repo_root)
-    entry = data.get(warden)
-    if isinstance(entry, dict):
-        v = entry.get("verdict")
-        return v if isinstance(v, str) else None
-    return None
-
-
-def _last_verdict_is_blocking(repo_root: Path, warden: str) -> bool:
-    v = _last_verdict(repo_root, warden)
-    return v in ("REVISE", "BLOCK")
-
-
-# ── Provider-agnostic warden backends: verdict recording, cross-context, loop guard ──
+# ── Provider-agnostic warden backends: cross-context reads + loop guard ──
 # These are imported by the out-of-band driver (scripts/codex_warden.py); they are NOT
-# called on the hot hook path, so they add no per-tool-call import cost.
-
-def record_script_verdict(
-    repo_root: Path, store_key: str, verdict: str, reason: str, source: str = "script",
-) -> None:
-    """Record a model-backend verdict (SHIP/REVISE/BLOCK/COULD_NOT_RUN) under ``store_key``
-    (the ``<role>@<backend>`` warden key). Unlike ``mark_warden`` (human CLI, SHIP/TRIVIAL
-    only), a script records the real verdict — COULD_NOT_RUN is written verbatim so the
-    audit log distinguishes an infra failure from a genuine SHIP."""
-    _write_verdict(repo_root, store_key, verdict, reason, source=source)
+# called on the hot hook path, so they add no per-tool-call import cost. The verdict-store
+# primitives (``record_script_verdict`` etc.) live in warden_hooks/verdict_store.py and are
+# re-exported at the top of this module.
 
 
 def read_claude_verdict(repo_root: Path, role: str) -> str | None:

--- a/scripts/warden_hooks/verdict_store.py
+++ b/scripts/warden_hooks/verdict_store.py
@@ -1,0 +1,196 @@
+"""Verdict-store I/O capsule (LIA-306).
+
+Reads/writes the per-worktree ``.warden-verdicts.json`` plus the global
+``.warden-log`` audit trail and ``~/.claude/.warden-bypass-log``. This is the
+store the code-review + verification gates decide on (not the marker files).
+
+Unlike the pure leaf capsules (``globs``, ``command_parse``), these functions are
+NOT zero-coupling: they call entry-module helpers that tests monkeypatch
+(``_claude_marker_dir``, ``_git``) plus non-patched entry helpers
+(``_marker_dir_for_worktree``, ``_write_atomic``, ``_debug``) and the
+``MARKER_NAMES`` dispatch table. To keep those monkeypatches effective WITHOUT
+re-importing the ~4000-line entry on the hot hook path (the entry runs as
+``__main__`` at runtime, so ``import codex_warden_hooks`` would re-parse it), the
+entry injects itself via :func:`bind_entry`; every entry-owned reference is then
+resolved through the live (possibly monkeypatched) module at CALL time. Resolution
+is deferred to call time, so helpers defined later than the bind site are fine.
+
+Intra-capsule calls stay direct; only the 6 distinct entry-owned symbols
+(``_claude_marker_dir``, ``_marker_dir_for_worktree``, ``_git``,
+``_write_atomic``, ``_debug``, ``MARKER_NAMES`` — 9 call sites) go through
+``_entry.``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+#: The live entry module (``codex_warden_hooks``), injected by :func:`bind_entry`
+#: at entry-module import time. Entry-owned helpers are resolved through this so
+#: test monkeypatches on the entry module are honored at call time.
+_entry: Any = None
+
+
+def bind_entry(mod: Any) -> None:
+    """Bind the entry module so late-resolved helpers honor test monkeypatches.
+
+    Called once by ``codex_warden_hooks`` immediately after it imports this
+    capsule, with ``sys.modules[__name__]`` (the live module object). Storing the
+    reference (not the individual functions) means ``monkeypatch.setattr(h,
+    "_claude_marker_dir", ...)`` is seen here, and there is no re-import cost on
+    the hot hook path.
+    """
+    global _entry
+    if mod is None:
+        # Fail fast on mis-wiring: every capsule function dereferences ``_entry``,
+        # so a None bind would surface only later as an opaque AttributeError.
+        raise RuntimeError("verdict_store.bind_entry() requires the live entry module, got None")
+    _entry = mod
+
+
+def _verdicts_path(repo_root: Path) -> Path:
+    # Per-worktree: the code-review + verification gates decide on this store
+    # (not the marker files), so it must be isolated alongside the markers.
+    # Main repo resolves to the flat .claude/.warden-verdicts.json (back-compat).
+    return _entry._claude_marker_dir(repo_root) / ".warden-verdicts.json"
+
+
+def _verdicts_path_for_worktree(repo_root: Path, worktree_root: Path) -> Path:
+    # Deterministic verdict store for an EXPLICIT worktree (the admin-merge
+    # standing gate resolves the cwd worktree itself rather than relying on
+    # _current_worktree()'s os.getcwd() derivation). Mirrors _verdicts_path.
+    return _entry._marker_dir_for_worktree(repo_root, worktree_root) / ".warden-verdicts.json"
+
+
+def _audit_log_path(repo_root: Path) -> Path:
+    # Deliberately GLOBAL (flat), not per-worktree: this is an append-only audit
+    # trail that aggregates verdicts across every worktree. Do not namespace it.
+    return repo_root / ".claude" / ".warden-log"
+
+
+def _bypass_log_path() -> Path:
+    override = os.environ.get("DEUS_WARDEN_BYPASS_LOG")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude" / ".warden-bypass-log"
+
+
+def _write_bypass_log(
+    warden: str,
+    verdict: str,
+    session_type: str,
+    reason: str,
+    cwd: Path,
+) -> None:
+    try:
+        diff_stats = _entry._git(cwd, "diff", "--stat", "HEAD")
+        entry = {
+            "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "warden": warden,
+            "verdict": verdict,
+            "session_type": session_type,
+            "reason": reason,
+            "cwd": str(cwd),
+            "diff_stats": diff_stats,
+        }
+        path = _bypass_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except OSError:
+        _entry._debug("bypass log write failed")
+
+
+def _read_verdicts_at(path: Path) -> dict[str, Any]:
+    """Read a .warden-verdicts.json at an EXPLICIT path (no cwd derivation)."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_verdicts(repo_root: Path) -> dict[str, Any]:
+    return _read_verdicts_at(_verdicts_path(repo_root))
+
+
+def _read_verdict(marker_name: str, repo_root: Path) -> str | None:
+    """Return the verdict string for *marker_name* from .warden-verdicts.json.
+
+    Maps the marker name (e.g. ``"code-reviewed"``) to the warden key used in
+    the JSON (e.g. ``"code-reviewer"``) via ``MARKER_NAMES``.  Returns ``None``
+    if the file is absent, malformed, or the entry is missing.
+    """
+    warden = _entry.MARKER_NAMES.get(marker_name)
+    if not warden:
+        return None
+    data = _read_verdicts(repo_root)
+    entry = data.get(warden)
+    if not isinstance(entry, dict):
+        return None
+    v = entry.get("verdict")
+    return v if isinstance(v, str) else None
+
+
+def _clear_verdict(marker_name: str, repo_root: Path) -> None:
+    """Remove the *marker_name* entry from .warden-verdicts.json.
+
+    Maps the marker name to the warden key via ``MARKER_NAMES``.  Silently
+    skips if the file is absent or the key is not present.
+    """
+    warden = _entry.MARKER_NAMES.get(marker_name)
+    if not warden:
+        return
+    path = _verdicts_path(repo_root)
+    data = _read_verdicts(repo_root)
+    if warden not in data:
+        return
+    del data[warden]
+    try:
+        _entry._write_atomic(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
+    except OSError:
+        _entry._debug(f"_clear_verdict: failed to write {path}")
+
+
+def _write_verdict(repo_root: Path, warden: str, verdict: str, reason: str, source: str = "manual") -> None:
+    path = _verdicts_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = _read_verdicts(repo_root)
+    stamp = dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    data[warden] = {"verdict": verdict, "ts": stamp, "reason": reason, "source": source}
+    _entry._write_atomic(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+    log = _audit_log_path(repo_root)
+    safe_reason = reason.replace("|", "/").replace("\n", " ").strip()
+    with log.open("a", encoding="utf-8") as f:
+        f.write(f"{stamp} | {warden:<15} | {verdict:<7} | {safe_reason}\n")
+
+
+def _last_verdict(repo_root: Path, warden: str) -> str | None:
+    data = _read_verdicts(repo_root)
+    entry = data.get(warden)
+    if isinstance(entry, dict):
+        v = entry.get("verdict")
+        return v if isinstance(v, str) else None
+    return None
+
+
+def _last_verdict_is_blocking(repo_root: Path, warden: str) -> bool:
+    v = _last_verdict(repo_root, warden)
+    return v in ("REVISE", "BLOCK")
+
+
+def record_script_verdict(
+    repo_root: Path, store_key: str, verdict: str, reason: str, source: str = "script",
+) -> None:
+    """Record a model-backend verdict (SHIP/REVISE/BLOCK/COULD_NOT_RUN) under ``store_key``
+    (the ``<role>@<backend>`` warden key). Unlike ``mark_warden`` (human CLI, SHIP/TRIVIAL
+    only), a script records the real verdict — COULD_NOT_RUN is written verbatim so the
+    audit log distinguishes an infra failure from a genuine SHIP."""
+    _write_verdict(repo_root, store_key, verdict, reason, source=source)


### PR DESCRIPTION
## What

LIA-306 step 2 of decomposing the ~4000-line live gate engine `scripts/codex_warden_hooks.py`. Moves the 13 verdict-store I/O functions verbatim into a new `scripts/warden_hooks/verdict_store.py`:

`_verdicts_path`, `_verdicts_path_for_worktree`, `_audit_log_path`, `_bypass_log_path`, `_write_bypass_log`, `_read_verdicts_at`, `_read_verdicts`, `_read_verdict`, `_clear_verdict`, `_write_verdict`, `_last_verdict`, `_last_verdict_is_blocking`, `record_script_verdict`.

Entry: **−119 net (4119 → 4000)**. Also drops the dead `PurePosixPath` import.

## The injection seam (why this isn't a step-1 pure leaf)

Unlike step-1's pure leaves (`globs`, `command_parse`), this cluster transitively depends on entry-module helpers that tests monkeypatch — `_claude_marker_dir` (`test_warden_review.py:45`, `test_phase3_cogate_oracle.py:41`) and `_git` (`:385-402`) — plus `_write_atomic`, `_debug`, `_marker_dir_for_worktree`, `MARKER_NAMES`.

A capsule capturing those by name at import would not see `monkeypatch.setattr(h, "_claude_marker_dir", ...)`. So the entry injects itself via `bind_entry(sys.modules[__name__])` and the capsule resolves entry-owned helpers through that live reference **at call time** (9 call sites, 6 symbols). This:
- preserves every test monkeypatch (the bind target IS the module tests patch),
- costs **zero** hot-path re-import (the entry runs as `__main__` at runtime, so `import codex_warden_hooks` would re-parse it — avoided),
- defers resolution to call time, so helpers defined later than the bind site are fine.

`bind_entry()` fail-fast raises on a `None` bind. Intra-cluster calls stay direct. All symbols re-exported, so `hooks.<name>` (tests) and `codex_warden.py`'s `record_script_verdict` import are unchanged.

## Verification

**Tests — 380/380 on both interpreters** (exact CI command, independently reproduced by the verification-gate warden):
```
Python 3.14.5  → 380 passed in 8.58s
Python 3.12.13 → 380 passed in 8.86s   (CI-parity venv)
```

**Import / bind:** `import codex_warden_hooks` OK; `verdict_store._entry is h` → True; `bind_entry(None)` raises RuntimeError; `h.record_script_verdict is verdict_store.record_script_verdict` → True.

**hook-pr-smoke-test** (real invocation — this diff modifies a hook-path script). Ran `python3 scripts/codex_warden_hooks.py run <behavior>` with hook JSON on stdin + `--repo-root <tmp>`, exercising the moved functions end-to-end:

| # | Path | Behavior | Result |
|---|------|----------|--------|
| 1 | Block | `run verification-gate`, `verified` unset | verbatim `[verification-gate] BLOCKED ...` deny JSON (moved `_read_verdict`→None) |
| 2 | Write | `mark verified SHIP` | store written via moved `_write_verdict` |
| 3 | Allow | `run verification-gate`, now SHIP | exit 0, empty output (moved `_read_verdict`==SHIP) |
| 4 | Happy | `run session-init` | exit 0 (moved `_clear_verdict`/`_read_verdicts`; correctly leaves verification-gate key, clears only plan-reviewer@backends) |

Audit log appended 2 lines; bypass-log env override honored.

**Structural:** grep `^def` → 0 of the 13 in entry, 1 each in capsule; `_is_bg_session` retained in entry; moved bodies verbatim except the `_entry.` prefix; scope = exactly the two files.

## Gates
plan-reviewer ✅ (claude+gpt) · code-reviewer ✅ (claude+gpt) · verification-gate ✅ (independently reproduced 380×2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)