### PR TITLE
feat(ingress): quiet-hours gate to defer autonomous merges to a nightly window (LIA-321)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,18 @@ LINEAR_API_TOKEN=
 # LINEAR_BOT_USER_ID=
 # Auto-merge agent PRs after CI passes (0=off, 1=on)
 # LINEAR_AUTO_MERGE=0
+# Quiet-hours merge window (LIA-321): defer autonomous merges to a nightly
+# window so they batch overnight instead of churning service restarts during
+# active hours. Format "<startHour>-<endHour>" in LOCAL wall-clock hours,
+# end-exclusive, wrap-around aware (e.g. "4-5" = 04:00-05:00; "22-6" spans
+# midnight). Unset/empty/malformed = always-open (continuous merge, default).
+# NOTE: uses the PROCESS-LOCAL timezone (Date.getHours); assumes the process TZ
+# matches your local TZ (true for macOS launchd). A Linux/container deploy with
+# TZ=UTC would shift the window — set TZ accordingly there.
+# LINEAR_AUTO_MERGE_WINDOW=4-5
+# How often (ms) to sweep deferred PRs so they merge once the window opens.
+# Only active when LINEAR_AUTO_MERGE_WINDOW is set. Default 900000 (15 min).
+# AUTO_MERGE_SWEEP_INTERVAL_MS=900000
 # Host project path for dispatch agents (mounted writable in container)
 # LINEAR_DISPATCH_PROJECT=~/deus
 # Comma-separated path prefixes blocked from auto-apply patches (default: .github/workflows/)

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-20" # auto-bump @1781909323
+last_verified: "2026-06-20" # auto-bump @1781945968
 governs:
   - src/
   - evolution/

