### PR TITLE
fix(ingress): move gateway port default off Odysseus's 3007 + cover it in the port-collision guard (LIA-315)

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-06-19" # auto-bump @1781856500
+last_verified: "2026-06-19" # auto-bump @1781859131
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781856500
+last_verified: "2026-06-19" # auto-bump @1781859131
 governs:
   - src/
   - evolution/

--- a/src/checks.test.ts
+++ b/src/checks.test.ts
@@ -336,6 +336,9 @@ describe('detectPortCollision', () => {
   const PORT_VARS = [
     'ODYSSEUS_HTTP_ENABLED',
     'ODYSSEUS_HTTP_PORT',
+    'INGRESS_GATEWAY_ENABLED',
+    'INGRESS_GATEWAY_PORT',
+    'INGRESS_LINEAR_VIA_GATEWAY',
     'LINEAR_WEBHOOK_PORT',
     'LINEAR_WEBHOOK_SECRET',
     'LINEAR_API_KEY',
@@ -351,7 +354,11 @@ describe('detectPortCollision', () => {
       LINEAR_API_KEY: 'lin_x',
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
-    expect(detectPortCollision()).toEqual({ collision: true, port: 3005 });
+    expect(detectPortCollision()).toEqual({
+      collision: true,
+      port: 3005,
+      services: ['ODYSSEUS_HTTP_PORT', 'LINEAR_WEBHOOK_PORT'],
+    });
   });
 
   it('no collision when the ports differ', () => {
@@ -361,7 +368,11 @@ describe('detectPortCollision', () => {
       LINEAR_API_KEY: 'lin_x',
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
-    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
   });
 
   it('no collision when Odysseus is disabled (even on equal ports)', () => {
@@ -369,7 +380,11 @@ describe('detectPortCollision', () => {
       LINEAR_API_KEY: 'lin_x',
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
-    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
   });
 
   it('no collision when the webhook secret is absent (webhook would not start)', () => {
@@ -377,7 +392,11 @@ describe('detectPortCollision', () => {
       ODYSSEUS_HTTP_ENABLED: 'true',
       LINEAR_API_KEY: 'lin_x',
     });
-    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
   });
 
   it('flags a collision when only LINEAR_API_TOKEN (not LINEAR_API_KEY) is set', () => {
@@ -386,7 +405,11 @@ describe('detectPortCollision', () => {
       LINEAR_API_TOKEN: 'lin_tok',
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
-    expect(detectPortCollision()).toEqual({ collision: true, port: 3005 });
+    expect(detectPortCollision()).toEqual({
+      collision: true,
+      port: 3005,
+      services: ['ODYSSEUS_HTTP_PORT', 'LINEAR_WEBHOOK_PORT'],
+    });
   });
 
   it('no collision when no Linear API key/token (webhook would not start)', () => {
@@ -394,7 +417,11 @@ describe('detectPortCollision', () => {
       ODYSSEUS_HTTP_ENABLED: '1',
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
-    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
   });
 
   it('treats a non-numeric port as the 3005 default (NaN guard)', () => {
@@ -404,7 +431,11 @@ describe('detectPortCollision', () => {
       LINEAR_API_KEY: 'lin_x',
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
-    expect(detectPortCollision()).toEqual({ collision: true, port: 3005 });
+    expect(detectPortCollision()).toEqual({
+      collision: true,
+      port: 3005,
+      services: ['ODYSSEUS_HTTP_PORT', 'LINEAR_WEBHOOK_PORT'],
+    });
   });
 
   it('lets process.env win over .env (mirrors index.ts merge order)', () => {
@@ -416,6 +447,78 @@ describe('detectPortCollision', () => {
       LINEAR_WEBHOOK_SECRET: 'sec',
     });
     // process.env says 4000, .env says 3005 → resolves 4000 ≠ 3005 → no collision
-    expect(detectPortCollision()).toEqual({ collision: false, port: null });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
+  });
+
+  // ── ingress gateway coverage (gateway default 3007 once collided with the
+  // common Odysseus deployment port; the detector now binds-aware-compares it) ──
+
+  it('flags a gateway↔Odysseus collision when both bind the same port', () => {
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: '3007',
+      INGRESS_GATEWAY_ENABLED: '1',
+      INGRESS_GATEWAY_PORT: '3007',
+    });
+    expect(detectPortCollision()).toEqual({
+      collision: true,
+      port: 3007,
+      services: ['ODYSSEUS_HTTP_PORT', 'INGRESS_GATEWAY_PORT'],
+    });
+  });
+
+  it('no collision: gateway on its new 3009 default vs Odysseus 3005 default', () => {
+    // Gateway enabled, port unset → 3009 default; Odysseus enabled at 3005;
+    // no webhook secret so the standalone webhook does not bind.
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: '3005',
+      INGRESS_GATEWAY_ENABLED: '1',
+    });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
+  });
+
+  it('no false positive in the live via-gateway config (webhook routed, not bound)', () => {
+    // Live host: Odysseus 3007, gateway 3008, Linear routed through the gateway.
+    // The standalone webhook never binds, so it must be excluded from the set.
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: '3007',
+      INGRESS_GATEWAY_ENABLED: '1',
+      INGRESS_GATEWAY_PORT: '3008',
+      INGRESS_LINEAR_VIA_GATEWAY: '1',
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({
+      collision: false,
+      port: null,
+      services: null,
+    });
+  });
+
+  it('via-gateway set but gateway disabled → standalone webhook still binds and can collide', () => {
+    // INGRESS_LINEAR_VIA_GATEWAY only suppresses the webhook when the gateway is
+    // actually enabled (else index.ts falls back to the standalone :3005 server).
+    mockReadEnvFile.mockReturnValue({
+      ODYSSEUS_HTTP_ENABLED: '1',
+      ODYSSEUS_HTTP_PORT: '3005',
+      INGRESS_LINEAR_VIA_GATEWAY: '1',
+      LINEAR_API_KEY: 'lin_x',
+      LINEAR_WEBHOOK_SECRET: 'sec',
+    });
+    expect(detectPortCollision()).toEqual({
+      collision: true,
+      port: 3005,
+      services: ['ODYSSEUS_HTTP_PORT', 'LINEAR_WEBHOOK_PORT'],
+    });
   });
 });

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -78,28 +78,41 @@ export function hasApiCredentials(): boolean {
 }
 
 /**
- * Detect an ODYSSEUS_HTTP_PORT / LINEAR_WEBHOOK_PORT collision (LIA-301).
+ * Detect a TCP port collision between any two Deus servers that bind a port
+ * at startup (LIA-301, extended for the ingress gateway).
  *
- * Both default to 3005 (config.ts ODYSSEUS_HTTP_PORT and linear-webhook.ts
- * DEFAULT_WEBHOOK_PORT), so a fresh install that enables the Web UI while the
- * Linear webhook is also configured tries to bind the same port twice →
- * EADDRINUSE deep in startup. Run as a fatal startup check (startup-gate.ts)
- * BEFORE any server binds so the operator gets an actionable message instead.
+ * Covered binders: the Odysseus Web UI (ODYSSEUS_HTTP_PORT, default 3005), the
+ * ingress gateway (INGRESS_GATEWAY_PORT, default 3009), and the standalone
+ * Linear webhook server (LINEAR_WEBHOOK_PORT, default 3005). Odysseus and the
+ * webhook both default to 3005, and the gateway default once collided with the
+ * common Odysseus deployment port 3007 — a shared port EADDRINUSEs deep in
+ * startup. Run as a fatal startup check (startup-gate.ts) BEFORE any server
+ * binds so the operator gets an actionable message instead.
  *
- * Resolves both sides via readEnvFile + process.env (process.env wins, matching
+ * Only services that will ACTUALLY bind are compared:
+ *  - Odysseus: ODYSSEUS_HTTP_ENABLED on.
+ *  - Gateway: INGRESS_GATEWAY_ENABLED on.
+ *  - Standalone webhook: api key + secret present AND NOT routed via the gateway
+ *    (INGRESS_LINEAR_VIA_GATEWAY with the gateway enabled means the webhook does
+ *    not bind its own port — index.ts:485 — so it must be excluded to avoid a
+ *    false positive against the gateway in the live via-gateway config).
+ *
+ * Resolves every side via readEnvFile + process.env (process.env wins, matching
  * the index.ts:390-392 merge order) instead of importing the config.ts
  * constants — those are frozen at module load from process.env only and would
  * miss .env-only values, which is exactly the fresh-install case this guards.
- * Mirrors the actual webhook-start conditions (index.ts: linearApiKey + secret)
- * so it never false-positives when the webhook would not start.
  */
 export function detectPortCollision(): {
   collision: boolean;
   port: number | null;
+  services: [string, string] | null;
 } {
   const env = readEnvFile([
     'ODYSSEUS_HTTP_ENABLED',
     'ODYSSEUS_HTTP_PORT',
+    'INGRESS_GATEWAY_ENABLED',
+    'INGRESS_GATEWAY_PORT',
+    'INGRESS_LINEAR_VIA_GATEWAY',
     'LINEAR_WEBHOOK_PORT',
     'LINEAR_WEBHOOK_SECRET',
     'LINEAR_API_KEY',
@@ -110,26 +123,60 @@ export function detectPortCollision(): {
   // which also treats an empty process.env value as "use .env"). `||` (not `??`)
   // is deliberate so an empty-string env var doesn't shadow the .env value.
   const resolve = (k: string): string | undefined => process.env[k] || env[k];
+  const isOn = (raw: string | undefined): boolean =>
+    raw === '1' || raw === 'true';
+  // NaN/unset → the service's own default, mirroring each binder's guard.
+  const parsePort = (raw: string | undefined, dflt: number): number => {
+    const n = parseInt(raw || String(dflt), 10);
+    return Number.isNaN(n) ? dflt : n;
+  };
 
-  const enabledRaw = resolve('ODYSSEUS_HTTP_ENABLED');
-  const odysseusEnabled = enabledRaw === '1' || enabledRaw === 'true';
-  const webhookWillStart =
-    !!(resolve('LINEAR_API_KEY') || resolve('LINEAR_API_TOKEN')) &&
-    !!resolve('LINEAR_WEBHOOK_SECRET');
-  if (!odysseusEnabled || !webhookWillStart) {
-    return { collision: false, port: null };
+  // Collect the (env-var name, port) of every server that will actually bind.
+  const binders: Array<{ service: string; port: number }> = [];
+
+  if (isOn(resolve('ODYSSEUS_HTTP_ENABLED'))) {
+    binders.push({
+      service: 'ODYSSEUS_HTTP_PORT',
+      port: parsePort(resolve('ODYSSEUS_HTTP_PORT'), 3005),
+    });
   }
 
-  // NaN → 3005, mirroring linear-webhook.ts's own DEFAULT_WEBHOOK_PORT guard.
-  const parsePort = (raw: string | undefined): number => {
-    const n = parseInt(raw || '3005', 10);
-    return Number.isNaN(n) ? 3005 : n;
-  };
-  const odysseusPort = parsePort(resolve('ODYSSEUS_HTTP_PORT'));
-  const webhookPort = parsePort(resolve('LINEAR_WEBHOOK_PORT'));
+  const gatewayEnabled = isOn(resolve('INGRESS_GATEWAY_ENABLED'));
+  if (gatewayEnabled) {
+    binders.push({
+      service: 'INGRESS_GATEWAY_PORT',
+      port: parsePort(resolve('INGRESS_GATEWAY_PORT'), 3009),
+    });
+  }
 
-  const collision = odysseusPort === webhookPort;
-  return { collision, port: collision ? odysseusPort : null };
+  // The standalone webhook binds only when it would start AND is not routed
+  // through the gateway (the latter does not bind its own port).
+  const viaGateway =
+    isOn(resolve('INGRESS_LINEAR_VIA_GATEWAY')) && gatewayEnabled;
+  const webhookWillBind =
+    !!(resolve('LINEAR_API_KEY') || resolve('LINEAR_API_TOKEN')) &&
+    !!resolve('LINEAR_WEBHOOK_SECRET') &&
+    !viaGateway;
+  if (webhookWillBind) {
+    binders.push({
+      service: 'LINEAR_WEBHOOK_PORT',
+      port: parsePort(resolve('LINEAR_WEBHOOK_PORT'), 3005),
+    });
+  }
+
+  // First pair (n is tiny, so an O(n²) scan is fine) sharing a port collides.
+  for (let i = 0; i < binders.length; i++) {
+    for (let j = i + 1; j < binders.length; j++) {
+      if (binders[i].port === binders[j].port) {
+        return {
+          collision: true,
+          port: binders[i].port,
+          services: [binders[i].service, binders[j].service],
+        };
+      }
+    }
+  }
+  return { collision: false, port: null, services: null };
 }
 
 /** Check if a Gemini API key is configured for memory embeddings. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,8 +93,12 @@ export const INGRESS_GATEWAY_ENABLED =
   process.env.INGRESS_GATEWAY_ENABLED === 'true';
 export const INGRESS_GATEWAY_HOST =
   process.env.INGRESS_GATEWAY_HOST || '127.0.0.1';
+// Default 3009: collision-free against every other service default
+// (cred-proxy 3001, tool-proxy 3003, Odysseus 3005) and against the common
+// Odysseus deployment port 3007. A shared port would EADDRINUSE deep in startup
+// — detectPortCollision() (checks.ts) guards against it as a fatal startup check.
 export const INGRESS_GATEWAY_PORT = parseInt(
-  process.env.INGRESS_GATEWAY_PORT || '3007',
+  process.env.INGRESS_GATEWAY_PORT || '3009',
   10,
 );
 export const INGRESS_MAX_BODY_BYTES = parseInt(

--- a/src/startup-gate.test.ts
+++ b/src/startup-gate.test.ts
@@ -9,7 +9,11 @@ vi.mock('./checks.js', () => ({
   hasAnyChannelAuth: vi.fn(() => false),
   hasContainerImage: vi.fn(() => false),
   countRegisteredGroups: vi.fn(() => 0),
-  detectPortCollision: vi.fn(() => ({ collision: false, port: null })),
+  detectPortCollision: vi.fn(() => ({
+    collision: false,
+    port: null,
+    services: null,
+  })),
 }));
 
 vi.mock('./logger.js', () => ({
@@ -58,7 +62,11 @@ beforeEach(() => {
   mockHasAnyChannelAuth.mockReturnValue(false);
   mockHasContainerImage.mockReturnValue(false);
   mockCountRegisteredGroups.mockReturnValue(0);
-  mockDetectPortCollision.mockReturnValue({ collision: false, port: null });
+  mockDetectPortCollision.mockReturnValue({
+    collision: false,
+    port: null,
+    services: null,
+  });
 });
 
 // ── runStartupChecks ──────────────────────────────────────────────────────
@@ -149,7 +157,11 @@ describe('runStartupChecks', () => {
 
   it('returns fatal when the Odysseus/Linear webhook ports collide (LIA-301)', () => {
     mockHasApiCredentials.mockReturnValue(true);
-    mockDetectPortCollision.mockReturnValue({ collision: true, port: 3005 });
+    mockDetectPortCollision.mockReturnValue({
+      collision: true,
+      port: 3005,
+      services: ['ODYSSEUS_HTTP_PORT', 'LINEAR_WEBHOOK_PORT'],
+    });
     const report = runStartupChecks();
     const fatal = report.fatals.find((r) => r.name === 'Port configuration');
     expect(fatal).toBeDefined();

--- a/src/startup-gate.ts
+++ b/src/startup-gate.ts
@@ -62,16 +62,18 @@ registerStartupCheck({
   name: 'Port configuration',
   level: 'fatal',
   run: () => {
-    const { collision, port } = detectPortCollision();
+    const { collision, port, services } = detectPortCollision();
     return {
       name: 'Port configuration',
       level: 'fatal',
       ok: !collision,
       // hint is only surfaced for non-ok results (formatResult), but keep it
       // truthful on both paths rather than rendering "both null" on success.
+      // services is non-null whenever collision is true (detectPortCollision
+      // return contract); TS can't narrow it through the destructured struct.
       hint: collision
-        ? `ODYSSEUS_HTTP_PORT and LINEAR_WEBHOOK_PORT are both ${port}. The Web UI and Linear webhook servers cannot share a port — set one to a different value in .env.`
-        : 'Web UI and Linear webhook ports are distinct.',
+        ? `${services![0]} and ${services![1]} are both set to ${port}. Two servers cannot bind the same port — set one to a different value in .env.`
+        : 'All configured server ports are distinct.',
     };
   },
 });


### PR DESCRIPTION
## Problem
`INGRESS_GATEWAY_PORT` defaulted to **3007**, which collides with the common Odysseus deployment port (`ODYSSEUS_HTTP_PORT=3007`) — the live install had to override the gateway to `:3008`. A shared port `EADDRINUSE`s deep in startup. The existing fatal startup guard `detectPortCollision()` (LIA-301) only compared Odysseus vs the Linear webhook and was blind to the gateway.

This is the "gateway default port collision" follow-up from the LIA-315 ingress-gateway work (Phase 2/3/5 already merged).

## Changes
1. **`src/config.ts`** — `INGRESS_GATEWAY_PORT` default `3007` → `3009` (collision-free against every other service default: cred-proxy 3001, tool-proxy 3003, Odysseus 3005, and the common deployed ports). No live runtime effect — the plist override (`:3008`) wins.
2. **`src/checks.ts`** — generalize `detectPortCollision()` from a pairwise check to a **binds-aware scan** over every server that binds a port (Odysseus, ingress gateway, standalone Linear webhook), reporting the colliding pair by env-var name. Return contract gains `services: [string, string] | null`.
   - **Correctness:** the standalone Linear webhook is excluded from the binder set when routed through the gateway (`INGRESS_LINEAR_VIA_GATEWAY` + gateway enabled) — it never binds its own port (`src/index.ts:485`), so including it would false-positive against the gateway in the live config.
3. **`src/startup-gate.ts`** — fatal "Port configuration" hint now names the two colliding env vars.

## Tests
`src/checks.test.ts` + `src/startup-gate.test.ts`: existing cases updated for the new contract; added gateway↔Odysseus collision, the new-3009-default-is-clean case, the **live via-gateway no-false-positive** regression guard, and via-gateway-but-gateway-disabled (standalone fallback still binds).

Verified: `tsc --noEmit` clean; full `npx vitest run` = **1799 passed (102 files)**.

## Notes
- No Linear issue (free-plan cap reached) — tracked via session log.
- Restart step on merge is macOS-only (`launchctl kickstart com.deus`); other deploys use their own service manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)