### PR TITLE
feat(ingress): add R5 DoS/spend caps + R6 per-event audit (LIA-315 Phase 3)

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-06-19" # auto-bump @1781825634
+last_verified: "2026-06-19" # auto-bump @1781856500
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781855611
+last_verified: "2026-06-19" # auto-bump @1781856500
 governs:
   - src/
   - evolution/

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,6 +130,39 @@ export const WEBHOOK_SOURCES_PATH = path.join(
   'webhook-sources.json',
 );
 
+// LIA-315 Phase 3: R5 DoS/spend caps + R6 audit. Dormant — consumed by the Phase-4
+// webhook dispatch facade (src/ingress/caps.ts + audit.ts). Guard every numeric
+// flag against NaN/0/negative so a bad env value falls back to the safe default
+// (an unguarded `Number('') === 0` would disable a cap; see CLAUDE.md eval-diagnostics).
+function ingressPositive(raw: string | undefined, def: number): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+// Global ceiling on concurrent in-flight webhook runs (shared across all sources).
+export const INGRESS_MAX_INFLIGHT = ingressPositive(
+  process.env.INGRESS_MAX_INFLIGHT,
+  3,
+);
+// Per-source token-bucket: burst capacity + ms-to-refill-one-token (~10/min default).
+export const INGRESS_SOURCE_RATE_CAPACITY = ingressPositive(
+  process.env.INGRESS_SOURCE_RATE_CAPACITY,
+  10,
+);
+export const INGRESS_SOURCE_RATE_REFILL_MS = ingressPositive(
+  process.env.INGRESS_SOURCE_RATE_REFILL_MS,
+  6000,
+);
+// Hard daily spend ceiling. Unit = tokens-per-day as fed by Phase 4 `recordSpend`;
+// ~1M tokens/day is a deliberately conservative cap for an anonymous webhook source.
+export const INGRESS_DAILY_SPEND_LIMIT = ingressPositive(
+  process.env.INGRESS_DAILY_SPEND_LIMIT,
+  1_000_000,
+);
+// Append-only per-event audit sink. Under CONFIG_DIR (operator-owned, NEVER mounted
+// into a container — R6 "off the container's writable path").
+export const INGRESS_AUDIT_DIR =
+  process.env.INGRESS_AUDIT_DIR || path.join(CONFIG_DIR, 'ingress-audit');
+
 export const IPC_POLL_INTERVAL = 1000;
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
 // Sessions older than this many hours are reset to a fresh start.

