### PR TITLE
docs(rules): codify warden co-gate bucket marking + freshness reflexes (RETRO-2026-06-19-01/02/06)

### DIFF
--- a/.claude/rules/orchestration-rules.md
+++ b/.claude/rules/orchestration-rules.md
@@ -1,6 +1,7 @@
 # Orchestration Rules
 # Applies to all agent dispatch, pipeline automation, and task orchestration.
-# Covers: issue creation, gate discipline, state management, and MCP tool hygiene.
+# Covers: issue creation, gate discipline, state management, MCP tool hygiene,
+# warden co-gate verdict marking, session-start freshness, and pipeline co-authorship.
 # Separated from core-behavioral-rules.md because these are pipeline-specific
 # (not general coding/commit rules) and were triggered by observed failures:
 # auth-error fallbacks labeled as "Scoped", agents working on stale requirements
@@ -28,3 +29,19 @@
 
 ## Tool Hygiene
 - When creating or updating issues via MCP tools, verify the rendered output matches intent. Double-escaped markdown, broken formatting, and missing fields are bugs, not cosmetic issues — they degrade agent scoping and human review.
+
+## Warden Co-Gate Verdict Marking
+- The plan-review (edit) and code-review/verification/ai-eng (commit) gates decide on the verdict STORE (`.warden-verdicts.json`), not the marker files. The `run()` hook dispatcher resolves the bucket from the **hook EVENT's cwd** (`event["cwd"]`, which equals the committing session's working directory) and pins it via `worktree_override` for every gate runner — deliberately NOT the hook process's `os.getcwd()`, since the two can differ. Mark verdicts (both claude + gpt backends) into the bucket that matches that cwd, or the gate won't see them.
+- cwd is the MAIN repo (`~/deus`, editing a worktree's files via `git -C <wt>`): the gate reads the FLAT `.claude/.warden-verdicts.json`. Mark from cwd=`~/deus` with NO `--worktree-root`.
+- cwd is INSIDE a linked worktree (`EnterWorktree`, or Claude launched there): the gate reads the per-worktree `.claude/worktree-markers/<sha1(worktree_abspath)[:12]>/.warden-verdicts.json`. Mark from that cwd with NO `--worktree-root`, or from any cwd with `--worktree-root <wt>`. A flat mark is IGNORED here.
+- Rule of thumb: match the bucket to the committing session's cwd — not "always flat" nor "always worktree". `--worktree-root` is only for an out-of-band writer whose cwd is not the gate's worktree (e.g. the gpt driver, or marking for a worktree you are not cwd'd into). If `mark`/`record-verdict` prints "cwd is not inside a worktree ... using the main-repo (flat) bucket", your mark went to the flat bucket — intended only for case 1.
+- Mechanism (source of truth): `codex_warden_hooks.py` `run` (event-cwd → `worktree_override` for every gate runner), `_claude_marker_dir` (bucket resolution), `_current_worktree`/`_worktree_for_cwd` (cwd→worktree), `_with_cli_worktree` (CLI writer side), `run_warden_backends_gate` (gate read); `warden_hooks/verdict_store.py` `_verdicts_path`.
+- SUPERSEDES RETRO-2026-06-17-02's "always mark from inside the worktree with `--worktree-root`": that is correct only for case 2, and post-#868/#869 the cwd-dependent rule above is canonical.
+
+## Session-Start State Freshness
+- Before treating local/worktree state as ground truth or implementing anything, run `git fetch origin` then `git --no-pager diff --stat HEAD origin/main`. Worktrees are pinned at creation and `origin/main` merges continuously (autonomous pipeline + work-fork), so a local checkout can be days behind.
+- For any task that "needs implementing," first confirm it is not already on `origin/main` — a stale start otherwise reconstructs work that already shipped. Verify-don't-trust catches bad code before it lands, but the rediscovery cost is paid regardless; the fetch is the cheap defense.
+
+## Autonomous Pipeline Co-Authorship
+- The autonomous pipeline and work-fork are routine co-authors of `origin/main` and may merge work mid-session/overnight. Before building on or deploying their merged work: (i) re-check merge state via `mergeCommit`/`mergedAt` (not a stale "OPEN" read), (ii) for load-bearing surfaces (memory heart, gates) re-verify the controlling invariant first-hand, (iii) chain a distinct session log via `continues` — never overwrite the pipeline's logs on `/compress`.
+- A pipeline merge is a hypothesis until verified first-hand, same as any delegated verdict (core-behavioral-rules.md § Verification & Honesty). Don't race the pipeline on its own PRs.


### PR DESCRIPTION
## What

Folds three 2026-06-19 session-retrospective recommendations into `.claude/rules/orchestration-rules.md` (one gated docs edit, no code touched):

- **RETRO-19-01 — Warden Co-Gate Verdict Marking** (the window's #1 time sink). Documents that the warden gate resolves the verdict bucket from the **hook EVENT cwd** — `run()` reads `event["cwd"]` and wraps every gate runner in `worktree_override` — so verdicts must be marked into the bucket matching the committing session's cwd:
  - cwd = main `~/deus` → FLAT `.claude/.warden-verdicts.json` (no `--worktree-root`);
  - cwd inside a linked worktree → per-worktree `.claude/worktree-markers/<sha1(worktree_abspath)[:12]>/.warden-verdicts.json`.
  - Supersedes RETRO-2026-06-17-02's one-sided "always `--worktree-root` from inside the worktree" guidance (inverted by #868/#869).
- **RETRO-19-02 — Session-Start State Freshness.** `git fetch origin` + `diff --stat HEAD origin/main` before treating local/worktree state as ground truth (worktrees lag a continuously-merging main).
- **RETRO-19-06 — Autonomous Pipeline Co-Authorship.** Verify-don't-trust reflex for pipeline-merged work (re-check `mergeCommit`/`mergedAt`, re-verify load-bearing invariants first-hand, chain logs via `continues`).

## Why

These three were repeatedly re-derived per-session or paid as a rediscovery tax; the retro folds them into one rules-file edit. RETRO-19-01 in particular corrects an INVERTED prior rule.

## Verification

- Mechanism for the co-gate rule verified **first-hand** against `scripts/codex_warden_hooks.py:3641-3656` (`run` dispatcher / `worktree_override`) and `:500-512` (`_claude_marker_dir`), plus `scripts/warden_hooks/verdict_store.py`. (An initial draft mis-stated the lever as `os.getcwd()`; the code-reviewer co-gate caught it and it was corrected to `event["cwd"]` via `run()`.)
- plan-reviewer **SHIP** (claude + gpt); code-reviewer **SHIP** (claude + gpt); verification-gate SHIP.
- The plan-review gate was **self-tested live** in case-2 (this session's cwd was inside the worktree, so its verdicts landed in — and were read from — the per-worktree bucket exactly as the new rule describes).
- Docs-only change; no build/tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)