### PR TITLE
feat(ingress): GitHub CI/PR webhook → gateway (/github) — push, not polling (LIA-315 Phase 4)

### DIFF
--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-06-19" # auto-bump @1781859131
+last_verified: "2026-06-19" # auto-bump @1781862796
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781861286
+last_verified: "2026-06-19" # auto-bump @1781862796
 governs:
   - src/
   - evolution/

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,6 +127,13 @@ export const NGROK_STATIC_DOMAIN = process.env.NGROK_STATIC_DOMAIN || '';
 export const INGRESS_LINEAR_VIA_GATEWAY =
   process.env.INGRESS_LINEAR_VIA_GATEWAY === '1' ||
   process.env.INGRESS_LINEAR_VIA_GATEWAY === 'true';
+// Route GitHub CI/PR webhooks through the gateway (/github) to drive merge-on-green +
+// done-on-merge by push instead of polling. Off by default; requires INGRESS_GATEWAY_ENABLED.
+// The signing secret (GITHUB_WEBHOOK_SECRET) is read in-module, not here (secrets-not-in-config).
+// LIA-315 Phase 4 (GitHub source 0).
+export const INGRESS_GITHUB_ENABLED =
+  process.env.INGRESS_GITHUB_ENABLED === '1' ||
+  process.env.INGRESS_GITHUB_ENABLED === 'true';
 // Per-source webhook config, OUTSIDE project root, never mounted into containers
 // (same pattern as SENDER_ALLOWLIST_PATH). Consumed in Phase 4 by the webhook channel.
 export const WEBHOOK_SOURCES_PATH = path.join(

--- a/src/db.ts
+++ b/src/db.ts
@@ -1491,6 +1491,22 @@ export function getIssuePr(
     | undefined;
 }
 
+/**
+ * Reverse lookup: GitHub PR url → the Linear issue it belongs to. Used by the GitHub
+ * ingress webhook to map an inbound event to its issue. The `linear_issue_prs` table is
+ * keyed by `issue_id` (one PR per issue), so a `pr_url` match is unambiguous; an unknown
+ * PR returns undefined (the handler treats that as a safe no-op).
+ */
+export function getIssueByPrUrl(
+  prUrl: string,
+): { issue_id: string; identifier: string | null } | undefined {
+  return db
+    .prepare(
+      `SELECT issue_id, identifier FROM linear_issue_prs WHERE pr_url = ?`,
+    )
+    .get(prUrl) as { issue_id: string; identifier: string | null } | undefined;
+}
+
 export function updatePrAutoMergeState(
   issueId: string,
   state: 'none' | 'pending' | 'merged' | 'failed',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   INGRESS_GATEWAY_ENABLED,
   INGRESS_GATEWAY_HOST,
   INGRESS_GATEWAY_PORT,
+  INGRESS_GITHUB_ENABLED,
   INGRESS_IP_ALLOWLIST,
   INGRESS_LINEAR_VIA_GATEWAY,
   INGRESS_MAX_BODY_BYTES,
@@ -82,6 +83,7 @@ import {
   startLinearWebhookServer,
   createLinearIngressHandler,
 } from './linear-webhook.js';
+import { createGitHubIngressHandler } from './ingress/github-ingress.js';
 import { registerLinearUpdater } from './events/listeners/linear-updater.js';
 import { registerObservabilitySink } from './events/listeners/observability-sink.js';
 
@@ -514,6 +516,37 @@ async function main(): Promise<void> {
           } catch (err) {
             logger.error({ err }, 'linear-webhook: server failed to start');
           }
+        }
+      }
+
+      // Route GitHub CI/PR webhooks through the gateway (/github): merge-on-green +
+      // done-on-merge by push instead of polling. The wrappers are merge-only — they can
+      // NEVER move an issue to "Ready for Agent", so the public endpoint adds no agent-spawn
+      // surface. The poller stays active as the reconciliation safety net. LIA-315 Phase 4.
+      // process.env (plist EnvironmentVariables) wins; fall back to ~/deus/.env, matching the
+      // NGROK_AUTHTOKEN read above (secrets are not config.ts constants).
+      const githubWebhookSecret =
+        process.env.GITHUB_WEBHOOK_SECRET ||
+        readEnvFile(['GITHUB_WEBHOOK_SECRET']).GITHUB_WEBHOOK_SECRET;
+      if (githubWebhookSecret && INGRESS_GITHUB_ENABLED) {
+        if (INGRESS_GATEWAY_ENABLED) {
+          const { mergeIfGreen, markDoneIfMerged } =
+            await import('./linear-auto-merge.js');
+          const { getIssueByPrUrl } = await import('./db.js');
+          ingressHandlers.push(
+            createGitHubIngressHandler({
+              ctx: linearCtx,
+              secret: githubWebhookSecret,
+              mergeIfGreen,
+              markDoneIfMerged,
+              getIssueByPrUrl,
+            }),
+          );
+          logger.info('github-webhook: routed via ingress gateway (/github)');
+        } else {
+          logger.warn(
+            'github-webhook: INGRESS_GITHUB_ENABLED set but INGRESS_GATEWAY_ENABLED off — GitHub events stay on the existing poller',
+          );
         }
       }
 