--- a/src/ingress/audit.test.ts
+++ b/src/ingress/audit.test.ts
@@ -1,0 +1,97 @@
+// Unit tests for the R6 audit sink — edge cases NOT covered by the blind oracle
+// (ingress-audit-phase3.oracle.test.ts). The oracle owns redaction CONTENT,
+// whitelist, no-throw, day-partition, and failure-surfacing; these cover numeric
+// retention, dir auto-create, concurrent appends, and multi-secret-per-field.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scrubAuditEvent, appendAuditEvent } from './audit.js';
+
+const TS = Date.UTC(2026, 0, 15, 9, 30, 0); // 2026-01-15
+const STAMP = '2026-01-15';
+
+let auditDir: string;
+beforeEach(async () => {
+  auditDir = await mkdtemp(join(tmpdir(), 'ingress-audit-unit-'));
+});
+afterEach(async () => {
+  await rm(auditDir, { recursive: true, force: true });
+});
+
+describe('scrubAuditEvent retention + coercion', () => {
+  it('retains a numeric status and event/decision enums', () => {
+    const out = scrubAuditEvent({
+      ts: TS,
+      source: 'github',
+      event: 'admitted',
+      decision: 'admitted',
+      status: 200,
+    });
+    expect(out.ts).toBe(TS);
+    expect(out.source).toBe('github');
+    expect(out.event).toBe('admitted');
+    expect(out.decision).toBe('admitted');
+    expect(out.status).toBe(200);
+  });
+
+  it('coerces a missing/non-string source to empty and missing ts to 0', () => {
+    const out = scrubAuditEvent({ event: 'received' });
+    expect(out.source).toBe('');
+    expect(out.ts).toBe(0);
+    expect(out.event).toBe('received');
+  });
+
+  it('redacts MULTIPLE distinct secrets in a single field', () => {
+    const out = scrubAuditEvent({
+      ts: TS,
+      source: 'x',
+      event: 'rejected',
+      reason:
+        'a=Bearer tok_abcdefabcdefabcdef b=0123456789abcdef0123456789abcdef',
+    });
+    expect(out.reason).not.toContain('tok_abcdefabcdefabcdef');
+    expect(out.reason).not.toContain('0123456789abcdef0123456789abcdef');
+    // Both replaced with the marker.
+    expect(
+      (out.reason!.match(/\[REDACTED\]/g) ?? []).length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('appendAuditEvent filesystem behavior', () => {
+  it('auto-creates a missing (nested) audit directory', async () => {
+    const nested = join(auditDir, 'deep', 'nested', 'audit');
+    const res = await appendAuditEvent(
+      { ts: TS, source: 'github', event: 'received' },
+      { auditDir: nested },
+    );
+    expect(res.ok).toBe(true);
+    const files = await readdir(nested);
+    expect(files).toContain(`ingress-audit-${STAMP}.jsonl`);
+  });
+
+  it('concurrent appends to the same day all land (append-only, no truncation)', async () => {
+    const n = 12;
+    const results = await Promise.all(
+      Array.from({ length: n }, (_, i) =>
+        appendAuditEvent(
+          { ts: TS, source: `s${i}`, event: 'received' },
+          { auditDir },
+        ),
+      ),
+    );
+    expect(results.every((r) => r.ok)).toBe(true);
+    const file = join(auditDir, `ingress-audit-${STAMP}.jsonl`);
+    const lines = (await readFile(file, 'utf8'))
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(n);
+    // Every line is independently valid JSON (no interleaved/torn writes).
+    const sources = lines.map((l) => JSON.parse(l).source).sort();
+    expect(sources).toEqual(
+      Array.from({ length: n }, (_, i) => `s${i}`).sort(),
+    );
+  });
+});

--- a/src/ingress/audit.ts
+++ b/src/ingress/audit.ts
@@ -1,0 +1,154 @@
+// R6 (LIA-315 Phase 3): append-only, secret-scrubbed, per-event audit sink for the
+// ingress gateway. Every webhook-originated event gets a durable forensic record on
+// a host path that is NEVER mounted into any container (the writable-path isolation
+// the threat model requires). This is the per-EVENT audit — distinct from the
+// gateway's per-REQUEST scrubbed log (`gateway.ts`), which goes to the pino logger.
+//
+// Dormant in Phase 3: no caller yet. Phase 4 (webhook dispatch) wires the admission
+// facade (`caps.ts`) to call `appendAuditEvent` before any dispatch.
+//
+// Cross-platform: all paths derive from `CONFIG_DIR` (src/config.ts), built via
+// `path.join(HOME_DIR, '.config', 'deus')` — already OS-portable. No `platform.ts`
+// routing is needed here (the construction uses only `path.join`).
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export type IngressAuditEventType =
+  | 'received'
+  | 'admitted'
+  | 'rejected'
+  | 'dispatched';
+export type IngressAuditDecision = 'admitted' | 'rejected';
+
+/**
+ * The ONLY shape that reaches disk. The field set is a deliberate whitelist of
+ * non-secret metadata — there is intentionally no `body`/`headers`/`token` field,
+ * so a raw request body or credential structurally cannot be recorded.
+ */
+export interface IngressAuditEvent {
+  ts: number; // epoch ms — also selects the day-partition file
+  source: string;
+  event: IngressAuditEventType;
+  decision?: IngressAuditDecision;
+  reason?: string;
+  requestId?: string;
+  path?: string;
+  status?: number;
+  // Index signature so callers/tests can inspect the record as a plain map. The
+  // type is permissive on purpose — the SECURITY guarantee is the RUNTIME
+  // structural whitelist in `scrubAuditEvent` (only the named keys above are ever
+  // copied onto disk), not the static shape.
+  [key: string]: unknown;
+}
+
+/** Surfaces write failure to the caller (never silently swallowed). */
+export type AuditWriteResult = { ok: true } | { ok: false; error: unknown };
+
+// Free-text string fields retained onto disk. Each passes through substring
+// redaction (a secret embedded in one of these is replaced, not dropped wholesale).
+// `event`/`decision` are NOT here — they are controlled enums validated separately
+// (never user-free-text, so nothing to redact). Everything not named here or in the
+// enum/numeric handling below is dropped (structural whitelist).
+const REDACTED_FIELDS = ['source', 'reason', 'requestId', 'path'] as const;
+
+const EVENT_TYPES: ReadonlySet<string> = new Set([
+  'received',
+  'admitted',
+  'rejected',
+  'dispatched',
+]);
+const DECISIONS: ReadonlySet<string> = new Set(['admitted', 'rejected']);
+
+// Secret SHAPES redacted from retained string values (defense-in-depth on top of
+// the structural whitelist — a secret embedded inside an otherwise-safe field like
+// `reason` or `source` is replaced, not the whole field dropped). Order matters:
+// the broad bearer/sha256 patterns run before the bare-hex catch-all so a
+// `sha256=<hex>` is redacted as a unit.
+const REDACTION_PATTERNS: RegExp[] = [
+  /Bearer\s+[A-Za-z0-9._~+/=-]+/gi, // `Bearer <token>`
+  /sha\d*=[A-Fa-f0-9]+/gi, // `sha256=<hex>` signature digests
+  /[A-Fa-f0-9]{32,}/g, // bare long hex tokens (API keys, digests)
+];
+const REDACTED = '[REDACTED]';
+
+function redactSecrets(value: string): string {
+  let out = value;
+  for (const re of REDACTION_PATTERNS) out = out.replace(re, REDACTED);
+  return out;
+}
+
+/**
+ * Structural whitelist + secret redaction. Pure and TOTAL — never throws, even on
+ * maximally-malformed input (undefined, non-string fields, missing `ts`). A throw
+ * here would propagate into the fail-closed admission gate (`caps.ts`), so the
+ * no-throw contract is load-bearing.
+ */
+export function scrubAuditEvent(raw: unknown): IngressAuditEvent {
+  const src =
+    raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+
+  const out: IngressAuditEvent = {
+    ts:
+      typeof src.ts === 'number' && Number.isFinite(src.ts)
+        ? (src.ts as number)
+        : 0,
+    source: '',
+    // Validated enum: only a known event type survives; anything else defaults.
+    event:
+      typeof src.event === 'string' && EVENT_TYPES.has(src.event)
+        ? (src.event as IngressAuditEventType)
+        : 'received',
+  };
+
+  for (const key of REDACTED_FIELDS) {
+    const v = src[key];
+    // Non-string values for a string field are dropped (not coerced) — keeps the
+    // record clean and the scrub total.
+    if (typeof v === 'string') out[key] = redactSecrets(v);
+  }
+
+  if (typeof src.decision === 'string' && DECISIONS.has(src.decision)) {
+    out.decision = src.decision as IngressAuditDecision;
+  }
+  if (typeof src.status === 'number' && Number.isFinite(src.status)) {
+    out.status = src.status;
+  }
+
+  return out;
+}
+
+function dayStamp(ts: number): string {
+  // UTC day partition: YYYY-MM-DD. Bad/zero ts falls back to the epoch day rather
+  // than throwing — the facade always supplies a real `now`, so this is a backstop.
+  const d = new Date(Number.isFinite(ts) ? ts : 0);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Scrub → JSON line → O_APPEND to `<auditDir>/ingress-audit-YYYY-MM-DD.jsonl`
+ * (day selected by the event's UTC `ts`). Creates `auditDir` if absent.
+ *
+ * Append-only: `fs.appendFile` opens with flag `'a'` (O_APPEND) so concurrent
+ * writes never truncate and each record lands at end-of-file.
+ *
+ * Surfaces failure as `{ ok: false, error }` and NEVER throws into the caller —
+ * the admission facade depends on this to make the pre-dispatch audit fail-closed.
+ */
+export async function appendAuditEvent(
+  event: IngressAuditEvent,
+  opts: { auditDir: string },
+): Promise<AuditWriteResult> {
+  try {
+    const scrubbed = scrubAuditEvent(event);
+    const file = path.join(
+      opts.auditDir,
+      `ingress-audit-${dayStamp(scrubbed.ts)}.jsonl`,
+    );
+    await fs.mkdir(opts.auditDir, { recursive: true });
+    await fs.appendFile(file, `${JSON.stringify(scrubbed)}\n`, { flag: 'a' });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}

--- a/src/ingress/caps.test.ts
+++ b/src/ingress/caps.test.ts
@@ -1,0 +1,148 @@
+// Unit tests for the R5 cap primitives + facade — edge cases NOT covered by the
+// blind oracle (ingress-caps-phase3.oracle.test.ts). The oracle owns the
+// fail-closed security contract; these cover refill arithmetic, accumulation, and
+// the rate-limit rejection path.
+
+import { describe, it, expect } from 'vitest';
+import {
+  InflightCap,
+  SourceRateLimiter,
+  DailySpendLedger,
+  createIngressCaps,
+  type IngressCapsConfig,
+  type AuditWriter,
+} from './caps.js';
+import type { AuditWriteResult, IngressAuditEvent } from './audit.js';
+
+function okWriter(): AuditWriter & { calls: IngressAuditEvent[] } {
+  const calls: IngressAuditEvent[] = [];
+  return {
+    calls,
+    async append(e: IngressAuditEvent): Promise<AuditWriteResult> {
+      calls.push(e);
+      return { ok: true };
+    },
+  };
+}
+
+function cfg(over: Partial<IngressCapsConfig> = {}): IngressCapsConfig {
+  return {
+    maxInflight: 2,
+    rateCapacity: 2,
+    rateRefillMs: 1000,
+    dailySpendLimit: 100,
+    ...over,
+  };
+}
+
+const T0 = Date.UTC(2026, 2, 1, 0, 0, 0); // 2026-03-01 00:00 UTC
+
+describe('InflightCap edge cases', () => {
+  it('release below zero is a no-op; capacity stays exactly the ceiling', () => {
+    const cap = new InflightCap(1);
+    cap.release(); // nothing acquired
+    cap.release();
+    expect(cap.inUse()).toBe(0);
+    expect(cap.tryAcquire()).toBe(true);
+    expect(cap.tryAcquire()).toBe(false); // ceiling 1 honored
+  });
+
+  it('ceiling of 0 admits nothing (fail-closed)', () => {
+    const cap = new InflightCap(0);
+    expect(cap.tryAcquire()).toBe(false);
+    expect(cap.inUse()).toBe(0);
+  });
+});
+
+describe('SourceRateLimiter refill arithmetic', () => {
+  it('preserves the sub-quantum remainder (no double grant from leftover time)', () => {
+    const lim = new SourceRateLimiter(1, 1000); // capacity 1, 1s/token
+    expect(lim.tryConsume('s', T0)).toBe(true); // tokens 1 -> 0
+    expect(lim.tryConsume('s', T0 + 1500)).toBe(true); // +1 token (floor 1.5)=1
+    // Only 500ms of credit remains; another 500ms (total +2000 from T0) tops it up.
+    expect(lim.tryConsume('s', T0 + 1999)).toBe(false); // <1 full token since last grant
+    expect(lim.tryConsume('s', T0 + 2000)).toBe(true); // now a full token elapsed
+  });
+
+  it('caps refill at capacity (no unbounded accumulation over long idle)', () => {
+    const lim = new SourceRateLimiter(2, 1000);
+    lim.tryConsume('s', T0); // 2 -> 1
+    lim.tryConsume('s', T0); // 1 -> 0
+    // Idle 1 hour: refill is clamped to capacity (2), not 3600.
+    expect(lim.tryConsume('s', T0 + 3_600_000)).toBe(true); // 2 -> 1
+    expect(lim.tryConsume('s', T0 + 3_600_000)).toBe(true); // 1 -> 0
+    expect(lim.tryConsume('s', T0 + 3_600_000)).toBe(false); // capped, no 3rd
+  });
+
+  it('refillMs <= 0 never refills a drained bucket (guarded)', () => {
+    const lim = new SourceRateLimiter(1, 0);
+    expect(lim.tryConsume('s', T0)).toBe(true);
+    expect(lim.tryConsume('s', T0 + 10_000)).toBe(false);
+  });
+});
+
+describe('DailySpendLedger accumulation', () => {
+  it('accumulates across multiple adds within the same UTC day', () => {
+    const led = new DailySpendLedger(100);
+    led.add(30, T0);
+    led.add(30, T0 + 3_600_000); // same day, +1h
+    expect(led.check(T0)).toBe(true); // 60 < 100
+    led.add(40, T0 + 7_200_000); // total 100
+    expect(led.check(T0)).toBe(false); // hard cutoff
+  });
+
+  it('a fresh day zeroes the running total even after a prior-day breach', () => {
+    const led = new DailySpendLedger(50);
+    led.add(50, T0);
+    expect(led.check(T0)).toBe(false);
+    const nextDay = T0 + 24 * 3_600_000;
+    expect(led.check(nextDay)).toBe(true);
+    led.add(50, nextDay);
+    expect(led.check(nextDay)).toBe(false); // independent budget
+    expect(led.check(T0)).toBe(true); // querying the old day reads 0 (not stored)
+  });
+});
+
+describe('createIngressCaps rate-limit rejection', () => {
+  it('rate-limit rejection releases the inflight slot and reports the reason', async () => {
+    const writer = okWriter();
+    const caps = createIngressCaps(
+      cfg({ rateCapacity: 1, maxInflight: 5 }),
+      writer,
+    );
+
+    const first = await caps.tryAdmit({ source: 'A' }, T0);
+    expect(first.ok).toBe(true);
+    expect(caps.snapshot().inUse).toBe(1);
+
+    // Source A's bucket (capacity 1) is now empty -> rate-limit.
+    const second = await caps.tryAdmit({ source: 'A' }, T0);
+    expect(second.ok).toBe(false);
+    expect(second.ok === false && second.reason).toBe('rate-limit');
+    // Slot acquired during the gate was released — only the first admit holds one.
+    expect(caps.snapshot().inUse).toBe(1);
+  });
+
+  it('release() frees a post-dispatch slot so a later admit succeeds', async () => {
+    const writer = okWriter();
+    const caps = createIngressCaps(
+      cfg({ maxInflight: 1, rateCapacity: 5 }),
+      writer,
+    );
+
+    expect((await caps.tryAdmit({ source: 'A' }, T0)).ok).toBe(true);
+    expect((await caps.tryAdmit({ source: 'A' }, T0)).ok).toBe(false); // at cap
+    caps.release();
+    expect(caps.snapshot().inUse).toBe(0);
+    expect((await caps.tryAdmit({ source: 'A' }, T0)).ok).toBe(true);
+  });
+
+  it('recordSpend drives the gate, and a new day re-opens it', async () => {
+    const writer = okWriter();
+    const caps = createIngressCaps(cfg({ dailySpendLimit: 100 }), writer);
+    caps.recordSpend(100, T0);
+    expect((await caps.tryAdmit({ source: 'A' }, T0)).ok).toBe(false);
+    const nextDay = T0 + 24 * 3_600_000;
+    expect((await caps.tryAdmit({ source: 'A' }, nextDay)).ok).toBe(true);
+  });
+});

--- a/src/ingress/caps.ts
+++ b/src/ingress/caps.ts
@@ -1,0 +1,262 @@
+// R5 (LIA-315 Phase 3): DoS/cost caps for webhook-originated agent runs, plus the
+// R6 pre-dispatch audit gate. An anonymous external trigger must not be able to
+// spawn unbounded container runs or burn unbounded LLM spend, and no run may be
+// admitted without a durable forensic record.
+//
+// Three independent primitives (each unit-testable in isolation) + one facade
+// (`createIngressCaps`) that encodes the fail-closed admission ORDERING once, so
+// Phase 4 (the webhook dispatch path — the concrete, already-planned caller) does
+// not re-implement the subtle sequence.
+//
+// Dormant in Phase 3: nothing in the live runtime constructs the facade yet.
+
+import type { AuditWriteResult, IngressAuditEvent } from './audit.js';
+
+export interface IngressCapsConfig {
+  /** Global in-flight ceiling, shared across ALL webhook sources. */
+  maxInflight: number;
+  /** Per-source token-bucket capacity (burst). */
+  rateCapacity: number;
+  /** Milliseconds to refill ONE token in a source's bucket. */
+  rateRefillMs: number;
+  /** Hard daily spend ceiling (unit-agnostic; Phase 4 feeds the unit). */
+  dailySpendLimit: number;
+}
+
+/**
+ * Counting semaphore for the global number of concurrent in-flight webhook runs.
+ * `tryAcquire` fails CLOSED at the ceiling; `release` is clamped at 0 so an
+ * over-release (double-release / release-without-acquire) can never inflate the
+ * effective capacity above the ceiling.
+ */
+export class InflightCap {
+  private used = 0;
+  constructor(private readonly ceiling: number) {}
+
+  tryAcquire(): boolean {
+    if (this.used >= this.ceiling) return false;
+    this.used += 1;
+    return true;
+  }
+
+  release(): void {
+    if (this.used > 0) this.used -= 1;
+  }
+
+  inUse(): number {
+    return this.used;
+  }
+}
+
+/**
+ * Per-source token bucket with lazy refill. One bucket per source name; one
+ * source draining its bucket does NOT affect another (isolation).
+ *
+ * `last` advances only by whole consumed quanta (`refill * refillMs`), preserving
+ * the sub-quantum remainder, so a token is granted exactly once per `refillMs`.
+ *
+ * SEQUENCING CONSTRAINT (Phase 4): `tryConsume` must only ever be called with a
+ * source name drawn from the VALIDATED operator source config — never an arbitrary
+ * attacker-controlled path segment. The webhook channel validates source identity
+ * before calling, which is what bounds the per-source `Map` key set.
+ */
+export class SourceRateLimiter {
+  private readonly buckets = new Map<
+    string,
+    { tokens: number; last: number }
+  >();
+  constructor(
+    private readonly capacity: number,
+    private readonly refillMs: number,
+  ) {}
+
+  tryConsume(source: string, now: number): boolean {
+    let b = this.buckets.get(source);
+    if (!b) {
+      b = { tokens: this.capacity, last: now };
+      this.buckets.set(source, b);
+    } else if (now > b.last && this.refillMs > 0) {
+      const refill = Math.floor((now - b.last) / this.refillMs);
+      if (refill > 0) {
+        b.tokens = Math.min(this.capacity, b.tokens + refill);
+        b.last += refill * this.refillMs;
+      }
+    }
+    if (b.tokens >= 1) {
+      b.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Daily spend ledger with a hard cutoff. `check` reports whether today's running
+ * total is still UNDER the ceiling; once it reaches the ceiling, `check` returns
+ * false until the UTC day rolls over (a fresh day starts at zero).
+ *
+ * `check` is a pure read (no mutation); `add` performs the rollover reset.
+ * Single-threaded correctness: the Node event loop serializes check→add, so there
+ * is no check-then-act race. A future worker-thread / distributed host would need
+ * an atomic check-and-increment instead.
+ */
+export class DailySpendLedger {
+  private day = '';
+  private total = 0;
+  constructor(private readonly limit: number) {}
+
+  private static dayKey(now: number): string {
+    return new Date(Number.isFinite(now) ? now : 0).toISOString().slice(0, 10);
+  }
+
+  check(now: number): boolean {
+    const todayTotal =
+      DailySpendLedger.dayKey(now) === this.day ? this.total : 0;
+    return todayTotal < this.limit;
+  }
+
+  add(cost: number, now: number): void {
+    const key = DailySpendLedger.dayKey(now);
+    if (key !== this.day) {
+      this.day = key;
+      this.total = 0;
+    }
+    this.total += cost;
+  }
+}
+
+export type AdmitResult =
+  | { ok: true }
+  | { ok: false; reason: AdmitRejectReason };
+
+export type AdmitRejectReason =
+  | 'spend-limit'
+  | 'inflight-cap'
+  | 'rate-limit'
+  | 'audit-unavailable';
+
+/** The minimum a webhook event must carry to be admitted + audited. */
+export interface AdmitEventInput {
+  source: string;
+  requestId?: string;
+  // Phase-4 caller constraint: pass the SANITIZED URL path only (no query string).
+  // The audit redactor catches Bearer/hex/sha-digest shapes but a short non-hex
+  // secret in a query param (`?secret=abc12`) would escape it, so credentials must
+  // never reach `path` in the first place.
+  path?: string;
+}
+
+/** Injected dependency so the facade is testable with succeeding/failing writers. */
+export interface AuditWriter {
+  append(event: IngressAuditEvent): Promise<AuditWriteResult>;
+}
+
+export interface IngressCaps {
+  tryAdmit(event: AdmitEventInput, now: number): Promise<AdmitResult>;
+  release(): void;
+  recordSpend(cost: number, now: number): void;
+  snapshot(): { inUse: number };
+}
+
+/**
+ * The single fail-closed R5+R6 admission gate. Ordering (each step fails closed):
+ *
+ *   1. spend.check        — pure read; over-limit rejects BEFORE acquiring a slot,
+ *                           so a spend rejection consumes no inflight slot.
+ *   2. inflight.tryAcquire — reversible; released on any later failure.
+ *   3. rate.tryConsume     — if empty, release the slot and reject.
+ *   4. MANDATORY audit     — append the `admitted` record. The await is wrapped in
+ *                            try/catch: on a {ok:false} result OR any thrown/
+ *                            rejected error, release the slot and reject
+ *                            'audit-unavailable'. This makes the slot-safe + the
+ *                            "no admission without a durable record" guarantees
+ *                            UNCONDITIONAL — even a future no-throw-contract
+ *                            violation in the writer cannot leak a slot (a leaked
+ *                            slot would drain the cap to 0 and mimic a real DoS).
+ *
+ * Note: the per-source rate token consumed at step 3 is NOT refunded if step 4
+ * fails or if Phase 4 aborts a post-admit dispatch — deliberate (penalize
+ * admission attempts, not just dispatches). Rejections at steps 1–3 emit a
+ * best-effort, fire-and-forget `rejected` audit event (a missing rejection record
+ * is not a security hole, unlike a missing admission record).
+ */
+export function createIngressCaps(
+  cfg: IngressCapsConfig,
+  audit: AuditWriter,
+): IngressCaps {
+  const inflight = new InflightCap(cfg.maxInflight);
+  const rate = new SourceRateLimiter(cfg.rateCapacity, cfg.rateRefillMs);
+  const spend = new DailySpendLedger(cfg.dailySpendLimit);
+
+  // Fire-and-forget rejection breadcrumb; swallow errors so a broken writer never
+  // surfaces an unhandled rejection (the security control is the reject itself).
+  const emitRejected = (
+    event: AdmitEventInput,
+    now: number,
+    reason: AdmitRejectReason,
+  ): void => {
+    void audit
+      .append({
+        ts: now,
+        source: event.source,
+        event: 'rejected',
+        decision: 'rejected',
+        reason,
+        requestId: event.requestId,
+        path: event.path,
+      })
+      .catch(() => {});
+  };
+
+  return {
+    async tryAdmit(event: AdmitEventInput, now: number): Promise<AdmitResult> {
+      if (!spend.check(now)) {
+        emitRejected(event, now, 'spend-limit');
+        return { ok: false, reason: 'spend-limit' };
+      }
+      if (!inflight.tryAcquire()) {
+        emitRejected(event, now, 'inflight-cap');
+        return { ok: false, reason: 'inflight-cap' };
+      }
+      if (!rate.tryConsume(event.source, now)) {
+        inflight.release();
+        emitRejected(event, now, 'rate-limit');
+        return { ok: false, reason: 'rate-limit' };
+      }
+      // Mandatory pre-dispatch audit — fail-closed on result OR throw.
+      try {
+        const r = await audit.append({
+          ts: now,
+          source: event.source,
+          event: 'admitted',
+          decision: 'admitted',
+          requestId: event.requestId,
+          path: event.path,
+        });
+        if (!r.ok) {
+          inflight.release();
+          return { ok: false, reason: 'audit-unavailable' };
+        }
+      } catch {
+        inflight.release();
+        return { ok: false, reason: 'audit-unavailable' };
+      }
+      return { ok: true };
+    },
+
+    release(): void {
+      inflight.release();
+    },
+
+    // Phase-4 caller constraint: pass the SAME `now` to the `tryAdmit` that gated a
+    // run and to its matching `recordSpend`, so the ledger's day-key cannot diverge
+    // across the UTC boundary (the check and the add must agree on "today").
+    recordSpend(cost: number, now: number): void {
+      spend.add(cost, now);
+    },
+
+    snapshot(): { inUse: number } {
+      return { inUse: inflight.inUse() };
+    },
+  };
+}

--- a/src/ingress/ingress-audit-phase3.oracle.test.ts
+++ b/src/ingress/ingress-audit-phase3.oracle.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Oracle tests for Ingress Gateway Phase 3 — R6 per-event audit
+ * (structural whitelist scrub + secret redaction + append-only JSONL writer).
+ *
+ * Authored from the SPEC (the public contract in the LIA-315 Phase 3 issue),
+ * BEFORE any implementation exists (oracle-author warden). The module under
+ * test (`./audit.js`) DOES NOT EXIST YET, so these tests are RED: the import
+ * fails to resolve / the symbols are absent. They must go GREEN only once the
+ * implementer adds `src/ingress/audit.ts` to the EXACT contract below — never
+ * by weakening a case here.
+ *
+ * Independence note: written blind to any implementation. Every expected value
+ * traces to the spec, not to chosen code.
+ *
+ * Every test is tagged `@oracle` so the commit-side oracle-integrity gate can
+ * protect it from silent weakening.
+ *
+ * Determinism: writer day-partition is driven by an EXPLICIT event.ts value;
+ * the audit dir is a fresh os.tmpdir() mkdtemp dir, cleaned up after.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  scrubAuditEvent,
+  appendAuditEvent,
+  type IngressAuditEvent,
+} from './audit.js';
+
+// ---------------------------------------------------------------------------
+// Planted secrets — these must NEVER survive scrub/redaction into retained
+// string fields nor onto disk. Each is a recognisable secret SHAPE per spec.
+// ---------------------------------------------------------------------------
+const SECRET_SHA256 = 'sha256=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'; // sha256=<40 hex>
+const SECRET_HEX40 = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0'; // 40-char hex token
+const SECRET_BEARER = 'Bearer abc123ABC456def789GHI012jkl345MNO678'; // Bearer <token>
+
+// Deterministic UTC-day timestamps for the writer partition assertions.
+const DAY_D_TS = Date.UTC(2026, 0, 15, 9, 30, 0); // 2026-01-15
+const DAY_D_TS_2 = Date.UTC(2026, 0, 15, 18, 45, 0); // same UTC day, later
+const DAY_NEXT_TS = Date.UTC(2026, 0, 16, 1, 0, 0); // 2026-01-16 — next UTC day
+const DAY_D_STAMP = '2026-01-15';
+const DAY_NEXT_STAMP = '2026-01-16';
+
+let auditDir: string;
+
+beforeEach(async () => {
+  auditDir = await mkdtemp(join(tmpdir(), 'ingress-audit-oracle-'));
+});
+
+afterEach(async () => {
+  await rm(auditDir, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// CASE 7 — scrubAuditEvent: secret redaction CONTENT in RETAINED string fields
+// ===========================================================================
+describe('@oracle scrubAuditEvent — redacts secret-shaped substrings in retained fields', () => {
+  it('@oracle replaces each planted secret with the literal [REDACTED] and removes the raw secret', () => {
+    // @oracle: spec R6 — redact secret-shaped substrings by REPLACING with '[REDACTED]' (never silent omission)
+    const raw = {
+      ts: DAY_D_TS,
+      source: `telegram:${SECRET_HEX40}`, // secret embedded in a retained field
+      event: 'rejected',
+      decision: 'rejected',
+      // reason is a retained string field; plant all three secret shapes.
+      reason: `auth failed token=${SECRET_BEARER} digest=${SECRET_SHA256}`,
+    };
+
+    const out = scrubAuditEvent(raw);
+
+    const serialized = JSON.stringify(out);
+    // Raw secrets must NOT appear anywhere in the scrubbed event.
+    expect(serialized).not.toContain(SECRET_HEX40);
+    expect(serialized).not.toContain(SECRET_BEARER);
+    expect(serialized).not.toContain(SECRET_SHA256);
+    // The hex portion of the sha256 digest must also be gone.
+    expect(serialized).not.toContain(
+      'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    );
+
+    // Redaction is by REPLACEMENT — the marker must be present (not silent drop)
+    // in BOTH retained string fields that carried a secret.
+    expect(out.reason).toContain('[REDACTED]');
+    expect(out.source).toContain('[REDACTED]');
+  });
+});
+
+// ===========================================================================
+// CASE 8 — scrubAuditEvent: structural whitelist (drops unknown/unsafe keys)
+// ===========================================================================
+describe('@oracle scrubAuditEvent — structural whitelist drops unsafe keys', () => {
+  it('@oracle returns an event WITHOUT body/headers/authorization/token keys', () => {
+    // @oracle: spec R6 — whitelist scrub drops unknown/unsafe keys (body, headers, token, ...)
+    const raw = {
+      ts: DAY_D_TS,
+      source: 'telegram',
+      event: 'received',
+      // Disallowed/unsafe keys that must NOT survive the whitelist.
+      body: { secret: 'super-sensitive-payload' },
+      headers: { authorization: SECRET_BEARER },
+      authorization: SECRET_BEARER,
+      token: SECRET_HEX40,
+    };
+
+    const out = scrubAuditEvent(raw) as Record<string, unknown>;
+
+    expect(Object.prototype.hasOwnProperty.call(out, 'body')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(out, 'headers')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(out, 'authorization')).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(out, 'token')).toBe(false);
+
+    // And as a defense-in-depth check, the raw payload string is nowhere.
+    expect(JSON.stringify(out)).not.toContain('super-sensitive-payload');
+  });
+});
+
+// ===========================================================================
+// CASE 9 — scrubAuditEvent: NEVER throws on maximally-malformed input
+// ===========================================================================
+describe('@oracle scrubAuditEvent — never throws on malformed input', () => {
+  it('@oracle returns an object for undefined input (does not throw)', () => {
+    // @oracle: spec R6 — scrub never throws even on maximally-malformed input
+    let out: unknown;
+    expect(() => {
+      out = scrubAuditEvent(undefined);
+    }).not.toThrow();
+    expect(typeof out).toBe('object');
+    expect(out).not.toBeNull();
+  });
+
+  it('@oracle returns an object for non-string fields / missing ts (does not throw)', () => {
+    // @oracle: spec R6 — scrub tolerates wrong-typed/missing fields without throwing
+    const malformed = {
+      // ts missing entirely
+      source: 12345, // non-string
+      reason: { nested: 'object-not-a-string' }, // non-string
+      event: ['array', 'not', 'string'],
+    };
+    let out: unknown;
+    expect(() => {
+      out = scrubAuditEvent(malformed);
+    }).not.toThrow();
+    expect(typeof out).toBe('object');
+    expect(out).not.toBeNull();
+  });
+});
+
+// ===========================================================================
+// CASE 10 — appendAuditEvent: end-to-end + scrub-on-write
+// ===========================================================================
+describe('@oracle appendAuditEvent — scrubs before writing, append-only JSONL', () => {
+  it('@oracle writes a scrubbed, newline-terminated JSON line to the UTC-day file with no raw secret', async () => {
+    // @oracle: spec R6 — scrub-on-write; day-partitioned JSONL; no raw secret on disk
+    const event = {
+      ts: DAY_D_TS,
+      source: 'telegram',
+      event: 'rejected',
+      decision: 'rejected',
+      reason: `blocked token=${SECRET_BEARER}`,
+      // disallowed field that must be scrubbed away before hitting disk.
+      body: 'raw-request-body-should-never-persist',
+    } as unknown as IngressAuditEvent;
+
+    const result = await appendAuditEvent(event, { auditDir });
+    expect(result.ok).toBe(true);
+
+    // (a) The file lives at the event.ts UTC-day partition path.
+    const expectedFile = join(auditDir, `ingress-audit-${DAY_D_STAMP}.jsonl`);
+    const contents = await readFile(expectedFile, 'utf8');
+
+    // (b) The raw secret must NOT be present in the file bytes.
+    expect(contents).not.toContain(SECRET_BEARER);
+    // (c) The disallowed body field must be absent from disk.
+    expect(contents).not.toContain('raw-request-body-should-never-persist');
+
+    // (d) The line parses as valid JSON and is newline-terminated (append-only).
+    expect(contents.endsWith('\n')).toBe(true);
+    const lines = contents.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.source).toBe('telegram');
+    expect(parsed.event).toBe('rejected');
+  });
+});
+
+// ===========================================================================
+// CASE 11 — appendAuditEvent: append-only ordering + day partition
+// ===========================================================================
+describe('@oracle appendAuditEvent — append-only + per-UTC-day partitioning', () => {
+  it('@oracle two same-day events land in one file in order; a different-day event lands in a different file', async () => {
+    // @oracle: spec R6 — O_APPEND ordering within a day; separate file per UTC day
+    const e1 = {
+      ts: DAY_D_TS,
+      source: 'telegram',
+      event: 'received',
+    } as unknown as IngressAuditEvent;
+    const e2 = {
+      ts: DAY_D_TS_2,
+      source: 'whatsapp',
+      event: 'admitted',
+      decision: 'admitted',
+    } as unknown as IngressAuditEvent;
+    const e3 = {
+      ts: DAY_NEXT_TS,
+      source: 'slack',
+      event: 'dispatched',
+    } as unknown as IngressAuditEvent;
+
+    expect((await appendAuditEvent(e1, { auditDir })).ok).toBe(true);
+    expect((await appendAuditEvent(e2, { auditDir })).ok).toBe(true);
+    expect((await appendAuditEvent(e3, { auditDir })).ok).toBe(true);
+
+    // Same UTC day -> exactly two lines, in append order.
+    const dayFile = join(auditDir, `ingress-audit-${DAY_D_STAMP}.jsonl`);
+    const dayContents = await readFile(dayFile, 'utf8');
+    const dayLines = dayContents.split('\n').filter((l) => l.length > 0);
+    expect(dayLines).toHaveLength(2);
+    expect(JSON.parse(dayLines[0]).source).toBe('telegram'); // e1 first
+    expect(JSON.parse(dayLines[1]).source).toBe('whatsapp'); // e2 second
+
+    // Different UTC day -> a DISTINCT day-stamped file with the third event.
+    const nextFile = join(auditDir, `ingress-audit-${DAY_NEXT_STAMP}.jsonl`);
+    const nextContents = await readFile(nextFile, 'utf8');
+    const nextLines = nextContents.split('\n').filter((l) => l.length > 0);
+    expect(nextLines).toHaveLength(1);
+    expect(JSON.parse(nextLines[0]).source).toBe('slack');
+
+    // Exactly two day-partition files were produced (no cross-contamination).
+    const files = (await readdir(auditDir)).filter((f) =>
+      f.startsWith('ingress-audit-'),
+    );
+    expect(files.sort()).toEqual(
+      [
+        `ingress-audit-${DAY_D_STAMP}.jsonl`,
+        `ingress-audit-${DAY_NEXT_STAMP}.jsonl`,
+      ].sort(),
+    );
+  });
+});
+
+// ===========================================================================
+// CASE 12 — appendAuditEvent: surfaces failure as {ok:false} (never throws)
+// ===========================================================================
+describe('@oracle appendAuditEvent — surfaces write failure without throwing', () => {
+  it('@oracle returns {ok:false} when auditDir cannot be created (parent is a FILE)', async () => {
+    // @oracle: spec R6 — writer surfaces failure as {ok:false}; never throws into caller
+    // Make the PARENT of the intended auditDir a regular FILE so mkdir -p fails.
+    const blocker = join(auditDir, 'blocker-file');
+    await writeFile(blocker, 'i am a file, not a directory');
+    // auditDir now points UNDER a file -> mkdir/append must fail.
+    const badAuditDir = join(blocker, 'nested', 'audit');
+
+    const event = {
+      ts: DAY_D_TS,
+      source: 'telegram',
+      event: 'received',
+    } as unknown as IngressAuditEvent;
+
+    let result: { ok: boolean } | undefined;
+    await expect(
+      (async () => {
+        result = await appendAuditEvent(event, { auditDir: badAuditDir });
+      })(),
+    ).resolves.toBeUndefined(); // i.e. it did NOT throw/reject
+
+    expect(result).toBeDefined();
+    expect(result!.ok).toBe(false);
+  });
+});

--- a/src/ingress/ingress-caps-phase3.oracle.test.ts
+++ b/src/ingress/ingress-caps-phase3.oracle.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Oracle tests for Ingress Gateway Phase 3 — R5 DoS/spend caps (fail-closed)
+ * + R6 pre-dispatch audit gating.
+ *
+ * Authored from the SPEC (the public contract in the LIA-315 Phase 3 issue),
+ * BEFORE any implementation exists (oracle-author warden). The module under
+ * test (`./caps.js`) DOES NOT EXIST YET, so these tests are RED: the import
+ * fails to resolve / the symbols are absent. They must go GREEN only once the
+ * implementer adds `src/ingress/caps.ts` to the EXACT contract below — never
+ * by weakening a case here.
+ *
+ * Independence note: written blind to any implementation. Every expected value
+ * traces to the spec, not to chosen code.
+ *
+ * Every test is tagged `@oracle` so the commit-side oracle-integrity gate can
+ * protect it from silent weakening.
+ *
+ * Determinism: the cap/ledger/limiter logic is driven by an EXPLICIT `now`
+ * argument in every assertion — never the real wall clock.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  InflightCap,
+  SourceRateLimiter,
+  DailySpendLedger,
+  createIngressCaps,
+  type IngressCapsConfig,
+  type AuditWriter,
+  type AdmitResult,
+} from './caps.js';
+import type { AuditWriteResult, IngressAuditEvent } from './audit.js';
+
+// ---------------------------------------------------------------------------
+// Deterministic UTC-day timestamps (explicit epoch ms; no wall-clock reliance)
+// ---------------------------------------------------------------------------
+// Two DISTINCT UTC days, chosen so the day-rollover assertions are unambiguous.
+const DAY_D = Date.UTC(2026, 0, 15, 12, 0, 0); // 2026-01-15 12:00:00 UTC
+const DAY_D_LATER = Date.UTC(2026, 0, 15, 23, 59, 59); // same UTC day, later
+const DAY_NEXT = Date.UTC(2026, 0, 16, 0, 0, 1); // 2026-01-16 — the NEXT UTC day
+
+// ---------------------------------------------------------------------------
+// Test doubles for the injected AuditWriter (NOT a mock of the module under
+// test — these are caller-supplied dependencies the contract explicitly allows
+// so tests can supply succeeding / failing / throwing writers).
+// ---------------------------------------------------------------------------
+
+/** Records every event it is asked to append; always succeeds. */
+function makeSucceedingWriter(): AuditWriter & { calls: IngressAuditEvent[] } {
+  const calls: IngressAuditEvent[] = [];
+  return {
+    calls,
+    async append(event: IngressAuditEvent): Promise<AuditWriteResult> {
+      calls.push(event);
+      return { ok: true };
+    },
+  };
+}
+
+/** Resolves a {ok:false} failure result (the RESULT-path failure). */
+function makeResultFailWriter(): AuditWriter & { calls: IngressAuditEvent[] } {
+  const calls: IngressAuditEvent[] = [];
+  return {
+    calls,
+    async append(event: IngressAuditEvent): Promise<AuditWriteResult> {
+      calls.push(event);
+      return { ok: false, error: new Error('disk full') };
+    },
+  };
+}
+
+/** Rejects/throws (the THROW-path failure — exercises the catch branch). */
+function makeThrowingWriter(): AuditWriter & { calls: IngressAuditEvent[] } {
+  const calls: IngressAuditEvent[] = [];
+  return {
+    calls,
+    async append(event: IngressAuditEvent): Promise<AuditWriteResult> {
+      calls.push(event);
+      throw new Error('writer exploded');
+    },
+  };
+}
+
+function baseConfig(over: Partial<IngressCapsConfig> = {}): IngressCapsConfig {
+  return {
+    maxInflight: 2,
+    rateCapacity: 3,
+    rateRefillMs: 1000,
+    dailySpendLimit: 100,
+    ...over,
+  };
+}
+
+// ===========================================================================
+// CASE 1 — InflightCap: fail-closed ceiling + clamped over-release
+// ===========================================================================
+describe('@oracle InflightCap — fail-closed global in-flight ceiling', () => {
+  it('@oracle acquires up to ceiling then returns false (fail-closed)', () => {
+    // @oracle: spec R5 — global in-flight ceiling; tryAcquire() === false at cap
+    const cap = new InflightCap(2);
+    expect(cap.tryAcquire()).toBe(true);
+    expect(cap.tryAcquire()).toBe(true);
+    expect(cap.inUse()).toBe(2);
+    // At ceiling: next acquire MUST fail closed.
+    expect(cap.tryAcquire()).toBe(false);
+    expect(cap.inUse()).toBe(2);
+  });
+
+  it('@oracle release() restores exactly one slot', () => {
+    // @oracle: spec R5 — release frees exactly one inflight slot
+    const cap = new InflightCap(2);
+    cap.tryAcquire();
+    cap.tryAcquire();
+    expect(cap.tryAcquire()).toBe(false);
+    cap.release();
+    expect(cap.inUse()).toBe(1);
+    // Exactly one slot was freed — one more acquire succeeds, the next fails.
+    expect(cap.tryAcquire()).toBe(true);
+    expect(cap.tryAcquire()).toBe(false);
+  });
+
+  it('@oracle over-release is clamped >= 0 and cannot inflate capacity', () => {
+    // @oracle: spec R5 — over-release clamps inUse>=0; cannot raise ceiling
+    const cap = new InflightCap(2);
+    // Release far more than ever acquired.
+    cap.release();
+    cap.release();
+    cap.release();
+    expect(cap.inUse()).toBe(0);
+    // Capacity is still exactly the ceiling — never inflated by over-release.
+    expect(cap.tryAcquire()).toBe(true);
+    expect(cap.tryAcquire()).toBe(true);
+    expect(cap.tryAcquire()).toBe(false); // ceiling still 2, not 5
+    expect(cap.inUse()).toBe(2);
+  });
+});
+
+// ===========================================================================
+// CASE 2 — SourceRateLimiter: per-source token bucket + lazy refill
+// ===========================================================================
+describe('@oracle SourceRateLimiter — per-source token bucket', () => {
+  it('@oracle drains a source to empty then rejects, isolates other sources, refills lazily', () => {
+    // @oracle: spec R5 — per-source bucket: capacity, isolation, lazy refill
+    const limiter = new SourceRateLimiter(3, 1000); // capacity 3, 1000ms / token
+    const now = DAY_D;
+
+    // Drain source 'A' of its 3 tokens at a FIXED instant.
+    expect(limiter.tryConsume('A', now)).toBe(true);
+    expect(limiter.tryConsume('A', now)).toBe(true);
+    expect(limiter.tryConsume('A', now)).toBe(true);
+    // 'A' is now empty at this instant — next consume fails closed.
+    expect(limiter.tryConsume('A', now)).toBe(false);
+
+    // SAME instant, DIFFERENT source 'B' — buckets are per-source isolated.
+    expect(limiter.tryConsume('B', now)).toBe(true);
+
+    // Advancing now by one refillMs gives 'A' exactly one fresh token.
+    expect(limiter.tryConsume('A', now + 1000)).toBe(true);
+    // ...and only one — a second consume at the same advanced instant fails.
+    expect(limiter.tryConsume('A', now + 1000)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// CASE 3 — DailySpendLedger: hard daily cutoff + UTC-day rollover
+// ===========================================================================
+describe('@oracle DailySpendLedger — hard daily ceiling with UTC rollover', () => {
+  it('@oracle blocks once today total reaches the limit, allows again next UTC day', () => {
+    // @oracle: spec R5 — daily hard ceiling; check()===false at limit; UTC rollover resets
+    const ledger = new DailySpendLedger(100);
+    // Below the limit on day D: allowed.
+    expect(ledger.check(DAY_D)).toBe(true);
+    ledger.add(60, DAY_D);
+    expect(ledger.check(DAY_D)).toBe(true); // 60 < 100
+    ledger.add(40, DAY_D_LATER); // total 100 on the SAME UTC day
+    // At/above the limit on day D: hard cutoff (today's total < limit is FALSE).
+    expect(ledger.check(DAY_D)).toBe(false);
+    expect(ledger.check(DAY_D_LATER)).toBe(false);
+    // The NEXT UTC day starts fresh — allowed again (rollover).
+    expect(ledger.check(DAY_NEXT)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// CASE 4 — Facade fail-closed composition (succeeding writer)
+// ===========================================================================
+describe('@oracle createIngressCaps — fail-closed admission composition', () => {
+  it('@oracle rejects spend-limit WITHOUT consuming an inflight slot', async () => {
+    // @oracle: spec R5 — spend.check is first; over-limit => reason 'spend-limit', inUse unchanged
+    const writer = makeSucceedingWriter();
+    const caps = createIngressCaps(
+      baseConfig({ dailySpendLimit: 100 }),
+      writer,
+    );
+    // Drive spend to the limit BEFORE admitting.
+    caps.recordSpend(100, DAY_D);
+    const before = caps.snapshot().inUse;
+
+    const res: AdmitResult = await caps.tryAdmit({ source: 'A' }, DAY_D);
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toBe('spend-limit');
+    // No inflight slot was consumed (spend gate precedes acquire).
+    expect(caps.snapshot().inUse).toBe(before);
+  });
+
+  it('@oracle rejects inflight-cap when already at the ceiling', async () => {
+    // @oracle: spec R5 — at inflight ceiling => reason 'inflight-cap'
+    const writer = makeSucceedingWriter();
+    const caps = createIngressCaps(baseConfig({ maxInflight: 1 }), writer);
+
+    // First admit succeeds and occupies the only slot.
+    const first = await caps.tryAdmit({ source: 'A' }, DAY_D);
+    expect(first.ok).toBe(true);
+    expect(caps.snapshot().inUse).toBe(1);
+
+    // Second admit hits the cap and is rejected with 'inflight-cap'.
+    const second = await caps.tryAdmit({ source: 'A' }, DAY_D);
+    expect(second.ok).toBe(false);
+    expect(second.ok === false && second.reason).toBe('inflight-cap');
+    expect(caps.snapshot().inUse).toBe(1); // unchanged — no extra slot consumed
+  });
+
+  it('@oracle successful admit produces exactly one durable "admitted" audit append and increments inUse', async () => {
+    // @oracle: spec R6 — a successful admit ALWAYS produced one durable 'admitted' append
+    const writer = makeSucceedingWriter();
+    const caps = createIngressCaps(baseConfig(), writer);
+    const before = caps.snapshot().inUse;
+
+    const res = await caps.tryAdmit(
+      { source: 'A', requestId: 'req-1', path: '/hook' },
+      DAY_D,
+    );
+    expect(res.ok).toBe(true);
+    expect(caps.snapshot().inUse).toBe(before + 1);
+
+    // Exactly one 'admitted' event was appended (mandatory pre-dispatch audit).
+    const admitted = writer.calls.filter((e) => e.event === 'admitted');
+    expect(admitted).toHaveLength(1);
+    expect(admitted[0].source).toBe('A');
+  });
+});
+
+// ===========================================================================
+// CASE 5 — Fail-closed audit, RESULT path ({ok:false}) — GPT co-gate case
+// ===========================================================================
+describe('@oracle createIngressCaps — audit RESULT-failure releases the slot', () => {
+  it('@oracle rejects "audit-unavailable" and leaks NO inflight slot when append resolves {ok:false}', async () => {
+    // @oracle: spec R6 — {ok:false} append => reject 'audit-unavailable' + release acquired slot (no leak)
+    const writer = makeResultFailWriter();
+    const caps = createIngressCaps(baseConfig(), writer);
+    const before = caps.snapshot().inUse;
+
+    const res = await caps.tryAdmit({ source: 'A' }, DAY_D);
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toBe('audit-unavailable');
+    // The slot acquired during the gate MUST be released — inUse returns to baseline.
+    expect(caps.snapshot().inUse).toBe(before);
+  });
+});
+
+// ===========================================================================
+// CASE 6 — Fail-closed audit, THROW path (rejected promise) — Claude co-gate
+// DISTINCT from case 5: exercises the catch branch, not the result-check branch.
+// ===========================================================================
+describe('@oracle createIngressCaps — audit THROW-failure releases the slot', () => {
+  it('@oracle rejects "audit-unavailable" and leaks NO inflight slot when append throws/rejects', async () => {
+    // @oracle: spec R6 — thrown/rejected append => reject 'audit-unavailable' + release acquired slot (catch branch)
+    const writer = makeThrowingWriter();
+    const caps = createIngressCaps(baseConfig(), writer);
+    const before = caps.snapshot().inUse;
+
+    // Must NOT propagate the throw into the caller — contract: never throws.
+    const res = await caps.tryAdmit({ source: 'A' }, DAY_D);
+    expect(res.ok).toBe(false);
+    expect(res.ok === false && res.reason).toBe('audit-unavailable');
+    expect(caps.snapshot().inUse).toBe(before);
+  });
+});


### PR DESCRIPTION
## What

LIA-315 **Phase 3** of the centralized ingress gateway: the fail-closed admission primitives that **must exist before any webhook dispatch path** (the v3 safety invariant — no anonymous webhook may trigger an agent run until R5 caps AND R6 audit exist).

- **R5 — DoS/spend caps** (`src/ingress/caps.ts`):
  - `InflightCap` — global in-flight ceiling (fail-closed at cap; over-release clamped).
  - `SourceRateLimiter` — per-source token bucket, lazy refill, sources isolated.
  - `DailySpendLedger` — hard daily spend ceiling with UTC-day rollover.
  - `createIngressCaps` facade — single async admission gate. Ordering: `spend.check` → `inflight.tryAcquire` → `rate.tryConsume` (release slot on rate fail) → **mandatory pre-dispatch audit** wrapped in try/catch that releases the slot and rejects `audit-unavailable` on **either** a `{ok:false}` result **or** a thrown/rejected promise. No inflight-slot leak on any path; **no admission without a durable audit record**.
- **R6 — per-event audit** (`src/ingress/audit.ts`):
  - `scrubAuditEvent` — total (never throws), structural field whitelist + `[REDACTED]` substring redaction (Bearer / sha-digest / long-hex shapes).
  - `appendAuditEvent` — O_APPEND, UTC day-partitioned JSONL, surfaces failure as `{ok:false}` (never throws), writes under `CONFIG_DIR` (operator-owned, **never a container mount**).
- **Config** (`src/config.ts`): additive `INGRESS_*` flags, each guarded against NaN/0/negative.

## Phasing / safety

**Dormant** — no runtime wiring; nothing constructs the facade yet. Phase 4 wires it into the webhook dispatch path. Default path byte-identical. This is the prerequisite that lands **before** Phase 4 per the epic plan's v3 safety invariant.

## Process

- **Oracle-first**: the two `*.oracle.test.ts` files were authored **blind** (independent oracle-author, before implementation) and drove the fail-closed contract; they passed unchanged.
- **Co-gate (Claude + GPT)** on both plan and code:
  - GPT plan-reviewer caught the R6 hole (best-effort audit would let dispatch proceed without a record) → made the pre-dispatch audit fail-closed.
  - Claude plan-reviewer caught the audit-**throw** path could leak an inflight slot → added the defensive try/catch + a distinct throw-path oracle case.
  - Both code-reviewers SHIP; Claude's Phase-4 invariant notes (sanitized `path`, matching `now`) folded inline.

## Verification

- Oracle 17 + ingress 74 + **full suite 1760** green; `npm run build` + `eslint` clean.
- Rebased onto current `main` (#889 Phase 5 etc.); rebuilt + retested clean; drift pre-push checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)