### PR TITLE
feat(warden): co-gate wrapper + codex_warden --worktree-root parity (RETRO-2026-06-19-04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,10 @@ jobs:
         # openai_compat backends, the role specs, the strict-AND gate / loop guard / HITL
         # override (test_warden_review), the driver (test_codex_warden), the codex engine
         # (test_codex_review), the Phase 3 co-gate oracle, and the full hook engine incl.
-        # the admin-merge + structural-check gates (test_codex_warden_hooks). All hermetic —
-        # the gh CLI and model seams are mocked, so no codex CLI / gh / network is touched.
-        run: python3 -m pytest scripts/tests/test_warden_review.py scripts/tests/test_codex_warden.py scripts/tests/test_codex_review.py scripts/tests/test_phase3_cogate_oracle.py scripts/tests/test_codex_warden_hooks.py -v
+        # the admin-merge + structural-check gates (test_codex_warden_hooks), and the
+        # one-command co-gate marker wrapper (test_cogate). All hermetic — the gh CLI and
+        # model seams are mocked, so no codex CLI / gh / network is touched.
+        run: python3 -m pytest scripts/tests/test_warden_review.py scripts/tests/test_codex_warden.py scripts/tests/test_codex_review.py scripts/tests/test_phase3_cogate_oracle.py scripts/tests/test_codex_warden_hooks.py scripts/tests/test_cogate.py -v
 
       - name: Session type contract tests
         run: python3 -m pytest tests/test_session_type_contract.py -v

--- a/scripts/codex_warden.py
+++ b/scripts/codex_warden.py
@@ -68,6 +68,11 @@ def main(argv: list[str] | None = None) -> int:
                          f"{', '.join(registry.available_backends()) or '(none)'})")
     ap.add_argument("--warden-mark", action="store_true",
                     help="record the verdict into the warden store (co-gate); advisory if omitted")
+    ap.add_argument("--worktree-root", default=None,
+                    help="target worktree toplevel for the review + verdict bucket (default: the "
+                         "cwd's repo/worktree toplevel). Lets an out-of-band caller target a "
+                         "specific worktree's bucket from any cwd, matching codex_warden_hooks.py "
+                         "mark --worktree-root.")
     src = ap.add_mutually_exclusive_group()
     src.add_argument("--rev-range", help="commit sha or a..b range (default: working tree)")
     src.add_argument("--diff-file", help="path to a unified diff file to review")
@@ -86,13 +91,27 @@ def main(argv: list[str] | None = None) -> int:
     spec = ROLE_SPECS[args.role]
     skey = store_key(args.role, args.backend)
 
-    try:
-        # cfr.repo_root() returns a str; the warden-hooks helpers need a Path (they do
-        # `repo_root / ".git"` etc.). The backend's cwd stays a str (codex --cd).
-        root = Path(cr.cfr.repo_root())
-    except cr.ReviewError as exc:
-        sys.stderr.write(f"[codex-warden] {exc.message}\n")
-        return exc.code
+    if args.worktree_root:
+        # Flag-first: resolve --worktree-root WITHOUT cr.cfr.repo_root(). That call raises
+        # ReviewError → USAGE_ERROR when cwd is outside a git repo, so resolving the flag only
+        # afterwards would still make `--worktree-root <wt>` fail from an arbitrary cwd —
+        # defeating the out-of-band targeting this flag exists for. The worktree toplevel drives
+        # BOTH the review target (diff gather + sandbox cwd) and the verdict bucket, which is
+        # exactly what an out-of-band co-gate driver wants: "review worktree X, mark into X."
+        root = Path(args.worktree_root).resolve(strict=False)
+        if not root.is_dir():
+            sys.stderr.write(
+                f"[codex-warden] --worktree-root does not exist or is not a directory: {root}\n"
+            )
+            return USAGE_ERROR
+    else:
+        try:
+            # cfr.repo_root() returns a str; the warden-hooks helpers need a Path (they do
+            # `repo_root / ".git"` etc.). The backend's cwd stays a str (codex --cd).
+            root = Path(cr.cfr.repo_root())
+        except cr.ReviewError as exc:
+            sys.stderr.write(f"[codex-warden] {exc.message}\n")
+            return exc.code
 
     # `root` (the worktree toplevel) is for gathering the diff + the codex sandbox cwd.
     # Warden state (verdict store, cross-review files, loop counter) is namespaced under

