### PR TITLE
feat(maintenance): rotate the unbounded memory-tree query log (LIA-218)

### DIFF
--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -88,6 +88,11 @@ def main():
         "prune_warden_baks", [prune_baks, "--keep", "10"], dry_run
     )
 
+    rotate_qlog = str(SCRIPTS_DIR / "maintenance" / "rotate_query_log.py")
+    results["rotate_query_log"] = run_task(
+        "rotate_query_log", [rotate_qlog], dry_run
+    )
+
     # ── Weekly tasks (Sunday or --weekly) ────────────────────────────────────
 
     if run_weekly:

--- a/scripts/maintenance/rotate_query_log.py
+++ b/scripts/maintenance/rotate_query_log.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Rotate the memory-tree query log (LIA-218).
+
+`_log_query()` in scripts/memory_tree.py appends one JSON line per memory-tree
+query to `~/.deus/memory_tree_queries.jsonl` (override: $DEUS_TREE_LOG). It is
+append-only with no cap, so benchmark/calibration sweeps grow it without bound
+(observed: 248 MB / 710k lines). An oversized log slows the one consumer that
+reads the whole file — `scripts/mine_implicit_feedback.py` — and dilutes its
+real-user signal with synthetic noise.
+
+This standalone maintenance tool keeps the most recent N lines live and ARCHIVES
+the older prefix (gzipped, never deleted) under `~/.deus/archive/`. It is wired
+into scripts/maintenance.py's daily block (launchd 04:30), so the live file is
+bounded on a real schedule while the full history stays recoverable.
+
+Design — copy-on-write swap with tail-capture:
+  1. Record the live file's byte size S, read bytes [0, S) and split into the
+     archive prefix and the kept tail by line position.       O(N) on line count
+  2. gzip the archive prefix to a dated archive file.
+  3. Capture any bytes appended in [S, EOF) since step 1 (the writer never
+     blocks — it opens `open("a")` fresh per line and swallows errors — so we
+     cannot lock it; instead we re-read the delta up to 3x until stable).
+  4. Write `kept + delta` to a temp file on the SAME filesystem and
+     `os.replace()` it over the live log.                              O(1) swap
+
+The residual sub-millisecond race (an append landing between the final delta
+read and `os.replace`) is mitigated by running at the 04:30 idle window and by
+the SQLite `queries_log` secondary copy in memory_tree.py (most fields survive
+there regardless). Archives are pruned only after --archive-keep-days (default
+365), so nothing is silently lost within a year.
+
+Run with --help for flags. Safe to run repeatedly: below --max-lines it is a
+no-op, so a second run never produces a duplicate archive.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Same default + env override as scripts/memory_tree.py:_LOG_PATH, so test
+# isolation via $DEUS_TREE_LOG works against both writer and rotator.
+_DEFAULT_LOG = os.environ.get("DEUS_TREE_LOG", "~/.deus/memory_tree_queries.jsonl")
+
+
+def _count_lines(path: Path) -> int:
+    n = 0
+    with path.open("rb") as f:
+        for _ in f:
+            n += 1
+    return n
+
+
+def _date_of(line: bytes) -> str:
+    """The YYYY-MM-DD prefix of a log line's `ts` field, or 'unknown'.
+
+    Only the date (not the full ISO timestamp) is used in archive filenames —
+    the ISO `ts` contains ':' which is not a legal filename character on
+    Windows, and day granularity is enough to identify an archive.
+    """
+    try:
+        import json
+
+        ts = json.loads(line).get("ts", "")
+        return ts[:10] if len(ts) >= 10 else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _prune_archives(archive_dir: Path, keep_days: int, dry_run: bool, verbose: bool) -> int:
+    """Delete archive gzips older than keep_days (by mtime). Best-effort."""
+    if keep_days <= 0 or not archive_dir.is_dir():
+        return 0
+    cutoff = time.time() - keep_days * 86400
+    removed = 0
+    for gz in archive_dir.glob("memory_tree_queries-*.jsonl.gz"):
+        try:
+            if gz.stat().st_mtime >= cutoff:
+                continue
+        except OSError:
+            continue
+        if dry_run:
+            print(f"  would prune archive {gz.name}")
+            removed += 1
+            continue
+        try:
+            gz.unlink()
+            removed += 1
+            if verbose:
+                print(f"  pruned archive {gz.name}")
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            print(f"  WARN could not prune {gz}: {e}", file=sys.stderr)
+    return removed
+
+
+def rotate(
+    log_path: Path,
+    max_lines: int,
+    keep_lines: int,
+    archive_keep_days: int,
+    dry_run: bool,
+    verbose: bool,
+) -> tuple[int, int]:
+    """Rotate the log if it exceeds max_lines. Returns (archived, kept) lines.
+
+    No-op (returns (0, total)) when the file is missing or at/under max_lines.
+    """
+    if not log_path.exists():
+        print(f"rotate_query_log: no {log_path} — nothing to rotate")
+        return 0, 0
+
+    # [1] Freeze the size we are responsible for and read that prefix. Anything
+    #     appended after S is captured separately in [3] so it is never lost.
+    size_s = log_path.stat().st_size
+    with log_path.open("rb") as f:
+        prefix = f.read(size_s)
+    lines = prefix.splitlines(keepends=True)
+    total = len(lines)
+
+    if total <= max_lines:
+        if verbose:
+            print(f"rotate_query_log: {total} lines <= max {max_lines} — no-op")
+        # Still prune stale archives even when the live file is small.
+        _prune_archives(log_path.parent / "archive", archive_keep_days, dry_run, verbose)
+        return 0, total
+
+    archive_lines = lines[: total - keep_lines]
+    kept = lines[total - keep_lines:]
+    archive_count = len(archive_lines)
+
+    if dry_run:
+        print(
+            f"rotate_query_log: would archive {archive_count} lines, "
+            f"keep {len(kept)} (total {total}, max {max_lines})"
+        )
+        _prune_archives(log_path.parent / "archive", archive_keep_days, dry_run, verbose)
+        return archive_count, len(kept)
+
+    # [2] gzip the archive prefix to a dated file (write temp, then rename).
+    archive_dir = log_path.parent / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    first_d, last_d = _date_of(archive_lines[0]), _date_of(archive_lines[-1])
+    archive_path = archive_dir / f"memory_tree_queries-{first_d}_to_{last_d}.jsonl.gz"
+    # Never clobber an existing same-date archive (possible only under manual
+    # --max-lines forcing; the normal daily schedule no-ops once the live file
+    # is back under max_lines). Disambiguate with a -N suffix to preserve data.
+    if archive_path.exists():
+        n = 2
+        while (archive_dir / f"memory_tree_queries-{first_d}_to_{last_d}-{n}.jsonl.gz").exists():
+            n += 1
+        archive_path = archive_dir / f"memory_tree_queries-{first_d}_to_{last_d}-{n}.jsonl.gz"
+    tmp_gz = archive_path.with_suffix(".gz.tmp")
+    with gzip.open(tmp_gz, "wb") as gz:
+        for line in archive_lines:
+            gz.write(line)
+    os.replace(tmp_gz, archive_path)
+
+    # [3] Capture bytes appended since [1] (re-read up to 3x; keep the last
+    #     snapshot if still growing — safe here because each writer append is a
+    #     single write() syscall, so a read never sees a half-written line).
+    delta = b""
+    for _ in range(3):
+        cur = log_path.stat().st_size
+        if cur <= size_s:
+            break
+        with log_path.open("rb") as f:
+            f.seek(size_s)
+            new = f.read()
+        if new == delta:
+            break
+        delta = new
+
+    # [4] Atomically replace the live log with kept tail + captured delta.
+    #     Temp file lives in the SAME directory (filesystem) so os.replace is
+    #     atomic — a /tmp temp could be a cross-device rename and fail.
+    # TODO(windows, 2026-06-20): os.replace over a file another process holds
+    #     open for append raises PermissionError on Windows. Revisit when the
+    #     deus-cmd.sh Windows port lands (Windows support is blocked on it today).
+    fd, tmp_name = tempfile.mkstemp(dir=str(log_path.parent), prefix=".qlog-rot-")
+    try:
+        with os.fdopen(fd, "wb") as out:
+            for line in kept:
+                out.write(line)
+            if delta:
+                out.write(delta)
+        os.replace(tmp_name, log_path)
+    except BaseException:
+        # Leave the live log untouched on any failure; clean up the temp.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    print(
+        f"rotate_query_log: archived {archive_count} lines -> {archive_path.name}, "
+        f"kept {len(kept)} live"
+    )
+    _prune_archives(archive_dir, archive_keep_days, dry_run, verbose)
+    return archive_count, len(kept)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--log-path", type=Path, default=Path(os.path.expanduser(_DEFAULT_LOG)),
+        help="Query log to rotate (default: $DEUS_TREE_LOG or ~/.deus/memory_tree_queries.jsonl).",
+    )
+    parser.add_argument(
+        "--max-lines", type=int,
+        default=int(os.environ.get("DEUS_TREE_LOG_MAX_LINES", "100000")),  # LIA-218
+        help="Rotate only when the log exceeds this many lines (default: 100000).",
+    )
+    parser.add_argument(
+        "--keep-lines", type=int,
+        default=int(os.environ.get("DEUS_TREE_LOG_KEEP_LINES", "50000")),  # LIA-218
+        help="Lines to retain live after rotation (default: 50000).",
+    )
+    parser.add_argument(
+        "--archive-keep-days", type=int,
+        default=int(os.environ.get("DEUS_TREE_LOG_ARCHIVE_KEEP_DAYS", "365")),  # LIA-218
+        help="Prune archive gzips older than this many days (default: 365; 0 disables).",
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would happen; touch nothing.")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Also print no-op and per-archive detail.")
+    args = parser.parse_args(argv)
+
+    if args.keep_lines < 0 or args.max_lines < 0:
+        print("--max-lines and --keep-lines must be >= 0", file=sys.stderr)
+        return 1
+    if args.keep_lines > args.max_lines:
+        # Keeping more than the rotate threshold would never shrink the file.
+        print("--keep-lines must be <= --max-lines", file=sys.stderr)
+        return 1
+
+    rotate(
+        args.log_path, args.max_lines, args.keep_lines,
+        args.archive_keep_days, args.dry_run, args.verbose,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_rotate_query_log.py
+++ b/scripts/tests/test_rotate_query_log.py
@@ -1,0 +1,163 @@
+"""Tests for LIA-218 query-log rotation (scripts/maintenance/rotate_query_log.py).
+
+Hermetic: every test builds a throwaway log under pytest's tmp_path, so nothing
+touches the real ~/.deus/memory_tree_queries.jsonl. Lines mimic the production
+JSONL shape (one JSON object per line, with a `ts` field).
+"""
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1] / "maintenance" / "rotate_query_log.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("rotate_query_log", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["rotate_query_log"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rql = _load()
+
+
+def _write_log(path: Path, n: int, day: str = "2026-06-01") -> None:
+    """Write n production-shaped JSONL lines."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for i in range(n):
+            f.write(json.dumps({
+                "ts": f"{day}T00:00:{i % 60:02d}",
+                "query": f"query number {i}",
+                "trace": [],
+                "final_confidence": 0.5,
+                "results": [],
+                "fell_back": False,
+            }) + "\n")
+
+
+def _archive_lines(archive_dir: Path) -> int:
+    total = 0
+    for gz in archive_dir.glob("memory_tree_queries-*.jsonl.gz"):
+        with gzip.open(gz, "rt") as f:
+            total += sum(1 for _ in f)
+    return total
+
+
+def test_under_threshold_is_noop(tmp_path: Path):
+    log = tmp_path / "queries.jsonl"
+    _write_log(log, 50)
+    before = log.read_bytes()
+
+    archived, kept = rql.rotate(log, max_lines=100, keep_lines=50,
+                                archive_keep_days=365, dry_run=False, verbose=False)
+
+    assert (archived, kept) == (0, 50)
+    assert log.read_bytes() == before  # untouched
+    assert not (tmp_path / "archive").exists()
+
+
+def test_over_threshold_archives_and_keeps_without_loss(tmp_path: Path):
+    log = tmp_path / "queries.jsonl"
+    _write_log(log, 1000)
+
+    archived, kept = rql.rotate(log, max_lines=100, keep_lines=50,
+                                archive_keep_days=365, dry_run=False, verbose=False)
+
+    assert kept == 50
+    assert archived == 950
+    # Live file trimmed to exactly the last 50 lines, all valid JSON.
+    live = log.read_text().splitlines()
+    assert len(live) == 50
+    for line in live:
+        json.loads(line)
+    # The last live line is the original last line (recency preserved).
+    assert json.loads(live[-1])["query"] == "query number 999"
+    # No loss: archived + kept == original total.
+    archive_dir = tmp_path / "archive"
+    assert _archive_lines(archive_dir) == 950
+    assert _archive_lines(archive_dir) + len(live) == 1000
+
+
+def test_second_run_is_noop(tmp_path: Path):
+    log = tmp_path / "queries.jsonl"
+    _write_log(log, 1000)
+    rql.rotate(log, max_lines=100, keep_lines=50, archive_keep_days=365,
+               dry_run=False, verbose=False)
+    after_first = log.read_bytes()
+    archive_count_first = len(list((tmp_path / "archive").glob("*.jsonl.gz")))
+
+    archived, kept = rql.rotate(log, max_lines=100, keep_lines=50,
+                                archive_keep_days=365, dry_run=False, verbose=False)
+
+    assert archived == 0  # now 50 lines <= max 100
+    assert log.read_bytes() == after_first  # idempotent, no re-trim
+    # No duplicate archive produced on the no-op pass.
+    assert len(list((tmp_path / "archive").glob("*.jsonl.gz"))) == archive_count_first
+
+
+def test_dry_run_touches_nothing(tmp_path: Path):
+    log = tmp_path / "queries.jsonl"
+    _write_log(log, 1000)
+    before_bytes = log.read_bytes()
+    before_mtime = log.stat().st_mtime
+
+    archived, kept = rql.rotate(log, max_lines=100, keep_lines=50,
+                                archive_keep_days=365, dry_run=True, verbose=False)
+
+    assert (archived, kept) == (950, 50)  # reports intent
+    assert log.read_bytes() == before_bytes  # live untouched
+    assert log.stat().st_mtime == before_mtime
+    assert not (tmp_path / "archive").exists()  # no archive written
+
+
+def test_archive_filename_uses_date_range(tmp_path: Path):
+    log = tmp_path / "queries.jsonl"
+    _write_log(log, 1000, day="2026-04-14")
+
+    rql.rotate(log, max_lines=100, keep_lines=50, archive_keep_days=365,
+               dry_run=False, verbose=False)
+
+    names = [p.name for p in (tmp_path / "archive").glob("*.jsonl.gz")]
+    assert len(names) == 1
+    # Date-only range (no colons → Windows-safe filename).
+    assert names[0] == "memory_tree_queries-2026-04-14_to_2026-04-14.jsonl.gz"
+    assert ":" not in names[0]
+
+
+def test_same_date_archive_is_not_clobbered(tmp_path: Path):
+    # A pre-existing archive with the same date range must survive a second
+    # rotation on the same day (manual --max-lines forcing edge).
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    existing = archive_dir / "memory_tree_queries-2026-04-14_to_2026-04-14.jsonl.gz"
+    with gzip.open(existing, "wt") as f:
+        f.write('{"prior": "archive"}\n')
+
+    log = tmp_path / "queries.jsonl"
+    _write_log(log, 1000, day="2026-04-14")
+    rql.rotate(log, max_lines=100, keep_lines=50, archive_keep_days=365,
+               dry_run=False, verbose=False)
+
+    names = sorted(p.name for p in archive_dir.glob("*.jsonl.gz"))
+    # Both the prior archive and the new -2 archive exist; nothing overwritten.
+    assert names == [
+        "memory_tree_queries-2026-04-14_to_2026-04-14-2.jsonl.gz",
+        "memory_tree_queries-2026-04-14_to_2026-04-14.jsonl.gz",
+    ]
+    with gzip.open(existing, "rt") as f:
+        assert f.read() == '{"prior": "archive"}\n'  # untouched
+
+
+def test_missing_log_is_noop(tmp_path: Path):
+    log = tmp_path / "does-not-exist.jsonl"
+    archived, kept = rql.rotate(log, max_lines=100, keep_lines=50,
+                                archive_keep_days=365, dry_run=False, verbose=False)
+    assert (archived, kept) == (0, 0)


### PR DESCRIPTION
## What
Bounds `~/.deus/memory_tree_queries.jsonl`, which grew append-only with no cap (observed **248 MB / 710k lines**). The oversized log slows the one consumer that reads it whole (`scripts/mine_implicit_feedback.py`) and dilutes its real-user signal with benchmark/calibration sweep noise.

## How
New `scripts/maintenance/rotate_query_log.py`, wired as a **daily** task in `scripts/maintenance.py` (launchd 04:30):
- Keeps the last `DEUS_TREE_LOG_KEEP_LINES` (default 50k) lines live; archives the older prefix **gzipped** under `~/.deus/archive/` — **archive-not-delete** (pruned only after `DEUS_TREE_LOG_ARCHIVE_KEEP_DAYS`, default 365).
- Rotates only when the log exceeds `DEUS_TREE_LOG_MAX_LINES` (default 100k); below threshold = no-op.
- **Append-safe** copy-on-write + tail-capture swap; atomic `os.replace` of `keep + delta` on the same filesystem. Residual sub-ms race bounded by the 04:30 idle window + the SQLite `queries_log` secondary copy.
- Same-date archives get a `-N` suffix so a forced re-run never clobbers prior data.

## Safety
- **no-db-deletion**: archives, never deletes within retention; ADR exempts flat-file archive ops.
- **No data loss**: tests assert `keep + archive == original` and that a pre-existing same-date archive survives untouched.
- **Verified live**: `--dry-run` on the real 710,885-line log reports "would archive 660,885, keep 50,000", file byte-identical after (MD5 unchanged).

## Cross-platform note
`os.replace` over a file held open for append raises `PermissionError` on **Windows** — flagged `TODO(windows, 2026-06-20)`. Not a blocker (Windows support already gated on the deus-cmd.sh port).

## Tests
7 hermetic tests: under-threshold no-op, no-loss, idempotency, dry-run safety, date-range filename, same-date no-clobber, missing-log no-op.

## Gates
plan-reviewer (claude+gpt) SHIP · code-reviewer (claude+gpt) SHIP (both caught the same-date clobber → fixed + re-reviewed) · verification-gate (Opus) SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)