### PR TITLE
feat(skills): add learn-this — vault-native learning companion to /teach

### DIFF
--- a/.claude/skills/learn-this/LEARNING-NODE-FORMAT.md
+++ b/.claude/skills/learn-this/LEARNING-NODE-FORMAT.md
@@ -1,0 +1,89 @@
+# Learning Node Format
+
+Companion doc for the `/learn-this` skill only (not a cross-skill format spec). It defines the
+vault memory node `/learn-this` writes for each learning. It is the vault-native equivalent of
+`/teach`'s `LEARNING-RECORD-FORMAT.md`, adapted to a semantic-vault node so the learning is
+retrievable across sessions and projects.
+
+## Location
+
+```
+$VAULT/Learning/<topic-slug>/NNNN-<dash-case-name>.md
+```
+
+`NNNN` increments per topic folder (scan for the highest existing number, add one).
+
+## Frontmatter
+
+```yaml
+---
+id: <32-char hex — REQUIRED; mint via the command below>
+type: learning-record
+title: "<Topic>: <what was learned> (short)"
+description: >
+  The embedding source. 1-3 sentences: WHAT was learned and WHY it matters for
+  future sessions. Future `memory_tree.py query` calls match on THIS text, so make
+  it a tight, searchable summary — not a section header.
+level: 2
+date: YYYY-MM-DD
+topic: "<Topic>"
+see_also:
+  - STUDY.md
+  - Learning/<topic-slug>/<related-node>.md
+  # - <path to a related /teach workspace, if any>
+---
+```
+
+Schema notes (matching `scripts/memory_tree.py` frontmatter parsing):
+- **`id`** — REQUIRED. The indexer (`discover_node`) and the auto-embed hook return `no_id` and
+  skip any node lacking it, so an id-less node is never retrievable. Mint a 32-char hex id in the
+  `make_id` format (48-bit ms timestamp + 80-bit random):
+  `python3 -c "import time,secrets; print((int(time.time()*1000).to_bytes(6,'big')+secrets.token_bytes(10)).hex())"`
+- **`type`** — always `learning-record` for these nodes.
+- **`title`** — display name.
+- **`description`** — REQUIRED. This is what gets embedded and retrieved. If absent, the node is
+  not indexable.
+- **`level`** — depth in the tree (2 is fine for a leaf learning node).
+- **`see_also`** — cross-edges to related nodes (other learnings, `STUDY.md`, a `/teach` workspace).
+  This is the bridge that keeps `/learn-this` and `/teach` linked without duplicating content.
+
+## Body
+
+```markdown
+## What was learned
+- The concept, in the user's own compressed terms.
+
+## Why it matters / mission link
+- The real-world goal this serves.
+
+## Misconception corrected (if any)
+- Was: <the wrong prior belief>. Now: <the correction> — these predict future stumbling blocks.
+
+## Evidence of understanding
+- How the user demonstrated it (recalled, solved N problems, explained from first principles).
+
+## Next (zone of proximal development)
+- What this unlocks to teach next; what to defer and why.
+
+## Sources
+- NotebookLM notebook/artifact links + any external citations used.
+```
+
+A learning node can be short. The value is recording *that* this is now known and *why* it changes
+what to teach next — not filling every section. Omit sections that add nothing.
+
+## When to write one
+
+Write a node only when at least one is true (mirrors `/teach`'s discipline):
+1. The user demonstrated genuine understanding of something non-trivial (evidence, not exposure).
+2. The user disclosed prior knowledge worth not re-teaching.
+3. A misconception was corrected.
+4. The mission shifted in response to learning.
+
+Do **not** write a node for material merely covered. Coverage is not learning — wait for evidence.
+
+## Supersession (never delete)
+
+If a later learning corrects an earlier node, add a new node and set the old node's frontmatter to
+`superseded_by: Learning/<topic-slug>/<new-node>.md` (and optionally `orphaned_at`/`orphan_reason`).
+The vault is soft-append — never delete a node; the history of how understanding evolved is signal.

--- a/.claude/skills/learn-this/SKILL.md
+++ b/.claude/skills/learn-this/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: learn-this
+description: Teach the user a topic and persist what they learn as queryable vault memory, grounded in NotebookLM. Vault-native companion to /teach.
+user_invocable: true
+argument-hint: "What do you want to learn?"
+---
+
+# /learn-this
+
+Teach the user something and make the learning **stick across sessions** by persisting it into the
+semantic memory vault, so the next session (and any project) can recall what they already know.
+
+This is the **vault-native** sibling of `/teach`. Where `/teach` builds a directory-based,
+multi-week course workspace (mission file, lesson HTML, local learning-records), `/learn-this`
+keeps no local workspace: it writes each learning as a **vault memory node** retrievable anywhere
+via `memory_tree.py`, and grounds knowledge in **NotebookLM** rather than parametric guessing.
+
+## Relationship to /teach (read this — single source of truth)
+
+- `/teach` → a self-contained course workspace in the current directory. Best for a sustained,
+  structured curriculum with rich interactive HTML lessons.
+- `/learn-this` → lightweight, cross-session learning capture into the global vault + NotebookLM.
+  Best for "teach me X and remember that I learned it" across projects.
+
+**Never duplicate a learning record across both.** A `/teach` workspace owns its local
+`learning-records/`; `/learn-this` owns `$VAULT/Learning/`. If a learning relates to a `/teach`
+course, link it with a `see_also` edge — do not copy it.
+
+## Steps
+
+### 1. Resolve the vault path
+
+Read `~/.config/deus/config.json` and use its `vault_path`. If `DEUS_VAULT_PATH` is set, use that
+instead. All paths below use `$VAULT` for this resolved path. (Same resolution as `/checkpoint`,
+`/compress`, `/preserve` — keep it portable; never hardcode a personal path.)
+
+### 2. Establish the mission
+
+Understand **why** the user wants to learn this — the concrete real-world goal it serves. This
+grounds every teaching choice. If it is unclear, ask before teaching; a vague mission produces
+abstract, ungrounded lessons. The mission is captured inside the first learning node (step 6), not
+in a separate file.
+
+### 3. Compute the zone of proximal development — from the vault
+
+Query the vault for what the user already knows on this topic:
+
+```bash
+python3 ~/deus/scripts/memory_tree.py query "<topic> — what has the user already learned?"
+```
+
+Read the returned learning nodes. Teach the **next** thing that builds on them — challenging "just
+enough", neither re-teaching the known nor jumping past a gap. This is the cross-session ZPD (vs
+`/teach`, which reads a local `learning-records/` folder).
+
+### 4. Ground the knowledge in NotebookLM
+
+Do not trust parametric knowledge. Pull high-trust material from NotebookLM:
+
+- Pick a relevant notebook (the user's course notebooks are listed in the vault's `STUDY.md`).
+  `mcp__notebooklm-mcp__notebook_query` for explanations, definitions, and citations.
+- For a long-form lesson, `mcp__notebooklm-mcp__studio_create` (audio / video / slides), poll
+  `mcp__notebooklm-mcp__studio_status`, and link the artifact in the learning node.
+
+**Auth degradation is explicit, never silent.** If a NotebookLM call fails authentication, tell the
+user to run `nlm login` in their terminal, and ask whether to proceed *without* NotebookLM grounding
+(flagging that the lesson will then rest on lower-trust sources). Do not silently skip grounding.
+
+### 5. Deliver the lesson
+
+Teach in the user's style (see the `ai-role` and study preferences in the vault):
+
+- **Visual-first** — diagrams / flowcharts before walls of text (Mermaid where useful).
+- **Feynman-first** — simple analogy → why it matters → how it connects to what they already know.
+- Keep it short and within working memory; one tangible win per lesson, tied to the mission.
+- Cite the NotebookLM sources so claims are checkable.
+- Close with a **tight retrieval-practice loop**: ask the user to recall/apply it and give immediate
+  feedback. Effortful retrieval is what builds long-term retention (storage strength), not fluency.
+
+### 6. Persist a learning record as a vault node
+
+**Only when there is real evidence of understanding** (a correct recall, a solved problem, a
+corrected misconception) — coverage is not learning. Write:
+
+```
+$VAULT/Learning/<topic-slug>/NNNN-<dash-case-name>.md
+```
+
+`NNNN` = next integer in that topic folder (scan for the highest existing). Use the frontmatter and
+guidance in [LEARNING-NODE-FORMAT.md](./LEARNING-NODE-FORMAT.md). **Write an `id` in the
+frontmatter** — the memory tree indexer and the auto-embed hook *skip* any node without one (they
+return `no_id`), so an id-less node is silently never retrievable. Mint one in the `make_id` format
+(32-char hex = 48-bit ms timestamp + 80-bit random):
+
+```bash
+python3 -c "import time,secrets; print((int(time.time()*1000).to_bytes(6,'big')+secrets.token_bytes(10)).hex())"
+```
+
+The `description` field is the embedding source — make it a tight summary of *what was learned and
+why it matters*, since that is what future `memory_tree.py query` calls match on. Add `see_also`
+edges to related learning nodes, the vault `STUDY.md`, and any related `/teach` workspace.
+
+### 7. Make it retrievable
+
+Writing the node file triggers the vault PostToolUse hook (`memory_tree_hook.py`), which embeds the
+node into the **memory tree** — so the `memory_tree.py query` in step 3 finds it in future sessions
+automatically. If you need it indexed immediately, or the hook is not active (e.g. a headless run),
+run:
+
+```bash
+python3 ~/deus/scripts/memory_tree.py build
+```
+
+(walks the vault and upserts new nodes + edges). **Do not use `memory_indexer.py --add`** — that
+indexes *session logs* into a separate atom/search database, not the navigation tree that step 3
+queries; a learning node added there would not be reachable via `memory_tree.py query`.
+
+### 8. Wisdom — point to a community
+
+When a question needs real-world practice beyond what you can give, point the user to a
+high-reputation community (forum, subreddit, local group) where they can test the skill. Respect a
+stated preference not to join communities.
+
+## Notes
+
+- The mission may shift as the user learns; when it does, write a new learning node capturing the
+  shift rather than rewriting history (vault is soft-append; never overwrite a node's meaning).
+- Keep lessons grounded in the mission — abstract lessons with no real-world anchor do not stick.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ renaming a repo-owned skill, update this table in the same change.
 | `/grill-with-docs` | Grill a plan and capture decisions as ADRs + glossary as you go |
 | `/grilling` | The relentless plan/design interview engine (used by `/grill-me` and `/grill-with-docs`) |
 | `/handoff` | Write a structured handoff document so the next agent starts with context |
+| `/learn-this` | Teach a topic and persist it as queryable vault memory, grounded in NotebookLM (vault-native companion to `/teach`) |
 | `/linear-slice` | Decompose a plan into dependency-ordered Linear issues (tracer-bullet slices) and release them into the dispatch pipeline |
 | `/onboard` | Onboard the current project into Deus code intelligence (codegraph + code_search indexing) |
 | `/preferences` | View or modify Deus user preferences |

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-19" # auto-bump @1781857342
+last_verified: "2026-06-19" # auto-bump @1781858546
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

New user-invocable host skill `learn-this` (`.claude/skills/learn-this/SKILL.md` +
`LEARNING-NODE-FORMAT.md`, markdown only). Teaches a topic and persists each learning as a
**queryable memory-tree node** under `$VAULT/Learning/`, grounded in **NotebookLM**.

Second of two follow-up skills from the brainstormer pass after the mattpocock import (#888).
Companion to `linear-slice` (#897).

## Design

- **Coexists with `/teach`** (user-confirmed, not a replacement): `/teach` = directory-based
  course workspace with lesson HTML; `/learn-this` = vault-global, cross-session learning capture.
  Bridged by `see_also`, no duplicated records (single-source-of-truth).
- **ZPD from the vault:** computes what to teach next via `memory_tree.py query` over prior
  learning nodes (cross-session, vs teach's local `learning-records/`).
- **NotebookLM grounding** with **explicit** auth degradation: on auth failure, tells the user to
  run `nlm login` and asks before proceeding ungrounded — never silent.
- **Vault-node persistence:** writes a `learning-record` node with a **required 32-char hex `id`**,
  registered via the vault PostToolUse embed hook (`memory_tree.py build` fallback). Soft-delete
  only (supersession).

## Alternatives considered (per pros-cons)

- **Replace `/teach`** vs coexist → chose coexist; teach's lesson-HTML course model is distinct and
  was just merged faithfully (#888). Avoids a single-source-of-truth conflict by separating paths.
- **`id` at write vs let the indexer assign** → must write at creation: verified `discover_node`
  returns `no_id` and skips id-less nodes (`memory_tree.py:~1192`), so delegation would silently
  drop every node. Empirically confirmed an id-bearing node is discovered + retrieved (temp DB).
- **`memory_indexer.py --add` vs `memory_tree.py build`** → the tree, not the session-log/atom
  index: step 3 retrieves via `memory_tree.py query`, which reads the tree DB. `--add` targets a
  different DB and would make nodes unreachable.

## Review

- plan-reviewer + code-reviewer both **SHIP** (Claude + GPT co-gate). The Claude code-reviewer
  caught a real bug (id omission) and a false positive (`~/deus` path — confirmed the established
  convention across compress/handoff/wardens); both addressed.

## Note

Touches the same AGENTS.md region + pattern bump as #897 — will rebase after the first lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)