### PR TITLE
feat(maintenance): weekly local judge-calibration watchdog (LIA-261)

### DIFF
--- a/evolution/eval/baselines.json
+++ b/evolution/eval/baselines.json
@@ -20,5 +20,23 @@
         "note": "Pre-LIA-326 measurement on a different judge (Ollama gemma4:e4b), NOT the CI gate's Gemini judge -- kept for history, not used as the gemini threshold."
       }
     }
+  },
+  "quality_pearson": {
+    "floor": 0.58,
+    "comment": "Regression floor for the LOCAL judge-calibration watchdog (scripts/maintenance/judge_calibration.py, LIA-261), measured on the LOCAL gemma4:e4b judge against the pinned Gemini ground truth (finetune/judge-bench/fixture-v1.jsonl, n=200), QUALITY dimension. NOT a CI gate: judge-gate.yml runs the Gemini judge (CI has no Ollama); this anchors the local judge, which only exists locally, so it runs as a scheduled weekly maintenance task. Three runs span 0.670-0.682 (run-to-run Ollama nondeterminism ~0.012); the bootstrap 95% CI lower bound of the composite is ~0.595. floor 0.58 sits just below that CI lower bound and ~0.09 below the worst observed quality run, so a healthy run never false-alarms, while a >=0.10 Pearson drop -- the established real-degradation threshold (a 2026-05-20 grammar change degraded quality Pearson 0.06-0.12) -- trips it. The code fallback _DEFAULT_QUALITY_FLOOR (judge_calibration.py) stays at the conservative 0.50 for when this file is missing/malformed -- the file floor and the fallback constant deliberately diverge, same as safety_recall.",
+    "provenance": {
+      "observed": 0.682,
+      "judge": "gemma4:e4b",
+      "runtime": "ollama",
+      "recorded": "2026-06-23",
+      "fixtures": 200,
+      "dim": "quality",
+      "runs": 3,
+      "comment": "Fresh confirmation run 2026-06-23: quality Pearson 0.682 (Spearman 0.683, MAE 0.198), 0/200 parse errors, avg latency 3.9s/record, composite_pearson 0.672 (95% CI 0.595-0.742). Personalization is deliberately excluded from the watchdog (structurally dead -- the limiter is the judge model, not the rubric; see CLAUDE.md perso-structural). tool_use/safety are out of v1 scope.",
+      "prior": [
+        {"observed": 0.673, "recorded": "2026-06-06", "source": "#713 results-v1.json", "note": "n=200 gemma4:e4b fixture-v1 ollama, same fixture+judge+runtime"},
+        {"observed": 0.670, "recorded": "2026-06-12", "source": "lia285-diag PRE", "note": "n=200 gemma4:e4b fixture-v1 ollama, same fixture+judge+runtime"}
+      ]
+    }
   }
 }

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-21" # auto-bump @1782013894
+last_verified: "2026-06-23" # auto-bump @1782200823
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-21" # auto-bump @1782013894
+last_verified: "2026-06-23" # auto-bump @1782200823
 governs:
   - src/
   - evolution/

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -119,6 +119,18 @@ def main():
             [compression_bench, "--vault-integrity"],
             dry_run,
         )
+
+        # Local judge calibration watchdog (LIA-261): anchor the local gemma4:e4b
+        # evolution judge to the pinned Gemini ground truth; WARN on a quality-
+        # Pearson regression. 130min ceiling > the watchdog's own 7200s bench
+        # timeout, so the watchdog returns a clean INCONCLUSIVE (exit 0) before a
+        # hard maintenance TIMEOUT could mark it FAILED on pure infra slowness.
+        # run_task prepends the Python interpreter, so this (like every sibling
+        # maintenance script) runs as `python3 judge_calibration.py` and stays 644.
+        judge_calib = str(SCRIPTS_DIR / "maintenance" / "judge_calibration.py")
+        results["judge_calibration"] = run_task(
+            "judge_calibration", [judge_calib], dry_run, timeout=7800,
+        )
     else:
         print(f"\n── Weekly tasks skipped (not Sunday, use --weekly to force) ──")
 

