### PR TITLE
feat(wardens): no-numb comprehension warden - gated /quiz-me hook + skill (LIA-328)

### DIFF
--- a/.claude/hooks/nonumb-gate.sh
+++ b/.claude/hooks/nonumb-gate.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# no-numb gate — Deus comprehension warden, Stop-hook doorbell.  LIA-328.
+#
+# Adapted from the MIT-licensed no-numb plugin (github.com/Ciucky/no-numb).
+# See .claude/skills/ATTRIBUTION-no-numb.md.
+#
+# Job: a "doorbell," nothing more. Did Claude edit a file this run, and have we
+# not already quizzed for it? If so, block the stop and tell Claude to run the
+# quiz-me skill. ALL judgement (what/whether/how to quiz) lives in the skill.
+#
+# DEFAULT OFF. Enabled only when the interactive shell exports DEUS_NONUMB (or
+# ~/.config/deus/nonumb.json sets "enabled": true). This gates ONLY interactive
+# sessions by construction: launchd (com.deus) and container agents do not
+# inherit an interactive shell's environment. DO NOT add DEUS_NONUMB to any
+# launchd EnvironmentVariables block — that would silently opt a daemon in and
+# trap a non-interactive run at AskUserQuestion.
+#
+# Pattern: Guard / Chain-of-Responsibility — bail on the first exit condition,
+# fall through to the block. Fails OPEN everywhere (missing jq, missing/garbled
+# transcript, missing config): trapping the session on a parse bug is worse than
+# missing one quiz.
+#
+# Requires: jq (a documented Deus prereq). Missing jq → no-op.
+#
+# Stop-hook I/O schema — input `transcript_path` + the `stop_hook_active`
+# re-entry guard (true while already continuing from a Stop hook), and the
+# `{decision:"block", reason}` output contract: https://code.claude.com/docs/en/hooks
+
+input="$(cat)"
+
+# Read a field from the hook's stdin JSON. Falls back to empty on error.
+field() { printf '%s' "$input" | jq -r "$1" 2>/dev/null; }
+
+# 1) Already quizzed this cycle → let Claude stop. When we block, the quiz runs
+#    as a CONTINUATION of the same run, so the edits are still "this run" when
+#    Claude tries to stop again. Without this guard the hook re-blocks forever.
+#    Claude Code sets stop_hook_active=true on that continuation.
+[ "$(field '.stop_hook_active // false')" = "true" ] && exit 0
+
+# 2) jq drives the transcript scan; if it is absent, fail open (no quiz).
+command -v jq >/dev/null 2>&1 || exit 0
+
+# 3) Enabled check (DEFAULT OFF). Enabled iff the env opt-in is truthy OR the
+#    config sets "enabled": true.
+config="${HOME}/.config/deus/nonumb.json"
+# Env opt-in is the primary switch; config.enabled is the alternative.  LIA-328
+case "${DEUS_NONUMB:-}" in
+  1 | true | on | yes | TRUE | On | Yes | YES) env_on=1 ;;
+  *) env_on=0 ;;
+esac
+cfg_on=0
+if [ -f "$config" ] && [ "$(jq -r '.enabled == true' "$config" 2>/dev/null)" = "true" ]; then
+  cfg_on=1
+fi
+if [ "$env_on" != "1" ] && [ "$cfg_on" != "1" ]; then
+  exit 0
+fi
+
+# 4) Ensure the config exists with defaults — created once, when first enabled.
+#    It lives in the deus config dir (not the repo) so it is user-agnostic,
+#    survives updates, and is a stable, editable home for the `depth` dial.
+if [ ! -f "$config" ]; then
+  mkdir -p "${HOME}/.config/deus" 2>/dev/null &&
+    printf '{\n  "enabled": false,\n  "depth": "standard"\n}\n' >"$config" 2>/dev/null || true
+fi
+
+# 5) Doorbell: did Claude Edit/Write/MultiEdit/NotebookEdit any file since the
+#    user's last prompt (i.e. during this run)? No transcript → fail open.
+transcript="$(field '.transcript_path // empty')"
+[ -n "$transcript" ] && [ -f "$transcript" ] || exit 0
+
+edited="$(jq -s '
+  # Content can be nested as .message.content (common) or .content; handle both.
+  def blocks: (.message.content // .content // []);
+
+  # A genuine user prompt: a user line carrying real text (string content, or an
+  # array with a text block) — as opposed to a user line that is only tool_result.
+  def is_prompt:
+    .type == "user"
+    and (
+      ((blocks | type) == "string" and (blocks | length) > 0)
+      or ((blocks | type) == "array" and (blocks | any(.[]?; .type == "text")))
+    );
+
+  # An assistant turn that edited a file.
+  def is_edit:
+    .type == "assistant"
+    and (blocks | type) == "array"
+    and (blocks | any(.[]?;
+          .type == "tool_use"
+          and (.name == "Edit" or .name == "Write"
+               or .name == "MultiEdit" or .name == "NotebookEdit")));
+
+  . as $arr
+  | (([ range(0; ($arr | length)) | select($arr[.] | is_prompt) ] | last) // -1) as $start
+  | [ $arr[($start + 1):][] | select(is_edit) ] | length > 0
+' "$transcript" 2>/dev/null || echo false)"
+
+if [ "$edited" = "true" ]; then
+  jq -n '{
+    decision: "block",
+    reason: ("You edited files this turn. Before ending your turn, invoke the /quiz-me skill via the "
+      + "Skill tool: quiz the user (multiple-choice, via AskUserQuestion) on what you just did this turn, "
+      + "honoring the configured depth, and sampling across the five comprehension axes (what-changed, "
+      + "why-this-shape, what-would-break, how-was-it-verified, what-to-review-later). Do not end your turn "
+      + "until they pass. Skip with a one-line note only if the change is genuinely cosmetic (see the skill).")
+  }'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -164,6 +164,18 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/nonumb-gate.sh\"'",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/ATTRIBUTION-no-numb.md
+++ b/.claude/skills/ATTRIBUTION-no-numb.md
@@ -1,0 +1,30 @@
+# Attribution — Ciucky/no-numb
+
+The `quiz-me` skill and the `.claude/hooks/nonumb-gate.sh` Stop-hook doorbell
+were adapted from the open-source plugin
+**[Ciucky/no-numb](https://github.com/Ciucky/no-numb)** (MIT-licensed, by
+Andrei Alexandru).
+
+| Deus file | Adapted from |
+|-----------|--------------|
+| `.claude/hooks/nonumb-gate.sh` | `hooks/gate.sh` — the Stop-hook "doorbell" (transcript edit-detection, `stop_hook_active` re-block trap) |
+| `.claude/skills/quiz-me/SKILL.md` | `skills/quiz-me/SKILL.md` — the comprehension-quiz skill structure |
+
+## What we changed (Deus-native, LIA-328)
+
+- **Default OFF + env opt-in (`DEUS_NONUMB`)** instead of upstream's default-ON,
+  so the Stop hook never gates the autonomous pipeline / launchd / container
+  sessions (which do not inherit an interactive shell's env).
+- **Five comprehension axes** (what-changed, why-this-shape, what-would-break,
+  how-was-it-verified, what-to-review-later) layered onto the depth dial, with
+  an added **`principle`** depth tier (the transferable lesson).
+- **Length-balanced distractor + slot-rotation rules** to keep the quiz from
+  being gameable by answer length or position.
+- Config moved to `~/.config/deus/nonumb.json` (the Deus config dir).
+- `LIA-328` flag-lint citation for the `$DEUS_NONUMB` shell gate.
+
+Full design + roadmap: `Second Brain/Deus/Research/no-numb-comprehension-warden-spec.md`
+and Linear LIA-328.
+
+The MIT license permits this adaptation; the original copyright remains with the
+no-numb author.

--- a/.claude/skills/quiz-me/SKILL.md
+++ b/.claude/skills/quiz-me/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: quiz-me
+description: Use right after writing or editing code or files for the user — before ending your turn — to quiz them on what was just built and confirm they actually understand it. Also triggers on "quiz me", "test my understanding", "check what I learned", "comprehension check", or recovering the understanding that vaporizes when you orchestrate an agent instead of authoring the code yourself.
+user_invocable: true
+---
+
+# /quiz-me — quiz the user on what was just built
+
+Adapted from the MIT-licensed no-numb plugin (github.com/Ciucky/no-numb); see
+`.claude/skills/ATTRIBUTION-no-numb.md`. Runs **host-side**.
+
+## Overview
+
+After you write code for someone, they usually understand the result at a high
+level — what it does, its inputs and outputs — but not the internals or the
+*why*. That understanding "vaporizes." This skill has you administer a short
+comprehension quiz on **what you just did this turn**, so the understanding
+sticks. Being tested is itself the learning (retrieval practice); the quiz is
+not just a check.
+
+**Core principle:** quiz what *this turn* produced, from your own memory of what
+you just did — not generic trivia, not the whole codebase, not what the app does
+at a high level.
+
+## When to run
+
+- Right after a turn in which you edited or wrote files, before finishing.
+- When the user runs `/quiz-me`.
+- When the no-numb Stop hook (`.claude/hooks/nonumb-gate.sh`) blocks your turn
+  and asks you to quiz. (That gate is DEFAULT-OFF; it fires only when the user
+  has opted in via `DEUS_NONUMB` or `~/.config/deus/nonumb.json`.)
+
+## Step 1 — Is it worth quizzing?
+
+Look at what you changed this turn. **Bias toward quizzing.** Only skip when the
+change is *genuinely cosmetic*: formatting / whitespace, a variable rename, a CSS
+color tweak, a typo fix, a version bump. Everything else → quiz. **When in
+doubt, quiz.** If you do skip, say so in one line and stop — don't quiz on
+nothing.
+
+## Step 2 — Read the settings
+
+Read `~/.config/deus/nonumb.json` for `depth` (`"standard"` or `"deep"`; default
+to `"standard"` if the file or key is missing). The optional `"principle"` depth
+is the most advanced tier (below). Note whether this was a **code** change or a
+**non-code** change (docs/prose/config) — it changes how the depth dial applies.
+
+## Step 3 — The two dials: depth × axis
+
+A good quiz crosses **two independent dials**. Decide each per question.
+
+### Dial A — depth (how hard to retrieve the answer)
+The single test for standard vs deep:
+
+> **Do you need to read the code to answer it? Yes → deep. No → standard.**
+
+- **`standard`** (default) — answerable WITHOUT opening a file, from
+  understanding the *decisions*. Do **not** reference specific files, lines, or
+  function names. *"Why does X break if that guard is removed?"*
+- **`deep`** — only answerable BY reading the code. **Always point them to where
+  to look** (file + function/region). Favor reasoning over recall. *"In the
+  doorbell check in `gate.sh`, what edit would slip past it?"*
+- **`principle`** (advanced, one tier up) — strip the specifics and ask the
+  *transferable* lesson: what general class of bug/decision is this, and where
+  else does it apply? *"This is an instance of what general failure pattern, and
+  where else would it bite?"*
+
+### Dial B — comprehension axis (which facet you probe)
+Sample **across** these five axes — don't ask five of the same kind. The number
+of questions scales to the change, with a **minimum floor so a quiz can't be
+trivially passed with one softball**: at least **2** questions for any
+non-cosmetic change, and at least **4** for a new file or a substantial refactor.
+A one-line fix → 2; a new module → 4+. Don't pad past what the change warrants,
+and don't force all five axes on a tiny change.
+
+| Axis | Probes |
+|---|---|
+| **what changed** | name the real edit + new behavior |
+| **why this shape** | the tradeoff chosen over the obvious alternative |
+| **what would break** | predict a regression if a key line changed |
+| **how was it verified** | name the actual test/command run — *or admit there wasn't one* |
+| **what to review later** | one remaining uncertainty/risk worth flagging |
+
+The **how-was-it-verified** axis is the highest-value one: it forces you to
+confront whether you actually ran anything. If the honest answer is "it wasn't
+verified," say so plainly — that surfaces the gap to the user before they move
+on. **In gate-triggered mode** you (the model) already know what commands you
+ran this turn and the user does not — so don't quiz them on a fact only you hold.
+Instead, *disclose* it: state what was actually run (or that nothing was), and if
+you want a question on this axis, ask what the verification would need to cover,
+not "what did Claude run."
+
+**Non-code changes** (docs/prose): the read-the-code test doesn't apply — ask
+about *what changed* and treat depth as a difficulty knob. Config files are
+code-like enough that deep/principle work normally.
+
+**Stay below the awareness line (every mode):** never ask *"what does this app
+do"* or *"what are its inputs and outputs."* That's the high-level understanding
+the user already has — testing it teaches nothing. Aim at the internals, the
+*why*, and the transferable lesson — the part that vaporizes.
+
+## Step 4 — Deliver as multiple choice, one at a time
+
+Deliver with `AskUserQuestion`, **one question per call**, with **four options**
+each.
+
+- **Plausible distractors.** The wrong options must be the misconceptions
+  someone would actually hold if they didn't understand this code. Obvious-dummy
+  options turn it back into trivia and let them pass by elimination.
+- **Length-balanced options.** Write all four options at roughly the **same
+  length and specificity**. Never let the correct answer be the longest or most
+  detailed — that is a tell that lets the user pattern-match the answer without
+  understanding it. (Equalize: if the correct answer needs a clause, give the
+  distractors one too.)
+- **Vary where the correct answer sits.** Decide the correct option's slot
+  (1st–4th) *before* you write the options, and rotate it across questions
+  (e.g. 2nd, 4th, 1st, 3rd). **Never default the correct answer to the first
+  slot** — a quiz whose answer is always option 1 is passed by reflex.
+
+> Multiple choice is required, not a style preference. `AskUserQuestion` is a
+> tool call, so your turn stays alive and the gate can hold. A plain-text
+> question would force you to end your turn and wait for a reply — which releases
+> the gate. Do not switch to prose questions during a gated quiz. (The "Other"
+> free-text box is fine for the rare question that needs a typed answer, since it
+> stays inside the tool call.)
+
+## Step 5 — Grade and explain
+
+After each answer: if correct, confirm in a sentence. If wrong, show the correct
+option **and explain *why*** — the specific low-level detail they missed. This
+explanation is where the learning actually lands, so make it real, not a
+restatement.
+
+## Step 6 — Retake on any miss
+
+Any wrong answer means the user retakes the **full** quiz. Regenerate it with
+light rewording and reordering so they can't just memorize the answer key. **Stay
+in this turn and keep going until they pass** — do not end your turn, summarize,
+or move on to other work until every answer is correct (or the user deliberately
+interrupts). On a pass, you're done; just conclude normally.
+
+## Quick reference
+
+| Depth | The test | References files/lines? |
+|---|---|---|
+| `standard` | answer it *without* reading code | **no** |
+| `deep` | must *read* the code to answer | **yes** — point them there |
+| `principle` | the transferable lesson, specifics stripped | sometimes |
+
+## Common mistakes
+
+- **Quizzing the whole repo.** Only quiz what *this turn* changed.
+- **Trivia distractors.** Make the wrong answers tempting, not silly.
+- **The longest option is the answer.** Length-balance every question.
+- **All one axis.** Sample across the five; don't skip how-was-it-verified.
+- **Drifting too high.** "What does the app do" tests what they didn't lose.
+- **Standard that references code, or deep that doesn't point to it.**
+- **Switching to prose in a gated turn.** Keep it `AskUserQuestion` MC.
+- **Skipping too eagerly.** Only *genuinely cosmetic* changes skip.
+- **Correct answer always first.** Vary its slot every question.

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-19" # auto-bump @1781873107
+last_verified: "2026-06-20" # auto-bump @1781974508
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

Phase 1 of the **No-Numb comprehension warden** (LIA-328): make *actually understanding what the agent built* the default path, not the disciplined-person path. Adapted from the MIT [no-numb](https://github.com/Ciucky/no-numb) plugin, made Deus-native.

A `Stop`-hook doorbell detects file edits this turn and, when opted in, blocks the stop until the user passes a `/quiz-me` comprehension quiz across **five axes** (what-changed, why-this-shape, what-would-break, **how-was-it-verified**, what-to-review-later) at a **depth dial** (standard / deep / principle).

## Key decision: DEFAULT-OFF + env opt-in (`DEUS_NONUMB`)

Diverges from upstream's default-ON. This hook ships in the repo where the autonomous pipeline runs host-side. Default-ON would risk gating pipeline/background sessions, which would then hit `AskUserQuestion` with no human. The env opt-in gates **only interactive shells by construction** -- launchd (`com.deus`) and container agents do not inherit an interactive shell's env (verified: `com.deus.plist` EnvironmentVariables is a closed dict with no `DEUS_NONUMB`; no plist sets it). The voluntary `/quiz-me` skill works regardless.

## Files

| File | Role |
|------|------|
| `.claude/hooks/nonumb-gate.sh` | Stop-hook doorbell. Guard/Chain-of-Responsibility; fails **open** everywhere (missing jq/transcript/config); `stop_hook_active` re-block trap. |
| `.claude/skills/quiz-me/SKILL.md` | Quiz-generation spec: two dials (depth x axis), five axes, length-balanced distractors, slot rotation, min-question floor (>=2 / >=4), retake-until-pass, gated-mode verification disclosure. |
| `.claude/skills/ATTRIBUTION-no-numb.md` | MIT attribution to Ciucky/no-numb. |
| `.claude/settings.json` | Additive `Stop` hook (merged; existing SessionStart/UserPromptSubmit/PreToolUse/PostToolUse hooks intact). |

Stop-hook I/O schema (`transcript_path`, `stop_hook_active`, `{decision:"block",reason}`): https://code.claude.com/docs/en/hooks

## Verification (hook-pr-smoke-test)

Real-invocation smoke suite (real stdin JSON + real env, sandboxed `HOME`) -- **15/15 assertions pass**:

\`\`\`
Test 1 - OFF path (no DEUS_NONUMB, no config): exit 0, no block, no config created
Test 2 - stop_hook_active:true: exit 0, no re-block (infinite-loop trap)
Test 3 - enabled + edit this turn: exit 0, emits decision:block, config lazily created
Test 4 - enabled + no edit this turn: exit 0, no block
Test 5 - jq genuinely absent (sandbox PATH, jq hidden): exit 0 fail-open, no block
Test 6 - missing transcript path: exit 0 fail-open, no block
RESULT: 15 passed, 0 failed
\`\`\`

Plus a **real-transcript run** against this live session's 556-line transcript: `DEUS_NONUMB=1` -> `decision:block`; default-OFF -> exits 0 silently. (Per LIA-246, the live process runs `~/deus/scripts` not the worktree, so a `claude logs` of the worktree gate is impossible pre-merge; the faithful real-invocation test is the accepted substitute.)

`drift_check.py` green; `flag_lint.py` green (the `$DEUS_NONUMB` shell read carries a `LIA-328` citation within the 3-line window).

## Co-gate

| Gate | Verdict |
|------|---------|
| plan-reviewer | SHIP (claude + gpt) |
| code-reviewer | SHIP (claude + gpt + glm) |
| ai-eng-warden | SHIP (claude + gpt) |
| verification-gate (Opus) | SHIP -- all 6 behavioral claims reproduced from real output |

## Rollback

Revert the `Stop` array addition in `.claude/settings.json` (gate is default-OFF so it no-ops until then anyway).

## Scope / follow-ups (NOT in this PR)

Spec: `Research/no-numb-comprehension-warden-spec.md`. Later phases: learning-card persistence -> vault atom (P2), spaced repetition (P3), independent grader (P4), rich HTML deck (P5), signal-sampled gating (P6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)