### PR TITLE
feat(wardens): add opt-in Z.ai GLM-5.2 model-reviewer backend (glm)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,26 @@ LLAMA_CPP_MODEL=
 # LLAMA_CPP_REVIEW_MODEL=   # cross-family code-review candidate generator (scripts/cross_family_review.py)
 # LLAMA_CPP_CONTEXT_WINDOW=32768
 # LLAMA_CPP_API_KEY=
+
+# === Warden model-reviewer backends (host-side co-gate; opt-in per .claude/wardens/config.json) ===
+# These power the out-of-band model reviewers in the warden co-gate. A backend only runs when a
+# role lists it in .claude/wardens/config.json AND its vars are set; otherwise it abstains
+# (COULD_NOT_RUN -> the gate fails open). Leaving these blank changes nothing.
+#
+# Z.ai GLM (backend id "glm"): reviews via Z.ai's OpenAI-compatible endpoint. WARDEN_GLM_API_KEY
+# must be a METERED Z.ai API key -- NOT a GLM Coding Plan key (the Coding Plan is restricted to
+# whitelisted coding tools and forbids SDK / third-party use). Only the WARDEN_GLM_* vars are
+# auto-loaded from ~/deus/.env by codex_warden.py.
+# WARDEN_GLM_API_KEY=
+# WARDEN_GLM_BASE_URL=https://api.z.ai/api/paas/v4   # optional; this is the default
+# WARDEN_GLM_MODEL=glm-5.2                              # optional; this is the default
+#
+# Generic OpenAI-compatible reviewer (backend id "openai_compat"): any /v1 endpoint
+# (local llama.cpp/Ollama, OpenRouter, OpenAI). Export these in your environment to use it.
+# WARDEN_OPENAI_COMPAT_BASE_URL=   # e.g. http://127.0.0.1:8080/v1
+# WARDEN_OPENAI_COMPAT_MODEL=
+# WARDEN_OPENAI_COMPAT_API_KEY=    # omit for a keyless local server
+
 # Agent effort level (low/medium/high)
 # DEUS_AGENT_EFFORT=
 # Auth provider override (default: auto)

--- a/scripts/codex_warden.py
+++ b/scripts/codex_warden.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -40,6 +41,30 @@ from warden_review.constants import BACKEND_GPT, store_key  # noqa: E402
 from warden_review.roles import ROLE_SPECS  # noqa: E402
 
 _CODE_FROM_CATEGORY = {"rate_limit": RATE_LIMIT, "auth": AUTH_ERROR}
+
+
+def _load_glm_env(path: Path | None = None) -> None:
+    """Load ONLY ``WARDEN_GLM_*`` keys from the gitignored ``~/deus/.env`` into ``os.environ``
+    when not already set (a real exported env var always wins). No-op when the file is absent.
+
+    Scoped strictly to the ``WARDEN_GLM_`` prefix so it can NEVER change the activation of the
+    openai_compat backend (or anything else) — preserving the zero-behavior-change contract for
+    users who did not opt into the ``glm`` backend. Called from ``main()`` only (never at import),
+    so it cannot poison a test process that imports this module. ``path`` is for tests.
+    """
+    env_path = path or (Path.home() / "deus" / ".env")
+    try:
+        text = env_path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return  # absent / unreadable → no-op
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if key.startswith("WARDEN_GLM_") and key not in os.environ:
+            os.environ[key] = value.strip()
 
 
 def _render_human(role: str, backend: str, v) -> None:
@@ -82,6 +107,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--compact", action="store_true", help="compact JSON")
     ap.add_argument("--select", help="comma-separated dot-paths to project from the JSON")
     args = ap.parse_args(argv)
+
+    # Load WARDEN_GLM_* from ~/deus/.env (gitignored) if present — scoped to the GLM prefix so it
+    # cannot affect any other backend. No-op when the file is absent or the keys are already set.
+    _load_glm_env()
 
     spec = ROLE_SPECS[args.role]
     skey = store_key(args.role, args.backend)

--- a/scripts/tests/test_warden_review.py
+++ b/scripts/tests/test_warden_review.py
@@ -23,12 +23,20 @@ if _SCRIPTS_DIR not in sys.path:
 import httpx
 
 import codex_review as cr