--- a/scripts/maintenance/_notify.py
+++ b/scripts/maintenance/_notify.py
@@ -1,0 +1,27 @@
+"""Shared best-effort desktop notifier for maintenance probes (no-op off macOS)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def macos_notify(title: str, message: str) -> None:
+    """Best-effort macOS banner. Never raises; no-op on non-Darwin platforms."""
+    if sys.platform != "darwin":
+        return
+    try:
+        # json.dumps escapes the " and \ that AppleScript string literals need —
+        # the correct sanitizer for embedding arbitrary text in the `-e` script
+        # (shlex.quote would be wrong here). ensure_ascii=False is required: the
+        # default \uXXXX escaping mangles non-ASCII (e.g. the em dash in a WARN
+        # message), which AppleScript does not decode; UTF-8 passes through fine.
+        def _lit(s: str) -> str:
+            return json.dumps(s, ensure_ascii=False)
+        subprocess.run(
+            ["osascript", "-e",
+             f"display notification {_lit(message)} with title {_lit(title)}"],
+            capture_output=True, timeout=10,
+        )
+    except Exception:
+        pass

--- a/scripts/maintenance/judge_calibration.py
+++ b/scripts/maintenance/judge_calibration.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Judge calibration watchdog (LIA-261) — LOCAL weekly.
+
+The evolution loop scores every interaction with a LOCAL Ollama judge
+(gemma4:e4b). If that judge silently drifts out of agreement with the pinned
+Gemini ground truth, every downstream reflection/metric is quietly poisoned and
+nothing warns. The CI safety-recall gate (.github/workflows/judge-gate.yml,
+LIA-326) cannot cover this: CI has no Ollama, so it runs the *Gemini* judge.
+This watchdog is the local sibling that anchors the *local* judge.
+
+It re-runs `evolution/benchmark_judge.py` against the committed Gemini-labeled
+fixture and checks the QUALITY-dimension Pearson against a measured floor in
+`evolution/eval/baselines.json` (sibling to `safety_recall`). Quality is the
+load-bearing composite dimension; personalization is excluded (structurally
+dead — the limiter is the judge model, not the rubric; see CLAUDE.md
+perso-structural). tool_use/safety are out of v1 scope.
+
+Contract (mirrors safety_redteam.py::_classify_gate_outcome — infra precedence):
+  - Any judge-infra failure (Ollama down, bench crash/timeout, too few records,
+    too many parse errors, or an unreadable Pearson) -> INCONCLUSIVE, exit 0.
+    A degraded run can NEVER be misread as a regression: we never false-alarm.
+  - Quality Pearson below the floor on a clean full run -> WARN, exit nonzero
+    (+ best-effort macOS banner). This is the ONLY alert.
+  - Otherwise -> OK, exit 0.
+
+Wired into scripts/maintenance.py's WEEKLY (Sunday) block, not the daily one: an
+n=200 Ollama bench takes ~12-130min depending on contention (eval-diagnostics
+ollama-contention), too heavy for the 04:30 daily run.
+
+The fixture (finetune/judge-bench/fixture-v1.jsonl) is gitignored / local-only;
+if it is absent the bench exits and this watchdog returns INCONCLUSIVE — the
+same "opt-in surface absent -> skip, never fail maintenance" stance as
+credential_probe.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Reuse the shared maintenance notifier (no platform guard needed at call site).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _notify import macos_notify  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASELINES_PATH = _REPO_ROOT / "evolution" / "eval" / "baselines.json"
+
+# Conservative fallback floor when baselines.json is missing/malformed: set well
+# below any healthy observed value (~0.67) so a missing file never false-alarms
+# — mirrors safety_redteam's 0.80 fallback sitting below its 0.86 file floor.
+_DEFAULT_QUALITY_FLOOR = 0.50
+
+_DIM = "quality"
+# Require near-full fixture coverage; a short run is untrustworthy -> INCONCLUSIVE.
+_MIN_N = 150
+# A high local-judge JSON-parse-error rate means the judge output is garbage, so
+# the Pearson can't be believed -> INCONCLUSIVE. Local analogue of the safety
+# gate's n_errored>0 (which gates on Gemini *call* failures, a different mode).
+_MAX_PARSE_ERROR_RATE = 0.10
+
+# Machine-adaptive overrides (design rule: env override, no hardcoded limits).
+DEFAULT_FIXTURE = Path(
+    os.environ.get(  # LIA-261
+        "DEUS_JUDGE_CALIB_FIXTURE",
+        str(_REPO_ROOT / "finetune" / "judge-bench" / "fixture-v1.jsonl"),
+    )
+)
+DEFAULT_MODEL = os.environ.get("DEUS_JUDGE_CALIB_MODEL", "gemma4:e4b")  # LIA-261
+# Bench wall-clock can reach ~130min under contention; default 2h. maintenance.py
+# wraps this task with a slightly larger timeout so THIS timeout fires first and
+# yields a clean INCONCLUSIVE rather than a hard maintenance TIMEOUT.
+DEFAULT_TIMEOUT_S = int(os.environ.get("DEUS_JUDGE_CALIB_TIMEOUT_S", "7200"))  # LIA-261
+
+
+def _load_floor() -> float:
+    """Return the quality-Pearson floor from baselines.json.
+
+    Falls back to _DEFAULT_QUALITY_FLOOR (0.50) if the file is missing,
+    malformed, or the key is absent/out-of-range, so the watchdog stays usable
+    (and quiet) even when the baseline file is unavailable.
+    """
+    try:
+        data = json.loads(_BASELINES_PATH.read_text(encoding="utf-8"))
+        floor = data["quality_pearson"]["floor"]
+        if isinstance(floor, (int, float)) and 0.0 <= float(floor) <= 1.0:
+            return float(floor)
+    except (OSError, ValueError, KeyError, TypeError):
+        pass
+    return _DEFAULT_QUALITY_FLOOR
+
+
+def _run_benchmark(
+    fixture: Path, model: str, timeout_s: int, repo_root: Path = _REPO_ROOT,
+) -> "dict | None":
+    """Run benchmark_judge against the fixture for one model.
+
+    Returns that model's result row from the json-out payload, or None on ANY
+    infra failure (Ollama down -> bench exits 1; nonzero exit; timeout; missing
+    fixture; missing/malformed json-out; no row matching `model`). None ->
+    caller maps to INCONCLUSIVE. List-form args + shell=False: fixture/model are
+    passed as distinct argv elements, never interpolated into a shell string.
+    """
+    if not fixture.exists():
+        print(f"  fixture absent ({fixture}) — skipping", flush=True)
+        return None
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "judge_calib.json"
+        cmd = [
+            sys.executable, "-m", "evolution.benchmark_judge",
+            "--fixture", str(fixture),
+            "--models", model,
+            "--safety-probes", "",   # empty (falsy) -> bench skips safety probes
+            "--json-out", str(out_path),
+            "--quiet",
+        ]
+        try:
+            result = subprocess.run(
+                cmd, cwd=str(repo_root), capture_output=True, text=True,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"  bench timed out after {timeout_s}s — inconclusive", flush=True)
+            return None
+        except OSError as e:
+            print(f"  bench failed to launch: {e} — inconclusive", flush=True)
+            return None
+        if result.returncode != 0:
+            tail = (result.stderr or result.stdout or "").strip().splitlines()[-1:] or [""]
+            print(f"  bench exited {result.returncode} ({tail[0]}) — inconclusive", flush=True)
+            return None
+        try:
+            data = json.loads(out_path.read_text(encoding="utf-8"))
+            rows = data["results"]
+        except (OSError, ValueError, KeyError, TypeError):
+            print("  bench json-out missing/malformed — inconclusive", flush=True)
+            return None
+    for row in rows if isinstance(rows, list) else []:
+        if isinstance(row, dict) and row.get("model") == model:
+            return row
+    print(f"  no result row for model {model} — inconclusive", flush=True)
+    return None
+
+
+def _classify_outcome(result: "dict | None", floor: float) -> "tuple[int, str, str]":
+    """Map a bench result row to (exit_code, status, message).
+
+    Priority chain (infra precedence, like safety_redteam._classify_gate_outcome):
+    a partial/degraded run can never be read as a regression.
+    """
+    if result is None:
+        return 0, "INCONCLUSIVE", "judge infra unavailable — not measured"
+    n = int(result.get("n", 0))
+    if n < _MIN_N:
+        return 0, "INCONCLUSIVE", f"only {n} records (< {_MIN_N}) — partial run, not measured"
+    parse_errors = int(result.get("parse_errors", 0))
+    rate = parse_errors / n  # n >= _MIN_N > 0 here (guarded above)
+    if rate > _MAX_PARSE_ERROR_RATE:
+        return (
+            0, "INCONCLUSIVE",
+            f"{parse_errors}/{n} ({rate:.0%}) judge parse errors (> {_MAX_PARSE_ERROR_RATE:.0%}) "
+            "— judge output untrustworthy, not measured",
+        )
+    dims = result.get("dims")
+    quality = dims.get(_DIM) if isinstance(dims, dict) else None
+    pearson = quality.get("pearson") if isinstance(quality, dict) else None
+    if not isinstance(pearson, (int, float)):
+        # None when benchmark_judge's _pearson got a degenerate (constant) column;
+        # also covers a malformed/missing dims payload. Either way: not measurable.
+        return 0, "INCONCLUSIVE", f"{_DIM} Pearson unreadable — not measured"
+    pearson = float(pearson)
+    if pearson < floor:
+        return (
+            1, "WARN",
+            f"{_DIM} Pearson {pearson:.3f} < {floor:.3f} floor — local judge calibration "
+            f"REGRESSION on {n} records",
+        )
+    return 0, "OK", f"{_DIM} Pearson {pearson:.3f} >= {floor:.3f} floor — calibrated ({n} records)"
+
+
+def main(argv: "list[str] | None" = None, notifier=macos_notify, runner=_run_benchmark) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument("--model", type=str, default=DEFAULT_MODEL)
+    parser.add_argument("--timeout-s", type=int, default=DEFAULT_TIMEOUT_S)
+    args = parser.parse_args(argv)
+
+    floor = _load_floor()
+    print(
+        f"judge_calibration: anchoring {args.model} on {args.fixture.name} "
+        f"({_DIM} Pearson floor {floor:.3f})",
+        flush=True,
+    )
+    result = runner(args.fixture, args.model, args.timeout_s)
+    # Free multi-dim early-warning: log the composite Pearson (not gated on) so a
+    # broad judge drift is visible before it concentrates into the quality dim.
+    if isinstance(result, dict) and isinstance(result.get("composite_pearson"), (int, float)):
+        print(f"  composite Pearson {result['composite_pearson']:.3f} (FYI, not gated)")
+    exit_code, status, message = _classify_outcome(result, floor)
+    print(f"  [{status}] {message}")
+    if status == "WARN":
+        notifier("Deus judge calibration", message)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_judge_calibration.py
+++ b/scripts/tests/test_judge_calibration.py
@@ -1,0 +1,181 @@
+"""Tests for the judge calibration watchdog (scripts/maintenance/judge_calibration.py).
+
+Hermetic: the bench subprocess is replaced by an injected `runner` returning a
+synthetic result row, and the macOS notifier by a recorder — nothing shells out
+and Ollama is never touched. `_load_floor` is exercised against throwaway
+baselines.json files under tmp_path. The contract under test mirrors
+safety_redteam's infra-precedence (`_classify_gate_outcome`): a degraded/partial
+run is INCONCLUSIVE (exit 0), never a false-alarm regression.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1] / "maintenance" / "judge_calibration.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("judge_calibration", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["judge_calibration"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+jc = _load()
+
+FLOOR = 0.58
+
+
+def _row(pearson, n=200, parse_errors=0, model="gemma4:e4b"):
+    """A benchmark_judge json-out result row (shape: dims.quality.pearson)."""
+    return {
+        "model": model,
+        "n": n,
+        "parse_errors": parse_errors,
+        "dims": {"quality": {"pearson": pearson, "spearman": 0.6, "mae": 0.2}},
+    }
+
+
+# ── _classify_outcome ─────────────────────────────────────────────────────────
+
+def test_classify_ok_when_pearson_at_or_above_floor():
+    for p in (FLOOR, FLOOR + 0.01, 0.67):
+        code, status, _ = jc._classify_outcome(_row(p), FLOOR)
+        assert (code, status) == (0, "OK"), p
+
+
+def test_classify_warn_below_floor_exits_nonzero():
+    code, status, msg = jc._classify_outcome(_row(FLOOR - 0.05), FLOOR)
+    assert code == 1 and status == "WARN"
+    # Message must name the dimension AND both numbers, for an actionable alert.
+    assert "quality" in msg
+    assert f"{FLOOR:.3f}" in msg and f"{FLOOR - 0.05:.3f}" in msg
+
+
+def test_classify_none_result_is_inconclusive_exit0():
+    code, status, _ = jc._classify_outcome(None, FLOOR)
+    assert (code, status) == (0, "INCONCLUSIVE")
+
+
+def test_classify_too_few_records_is_inconclusive():
+    # Below _MIN_N: a partial run, even with a great Pearson, must not be trusted.
+    code, status, _ = jc._classify_outcome(_row(0.9, n=jc._MIN_N - 1), FLOOR)
+    assert (code, status) == (0, "INCONCLUSIVE")
+
+
+def test_classify_min_n_boundary_is_measured():
+    # Exactly _MIN_N records is a full-enough run -> measured (here, OK).
+    code, status, _ = jc._classify_outcome(_row(0.9, n=jc._MIN_N), FLOOR)
+    assert (code, status) == (0, "OK")
+
+
+def test_classify_high_parse_error_rate_is_inconclusive():
+    # >10% malformed judge outputs: Pearson untrustworthy regardless of value.
+    n = 200
+    bad = int(n * jc._MAX_PARSE_ERROR_RATE) + 1
+    code, status, _ = jc._classify_outcome(_row(0.2, n=n, parse_errors=bad), FLOOR)
+    assert (code, status) == (0, "INCONCLUSIVE")
+
+
+def test_classify_parse_errors_within_tolerance_still_measured():
+    n = 200
+    ok_errs = int(n * jc._MAX_PARSE_ERROR_RATE)  # exactly at the threshold, not over
+    code, status, _ = jc._classify_outcome(_row(0.2, n=n, parse_errors=ok_errs), FLOOR)
+    # A real regression (0.2 < floor) IS flagged when the run is clean enough.
+    assert (code, status) == (1, "WARN")
+
+
+def test_classify_unreadable_pearson_is_inconclusive():
+    row = _row(None)
+    row["dims"]["quality"]["pearson"] = None  # degenerate/constant column
+    code, status, _ = jc._classify_outcome(row, FLOOR)
+    assert (code, status) == (0, "INCONCLUSIVE")
+
+
+def test_classify_missing_dims_is_inconclusive():
+    code, status, _ = jc._classify_outcome({"model": "m", "n": 200, "parse_errors": 0}, FLOOR)
+    assert (code, status) == (0, "INCONCLUSIVE")
+
+
+# ── _load_floor ───────────────────────────────────────────────────────────────
+
+def _patch_baselines(monkeypatch, tmp_path, content):
+    p = tmp_path / "baselines.json"
+    if content is not None:
+        p.write_text(content)
+    monkeypatch.setattr(jc, "_BASELINES_PATH", p)
+    return p
+
+
+def test_load_floor_reads_file_value(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, json.dumps({"quality_pearson": {"floor": 0.6}}))
+    assert jc._load_floor() == 0.6
+
+
+def test_load_floor_falls_back_when_missing(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, None)
+    assert jc._load_floor() == jc._DEFAULT_QUALITY_FLOOR
+
+
+def test_load_floor_falls_back_when_malformed(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, "{ not json")
+    assert jc._load_floor() == jc._DEFAULT_QUALITY_FLOOR
+
+
+def test_load_floor_falls_back_when_key_absent(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, json.dumps({"safety_recall": {"floor": 0.86}}))
+    assert jc._load_floor() == jc._DEFAULT_QUALITY_FLOOR
+
+
+def test_load_floor_falls_back_when_out_of_range(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, json.dumps({"quality_pearson": {"floor": 1.5}}))
+    assert jc._load_floor() == jc._DEFAULT_QUALITY_FLOOR
+
+
+# ── main (injected runner + recording notifier) ───────────────────────────────
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, title, message):
+        self.calls.append((title, message))
+
+
+def test_main_healthy_exit0_no_notify(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, json.dumps({"quality_pearson": {"floor": FLOOR}}))
+    rec = _Recorder()
+    code = jc.main(argv=[], notifier=rec, runner=lambda *a: _row(0.67))
+    assert code == 0
+    assert rec.calls == []  # OK never notifies
+
+
+def test_main_regression_exit1_notifies_once(monkeypatch, tmp_path):
+    _patch_baselines(monkeypatch, tmp_path, json.dumps({"quality_pearson": {"floor": FLOOR}}))
+    rec = _Recorder()
+    code = jc.main(argv=[], notifier=rec, runner=lambda *a: _row(0.40))
+    assert code == 1
+    assert len(rec.calls) == 1
+    assert "quality" in rec.calls[0][1]
+
+
+def test_main_infra_failure_exit0_no_notify(monkeypatch, tmp_path):
+    # runner returns None (Ollama down / timeout / bad json) -> INCONCLUSIVE, quiet.
+    _patch_baselines(monkeypatch, tmp_path, json.dumps({"quality_pearson": {"floor": FLOOR}}))
+    rec = _Recorder()
+    code = jc.main(argv=[], notifier=rec, runner=lambda *a: None)
+    assert code == 0
+    assert rec.calls == []
+
+
+def test_run_benchmark_missing_fixture_returns_none(tmp_path):
+    # The real runner short-circuits to None (INCONCLUSIVE) when the fixture is
+    # absent — never shells out. Exercises the live function, no Ollama needed.
+    missing = tmp_path / "nope.jsonl"
+    assert jc._run_benchmark(missing, "gemma4:e4b", timeout_s=1) is None