--- a/scripts/cogate.py
+++ b/scripts/cogate.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""One-command warden CO-GATE marker: mark the in-session Claude verdict AND run+mark the
+GPT verdict for a role, BOTH into the single per-worktree bucket the commit/edit gate reads.
+
+Why this exists: the co-gate needs two verdicts in the SAME bucket — the in-session Claude
+warden's (a `.<marker>` + role-keyed verdict) and a model backend's (`<role>@<backend>`).
+Marking them by hand is a 2-step that ALSO has to resolve the FLAT-vs-per-worktree bucket
+correctly: the Claude `mark` CLI defaults its `--repo-root` to the script's own toplevel (so
+from a linked worktree's own copy it writes the FLAT in-worktree store), while the GPT driver
+namespaces under the PRIMARY repo's per-worktree bucket via ``primary_repo_root`` — and the
+gate (warden-shim.sh → ``--git-common-dir`` parent) reads the per-worktree bucket. Get the two
+out of sync and the gate sees only one verdict and blocks. This wrapper resolves the worktree
+ONCE and routes BOTH marks through ``primary_repo_root`` + ``worktree_override``, the exact
+resolution the gate uses, so they can never split.
+
+It does NOT run Claude headlessly (there is no headless-Claude warden runner; the Claude
+verdict is produced by the in-session ``Agent(subagent_type=...)`` dispatch + the
+verdict-tracker hook). You pass that already-decided Claude verdict in; the wrapper records it
+and runs the GPT half.
+
+    # After the in-session plan-reviewer/code-reviewer agent returned SHIP:
+    python3 scripts/cogate.py --role code-reviewer --claude-verdict SHIP \
+        --claude-reason "code-reviewer SHIP: no blocking issues"
+
+    # Target a specific worktree from any cwd (out-of-band driver):
+    python3 scripts/cogate.py --role plan-reviewer --claude-verdict SHIP \
+        --claude-reason "..." --content-file plan.md --worktree-root /path/to/wt
+
+Exit codes (typed, agent-native — see scripts/_exit_codes.py):
+    0  SUCCESS        co-gate will PASS (Claude accepted AND GPT SHIP; or --skip-gpt + accepted)
+    2  USAGE_ERROR    bad arguments, or the Claude mark was REFUSED (e.g. bg-session TRIVIAL,
+                      or a TRIVIAL bypass after a prior REVISE/BLOCK) — GPT is NOT run
+    5  INTERNAL_ERROR a recorded verdict is REVISE/BLOCK — the gate will BLOCK
+    4/5/7             GPT COULD_NOT_RUN (auth/internal/rate): the gate fails OPEN (non-blocking),
+                      but this exits non-zero + warns LOUDLY so the operator sees GPT did not run
+Cross-platform: pathlib + in-process calls / arg-list only, no shell.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import codex_review as cr  # noqa: E402  (default worktree resolution + DEFAULT_TIMEOUT)
+import codex_warden  # noqa: E402  (the GPT half is its main(), invoked in-process)
+import codex_warden_hooks as whooks  # noqa: E402  (mark_warden, bucket resolution, readback)
+from _agent_io import agent_output, is_agent_context  # noqa: E402
+from _exit_codes import INTERNAL_ERROR, SUCCESS, USAGE_ERROR  # noqa: E402
+from warden_review.constants import BACKEND_GPT, store_key  # noqa: E402
+from warden_hooks.verdict_store import _read_verdicts  # noqa: E402
+
+# Only the GPT-wired warden roles (warden_review.constants.WIRED_ROLES) have a model backend, so
+# only these can be co-gated. The token is the EXACT codex_warden.py --role string (no aliases)
+# so the marker lookup and the GPT invocation are single-sourced and can never disagree.
+# Claude-only roles (threat-modeler/.threat-modeled, verification-gate/.verified) have no GPT
+# backend; mark those with `codex_warden_hooks.py mark <marker> SHIP` directly.
+ROLE_TO_MARKER = {
+    "plan-reviewer": "plan-reviewed",
+    "code-reviewer": "code-reviewed",
+    "ai-eng-warden": "ai-eng-reviewed",
+}
+
+_PASSING_GPT = "SHIP"
+_BLOCKING = {"REVISE", "BLOCK"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Mark the Claude verdict + run/mark the GPT verdict for a warden role, "
+                    "both into the per-worktree bucket the co-gate reads.",
+    )
+    ap.add_argument("--role", required=True, choices=sorted(ROLE_TO_MARKER),
+                    help="warden role to co-gate (GPT-wired roles only)")
+    ap.add_argument("--claude-verdict", required=True, choices=["SHIP", "TRIVIAL"],
+                    help="the in-session Claude warden's already-decided verdict")
+    ap.add_argument("--claude-reason", required=True,
+                    help="justification for the Claude verdict (audit-logged)")
+    ap.add_argument("--worktree-root", default=None,
+                    help="target worktree toplevel (default: the cwd's repo/worktree toplevel)")
+    src = ap.add_mutually_exclusive_group()
+    src.add_argument("--rev-range", help="commit sha or a..b range for the GPT review (default: working tree)")
+    src.add_argument("--content-file",
+                     help="file read verbatim as the GPT review target (non-diff roles, e.g. a plan)")
+    ap.add_argument("--gpt-timeout", type=float, default=cr.DEFAULT_TIMEOUT,
+                    help=f"per-call timeout for the GPT half, forwarded as --timeout "
+                         f"(default {cr.DEFAULT_TIMEOUT:.0f})")
+    ap.add_argument("--gpt-model", help="GPT backend model id (default: backend/config default)")
+    ap.add_argument("--skip-gpt", action="store_true",
+                    help="mark the Claude verdict only; do NOT run the GPT half (advisory/testing)")
+    ap.add_argument("--json", action="store_true", help="emit JSON (agent-native)")
+    ap.add_argument("--compact", action="store_true", help="compact JSON")
+    ap.add_argument("--select", help="comma-separated dot-paths to project from the JSON")
+    args = ap.parse_args(argv)
+
+    # 1) Resolve the target worktree ONCE — flag-first (so it works from any cwd), exactly like
+    #    codex_warden.py. marker_root = the PRIMARY repo, the bucket namespace the gate uses.
+    if args.worktree_root:
+        wt = Path(args.worktree_root).resolve(strict=False)
+        if not wt.is_dir():
+            sys.stderr.write(f"[cogate] --worktree-root does not exist or is not a directory: {wt}\n")
+            return USAGE_ERROR
+    else:
+        try:
+            wt = Path(cr.cfr.repo_root())
+        except cr.ReviewError as exc:
+            sys.stderr.write(f"[cogate] {exc.message}\n")
+            return exc.code
+    marker_root = whooks.primary_repo_root(wt)
+    marker = ROLE_TO_MARKER[args.role]
+    bucket = None
+    with whooks.worktree_override(wt):
+        # Surface where marks land so the operator can see the resolved bucket (the whole point).
+        try:
+            from warden_hooks.verdict_store import _verdicts_path
+            bucket = _verdicts_path(marker_root)
+        except Exception:  # pragma: no cover — display-only
+            bucket = None
+
+    # 2) Mark the Claude verdict into that bucket. mark_warden enforces the bg-session TRIVIAL
+    #    refusal + the post-REVISE/BLOCK guard for free; a non-zero return means REFUSED.
+    with whooks.worktree_override(wt):
+        claude_rc = whooks.mark_warden(marker, args.claude_verdict, args.claude_reason, marker_root)
+    if claude_rc != 0:
+        # Refused (e.g. bg TRIVIAL, or trivial-bypass after REVISE). Do NOT burn a GPT call —
+        # abort so the operator fixes the Claude side first. mark_warden already printed why.
+        sys.stderr.write("[cogate] Claude mark refused — aborting before the GPT half.\n")
+        return USAGE_ERROR if claude_rc in (1, 2) else claude_rc
+
+    # 3) Run the GPT half in-process, targeting the SAME worktree via --worktree-root, and
+    #    forwarding the timeout. (Skipped for the advisory/test path.)
+    gpt_rc = SUCCESS
+    if not args.skip_gpt:
+        gpt_argv = ["--role", args.role, "--backend", BACKEND_GPT, "--warden-mark",
+                    "--worktree-root", str(wt), "--timeout", str(args.gpt_timeout)]
+        if args.gpt_model:
+            gpt_argv += ["--model", args.gpt_model]
+        if args.content_file:
+            gpt_argv += ["--content-file", args.content_file]
+        elif args.rev_range:
+            gpt_argv += ["--rev-range", args.rev_range]
+        gpt_rc = codex_warden.main(gpt_argv)
+
+    # 4) Read BOTH verdicts back from the resolved bucket and compute the combined outcome by
+    #    mirroring run_warden_backends_gate: Claude passes on SHIP or accepted-TRIVIAL; GPT passes
+    #    on SHIP; GPT COULD_NOT_RUN makes the real gate fail OPEN (non-blocking).
+    with whooks.worktree_override(wt):
+        claude_verdict = whooks.read_claude_verdict(marker_root, args.role)
+        gpt_verdict = None
+        if not args.skip_gpt:
+            gpt_verdict = (_read_verdicts(marker_root).get(store_key(args.role, BACKEND_GPT)) or {}).get("verdict")
+
+    # Outcome
+    gate_blocked = (claude_verdict in _BLOCKING) or (gpt_verdict in _BLOCKING)
+    gpt_could_not_run = (not args.skip_gpt) and gpt_rc != SUCCESS and gpt_verdict not in (_PASSING_GPT, *_BLOCKING)
+    if args.skip_gpt:
+        passed = claude_verdict not in _BLOCKING
+        outcome = "PASS (claude-only, --skip-gpt)" if passed else "BLOCK"
+        exit_code = SUCCESS if passed else INTERNAL_ERROR
+    elif gate_blocked:
+        outcome, exit_code = "BLOCK", INTERNAL_ERROR
+    elif gpt_could_not_run:
+        outcome, exit_code = "GPT_COULD_NOT_RUN (gate fails open)", (gpt_rc or INTERNAL_ERROR)
+    elif gpt_verdict == _PASSING_GPT:
+        outcome, exit_code = "PASS", SUCCESS
+    else:
+        # GPT verdict missing/unrecognized with a zero rc — be conservative, treat as not-green.
+        outcome, exit_code = f"NOT GREEN (gpt={gpt_verdict!r})", INTERNAL_ERROR
+
+    payload = {
+        "role": args.role, "outcome": outcome, "exit_code": exit_code,
+        "claude_verdict": claude_verdict, "gpt_verdict": gpt_verdict,
+        "bucket": str(bucket) if bucket else None,
+    }
+    out = agent_output(payload, use_json=args.json or is_agent_context(),
+                       compact=args.compact, select=args.select)
+    if out is not None:
+        print(out)
+    else:
+        print(f"═══ co-gate {args.role} — {outcome} ═══")
+        print(f"  claude: {claude_verdict}   gpt: {gpt_verdict if not args.skip_gpt else '(skipped)'}")
+        if bucket:
+            print(f"  bucket: {bucket}")
+        if gpt_could_not_run:
+            sys.stderr.write(
+                "[cogate] WARNING: the GPT backend COULD NOT RUN — the real co-gate fails OPEN "
+                "(it will not block the commit), but no GPT review actually happened. "
+                "Investigate (auth/rate/timeout) before relying on this verdict.\n"
+            )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_codex_warden.py
+++ b/scripts/tests/test_codex_warden.py
@@ -104,6 +104,55 @@ def test_driver_plan_reviewer_without_content_file_errors(git_repo, monkeypatch)
     assert rc == USAGE_ERROR
 
 
