### PR TITLE
feat(maintenance): nightly credential expiry probe for Codex + gcal

### DIFF
--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -93,6 +93,13 @@ def main():
         "rotate_query_log", [rotate_qlog], dry_run
     )
 
+    # run_task prepends the Python interpreter, so this (like every sibling
+    # maintenance script) runs as `python3 credential_probe.py` and stays 644.
+    cred_probe = str(SCRIPTS_DIR / "maintenance" / "credential_probe.py")
+    results["credential_probe"] = run_task(
+        "credential_probe", [cred_probe], dry_run
+    )
+
     # ── Weekly tasks (Sunday or --weekly) ────────────────────────────────────
 
     if run_weekly:

--- a/scripts/maintenance/credential_probe.py
+++ b/scripts/maintenance/credential_probe.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Credential expiry health probe (read-only).
+
+8 `fix(auth)` commits over two months were reactive fixes to overnight 401s.
+`auth-refresh.ts` already refreshes credentials every 30min and alerts when a
+refresh ATTEMPT fails, but if the refresher silently stops keeping a token fresh
+(daemon down, file stale), nothing proactively warns before the next day's work.
+
+This standalone tool fills that gap: a nightly read-only check that each probed
+surface's durable auth mechanism is intact, alerting if not. It is wired into
+scripts/maintenance.py's daily block (launchd 04:30).
+
+SECURITY: this reads ONLY expiry metadata. It NEVER reads, logs, or prints a
+token, refresh-token, or API-key VALUE — every message contains a status and a
+minute count, nothing more.
+
+Surfaces probed (both are SINGLE-SOURCE files, so a file read is the whole
+truth):
+- Codex (~/.codex/auth.json): a dedicated refresher renews the OAuth token once
+  it drops inside the 45min REFRESH_GATE_MS, on a 30min cadence. So the gate
+  value is NOT a safe threshold: a HEALTHY token legitimately sits 15-45min from
+  expiry while waiting for the next tick (worst case: missed a tick at 46min ->
+  next tick ~16min -> refreshed). The healthy FLOOR is 45-30 = 15min, so we warn
+  only on "expired OR within GRACE" (default 10min, below the floor) — a healthy
+  token never warns, yet a token the refresher failed to renew is caught ~10min
+  out. (api-key mode does not expire.)
+- gcal (integrations/gcal/tokens.json): keepalive runs DAILY and Google access
+  tokens are ~1h-lived, refreshed on demand, so a stale gcal ACCESS token is
+  normal. The real signal is the DURABLE credential: tokens.json present, valid
+  JSON, non-empty refresh_token. (Network revocation check is out of scope.)
+
+Claude is deliberately NOT probed: on macOS the runtime resolves the FRESHEST of
+~/.claude/.credentials.json AND the OS keychain (anthropic.ts resolveFreshest-
+Credentials) — the file is a Deus-managed cache that can lag the keychain, so a
+file-only probe would false-positive exactly as the stale-file 401 bug it guards
+against. Probing it correctly means duplicating that keychain resolution; and
+Claude is already the best-covered surface (auth-refresh.ts serves-freshest and
+alerts on its own refresh failure). So it is left to that path.
+
+A surface whose credential file is absent is treated as "not configured" and
+SKIPPED (Codex and gcal are opt-in; a minimal install must not fail daily
+maintenance). Exit 0 if no surface WARNs (OK or SKIP); non-zero if any surface
+WARNs (so maintenance.py marks the task failed and the launchd error log
+surfaces it). A failed refresher leaves the file PRESENT-but-expired, which is a
+WARN, so SKIP-on-missing does not weaken the core refresher-failure detection.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_CODEX = Path(os.path.expanduser("~/.codex/auth.json"))
+DEFAULT_GCAL = _REPO_ROOT / "integrations" / "gcal" / "tokens.json"
+
+# Healthy floor = REFRESH_GATE_MS(45) - refresh cadence(30) = 15min. GRACE must
+# stay below it so a healthy token (always >=15min when the refresher is alive)
+# never warns. See auth-refresh.ts:44,390 and com.deus.oauth-refresh StartInterval.
+DEFAULT_GRACE_MIN = int(os.environ.get("DEUS_CRED_PROBE_GRACE_MIN", "10"))  # #920
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _decode_jwt_exp_ms(token: str) -> int | None:
+    """Return the `exp` claim of a JWT as epoch-ms, or None if unreadable.
+
+    Expiry read only — the signature is NOT verified (we check freshness, not
+    authenticity). urlsafe base64 with the standard right-pad to a multiple of 4.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        data = json.loads(base64.urlsafe_b64decode(payload))
+    except Exception:
+        return None
+    exp = data.get("exp")
+    # Fail closed: a non-numeric/absent exp returns None -> caller WARNs.
+    return int(exp) * 1000 if isinstance(exp, (int, float)) else None
+
+
+def _expiry_status(remaining_ms: int, grace_ms: int) -> tuple[str, str]:
+    """OK/WARN verdict for an expiry-window surface."""
+    mins = remaining_ms // 60000
+    if remaining_ms <= grace_ms:
+        return "WARN", (
+            "expired" if remaining_ms <= 0 else f"only {mins}min to expiry (refresher stalled?)"
+        )
+    return "OK", f"fresh ({mins}min to expiry)"
+
+
+def check_codex(path: Path, grace_ms: int, now_ms: int) -> tuple[str, str]:
+    if not path.exists():
+        return "SKIP", "not configured (no auth file)"  # Codex is opt-in
+    try:
+        d = json.loads(path.read_text())
+    except Exception:
+        return "WARN", "auth file malformed"
+    if not isinstance(d, dict):
+        return "WARN", "auth file malformed"
+    # API-key mode does not expire — but the key must actually be present.
+    if d.get("auth_mode") == "apikey":
+        if d.get("OPENAI_API_KEY"):
+            return "OK", "api-key mode (no expiry)"
+        return "WARN", "api-key mode but no OPENAI_API_KEY"
+    # OAuth (chatgpt) mode: a usable access-token JWT is required. A missing
+    # token here is a logged-out/corrupted state, NOT a healthy no-expiry case.
+    tokens = d.get("tokens")
+    access = tokens.get("access_token") if isinstance(tokens, dict) else None
+    if not isinstance(access, str):
+        return "WARN", "no OAuth access token (logged out?)"
+    exp_ms = _decode_jwt_exp_ms(access)
+    if exp_ms is None:
+        return "WARN", "access token not a readable JWT"
+    return _expiry_status(exp_ms - now_ms, grace_ms)
+
+
+def check_gcal(path: Path) -> tuple[str, str]:
+    # Durable-credential model: gcal access tokens are short-lived and refreshed
+    # on demand, so access-token staleness is NORMAL. Only the refresh_token
+    # (the durable credential) being gone is a real failure.
+    if not path.exists():
+        return "SKIP", "not configured (no tokens file)"  # gcal is opt-in
+    try:
+        d = json.loads(path.read_text())
+    except Exception:
+        return "WARN", "tokens file malformed"
+    if not isinstance(d, dict):
+        return "WARN", "tokens file malformed"
+    if not d.get("refresh_token"):
+        return "WARN", "no refresh_token (re-auth needed)"
+    return "OK", "refresh_token present"
+
+
+def _macos_notify(title: str, message: str) -> None:
+    """Best-effort macOS banner. Never raises; no-op off macOS."""
+    if sys.platform != "darwin":
+        return
+    try:
+        subprocess.run(
+            ["osascript", "-e", f'display notification {json.dumps(message)} with title {json.dumps(title)}'],
+            capture_output=True, timeout=10,
+        )
+    except Exception:
+        pass
+
+
+def run_probe(codex_path: Path, gcal_path: Path, grace_ms: int, now_ms: int) -> list[tuple[str, str, str]]:
+    """Return [(surface, status, detail)] for all probed surfaces."""
+    return [
+        ("codex", *check_codex(codex_path, grace_ms, now_ms)),
+        ("gcal", *check_gcal(gcal_path)),
+    ]
+
+
+def main(argv: list[str] | None = None, notifier=_macos_notify, now_ms: int | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--codex-auth", type=Path, default=DEFAULT_CODEX)
+    parser.add_argument("--gcal-tokens", type=Path, default=DEFAULT_GCAL)
+    parser.add_argument(
+        "--grace-min", type=int, default=DEFAULT_GRACE_MIN,
+        help="WARN if a Codex token is within this many minutes of expiry "
+             "(default 10; must stay below the 15min healthy floor).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.grace_min >= 15:
+        # The 15min healthy floor (45min gate - 30min cadence) is the hard
+        # ceiling; a grace at/above it would WARN on healthy tokens.
+        print("credential_probe: --grace-min must be < 15 (the healthy floor)", file=sys.stderr)
+        return 2
+
+    now = now_ms if now_ms is not None else _now_ms()
+    grace_ms = args.grace_min * 60000
+
+    results = run_probe(args.codex_auth, args.gcal_tokens, grace_ms, now)
+
+    warns = [(s, d) for s, st, d in results if st == "WARN"]
+    n_ok = sum(1 for _, st, _ in results if st == "OK")
+    n_skip = sum(1 for _, st, _ in results if st == "SKIP")
+    for surface, status, detail in results:
+        print(f"  [{surface}] {status} — {detail}")
+    print(f"credential_probe: {n_ok} OK, {len(warns)} WARN, {n_skip} skipped")
+
+    if warns:
+        summary = "; ".join(f"{s}: {d}" for s, d in warns)
+        notifier("Deus credential probe", summary)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_credential_probe.py
+++ b/scripts/tests/test_credential_probe.py
@@ -1,0 +1,182 @@
+"""Tests for the credential expiry health probe (scripts/maintenance/credential_probe.py).
+
+Hermetic: every test builds throwaway token files under tmp_path with an injected
+`now_ms`, so nothing touches real credentials and nothing shells out (the macOS
+notifier is replaced by a recorder). SECURITY-relevant: a test asserts no token
+value ever appears in the probe's output. Claude is intentionally not probed (its
+macOS keychain dual-source resolution can't be read from the file alone), so there
+are no Claude cases here.
+"""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1] / "maintenance" / "credential_probe.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("credential_probe", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["credential_probe"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cp = _load()
+
+NOW = 1_800_000_000_000  # fixed "now" in ms
+MIN = 60_000
+
+
+def _jwt(exp_seconds: int) -> str:
+    """A minimal unsigned (alg:none) JWT carrying only an `exp` claim.
+
+    Intentionally unsigned: the probe reads expiry, it does NOT verify the
+    signature, so the test needs no crypto dependency.
+    """
+    def b64(obj: dict) -> str:
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    return f"{b64({'alg': 'none'})}.{b64({'exp': exp_seconds})}.sig"
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.write_text(json.dumps(obj))
+
+
+# ── Codex ───────────────────────────────────────────────────────────────────
+
+def test_codex_healthy_waiting_for_tick_is_ok(tmp_path: Path):
+    # 30min and 16min from expiry: inside the 45min gate but ABOVE the 10min
+    # grace — healthy, refresher will renew on its next tick. NOT a warning.
+    for mins in (30, 16):
+        p = tmp_path / f"codex_{mins}.json"
+        _write(p, {"auth_mode": "chatgpt", "tokens": {"access_token": _jwt((NOW + mins * MIN) // 1000)}})
+        assert cp.check_codex(p, 10 * MIN, NOW)[0] == "OK", f"{mins}min should be OK"
+
+
+def test_codex_within_grace_and_expired_warn(tmp_path: Path):
+    for secs_from_now, expect_detail in ((5 * MIN, "expiry"), (-5 * MIN, "expired")):
+        p = tmp_path / "codex.json"
+        _write(p, {"auth_mode": "chatgpt", "tokens": {"access_token": _jwt((NOW + secs_from_now) // 1000)}})
+        status, detail = cp.check_codex(p, 10 * MIN, NOW)
+        assert status == "WARN" and expect_detail in detail
+
+
+def test_codex_apikey_mode_with_key_is_ok(tmp_path: Path):
+    p = tmp_path / "apikey.json"
+    _write(p, {"auth_mode": "apikey", "OPENAI_API_KEY": "x", "tokens": {}})
+    status, detail = cp.check_codex(p, 10 * MIN, NOW)
+    assert status == "OK" and "api-key" in detail
+
+
+def test_codex_apikey_mode_without_key_warns(tmp_path: Path):
+    p = tmp_path / "nokey.json"
+    _write(p, {"auth_mode": "apikey", "tokens": {}})  # no OPENAI_API_KEY
+    assert cp.check_codex(p, 10 * MIN, NOW)[0] == "WARN"
+
+
+def test_codex_oauth_mode_no_token_warns(tmp_path: Path):
+    # chatgpt mode but no access token = logged out/corrupted = WARN. Both
+    # shapes: tokens dict present-but-empty, and tokens key absent entirely.
+    for body in ({"auth_mode": "chatgpt", "tokens": {}}, {"auth_mode": "chatgpt"}):
+        p = tmp_path / "partial.json"
+        _write(p, body)
+        status, detail = cp.check_codex(p, 10 * MIN, NOW)
+        assert status == "WARN" and "logged out" in detail
+
+
+def test_codex_malformed_jwt_warns(tmp_path: Path):
+    p = tmp_path / "bad.json"
+    _write(p, {"auth_mode": "chatgpt", "tokens": {"access_token": "not-a-jwt"}})
+    assert cp.check_codex(p, 10 * MIN, NOW)[0] == "WARN"
+
+
+def test_codex_missing_skips_malformed_warns(tmp_path: Path):
+    # Missing file = not configured = SKIP. Present-but-broken = WARN.
+    assert cp.check_codex(tmp_path / "nope.json", 10 * MIN, NOW)[0] == "SKIP"
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert cp.check_codex(bad, 10 * MIN, NOW)[0] == "WARN"
+
+
+# ── gcal (durable-credential model — access-token expiry IGNORED) ────────────
+
+def test_gcal_ok_with_refresh_token_even_if_access_expired(tmp_path: Path):
+    p = tmp_path / "tokens.json"
+    _write(p, {"refresh_token": "present", "expiry_date": NOW - 10 * MIN})  # access expired
+    status, detail = cp.check_gcal(p)
+    assert status == "OK" and "refresh_token present" in detail
+
+
+def test_gcal_missing_skips_no_refresh_token_warns(tmp_path: Path):
+    assert cp.check_gcal(tmp_path / "absent.json")[0] == "SKIP"  # not configured
+    p = tmp_path / "tokens.json"
+    _write(p, {"access_token": "x", "expiry_date": NOW + 99 * MIN})  # no refresh_token
+    assert cp.check_gcal(p)[0] == "WARN"
+
+
+# ── shared robustness ────────────────────────────────────────────────────────
+
+def test_non_dict_json_warns_not_crashes(tmp_path: Path):
+    # Valid JSON that isn't an object (e.g. `[]`) must WARN, not raise.
+    p = tmp_path / "list.json"
+    p.write_text("[]")
+    assert cp.check_codex(p, 10 * MIN, NOW)[0] == "WARN"
+    assert cp.check_gcal(p)[0] == "WARN"
+
+
+# ── main() exit codes + notifier + secret hygiene ────────────────────────────
+
+def _all_ok(tmp_path: Path) -> list[str]:
+    codex = tmp_path / "x.json"; _write(codex, {"auth_mode": "apikey", "OPENAI_API_KEY": "x", "tokens": {}})
+    gcal = tmp_path / "g.json"; _write(gcal, {"refresh_token": "r"})
+    return ["--codex-auth", str(codex), "--gcal-tokens", str(gcal)]
+
+
+def test_main_all_ok_exit_zero_no_notify(tmp_path: Path, capsys):
+    fired = []
+    rc = cp.main(_all_ok(tmp_path), notifier=lambda *a: fired.append(a), now_ms=NOW)
+    assert rc == 0 and fired == []
+    assert "2 OK, 0 WARN, 0 skipped" in capsys.readouterr().out
+
+
+def test_unconfigured_surfaces_skip_not_fail(tmp_path: Path, capsys):
+    # Both opt-in surfaces absent (minimal install) -> SKIP -> exit 0, no alert.
+    fired = []
+    rc = cp.main(["--codex-auth", str(tmp_path / "absent-codex.json"),
+                  "--gcal-tokens", str(tmp_path / "absent-gcal.json")],
+                 notifier=lambda *a: fired.append(a), now_ms=NOW)
+    assert rc == 0 and fired == []
+    assert "0 OK, 0 WARN, 2 skipped" in capsys.readouterr().out
+
+
+def test_main_any_warn_exits_nonzero_and_notifies(tmp_path: Path):
+    args = _all_ok(tmp_path)
+    gcal = tmp_path / "g.json"; _write(gcal, {"access_token": "x"})  # break gcal: no refresh_token
+    fired = []
+    rc = cp.main(args, notifier=lambda *a: fired.append(a), now_ms=NOW)
+    assert rc == 1 and len(fired) == 1
+
+
+def test_grace_min_at_or_above_floor_is_rejected(tmp_path: Path):
+    rc = cp.main(_all_ok(tmp_path) + ["--grace-min", "15"], notifier=lambda *a: None, now_ms=NOW)
+    assert rc == 2
+
+
+def test_output_never_leaks_token_values(tmp_path: Path, capsys):
+    codex = tmp_path / "x.json"
+    _write(codex, {"auth_mode": "chatgpt", "tokens": {"access_token": _jwt((NOW + 99 * MIN) // 1000)}})
+    gcal = tmp_path / "g.json"; _write(gcal, {"refresh_token": "SECRET-REFRESH"})
+    fired = []
+    cp.main(["--codex-auth", str(codex), "--gcal-tokens", str(gcal)],
+            notifier=lambda *a: fired.append(a), now_ms=NOW)
+    out = capsys.readouterr().out
+    # Neither stdout nor any notifier argument carries a raw token value.
+    assert "SECRET-REFRESH" not in out and "SECRET-REFRESH" not in str(fired)


### PR DESCRIPTION
## What
Proactive nightly read-only check for the recurring overnight-401 failure mode (8 reactive `fix(auth)` commits over two months). `auth-refresh.ts` refreshes every 30 min and alerts on a refresh-*attempt* failure, but nothing warns when the refresher silently stops keeping a token fresh.

## How
`scripts/maintenance/credential_probe.py` (daily task in `maintenance.py`, launchd 04:30) checks:
- **Codex** (`~/.codex/auth.json`): JWT `exp`, or api-key mode (no expiry). WARNs only on expired-or-within-**10 min grace** (below the **15 min healthy floor** = 45 min refresh gate − 30 min cadence), so healthy auto-refreshed tokens never false-positive.
- **gcal** (`integrations/gcal/tokens.json`): durable `refresh_token` presence (access-token staleness is normal — refreshed on demand).

An absent opt-in surface **SKIPs** (a minimal install never fails maintenance). Exit non-zero on any WARN → macOS notify + launchd error log.

## Security
Reads expiry metadata only; never logs a token value (asserted by test).

## Why Claude is excluded
On macOS, Claude auth resolves to the **freshest of file + OS keychain** (`anthropic.ts resolveFreshestCredentials`) — a file-only probe would reproduce the stale-file 401 bug. It's already covered by `auth-refresh.ts` serve-freshest + failure alerting.

## Tests
15 hermetic tests (expiry bands, api-key mode, logged-out, SKIP semantics, non-dict JSON, secret hygiene).

## Gates
plan-reviewer (claude+gpt, 3 rounds) · code-reviewer (claude+gpt, 5 rounds — caught 2 false-negatives + the keychain dual-source) · verification-gate (Opus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)