### PR TITLE
chore(gitignore): ignore warden co-gate + experiment runtime ephemera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,15 @@ dist/
 .claude/.warden-verdicts.json.bak-*
 # Per-worktree gate state (markers + verdict store, namespaced by worktree)
 .claude/worktree-markers/
+# Co-gate backend verdict markers (user-local; per-role @<backend>)
+.claude/.*@*
+# Co-gate loop backups (timestamped runtime ephemera)
+.claude/.co-gate-loop-*.bak-*
+# Plan revise log + scratch plan docs (host-local working notes)
+.claude/plan-revise-log.jsonl
+.claude/.plan-*.md
+# One-time migration nudge flag (host-local)
+.claude/.migration-nudged
 
 # Warden config (user-local toggle state and custom instructions)
 .claude/wardens/config.json
@@ -27,6 +36,8 @@ dist/
 store/
 data/
 logs/
+# Local experiment scratch space (never shipped)
+/experiments/
 
 # Groups - only track base structure and template files
 groups/*


### PR DESCRIPTION
## What

Adds 6 `.gitignore` patterns so 8 untracked user-local runtime artifacts stop dirtying `git status` on `main`.

## Why

These are all regenerated per-session and never meant to be committed — they were accumulating as untracked noise:

| Ignored | Rule |
|---|---|
| `.claude/.code-reviewer@gpt`, `.ai-eng-warden@gpt`, `.plan-reviewer@gpt` | `.claude/.*@*` (co-gate per-role backend verdict markers) |
| `.claude/.co-gate-loop-*.bak-*` | co-gate loop backups |
| `.claude/plan-revise-log.jsonl`, `.claude/.plan-*.md` | plan revise log + scratch plan docs |
| `.claude/.migration-nudged` | one-time migration nudge flag |
| `experiments/` | local experiment scratch (anchored `/experiments/` per review) |

These sit alongside the existing `.claude/.plan-reviewed` / `.code-reviewed` / `.warden-verdicts.json.bak-*` ignores — same "user-local warden ephemera" family.

## Verification

- `git check-ignore -v` matches all 8 target paths to their intended rule.
- `git ls-files` against every new glob returns empty — **no currently-tracked file is caught**.
- Comments each on their own line (per the `.gitignore`-no-inline-comments gotcha).
- `/experiments/` anchored to repo root (code-reviewer recommendation) to avoid shadowing a hypothetical future nested `experiments/` dir; confirmed it still matches `experiments/sandcastle/`.

Wardens: plan-reviewer SHIP (Claude + GPT), code-reviewer SHIP (Claude + GPT), verified.

**Out of scope (deferred):** `.claude/.warden-log` + `.claude/.warden-verdicts.json` are already *tracked* and get modified every session — a separate behavioral question (the commit gate reads the verdict store), not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)