+# ── RETRO-19-04: --worktree-root targets a specific worktree's review + bucket ──────
+
+def test_driver_worktree_root_routes_to_target_bucket(tmp_path, monkeypatch):
+    # --worktree-root <target> must record the verdict into <target>'s bucket, NOT the
+    # cwd-derived repo_root's — that is the parity the flag exists for.
+    cwd_repo = tmp_path / "cwd"
+    target = tmp_path / "target"
+    subprocess.run(["git", "init", "-q", str(cwd_repo)], check=True)
+    subprocess.run(["git", "init", "-q", str(target)], check=True)
+    monkeypatch.setattr(cw.cr.cfr, "repo_root", lambda: str(cwd_repo))
+    monkeypatch.setattr(cw.cr.cfr, "get_diff", lambda root, rr, df: _DIFF)
+    monkeypatch.setattr(cw.registry, "is_registered", lambda b: True)
+    monkeypatch.setattr(cw.registry, "get_backend",
+                        lambda b: _fake_backend(Verdict("SHIP", [], "ok")))
+
+    rc = cw.main(["--role", "code-reviewer", "--warden-mark", "--worktree-root", str(target)])
+    assert rc == 0
+    assert cw.whooks._read_verdict("code-reviewer@gpt", target) == "SHIP"
+    assert cw.whooks._read_verdict("code-reviewer@gpt", cwd_repo) is None
+
+
+def test_driver_worktree_root_resolved_before_repo_root_raises(tmp_path, monkeypatch):
+    # Flag-first ordering: --worktree-root must be resolved WITHOUT calling cr.cfr.repo_root()
+    # (which raises → USAGE_ERROR outside a git repo). If repo_root were consulted, this boom
+    # would propagate and fail the test — proving the flag works from an arbitrary cwd.
+    target = tmp_path / "target"
+    subprocess.run(["git", "init", "-q", str(target)], check=True)
+
+    def _boom():
+        raise RuntimeError("cr.cfr.repo_root() must NOT be called when --worktree-root is set")
+    monkeypatch.setattr(cw.cr.cfr, "repo_root", _boom)
+    monkeypatch.setattr(cw.cr.cfr, "get_diff", lambda root, rr, df: _DIFF)
+    monkeypatch.setattr(cw.registry, "is_registered", lambda b: True)
+    monkeypatch.setattr(cw.registry, "get_backend",
+                        lambda b: _fake_backend(Verdict("SHIP", [], "ok")))
+
+    rc = cw.main(["--role", "code-reviewer", "--warden-mark", "--worktree-root", str(target)])
+    assert rc == 0
+    assert cw.whooks._read_verdict("code-reviewer@gpt", target) == "SHIP"
+
+
+def test_driver_worktree_root_missing_dir_usage_error(tmp_path, monkeypatch):
+    from _exit_codes import USAGE_ERROR
+    monkeypatch.setattr(cw.cr.cfr, "repo_root", lambda: str(tmp_path))
+    rc = cw.main(["--role", "code-reviewer", "--warden-mark",
+                  "--worktree-root", str(tmp_path / "does-not-exist")])
+    assert rc == USAGE_ERROR
+
+
 def test_driver_out_writes_json(git_repo, tmp_path, monkeypatch):
     monkeypatch.setattr(cw.cr.cfr, "repo_root", lambda: str(git_repo))
     monkeypatch.setattr(cw.cr.cfr, "get_diff", lambda root, rr, df: _DIFF)

