### PR TITLE
fix(whatsapp): stop mislabeling intentional shutdown as "Logged out"

### DIFF
--- a/packages/mcp-whatsapp/src/classify-disconnect.test.ts
+++ b/packages/mcp-whatsapp/src/classify-disconnect.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { DisconnectReason } from '@whiskeysockets/baileys';
+
+import { classifyDisconnect } from './whatsapp.js';
+
+/**
+ * classifyDisconnect decides whether a connection-close should reconnect, and
+ * distinguishes the two non-reconnect cases so an intentional teardown is not
+ * mislabeled as a real logout (the bug: every graceful restart logged
+ * "Logged out. Re-authenticate to continue.").
+ */
+describe('classifyDisconnect', () => {
+  it('treats an intentional teardown as intentional-shutdown (never reconnect)', () => {
+    expect(classifyDisconnect(undefined, true)).toBe('intentional-shutdown');
+    expect(classifyDisconnect(408, true)).toBe('intentional-shutdown');
+    // Intentional takes precedence even if the close also carried loggedOut.
+    expect(classifyDisconnect(DisconnectReason.loggedOut, true)).toBe(
+      'intentional-shutdown',
+    );
+  });
+
+  it('treats a real, non-intentional loggedOut as logged-out (needs re-auth)', () => {
+    expect(classifyDisconnect(DisconnectReason.loggedOut, false)).toBe(
+      'logged-out',
+    );
+  });
+
+  it('reconnects on any other non-intentional close', () => {
+    expect(classifyDisconnect(undefined, false)).toBe('reconnect');
+    expect(classifyDisconnect(408, false)).toBe('reconnect'); // timed out
+    expect(classifyDisconnect(440, false)).toBe('reconnect'); // connection replaced
+    expect(classifyDisconnect(DisconnectReason.restartRequired, false)).toBe(
+      'reconnect',
+    );
+  });
+});

--- a/packages/mcp-whatsapp/src/whatsapp.ts
+++ b/packages/mcp-whatsapp/src/whatsapp.ts
@@ -58,6 +58,19 @@ const logger = pino(
 );
 const baileysLogger = pino({ level: 'silent' });
 
+/**
+ * Decide whether a close should reconnect, and split the two non-reconnect
+ * cases so an intentional teardown is never mislabeled as a real logout.
+ */
+export function classifyDisconnect(
+  reason: number | undefined,
+  intentional: boolean,
+): 'reconnect' | 'intentional-shutdown' | 'logged-out' {
+  if (intentional) return 'intentional-shutdown';
+  if (reason === DisconnectReason.loggedOut) return 'logged-out';
+  return 'reconnect';
+}
+
 export class WhatsAppProvider implements ChannelProvider {
   readonly name = 'whatsapp';
 
@@ -156,11 +169,10 @@ export class WhatsAppProvider implements ChannelProvider {
         const reason = (
           lastDisconnect?.error as { output?: { statusCode?: number } }
         )?.output?.statusCode;
-        const shouldReconnect =
-          reason !== DisconnectReason.loggedOut && !this.intentionalDisconnect;
-        logger.info({ reason, shouldReconnect }, 'Connection closed');
+        const kind = classifyDisconnect(reason, this.intentionalDisconnect);
+        logger.info({ reason, kind }, 'Connection closed');
 
-        if (shouldReconnect) {
+        if (kind === 'reconnect') {
           // The connection didn't prove stable — let the backoff keep growing.
           this.reconnect.markDisconnected();
           // Single-flight + exponential backoff. Replaces the old zero-delay
@@ -176,6 +188,8 @@ export class WhatsAppProvider implements ChannelProvider {
               'Reconnecting...',
             );
           }
+        } else if (kind === 'intentional-shutdown') {
+          logger.info('WhatsApp socket closed (intentional shutdown).');
         } else {
           logger.info('Logged out. Re-authenticate to continue.');
         }

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-06-20" # auto-bump @1781946645
+last_verified: "2026-06-20" # auto-bump @1781949213
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-20" # auto-bump @1781946645
+last_verified: "2026-06-20" # auto-bump @1781949213
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
## Problem
The WhatsApp `connection.update` 'close' handler (`packages/mcp-whatsapp/src/whatsapp.ts`) logged **"Logged out. Re-authenticate to continue."** whenever `shouldReconnect` was false — but that's false for two distinct reasons:
1. a real logout (`reason === DisconnectReason.loggedOut`), or
2. an **intentional graceful teardown** (`intentionalDisconnect === true`, set only by `disconnect()`).

So every normal/graceful restart printed the re-auth message. Observed live during a restart burst: dozens of "Logged out" lines with **no `reason` field** (= intentional shutdowns), making a healthy service look like it was failing WhatsApp auth. This is the misleading signal behind recurring "it crashed / logged out again" reports.

## Fix (behavior-preserving)
Extract a pure helper and dispatch on it:
```ts
classifyDisconnect(reason, intentional): 'reconnect' | 'intentional-shutdown' | 'logged-out'
```
- `kind === 'reconnect'` ⟺ `reason !== loggedOut && !intentional` — **identical** to the old `shouldReconnect`. Reconnect/backoff path unchanged.
- The old single `else` (always "Logged out") is split: `'intentional-shutdown'` → "WhatsApp socket closed (intentional shutdown)."; `'logged-out'` → the existing re-auth message (only for a real, non-intentional logout).

Pure log-clarity fix — no change to reconnect logic, backoff, or `disconnect()`.

## Files
- `packages/mcp-whatsapp/src/whatsapp.ts` — helper + 3-way dispatch
- `packages/mcp-whatsapp/src/classify-disconnect.test.ts` (new) — unit tests for all 3 cases incl. intentional-overrides-loggedOut

## Verification
- `npx vitest run` → **15 passed** (3 new + 12 existing backoff)
- `npm run build` (tsc) → exit 0
- verification-gate formally confirmed the reconnect predicate is unchanged

## Gates
plan-reviewer + code-reviewer co-gate (**Claude + GPT**, +GLM cross-family on code) SHIP; verification-gate SHIP. `packages/`-only → ai-eng-warden N/A.

## Context
Found while diagnosing a perceived "crash loop" (it wasn't one — service healthy, `launchd runs=2`). Related operational issue filed separately: **LIA-327** (Linear API rate-limit amplification from the GitHub webhook flood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)