### PR DESCRIPTION
## What
Adds a **scheduled LOCAL weekly** watchdog that anchors the local `gemma4:e4b` evolution judge to the pinned Gemini ground truth and **WARNs on a quality-Pearson regression**. PR #3 of a 6-PR recurring-task automation program.

This is the local sibling of the CI safety-recall gate (LIA-326). `judge-gate.yml` runs the **Gemini** judge (CI has no Ollama), so the **local** judge — which scores every evolution interaction and drives every reflection/metric — had no calibration check. If it silently drifts out of agreement with ground truth, downstream is quietly poisoned and nothing warns. This fills that gap.

## How
- **`scripts/maintenance/judge_calibration.py`** — re-runs `evolution/benchmark_judge.py` against the gitignored Gemini-labeled fixture (n=200) and checks the **quality**-dimension Pearson vs a measured floor. Infra precedence (mirrors `safety_redteam._classify_gate_outcome`): Ollama down / bench timeout / `<150` records / `>10%` parse errors / unreadable Pearson → **INCONCLUSIVE, exit 0 — never a false alarm**. Below floor on a clean run → **WARN, exit nonzero** (+ best-effort macOS banner). The only alert.
- **`evolution/eval/baselines.json`** — adds a `quality_pearson` sibling to `safety_recall`, floor **0.58**. Measured: observed **0.682** fresh (2026-06-23, n=200, 0 parse errors), priors 0.673 (#713) / 0.670 (lia285); floor sits ~0.09 below the worst observed run and below the bootstrap 95% CI lower bound (~0.595), tripping only on the established ≥0.10-drop real-regression threshold. Conservative code fallback 0.50 for a missing file.
- **`scripts/maintenance.py`** — wires it into the **weekly (Sunday)** block, `timeout=7800s` > the watchdog's own 7200s bench timeout (slow Ollama → clean INCONCLUSIVE, not a hard FAILED). Weekly not daily: an n=200 Ollama bench takes ~12–130 min.
- **`scripts/maintenance/_notify.py`** — shared macOS notifier (no-op off macOS; `ensure_ascii=False` so non-ASCII WARN text isn't mangled by AppleScript). credential_probe migration to this helper deferred to a follow-up.
- **`scripts/tests/test_judge_calibration.py`** — 18 hermetic tests (injected runner + recording notifier; no Ollama, no shell-out).

Quality dimension only; personalization is excluded (structurally dead — the limiter is the judge model, not the rubric). tool_use/safety out of v1 scope.

## Verification
- `pytest` — **82 pass** (18 new + credential_probe + safety_redteam regression).
- **Natural end-to-end run** (default args, no scripted steps): `[OK] quality Pearson 0.677 >= 0.580 floor — calibrated (200 records)` — exercised the real shell-out + json-out parse + classify + exit-0 path on the live judge.
- `maintenance.py --weekly --dry-run` lists the task; `flag_lint` clean (3 `DEUS_JUDGE_CALIB_*` env reads cited `# LIA-261`).

## Gates
plan-reviewer (claude+gpt), code-reviewer (claude+gpt), ai-eng-warden (claude+gpt) all **SHIP**; verification-gate (Opus) **SHIP**. GLM backend unreachable (z.ai timeout, 3 attempts) → fail-open; its only finding (`ensure_ascii`) was fixed before it went unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)