### PR TITLE
feat(ingress): reduced-privilege webhook profile + per-token tool scope (LIA-315 Phase 2)

### DIFF
--- a/container/agent-runner/src/allowed-tools-phase2.oracle.test.ts
+++ b/container/agent-runner/src/allowed-tools-phase2.oracle.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Oracle tests for Ingress Gateway Phase 2 — SAFE_CURATED filtering in buildAllowedTools.
+ * Authored from the spec BEFORE implementation exists (oracle-author warden).
+ * These tests are RED against origin/main and must go GREEN once the
+ * implementer adds:
+ *   - SAFE_CURATED: Set<string> const in allowed-tools.ts
+ *   - profile?: 'full' | 'webhook' to AllowedToolsOpts
+ *   - curatedTools?: string[] to AllowedToolsOpts
+ *   - webhook branch in buildAllowedTools:
+ *       returns minimal base ['Read','Glob','Grep','WebSearch','TodoWrite','ToolSearch']
+ *       PLUS curatedTools filtered to SAFE_CURATED membership only
+ *   - full / undefined profile: byte-identical to today's list
+ *
+ * Every test is tagged @oracle so the oracle-integrity gate can protect it.
+ *
+ * TEST-SEAM REQUIREMENTS imposed on the implementer:
+ *   - SAFE_CURATED must be exported from allowed-tools.ts so the oracle can
+ *     introspect membership. If the implementer prefers not to export it,
+ *     the oracle assertions below use 'Bash' as a known-unsafe name (which
+ *     must NOT be in SAFE_CURATED per the spec: "NO Bash/Write/Edit/Task/
+ *     mcp__deus__*") and a caller-supplied safe name. Exporting SAFE_CURATED
+ *     is strongly preferred — it makes the oracle self-describing.
+ *
+ * Assumption: 'Bash', 'Write', 'Edit', 'Task', 'mcp__deus__*' are NOT in
+ * SAFE_CURATED per the spec ("NO Bash/Task/Write/Edit/mcp__deus__*").
+ * The oracle uses 'Bash' as the canonical "known unsafe" sentinel.
+ * A safe curated name is caller-supplied in each test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAllowedTools } from './allowed-tools.js';
+
+// Minimal opts for the 'full' profile (regression baseline)
+const FULL_BASE_OPTS = {
+  teamsNeeded: false,
+  hasGcalMcp: false,
+  hasLinearMcp: false,
+};
+
+// The webhook minimal base set — exactly these, no more, per spec
+const WEBHOOK_MINIMAL_BASE = [
+  'Read',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'TodoWrite',
+  'ToolSearch',
+];
+
+// Tools that MUST NOT appear in a webhook profile (spec: "NO Bash/Task/Write/Edit/mcp__deus__*")
+const WEBHOOK_EXCLUDED_ALWAYS = [
+  'Bash',
+  'Write',
+  'Edit',
+  'Task',
+  'mcp__deus__*',
+];
+
+describe('oracle (e): SAFE_CURATED filtering — webhook profile', () => {
+  it('webhook profile returns the minimal base set', () => {
+    // @oracle: webhook minimal base is exactly Read/Glob/Grep/WebSearch/TodoWrite/ToolSearch
+    const tools = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'webhook',
+      curatedTools: [],
+    });
+
+    for (const expected of WEBHOOK_MINIMAL_BASE) {
+      expect(tools).toContain(expected);
+    }
+  });
+
+  it('webhook profile EXCLUDES Bash, Write, Edit, Task, mcp__deus__*', () => {
+    // @oracle: R1 — dangerous tools absent from webhook manifest regardless of curatedTools
+    const tools = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'webhook',
+      curatedTools: [],
+    });
+
+    for (const excluded of WEBHOOK_EXCLUDED_ALWAYS) {
+      expect(tools).not.toContain(excluded);
+    }
+  });
+
+  it('a curated name NOT in SAFE_CURATED is EXCLUDED from webhook manifest', () => {
+    // @oracle: SAFE_CURATED filtering — unknown/unsafe curated names are silently dropped
+    // 'Bash' is guaranteed NOT in SAFE_CURATED (spec prohibits it from webhook profile)
+    const tools = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'webhook',
+      curatedTools: ['Bash'], // unsafe name — must be filtered out
+    });
+
+    expect(tools).not.toContain('Bash');
+  });
+
+  it('a curated name IN SAFE_CURATED IS INCLUDED in webhook manifest', () => {
+    // @oracle: SAFE_CURATED filtering — approved curated names pass through
+    // The spec guarantees that at minimum 'Read' and 'Glob' are in the base set;
+    // a truly "curated" addition would be a tool NOT already in the minimal base.
+    // We use 'WebFetch' as a plausible safe curated tool to exercise the include path.
+    // If the implementer excludes 'WebFetch' from SAFE_CURATED, they must update
+    // this test with a tool they DO include — and that is the discriminating action.
+    const tools = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'webhook',
+      curatedTools: ['WebFetch'], // expected to be in SAFE_CURATED
+    });
+
+    // WebFetch is a read-only, no-side-effect tool appropriate for webhook agents
+    expect(tools).toContain('WebFetch');
+  });
+
+  it('a mix of SAFE and unsafe curated names: only SAFE ones pass through', () => {
+    // @oracle: SAFE_CURATED intersection — mixed curated list is correctly filtered
+    // 'Bash' is unsafe (must be dropped), 'WebFetch' is safe (must pass through)
+    const tools = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'webhook',
+      curatedTools: ['Bash', 'WebFetch', 'Write', 'Read'],
+    });
+
+    // Unsafe names are dropped
+    expect(tools).not.toContain('Bash');
+    expect(tools).not.toContain('Write'); // also excluded per spec
+
+    // Safe curated names pass through
+    expect(tools).toContain('WebFetch');
+    // 'Read' is already in the minimal base, so it appears regardless
+    expect(tools).toContain('Read');
+  });
+
+  it('webhook profile does NOT include SendMessage, TeamCreate, TeamDelete', () => {
+    // @oracle: webhook profile is strictly reduced — team/multi-agent tools absent
+    const tools = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'webhook',
+      curatedTools: [],
+    });
+
+    expect(tools).not.toContain('SendMessage');
+    expect(tools).not.toContain('TeamCreate');
+    expect(tools).not.toContain('TeamDelete');
+  });
+});
+
+describe('oracle (e): full profile — byte-identical regression guard', () => {
+  it("profile='full' returns today's list including Bash, Write, Edit, Task, mcp__deus__*", () => {
+    // @oracle: profile=full must be byte-identical to the pre-change behavior
+    const fullTools = buildAllowedTools({ ...FULL_BASE_OPTS, profile: 'full' });
+    const defaultTools = buildAllowedTools({ ...FULL_BASE_OPTS });
+
+    // Must include all the tools present in today's list
+    for (const tool of ['Bash', 'Write', 'Edit', 'Task', 'mcp__deus__*']) {
+      expect(fullTools).toContain(tool);
+    }
+
+    // profile=full must equal the default (no profile) output exactly
+    expect(fullTools).toEqual(defaultTools);
+  });
+
+  it('undefined profile is identical to full profile (backward compat)', () => {
+    // @oracle: omitting profile must not change behavior for existing callers
+    const undefinedProfile = buildAllowedTools({ ...FULL_BASE_OPTS });
+    const explicitFull = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'full',
+    });
+
+    expect(undefinedProfile).toEqual(explicitFull);
+  });
+
+  it('curatedTools ignored when profile is full', () => {
+    // @oracle: curatedTools has no effect on full profile — pure backward compat
+    const withCurated = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'full',
+      curatedTools: ['Read', 'Glob'],
+    });
+    const withoutCurated = buildAllowedTools({
+      ...FULL_BASE_OPTS,
+      profile: 'full',
+    });
+
+    expect(withCurated).toEqual(withoutCurated);
+  });
+});