--- a/src/index.ts
+++ b/src/index.ts
@@ -601,6 +601,31 @@ async function main(): Promise<void> {
       sweepPendingAutoMerges(linearCtx).catch((err) => {
         logger.warn({ err }, 'auto-merge: startup sweep failed');
       });
+
+      // Periodic pending-merge sweep — registered ONLY when the quiet-hours
+      // window is configured, so deferred PRs merge once the window opens
+      // without waiting for a restart. No window => no interval => the exact
+      // pre-feature startup-only behavior is preserved (zero-change default).
+      // (LIA-321 quiet-hours merge gate.)
+      const { parseMergeWindow } = await import('./linear-auto-merge.js');
+      const { isAutoMergeEnabled } = await import('./config.js');
+      if (parseMergeWindow() && isAutoMergeEnabled()) {
+        const { envPositiveInt } = await import('./env-utils.js');
+        const sweepMs = envPositiveInt('AUTO_MERGE_SWEEP_INTERVAL_MS', 900_000);
+        // Capture the narrowed (non-null) ctx — the setInterval closure runs
+        // later, so TS won't carry the outer non-null narrowing into it.
+        const sweepCtx = linearCtx;
+        const periodicSweep = setInterval(() => {
+          sweepPendingAutoMerges(sweepCtx).catch((err) => {
+            logger.warn({ err }, 'auto-merge: periodic sweep failed');
+          });
+        }, sweepMs);
+        periodicSweep.unref();
+        logger.info(
+          { sweepMs, window: process.env.LINEAR_AUTO_MERGE_WINDOW },
+          'auto-merge: periodic pending-merge sweep registered (quiet-hours window active)',
+        );
+      }
       const { runInlineCompletionCheck } = await import('./linear-webhook.js');
       const ctx = linearCtx;
       sweepStaleInReview(ctx, (issueData) =>

--- a/src/linear-auto-merge.test.ts
+++ b/src/linear-auto-merge.test.ts
@@ -800,3 +800,224 @@ describe('mergeIfGreen / markDoneIfMerged — GitHub-webhook merge-only entries 
     expect(ctx.client.updateIssue).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Quiet-hours merge gate (LIA-321) — window parser + mergeOrFail gate.
+// Oracle authored blind from the spec (B1-B5 park/comment, C1-C3 happy-path,
+// W1 wrap-around); B5 drives two sequential outside-window calls because the
+// comment dedup is Set-based (module-level deferralCommentsSent), not state-
+// based — triggerAutoMerge pre-sets state='pending' before mergeOrFail.
+// ---------------------------------------------------------------------------
+
+describe('parseMergeWindow / isWithinMergeWindow (LIA-321)', () => {
+  afterEach(() => {
+    delete process.env.LINEAR_AUTO_MERGE_WINDOW;
+  });
+
+  it('unset / empty / malformed / out-of-range / zero-width → null (always-open)', async () => {
+    const { parseMergeWindow } = await import('./linear-auto-merge.js');
+    for (const raw of [
+      undefined,
+      '',
+      '   ',
+      '4',
+      '4-5-6',
+      'a-b',
+      '4-25',
+      '-1-5',
+      '4-4',
+    ]) {
+      expect(parseMergeWindow(raw as string | undefined)).toBeNull();
+    }
+  });
+
+  it('valid "4-5" parses to {start:4,end:5}', async () => {
+    const { parseMergeWindow } = await import('./linear-auto-merge.js');
+    expect(parseMergeWindow('4-5')).toEqual({ start: 4, end: 5 });
+  });
+
+  it('unset window → always inside (no gate)', async () => {
+    const { isWithinMergeWindow } = await import('./linear-auto-merge.js');
+    expect(isWithinMergeWindow(new Date('2025-01-15T12:00:00'))).toBe(true);
+  });
+
+  it('"4-5": 04:30 inside, 05:30 + 03:30 outside', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    const { isWithinMergeWindow } = await import('./linear-auto-merge.js');
+    expect(isWithinMergeWindow(new Date('2025-01-15T04:30:00'))).toBe(true);
+    expect(isWithinMergeWindow(new Date('2025-01-15T05:30:00'))).toBe(false);
+    expect(isWithinMergeWindow(new Date('2025-01-15T03:30:00'))).toBe(false);
+  });
+
+  it('wrap-around "22-6": 23:00 + 02:00 inside, 12:00 outside', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '22-6';
+    const { isWithinMergeWindow } = await import('./linear-auto-merge.js');
+    expect(isWithinMergeWindow(new Date('2025-01-15T23:00:00'))).toBe(true);
+    expect(isWithinMergeWindow(new Date('2025-01-15T02:00:00'))).toBe(true);
+    expect(isWithinMergeWindow(new Date('2025-01-15T12:00:00'))).toBe(false);
+  });
+});
+
+describe('mergeOrFail quiet-hours gate (LIA-321)', () => {
+  const PR = 'https://github.com/test-owner/test-repo/pull/999';
+  const checks = (bucket: 'pass' | 'pending' | 'fail') => ({
+    stdout: JSON.stringify([{ bucket, name: 'ci' }]),
+  });
+
+  function mergeCallArgs(): string[] | undefined {
+    const call = execFileMock.mock.calls.find(
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && (c[1] as string[]).includes('merge'),
+    );
+    return call ? (call[1] as string[]) : undefined;
+  }
+
+  beforeEach(() => {
+    process.env.LINEAR_AUTO_MERGE = '1';
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    delete process.env.LINEAR_AUTO_MERGE;
+    delete process.env.LINEAR_AUTO_MERGE_WINDOW;
+    vi.useRealTimers();
+  });
+
+  it('B1: outside window → NO gh pr merge call', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock.mockReturnValueOnce(checks('pass'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-b1', PR);
+    await mergeIfGreen(ctx, 'qh-b1', PR, 'LIA-999');
+    expect(mergeCallArgs()).toBeUndefined();
+  });
+
+  it('B2: outside window → parked as "pending" (not "failed"/"none")', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock.mockReturnValueOnce(checks('pass'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-b2', PR);
+    await mergeIfGreen(ctx, 'qh-b2', PR, 'LIA-999');
+    expect(getIssuePr('qh-b2')?.auto_merge_state).toBe('pending');
+  });
+
+  it('B3: outside window → no issue state change (no handleMergeFailure)', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock.mockReturnValueOnce(checks('pass'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-b3', PR);
+    await mergeIfGreen(ctx, 'qh-b3', PR, 'LIA-999');
+    expect(ctx.client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it('B4: first park (prev state none) → one deferred comment', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock.mockReturnValueOnce(checks('pass'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-b4', PR);
+    await mergeIfGreen(ctx, 'qh-b4', PR, 'LIA-999');
+    expect(ctx.client.createComment).toHaveBeenCalledTimes(1);
+    expect(ctx.client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId: 'qh-b4',
+        body: expect.stringMatching(/deferred|quiet.hours|window/i),
+      }),
+    );
+  });
+
+  it('B5: re-park (two outside-window calls) → exactly one comment', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-b5', PR);
+    await mergeIfGreen(ctx, 'qh-b5', PR, 'LIA-999'); // first park: comment
+    await mergeIfGreen(ctx, 'qh-b5', PR, 'LIA-999'); // re-park: suppressed
+    expect(ctx.client.createComment).toHaveBeenCalledTimes(1);
+    expect(getIssuePr('qh-b5')?.auto_merge_state).toBe('pending');
+    expect(mergeCallArgs()).toBeUndefined();
+  });
+
+  it('C1: inside window → --admin merge proceeds → Done', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '4-5';
+    vi.setSystemTime(new Date('2025-01-15T04:30:00'));
+    execFileMock
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce({ stdout: '' });
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-c1', PR);
+    await mergeIfGreen(ctx, 'qh-c1', PR, 'LIA-999');
+    expect(mergeCallArgs()).toBeDefined();
+    expect(mergeCallArgs()).toContain('--admin');
+    expect(ctx.client.updateIssue).toHaveBeenCalledWith(
+      'qh-c1',
+      expect.objectContaining({ stateId: 'done-id' }),
+    );
+  });
+
+  it('C2: no window env → merge proceeds (backward compat)', async () => {
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce({ stdout: '' });
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-c2', PR);
+    await mergeIfGreen(ctx, 'qh-c2', PR, 'LIA-999');
+    expect(mergeCallArgs()).toBeDefined();
+    expect(mergeCallArgs()).toContain('--admin');
+  });
+
+  it('C3: empty window string → merge proceeds (backward compat)', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '';
+    vi.setSystemTime(new Date('2025-01-15T03:00:00'));
+    execFileMock
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce({ stdout: '' });
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-c3', PR);
+    await mergeIfGreen(ctx, 'qh-c3', PR, 'LIA-999');
+    expect(mergeCallArgs()).toBeDefined();
+  });
+
+  it('W1: wrap-around "22-6" at 23:00 inside → merge proceeds', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '22-6';
+    vi.setSystemTime(new Date('2025-01-15T23:00:00'));
+    execFileMock
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce(checks('pass'))
+      .mockReturnValueOnce({ stdout: '' });
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-w1', PR);
+    await mergeIfGreen(ctx, 'qh-w1', PR, 'LIA-999');
+    expect(mergeCallArgs()).toBeDefined();
+  });
+
+  it('W1b: wrap-around "22-6" at 12:00 outside → parked, no merge', async () => {
+    process.env.LINEAR_AUTO_MERGE_WINDOW = '22-6';
+    vi.setSystemTime(new Date('2025-01-15T12:00:00'));
+    execFileMock.mockReturnValueOnce(checks('pass'));
+    const { mergeIfGreen } = await import('./linear-auto-merge.js');
+    const ctx = makeAutoMergeCtx();
+    upsertIssuePr('qh-w1b', PR);
+    await mergeIfGreen(ctx, 'qh-w1b', PR, 'LIA-999');
+    expect(mergeCallArgs()).toBeUndefined();
+    expect(getIssuePr('qh-w1b')?.auto_merge_state).toBe('pending');
+  });
+});

--- a/src/linear-auto-merge.ts
+++ b/src/linear-auto-merge.ts
@@ -30,6 +30,74 @@ const execFileAsync = promisify(execFile);
 
 const CI_POLL_INTERVAL_MS = 60_000;
 // Separate from linear-dispatcher.ts's inline version due to circular import (LinearContext)
+
+// ---------------------------------------------------------------------------
+// Quiet-hours merge gate (LIA-321).
+//
+// LINEAR_AUTO_MERGE_WINDOW="<startHour>-<endHour>" (local wall-clock hours, e.g.
+// "4-5" = [04:00,05:00)) defers autonomous merges to a nightly window so they
+// batch overnight instead of churning service restarts during active hours.
+// UNSET/empty/malformed => always-open (no gate): the continuous-merge default
+// is preserved (fail-open). Wrap-around aware ("22-6" spans midnight).
+//
+// `deferralCommentsSent` dedups the "deferred" Linear comment in-memory rather
+// than via auto_merge_state — `triggerAutoMerge` already sets state='pending'
+// BEFORE reaching `mergeOrFail`, so a state-read guard would wrongly suppress
+// the first comment on the main autonomous path. Restart-reset is acceptable
+// (at most one re-announce per parked PR per process lifetime). auto_merge_state
+// MUST stay 'pending' so `getPendingAutoMerges` still picks the PR up.
+// `inFlightPolls` prevents the periodic sweep from stacking concurrent pollers
+// on a genuinely-slow-CI PR. Both Sets give O(1) membership over a tiny set.
+const deferralCommentsSent = new Set<string>();
+const inFlightPolls = new Set<string>();
+
+export function parseMergeWindow(
+  raw: string | undefined = process.env.LINEAR_AUTO_MERGE_WINDOW,
+): { start: number; end: number } | null {
+  if (!raw || !raw.trim()) return null;
+  const parts = raw.split('-');
+  if (parts.length !== 2) {
+    logger.warn(
+      { raw },
+      'auto-merge: malformed LINEAR_AUTO_MERGE_WINDOW (expected "H-H") — ignoring (always-open)',
+    );
+    return null;
+  }
+  const start = Number(parts[0]);
+  const end = Number(parts[1]);
+  const valid = (n: number) => Number.isInteger(n) && n >= 0 && n <= 23;
+  if (!valid(start) || !valid(end)) {
+    logger.warn(
+      { raw },
+      'auto-merge: LINEAR_AUTO_MERGE_WINDOW hours must be integers 0-23 — ignoring (always-open)',
+    );
+    return null;
+  }
+  if (start === end) {
+    logger.warn(
+      { raw },
+      'auto-merge: LINEAR_AUTO_MERGE_WINDOW start === end (zero-width) — ignoring (always-open)',
+    );
+    return null;
+  }
+  return { start, end };
+}
+
+/**
+ * True when `now` (local wall clock) falls inside the configured quiet-hours
+ * window, OR when no valid window is configured (always-open). Uses
+ * Date.getHours() = process-local TZ (assumes process TZ matches the user's
+ * local TZ; documented in .env.example).
+ */
+export function isWithinMergeWindow(now: Date = new Date()): boolean {
+  const win = parseMergeWindow();
+  if (!win) return true;
+  const h = now.getHours();
+  return win.start > win.end
+    ? h >= win.start || h < win.end // wrap-around (e.g. 22-6)
+    : h >= win.start && h < win.end; // normal (e.g. 4-5)
+}
+
 async function tripCircuitBreaker(
   ctx: LinearContext,
   issueId: string,
@@ -297,9 +365,24 @@ export async function attemptAutoMerge(
     // CI still running — hand off to a detached bounded poll so the caller (an
     // awaited webhook cooldown callback) returns immediately. The PR stays
     // auto_merge_state='pending'; the startup sweep re-runs this on restart.
-    fireAndForget(() => pollUntilMergeable(ctx, issueId, prUrl, ident), {
-      name: 'auto-merge.poll',
-    });
+    // inFlightPolls (LIA-321): one poller per issue — the periodic quiet-hours
+    // sweep re-enters attemptAutoMerge every interval, so without this guard a
+    // genuinely-slow-CI PR would stack overlapping pollers.
+    if (inFlightPolls.has(issueId)) {
+      logger.info(
+        { issueId, prUrl },
+        'auto-merge: poll already in flight — skipping duplicate spawn',
+      );
+      return;
+    }
+    inFlightPolls.add(issueId);
+    fireAndForget(
+      () =>
+        pollUntilMergeable(ctx, issueId, prUrl, ident).finally(() =>
+          inFlightPolls.delete(issueId),
+        ),
+      { name: 'auto-merge.poll' },
+    );
     return;
   }
 
@@ -318,8 +401,30 @@ async function mergeOrFail(
   prUrl: string,
   ident: string,
 ): Promise<void> {
+  // Quiet-hours gate (LIA-321): outside the configured window, PARK for the
+  // sweep instead of merging now. Not a failure — never routes to
+  // handleMergeFailure (no agent re-dispatch, no circuit-breaker).
+  if (!isWithinMergeWindow()) {
+    updatePrAutoMergeState(issueId, 'pending');
+    if (!deferralCommentsSent.has(issueId)) {
+      deferralCommentsSent.add(issueId);
+      const win = parseMergeWindow();
+      const fmt = (h: number) => String(h).padStart(2, '0');
+      await ctx.client.createComment({
+        issueId,
+        body: `**Auto-merge deferred** — CI is green, holding PR ${prUrl} until the quiet-hours window (${fmt(win!.start)}:00–${fmt(win!.end)}:00 local). It will merge on the next in-window sweep.`,
+      });
+      logger.info(
+        { issueId, prUrl, window: process.env.LINEAR_AUTO_MERGE_WINDOW },
+        'auto-merge: deferred to quiet-hours window',
+      );
+    }
+    return;
+  }
+
   const result = await mergePr(prUrl);
   if (result.merged) {
+    deferralCommentsSent.delete(issueId);
     await handleMergeSuccess(ctx, issueId, prUrl, ident);
   } else {
     await handleMergeFailure(
@@ -392,10 +497,9 @@ export async function markDoneIfMerged(
  *  - exhausted (still pending past the cap) → PARK: leave auto_merge_state
  *    'pending', no requeue, no circuit-breaker, but POST a comment so the parked
  *    PR is visible, not dark. pending != failure, so we must NOT thrash the
- *    agent. sweepPendingAutoMerges re-runs this on the next restart. NOTE: that
- *    sweep is startup-only, so a parked PR waits until the next deploy/restart —
- *    acceptable for a solo pipeline that restarts on every deploy; a periodic
- *    sweep is a deferred option.
+ *    agent. sweepPendingAutoMerges re-runs this on the next startup AND, when the
+ *    quiet-hours window (LIA-321) is configured, on the periodic sweep registered
+ *    in index.ts — so a parked PR no longer waits for a restart in that mode.
  *
  * CAVEAT: queryPrChecks maps a transient gh error (auth/network/rate-limit) to
  * 'pending' (see its catch), so a SUSTAINED gh outage looks like slow CI and


### PR DESCRIPTION
## Why
The autonomous auto-merge pipeline lands each PR the moment CI goes green — any hour. Each merge triggers a post-merge build + `launchctl kickstart`, so the live service restarts repeatedly during active hours (diagnosed this session: a burst of #906–#910 merges churned the `com.deus` service through ~6 graceful restarts between 00:35 and 01:58). This adds an opt-in **quiet-hours window** so merges batch overnight instead.

## What
- **`mergeOrFail` gate** (the verified sole chokepoint for every green-merge path — `attemptAutoMerge`, `mergeIfGreen` /github webhook, `pollUntilMergeable`): outside `LINEAR_AUTO_MERGE_WINDOW`, **park** the PR (`auto_merge_state='pending'`) instead of merging. Never routes to `handleMergeFailure` — a defer is not a failure, so no agent re-dispatch / circuit-breaker.
- **`parseMergeWindow` / `isWithinMergeWindow`** — `"<startHour>-<endHour>"` local wall-clock, end-exclusive, wrap-around aware (`"22-6"` spans midnight). Unset/empty/malformed/zero-width/out-of-range → always-open (fail-open to current behavior).
- **Periodic sweep** (`index.ts`) — registered **only** when the window is configured, so parked PRs merge once the window opens without waiting for a restart. Window unset ⇒ no interval ⇒ exact pre-feature startup-only behavior (**zero-change default-off**). `.unref()`'d.
- **`deferralCommentsSent`** Set — posts the "deferred" Linear comment once per park (state-based dedup is unreliable: `triggerAutoMerge` pre-sets `'pending'` before `mergeOrFail`).
- **`inFlightPolls`** Set — prevents the sweep from stacking concurrent pollers on a slow-CI PR.

## Config (default-off; nothing changes until set)
```
LINEAR_AUTO_MERGE_WINDOW=4-5         # 04:00–05:00 local; unset = continuous merge (default)
AUTO_MERGE_SWEEP_INTERVAL_MS=900000  # 15 min; only active when the window is set
```
Activate later via `com.deus.plist` EnvironmentVariables + `launchctl unload/load`. Rollback = unset the var.

## Tests / verification
- Build (tsc) clean; **full suite 1885/1885** across 108 files.
- 16 new tests: window-parser edge cases (unset/empty/malformed/out-of-range/zero-width/wrap-around) + an independent **blind oracle** (authored from the spec before impl): B1–B5 (park-not-merge, `'pending'` not `'failed'`, no state change, one-time comment, re-park dedup), C1–C3 (inside-window / unset / empty → merge), W1/W1b (wrap-around). Verification-gate (Opus) confirmed the oracle is genuinely red-green.

## Gates
plan-review **co-gate** Claude+GPT SHIP (GPT caught 2 real defects — broken state-based comment dedup + non-zero-change sweep — both fixed); code-review co-gate Claude+GPT SHIP; verification-gate (Opus) SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)