--- a/src/ingress/github-ingress.test.ts
+++ b/src/ingress/github-ingress.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import crypto from 'crypto';
+import { createGitHubIngressHandler } from './github-ingress.js';
+import type { GitHubIngressDeps } from './github-ingress.js';
+import type { VerifyResult } from './hmac.js';
+import type { LinearContext } from '../linear-dispatcher.js';
+
+/** verify() is synchronous here; the interface types it as VerifyResult | Promise. */
+const ok = (r: VerifyResult | Promise<VerifyResult>): boolean =>
+  (r as VerifyResult).ok;
+
+const SECRET = 'test-gh-secret';
+const REPO = 'test-owner/test-repo';
+const PR_NUM = 613;
+const PR_URL = `https://github.com/${REPO}/pull/${PR_NUM}`;
+
+function sign(body: Buffer, secret = SECRET): string {
+  return (
+    'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex')
+  );
+}
+
+let mergeIfGreen: ReturnType<typeof vi.fn>;
+let markDoneIfMerged: ReturnType<typeof vi.fn>;
+let getIssueByPrUrl: ReturnType<typeof vi.fn>;
+
+function makeHandler(overrides: Partial<GitHubIngressDeps> = {}) {
+  mergeIfGreen = vi.fn().mockResolvedValue(undefined);
+  markDoneIfMerged = vi.fn().mockResolvedValue(undefined);
+  getIssueByPrUrl = vi
+    .fn()
+    .mockReturnValue({ issue_id: 'issue-1', identifier: 'LIA-1' });
+  return createGitHubIngressHandler({
+    ctx: {} as unknown as LinearContext,
+    secret: SECRET,
+    mergeIfGreen,
+    markDoneIfMerged,
+    getIssueByPrUrl,
+    ...overrides,
+  } as GitHubIngressDeps);
+}
+
+function req(
+  event: string,
+  sig?: string,
+  deliveryId: string | null = 'delivery-1', // null = omit the delivery header
+) {
+  const headers: Record<string, string> = {};
+  if (event) headers['x-github-event'] = event;
+  if (sig !== undefined) headers['x-hub-signature-256'] = sig;
+  if (deliveryId !== null) headers['x-github-delivery'] = deliveryId;
+  return { headers } as never;
+}
+
+function fakeRes() {
+  const out: { status?: number; body?: string } = {};
+  const res = {
+    writable: true,
+    writeHead: (s: number) => {
+      out.status = s;
+      return res;
+    },
+    end: (b?: string) => {
+      out.body = b;
+    },
+  } as never;
+  return { res, out };
+}
+
+function body(obj: object): Buffer {
+  return Buffer.from(JSON.stringify(obj));
+}
+
+const checkSuiteSuccess = {
+  action: 'completed',
+  repository: { full_name: REPO },
+  check_suite: { conclusion: 'success', pull_requests: [{ number: PR_NUM }] },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createGitHubIngressHandler — verify (fail-closed auth + replay)', () => {
+  it('registers the /github prefix', () => {
+    expect(makeHandler().pathPrefix).toBe('/github');
+  });
+
+  it('accepts a valid signature + delivery id', () => {
+    const b = body(checkSuiteSuccess);
+    expect(makeHandler().verify(req('check_suite', sign(b)), b)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('rejects a bad signature', () => {
+    const b = body(checkSuiteSuccess);
+    expect(
+      ok(makeHandler().verify(req('check_suite', sign(b, 'wrong')), b)),
+    ).toBe(false);
+  });
+
+  it('rejects a missing signature', () => {
+    const b = body(checkSuiteSuccess);
+    expect(ok(makeHandler().verify(req('check_suite', undefined), b))).toBe(
+      false,
+    );
+  });
+
+  it('rejects a missing delivery id (replay header)', () => {
+    const b = body(checkSuiteSuccess);
+    expect(ok(makeHandler().verify(req('check_suite', sign(b), null), b))).toBe(
+      false,
+    );
+  });
+
+  it('rejects a replayed delivery id', () => {
+    const b = body(checkSuiteSuccess);
+    const h = makeHandler();
+    expect(ok(h.verify(req('check_suite', sign(b), 'dup'), b))).toBe(true);
+    expect(ok(h.verify(req('check_suite', sign(b), 'dup'), b))).toBe(false);
+  });
+});
+
+describe('createGitHubIngressHandler — handle (merge-only dispatch)', () => {
+  it('ping → 200, no action', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(req('ping'), res, body({}));
+    expect(out.status).toBe(200);
+    expect(mergeIfGreen).not.toHaveBeenCalled();
+    expect(markDoneIfMerged).not.toHaveBeenCalled();
+  });
+
+  it('non-allowlisted event → 204 no-op', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(req('push'), res, body({}));
+    expect(out.status).toBe(204);
+    expect(mergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  it('check_suite success on a tracked PR → mergeIfGreen, 200', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(
+      req('check_suite'),
+      res,
+      body(checkSuiteSuccess),
+    );
+    expect(out.status).toBe(200);
+    expect(mergeIfGreen).toHaveBeenCalledTimes(1);
+    expect(mergeIfGreen).toHaveBeenCalledWith({}, 'issue-1', PR_URL, 'LIA-1');
+    expect(markDoneIfMerged).not.toHaveBeenCalled();
+  });
+
+  it('check_suite NON-success → no merge, 204 no-op (no DB lookup)', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(
+      req('check_suite'),
+      res,
+      body({
+        repository: { full_name: REPO },
+        check_suite: {
+          conclusion: 'failure',
+          pull_requests: [{ number: PR_NUM }],
+        },
+      }),
+    );
+    expect(out.status).toBe(204);
+    expect(mergeIfGreen).not.toHaveBeenCalled();
+    // Non-actionable events must not even hit the DB lookup.
+    expect(getIssueByPrUrl).not.toHaveBeenCalled();
+  });
+
+  it('pull_request closed+merged → markDoneIfMerged, 200', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(
+      req('pull_request'),
+      res,
+      body({
+        action: 'closed',
+        repository: { full_name: REPO },
+        pull_request: { number: PR_NUM, merged: true },
+      }),
+    );
+    expect(out.status).toBe(200);
+    expect(markDoneIfMerged).toHaveBeenCalledTimes(1);
+    expect(mergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  it('pull_request closed but NOT merged → 204 no-op', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(
+      req('pull_request'),
+      res,
+      body({
+        action: 'closed',
+        repository: { full_name: REPO },
+        pull_request: { number: PR_NUM, merged: false },
+      }),
+    );
+    expect(out.status).toBe(204);
+    expect(markDoneIfMerged).not.toHaveBeenCalled();
+  });
+
+  it('unknown / untracked PR → 204 no-op (no merge fn called)', async () => {
+    const { res, out } = fakeRes();
+    const h = makeHandler({
+      getIssueByPrUrl: vi.fn().mockReturnValue(undefined),
+    });
+    await h.handle(req('check_suite'), res, body(checkSuiteSuccess));
+    expect(out.status).toBe(204);
+    expect(mergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  it('check_suite with no PR in payload → 204 no-op', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(
+      req('check_suite'),
+      res,
+      body({
+        repository: { full_name: REPO },
+        check_suite: { conclusion: 'success', pull_requests: [] },
+      }),
+    );
+    expect(out.status).toBe(204);
+    expect(mergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  it('malformed JSON → 400', async () => {
+    const { res, out } = fakeRes();
+    await makeHandler().handle(
+      req('check_suite'),
+      res,
+      Buffer.from('not json'),
+    );
+    expect(out.status).toBe(400);
+  });
+});

--- a/src/ingress/github-ingress.ts
+++ b/src/ingress/github-ingress.ts
@@ -1,0 +1,192 @@
+// GitHub webhook handler for the centralized ingress gateway (the `/github` route).
+//
+// Replaces polling the GitHub API for CI/PR state with push: GitHub posts an event,
+// we react. SECURITY (the endpoint is PUBLIC via ngrok — anyone can POST):
+//   - verify() fails CLOSED on a bad/missing `X-Hub-Signature-256` HMAC (verifyHmacSha256)
+//     and on a duplicate `X-GitHub-Delivery` (checkReplay) — the gateway 403s on {ok:false}.
+//   - handle() NEVER trusts the payload as data: it extracts only the PR url, maps it to a
+//     Linear issue, then RE-QUERIES authoritative state via the merge-only wrappers
+//     (mergeIfGreen / markDoneIfMerged). Those cannot reach the agent-spawn ("Ready for Agent")
+//     path, so a forged-but-signed event can neither merge a red PR nor spawn an agent.
+//
+// LIA-315 Phase 4 (GitHub source 0), scoped to merge-on-green + done-on-merge only.
+
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { IngressHandler } from './gateway.js';
+import { verifyHmacSha256, ReplayStore, checkReplay } from './hmac.js';
+import type { ReplayConfig } from './hmac.js';
+import { logger } from '../logger.js';
+import type { LinearContext } from './../linear-dispatcher.js';
+
+/** GitHub redeliveries arrive within minutes; a short TTL bounds the dedup store. */
+const GITHUB_DELIVERY_TTL_MS = 10 * 60_000;
+
+/** Only these event types do anything; everything else is a 204 no-op. */
+const ALLOWED_EVENTS = new Set([
+  'check_suite',
+  'workflow_run',
+  'pull_request',
+  'ping',
+]);
+
+/** Minimal, optional-chained view of the GitHub payloads we read. */
+interface GitHubPayload {
+  action?: string;
+  repository?: { full_name?: string };
+  pull_request?: { number?: number; merged?: boolean };
+  check_suite?: {
+    conclusion?: string;
+    pull_requests?: Array<{ number?: number }>;
+  };
+  workflow_run?: {
+    conclusion?: string;
+    pull_requests?: Array<{ number?: number }>;
+  };
+}
+
+type MergeAction = (
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  identifier?: string,
+) => Promise<void>;
+
+export interface GitHubIngressDeps {
+  ctx: LinearContext;
+  secret: string;
+  mergeIfGreen: MergeAction;
+  markDoneIfMerged: MergeAction;
+  getIssueByPrUrl: (
+    prUrl: string,
+  ) => { issue_id: string; identifier: string | null } | undefined;
+}
+
+function headerString(v: string | string[] | undefined): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  if (!res.writable) return;
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Reconstruct the canonical PR html url (`https://github.com/<owner>/<repo>/pull/<n>`) from
+ * the event payload, to match the format stored in `linear_issue_prs` and parsed by the
+ * re-query fns. Returns undefined when the event carries no PR (e.g. a check_suite with an
+ * empty `pull_requests` array, common for fork PRs) — the handler then no-ops.
+ */
+function extractPrUrl(
+  event: string,
+  payload: GitHubPayload,
+): string | undefined {
+  const repo = payload.repository?.full_name;
+  if (!repo) return undefined;
+  let prNumber: number | undefined;
+  if (event === 'pull_request') prNumber = payload.pull_request?.number;
+  else if (event === 'check_suite')
+    prNumber = payload.check_suite?.pull_requests?.[0]?.number;
+  else if (event === 'workflow_run')
+    prNumber = payload.workflow_run?.pull_requests?.[0]?.number;
+  if (typeof prNumber !== 'number') return undefined;
+  return `https://github.com/${repo}/pull/${prNumber}`;
+}
+
+/** True when a check_suite / workflow_run event reports a successful conclusion. */
+function isCiSuccess(event: string, payload: GitHubPayload): boolean {
+  if (event === 'check_suite')
+    return payload.check_suite?.conclusion === 'success';
+  if (event === 'workflow_run')
+    return payload.workflow_run?.conclusion === 'success';
+  return false;
+}
+
+export function createGitHubIngressHandler(
+  deps: GitHubIngressDeps,
+): IngressHandler {
+  const { ctx, secret, mergeIfGreen, markDoneIfMerged, getIssueByPrUrl } = deps;
+  // ReplayStore is process-lifetime only: a post-restart redelivery passes dedup. That is
+  // acceptable because the merge-only actions are idempotent — re-querying authoritative
+  // state and no-op'ing on an already-merged / not-green PR is the second layer.
+  const replayStore = new ReplayStore(GITHUB_DELIVERY_TTL_MS);
+  const replayCfg: ReplayConfig = {
+    strategy: 'delivery-id',
+    idHeader: 'X-GitHub-Delivery',
+  };
+
+  return {
+    pathPrefix: '/github',
+
+    verify(req: IncomingMessage, bodyRaw: Buffer) {
+      const sig = verifyHmacSha256(
+        secret,
+        bodyRaw,
+        headerString(req.headers['x-hub-signature-256']),
+      );
+      if (!sig.ok) return sig;
+      return checkReplay(replayCfg, req.headers, replayStore, Date.now());
+    },
+
+    async handle(req: IncomingMessage, res: ServerResponse, bodyRaw: Buffer) {
+      const event = headerString(req.headers['x-github-event']);
+      if (!event || !ALLOWED_EVENTS.has(event)) {
+        writeJson(res, 204, { ok: true, ignored: 'event' });
+        return;
+      }
+      if (event === 'ping') {
+        writeJson(res, 200, { ok: true });
+        return;
+      }
+
+      let payload: GitHubPayload;
+      try {
+        payload = JSON.parse(bodyRaw.toString('utf-8')) as GitHubPayload;
+      } catch {
+        writeJson(res, 400, { ok: false, message: 'invalid json' });
+        return;
+      }
+
+      // Decide the action from the payload BEFORE any DB I/O, so a non-actionable event
+      // (e.g. a non-success check_suite — the common case) is a pure no-op with zero I/O on
+      // this public hot path.
+      const wantsMerge =
+        (event === 'check_suite' || event === 'workflow_run') &&
+        isCiSuccess(event, payload);
+      const wantsDone =
+        event === 'pull_request' &&
+        payload.action === 'closed' &&
+        payload.pull_request?.merged === true;
+      if (!wantsMerge && !wantsDone) {
+        writeJson(res, 204, { ok: true, ignored: 'no-action' });
+        return;
+      }
+
+      const prUrl = extractPrUrl(event, payload);
+      const issue = prUrl ? getIssueByPrUrl(prUrl) : undefined;
+      if (!prUrl || !issue) {
+        // Unknown / untracked PR — safe no-op.
+        writeJson(res, 204, { ok: true, ignored: 'pr' });
+        return;
+      }
+      const ident = issue.identifier ?? undefined;
+
+      // Re-query authoritative state inside the merge-only wrappers; never trust the payload.
+      if (wantsMerge) {
+        mergeIfGreen(ctx, issue.issue_id, prUrl, ident).catch((err) =>
+          logger.error({ err, prUrl }, 'github-webhook: mergeIfGreen failed'),
+        );
+      } else {
+        markDoneIfMerged(ctx, issue.issue_id, prUrl, ident).catch((err) =>
+          logger.error(
+            { err, prUrl },
+            'github-webhook: markDoneIfMerged failed',
+          ),
+        );
+      }
+
+      // Fast 2xx — any host action above is fire-and-forget.
+      writeJson(res, 200, { ok: true });
+    },
+  };
+}

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -717,3 +717,86 @@ describe('sweepPendingAutoMerges — detects PR already merged by GitHub', () =>
     expect(getPr('sweep-issue-1')?.auto_merge_state).toBe('merged');
   });
 });
+
+describe('mergeIfGreen / markDoneIfMerged — GitHub-webhook merge-only entries (LIA-315 Phase 4)', () => {
+  const PR = 'https://github.com/test-owner/test-repo/pull/300';
+  const checks = (bucket: 'pass' | 'pending' | 'fail') => ({
+    stdout: JSON.stringify([{ bucket, name: 'ci' }]),
+  });
+  const mergeCall = () =>
+    execFileMock.mock.calls.find(
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && (c[1] as string[]).includes('merge'),
+    );
+
+  beforeEach(() => {
+    process.env.LINEAR_AUTO_MERGE = '1';
+  });
+  afterEach(() => {
+    delete process.env.LINEAR_AUTO_MERGE;
+  });
+
+  it('mergeIfGreen: CI green → --admin merge → Done', async () => {
+    execFileMock
+      .mockReturnValueOnce(checks('pass')) // mergeIfGreen re-query
+      .mockReturnValueOnce(checks('pass')) // mergePr precheck
+      .mockReturnValueOnce({ stdout: '' }); // gh pr merge
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('mg-pass', PR);
+    await mergeIfGreen(ctx, 'mg-pass', PR, 'LIA-300');
+    expect(mergeCall()).toBeDefined();
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'mg-pass',
+      expect.objectContaining({ stateId: 'done-id' }),
+    );
+  });
+
+  // SECURITY: the public webhook must NEVER spawn an agent. On a stale/forged CI-green
+  // event for a now-red PR, mergeIfGreen must be a pure no-op — NO merge, and crucially NO
+  // requeue to "Ready for Agent" (which the dispatcher would turn into an agent run).
+  it('mergeIfGreen: CI fail → NO merge AND NO requeue to Ready for Agent', async () => {
+    execFileMock.mockReturnValueOnce(checks('fail'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('mg-fail', PR);
+    await mergeIfGreen(ctx, 'mg-fail', PR, 'LIA-301');
+    expect(mergeCall()).toBeUndefined();
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('mergeIfGreen: CI pending → pure no-op (no merge, no requeue)', async () => {
+    execFileMock.mockReturnValueOnce(checks('pending'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('mg-pend', PR);
+    await mergeIfGreen(ctx, 'mg-pend', PR, 'LIA-302');
+    expect(mergeCall()).toBeUndefined();
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('markDoneIfMerged: PR MERGED → moves issue to Done', async () => {
+    execFileMock.mockReturnValueOnce({
+      stdout: JSON.stringify({ state: 'MERGED' }),
+    });
+    const { markDoneIfMerged } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('md-merged', PR);
+    await markDoneIfMerged(ctx, 'md-merged', PR, 'LIA-303');
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'md-merged',
+      expect.objectContaining({ stateId: 'done-id' }),
+    );
+  });
+
+  it('markDoneIfMerged: PR still OPEN → no-op (no Done transition)', async () => {
+    execFileMock.mockReturnValueOnce({
+      stdout: JSON.stringify({ state: 'OPEN' }),
+    });
+    const { markDoneIfMerged } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('md-open', PR);
+    await markDoneIfMerged(ctx, 'md-open', PR, 'LIA-304');
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+});

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -335,6 +335,54 @@ async function mergeOrFail(
 }
 
 /**
+ * GitHub-ingress entry: merge the PR IFF its CI is currently green, else NO-OP.
+ *
+ * SECURITY (LIA-315 Phase 4): this is the ONLY merge entry the public `/github` webhook may
+ * call. Unlike `attemptAutoMerge`, it NEVER reaches `handleMergeFailure(requeue=true)` — on a
+ * `fail`/`pending` re-query it does nothing (the existing poller handles those). So a
+ * webhook delivery can never move an issue to "Ready for Agent" / spawn an agent. We re-query
+ * authoritative CI here rather than trust the webhook payload, so a forged-but-signed success
+ * event for a since-red PR is a safe no-op.
+ */
+export async function mergeIfGreen(
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  identifier?: string,
+): Promise<void> {
+  if (!isAutoMergeEnabled()) return;
+  const ident = identifier ?? 'unknown';
+  const checks = await queryPrChecks(prUrl);
+  if (checks.status === 'pass') {
+    await mergeOrFail(ctx, issueId, prUrl, ident);
+  } else {
+    logger.info(
+      { issueId, prUrl, status: checks.status },
+      'github-webhook: CI not green — no-op (poller handles fail/pending)',
+    );
+  }
+}
+
+/**
+ * GitHub-ingress entry: advance the issue to "Done" IFF the PR is actually merged, else NO-OP.
+ * Re-queries authoritative PR state (never trusts the payload). `handleMergeSuccess` only moves
+ * to "Done" — it can never spawn an agent. Intentionally NOT gated on `isAutoMergeEnabled()`
+ * (unlike `mergeIfGreen`): a genuinely-merged PR should reach "Done" regardless of that flag.
+ */
+export async function markDoneIfMerged(
+  ctx: LinearContext,
+  issueId: string,
+  prUrl: string,
+  identifier?: string,
+): Promise<void> {
+  const ident = identifier ?? 'unknown';
+  const state = await queryPrState(prUrl);
+  if (state?.state === 'MERGED') {
+    await handleMergeSuccess(ctx, issueId, prUrl, ident);
+  }
+}
+
+/**
  * Poll a PR's CI until it reaches a terminal state, then --admin-merge on pass.
  * Detached via fireAndForget so it never blocks the dispatch path (LIA-215).
  *


### PR DESCRIPTION
## What

LIA-315 **Phase 4 (GitHub source 0)**: react to GitHub CI/PR events via a **push** webhook at the gateway's `/github` route instead of polling (`gh pr checks` 60s×20, conflict sweep 30s, `gh pr checks --watch` by hand). The merge pipeline now reacts the instant CI finishes — the same shift `/linear` made.

## 🔒 Security (the endpoint is PUBLIC via ngrok — anyone can POST)

Every defense is fail-closed:
- **HMAC auth** — `verify()` rejects a bad/missing `X-Hub-Signature-256` (constant-time `verifyHmacSha256`) → gateway 403s.
- **Replay** — dedup on `X-GitHub-Delivery` (`checkReplay` delivery-id + bounded-TTL store).
- **Never trusts the payload as data** — extracts only the PR url, then **re-queries authoritative state via `gh`** and runs **merge-only** wrappers. A forged-but-signed event can't merge a red PR (we re-check CI) — and **can't spawn an agent**.
- **No agent-spawn surface** — `mergeIfGreen` / `markDoneIfMerged` are structurally incapable of reaching `handleMergeFailure(requeue=true)` (the "Ready for Agent" → dispatcher → agent path). **Plan-review round 1 caught that `attemptAutoMerge` *does* have that requeue path**; the wrappers design it out, and a unit test asserts CI-fail/pending → no merge AND no requeue.
- Gateway defense-in-depth (body cap, rate-limit) + action decided **before** any DB I/O (non-actionable event = zero-I/O 204).

## Changes

| File | |
|---|---|
| `src/linear-auto-merge.ts` | new exported `mergeIfGreen` (pass → `mergeOrFail`; else no-op) + `markDoneIfMerged` (MERGED → `handleMergeSuccess`) |
| `src/db.ts` | `getIssueByPrUrl` over `linear_issue_prs` (unknown PR → safe 204) |
| `src/ingress/github-ingress.ts` | the handler (allowlist {check_suite, workflow_run, pull_request, ping}) |
| `src/config.ts` | `INGRESS_GITHUB_ENABLED` flag (default off) |
| `src/index.ts` | register when gateway + flag + secret (`process.env` ‖ `.env`); fail-safe to poller if gateway off |
| tests | 44 (sig/replay/allowlist/dispatch + the merge-only security invariant incl. the CI-flipped-red race) |

## Review

- Plan co-gate (Claude + GPT): SHIP after 1 REVISE (the agent-spawn hole).
- Code co-gate (Claude + GPT): SHIP after 2 REVISE (personal repo id; `isCiSuccess`-before-DB; `.env` secret fallback). Security boundary independently re-verified against source.
- Build green; full suite **1819 tests** pass.

## Rollout

Flag off by default → **inert on merge**. The poller stays active as the reconciliation safety net (webhooks can be missed). Cutover = set `INGRESS_GITHUB_ENABLED=1` + `GITHUB_WEBHOOK_SECRET` in the `com.deus.plist` + register the GitHub webhook. Rollback = flag off + delete the webhook (non-destructive; the poller already covers everything).

LIA-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)