### PR TITLE
fix(memory): tune Web UI consolidation to >=3 turns AND >=500 chars (LIA-295)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-20" # auto-bump @1781906887
+last_verified: "2026-06-20" # auto-bump @1781909323
 governs:
   - src/
   - evolution/

--- a/src/consolidation-golden.test.ts
+++ b/src/consolidation-golden.test.ts
@@ -78,6 +78,9 @@ function makeGroup(): RegisteredGroup {
   } as unknown as RegisteredGroup;
 }
 
+// Intentionally short (~60 chars) — below the AND char floor by default. Each
+// @oracle test using it pins MIN_TURNS/MIN_CHARS low so the write path runs and
+// the byte snapshot / contract is what's exercised, not the threshold default.
 const WEBUI_FIXTURE = {
   messages: [
     { role: 'user', content: 'How do I configure X?' },
@@ -152,6 +155,11 @@ describe('@oracle auto-compress output', () => {
 
 describe('@oracle webui-consolidation output', () => {
   it('byte-stable web-session envelope handed to writeSessionLogAndIndex', () => {
+    // Pin thresholds low so this fixture writes regardless of the default — the
+    // oracle pins the ENVELOPE bytes, not the threshold default (cf. the skip
+    // test below). Fixture text/hash are unchanged, so the snapshot is too.
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS = '3';
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS = '50';
     consolidateWebConversation(WEBUI_FIXTURE);
 
     expect(mockWrite).toHaveBeenCalledTimes(1);
@@ -224,6 +232,10 @@ describe('@oracle skip contracts', () => {
       ],
     };
 
+    // Pin thresholds low so the fixture clears the AND gate and the test
+    // exercises the vault-skip + key-release contract, not the threshold.
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS = '3';
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS = '50';
     mockResolveVault.mockReturnValue(null);
     consolidateWebConversation(fixture);
     expect(mockWrite).not.toHaveBeenCalled();
@@ -261,6 +273,10 @@ describe('@oracle throw/await contracts', () => {
         { role: 'user', content: 'q3' },
       ],
     };
+    // Pin thresholds low so the fixture clears the AND gate and the test
+    // exercises the swallow + key-release contract, not the threshold.
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS = '3';
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS = '50';
     mockWrite.mockImplementation(() => {
       throw new Error('EACCES: permission denied');
     });

--- a/src/webui-consolidation.test.ts
+++ b/src/webui-consolidation.test.ts
@@ -36,15 +36,23 @@ function body(turns: Turn[]): unknown {
   return { messages: turns };
 }
 
-/** N user/assistant turn-pairs, first user message customizable for hashing. */
+/**
+ * N user/assistant turn-pairs, first user message customizable for hashing.
+ *
+ * Assistant messages are padded to ~200 chars each so a >=3-turn conversation
+ * clears the MIN_CHARS (500) floor under AND semantics — keeping the structural
+ * tests (path/tldr/idempotency/vault) consolidating without touching the
+ * first-user message they hash and quote.
+ */
 function conversation(
   userCount: number,
   firstUser = 'first question',
 ): unknown {
+  const pad = 'pad '.repeat(50).trim(); // ~199 chars of filler per assistant
   const turns: Turn[] = [];
   for (let i = 0; i < userCount; i++) {
     turns.push({ role: 'user', content: i === 0 ? firstUser : `q${i}` });
-    turns.push({ role: 'assistant', content: `a${i}` });
+    turns.push({ role: 'assistant', content: `a${i} ${pad}` });
   }
   return body(turns);
 }
@@ -64,10 +72,38 @@ afterEach(() => {
   settle?.();
 });
 
-describe('consolidateWebConversation — threshold', () => {
-  it('consolidates at the default 3-user-turn boundary (>=)', () => {
+describe('consolidateWebConversation — threshold (AND semantics)', () => {
+  it('consolidates when BOTH thresholds met (>=3 turns AND >=500 chars)', () => {
+    // The padded helper yields ~600 transcript chars for 3 turns.
     consolidateWebConversation(conversation(3, 'boundary-3-turns'));
     expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips when >=3 turns but below the char threshold', () => {
+    // 3 user turns, tiny content (~60 chars) — fails the AND on chars.
+    consolidateWebConversation(
+      body([
+        { role: 'user', content: 'a' },
+        { role: 'assistant', content: 'b' },
+        { role: 'user', content: 'c' },
+        { role: 'assistant', content: 'd' },
+        { role: 'user', content: 'e' },
+      ]),
+    );
+    expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
+  });
+
+  it('skips when >=500 chars but fewer than 3 turns', () => {
+    // 1 long user turn (>500 chars) — fails the AND on turns. (A single long
+    // answer is no longer enough on its own; replaces the old OR-era test.)
+    const long = 'x'.repeat(600);
+    consolidateWebConversation(
+      body([
+        { role: 'user', content: long },
+        { role: 'assistant', content: 'ok' },
+      ]),
+    );
+    expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
   });
 
   it('skips a short single-turn conversation (below both thresholds)', () => {
@@ -75,19 +111,11 @@ describe('consolidateWebConversation — threshold', () => {
     expect(mockWriteSessionLogAndIndex).not.toHaveBeenCalled();
   });
 
-  it('consolidates a 1-turn conversation that exceeds the char threshold', () => {
-    const long = 'x'.repeat(250);
-    consolidateWebConversation(
-      body([
-        { role: 'user', content: long },
-        { role: 'assistant', content: 'ok' },
-      ]),
-    );
-    expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
-  });
-
-  it('honors env-overridden MIN_TURNS', () => {
+  it('honors env-overridden MIN_TURNS and MIN_CHARS together', () => {
+    // AND semantics: lowering only MIN_TURNS would still fail the char floor,
+    // so this test must lower BOTH knobs. Keep both — do not strip MIN_CHARS.
     process.env.DEUS_WEBUI_CONSOLIDATE_MIN_TURNS = '2';
+    process.env.DEUS_WEBUI_CONSOLIDATE_MIN_CHARS = '50';
     consolidateWebConversation(conversation(2, 'two-turn-override'));
     expect(mockWriteSessionLogAndIndex).toHaveBeenCalledTimes(1);
   });
@@ -132,7 +160,8 @@ describe('consolidateWebConversation — vault + content', () => {
         { role: 'assistant', content: 'X is Y' },
         { role: 'user', content: 'and Z?' },
         { role: 'assistant', content: 'Z too' },
-        { role: 'user', content: 'thanks' },
+        // Padded so the conversation clears the 500-char floor under AND.
+        { role: 'user', content: `thanks ${'detail '.repeat(80)}` },
       ]),
     );
     const content = mockWriteSessionLogAndIndex.mock.calls[0][1];
@@ -164,7 +193,8 @@ describe('consolidateWebConversation — vault + content', () => {
         { role: 'user', content: 'hello there friend' },
         { role: 'assistant', content: 'hi' },
         { role: 'user', content: 'more' },
-        { role: 'user', content: 'and more text to cross threshold' },
+        // Padded so the conversation clears 3 turns AND the 500-char floor.
+        { role: 'user', content: `and more text ${'word '.repeat(100)}` },
       ]),
     );
     const content = mockWriteSessionLogAndIndex.mock.calls[0][1];

--- a/src/webui-consolidation.ts
+++ b/src/webui-consolidation.ts
@@ -31,10 +31,11 @@ function consolidationEnabled(): boolean {
   return raw !== '0' && raw !== 'false';
 }
 
-// Consolidate once the conversation reaches EITHER threshold (env-overridable;
+// Consolidate once the conversation reaches BOTH thresholds (env-overridable;
 // envPositiveInt clamps a non-positive/NaN override back to the fallback).
+// AND (not OR): a short chat or a single long answer isn't worth a vault file.
 const MIN_TURNS = () => envPositiveInt('DEUS_WEBUI_CONSOLIDATE_MIN_TURNS', 3);
-const MIN_CHARS = () => envPositiveInt('DEUS_WEBUI_CONSOLIDATE_MIN_CHARS', 200);
+const MIN_CHARS = () => envPositiveInt('DEUS_WEBUI_CONSOLIDATE_MIN_CHARS', 500);
 
 // In-flight guard keyed by conversation hash. A per-request boolean would not
 // survive across the queued turns GroupQueue serialises on the shared jid; this
@@ -92,9 +93,10 @@ export function consolidateWebConversation(body: unknown): void {
   if (transcriptLines.length === 0) return;
   const transcript = transcriptLines.join('\n\n');
 
-  // Threshold: consolidate once EITHER the user-turn count OR the total
-  // transcript length crosses its bound. Below both → not worth persisting yet.
-  if (userMessages.length < MIN_TURNS() && transcript.length < MIN_CHARS()) {
+  // Threshold: consolidate only once the user-turn count AND the total
+  // transcript length BOTH cross their bound. Skip if EITHER is below — a short
+  // chat or a single long answer is not worth persisting yet.
+  if (userMessages.length < MIN_TURNS() || transcript.length < MIN_CHARS()) {
     return;
   }
 


### PR DESCRIPTION
## What
Tunes the LIA-295 Web UI conversation auto-consolidation trigger from **>=3 user-turns OR >=200 chars** to **>=3 user-turns AND >=500 chars**.

## Why
The `OR 200 chars` bar consolidated almost any single substantive answer (one turn) on its own, producing many tiny `webui-*.md` vault files. AND semantics keeps only multi-turn, substantive conversations in vault memory. User decision.

## Changes
- `src/webui-consolidation.ts`: `MIN_CHARS` default 200 -> 500 (MIN_TURNS stays 3); skip condition flips `&&` -> `||` (skip-if-either-below = consolidate-only-if-both-above). Env knobs + kill switch unchanged.
- `src/webui-consolidation.test.ts`: helper pads assistant messages so >=3-turn convos clear 500; threshold block rewritten for all four AND quadrants; env-override test sets both knobs.
- `src/consolidation-golden.test.ts`: three `@oracle` tests pin thresholds low so their byte snapshots + skip/throw contracts stay byte-identical under the new default (the file's own skip-test already uses this env-pin pattern). No asserted output changed.

## Verification
- `npx vitest run` full suite: **1870 passed** (108 files)
- `npm run build`: clean
- Wardens: plan-reviewer + code-reviewer co-gate (Claude + GPT, GLM) all SHIP

## Out of scope (follow-ups)
- Final-assistant-answer lag in the consolidated transcript (`body` is request history)
- Static `topics: [webui, auto-consolidate]` frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)