### PR TITLE
refactor(agent-runner): drop dead llama.cpp buildInitialMessages (LIA-233)

### DIFF
--- a/container/agent-runner/src/llama-cpp-backend.gate.test.ts
+++ b/container/agent-runner/src/llama-cpp-backend.gate.test.ts
@@ -16,7 +16,6 @@ vi.mock('./tool-broker.js', () => ({
   })),
   executeBrokerTool: brokerExecute,
   getOpenAIToolDefinitions: vi.fn(() => []),
-  resolveGroupAttachmentPath: vi.fn((p: string) => `/workspace/group/${p}`),
 }));
 
 vi.mock('./context-registry.js', () => ({

--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -33,7 +33,6 @@ import {
   createOpenAIMcpToolBridge,
   executeBrokerTool,
   getOpenAIToolDefinitions,
-  resolveGroupAttachmentPath as resolveBrokerGroupAttachmentPath,
 } from './tool-broker.js';
 
 export interface RuntimeSession {
@@ -227,42 +226,6 @@ function getOptionalMcpServerConfigs(containerInput: ContainerInput): Array<{
   }
 
   return configs;
-}
-
-export function buildInitialMessages(
-  prompt: string,
-  containerInput: ContainerInput,
-  systemInstructions: string,
-): ChatMessage[] {
-  // For image attachments we use the OpenAI chat-completions vision shape
-  // (content array with `image_url`). llama-server with a multimodal GGUF
-  // accepts this; text-only GGUFs ignore the image content. The Deus
-  // capability flag `multimodal: false` documents the default.
-  const content: Array<Record<string, unknown>> = [
-    { type: 'text', text: prompt },
-  ];
-  for (const img of containerInput.imageAttachments || []) {
-    const imgPath = resolveBrokerGroupAttachmentPath(img.relativePath);
-    try {
-      const data = fs.readFileSync(imgPath).toString('base64');
-      content.push({
-        type: 'image_url',
-        image_url: { url: `data:${img.mediaType};base64,${data}` },
-      });
-    } catch {
-      // Ignore broken image reads — text prompt still proceeds.
-    }
-  }
-
-  // When there are no images we can use the simpler string-content form for
-  // smaller GGUF chat templates that don't handle structured content arrays.
-  const userMessage: ChatMessage =
-    containerInput.imageAttachments &&
-    containerInput.imageAttachments.length > 0
-      ? { role: 'user', content }
-      : { role: 'user', content: prompt };
-
-  return [{ role: 'system', content: systemInstructions }, userMessage];
 }
 
 async function createChatCompletion(body: {


### PR DESCRIPTION
Closes LIA-233.

`buildInitialMessages` built vision-shaped content from imageAttachments but had zero callers; the live driver runSingleTurn is text-only. The backend declares `multimodal: false`, so dropping the function keeps a single source of truth consistent with that flag (decision: delete over wire, evidenced). Removes the function, its unused import, and an orphaned test mock.

Verified: `tsc --noEmit` clean, 3 gate tests pass. code-reviewer SHIP.