--- a/scripts/tests/test_cogate.py
+++ b/scripts/tests/test_cogate.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/cogate.py — the one-command warden co-gate marker.
+
+The GPT half (codex_warden.main) is FAKED so no codex CLI / subscription quota is touched;
+the fake records the ``<role>@gpt`` verdict into the same resolved bucket the real driver
+would, so the wrapper's readback + combined-outcome logic is exercised end to end. The Claude
+half (mark_warden) runs for real against a temporary git repo.
+
+This is a background session (CLAUDE_JOB_DIR is set in the ambient env), so every test that
+depends on bg-vs-interactive detection sets/clears CLAUDE_JOB_DIR explicitly via monkeypatch —
+never relying on the ambient value.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import cogate
+from _exit_codes import INTERNAL_ERROR, SUCCESS, USAGE_ERROR
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    return tmp_path
+
+
+def _fake_gpt(verdict: str = "SHIP"):
+    """Stand-in for codex_warden.main: record <role>@gpt into the --worktree-root bucket
+    (mirroring the real driver) and return 0. Records every argv it was called with."""
+    calls: list[list[str]] = []
+
+    def _main(argv):
+        calls.append(list(argv))
+        role = argv[argv.index("--role") + 1]
+        wt = Path(argv[argv.index("--worktree-root") + 1])
+        with cogate.whooks.worktree_override(wt):
+            mr = cogate.whooks.primary_repo_root(wt)
+            cogate.whooks.record_script_verdict(mr, cogate.store_key(role, "gpt"), verdict, "fake gpt")
+        return SUCCESS
+
+    _main.calls = calls
+    return _main
+
+
+def _read_gpt(repo_root: Path, role: str):
+    with cogate.whooks.worktree_override(repo_root):
+        return cogate.whooks.read_claude_verdict(repo_root, role), \
+            (cogate.whooks._read_verdicts(cogate.whooks.primary_repo_root(repo_root))
+             .get(cogate.store_key(role, "gpt")) or {}).get("verdict")
+
+
+# (a) happy path — claude SHIP + gpt SHIP → both marked, combined PASS
+def test_happy_path_both_ship(git_repo, monkeypatch):
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)  # interactive
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", _fake_gpt("SHIP"))
+    rc = cogate.main(["--role", "code-reviewer", "--claude-verdict", "SHIP",
+                      "--claude-reason", "no blocking issues"])
+    assert rc == SUCCESS
+    claude_v, gpt_v = _read_gpt(git_repo, "code-reviewer")
+    assert claude_v == "SHIP" and gpt_v == "SHIP"
+    assert (git_repo / ".claude" / ".code-reviewed").exists()  # marker touched (Claude side)
+
+
+# (b) --worktree-root routes BOTH marks into the target's bucket, not the cwd's
+def test_worktree_root_routes_both_marks(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+    cwd_repo = tmp_path / "cwd"
+    target = tmp_path / "target"
+    subprocess.run(["git", "init", "-q", str(cwd_repo)], check=True)
+    subprocess.run(["git", "init", "-q", str(target)], check=True)
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(cwd_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", _fake_gpt("SHIP"))
+    rc = cogate.main(["--role", "plan-reviewer", "--claude-verdict", "SHIP",
+                      "--claude-reason", "sound", "--worktree-root", str(target)])
+    assert rc == SUCCESS
+    claude_t, gpt_t = _read_gpt(target, "plan-reviewer")
+    assert claude_t == "SHIP" and gpt_t == "SHIP"
+    # cwd bucket untouched
+    claude_c, gpt_c = _read_gpt(cwd_repo, "plan-reviewer")
+    assert claude_c is None and gpt_c is None
+
+
+# (c) bg-session + Claude TRIVIAL → REFUSED, and GPT is NOT run (abort-before-gpt)
+def test_bg_trivial_refused_aborts_before_gpt(git_repo, monkeypatch):
+    monkeypatch.setenv("CLAUDE_JOB_DIR", str(git_repo))  # exactly what _is_bg_session() checks
+    fake = _fake_gpt("SHIP")
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", fake)
+    rc = cogate.main(["--role", "code-reviewer", "--claude-verdict", "TRIVIAL",
+                      "--claude-reason", "tiny"])
+    assert rc == USAGE_ERROR          # mark_warden returns 2 in a bg session
+    assert fake.calls == []           # GPT half never invoked
+
+
+# (d) unknown / Claude-only role rejected at argparse
+def test_unknown_role_rejected(monkeypatch):
+    with pytest.raises(SystemExit) as ei:
+        cogate.main(["--role", "threat-modeler", "--claude-verdict", "SHIP",
+                     "--claude-reason", "x"])
+    assert ei.value.code == 2  # argparse usage error
+
+
+# (e) role→marker mapping is exactly the 3 GPT-wired roles
+def test_role_to_marker_mapping():
+    assert cogate.ROLE_TO_MARKER == {
+        "plan-reviewer": "plan-reviewed",
+        "code-reviewer": "code-reviewed",
+        "ai-eng-warden": "ai-eng-reviewed",
+    }
+
+
+# (f) INTERACTIVE accepted Claude TRIVIAL + GPT SHIP → combined PASS (exit 0), NOT a false fail
+def test_interactive_trivial_plus_ship_passes(git_repo, monkeypatch):
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)  # interactive → TRIVIAL allowed
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", _fake_gpt("SHIP"))
+    rc = cogate.main(["--role", "ai-eng-warden", "--claude-verdict", "TRIVIAL",
+                      "--claude-reason", "cosmetic"])
+    assert rc == SUCCESS
+    claude_v, gpt_v = _read_gpt(git_repo, "ai-eng-warden")
+    assert claude_v == "TRIVIAL" and gpt_v == "SHIP"
+
+
+# (g) --gpt-timeout is forwarded to codex_warden.main as --timeout
+def test_gpt_timeout_forwarded(git_repo, monkeypatch):
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+    fake = _fake_gpt("SHIP")
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", fake)
+    rc = cogate.main(["--role", "code-reviewer", "--claude-verdict", "SHIP",
+                      "--claude-reason", "ok", "--gpt-timeout", "123"])
+    assert rc == SUCCESS
+    argv = fake.calls[0]
+    assert "--timeout" in argv and argv[argv.index("--timeout") + 1] == "123.0"
+
+
+# GPT REVISE → combined BLOCK (the gate would block); exit non-zero
+def test_gpt_revise_blocks(git_repo, monkeypatch):
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", _fake_gpt("REVISE"))
+    rc = cogate.main(["--role", "code-reviewer", "--claude-verdict", "SHIP",
+                      "--claude-reason", "ok"])
+    assert rc == INTERNAL_ERROR
+
+
+# --skip-gpt marks Claude only and never invokes the GPT half
+def test_skip_gpt_marks_claude_only(git_repo, monkeypatch):
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+    fake = _fake_gpt("SHIP")
+    monkeypatch.setattr(cogate.cr.cfr, "repo_root", lambda: str(git_repo))
+    monkeypatch.setattr(cogate.codex_warden, "main", fake)
+    rc = cogate.main(["--role", "code-reviewer", "--claude-verdict", "SHIP",
+                      "--claude-reason", "ok", "--skip-gpt"])
+    assert rc == SUCCESS
+    assert fake.calls == []
+    claude_v, _ = _read_gpt(git_repo, "code-reviewer")
+    assert claude_v == "SHIP"


### PR DESCRIPTION
## RETRO-2026-06-19-04 — warden co-gate wrapper + `--worktree-root` parity

Collapses the manual 2-step warden co-gate marking (mark the in-session Claude verdict; run+mark the GPT verdict) **plus** the FLAT-vs-per-worktree bucket resolution into one namespace-aware command, so the orchestration-rules *"Warden Co-Gate Verdict Marking"* rule no longer has to be remembered under session pressure.

### Why
This change was dogfooded on its own gates and hit the exact footgun it removes: marking the Claude `plan-reviewed` verdict from a linked worktree's own `codex_warden_hooks.py` defaulted `--repo-root` to the worktree, writing the **flat-in-worktree** store, while the GPT driver namespaced under the **primary repo's per-worktree** bucket (`primary_repo_root`) — and the gate (`warden-shim.sh` → `git --git-common-dir` parent) reads the per-worktree bucket. The two marks split across buckets and the gate saw only one. The wrapper resolves the worktree **once** and routes both marks through `primary_repo_root` + `worktree_override`, the exact resolution the gate uses, so they can never desync.

### Changes
- **`scripts/codex_warden.py`** — add `--worktree-root` (flag-first resolution: resolved *before* `cr.cfr.repo_root()`, which raises `USAGE_ERROR` outside a git repo, so the flag works from any cwd). Parity with `codex_warden_hooks.py mark --worktree-root`.
- **`scripts/cogate.py`** *(new)* — one-command co-gate marker. Resolves the worktree once, marks the in-session Claude verdict via `mark_warden` (inheriting the bg-session TRIVIAL refusal + post-REVISE guard), runs+marks the GPT verdict via `codex_warden.main(--worktree-root …)` in-process, reads both back, and prints a combined outcome with typed exit codes. Scoped to the 3 GPT-wired roles (`plan-reviewer`, `code-reviewer`, `ai-eng-warden`); aborts before the GPT call if the Claude mark is refused.
- **tests** — `scripts/tests/test_cogate.py` (9 cases: happy path, `--worktree-root` routing, bg-TRIVIAL abort-before-GPT, role rejection, role→marker mapping, interactive accepted-TRIVIAL + SHIP → exit 0, `--gpt-timeout` forwarding, GPT REVISE → block, `--skip-gpt`) + 3 `--worktree-root` cases in `scripts/tests/test_codex_warden.py`; wired into the warden suite in `.github/workflows/ci.yml`.

### Scope notes
- The retro's *"runs the Claude review"* is delivered as *"marks the in-session Claude verdict"*: there is **no** headless-Claude warden runner (the Claude verdict is produced by the in-session `Agent` + verdict-tracker hook), and introducing one would be a new hot security surface. The wrapper orchestrates marking only.
- Claude-only roles (`threat-modeler`, `verification-gate`) have no GPT backend and are intentionally out of scope; use `codex_warden_hooks.py mark` for those.

### Verification
- Full warden suite green: **392 passed** (`test_warden_review`, `test_codex_warden`, `test_codex_review`, `test_phase3_cogate_oracle`, `test_codex_warden_hooks`, `test_cogate`).
- Both scripts compile; flag-lint clean; diff is code-only (no verdict-state files, no personal paths/secrets).
- Gated through plan-review (2 REVISE rounds → SHIP, both backends), code-review (SHIP, both backends), and verification (SHIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
