### PR TITLE
fix(ingress): register webhook chat on inbound to fix silent FK message loss (LIA-315)

### DIFF
--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-06-20" # auto-bump @1781906887
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-06-20" # auto-bump @1781906887
 governs:
   - src/
   - evolution/

--- a/src/channels/webhook.test.ts
+++ b/src/channels/webhook.test.ts
@@ -37,6 +37,19 @@ function sign(body: Buffer): string {
   );
 }
 
+function fakeRes() {
+  const out: { status?: number } = {};
+  const res = {
+    writeHead: (s: number) => {
+      out.status = s;
+      return res;
+    },
+    end: () => {},
+    writableEnded: false,
+  } as unknown as import('http').ServerResponse;
+  return { res, out };
+}
+
 function build(
   sources: ReturnType<typeof source>[],
   registeredGroups: Record<string, RegisteredGroup>,
@@ -49,7 +62,12 @@ function build(
     registeredGroups: () => registeredGroups,
   };
   const channel = createWebhookChannel(opts, sources, (h) => handlers.push(h));
-  return { channel, handler: handlers[0]!, onMessage: opts.onMessage };
+  return {
+    channel,
+    handler: handlers[0]!,
+    onMessage: opts.onMessage,
+    onChatMetadata: opts.onChatMetadata as ReturnType<typeof vi.fn>,
+  };
 }
 
 describe('createWebhookChannel — R3 fatal-skip makes the route inert', () => {
@@ -130,5 +148,44 @@ describe('createWebhookChannel — R3 fatal-skip makes the route inert', () => {
       (await handler.verify(makeReq('/hook/selfsrc', sign(body), body), body))
         .ok,
     ).toBe(true);
+  });
+});
+
+describe('createWebhookChannel — registers the chat lazily on inbound (FK fix)', () => {
+  it('does NOT call onChatMetadata at construction (no startup recency pollution)', () => {
+    // Registering chats at startup would bump chats.last_message_time on every
+    // restart (storeChatMetadata MAX()), making idle webhook chats look active.
+    const { onChatMetadata } = build(
+      [source('good', 'webhook-sandbox-good')],
+      {},
+    );
+    expect(onChatMetadata).not.toHaveBeenCalled();
+  });
+
+  it('handle() registers the chat (onChatMetadata, channel "webhook", event timestamp) before onMessage', async () => {
+    // The chats row must exist before storeMessage (messages.chat_jid FKs to
+    // chats.jid) or the first event throws SQLITE_CONSTRAINT_FOREIGNKEY silently.
+    const { handler, onChatMetadata, onMessage } = build(
+      [source('good', 'webhook-sandbox-good')],
+      {},
+    );
+    const body = Buffer.from('{"event":"x"}');
+    const { res } = fakeRes();
+    await handler.handle(makeReq('/hook/good', sign(body), body), res, body);
+
+    expect(onChatMetadata).toHaveBeenCalledTimes(1);
+    const [chatJid, ts, , channel] = onChatMetadata.mock.calls[0] as [
+      string,
+      string,
+      string,
+      string,
+      boolean,
+    ];
+    expect(chatJid).toBe('webhook:good');
+    expect(channel).toBe('webhook');
+    // Same timestamp as the dispatched message (correct recency, not startup time).
+    const [, msg] = (onMessage as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, { timestamp: string }];
+    expect(ts).toBe(msg.timestamp);
   });
 });

--- a/src/channels/webhook.ts
+++ b/src/channels/webhook.ts
@@ -217,6 +217,20 @@ export function createWebhookChannel(
         is_from_me: false,
         is_bot_message: false,
       };
+      // Register the chat row BEFORE onMessage → storeMessage (idiomatic
+      // register-chat-on-inbound, like every messaging channel). `messages.chat_jid`
+      // FKs to `chats(jid)`; without this the first event's storeMessage throws
+      // SQLITE_CONSTRAINT_FOREIGNKEY — silently, since onMessage is async and
+      // un-awaited after the 202. Doing it here (lazy, on a real event) — not at
+      // startup — means it never bumps `chats.last_message_time` for idle sources,
+      // and uses the event's own timestamp for correct recency.
+      opts.onChatMetadata(
+        jid,
+        message.timestamp,
+        `Webhook: ${source.name}`,
+        'webhook',
+        false,
+      );
       // Fire into the pipeline; the run + R5/R6 caps happen async in the
       // orchestrator. Respond 202 (accepted) — the sender is not held open for
       // a multi-minute agent run, and a caps rejection load-sheds server-side.


### PR DESCRIPTION
## What

Follow-up fix to the merged LIA-315 Phase 4 generic webhook channel (#906), found by **live end-to-end testing** (the mocked oracle never touched the DB).

The channel provisioned the per-source sandbox **group** but never registered the **chat** in `chats`. `messages.chat_jid` FKs to `chats(jid)` (enforced live), so the first inbound webhook event's `storeMessage` threw `SQLITE_CONSTRAINT_FOREIGNKEY` — **silently**, because `handle()` calls the async `onMessage` un-awaited after the 202. Net: the channel verified + 202'd but every event was lost (no message stored → no agent run).

## Fix

Register the chat **lazily in `handle()`** (idiomatic register-chat-on-inbound), immediately before `opts.onMessage`, with the event's own timestamp:
```ts
opts.onChatMetadata(jid, message.timestamp, `Webhook: ${source.name}`, 'webhook', false);
opts.onMessage(jid, message);
```
- FK satisfied in the same synchronous flow as `storeMessage` (no window; `handle()` runs only after `verify()` passes).
- Fires only on real events (not at construction) → no startup recency pollution of `chats.last_message_time`.
- Correct recency; no orphan chats for bad-signature/unknown-source traffic.

## Review

Co-gate caught two issues in the fix itself: a startup FK window (connect-time approach, GPT plan-reviewer) and restart recency pollution (construction-time approach, GPT ai-eng) → lazy-on-inbound. v3: plan (Claude+GPT), code (Claude+GPT+GLM), ai-eng (Claude+GPT) all SHIP; verification-gate (Opus) SHIP with a mutation check proving the regression test discriminates. Full suite 1869 green; lint at the 220 ratchet.

## Live verification

With a manual `chats` stand-in (before this fix), confirmed the full pipeline: signed POST → 202 (bad/unknown → 403), R6 `admitted` audit row, container spawned with `DEUS_TOOL_PROFILE=webhook` (R1 no-Bash) and no `LINEAR_API_KEY` (R2). This PR removes the need for the stand-in.

LIA-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)