### PR TITLE
fix(webui): capitalize Deus model label in OWUI

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781818417
+last_verified: "2026-06-19" # auto-bump @1781823123
 governs:
   - src/
   - evolution/

--- a/scripts/webui-serve.sh
+++ b/scripts/webui-serve.sh
@@ -47,7 +47,7 @@ mkdir -p "$DATA_DIR"
 export OPENAI_API_BASE_URL="http://127.0.0.1:${DEUS_PORT}/v1"
 export OPENAI_API_KEY="$DEUS_TOKEN"
 export ENABLE_OLLAMA_API="False"
-export DEFAULT_MODELS="deus"
+export DEFAULT_MODELS="Deus"
 
 # ── Identity / auth (single local user) ─────────────────────────────────────
 export WEBUI_NAME="Deus"
@@ -87,6 +87,6 @@ export USER_PERMISSIONS_FEATURES_IMAGE_GENERATION="False"
 export USER_PERMISSIONS_FEATURES_CODE_INTERPRETER="False"
 export USER_PERMISSIONS_FEATURES_NOTES="False"
 
-echo "[webui-serve] Open WebUI → Deus on http://127.0.0.1:${DEUS_PORT}/v1 (model: deus)"
+echo "[webui-serve] Open WebUI → Deus on http://127.0.0.1:${DEUS_PORT}/v1 (model: Deus)"
 echo "[webui-serve] UI: http://${WEBUI_HOST}:${WEBUI_PORT}/  DATA_DIR=$DATA_DIR"
 exec uvx --python 3.11 open-webui serve --host "$WEBUI_HOST" --port "$WEBUI_PORT"

--- a/src/odysseus-server.test.ts
+++ b/src/odysseus-server.test.ts
@@ -455,7 +455,7 @@ describe('gates', () => {
       headers: authHeaders,
     });
     expect(r.statusCode).toBe(200);
-    expect(JSON.parse(r.body).data[0].id).toBe('deus');
+    expect(JSON.parse(r.body).data[0].id).toBe('Deus');
   });
 
   it('400 when there is no user message', async () => {

--- a/src/odysseus-server.ts
+++ b/src/odysseus-server.ts
@@ -151,7 +151,7 @@ function writeSse(res: ServerResponse, frame: Record<string, unknown>): void {
 
 const MODELS_RESPONSE = {
   object: 'list',
-  data: [{ id: 'deus', object: 'model', created: 0, owned_by: 'deus' }],
+  data: [{ id: 'Deus', object: 'model', created: 0, owned_by: 'deus' }],
 };
 
 function chunkFrame(
@@ -163,7 +163,7 @@ function chunkFrame(
     id: `chatcmpl-${id}`,
     object: 'chat.completion.chunk',
     created: Math.floor(Date.now() / 1000),
-    model: 'deus',
+    model: 'Deus',
     choices: [{ index: 0, delta, finish_reason: finish }],
   };
 }
@@ -173,7 +173,7 @@ function completionFrame(id: string, content: string): Record<string, unknown> {
     id: `chatcmpl-${id}`,
     object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
-    model: 'deus',
+    model: 'Deus',
     choices: [
       {
         index: 0,


### PR DESCRIPTION
## What
Rename the OWUI model display label from lowercase **`deus`** to **`Deus`**.

OWUI uses the OpenAI-compatible model `id` returned by the Deus `/v1/models` endpoint (`src/odysseus-server.ts`) as the model-selector display label. It showed lowercase `deus`.

## Changes (5 sites, 3 files)
- `src/odysseus-server.ts`: `MODELS_RESPONSE` id `deus`→`Deus`; echoed `model` field in `chunkFrame` (streaming) and `completionFrame` (non-streaming). `owned_by` left lowercase (org identifier, not displayed).
- `scripts/webui-serve.sh`: `DEFAULT_MODELS` `deus`→`Deus` (so OWUI auto-selects the renamed model) + cosmetic startup echo.
- `src/odysseus-server.test.ts`: assertion `toBe('deus')`→`toBe('Deus')`.

## Why it's safe
The server never reads the inbound request `model` field (existing tests send `model: 'gpt'` and pass), so the id is display-only and echoed in responses.

## Verification
- `npm run build` → exits 0
- `npx vitest run src/odysseus-server.test.ts` → 37/37 pass

## Notes
- `scripts/webui-serve.sh` is Unix-only (Bash); no Windows-equivalent path is affected.
- OWUI persists models by id in `~/.deus/owui`; a stale `deus` entry is harmless and `DEFAULT_MODELS="Deus"` auto-selects the new one. Requires a `deus web` restart to take effect live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)