--- a/container/agent-runner/src/allowed-tools.ts
+++ b/container/agent-runner/src/allowed-tools.ts
@@ -42,6 +42,41 @@ export function computeTeamsNeeded(
   );
 }
 
+// LIA-315 Phase 2: minimal base toolset for webhook-originated (publicIngress)
+// runs — read-only + orchestration-free. NO Bash/Write/Edit/Task/mcp__deus__* (R1).
+const WEBHOOK_BASE = [
+  'Read',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'TodoWrite',
+  'ToolSearch',
+];
+
+// LIA-315 Phase 2: tools that MAY be offered to a reduced-privilege webhook run
+// (the webhook profile includes only `curatedTools ∩ SAFE_CURATED`). Hardcoded —
+// never env-configurable — so a malformed/injected DEUS_CURATED_TOOLS can never
+// widen the manifest. Curated names not in this set are silently dropped.
+//
+// EXACT tool names only (no globs): the host tool-proxy authorizes a scoped token
+// by exact match (isToolAllowedForToken → Set.has(rawName)), so a glob like
+// `mcp__linear__*` could never match a real call. Host-brokered MCP curated tools
+// are deferred to Phase 4, when the manifest-glob ↔ proxy-exact namespace split is
+// reconciled. Entry criteria: read-only, no in-container shell/file-write, no
+// raw-secret access.
+//
+// SYNC-REQUIRED: this set is mirrored host-side in src/container-runner.ts
+// (SAFE_CURATED) because the host and the container build as isolated packages and
+// cannot share a module (cf. LIA-223 host↔container hand-duplicated contracts). The
+// host pre-filters DEUS_CURATED_TOOLS + the scoped token; this is defense-in-depth.
+export const SAFE_CURATED = new Set<string>([
+  'Read',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+]);
+
 export interface AllowedToolsOpts {
   /** Result of computeTeamsNeeded — gates TeamCreate/TeamDelete only. */
   teamsNeeded: boolean;
@@ -49,6 +84,14 @@ export interface AllowedToolsOpts {
   hasGcalMcp: boolean;
   /** Linear MCP server is available for this run. */
   hasLinearMcp: boolean;
+  /**
+   * LIA-315 Phase 2: execution profile. 'webhook' returns the reduced-privilege
+   * manifest (WEBHOOK_BASE + curatedTools ∩ SAFE_CURATED). 'full' or undefined
+   * returns the standard manifest (byte-identical to pre-Phase-2 behavior).
+   */
+  profile?: 'full' | 'webhook';
+  /** LIA-315 Phase 2: curated tool names a webhook run requested (filtered by SAFE_CURATED). */
+  curatedTools?: string[];
 }
 
 /**
@@ -56,9 +99,20 @@ export interface AllowedToolsOpts {
  *
  * SendMessage is unconditional (pairs with the always-present Task tool).
  * Only TeamCreate/TeamDelete are gated behind `teamsNeeded`.
+ *
+ * LIA-315 Phase 2: `profile: 'webhook'` returns a reduced-privilege manifest;
+ * any other value (incl. undefined) returns the standard full manifest.
  */
 export function buildAllowedTools(opts: AllowedToolsOpts): string[] {
-  const { teamsNeeded, hasGcalMcp, hasLinearMcp } = opts;
+  const { teamsNeeded, hasGcalMcp, hasLinearMcp, profile, curatedTools } = opts;
+  if (profile === 'webhook') {
+    // Reduced-privilege: minimal base + only the curated tools on the SAFE_CURATED
+    // allowlist. Unsafe/unknown curated names drop silently (no info leak).
+    return [
+      ...WEBHOOK_BASE,
+      ...(curatedTools ?? []).filter((t) => SAFE_CURATED.has(t)),
+    ];
+  }
   return [
     'Bash',
     'Read',

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -838,10 +838,21 @@ async function runQuery(
   // LIA-151's tool_selection ground truth. The openai/llama-cpp backends branch
   // out earlier (index.ts ~1104/1119) and never reach here, so available_tools
   // is intentionally empty for them in v1.
+  // LIA-315 Phase 2: reduced-privilege profile for webhook-originated runs.
+  // The host (container-runner.ts) injects these for publicIngress groups only;
+  // a normal run has neither set, so profile defaults to 'full' (unchanged).
+  const toolProfile =
+    process.env.DEUS_TOOL_PROFILE === 'webhook' ? 'webhook' : 'full'; // LIA-315
+  const curatedTools = (process.env.DEUS_CURATED_TOOLS ?? '') // LIA-315
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
   const allowedTools = buildAllowedTools({
     teamsNeeded,
     hasGcalMcp,
     hasLinearMcp,
+    profile: toolProfile,
+    curatedTools,
   });
   // LIA-154: capture the offered manifest (default-on; DEUS_AVAILABLE_TOOLS_LOG=0 opts out).
   if (process.env.DEUS_AVAILABLE_TOOLS_LOG !== '0') {

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-16" # auto-bump @1781614772
+last_verified: "2026-06-19" # auto-bump @1781818417
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-16" # auto-bump @1781614772
+last_verified: "2026-06-19" # auto-bump @1781818417
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-18" # auto-bump @1781780198
+last_verified: "2026-06-19" # auto-bump @1781818417
 governs:
   - src/
   - evolution/

--- a/src/container-runner-phase2.oracle.test.ts
+++ b/src/container-runner-phase2.oracle.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Oracle tests for Ingress Gateway Phase 2 — buildContainerArgs env isolation.
+ * Authored from the spec BEFORE implementation exists (oracle-author warden).
+ * These tests are RED against origin/main and must go GREEN once the
+ * implementer adds:
+ *   - publicIngress?: boolean to ContainerConfig (types.ts)
+ *   - buildContainerArgs branch for publicIngress=true:
+ *       * omit LINEAR_API_KEY
+ *       * mint scoped token via getOrCreateScopedToken
+ *       * push -e DEUS_TOOL_PROFILE=webhook
+ *       * push -e DEUS_CURATED_TOOLS=<list>
+ *   - default (no publicIngress) path is byte-identical to pre-change behavior
+ *
+ * Every test is tagged @oracle so the oracle-integrity gate can protect it.
+ *
+ * TEST-SEAM REQUIREMENTS imposed on the implementer:
+ *   - buildContainerArgs MUST be exported from src/container-runner.ts.
+ *     It is currently module-internal. The implementer must add:
+ *       export function buildContainerArgs(...) { ... }
+ *     This export is the ONLY addition needed to src/container-runner.ts for
+ *     testability; the function's internal behavior is what the oracle tests.
+ *   - getOrCreateScopedToken and isToolAllowedForToken must be exported from
+ *     src/group-tokens.ts (per the Phase 2 spec).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { RegisteredGroup } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks (same pattern as container-runner.test.ts)
+// ---------------------------------------------------------------------------
+
+vi.mock('./config.js', () => ({
+  CONTAINER_IMAGE: 'deus-agent:latest',
+  CONTAINER_MAX_OUTPUT_SIZE: 10485760,
+  CONTAINER_TIMEOUT: 1800000,
+  CONFIG_DIR: '/tmp/deus-test-config',
+  CONTEXT_AUTO_COMPACT_PCT: 75,
+  CONTEXT_WARN_PCT: 70,
+  CREDENTIAL_PROXY_PORT: 3001,
+  DATA_DIR: '/tmp/deus-test-data',
+  DEUS_CONTEXT_FILE_MAX_CHARS: '',
+  DEUS_OPENAI_MODEL: '',
+  GROUPS_DIR: '/tmp/deus-test-groups',
+  HOME_DIR: '/tmp/deus-test-home',
+  IDLE_TIMEOUT: 1800000,
+  LLAMA_CPP_AGENT_MODEL: '',
+  LLAMA_CPP_MODEL: '',
+  LLAMA_CPP_PORT: '8765',
+  TIMEZONE: 'America/Los_Angeles',
+  TOOL_PROXY_PORT: 3003,
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('./container-runtime.js', () => ({
+  CONTAINER_HOST_GATEWAY: 'host.docker.internal',
+  CONTAINER_RUNTIME_BIN: 'docker',
+  hostGatewayArgs: vi.fn(() => []),
+  readonlyMountArgs: vi.fn((hostPath: string, containerPath: string) => [
+    '-v',
+    `${hostPath}:${containerPath}:ro`,
+  ]),
+}));
+
+vi.mock('./credential-proxy.js', () => ({
+  detectAuthMode: vi.fn(() => 'api-key'),
+}));
+
+vi.mock('./group-folder.js', () => ({
+  resolveGroupFolderPath: vi.fn(
+    (folder: string) => `/tmp/deus-test-groups/${folder}`,
+  ),
+  resolveGroupIpcPath: vi.fn(
+    (folder: string) => `/tmp/deus-test-groups/${folder}/ipc`,
+  ),
+}));
+
+// The group-tokens mock must forward to the REAL module so that
+// getOrCreateScopedToken's scoping behavior is tested end-to-end.
+// We use vi.importActual to let both the oracle and the new API work through
+// the real module — the mock is needed only to give the oracle test visibility
+// into scoped vs. unscoped token behavior via isToolAllowedForToken.
+//
+// NOTE: If the implementer also mocks group-tokens for their own test, they
+// MUST ensure this oracle file uses the real module. The simplest way is to
+// not mock group-tokens at all in this file — which is what we do here.
+//
+// We DO NOT mock group-tokens.js here on purpose. The real module is used.
+
+vi.mock('./db.js', () => ({
+  getProjectById: vi.fn(() => undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the flat args array from buildContainerArgs/spawn into a map of
+ * env vars: { 'LINEAR_API_KEY': 'abc', 'DEUS_TOOL_PROFILE': 'webhook', ... }
+ */
+function parseEnvArgs(args: string[]): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '-e' && i + 1 < args.length) {
+      const pair = args[i + 1];
+      const eqIdx = pair.indexOf('=');
+      if (eqIdx !== -1) {
+        env[pair.slice(0, eqIdx)] = pair.slice(eqIdx + 1);
+      }
+    }
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// Oracle case (b): default group — byte-identical pre-change behavior
+// ---------------------------------------------------------------------------
+
+describe('oracle (b): default group (no publicIngress) — regression guard', () => {
+  const savedLinearKey = process.env.LINEAR_API_KEY;
+
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = 'valid-linear-key-abc123';
+  });
+
+  afterEach(() => {
+    if (savedLinearKey === undefined) {
+      delete process.env.LINEAR_API_KEY;
+    } else {
+      process.env.LINEAR_API_KEY = savedLinearKey;
+    }
+  });
+
+  it('default group includes LINEAR_API_KEY env entry when key is set', async () => {
+    // @oracle: default group args include LINEAR_API_KEY — ALL normal runs unaffected
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Normal Group',
+      folder: 'normal-group',
+      trigger: '@Deus',
+      added_at: new Date().toISOString(),
+      // No containerConfig, no publicIngress
+    };
+
+    const args = buildContainerArgs(
+      [],
+      'test-container',
+      'claude',
+      'iid-123',
+      group,
+    );
+    const env = parseEnvArgs(args);
+
+    // LINEAR_API_KEY MUST be present for a normal group
+    expect(env).toHaveProperty('LINEAR_API_KEY');
+    expect(env['LINEAR_API_KEY']).toBe('valid-linear-key-abc123');
+  });
+
+  it('default group does NOT include DEUS_TOOL_PROFILE', async () => {
+    // @oracle: no DEUS_TOOL_PROFILE on normal runs — flag is additive only
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Normal Group',
+      folder: 'normal-group-b',
+      trigger: '@Deus',
+      added_at: new Date().toISOString(),
+    };
+
+    const args = buildContainerArgs(
+      [],
+      'test-container-b',
+      'claude',
+      'iid-456',
+      group,
+    );
+    const env = parseEnvArgs(args);
+
+    expect(env).not.toHaveProperty('DEUS_TOOL_PROFILE');
+    expect(env).not.toHaveProperty('DEUS_CURATED_TOOLS');
+  });
+
+  it('undefined group (anonymous) still includes LINEAR_API_KEY and no DEUS_TOOL_PROFILE', async () => {
+    // @oracle: regression guard — no-group path is also byte-identical
+    const { buildContainerArgs } = await import('./container-runner.js');
+
+    const args = buildContainerArgs(
+      [],
+      'test-container-anon',
+      'claude',
+      'iid-789',
+      undefined,
+    );
+    const env = parseEnvArgs(args);
+
+    expect(env).toHaveProperty('LINEAR_API_KEY');
+    expect(env).not.toHaveProperty('DEUS_TOOL_PROFILE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Oracle case (a): publicIngress group — env isolation
+// ---------------------------------------------------------------------------
+
+describe('oracle (a): publicIngress=true group — reduced-privilege env', () => {
+  const savedLinearKey = process.env.LINEAR_API_KEY;
+
+  beforeEach(async () => {
+    process.env.LINEAR_API_KEY = 'real-linear-key-xyz789';
+    // Clear token state so each test starts fresh
+    const { _clearTokens } = await import('./group-tokens.js');
+    _clearTokens();
+  });
+
+  afterEach(async () => {
+    if (savedLinearKey === undefined) {
+      delete process.env.LINEAR_API_KEY;
+    } else {
+      process.env.LINEAR_API_KEY = savedLinearKey;
+    }
+    // Clean up token state after each test
+    const { _clearTokens } = await import('./group-tokens.js');
+    _clearTokens();
+  });
+
+  it('publicIngress group OMITS LINEAR_API_KEY even when process.env has it', async () => {
+    // @oracle: R2 — no raw secrets in webhook container (LINEAR_API_KEY omitted)
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: {
+        publicIngress: true,
+        // curatedTools not set; implementation uses [] default per spec
+      },
+    };
+
+    const args = buildContainerArgs(
+      [],
+      'webhook-container',
+      'claude',
+      'iid-wh1',
+      group,
+    );
+    const env = parseEnvArgs(args);
+
+    // LINEAR_API_KEY MUST NOT appear anywhere in args for a publicIngress group
+    expect(env).not.toHaveProperty('LINEAR_API_KEY');
+    // Belt-and-suspenders: raw string scan to catch any format variation
+    const argString = args.join(' ');
+    expect(argString).not.toMatch(/LINEAR_API_KEY=/);
+  });
+
+  it('publicIngress group includes DEUS_TOOL_PROFILE=webhook', async () => {
+    // @oracle: R1 — webhook container gets reduced-privilege tool profile flag
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group-profile',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: {
+        publicIngress: true,
+      },
+    };
+
+    const args = buildContainerArgs(
+      [],
+      'webhook-container-p',
+      'claude',
+      'iid-wh2',
+      group,
+    );
+    const env = parseEnvArgs(args);
+
+    expect(env['DEUS_TOOL_PROFILE']).toBe('webhook');
+  });
+
+  it('publicIngress group mints a SCOPED token (isToolAllowedForToken enforces scope)', async () => {
+    // @oracle: R2 — the minted DEUS_PROXY_TOKEN is a scoped token, not unscoped
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const { isToolAllowedForToken } = await import('./group-tokens.js');
+
+    const curatedTools = ['Read', 'Glob'];
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group-scoped',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: {
+        publicIngress: true,
+        curatedTools,
+      },
+    };
+
+    const args = buildContainerArgs(
+      [],
+      'webhook-container-s',
+      'claude',
+      'iid-wh3',
+      group,
+    );
+    const env = parseEnvArgs(args);
+
+    const mintedToken = env['DEUS_PROXY_TOKEN'];
+    expect(mintedToken).toBeDefined();
+    expect(mintedToken).toMatch(/^[0-9a-f]{64}$/);
+
+    // The minted token must be scoped to curatedTools only
+    // Tools in scope: allowed
+    expect(isToolAllowedForToken(mintedToken, 'Read')).toBe(true);
+    expect(isToolAllowedForToken(mintedToken, 'Glob')).toBe(true);
+
+    // Tools NOT in scope: rejected — this is the R2 enforcement
+    expect(isToolAllowedForToken(mintedToken, 'Bash')).toBe(false);
+    expect(isToolAllowedForToken(mintedToken, 'Write')).toBe(false);
+    expect(isToolAllowedForToken(mintedToken, 'mcp__deus__memory')).toBe(false);
+  });
+
+  // Code-review finding (GPT co-gate): the host mints the scoped token + exports
+  // DEUS_CURATED_TOOLS, so it must bound the curated set by SAFE_CURATED — not the
+  // raw config — or a sensitive tool named in config would be authorized by the
+  // tool-proxy. NOT @oracle-tagged — added post-implementation from review.
+  it('host filters a SENSITIVE curated tool out of the token scope AND env', async () => {
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const { isToolAllowedForToken } = await import('./group-tokens.js');
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group-sensitive',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: {
+        publicIngress: true,
+        // 'Read' is in SAFE_CURATED; the rest are sensitive / not allowlisted.
+        curatedTools: ['Read', 'mcp__deus__memory', 'Bash', 'Write'],
+      },
+    };
+    const args = buildContainerArgs(
+      [],
+      'wh-sensitive',
+      'claude',
+      'iid-wh-x',
+      group,
+    );
+    const env = parseEnvArgs(args);
+    const token = env['DEUS_PROXY_TOKEN'];
+
+    // The safe tool survives; the sensitive ones are dropped from BOTH layers.
+    expect(isToolAllowedForToken(token, 'Read')).toBe(true);
+    expect(isToolAllowedForToken(token, 'mcp__deus__memory')).toBe(false);
+    expect(isToolAllowedForToken(token, 'Bash')).toBe(false);
+
+    const curated = (env['DEUS_CURATED_TOOLS'] ?? '')
+      .split(',')
+      .filter(Boolean);
+    expect(curated).toContain('Read');
+    expect(curated).not.toContain('mcp__deus__memory');
+    expect(curated).not.toContain('Bash');
+    expect(curated).not.toContain('Write');
+  });
+
+  // Code-review finding (GPT co-gate): the webhook profile is enforced only on
+  // the Claude path; openai/llama-cpp bypass buildAllowedTools. buildContainerArgs
+  // must refuse to launch a publicIngress group on a non-Claude backend (fail-closed).
+  // NOT @oracle-tagged — added post-implementation from review, not the blind spec.
+  it('publicIngress group THROWS for a non-Claude backend (openai)', async () => {
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group-openai',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: { publicIngress: true },
+    };
+    expect(() =>
+      buildContainerArgs([], 'wh-openai', 'openai', 'iid-wh-o', group),
+    ).toThrow(/claude/i);
+  });
+
+  it('publicIngress group THROWS for a non-Claude backend (llama-cpp)', async () => {
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group-llama',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: { publicIngress: true },
+    };
+    expect(() =>
+      buildContainerArgs([], 'wh-llama', 'llama-cpp', 'iid-wh-l', group),
+    ).toThrow(/claude/i);
+  });
+
+  it('default group on a non-Claude backend is unaffected (no throw)', async () => {
+    const { buildContainerArgs } = await import('./container-runner.js');
+    const group: RegisteredGroup = {
+      name: 'Normal Group',
+      folder: 'normal-openai',
+      trigger: '@Deus',
+      added_at: new Date().toISOString(),
+    };
+    expect(() =>
+      buildContainerArgs([], 'normal-openai-c', 'openai', 'iid-n-o', group),
+    ).not.toThrow();
+  });
+
+  it('publicIngress group includes DEUS_CURATED_TOOLS env var with the curated list', async () => {
+    // @oracle: host->container protocol — DEUS_CURATED_TOOLS injected as comma list
+    const { buildContainerArgs } = await import('./container-runner.js');
+
+    const curatedTools = ['Read', 'Glob', 'WebSearch'];
+    const group: RegisteredGroup = {
+      name: 'Webhook Group',
+      folder: 'webhook-group-curated',
+      trigger: '@Webhook',
+      added_at: new Date().toISOString(),
+      containerConfig: {
+        publicIngress: true,
+        curatedTools,
+      },
+    };
+
+    const args = buildContainerArgs(
+      [],
+      'webhook-container-c',
+      'claude',
+      'iid-wh4',
+      group,
+    );
+    const env = parseEnvArgs(args);
+
+    expect(env).toHaveProperty('DEUS_CURATED_TOOLS');
+    const curated = (env['DEUS_CURATED_TOOLS'] ?? '').split(',');
+    expect(curated).toContain('Read');
+    expect(curated).toContain('Glob');
+    expect(curated).toContain('WebSearch');
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -29,7 +29,10 @@ import {
   TIMEZONE,
   TOOL_PROXY_PORT,
 } from './config.js';
-import { getOrCreateGroupToken } from './group-tokens.js';
+import {
+  getOrCreateGroupToken,
+  getOrCreateScopedToken,
+} from './group-tokens.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
 
@@ -90,7 +93,27 @@ function containsCodeBlock(text: string | null): boolean {
  */
 export const CONTAINER_TIMEOUT_ERROR_PREFIX = 'Container timed out after';
 
-function buildContainerArgs(
+// LIA-315 Phase 2: host-side authoritative allowlist for a webhook (publicIngress)
+// run's curated tools. The host is the trust boundary — it mints the scoped proxy
+// token and exports DEUS_CURATED_TOOLS — so it must bound BOTH by this set, not by
+// the raw config. A malformed config naming a sensitive tool (e.g. mcp__deus__*)
+// must not end up in the token scope the tool-proxy authorizes against.
+//
+// SYNC-REQUIRED: mirror of SAFE_CURATED in container/agent-runner/src/allowed-tools.ts
+// (host and container build as isolated packages — no shared module, cf. LIA-223).
+// Exact names only (the token scope is matched exactly); MCP-glob curated tools are
+// deferred to Phase 4. Exported so a host-side test can assert byte-equality with the
+// container copy (safe-curated-sync.test.ts) — the automated guard against silent drift.
+export const SAFE_CURATED = new Set<string>([
+  'Read',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+]);
+
+// Exported as a test seam (LIA-315 Phase 2 @oracle byte-identity + isolation tests).
+export function buildContainerArgs(
   mounts: ReturnType<typeof buildVolumeMounts>,
   containerName: string,
   backend: AgentRuntimeId,
@@ -99,9 +122,37 @@ function buildContainerArgs(
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
+  // LIA-315 Phase 2: webhook-originated (publicIngress) groups run reduced-privilege:
+  // a SCOPED proxy token (curated tools only), no raw secrets, and the webhook tool
+  // profile. A normal group keeps the unscoped token + full env (byte-identical).
+  const isPublicIngress = group?.containerConfig?.publicIngress === true;
+  // Bound the curated set by the host SAFE_CURATED allowlist BEFORE it reaches
+  // either the token scope or the container — the raw config is untrusted input.
+  const curatedTools = (group?.containerConfig?.curatedTools ?? []).filter(
+    (t) => SAFE_CURATED.has(t),
+  );
+
+  // R1 (LIA-315) fail-closed: the reduced-privilege tool manifest is enforced
+  // only on the Claude path (buildAllowedTools). The openai/llama-cpp backends
+  // branch before it and run their own toolset, so a publicIngress run on a
+  // non-Claude backend would NOT be privilege-reduced. Refuse to launch rather
+  // than silently downgrade isolation. (Phase 2 is dormant — no publicIngress
+  // group exists yet — but this guards the Phase-4 dispatch wire against a
+  // misconfigured backend.)
+  if (isPublicIngress && backend !== 'claude') {
+    throw new Error(
+      `publicIngress group "${group?.folder}" requires the 'claude' backend ` +
+        `(reduced-privilege profile is claude-only); refusing to launch on '${backend}'`,
+    );
+  }
+
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
-  args.push('-e', `DEUS_PROXY_TOKEN=${getOrCreateGroupToken(group?.folder)}`);
+  const proxyToken =
+    isPublicIngress && group
+      ? getOrCreateScopedToken(group.folder, new Set(curatedTools))
+      : getOrCreateGroupToken(group?.folder);
+  args.push('-e', `DEUS_PROXY_TOKEN=${proxyToken}`);
   // LIA-154: exact per-dispatch join key for the in-container tool-call capture
   // hook → tool-calls/<id>.jsonl → readToolCalls() back on the host.
   args.push('-e', `DEUS_INTERACTION_ID=${interactionId}`);
@@ -124,15 +175,26 @@ function buildContainerArgs(
     `DEUS_CONTEXT_AUTO_COMPACT_PCT=${CONTEXT_AUTO_COMPACT_PCT}`,
   );
 
-  const linearKey = process.env.LINEAR_API_KEY || process.env.LINEAR_API_TOKEN;
-  if (linearKey) {
-    if (/^[A-Za-z0-9_-]+$/.test(linearKey)) {
-      args.push('-e', `LINEAR_API_KEY=${linearKey}`);
-    } else {
-      logger.warn(
-        'LINEAR_API_KEY contains invalid characters; Linear MCP disabled for this container',
-      );
+  // R2 (LIA-315): never inject raw secrets into a webhook (publicIngress) container.
+  // Curated actions that need Linear run host-brokered through the tool-proxy with
+  // the credential on the host, gated by the scoped token.
+  if (!isPublicIngress) {
+    const linearKey =
+      process.env.LINEAR_API_KEY || process.env.LINEAR_API_TOKEN;
+    if (linearKey) {
+      if (/^[A-Za-z0-9_-]+$/.test(linearKey)) {
+        args.push('-e', `LINEAR_API_KEY=${linearKey}`);
+      } else {
+        logger.warn(
+          'LINEAR_API_KEY contains invalid characters; Linear MCP disabled for this container',
+        );
+      }
     }
+  } else {
+    // R1 (LIA-315): tell the in-container agent-runner to build the reduced-
+    // privilege tool manifest, and which curated tools it may request.
+    args.push('-e', 'DEUS_TOOL_PROFILE=webhook');
+    args.push('-e', `DEUS_CURATED_TOOLS=${curatedTools.join(',')}`);
   }
 
   // Inject per-channel memory privacy allowlist if configured

--- a/src/group-tokens-phase2.oracle.test.ts
+++ b/src/group-tokens-phase2.oracle.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Oracle tests for Ingress Gateway Phase 2 — credential isolation primitives.
+ * Authored from the spec BEFORE implementation exists (oracle-author warden).
+ * These tests are RED against origin/main and must go GREEN once the
+ * implementer adds:
+ *   - getOrCreateScopedToken
+ *   - isToolAllowedForToken
+ *   - publicIngressFolders guard on getOrCreateGroupToken
+ *   - _clearTokens extension clearing tokenScopes + publicIngressFolders
+ *
+ * Every test is tagged @oracle so the oracle-integrity gate can protect it.
+ *
+ * TEST-SEAM REQUIREMENTS imposed on the implementer:
+ *   (none for this file — all new exports are public API per the spec)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getOrCreateGroupToken,
+  getOrCreateScopedToken,
+  isToolAllowedForToken,
+  validateGroupToken,
+  _clearTokens,
+} from './group-tokens.js';
+
+describe('group-tokens Phase 2 — oracle (c): scoped token enforcement', () => {
+  // @oracle: isToolAllowedForToken must use Set membership for scoped tokens
+  beforeEach(() => _clearTokens());
+
+  it('isToolAllowedForToken returns true for a tool IN the scope set', () => {
+    // @oracle: scoped token enforcement — tool in curated set is allowed
+    const curatedSet = new Set(['WebSearch', 'Read', 'Glob']);
+    const token = getOrCreateScopedToken('folder-curated', curatedSet);
+    expect(isToolAllowedForToken(token, 'WebSearch')).toBe(true);
+    expect(isToolAllowedForToken(token, 'Read')).toBe(true);
+    expect(isToolAllowedForToken(token, 'Glob')).toBe(true);
+  });
+
+  it('isToolAllowedForToken returns false for a tool NOT in the scope set', () => {
+    // @oracle: scoped token enforcement — tool outside curated set is rejected (R2)
+    const curatedSet = new Set(['WebSearch', 'Read', 'Glob']);
+    const token = getOrCreateScopedToken('folder-curated-b', curatedSet);
+    // Bash is in the global allowlist but NOT in the curated set
+    expect(isToolAllowedForToken(token, 'Bash')).toBe(false);
+    // mcp__deus__memory is a deus tool, NOT in the curated set
+    expect(isToolAllowedForToken(token, 'mcp__deus__memory')).toBe(false);
+  });
+
+  it('isToolAllowedForToken returns true for ALL tools on an unscoped (normal-group) token', () => {
+    // @oracle: unscoped tokens are unrestricted — normal groups unaffected
+    const token = getOrCreateGroupToken('normal-folder');
+    expect(isToolAllowedForToken(token, 'Bash')).toBe(true);
+    expect(isToolAllowedForToken(token, 'Write')).toBe(true);
+    expect(isToolAllowedForToken(token, 'mcp__deus__memory')).toBe(true);
+  });
+
+  it('per-source isolation: token A is rejected for token B curated tool (different folders)', () => {
+    // @oracle: per-source isolation — token A cannot access token B scope
+    // Two distinct folders; each minted with disjoint scopes.
+    const scopeA = new Set(['WebSearch']);
+    const scopeB = new Set(['Glob']);
+    const tokenA = getOrCreateScopedToken('source-folder-A', scopeA);
+    const tokenB = getOrCreateScopedToken('source-folder-B', scopeB);
+
+    // Token A: allowed for 'WebSearch', rejected for 'Glob' (token B's tool)
+    expect(isToolAllowedForToken(tokenA, 'WebSearch')).toBe(true);
+    expect(isToolAllowedForToken(tokenA, 'Glob')).toBe(false);
+
+    // Token B: allowed for 'Glob', rejected for 'WebSearch' (token A's tool)
+    expect(isToolAllowedForToken(tokenB, 'Glob')).toBe(true);
+    expect(isToolAllowedForToken(tokenB, 'WebSearch')).toBe(false);
+  });
+});
+
+describe('group-tokens Phase 2 — oracle (d): race and conflict guards', () => {
+  // @oracle: fail-closed mint namespace — race and conflict guards
+  beforeEach(() => _clearTokens());
+
+  it('getOrCreateGroupToken THROWS for a folder already registered as publicIngress', () => {
+    // @oracle: publicIngress folder must go through scoped path only — race guard
+    const scope = new Set(['Read']);
+    getOrCreateScopedToken('ingress-folder', scope);
+    // The folder is now registered in publicIngressFolders; the unscoped path must throw
+    expect(() => getOrCreateGroupToken('ingress-folder')).toThrow();
+  });
+
+  it('getOrCreateScopedToken THROWS when called twice with DIFFERENT scopes (scope conflict)', () => {
+    // @oracle: scope conflict — a folder maps to exactly one source/scope
+    const scopeX = new Set(['WebSearch']);
+    const scopeY = new Set(['Glob']); // different scope
+    getOrCreateScopedToken('conflict-folder', scopeX);
+    expect(() => getOrCreateScopedToken('conflict-folder', scopeY)).toThrow();
+  });
+
+  it('getOrCreateScopedToken is IDEMPOTENT — same scope returns the SAME token', () => {
+    // @oracle: same scope re-registers safely and returns the identical token
+    const scope = new Set(['WebSearch', 'Read']);
+    const t1 = getOrCreateScopedToken('idempotent-folder', scope);
+    const t2 = getOrCreateScopedToken(
+      'idempotent-folder',
+      new Set(['WebSearch', 'Read']),
+    );
+    expect(t1).toBe(t2);
+  });
+
+  it('_clearTokens also clears publicIngress folder registry and token scopes', () => {
+    // @oracle: _clearTokens must clear the new state for proper test isolation
+    const scope = new Set(['Read']);
+    const token = getOrCreateScopedToken('cleanup-folder', scope);
+    // Confirm the state was set
+    expect(isToolAllowedForToken(token, 'Read')).toBe(true);
+    expect(isToolAllowedForToken(token, 'Bash')).toBe(false);
+
+    _clearTokens();
+
+    // After clear, getOrCreateGroupToken on the same folder must NOT throw
+    // (folder is no longer registered as publicIngress)
+    expect(() => getOrCreateGroupToken('cleanup-folder')).not.toThrow();
+
+    // After clear, the old token is no longer in foldersByToken, but the
+    // critical property is that the scope entry is also gone — a fresh
+    // scoped token for the same folder should work, and the OLD token
+    // should now be treated as unscoped (no scope entry → returns true).
+    expect(isToolAllowedForToken(token, 'Bash')).toBe(true);
+  });
+
+  it('getOrCreateScopedToken mints a valid 64-char hex token', () => {
+    // @oracle: scoped tokens follow the same format as group tokens
+    const scope = new Set(['Read']);
+    const token = getOrCreateScopedToken('hex-folder', scope);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('validateGroupToken can resolve a scoped token back to its folder', () => {
+    // @oracle: scoped tokens are still registered in the reverse-lookup map
+    const scope = new Set(['Read']);
+    const token = getOrCreateScopedToken('resolve-folder', scope);
+    expect(validateGroupToken(token)).toBe('resolve-folder');
+  });
+});

--- a/src/group-tokens.ts
+++ b/src/group-tokens.ts
@@ -10,10 +10,26 @@ import crypto from 'crypto';
 const tokensByFolder = new Map<string, string>();
 const foldersByToken = new Map<string, string>();
 
+// Phase 2 (LIA-315): per-token tool-scope for reduced-privilege webhook runs.
+// A publicIngress (webhook) folder's token is restricted to a curated tool set;
+// the tool-proxy rejects any tool outside that set. Normal-group tokens are
+// never scoped and stay unrestricted.
+const tokenScopes = new Map<string, Set<string>>(); // token -> allowed curated tools
+const publicIngressFolders = new Set<string>(); // folders that MUST mint via the scoped path
+
 const ANONYMOUS_KEY = '_anonymous';
 
 export function getOrCreateGroupToken(folder?: string): string {
   const key = folder || ANONYMOUS_KEY;
+  // Race guard (R2): a publicIngress folder may only ever be minted via the
+  // scoped path, so its token always carries a scope. Reject the unscoped path
+  // BEFORE the idempotency return — otherwise an unscoped first-mint would
+  // silently produce a token that isToolAllowedForToken treats as unrestricted.
+  if (publicIngressFolders.has(key)) {
+    throw new Error(
+      `getOrCreateGroupToken: folder "${key}" is a publicIngress folder — use getOrCreateScopedToken`,
+    );
+  }
   const existing = tokensByFolder.get(key);
   if (existing) return existing;
 
@@ -23,12 +39,69 @@ export function getOrCreateGroupToken(folder?: string): string {
   return token;
 }
 
+function scopesEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+/**
+ * Mint (or return) a SCOPED token for a publicIngress (webhook) folder.
+ * Phase 2 (LIA-315), R2 linchpin. Fail-closed:
+ *   - new folder            -> mint, record scope.
+ *   - same folder + scope   -> idempotent, return existing token.
+ *   - same folder, DIFFERENT scope -> throw (a folder maps to exactly one
+ *     source/scope; never silently merge or override its authority).
+ *   - existing token with NO scope -> throw (folder was minted unscoped first).
+ */
+export function getOrCreateScopedToken(
+  folder: string,
+  scope: Set<string>,
+): string {
+  publicIngressFolders.add(folder);
+  const existing = tokensByFolder.get(folder);
+  if (existing) {
+    const existingScope = tokenScopes.get(existing);
+    if (!existingScope) {
+      throw new Error(
+        `getOrCreateScopedToken: folder "${folder}" already has an unscoped token`,
+      );
+    }
+    if (!scopesEqual(existingScope, scope)) {
+      throw new Error(
+        `getOrCreateScopedToken: folder "${folder}" already minted with a different scope`,
+      );
+    }
+    return existing;
+  }
+  const token = crypto.randomBytes(32).toString('hex');
+  tokensByFolder.set(folder, token);
+  foldersByToken.set(token, folder);
+  tokenScopes.set(token, new Set(scope));
+  return token;
+}
+
 export function validateGroupToken(token: string): string | null {
   return foldersByToken.get(token) ?? null;
+}
+
+/**
+ * Whether a token may invoke a given tool. Scoped (publicIngress) tokens are
+ * restricted to their curated set; unscoped (normal-group) tokens are
+ * unrestricted. Enforced in the tool-proxy (Phase 2, LIA-315). A scoped token
+ * can never lack an entry here — publicIngress folders mint only via the
+ * scoped path — so "no entry" unambiguously means a normal, unscoped group.
+ */
+export function isToolAllowedForToken(token: string, rawName: string): boolean {
+  const scope = tokenScopes.get(token);
+  if (!scope) return true; // unscoped — normal group, unrestricted
+  return scope.has(rawName);
 }
 
 /** @internal — for testing only */
 export function _clearTokens(): void {
   tokensByFolder.clear();
   foldersByToken.clear();
+  tokenScopes.clear();
+  publicIngressFolders.clear();
 }

--- a/src/safe-curated-sync.test.ts
+++ b/src/safe-curated-sync.test.ts
@@ -1,0 +1,28 @@
+/**
+ * LIA-315 Phase 2: automated sync guard for the SAFE_CURATED allowlist.
+ *
+ * SAFE_CURATED is hand-duplicated across the host (src/container-runner.ts —
+ * authoritative; bounds the scoped token + DEUS_CURATED_TOOLS) and the container
+ * (container/agent-runner/src/allowed-tools.ts — defense-in-depth; bounds the
+ * offered manifest). The two packages build in isolation with disjoint tsc rootDirs
+ * and cannot share a module (cf. LIA-223). A silent divergence — e.g. adding a tool
+ * to one copy but not the other — would widen one enforcement layer without failing
+ * any other test. This test fails CI the moment the two sets diverge.
+ *
+ * The container copy is loaded via a dynamic import with a non-literal specifier so
+ * `tsc` does not try to compile it under the host's rootDir (TS6059); vitest resolves
+ * it at runtime.
+ */
+import { describe, it, expect } from 'vitest';
+import { SAFE_CURATED as HOST_SAFE_CURATED } from './container-runner.js';
+
+const CONTAINER_ALLOWED_TOOLS =
+  '../container/agent-runner/src/allowed-tools.js';
+
+describe('SAFE_CURATED host/container sync (LIA-315)', () => {
+  it('the host and container allowlists are byte-identical', async () => {
+    const mod = await import(/* @vite-ignore */ CONTAINER_ALLOWED_TOOLS);
+    const containerSet = mod.SAFE_CURATED as Set<string>;
+    expect([...HOST_SAFE_CURATED].sort()).toEqual([...containerSet].sort());
+  });
+});

--- a/src/tool-proxy.ts
+++ b/src/tool-proxy.ts
@@ -24,7 +24,7 @@ import { execFile } from 'child_process';
 
 import { DEUS_PROXY_AUTH_ENABLED } from './config.js';
 import { getProjectById, getRegisteredGroupByFolder } from './db.js';
-import { validateGroupToken } from './group-tokens.js';
+import { validateGroupToken, isToolAllowedForToken } from './group-tokens.js';
 import { logger } from './logger.js';
 import { loadRegistry, isAllowed, getToolConfig } from './tool-registry.js';
 
@@ -164,6 +164,25 @@ export function startToolProxy(
           );
           res.writeHead(403, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: `Tool not allowed: ${rawName}` }));
+          return;
+        }
+
+        // Per-token scope check (LIA-315 Phase 2, R2). A scoped (publicIngress)
+        // token may invoke ONLY its curated tool set; everything else 403s here
+        // even though it passed the global allowlist. Unscoped (normal-group)
+        // tokens are unaffected — isToolAllowedForToken returns true for them.
+        // The `token &&` guard only no-ops when auth is disabled (dev, no token);
+        // publicIngress containers always receive an injected DEUS_PROXY_TOKEN, so
+        // the scope check always fires for them.
+        if (token && !isToolAllowedForToken(token, rawName)) {
+          logger.warn(
+            { tool: rawName },
+            'Tool proxy rejected tool outside token scope',
+          );
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({ error: `Tool not in token scope: ${rawName}` }),
+          );
           return;
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export interface ContainerConfig {
   // Injected as DEUS_MEMORY_PRIVACY env var. Default: all except sensitive.
   agentBackend?: AgentRuntimeId; // Optional override for this group's default backend.
   agentEffort?: AgentEffortLevel; // Optional override for this group's agent effort level.
+  publicIngress?: boolean; // LIA-315 Phase 2: webhook-originated reduced-privilege sandbox group.
+  curatedTools?: string[]; // LIA-315 Phase 2: host-brokered tools allowed (∩ SAFE_CURATED); [] = notify-only.
 }
 
 export interface ProjectType {


### PR DESCRIPTION
## LIA-315 Phase 2 — credential-isolation primitives (oracle-first)

Phase 2 of the centralized ingress gateway. Adds the **reduced-privilege container profile** + **per-token tool-scope primitive** for webhook-originated (`publicIngress`) runs. Phase 1 (gateway/tunnel/hmac infra) shipped inert in #877.

**Dormant plumbing** — no webhook dispatch path ships here (that's Phase 4, gated behind R5/R6 caps in Phase 3). No `publicIngress` group exists yet, so the default (normal-group) path is **byte-identical** to today.

### Threat-model requirements addressed
- **R1** — webhook runs get a reduced toolset (no `Bash`/`Write`/`Edit`/`Task`/`mcp__deus__*`).
- **R2** — no raw secrets in the webhook container; curated actions are host-brokered AND per-token-scoped.

### Changes
- **`src/group-tokens.ts`** — `getOrCreateScopedToken` + `isToolAllowedForToken` + a fail-closed mint namespace (a `publicIngress` folder mints only via the scoped path; scope conflicts and unscoped pre-mints throw). The R2 linchpin.
- **`src/tool-proxy.ts`** — scoped tokens `403` for any tool outside their curated set; unscoped (normal-group) tokens unaffected.
- **`src/container-runner.ts`** — `buildContainerArgs` branches on `publicIngress`: omits raw `LINEAR_API_KEY`, mints a scoped token, sets `DEUS_TOOL_PROFILE`/`DEUS_CURATED_TOOLS`. Curated set bounded host-side by `SAFE_CURATED`. **Fail-closed:** refuses a `publicIngress` run on a non-Claude backend (the reduced profile is claude-only in Phase 2).
- **`container/agent-runner/src/allowed-tools.ts`** — `buildAllowedTools` gains a `'webhook'` profile (minimal base + `curatedTools ∩ SAFE_CURATED`); `SAFE_CURATED` is exact-names-only.
- **`container/agent-runner/src/index.ts`** — reads `DEUS_TOOL_PROFILE`/`DEUS_CURATED_TOOLS` env, threads to `buildAllowedTools`.
- **`src/types.ts`** — `publicIngress?` / `curatedTools?` on `ContainerConfig`.
- **`src/safe-curated-sync.test.ts`** — `SAFE_CURATED` is hand-synced host/container (build-isolated packages, cf. LIA-223); this test asserts byte-equality and fails CI on drift.

### Authored oracle-first
The discriminating @oracle tests (3 files, 26 tests) were authored **blind from the spec** by an independent `oracle-author` agent BEFORE implementation — RED until the impl made them GREEN. Covers: publicIngress env isolation, default byte-identity, scoped-token 403, per-source isolation, the mint race/conflict guards, and `SAFE_CURATED` filtering.

### Co-gate (Claude + GPT) — both SHIP
- **plan-reviewer**: SHIP (v3, after 2 revisions — caught the v4 mint-race + a scope-conflict gap, both closed fail-closed).
- **code-reviewer**: SHIP both backends (4 rounds). The GPT co-gate caught a **non-Claude-backend isolation bypass** (now fail-closed) and **host token-scope minting from unfiltered config** (now `SAFE_CURATED`-bounded); Claude caught a glob/exact mismatch and the silent-drift risk (now sync-tested).
- **verification-gate**: SHIP (Opus).

### Verification
- Main suite **1728/1728**, agent-runner **187/187**, 30 Phase-2 tests, host typecheck clean, flag_lint clean, prettier-clean.

> **Container rebuild note:** touches `container/agent-runner/` — `./container/build.sh` is needed to pick up the agent-runner changes on deploy. No urgency: the primitives are dormant (no `publicIngress` group exists until Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)