### PR TITLE
refactor(wardens): extract CI-status capsule from gate engine (LIA-306)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -69,6 +69,24 @@ from warden_hooks.verdict_store import (  # noqa: E402
 # without re-importing this file on the hot hook path. See warden_hooks/verdict_store.py.
 _verdict_store.bind_entry(sys.modules[__name__])
 
+# GitHub Actions CI-status polling for the admin-merge gate (LIA-306). Pure leaf
+# (stdlib only) — re-exported so the entry's admin-merge callers + the tests that
+# monkeypatch _check_ci_status / read _CI_STATUS_* keep resolving by hooks.<name>.
+from warden_hooks.ci_status import (  # noqa: E402
+    _BUCKET_FAIL,
+    _BUCKET_PASS,
+    _BUCKET_PENDING,
+    _CI_STATUS_ERROR,
+    _CI_STATUS_GREEN,
+    _CI_STATUS_NO_CHECKS,
+    _CI_STATUS_NO_REQUIRED,
+    _CI_STATUS_PENDING,
+    _CI_STATUS_RED,
+    _check_ci_status,
+    _ci_block_reason,
+    _query_gh_checks,
+)
+
 
 @dataclasses.dataclass(frozen=True)
 class HookSpec:
@@ -821,170 +839,6 @@ def _set_commit_window(repo_root: Path) -> None:
 def _prompt(event: dict[str, Any]) -> str:
     prompt = event.get("prompt")
     return prompt if isinstance(prompt, str) else ""
-
-
-_CI_STATUS_GREEN = "green"
-_CI_STATUS_RED = "red"
-_CI_STATUS_PENDING = "pending"
-_CI_STATUS_NO_CHECKS = "no-checks"
-# Checks exist on the PR but none are branch-protection-required — an ambiguous
-# state we fail closed on rather than silently allow an unverified admin-merge.
-_CI_STATUS_NO_REQUIRED = "no-required"
-_CI_STATUS_ERROR = "error"
-
-# Bucket values returned by ``gh pr checks --json bucket``
-_BUCKET_PASS = frozenset({"pass", "skipping"})
-_BUCKET_PENDING = frozenset({"pending"})
-_BUCKET_FAIL = frozenset({"fail", "cancel"})
-
-
-def _query_gh_checks(
-    pr_ref: str, *, required_only: bool, timeout: int = 3
-) -> tuple[str, str, int]:
-    """Run ``gh pr checks`` once and classify the result.
-
-    Returns ``(status, message, num_checks)`` where status is one of the
-    ``_CI_STATUS_*`` constants and num_checks is how many checks were returned.
-    When *required_only* is set, the query is scoped with ``--required`` so the
-    gate sees only branch-protection-required checks. Failure to query defaults
-    to ``_CI_STATUS_ERROR`` so the caller blocks rather than falls open.
-    """
-    argv = ["gh", "pr", "checks", pr_ref, "--json", "bucket,name"]
-    if required_only:
-        argv.append("--required")
-    try:
-        result = subprocess.run(
-            argv,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=timeout,
-            check=False,
-        )
-    except FileNotFoundError:
-        return _CI_STATUS_ERROR, "gh CLI not found; cannot verify CI status", 0
-    except subprocess.TimeoutExpired:
-        return _CI_STATUS_ERROR, f"gh pr checks timed out after {timeout}s", 0
-    except OSError as exc:
-        return _CI_STATUS_ERROR, f"gh pr checks failed: {exc}", 0
-
-    if result.returncode not in (0, 1, 8):
-        # Exit code 1 = some checks failed (still parseable).
-        # Exit code 8 = checks pending (still parseable).
-        # Other codes indicate auth / network errors.
-        stderr_snippet = result.stderr.strip()[:200]
-        return (
-            _CI_STATUS_ERROR,
-            f"gh pr checks exited {result.returncode}: {stderr_snippet}",
-            0,
-        )
-
-    raw = result.stdout.strip()
-    if not raw:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
-
-    try:
-        checks = json.loads(raw)
-    except json.JSONDecodeError:
-        return _CI_STATUS_ERROR, "gh pr checks returned unparseable output", 0
-
-    if not isinstance(checks, list):
-        return _CI_STATUS_ERROR, "gh pr checks returned unexpected JSON shape", 0
-
-    if not checks:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
-
-    n = len(checks)
-    buckets = {str(c.get("bucket", "")) for c in checks if isinstance(c, dict)}
-    failed = [
-        str(c.get("name", "?"))
-        for c in checks
-        if isinstance(c, dict) and str(c.get("bucket", "")) in _BUCKET_FAIL
-    ]
-    pending = [
-        str(c.get("name", "?"))
-        for c in checks
-        if isinstance(c, dict) and str(c.get("bucket", "")) in _BUCKET_PENDING
-    ]
-
-    if failed:
-        return _CI_STATUS_RED, f"failing checks: {', '.join(failed[:5])}", n
-    if pending:
-        return _CI_STATUS_PENDING, f"pending checks: {', '.join(pending[:5])}", n
-    if buckets <= _BUCKET_PASS:
-        return _CI_STATUS_GREEN, "all checks passed", n
-
-    unknown = buckets - _BUCKET_PASS - _BUCKET_PENDING - _BUCKET_FAIL
-    return _CI_STATUS_ERROR, f"unknown check buckets: {', '.join(sorted(unknown))}", n
-
-
-def _check_ci_status(pr_ref: str, timeout: int = 3) -> tuple[str, str]:
-    """Classify CI for *pr_ref*, scoped to branch-protection-required checks.
-
-    The admin-merge gate must mirror branch protection — only checks the repo
-    actually marks required (e.g. ``ci``) may block a merge, never
-    advisory bots (TrueCourse, the platform test matrix, CodeQL) the repo
-    deliberately left non-required. Applies to every caller of this function
-    (the one-shot approve CLI, the PreToolUse hook, and merge_train).
-
-    Falls closed: an unverifiable status — or a PR that has checks but none
-    required — blocks rather than allowing an unreviewed admin-merge.
-    """
-    status, message, _ = _query_gh_checks(pr_ref, required_only=True, timeout=timeout)
-    if status != _CI_STATUS_NO_CHECKS:
-        return status, message
-
-    # No REQUIRED checks reported. Disambiguate against the unfiltered set:
-    # genuinely zero checks → allowed through (unchanged behaviour); checks
-    # present but none required → ambiguous, fail closed.
-    all_status, all_message, all_n = _query_gh_checks(
-        pr_ref, required_only=False, timeout=timeout
-    )
-    if all_status == _CI_STATUS_ERROR:
-        return all_status, all_message
-    if all_n == 0:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
-    # Thread the unfiltered status through so the operator sees WHAT is
-    # outstanding (e.g. a failing advisory check), not just the ambiguity.
-    return (
-        _CI_STATUS_NO_REQUIRED,
-        f"{all_n} check(s) present but none are branch-protection-required "
-        f"(unfiltered: {all_status} — {all_message})",
-    )
-
-
-def _ci_block_reason(pr_ref: str, status: str, detail: str) -> str | None:
-    """Return a block reason string if CI is not green, else ``None``."""
-    if status == _CI_STATUS_GREEN:
-        return None
-    if status == _CI_STATUS_NO_CHECKS:
-        return None
-    if status == _CI_STATUS_RED:
-        return (
-            f"[admin-merge-gate] CI is red — autonomy grant is conditional on green. "
-            f"Run `gh pr checks {pr_ref}` first.\n\n"
-            f"Detail: {detail}"
-        )
-    if status == _CI_STATUS_PENDING:
-        return (
-            f"[admin-merge-gate] CI is pending — autonomy grant is conditional on green. "
-            f"Run `gh pr checks {pr_ref}` first.\n\n"
-            f"Detail: {detail}"
-        )
-    if status == _CI_STATUS_NO_REQUIRED:
-        return (
-            f"[admin-merge-gate] Branch protection reports no required checks for "
-            f"{pr_ref}, yet the PR has checks — refusing admin-merge (fail-closed). "
-            f"Inspect with `gh api repos/<owner>/<repo>/branches/main/protection` and "
-            f"confirm the required-check names before merging.\n\n"
-            f"Detail: {detail}"
-        )
-    # _CI_STATUS_ERROR — fail closed
-    return (
-        f"[admin-merge-gate] CI status could not be verified — blocking as a precaution. "
-        f"Run `gh pr checks {pr_ref}` manually to confirm green, then retry.\n\n"
-        f"Detail: {detail}"
-    )
 
 
 def _admin_merge_marker(repo_root: Path) -> Path:

--- a/scripts/warden_hooks/__init__.py
+++ b/scripts/warden_hooks/__init__.py
@@ -1,9 +1,11 @@
 """Warden-hooks capsule package (LIA-306).
 
-Focused, zero-coupling leaf modules extracted from the ~4200-line
-``codex_warden_hooks.py`` gate engine. Each capsule is pure (stdlib only, no
-shared module state), so the entry module re-imports the symbols and the
-runtime + test surface stay byte-identical. The package resolves the same way
+Focused capsules extracted from the ~4200-line ``codex_warden_hooks.py`` gate
+engine. Two kinds: pure leaves (stdlib only, no shared module state — ``globs``,
+``command_parse``, ``ci_status``) and injection-seam modules that resolve a few
+monkeypatched entry-module helpers through a ``bind_entry`` reference at call
+time (``verdict_store``). Either way the entry module re-imports the symbols so
+the runtime + test surface stay byte-identical. The package resolves the same way
 ``warden_review`` does: ``scripts/`` is on ``sys.path`` for hook invocation
 (script dir), ``python3 -m pytest`` from the repo root (CI), and the
 spec-loaded test context.

--- a/scripts/warden_hooks/ci_status.py
+++ b/scripts/warden_hooks/ci_status.py
@@ -1,0 +1,184 @@
+"""GitHub Actions CI-status polling for the admin-merge gate (LIA-306).
+
+Classifies a PR's check state by shelling out to ``gh pr checks`` and maps it to
+the ``_CI_STATUS_*`` enum the admin-merge gate decides on (it mirrors branch
+protection — only branch-protection-*required* checks may block a merge). Fails
+closed: any unverifiable status blocks rather than allowing an unreviewed merge.
+
+Pure leaf (like ``globs`` / ``command_parse``): depends only on stdlib
+(``subprocess`` + ``json``) and its own module-level constants, with no shared
+entry-module state — so no ``bind_entry`` injection seam is needed. ``_check_ci_status``
+IS monkeypatched by tests, but its callers (``approve_admin_merge`` /
+``run_admin_merge_gate``) live in the entry module and reference the re-exported
+name, so ``monkeypatch.setattr(hooks, "_check_ci_status", ...)`` rebinds exactly
+what those callers see. Tests also read ``hooks._CI_STATUS_*``; the entry
+re-exports every constant, so those reads resolve.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+_CI_STATUS_GREEN = "green"
+_CI_STATUS_RED = "red"
+_CI_STATUS_PENDING = "pending"
+_CI_STATUS_NO_CHECKS = "no-checks"
+# Checks exist on the PR but none are branch-protection-required — an ambiguous
+# state we fail closed on rather than silently allow an unverified admin-merge.
+_CI_STATUS_NO_REQUIRED = "no-required"
+_CI_STATUS_ERROR = "error"
+
+# Bucket values returned by ``gh pr checks --json bucket``
+_BUCKET_PASS = frozenset({"pass", "skipping"})
+_BUCKET_PENDING = frozenset({"pending"})
+_BUCKET_FAIL = frozenset({"fail", "cancel"})
+
+
+def _query_gh_checks(
+    pr_ref: str, *, required_only: bool, timeout: int = 3
+) -> tuple[str, str, int]:
+    """Run ``gh pr checks`` once and classify the result.
+
+    Returns ``(status, message, num_checks)`` where status is one of the
+    ``_CI_STATUS_*`` constants and num_checks is how many checks were returned.
+    When *required_only* is set, the query is scoped with ``--required`` so the
+    gate sees only branch-protection-required checks. Failure to query defaults
+    to ``_CI_STATUS_ERROR`` so the caller blocks rather than falls open.
+    """
+    argv = ["gh", "pr", "checks", pr_ref, "--json", "bucket,name"]
+    if required_only:
+        argv.append("--required")
+    try:
+        result = subprocess.run(
+            argv,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return _CI_STATUS_ERROR, "gh CLI not found; cannot verify CI status", 0
+    except subprocess.TimeoutExpired:
+        return _CI_STATUS_ERROR, f"gh pr checks timed out after {timeout}s", 0
+    except OSError as exc:
+        return _CI_STATUS_ERROR, f"gh pr checks failed: {exc}", 0
+
+    if result.returncode not in (0, 1, 8):
+        # Exit code 1 = some checks failed (still parseable).
+        # Exit code 8 = checks pending (still parseable).
+        # Other codes indicate auth / network errors.
+        stderr_snippet = result.stderr.strip()[:200]
+        return (
+            _CI_STATUS_ERROR,
+            f"gh pr checks exited {result.returncode}: {stderr_snippet}",
+            0,
+        )
+
+    raw = result.stdout.strip()
+    if not raw:
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
+
+    try:
+        checks = json.loads(raw)
+    except json.JSONDecodeError:
+        return _CI_STATUS_ERROR, "gh pr checks returned unparseable output", 0
+
+    if not isinstance(checks, list):
+        return _CI_STATUS_ERROR, "gh pr checks returned unexpected JSON shape", 0
+
+    if not checks:
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
+
+    n = len(checks)
+    buckets = {str(c.get("bucket", "")) for c in checks if isinstance(c, dict)}
+    failed = [
+        str(c.get("name", "?"))
+        for c in checks
+        if isinstance(c, dict) and str(c.get("bucket", "")) in _BUCKET_FAIL
+    ]
+    pending = [
+        str(c.get("name", "?"))
+        for c in checks
+        if isinstance(c, dict) and str(c.get("bucket", "")) in _BUCKET_PENDING
+    ]
+
+    if failed:
+        return _CI_STATUS_RED, f"failing checks: {', '.join(failed[:5])}", n
+    if pending:
+        return _CI_STATUS_PENDING, f"pending checks: {', '.join(pending[:5])}", n
+    if buckets <= _BUCKET_PASS:
+        return _CI_STATUS_GREEN, "all checks passed", n
+
+    unknown = buckets - _BUCKET_PASS - _BUCKET_PENDING - _BUCKET_FAIL
+    return _CI_STATUS_ERROR, f"unknown check buckets: {', '.join(sorted(unknown))}", n
+
+
+def _check_ci_status(pr_ref: str, timeout: int = 3) -> tuple[str, str]:
+    """Classify CI for *pr_ref*, scoped to branch-protection-required checks.
+
+    The admin-merge gate must mirror branch protection — only checks the repo
+    actually marks required (e.g. ``ci``) may block a merge, never
+    advisory bots (TrueCourse, the platform test matrix, CodeQL) the repo
+    deliberately left non-required. Applies to every caller of this function
+    (the one-shot approve CLI, the PreToolUse hook, and merge_train).
+
+    Falls closed: an unverifiable status — or a PR that has checks but none
+    required — blocks rather than allowing an unreviewed admin-merge.
+    """
+    status, message, _ = _query_gh_checks(pr_ref, required_only=True, timeout=timeout)
+    if status != _CI_STATUS_NO_CHECKS:
+        return status, message
+
+    # No REQUIRED checks reported. Disambiguate against the unfiltered set:
+    # genuinely zero checks → allowed through (unchanged behaviour); checks
+    # present but none required → ambiguous, fail closed.
+    all_status, all_message, all_n = _query_gh_checks(
+        pr_ref, required_only=False, timeout=timeout
+    )
+    if all_status == _CI_STATUS_ERROR:
+        return all_status, all_message
+    if all_n == 0:
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
+    # Thread the unfiltered status through so the operator sees WHAT is
+    # outstanding (e.g. a failing advisory check), not just the ambiguity.
+    return (
+        _CI_STATUS_NO_REQUIRED,
+        f"{all_n} check(s) present but none are branch-protection-required "
+        f"(unfiltered: {all_status} — {all_message})",
+    )
+
+
+def _ci_block_reason(pr_ref: str, status: str, detail: str) -> str | None:
+    """Return a block reason string if CI is not green, else ``None``."""
+    if status == _CI_STATUS_GREEN:
+        return None
+    if status == _CI_STATUS_NO_CHECKS:
+        return None
+    if status == _CI_STATUS_RED:
+        return (
+            f"[admin-merge-gate] CI is red — autonomy grant is conditional on green. "
+            f"Run `gh pr checks {pr_ref}` first.\n\n"
+            f"Detail: {detail}"
+        )
+    if status == _CI_STATUS_PENDING:
+        return (
+            f"[admin-merge-gate] CI is pending — autonomy grant is conditional on green. "
+            f"Run `gh pr checks {pr_ref}` first.\n\n"
+            f"Detail: {detail}"
+        )
+    if status == _CI_STATUS_NO_REQUIRED:
+        return (
+            f"[admin-merge-gate] Branch protection reports no required checks for "
+            f"{pr_ref}, yet the PR has checks — refusing admin-merge (fail-closed). "
+            f"Inspect with `gh api repos/<owner>/<repo>/branches/main/protection` and "
+            f"confirm the required-check names before merging.\n\n"
+            f"Detail: {detail}"
+        )
+    # _CI_STATUS_ERROR — fail closed
+    return (
+        f"[admin-merge-gate] CI status could not be verified — blocking as a precaution. "
+        f"Run `gh pr checks {pr_ref}` manually to confirm green, then retry.\n\n"
+        f"Detail: {detail}"
+    )


### PR DESCRIPTION
## What

LIA-306 step 3 of decomposing the ~4000-line live gate engine `scripts/codex_warden_hooks.py`. Moves the GitHub Actions CI-status cluster verbatim into a new `scripts/warden_hooks/ci_status.py`:
- constants `_CI_STATUS_GREEN/RED/PENDING/NO_CHECKS/NO_REQUIRED/ERROR` + `_BUCKET_PASS/PENDING/FAIL`
- functions `_query_gh_checks`, `_check_ci_status`, `_ci_block_reason`

Entry: **−146 net (4000 → 3854)**.

## Pure leaf — no injection seam

Unlike the verdict-store capsule (which needed `bind_entry`), this cluster depends only on **stdlib** (`subprocess` + `json`) and its own constants — zero entry-module helpers. So it's a plain re-export (the step-1 `globs`/`command_parse` pattern).

`_check_ci_status` is monkeypatched by tests (14 refs), but its two entry callers — `approve_admin_merge` and `run_admin_merge_gate` — stay in the entry referencing the re-exported name, so `monkeypatch.setattr(hooks, "_check_ci_status", ...)` still rebinds what they see. All 9 constants + 3 functions are re-exported so `hooks.<name>` resolves for callers and for test lambdas that read `hooks._CI_STATUS_*`. `subprocess`/`json` imports stay in the entry (used by ~44/~37 other call sites).

Also corrects the `warden_hooks/__init__.py` package docstring, which still claimed every capsule is a "zero-coupling leaf" — inaccurate since `verdict_store` introduced the injection seam. Now describes both kinds.

## Verification

**Tests — 380/380 on both interpreters** (exact CI command, independently reproduced by the verification-gate warden):
```
Python 3.14.5  → 380 passed in 7.20s
Python 3.12.13 → 380 passed in 12.34s   (CI-parity venv)
```

**Re-export identity:** `import codex_warden_hooks as h` OK; `h._check_ci_status is ci_status._check_ci_status` (and `_ci_block_reason`, `_query_gh_checks`) all `is`-identical; all 9 constants resolve as `h.<name>` and equal the capsule values.

**hook-pr-smoke-test** (real module + real CLI invocation — this diff modifies a hook-path script):

| Path | Check | Result |
|------|-------|--------|
| block-string mapping | `_ci_block_reason` for all 6 `_CI_STATUS_*` | byte-identical (green/no-checks→None; red/pending/no-required/error→verbatim strings) |
| parse path | `_query_gh_checks` with faked `gh` | green (2 pass) + red (failing `test-windows`) classified correctly |
| re-export | `h._CI_STATUS_*` / `h._BUCKET_*` resolve | all present, values equal |
| real CLI | `python3 codex_warden_hooks.py approve-admin-merge ...` | exit 0 |

**Byte-identity:** moved block diffs identical to origin/main (only trailing blank-line separators differ, correctly not carried). **Structural:** 0 moved symbols left in entry; 2 entry caller-pairs intact (`approve_admin_merge` 869-870, `run_admin_merge_gate` 1845-1846).

## Gates
plan-reviewer ✅ (claude+gpt) · code-reviewer ✅ (claude+gpt) · verification-gate ✅ (independently reproduced 380×2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)