+import codex_warden as cw
 import codex_warden_hooks as h
 from _exit_codes import RATE_LIMIT
 from warden_review import registry
 from warden_review.backends import openai_compat as oac
 from warden_review.backends.base import ReviewRequest, Verdict
-from warden_review.constants import BACKEND_GPT, BACKEND_OPENAI_COMPAT, store_key
+from warden_review.backends.glm import GLMBackend
+from warden_review.constants import (
+    BACKEND_GLM,
+    BACKEND_GPT,
+    BACKEND_OPENAI_COMPAT,
+    KNOWN_MODEL_BACKENDS,
+    store_key,
+)
 from warden_review.roles import ROLE_SPECS
 
 _ROLE = "code-reviewer"
@@ -76,8 +84,8 @@ def _gate(repo: Path) -> int:
 def test_registry_lists_and_resolves_gpt():
     assert registry.is_registered(BACKEND_GPT)
     assert registry.get_backend(BACKEND_GPT).id() == BACKEND_GPT
-    # The registry now holds both model backends (gpt + openai_compat); claude is never registered.
-    assert set(registry.available_backends()) == {BACKEND_GPT, BACKEND_OPENAI_COMPAT}
+    # The registry now holds three model backends (gpt + openai_compat + glm); claude is never registered.
+    assert set(registry.available_backends()) == {BACKEND_GPT, BACKEND_OPENAI_COMPAT, BACKEND_GLM}
 
 
 def test_registry_unknown_backend_raises():
@@ -797,3 +805,114 @@ def test_run_restores_override_when_runner_raises(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError):
         h.run(args)
     assert h._WORKTREE_OVERRIDE == prev, "override must be restored after a runner raises"
