### PR TITLE
chore(lint): freeze ESLint warnings at 220 via --max-warnings ratchet (LIA-274)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 220",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-18" # auto-bump @1781735768
+last_verified: "2026-06-19" # auto-bump @1781855985
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
Closes LIA-274.

eslint.config.js downgrades several rules to "warn" with intent to tighten over time, but nothing enforced it — `npm run lint` exited 0 at any count. Adds `--max-warnings 220` (current clean-tree baseline, 0 errors) to the lint script; CI runs `npm run lint` (ci.yml:55,174) so a 221st warning now fails CI.

Alternatives considered: separate eslintrc override; `--max-warnings 0` + bulk disable. Chose the script flag (lowest-friction, matches the TrueCourse diff-gate philosophy). Verified: passes at 220, fails at 219. code-reviewer SHIP.