### PR TITLE
fix(telegram): catch bot.start() rejection so a polling reset can't kill the channel

### DIFF
--- a/packages/mcp-telegram/src/index.ts
+++ b/packages/mcp-telegram/src/index.ts
@@ -24,6 +24,20 @@ const logger = pino(
   pino.destination(2),
 );
 
+// Process-level safety net: a stray rejection (e.g. grammy's "Aborted delay"
+// from bot.start() during a stop mid-backoff) must not silently kill this MCP
+// channel child. Mirror the host process policy (src/index.ts): log unhandled
+// rejections without exiting, but exit on a genuine uncaught exception so the
+// host orchestrator can respawn a clean process.
+process.on('unhandledRejection', (reason) => {
+  logger.error({ reason }, 'Unhandled rejection');
+});
+process.on('uncaughtException', (err) => {
+  logger.error({ err }, 'Uncaught exception');
+  // eslint-disable-next-line no-restricted-syntax -- MCP server has no upstream catcher for an uncaught exception; exit so the host orchestrator respawns a clean stdio process (same rationale as the resetPolling suicide in telegram.ts).
+  process.exit(1);
+});
+
 const server = new McpServer(
   { name: '@deus-ai/telegram-mcp', version: '1.0.0' },
   { capabilities: { logging: {} } },

--- a/packages/mcp-telegram/src/telegram.test.ts
+++ b/packages/mcp-telegram/src/telegram.test.ts
@@ -65,6 +65,9 @@ describe('TelegramProvider', () => {
       return Promise.resolve();
     });
     mockStop.mockReset();
+    // bot.stop() is always awaited/`.catch()`'d in the provider — it must
+    // resolve to a thenable, not the bare `undefined` mockReset() leaves.
+    mockStop.mockResolvedValue(undefined);
     mockCommand.mockReset();
     mockOn.mockReset();
     mockCatch.mockImplementation((handler: Function) => {
@@ -144,6 +147,69 @@ describe('TelegramProvider', () => {
         .mockImplementation(() => undefined as never);
       await vi.runAllTimersAsync();
       mockExit.mockRestore();
+    });
+
+    it('routes a start() rejection during reset into the retry loop and recovers', async () => {
+      await provider.connect();
+      mockStop.mockClear();
+      mockStart.mockClear();
+
+      // First reset attempt: start() rejects with grammy's "Aborted delay"
+      // (stop() fired mid-backoff). It must be caught and routed into the
+      // retry loop, NOT float as an unhandled rejection. The next attempt
+      // succeeds via onStart.
+      mockStart
+        .mockImplementationOnce(() =>
+          Promise.reject(new Error('Aborted delay')),
+        )
+        .mockImplementation((options: any) => {
+          if (options?.onStart) {
+            options.onStart({ username: 'test_bot', id: 123 });
+          }
+          return Promise.resolve();
+        });
+
+      // Trip the reset threshold (MAX_CONSECUTIVE_ERRORS = 5).
+      for (let i = 0; i < 5; i++) {
+        catchHandler!({ message: `error ${i}` });
+      }
+
+      // Drive the backoff (BASE_BACKOFF_MS * 2^attempt = 1s, then 2s):
+      // attempt 1 rejects, attempt 2 succeeds.
+      await vi.advanceTimersByTimeAsync(1100);
+      await vi.advanceTimersByTimeAsync(2100);
+
+      expect(mockStart).toHaveBeenCalledTimes(2);
+      expect(provider.isConnected()).toBe(true);
+    });
+  });
+
+  describe('bot.start() rejection handling', () => {
+    it('rejects connect() when start() rejects before the bot connects', async () => {
+      // start() rejects without ever firing onStart (e.g. invalid token) —
+      // the failure must surface to the caller, not silently hang.
+      mockStart.mockImplementationOnce(() =>
+        Promise.reject(new Error('Aborted delay')),
+      );
+      await expect(provider.connect()).rejects.toThrow('Aborted delay');
+      // A failed connect must not report a phantom connection.
+      expect(provider.isConnected()).toBe(false);
+    });
+
+    it('resolves connect() and swallows a post-connect start() rejection', async () => {
+      // onStart fires (bot connected), then start() rejects (stop() mid-backoff).
+      // connect() must resolve and the rejection must be caught — if it floated,
+      // vitest would fail the test on the unhandled rejection.
+      mockStart.mockImplementationOnce((options: any) => {
+        if (options?.onStart) {
+          options.onStart({ username: 'test_bot', id: 123 });
+        }
+        return Promise.reject(new Error('Aborted delay'));
+      });
+      await expect(provider.connect()).resolves.toBeUndefined();
+      // Flush microtasks so the .catch handler runs before the test ends.
+      await Promise.resolve();
+      expect(provider.isConnected()).toBe(true);
     });
   });
 

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -371,11 +371,13 @@ export class TelegramProvider implements ChannelProvider {
       }
     });
 
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
+      let started = false;
       this.bot!.start({
         // message_reaction is not in the default allowed_updates set — opt in.
         allowed_updates: ['message', 'edited_message', 'message_reaction'],
         onStart: (botInfo) => {
+          started = true;
           this.botUsername = botInfo.username;
           this.connectTime = Date.now();
           this.consecutiveErrors = 0;
@@ -385,6 +387,25 @@ export class TelegramProvider implements ChannelProvider {
           );
           resolve();
         },
+      }).catch((err: unknown) => {
+        // grammy's bot.start() promise rejects (e.g. with "Aborted delay")
+        // when bot.stop() is called while it is in a retry-backoff sleep. If
+        // the bot never connected, surface the failure to the caller; if it
+        // had connected, this is an expected teardown — log and swallow so it
+        // never becomes an unhandled rejection that kills the MCP child.
+        if (!started) {
+          // The bot never came up — clear it so isConnected()/getStatus()
+          // don't report a phantom connection, then surface the failure.
+          this.bot = null;
+          reject(err);
+        } else {
+          // Expected teardown race (bot.stop() during shutdown/reset), not an
+          // error — warn so it is visible in log tailing without false alarms.
+          logger.warn(
+            { err, task: 'telegram.connect.start' },
+            'Telegram polling stopped after connect',
+          );
+        }
       });
     });
   }
