### PR TITLE
docs(webhook): document always-on self-host ingress (static ngrok domain + auto-start) (LIA-313)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ LINEAR_WEBHOOK_SECRET=...       # For webhook signature verification
 # LINEAR_AUTO_MERGE=1           # Optional: auto-merge agent PRs after CI
 ```
 
-Quality checks require a public URL to receive Linear webhook events. For local dev, use [ngrok](https://ngrok.com) (`ngrok http 3005`). Register the URL in Linear Settings → API → Webhooks. Dispatch (polling) works without a webhook URL.
+Quality checks require a public URL to receive Linear webhook events. For local dev, use [ngrok](https://ngrok.com) (`ngrok http 3005`). Register the URL in Linear Settings → API → Webhooks. Dispatch (polling) works without a webhook URL. For an always-on self-host, pin an ngrok static domain and run the tunnel under a process manager - see [Always-on self-host](docs/decisions/linear-webhook-pipeline.md#always-on-self-host-static-domain--auto-start).
 
 See [Linear automation architecture](docs/decisions/linear-webhook-pipeline.md) for the full setup, gate spec format, and configuration reference.
 

--- a/docs/decisions/linear-webhook-pipeline.md
+++ b/docs/decisions/linear-webhook-pipeline.md
@@ -280,6 +280,33 @@ ngrok http 3005
 
 Register the resulting HTTPS URL in the Linear workspace webhook settings. Set `LINEAR_WEBHOOK_SECRET` to the value from Linear's webhook configuration panel.
 
+### Always-on self-host (static domain + auto-start)
+
+A free-tier ngrok URL is ephemeral: it changes every time the tunnel restarts. On an always-on personal instance that is not a full production deployment, this causes the webhook to silently stop delivering events after any reboot or crash because the registered URL no longer matches the live tunnel.
+
+Two steps prevent this:
+
+**1. Pin a static domain.**
+The free ngrok plan includes one static domain. Reserve one in the ngrok dashboard, then start the tunnel with the `--url` flag so the public address never drifts:
+
+```bash
+ngrok http 3005 --url=<your-static-subdomain>.ngrok-free.dev
+```
+
+Register this static URL once in Linear Settings > API > Webhooks. It never needs to change.
+
+**2. Run the tunnel under a process manager.**
+Start ngrok automatically on boot and restart it on failure using your OS process manager:
+
+- **macOS:** create a launchd plist in `~/Library/LaunchAgents/` with `RunAtLoad` and `KeepAlive` set.
+- **Linux:** create a systemd user unit with `Restart=on-failure` and `WantedBy=default.target`.
+
+With both steps in place, the tunnel comes back on its own after a reboot or crash and the webhook URL remains valid.
+
+**Free-tier constraint:** ngrok allows only one simultaneous agent session on the free plan. Opening a second `ngrok` process (for example, a manual test tunnel) disconnects the managed one. Keep all tunnels in the process manager; avoid ad-hoc `ngrok` invocations while the managed tunnel is running.
+
+**Alternatives:** a Cloudflare named tunnel (`cloudflared tunnel run`) or any hosted endpoint (reverse proxy, VPS, fly.io machine) removes the single-session constraint and does not require ngrok at all.
+
 ### Webhook Registration
 
 Linear webhooks must be configured in the workspace settings (Settings > API > Webhooks). Required event: `Issue`. The HMAC secret is set once; rotating it requires updating `LINEAR_WEBHOOK_SECRET` and restarting.

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-17" # auto-bump @1781681048
+last_verified: "2026-06-19" # auto-bump @1781856000
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
Closes LIA-313.

The webhook docs framed ngrok as dev-only; the common self-host is an always-on personal instance where the default path silently fails (ephemeral free URL drifts on restart; nothing auto-starts the tunnel). Adds an "Always-on self-host" subsection: pin a static/dev ngrok domain (bare-host `--url=<sub>.ngrok-free.dev`), run under launchd/systemd with restart + run-at-boot, the free-tier one-session constraint, and cloudflared/hosted alternatives. Plus a README pointer.

Docs-only, user-agnostic. ngrok syntax verified against current docs. code-reviewer SHIP.