### PR TITLE
feat(ingress): route Linear webhooks through the gateway (/linear) (LIA-315 Phase 5)

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-06-18" # auto-bump @1781780198
+last_verified: "2026-06-19" # auto-bump @1781825634
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781823123
+last_verified: "2026-06-19" # auto-bump @1781825634
 governs:
   - src/
   - evolution/

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,12 @@ export const INGRESS_TUNNEL_ENABLED =
   process.env.INGRESS_TUNNEL_ENABLED === '1' ||
   process.env.INGRESS_TUNNEL_ENABLED === 'true';
 export const NGROK_STATIC_DOMAIN = process.env.NGROK_STATIC_DOMAIN || '';
+// Route Linear webhooks through the centralized ingress gateway (/linear) instead of the
+// standalone :3005 server. Off by default; requires INGRESS_GATEWAY_ENABLED. When off the
+// standalone Linear webhook server keeps running unchanged (rollback path). LIA-315 Phase 5.
+export const INGRESS_LINEAR_VIA_GATEWAY =
+  process.env.INGRESS_LINEAR_VIA_GATEWAY === '1' ||
+  process.env.INGRESS_LINEAR_VIA_GATEWAY === 'true';
 // Per-source webhook config, OUTSIDE project root, never mounted into containers
 // (same pattern as SENDER_ALLOWLIST_PATH). Consumed in Phase 4 by the webhook channel.
 export const WEBHOOK_SOURCES_PATH = path.join(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   INGRESS_GATEWAY_HOST,
   INGRESS_GATEWAY_PORT,
   INGRESS_IP_ALLOWLIST,
+  INGRESS_LINEAR_VIA_GATEWAY,
   INGRESS_MAX_BODY_BYTES,
   INGRESS_RATE_LIMIT_MAX,
   INGRESS_RATE_LIMIT_WINDOW_MS,
@@ -77,7 +78,10 @@ import {
 } from './linear-dispatcher.js';
 import type { LinearContext } from './linear-dispatcher.js';
 import { loadGateSpecs } from './linear-gate-specs.js';
-import { startLinearWebhookServer } from './linear-webhook.js';
+import {
+  startLinearWebhookServer,
+  createLinearIngressHandler,
+} from './linear-webhook.js';
 import { registerLinearUpdater } from './events/listeners/linear-updater.js';
 import { registerObservabilitySink } from './events/listeners/observability-sink.js';
 
@@ -471,20 +475,45 @@ async function main(): Promise<void> {
       );
       const gateSpecs = loadGateSpecs(wardensDir);
 
-      if (process.env.LINEAR_WEBHOOK_SECRET) {
+      const linearWebhookSecret = process.env.LINEAR_WEBHOOK_SECRET;
+      if (linearWebhookSecret) {
         if (gateSpecs.size === 0) {
           logger.warn(
             'linear-webhook: no gate specs found — webhook server will pass all transitions',
           );
         }
-        try {
-          const webhookSrv = await startLinearWebhookServer(
-            linearCtx,
-            gateSpecs,
+        if (INGRESS_LINEAR_VIA_GATEWAY && INGRESS_GATEWAY_ENABLED) {
+          // Route Linear webhooks through the centralized ingress gateway (/linear)
+          // instead of the standalone :3005 server. The gateway reads `ingressHandlers`
+          // live (Strategy registry), so pushing here — after the gateway is listening —
+          // is the documented contract (gateway.ts:52, index.ts ingressHandlers).
+          ingressHandlers.push(
+            createLinearIngressHandler(
+              linearCtx,
+              gateSpecs,
+              linearWebhookSecret,
+            ),
           );
-          webhookServers.push(webhookSrv);
-        } catch (err) {
-          logger.error({ err }, 'linear-webhook: server failed to start');
+          logger.info(
+            'linear-webhook: routed via ingress gateway (/linear); standalone :3005 server not started',
+          );
+        } else {
+          if (INGRESS_LINEAR_VIA_GATEWAY && !INGRESS_GATEWAY_ENABLED) {
+            // Fail-safe: never silently drop Linear ingestion when the flag is set but
+            // the gateway it depends on is off — keep the standalone server running.
+            logger.warn(
+              'linear-webhook: INGRESS_LINEAR_VIA_GATEWAY set but INGRESS_GATEWAY_ENABLED off — falling back to standalone :3005 server',
+            );
+          }
+          try {
+            const webhookSrv = await startLinearWebhookServer(
+              linearCtx,
+              gateSpecs,
+            );
+            webhookServers.push(webhookSrv);
+          } catch (err) {
+            logger.error({ err }, 'linear-webhook: server failed to start');
+          }
         }
       }
 

--- a/src/ingress/linear-ingress.test.ts
+++ b/src/ingress/linear-ingress.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import crypto from 'crypto';
+import type { LinearContext } from '../linear-dispatcher.js';
+import type { GateSpec } from '../linear-gate-specs.js';
+
+// ── Module-level mocks (declared before the units that consume them) ──────────
+// Spy the cache writers so we can assert dispatch happened without real writes,
+// and stub the dispatcher so the fire-and-forget handleIssueUpdate path is inert.
+
+vi.mock('../db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db.js')>();
+  return {
+    ...actual,
+    upsertIssueCache: vi.fn(),
+    softDeleteIssueCache: vi.fn(),
+  };
+});
+
+vi.mock('../linear-dispatcher.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../linear-dispatcher.js')>();
+  return {
+    ...actual,
+    executeAgentRun: vi.fn().mockResolvedValue({ text: '', error: '' }),
+  };
+});
+
+const { upsertIssueCache, _initTestDatabase } = await import('../db.js');
+const { createLinearIngressHandler } = await import('../linear-webhook.js');
+
+const SECRET = 'test-webhook-secret';
+
+/** Build a JSON body (with a fresh webhookTimestamp) + its valid HMAC-SHA256 hex sig. */
+function signed(payload: Record<string, unknown>, secret = SECRET) {
+  const body = Buffer.from(
+    JSON.stringify({ webhookTimestamp: Date.now(), ...payload }),
+  );
+  const sig = crypto.createHmac('sha256', secret).update(body).digest('hex');
+  return { body, sig };
+}
+
+function req(sig?: string, ts?: string) {
+  const headers: Record<string, string> = {};
+  if (sig !== undefined) headers['linear-signature'] = sig;
+  if (ts !== undefined) headers['linear-timestamp'] = ts;
+  return { headers } as never;
+}
+
+function fakeRes() {
+  const out: { status?: number; body?: string } = {};
+  const res = {
+    writeHead: (s: number) => {
+      out.status = s;
+      return res;
+    },
+    end: (b?: string) => {
+      out.body = b;
+    },
+  } as never;
+  return { res, out };
+}
+
+function makeHandler() {
+  return createLinearIngressHandler(
+    { vaultPath: undefined } as unknown as LinearContext,
+    new Map<string, GateSpec>(),
+    SECRET,
+  );
+}
+
+const issueData = {
+  id: 'i1',
+  identifier: 'LIA-1',
+  title: 't',
+  state: { name: 'In Review' },
+  teamId: 'team',
+  priority: 0,
+  createdAt: 'x',
+  updatedAt: 'y',
+};
+
+beforeEach(() => {
+  _initTestDatabase();
+  vi.clearAllMocks();
+});
+
+describe('createLinearIngressHandler', () => {
+  it('registers the /linear path prefix', () => {
+    expect(makeHandler().pathPrefix).toBe('/linear');
+  });
+
+  it('verify accepts a valid signature', async () => {
+    const { body, sig } = signed({ type: 'Issue', action: 'update' });
+    expect(await makeHandler().verify(req(sig), body)).toEqual({ ok: true });
+  });
+
+  it('verify rejects a tampered body', async () => {
+    const { sig } = signed({ type: 'Issue' });
+    const tampered = Buffer.from(JSON.stringify({ type: 'Issue', evil: true }));
+    expect((await makeHandler().verify(req(sig), tampered)).ok).toBe(false);
+  });
+
+  it('verify rejects a wrong-secret signature', async () => {
+    const { body, sig } = signed({ type: 'Issue' }, 'other-secret');
+    expect((await makeHandler().verify(req(sig), body)).ok).toBe(false);
+  });
+
+  it('verify rejects a missing signature header', async () => {
+    const { body } = signed({ type: 'Issue' });
+    expect(await makeHandler().verify(req(undefined), body)).toEqual({
+      ok: false,
+      reason: 'missing signature',
+    });
+  });
+
+  it('handle dispatches an Issue payload and returns 200', async () => {
+    const { body, sig } = signed({
+      type: 'Issue',
+      action: 'update',
+      data: issueData,
+    });
+    const { res, out } = fakeRes();
+    await makeHandler().handle(req(sig), res, body);
+    expect(out.status).toBe(200);
+    expect(upsertIssueCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('handle ignores a non-Issue payload but still returns 200', async () => {
+    const { body, sig } = signed({
+      type: 'Comment',
+      action: 'create',
+      data: { id: 'c1' },
+    });
+    const { res, out } = fakeRes();
+    await makeHandler().handle(req(sig), res, body);
+    expect(out.status).toBe(200);
+    expect(upsertIssueCache).not.toHaveBeenCalled();
+  });
+
+  it('handle returns 400 on a bad signature and does not dispatch', async () => {
+    const { body, sig } = signed({ type: 'Issue', data: issueData }, 'wrong');
+    const { res, out } = fakeRes();
+    await makeHandler().handle(req(sig), res, body);
+    expect(out.status).toBe(400);
+    expect(upsertIssueCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/linear-webhook.ts
+++ b/src/linear-webhook.ts
@@ -1,6 +1,10 @@
 import { createServer, Server } from 'http';
 import { LinearWebhookClient } from '@linear/sdk/webhooks';
-import type { EntityWebhookPayloadWithIssueData } from '@linear/sdk/webhooks';
+import type {
+  EntityWebhookPayloadWithIssueData,
+  LinearWebhookPayload,
+} from '@linear/sdk/webhooks';
+import type { IngressHandler } from './ingress/gateway.js';
 import { logger } from './logger.js';
 import { executeAgentRun, extractScopeBlock } from './linear-dispatcher.js';
 import { escapeXmlForPrompt } from './prompt-utils.js';
@@ -1959,6 +1963,123 @@ export async function sweepStaleGatedIssues(
   }
 }
 
+/**
+ * Core Issue-webhook processing, shared by the standalone :3005 server and the ingress
+ * gateway `/linear` handler so both fronts behave identically: refresh the issue cache,
+ * debounce a vault sync, and fire-and-forget the gate dispatch. Extracted verbatim from the
+ * original inline `handler.on('Issue', …)` body — no behaviour change.
+ */
+export function processIssueWebhook(
+  raw: EntityWebhookPayloadWithIssueData,
+  ctx: LinearContext,
+  gateSpecs: Map<string, GateSpec>,
+): void {
+  const d = raw.data;
+
+  if (raw.action === 'remove') {
+    softDeleteIssueCache(d.id);
+  } else if (d.state?.name) {
+    upsertIssueCache({
+      issue_id: d.id,
+      identifier: d.identifier,
+      title: d.title,
+      state_name: d.state.name,
+      team_id: d.teamId,
+      priority: d.priority,
+      created_at: d.createdAt,
+      updated_at: d.updatedAt,
+    });
+  }
+
+  if (ctx.vaultPath) {
+    debouncedVaultSync(ctx, ctx.vaultPath, d.teamId);
+  }
+
+  handleIssueUpdate(raw, ctx, gateSpecs).catch((err) => {
+    logger.error({ err }, 'linear-webhook: unhandled error in issue handler');
+  });
+}
+
+/** A request header coerced to a single string, or undefined if absent / an array. */
+function headerString(v: string | string[] | undefined): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Build the ingress-gateway handler for Linear webhooks (the `/linear` route). The gateway
+ * owns the body read and hands handlers a pre-read buffer, so this uses the SDK's BUFFER-based
+ * verification, not the stream-based `createHandler()`. The SDK `client.verify()` THROWS on
+ * failure (never returns false), hence the try/catch hooks. Replay source-of-truth is
+ * `body.webhookTimestamp ?? header` (matching the standalone server) — reproduced in `handle`
+ * via public primitives since the SDK's `parseVerifiedPayload` is private. Secret passed
+ * explicitly (same source as `startLinearWebhookServer`).
+ */
+export function createLinearIngressHandler(
+  ctx: LinearContext,
+  gateSpecs: Map<string, GateSpec>,
+  secret: string,
+): IngressHandler {
+  const client = new LinearWebhookClient(secret);
+
+  return {
+    pathPrefix: '/linear',
+
+    verify(req, bodyRaw) {
+      const sig = headerString(req.headers['linear-signature']);
+      if (!sig) {
+        return { ok: false, reason: 'missing signature' };
+      }
+      // Fast early-reject using the header timestamp; handle() re-checks with the
+      // authoritative body timestamp before dispatch.
+      const tsHeader = headerString(req.headers['linear-timestamp']);
+      try {
+        client.verify(bodyRaw, sig, tsHeader);
+        return { ok: true };
+      } catch (err) {
+        logger.debug({ err }, 'linear-ingress: signature verification failed');
+        return { ok: false, reason: 'invalid signature' };
+      }
+    },
+
+    async handle(req, res, bodyRaw) {
+      const sig = headerString(req.headers['linear-signature']);
+      const tsHeader = headerString(req.headers['linear-timestamp']);
+
+      // Reproduce the SDK's private parseVerifiedPayload: JSON.parse → derive the
+      // authoritative timestamp from the body (preferred over the header) → verify
+      // (signature + 60s replay check). This is the authoritative check; verify()'s
+      // header-ts check above is only a fast pre-filter.
+      let payload: LinearWebhookPayload;
+      try {
+        if (!sig) throw new Error('missing signature');
+        payload = JSON.parse(bodyRaw.toString('utf-8')) as LinearWebhookPayload;
+        const tsAuth =
+          (payload as { webhookTimestamp?: number }).webhookTimestamp ??
+          tsHeader;
+        client.verify(bodyRaw, sig, tsAuth);
+      } catch (err) {
+        logger.warn({ err }, 'linear-ingress: invalid webhook body/signature');
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, message: 'invalid webhook' }));
+        return;
+      }
+
+      if (payload.type === 'Issue') {
+        processIssueWebhook(
+          payload as unknown as EntityWebhookPayloadWithIssueData,
+          ctx,
+          gateSpecs,
+        );
+      }
+
+      // Fast 2xx — gate dispatch is already fire-and-forget inside processIssueWebhook,
+      // so Linear gets a prompt ack and never waits on gate processing.
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    },
+  };
+}
+
 export function startLinearWebhookServer(
   ctx: LinearContext,
   gateSpecs: Map<string, GateSpec>,
@@ -1982,31 +2103,11 @@ export function startLinearWebhookServer(
   const handler = webhookClient.createHandler();
 
   handler.on('Issue', (payload) => {
-    const raw = payload as EntityWebhookPayloadWithIssueData;
-    const d = raw.data;
-
-    if (raw.action === 'remove') {
-      softDeleteIssueCache(d.id);
-    } else if (d.state?.name) {
-      upsertIssueCache({
-        issue_id: d.id,
-        identifier: d.identifier,
-        title: d.title,
-        state_name: d.state.name,
-        team_id: d.teamId,
-        priority: d.priority,
-        created_at: d.createdAt,
-        updated_at: d.updatedAt,
-      });
-    }
-
-    if (ctx.vaultPath) {
-      debouncedVaultSync(ctx, ctx.vaultPath, d.teamId);
-    }
-
-    handleIssueUpdate(raw, ctx, gateSpecs).catch((err) => {
-      logger.error({ err }, 'linear-webhook: unhandled error in issue handler');
-    });
+    processIssueWebhook(
+      payload as EntityWebhookPayloadWithIssueData,
+      ctx,
+      gateSpecs,
+    );
   });
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What

LIA-315 **Phase 5** (brought forward): register Linear as the centralized ingress gateway's first handler (`/linear`) so `ngrok tunnel → gateway:3007 → /linear` works end-to-end. This unblocks retiring the legacy macOS `com.deus.ngrok` launchd agent (which tunnels `→ :3005`, the standalone Linear webhook server) in favour of the cross-platform `tunnel.ts` child process shipped in Phase 1 (#877).

**Phase-5-first rationale:** Linear webhooks are HMAC-signed into existing *trusted* gate dispatch, not the anonymous no-Bash sandbox that Phases 2–4 protect — so the Linear migration doesn't depend on them.

## Changes

| File | Change |
|---|---|
| `src/config.ts` | `INGRESS_LINEAR_VIA_GATEWAY` flag (default **off**; requires `INGRESS_GATEWAY_ENABLED`). |
| `src/linear-webhook.ts` | Extract `processIssueWebhook` (shared by the standalone server + the gateway handler, **no behaviour change**). Add `createLinearIngressHandler` using the SDK's **buffer-based** `verify()`/parse (composes with the gateway's pre-read body — no stream double-read). `handle()` reproduces the SDK's private `parseVerifiedPayload` (`JSON.parse → body.webhookTimestamp ?? header → verify`) for **exact replay parity** with the standalone path; fast `200`, fire-and-forget dispatch. |
| `src/index.ts` | Flag + gateway on → push the handler into `ingressHandlers` (Strategy registry, read live) and **skip** the standalone `:3005` server. **Fail-safe:** flag on + gateway off → warn and keep the standalone server (never drop ingestion). |
| `src/ingress/linear-ingress.test.ts` | 8 tests: sig valid / tampered / wrong-secret / missing; Issue dispatch → 200; non-Issue → 200 no-op; bad-sig → 400. |

The standalone `:3005` server is **kept intact** as the rollback path.

## Review

- Plan-reviewer co-gate (Claude + GPT): SHIP after 2 REVISE rounds — the `verify()`-throws contract and the `parseData` vs `parseVerifiedPayload` replay-parity bug, both fixed against verified SDK source.
- Code-reviewer co-gate (Claude + GPT): SHIP.
- Build green; full suite **1736 tests** pass.

## ⚠️ Cross-platform note (live cutover only)

The flag is off by default, so **this PR is inert at runtime** until the cutover. The cutover itself uses `launchctl` / `~/Library/LaunchAgents/com.deus.ngrok.plist` (macOS-only) to retire the legacy agent — the live host is the macOS box. The *code* (`tunnel.ts`) is already cross-platform; on Linux/WSL the equivalent teardown would be `kill $(pgrep ngrok)` / a systemd unit.

## Watch-items (behind the tunnel the gateway sees a loopback peer)

- **Rate-limit:** all Linear webhooks share one bucket (default `INGRESS_RATE_LIMIT_MAX=60`/min). Linear issue-event volume is well under that; env-tunable.
- **Body-cap:** `INGRESS_MAX_BODY_BYTES=256KB` (the standalone server had none). Far above typical Linear payloads; env-tunable.
- **IP allowlist** must stay empty (peer is `127.0.0.1`).

LIA-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)