@@ -425,20 +446,28 @@ export class TelegramProvider implements ChannelProvider {
             reject(new Error('Polling restart timed out'));
           }, 30_000);
 
-          bot.start({
-            onStart: (botInfo) => {
+          bot
+            .start({
+              onStart: (botInfo) => {
+                clearTimeout(timeout);
+                this.botUsername = botInfo.username;
+                this.connectTime = Date.now();
+                this.resetting = false;
+                this.consecutiveErrors = 0;
+                logger.info(
+                  { username: botInfo.username, id: botInfo.id },
+                  'Telegram bot reconnected after polling reset',
+                );
+                resolve();
+              },
+            })
+            .catch((err: unknown) => {
+              // Route a start() rejection (e.g. "Aborted delay" from the
+              // pre-retry stop()) into this attempt's catch instead of letting
+              // it float as an unhandled rejection.
               clearTimeout(timeout);
-              this.botUsername = botInfo.username;
-              this.connectTime = Date.now();
-              this.resetting = false;
-              this.consecutiveErrors = 0;
-              logger.info(
-                { username: botInfo.username, id: botInfo.id },
-                'Telegram bot reconnected after polling reset',
-              );
-              resolve();
-            },
-          });
+              reject(err);
+            });
         });
         return; // Success — exit retry loop
       } catch (err) {

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-06-20" # auto-bump @1781906887
+last_verified: "2026-06-20" # auto-bump @1781946645
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781855985
+last_verified: "2026-06-20" # auto-bump @1781946645
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
## Problem

The Telegram MCP channel **child process** died with an unhandled promise rejection `Error: "Aborted delay"` originating from grammy's `Bot.start()`.

grammy's `bot.start()` returns a promise that **rejects** with `"Aborted delay"` when `bot.stop()` is called while it is in a retry-backoff `sleep`. That returned promise was never `.catch()`'d at two call sites in `telegram.ts` (`connect()`, `resetPolling()`). `bot.stop()` runs in `resetPolling()` (after `MAX_CONSECUTIVE_ERRORS`), in the retry-loop catch, and in `disconnect()` — so the rejection fires during **normal operation** (a polling reset), not just shutdown. Under Node 26 an unhandled rejection is fatal, so the Telegram channel died until the next service restart.

Surfaced while diagnosing a perceived "crash" — the main `com.deus` process was actually fine (only deploy-driven SIGTERM restarts); this is a real latent bug it exposed.

## Changes

- **`telegram.ts` `connect()`** — catch the `bot.start()` rejection. If the bot never connected, clear `this.bot` and surface the failure to the caller (so `isConnected()`/`getStatus()` don't report a phantom connection); if it had connected, warn-log the expected teardown race.
- **`telegram.ts` `resetPolling()`** — route a `start()` rejection into the existing retry loop instead of letting it float.
- **`index.ts`** — child-level `unhandledRejection` (log, survive) + `uncaughtException` (log, exit) handlers, mirroring the host process policy (`src/index.ts`). The `process.exit` carries a justified `no-restricted-syntax` disable (MCP server signaling the host orchestrator, same rationale as the existing `resetPolling` suicide).
- **`telegram.test.ts`** — `mockStop` now resolves (the provider awaits `stop()`); 3 regression tests (pre-connect rejection surfaces + no phantom connection; post-connect rejection swallowed; reset rejection routes into retry and recovers).

## Verification

- `npx tsc` (package) — exit 0
- `npm run build` (full repo) — exit 0
- `npx vitest run` (full repo) — **108 files / 1870 tests passed**
- Gates: plan-reviewer Claude+GPT SHIP · code-reviewer Claude+GPT+GLM SHIP (GPT caught + I fixed an `isConnected()` state-lie on the failure path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)