+
+
+# ── glm backend (Z.ai): a WARDEN_GLM_* subclass of openai_compat, auth-required abstain ──
+# Reuses the openai_compat mock seam + helpers (_oac_body / _oac_req) — zero real HTTP.
+
+@pytest.fixture
+def glm_env(monkeypatch):
+    """A configured GLM key; base/model left to defaults. Clears the openai_compat vars so a
+    test cannot accidentally cross-read them (GLM must read only WARDEN_GLM_*)."""
+    monkeypatch.setenv("WARDEN_GLM_API_KEY", "zai-test-key")
+    monkeypatch.delenv("WARDEN_GLM_BASE_URL", raising=False)
+    monkeypatch.delenv("WARDEN_GLM_MODEL", raising=False)
+
+
+def test_glm_registry_and_known_backends():
+    assert registry.is_registered(BACKEND_GLM)
+    assert registry.get_backend(BACKEND_GLM).id() == BACKEND_GLM
+    assert GLMBackend().id() == BACKEND_GLM
+    assert BACKEND_GLM in KNOWN_MODEL_BACKENDS
+    # The registry now holds three model backends; claude is still never registered.
+    assert set(registry.available_backends()) == {BACKEND_GPT, BACKEND_OPENAI_COMPAT, BACKEND_GLM}
+
+
+def test_glm_abstains_without_api_key(monkeypatch):
+    # No key → abstain (fail open) BEFORE any network call. This is the no-op-when-unconfigured
+    # guarantee: a user who lists "glm" but sets no key never blocks a commit.
+    monkeypatch.delenv("WARDEN_GLM_API_KEY", raising=False)
+    called: list[int] = []
+    monkeypatch.setattr(oac, "_post_chat_completion",
+                        lambda *a, **k: called.append(1) or (200, _oac_body()))
+    v = GLMBackend().review(_oac_req())
+    assert v.could_not_run and not v.is_ship
+    assert v.category == "auth"
+    assert called == []   # no key → no HTTP attempted
+
+
+def test_glm_reads_glm_env_not_openai_compat(monkeypatch, glm_env):
+    # GLM must read WARDEN_GLM_*; an openai_compat var must NOT configure it. Default base/model
+    # apply, the key rides the Authorization header.
+    monkeypatch.setenv("WARDEN_GLM_MODEL", "glm-5.2-test")
+    monkeypatch.setenv("WARDEN_OPENAI_COMPAT_BASE_URL", "http://wrong:9/v1")  # must be ignored
+    seen: dict = {}
+    monkeypatch.setattr(oac, "_post_chat_completion",
+                        lambda e, p, hdr, t: seen.update(endpoint=e, payload=p, headers=hdr)
+                        or (200, _oac_body()))
+    v = GLMBackend().review(_oac_req())
+    assert v.verdict == "SHIP"
+    assert seen["endpoint"] == "https://api.z.ai/api/paas/v4/chat/completions"  # GLM default base
+    assert seen["payload"]["model"] == "glm-5.2-test"
+    assert seen["headers"]["Authorization"] == "Bearer zai-test-key"
+
+
+def test_glm_default_model_when_unset(monkeypatch, glm_env):
+    seen: dict = {}
+    monkeypatch.setattr(oac, "_post_chat_completion",
+                        lambda e, p, hdr, t: seen.update(payload=p) or (200, _oac_body()))
+    GLMBackend().review(_oac_req())
+    assert seen["payload"]["model"] == "glm-5.2"   # DEFAULT_MODEL
+
+
+def test_glm_fail_closed_on_invalid_verdict(monkeypatch, glm_env):
+    # The parent's fail-closed invariant is inherited: an invalid verdict NEVER becomes SHIP.
+    monkeypatch.setattr(oac, "_post_chat_completion",
+                        lambda *a, **k: (200, _oac_body(verdict="MAYBE")))
+    v = GLMBackend().review(_oac_req())
+    assert v.could_not_run and not v.is_ship
+
+
+def test_oac_module_aliases_still_resolve():
+    # Back-compat after the env-name hoist to class attributes: external importers of the old
+    # private module constants still resolve to the same strings.
+    assert oac._ENV_BASE_URL == oac.OpenAICompatBackend.ENV_BASE_URL == "WARDEN_OPENAI_COMPAT_BASE_URL"
+    assert oac._ENV_MODEL == "WARDEN_OPENAI_COMPAT_MODEL"
+    assert oac._ENV_API_KEY == "WARDEN_OPENAI_COMPAT_API_KEY"
+
+
+# ── _load_glm_env: the GLM-scoped .env loader (resolves the global-loader co-gate REVISE) ──
+
+def test_load_glm_env_noop_when_file_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv("WARDEN_GLM_API_KEY", raising=False)
+    cw._load_glm_env(tmp_path / "nope.env")   # absent → no exception, no change
+    assert "WARDEN_GLM_API_KEY" not in os.environ
+
+
+def test_load_glm_env_sets_unset_glm_key(tmp_path, monkeypatch):
+    monkeypatch.delenv("WARDEN_GLM_API_KEY", raising=False)
+    envf = tmp_path / ".env"
+    envf.write_text("# comment\nWARDEN_GLM_API_KEY=from-file\n", encoding="utf-8")
+    cw._load_glm_env(envf)
+    assert os.environ["WARDEN_GLM_API_KEY"] == "from-file"
+
+
+def test_load_glm_env_does_not_override_existing(tmp_path, monkeypatch):
+    monkeypatch.setenv("WARDEN_GLM_API_KEY", "from-env")
+    envf = tmp_path / ".env"
+    envf.write_text("WARDEN_GLM_API_KEY=from-file\n", encoding="utf-8")
+    cw._load_glm_env(envf)
+    assert os.environ["WARDEN_GLM_API_KEY"] == "from-env"   # a real exported env var wins
+
+
+def test_load_glm_env_ignores_non_glm_keys(tmp_path, monkeypatch):
+    # THE FIX: a global loader would activate openai_compat from a stale .env line. The
+    # GLM-scoped loader must IGNORE every non-WARDEN_GLM_ key.
+    monkeypatch.delenv("WARDEN_OPENAI_COMPAT_BASE_URL", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    envf = tmp_path / ".env"
+    envf.write_text("WARDEN_OPENAI_COMPAT_BASE_URL=http://sneaky:9/v1\nGEMINI_API_KEY=x\n",
+                    encoding="utf-8")
+    cw._load_glm_env(envf)
+    assert "WARDEN_OPENAI_COMPAT_BASE_URL" not in os.environ
+    assert "GEMINI_API_KEY" not in os.environ

--- a/scripts/warden_review/backends/glm.py
+++ b/scripts/warden_review/backends/glm.py
@@ -1,0 +1,41 @@
+"""Z.ai GLM model-reviewer backend (id ``glm``).
+
+A thin provider-specialization of :class:`OpenAICompatBackend`: it reviews via Z.ai's
+OpenAI-compatible ``/v1/chat/completions`` endpoint, reusing the parent's hardened
+``review()`` (per-run untrusted-diff sentinel boundary, fail-CLOSED verdict check, fail-OPEN
+transport handling) verbatim — only the env-var names and provider defaults differ.
+
+Config (a fresh clone sets these or the backend abstains — see ``REQUIRE_API_KEY``):
+  WARDEN_GLM_API_KEY   (required)  a METERED Z.ai API key. NOT a GLM Coding Plan key — the
+                                   Coding Plan is restricted to whitelisted coding tools and
+                                   forbids SDK / third-party use (z.ai docs), so it must not
+                                   drive this out-of-band warden backend.
+  WARDEN_GLM_BASE_URL  (optional)  defaults to Z.ai's OpenAI-compatible base.
+  WARDEN_GLM_MODEL     (optional)  defaults to ``glm-5.2``; ``ReviewRequest.model`` overrides.
+
+Activation is fully opt-in and additive: this backend only runs when a role lists ``glm`` in
+``.claude/wardens/config.json`` AND ``WARDEN_GLM_API_KEY`` is set; otherwise it abstains
+(COULD_NOT_RUN → the gate fails open). It NEVER changes the behavior of any other backend.
+"""
+from __future__ import annotations
+
+from ..constants import BACKEND_GLM
+from .openai_compat import OpenAICompatBackend
+
+
+class GLMBackend(OpenAICompatBackend):
+    """Backend id ``glm``: Z.ai GLM via its OpenAI-compatible endpoint."""
+
+    ENV_BASE_URL = "WARDEN_GLM_BASE_URL"
+    ENV_MODEL = "WARDEN_GLM_MODEL"
+    ENV_API_KEY = "WARDEN_GLM_API_KEY"
+    DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"  # Z.ai's OpenAI-compatible base (verified live)
+    # GLM-5.2 (a reasoning model) chosen for code-review quality: its chain-of-thought lifts
+    # verdict accuracy on subtle diffs. The reasoning is returned in a separate ``reasoning_content``
+    # field and intentionally ignored — the parent reads only ``message.content`` (the JSON verdict).
+    # Override WARDEN_GLM_MODEL to a cheaper tier (e.g. a GLM Flash) if review quality allows.
+    DEFAULT_MODEL = "glm-5.2"
+    REQUIRE_API_KEY = True  # authenticated endpoint → abstain (no-op) when no key is set
+
+    def id(self) -> str:
+        return BACKEND_GLM

--- a/scripts/warden_review/backends/openai_compat.py
+++ b/scripts/warden_review/backends/openai_compat.py
@@ -54,10 +54,8 @@ from .base import ModelReviewerBackend, ReviewRequest, Verdict
 # key must not auto-approve a commit). Mirrors codex.py's contract.
 _REVIEW_VERDICTS = (VERDICT_SHIP, VERDICT_REVISE, VERDICT_BLOCK)
 
-# Env keys — no hardcoded hosts (a fresh clone sets these or the backend abstains).
-_ENV_BASE_URL = "WARDEN_OPENAI_COMPAT_BASE_URL"
-_ENV_MODEL = "WARDEN_OPENAI_COMPAT_MODEL"
-_ENV_API_KEY = "WARDEN_OPENAI_COMPAT_API_KEY"
+# Env-var NAMES are class attributes on OpenAICompatBackend (see its docstring); module-level
+# aliases for the old private names are defined after the class for back-compat.
 
 # Single-call guard. Same VALUE as codex_review.WHOLE_DIFF_CHAR_LIMIT (200_000) but a
 # different SCOPE: that bounds the DIFF slice alone (minus the rules digest); this bounds the
@@ -129,23 +127,49 @@ def _parse_findings_json(raw: str) -> dict:
 
 
 class OpenAICompatBackend(ModelReviewerBackend):
-    """Backend id ``openai_compat``: any OpenAI-compatible /v1/chat/completions endpoint."""
+    """Backend id ``openai_compat``: any OpenAI-compatible /v1/chat/completions endpoint.
+
+    Subclass to add a provider: override the ``ENV_*`` / ``DEFAULT_*`` / ``REQUIRE_API_KEY``
+    class attributes (and ``id()``) and reuse ``review()`` verbatim — see ``backends/glm.py``.
+    """
+
+    # Env-var NAMES this backend reads (no hardcoded host: a fresh clone sets these or abstains).
+    ENV_BASE_URL = "WARDEN_OPENAI_COMPAT_BASE_URL"
+    ENV_MODEL = "WARDEN_OPENAI_COMPAT_MODEL"
+    ENV_API_KEY = "WARDEN_OPENAI_COMPAT_API_KEY"
+    # Provider-specific defaults (empty = none; generic openai_compat must be env-configured).
+    DEFAULT_BASE_URL = ""
+    DEFAULT_MODEL = ""
+    # Authenticated endpoints (e.g. Z.ai) set this so a keyless call abstains instead of being
+    # sent; generic openai_compat allows keyless (a local llama.cpp / Ollama needs no key).
+    REQUIRE_API_KEY = False
 
     def id(self) -> str:
         return BACKEND_OPENAI_COMPAT
 
     def review(self, request: ReviewRequest) -> Verdict:
-        base_url = os.environ.get(_ENV_BASE_URL, "").strip().rstrip("/")
+        base_url = (os.environ.get(self.ENV_BASE_URL, "").strip()
+                    or self.DEFAULT_BASE_URL).rstrip("/")
         if not base_url:
             # Fail open (never SHIP): the backend is registered but unconfigured here.
             return Verdict(
                 VERDICT_COULD_NOT_RUN,
-                error=f"{_ENV_BASE_URL} is not set — no endpoint to review against. Set it "
+                error=f"{self.ENV_BASE_URL} is not set — no endpoint to review against. Set it "
                       "to an OpenAI-compatible /v1 base URL (e.g. http://127.0.0.1:8080/v1).",
                 category="auth",
             )
 
-        model = request.model or os.environ.get(_ENV_MODEL, "").strip()
+        api_key = os.environ.get(self.ENV_API_KEY, "").strip()
+        if self.REQUIRE_API_KEY and not api_key:
+            # An authenticated endpoint with no key: abstain BEFORE building the prompt or
+            # calling out (fail open, never SHIP) — guarantees a no-op when unconfigured.
+            return Verdict(
+                VERDICT_COULD_NOT_RUN,
+                error=f"{self.ENV_API_KEY} is not set — this backend requires an API key.",
+                category="auth",
+            )
+
+        model = request.model or os.environ.get(self.ENV_MODEL, "").strip() or self.DEFAULT_MODEL
         rules_digest = cr.build_rules_digest(Path(request.rules_path))
         sentinel = f"<<<UNTRUSTED-DIFF-{secrets.token_hex(16)}>>>"  # 128-bit, infeasible to forge
         prompt = (
@@ -160,7 +184,6 @@ class OpenAICompatBackend(ModelReviewerBackend):
             )
 
         headers = {"Content-Type": "application/json"}
-        api_key = os.environ.get(_ENV_API_KEY, "").strip()
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"  # key never logged; header only
         payload: dict = {
@@ -220,3 +243,9 @@ class OpenAICompatBackend(ModelReviewerBackend):
                         findings.append({"file": file, **f})
         return Verdict(verdict=verdict, findings=findings,
                        summary=data.get("summary", ""), raw=raw)
+
+
+# Back-compat module-level aliases for the old private constant names (external importers).
+_ENV_BASE_URL = OpenAICompatBackend.ENV_BASE_URL
+_ENV_MODEL = OpenAICompatBackend.ENV_MODEL
+_ENV_API_KEY = OpenAICompatBackend.ENV_API_KEY

--- a/scripts/warden_review/constants.py
+++ b/scripts/warden_review/constants.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 BACKEND_CLAUDE = "claude"   # the in-session subagent transport (NOT in the registry)
 BACKEND_GPT = "gpt"         # GPT via the codex CLI
 BACKEND_OPENAI_COMPAT = "openai_compat"  # any OpenAI-compatible /v1 endpoint (llama.cpp/Ollama/OpenRouter/OpenAI)
+BACKEND_GLM = "glm"         # Z.ai GLM via its OpenAI-compatible /v1 endpoint (subclass of openai_compat)
 
 #: Model backends the registry/gate recognize. Claude is intentionally excluded — it is
 #: the in-session subagent transport, not an out-of-band model call. Grows by one per
 #: added provider (e.g. a local / openai-compatible backend).
-KNOWN_MODEL_BACKENDS = frozenset({BACKEND_GPT, BACKEND_OPENAI_COMPAT})
+KNOWN_MODEL_BACKENDS = frozenset({BACKEND_GPT, BACKEND_OPENAI_COMPAT, BACKEND_GLM})
 
 # ── Verdicts ────────────────────────────────────────────────────────────────────────
 VERDICT_SHIP = "SHIP"

--- a/scripts/warden_review/registry.py
+++ b/scripts/warden_review/registry.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from .backends.base import ModelReviewerBackend
-from .constants import BACKEND_GPT, BACKEND_OPENAI_COMPAT
+from .constants import BACKEND_GLM, BACKEND_GPT, BACKEND_OPENAI_COMPAT
 
 _FACTORIES: dict[str, Callable[[], ModelReviewerBackend]] = {}
 
@@ -51,8 +51,14 @@ def _register_builtins() -> None:
 
         return OpenAICompatBackend()
 
+    def _glm() -> ModelReviewerBackend:
+        from .backends.glm import GLMBackend
+
+        return GLMBackend()
+
     register(BACKEND_GPT, _codex)
     register(BACKEND_OPENAI_COMPAT, _openai_compat)
+    register(BACKEND_GLM, _glm)
 
 
 _register_builtins()


### PR DESCRIPTION
## What

Adds a dedicated `glm` warden co-gate backend — a thin subclass of `OpenAICompatBackend` that reviews via Z.ai's OpenAI-compatible endpoint (`https://api.z.ai/api/paas/v4`). It gives the co-gate a third, family-diverse reviewer (Claude + GPT + GLM).

## Safety: fully additive & opt-in

A role uses `glm` **only** when it lists `"glm"` in the gitignored `.claude/wardens/config.json` **and** `WARDEN_GLM_API_KEY` is set. Otherwise `GLMBackend` abstains (`COULD_NOT_RUN` → the gate fails open). **Zero behavior change** for anyone who does not opt in:
- `.claude/wardens/config.json` is gitignored; the repo ships only `config.json.example` (unchanged at `["claude","gpt"]`).
- `_role_backends` defaults to `["claude"]` when no config — the `glm` backend is registered-but-inert.
- `REQUIRE_API_KEY=True` makes it abstain before any HTTP when unconfigured.

## Changes

- **openai_compat**: hoist env-var names to overridable class attributes + add `DEFAULT_BASE_URL`/`DEFAULT_MODEL`/`REQUIRE_API_KEY` so providers subclass without reimplementing `review()`. Behaviorally identical for the existing backend (old module constants kept as aliases).
- **glm.py** (new): `GLMBackend` overrides `WARDEN_GLM_*` + Z.ai defaults; abstains (no HTTP) when no key.
- **codex_warden.py**: `_load_glm_env` loads **only** `WARDEN_GLM_*` keys from `~/deus/.env` (scoped so it cannot activate any other backend; no-op if absent; a real exported env var wins).
- **constants/registry**: register `"glm"`; **.env.example** documents the warden-backend vars.
- **tests**: GLM backend + `_load_glm_env` 4-case matrix + `openai_compat` behavioral-regression.

## Billing

Metered Z.ai API key only — the GLM Coding Plan is restricted to whitelisted coding tools and forbids SDK/third-party use, so it must not drive this out-of-band backend. Warden volume is a few calls/commit (cents/month).

## Verification

- **373 warden tests pass** (84 in `test_warden_review.py` incl. GLM + loader matrix + openai_compat regression; 289 adjacent).
- **Live smoke (both halves)**: with key → GLM-5.2 returns a real `SHIP` verdict on the actual diff; without key → abstains (fail-open), no HTTP attempted.
- **Co-gate review**: `code-reviewer` + `ai-eng-warden`, both Claude + GPT → **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)