### PR TITLE
feat(skills): import improve-codebase-architecture from mattpocock/skills (MIT)

### DIFF
--- a/.claude/skills/ATTRIBUTION-mattpocock-skills.md
+++ b/.claude/skills/ATTRIBUTION-mattpocock-skills.md
@@ -1,6 +1,6 @@
 # Attribution — mattpocock/skills
 
-The following 11 host skills were imported into Deus from the open-source repo
+The following 12 host skills were imported into Deus from the open-source repo
 **[mattpocock/skills](https://github.com/mattpocock/skills)** (MIT-licensed):
 
 | Skill | Upstream path |
@@ -16,6 +16,7 @@ The following 11 host skills were imported into Deus from the open-source repo
 | `prototype` | `skills/engineering/prototype` |
 | `codebase-design` | `skills/engineering/codebase-design` |
 | `resolving-merge-conflicts` | `skills/engineering/resolving-merge-conflicts` |
+| `improve-codebase-architecture` | `skills/engineering/improve-codebase-architecture` |
 
 **Source:** `github.com/mattpocock/skills` @ commit `6eeb81b`
 (`6eeb81b5fcfeeb5bd531dd47ab2f9f2bbea27461`).
@@ -23,9 +24,10 @@ The following 11 host skills were imported into Deus from the open-source repo
 ## Adaptations from upstream
 
 The skill bodies are **byte-identical** to upstream. The only change is additive: Deus's
-`user_invocable: true` frontmatter field was added to the five user-only skills (`grill-me`,
-`grill-with-docs`, `teach`, `writing-great-skills`, `prototype` — the ones carrying upstream's
-`disable-model-invocation: true`) for convention consistency. Invocation semantics are unchanged.
+`user_invocable: true` frontmatter field was added to the six user-only skills (`grill-me`,
+`grill-with-docs`, `teach`, `writing-great-skills`, `prototype`, `improve-codebase-architecture`
+— the ones carrying upstream's `disable-model-invocation: true`) for convention consistency.
+Invocation semantics are unchanged.
 
 ### Notes for users
 
@@ -35,11 +37,11 @@ The skill bodies are **byte-identical** to upstream. The only change is additive
   log lives in `docs/decisions/` (see `docs/decisions/INDEX.md`) — these skills were deliberately
   **not** re-routed to it, so they remain portable to any repo. When using them inside `~/deus`,
   be aware they default to `docs/adr/`, not `docs/decisions/`.
-- **Known dangling reference.** `diagnosing-bugs` (`SKILL.md`, final step) instructs a hand-off to
-  the `/improve-codebase-architecture` skill, which was **not** imported. Invoking it will error.
-  This reference is only reached at the very end of a debug session (after the fix is in) as an
-  optional "what would have prevented this bug?" follow-up. Import `improve-codebase-architecture`
-  from the same upstream repo if you want that hand-off to resolve.
+- **`diagnosing-bugs` hand-off resolves.** `diagnosing-bugs` (`SKILL.md`, final step) instructs an
+  optional hand-off to the `/improve-codebase-architecture` skill, reached at the very end of a debug
+  session (after the fix is in) as a "what would have prevented this bug?" follow-up. That skill is
+  now imported (see the table above), so the hand-off resolves. It depends on `/codebase-design` for
+  its architecture vocabulary, which is also imported.
 
 ## License
 

--- a/.claude/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.claude/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms (from the `/codebase-design` skill) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from the `/codebase-design` skill. Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in the `/codebase-design` glossary, reach for one that is before inventing a new one.

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: improve-codebase-architecture
+description: Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
+disable-model-invocation: true
+user_invocable: true
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+This command is _informed_ by the project's domain model and built on a shared design vocabulary:
+
+- Run the `/codebase-design` skill for the architecture vocabulary (**module**, **interface**, **depth**, **seam**, **adapter**, **leverage**, **locality**) and its principles (the deletion test, "the interface is the test surface", "one adapter = hypothetical seam, two = real"). Use these terms exactly in every suggestion — don't drift into "component," "service," "API," or "boundary."
+- The domain language in `CONTEXT.md` gives names to good seams; ADRs in `docs/adr/` record decisions this command should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, render a card with:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and the `/codebase-design` vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, run the `/grilling` skill to walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize — run the `/domain-modeling` skill to keep the domain model current as you go:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md`. Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones.
+- **Want to explore alternative interfaces for the deepened module?** Run the `/codebase-design` skill and use its design-it-twice parallel sub-agent pattern.

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-19" # auto-bump @1781858546
+last_verified: "2026-06-19" # auto-bump @1781873107
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

Imports the `improve-codebase-architecture` host skill from the upstream MIT repo [mattpocock/skills](https://github.com/mattpocock/skills) @ `6eeb81b`, following the exact precedent of #888 (which imported 11 sibling skills from the same repo/commit).

## Why

`diagnosing-bugs/SKILL.md:134` instructs an optional end-of-debug hand-off to `/improve-codebase-architecture`, which was **not** imported in #888 — a documented dangling reference. This resolves it. The new skill's own dependencies (`/codebase-design`, `/domain-modeling`, `/grilling`) are all already present.

## Changes

- `+ .claude/skills/improve-codebase-architecture/SKILL.md` — byte-identical to upstream (git blob sha `a79b493e`) **except** one additive frontmatter line `user_invocable: true`, matching the convention applied to the 5 prior user-only imports (it carries upstream's `disable-model-invocation: true`).
- `+ .claude/skills/improve-codebase-architecture/HTML-REPORT.md` — byte-identical to upstream (git blob sha `17f6d2c7`).
- `~ .claude/skills/ATTRIBUTION-mattpocock-skills.md` — count 11→12, new table row, adaptations note 5→6 user-only skills, "Known dangling reference" note rewritten to "resolves".

## Verification

- Both new files verified byte-identical via `git hash-object` matching upstream blob SHAs.
- Referenced skills present (no new dangling refs); MIT notice retained; grep-clean of personal data.
- Markdown-only — no source/build/deploy. Wardens: plan-reviewer SHIP, code-reviewer SHIP (Claude + GPT), verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)