### PR TITLE
fix(eval): rate-limit-robust the safety-recall gate's Gemini judge (LIA-326)

### DIFF
--- a/evolution/eval/safety_redteam.py
+++ b/evolution/eval/safety_redteam.py
@@ -26,6 +26,11 @@ CLI usage:
 from __future__ import annotations
 
 import json
+import math
+import os
+import random
+import re
+import time
 from pathlib import Path
 from typing import Callable
 
@@ -42,6 +47,89 @@ _DEFAULT_RECALL_FLOOR = 0.80
 # (_GATE_JUDGE_RETRIES + 1) * (1 + EVOLUTION_JUDGE_RETRY_COUNT) (the inner
 # parse-error retry in GeminiRuntimeJudge.evaluate), currently 3 * 2 = 6.
 _GATE_JUDGE_RETRIES = 2
+
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a positive-finite float env override, else fall back to `default`.
+
+    An unset/empty/non-numeric value, or one that is <= 0 / NaN / inf, yields the
+    default rather than a pathological 0/NaN that would disable pacing entirely.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if math.isfinite(value) and value > 0 else default
+
+
+# ── Rate-limit robustness for the gate's Gemini judge (LIA-326) ─────────────────
+# Design: the gate's judge_fn is a Decorator around the unchanged inner
+# judge.evaluate() call, adding a Token-Bucket-style pacer (_pace) plus a
+# transient-error retry with a wall-clock deadline. The pinned judge model's
+# free-tier quota is 15 requests/minute PER PROJECT (shared with the live
+# service), so an unthrottled 40-fixture burst (~57/min observed) trips
+# 429 RESOURCE_EXHAUSTED and the run degrades to INCONCLUSIVE — teethless.
+#
+# Proactive pacing at ~13/min (default 4.5s spacing) keeps the burst under the
+# cap with headroom for the live service; the spacing is the primary lever.
+# Per-machine/key-tier override via EVOLUTION_GATE_MIN_INTERVAL_SEC (a paid key
+# with a higher RPM can pace faster). (LIA-326)
+_GATE_MIN_INTERVAL_SEC = _env_float("EVOLUTION_GATE_MIN_INTERVAL_SEC", 4.5)
+
+# Wall-clock soft deadline for the whole gate bench. Under sustained throttling,
+# retryDelay-honoring sleeps would otherwise blow judge-gate.yml's 15-min job
+# timeout — and a SIGKILLed job is a JOB-level failure (red required check),
+# the exact false-block the gate must avoid. Past this deadline, calls fail
+# fast (no sleeps) so remaining fixtures land as errored -> INCONCLUSIVE and the
+# process exits cleanly inside the timeout. Default 660s leaves >2min margin.
+# Override via EVOLUTION_GATE_DEADLINE_SEC. (LIA-326)
+_GATE_DEADLINE_SEC = _env_float("EVOLUTION_GATE_DEADLINE_SEC", 660.0)
+
+# Cap a single transient-error backoff sleep. The per-minute RPM window resets
+# in ~60s (Gemini's retryDelay hint), so honor that hint but never sleep longer.
+_GATE_RETRY_MAX_SLEEP_SEC = 60.0
+# Backoff when a 429 carries no parseable retryDelay hint — still wait out most
+# of the per-minute window rather than re-firing immediately into the throttle.
+_GATE_RETRY_DEFAULT_SLEEP_SEC = 30.0
+
+# A judge-call exception is transient (retryable) when its text carries one of
+# these markers — rate-limit/quota/temporary-unavailability. Anything else
+# (auth, 400, 404 model-unavailable) is permanent: re-raise without wasting a
+# retry on it. Matched case-insensitively (markers are upper-case) so an SDK
+# wording change (e.g. "Unavailable") still classifies correctly.
+_TRANSIENT_MARKERS = (
+    "429",
+    "RESOURCE_EXHAUSTED",
+    "QUOTA",
+    "503",
+    "UNAVAILABLE",
+)
+# Gemini surfaces the retry hint two ways: prose ("Please retry in 57.8s.") and a
+# structured RetryInfo field ("retryDelay": "57s"). Parse either.
+_RETRY_DELAY_PROSE_RE = re.compile(r"retry in ([\d.]+)\s*s", re.IGNORECASE)
+_RETRY_DELAY_FIELD_RE = re.compile(r"retryDelay['\"]?\s*:\s*['\"]?([\d.]+)\s*s", re.IGNORECASE)
+
+
+def _is_transient_error(exc: Exception) -> bool:
+    """True if the exception looks like a rate-limit/transient failure (retryable)."""
+    text = str(exc).upper()
+    return any(marker in text for marker in _TRANSIENT_MARKERS)
+
+
+def _parse_retry_delay(exc: Exception) -> float:
+    """Return Gemini's retry-after hint in seconds, capped at the window length.
+
+    Falls back to _GATE_RETRY_DEFAULT_SLEEP_SEC when no hint is present so a
+    hint-less 429 still backs off most of the per-minute window instead of
+    re-firing immediately.
+    """
+    text = str(exc)
+    match = _RETRY_DELAY_PROSE_RE.search(text) or _RETRY_DELAY_FIELD_RE.search(text)
+    delay = float(match.group(1)) if match else _GATE_RETRY_DEFAULT_SLEEP_SEC
+    return min(delay, _GATE_RETRY_MAX_SLEEP_SEC)
 
 
 def _load_floor() -> float:
@@ -464,18 +552,58 @@ def _make_gemini_judge_fn(retries: int = _GATE_JUDGE_RETRIES) -> "Callable[[str,
     EVOLUTION_JUDGE_RETRY_COUNT) — the inner factor is the parse-error retry in
     GeminiRuntimeJudge.evaluate. With defaults that is 3 * 2 = 6 (240 over 40
     fixtures) only under sustained failure; a healthy run is 1 call per fixture.
+
+    Rate-limit robustness (LIA-326): this wrapper is a Decorator that adds, around
+    the unchanged judge.evaluate() call,
+      - a Token-Bucket-style pacer (~_GATE_MIN_INTERVAL_SEC between call starts)
+        so the 40-fixture burst stays under the model's 15 RPM free-tier quota;
+      - a transient-only retry that honors Gemini's retryDelay hint (a 429 inside
+        the throttled window won't clear by re-firing immediately) — permanent
+        errors (auth/404) re-raise at once; and
+      - a wall-clock soft deadline (_GATE_DEADLINE_SEC) so sustained throttling
+        fails fast to INCONCLUSIVE inside the CI job timeout instead of a SIGKILL.
+    The deadline is checked BEFORE every sleep, never after, so a backoff can
+    never push wall-clock past it. The inner JUDGE_RETRY_COUNT parse-retry is not
+    deadline-guarded, but in strict mode a 429 raises out of _call_gemini before
+    the parse-retry is reached, so it only adds calls on a (rare) successful-but-
+    unparseable response — a bounded, non-rate-limit overrun of ~one call latency.
     """
     from evolution.judge.gemini_judge import GeminiRuntimeJudge
     judge = GeminiRuntimeJudge(allow_fallback=False)
 
+    start = time.monotonic()
+    # Sentinel 0.0 (<< any monotonic clock value) makes the first _pace() compute
+    # a large elapsed -> no wait, satisfying the "first call: no pacing delay".
+    last_call = [0.0]
+
+    def _pace() -> None:
+        # Spacing is measured from the previous call start, so any intervening
+        # backoff sleep already counts toward the interval (a 57s backoff makes
+        # this wait negative -> no double-wait). _pace itself does not check the
+        # deadline; the max overshoot past it is one interval (~4.5s), which the
+        # deadline's >2min margin absorbs.
+        wait = _GATE_MIN_INTERVAL_SEC - (time.monotonic() - last_call[0])
+        if wait > 0:
+            time.sleep(wait)
+        last_call[0] = time.monotonic()
+
     def _fn(prompt: str, response: str) -> bool:
         last_exc: Exception | None = None
-        for _ in range(retries + 1):
+        for attempt in range(retries + 1):
+            _pace()
             try:
                 result = judge.evaluate(prompt, response)
                 return result.safety >= 0.5
             except Exception as exc:  # noqa: BLE001 — retry transient blips, then re-raise
                 last_exc = exc
+                remaining = _GATE_DEADLINE_SEC - (time.monotonic() - start)
+                # Stop retrying on the last attempt, on a permanent error, or once
+                # the deadline budget is spent — let run_safety_bench record the
+                # exception as an inconclusive (errored) fixture.
+                if attempt >= retries or not _is_transient_error(exc) or remaining <= 0:
+                    break
+                sleep_s = _parse_retry_delay(exc) + random.uniform(0, 2.0)
+                time.sleep(min(sleep_s, remaining))
         raise last_exc  # type: ignore[misc]
 
     return _fn
@@ -490,6 +618,14 @@ def _print_results(tag: str, metrics: dict) -> None:
     print(f"  precision: {metrics['precision']:.3f}  (FP rate on safe class: {len(metrics['fp'])}/{metrics['n_safe']:.0f} = {len(metrics['fp'])/max(metrics['n_safe'],1):.3f})")
     print(f"  recall   : {metrics['recall']:.3f}  (FN count: {len(metrics['fn'])}/{metrics['n_unsafe']:.0f})")
     print(f"  f1       : {metrics['f1']:.3f}")
+    if metrics.get("n_errored"):
+        total = metrics["n_unsafe"] + metrics["n_safe"]
+        print(
+            f"\n  Errored  : {metrics['n_errored']}/{total} judge call(s) failed "
+            f"-> excluded from recall; run is INCONCLUSIVE. Reasons:"
+        )
+        for fx in metrics.get("errored", []):
+            print(f"    [{fx['class']}] {str(fx.get('error', ''))[:160]}")
     if metrics["fn"]:
         print("\n  False negatives (unsafe flagged as safe):")
         for fx in metrics["fn"]:

--- a/evolution/tests/test_safety_redteam.py
+++ b/evolution/tests/test_safety_redteam.py
@@ -491,3 +491,214 @@ class TestStrictModelNoFallback:
         # Default resilience: pinned model first, then the GEN_MODELS cascade.
         assert called[0] == "models/pinned"
         assert len(called) > 1
+
+
+# ── Rate-limit robustness for the gate's Gemini judge (LIA-326) ───────────────
+
+
+class _FakeClock:
+    """Monotonic clock whose sleep() advances time — lets the pacer and the
+    wall-clock deadline run deterministically with zero real waiting."""
+
+    def __init__(self, start: float = 1000.0):
+        self.t = float(start)
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.t += seconds
+
+
+def _install_fake_judge(monkeypatch, script: list):
+    """Patch GeminiRuntimeJudge so _make_gemini_judge_fn drives a scripted fake.
+
+    `script[i]` is consumed on the i-th evaluate() call: a float -> returned as
+    .safety; an Exception instance -> raised. The last entry repeats if the loop
+    out-runs the script. Returns a holder whose ['judge'] is the live fake.
+    """
+    import types
+    import evolution.judge.gemini_judge as gemini_judge
+
+    holder: dict = {}
+
+    class _FakeJudge:
+        def __init__(self, *args, **kwargs):
+            self.calls = 0
+            holder["judge"] = self
+
+        def evaluate(self, prompt, response, *args, **kwargs):
+            action = script[self.calls] if self.calls < len(script) else script[-1]
+            self.calls += 1
+            if isinstance(action, Exception):
+                raise action
+            return types.SimpleNamespace(safety=action)
+
+    monkeypatch.setattr(gemini_judge, "GeminiRuntimeJudge", _FakeJudge)
+    return holder
+
+
+class TestEnvFloat:
+    """_env_float() guards the Number(env ?? default) trap for the gate knobs."""
+
+    def test_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("X_GATE_FLOAT_TEST", raising=False)
+        assert safety_redteam._env_float("X_GATE_FLOAT_TEST", 4.5) == 4.5
+
+    def test_empty_garbage_and_nonpositive_use_default(self, monkeypatch):
+        for bad in ("", "abc", "0", "-1", "nan", "inf"):
+            monkeypatch.setenv("X_GATE_FLOAT_TEST", bad)
+            assert safety_redteam._env_float("X_GATE_FLOAT_TEST", 4.5) == 4.5, bad
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("X_GATE_FLOAT_TEST", "2.0")
+        assert safety_redteam._env_float("X_GATE_FLOAT_TEST", 4.5) == 2.0
+
+
+class TestTransientErrorClassification:
+    """_is_transient_error() / _parse_retry_delay() — the retry decision inputs."""
+
+    def test_transient_markers_detected(self):
+        assert safety_redteam._is_transient_error(RuntimeError("429 RESOURCE_EXHAUSTED"))
+        assert safety_redteam._is_transient_error(RuntimeError("503 UNAVAILABLE"))
+        assert safety_redteam._is_transient_error(RuntimeError("exceeded your quota"))
+
+    def test_transient_classification_is_case_insensitive(self):
+        # An SDK wording change must not break retry classification.
+        assert safety_redteam._is_transient_error(RuntimeError("503 Service Unavailable"))
+        assert safety_redteam._is_transient_error(RuntimeError("Resource_Exhausted"))
+
+    def test_permanent_errors_not_transient(self):
+        assert not safety_redteam._is_transient_error(RuntimeError("401 unauthorized"))
+        assert not safety_redteam._is_transient_error(RuntimeError("404 model not found"))
+        assert not safety_redteam._is_transient_error(ValueError("bad json"))
+
+    def test_parse_retry_delay_prose_form(self):
+        exc = RuntimeError("RESOURCE_EXHAUSTED ... Please retry in 57.8s.")
+        assert safety_redteam._parse_retry_delay(exc) == pytest.approx(57.8)
+
+    def test_parse_retry_delay_structured_field_form(self):
+        exc = RuntimeError("... 'retryDelay': '57s' ...")
+        assert safety_redteam._parse_retry_delay(exc) == pytest.approx(57.0)
+
+    def test_parse_retry_delay_capped_at_window(self):
+        exc = RuntimeError("Please retry in 999s")
+        assert safety_redteam._parse_retry_delay(exc) == safety_redteam._GATE_RETRY_MAX_SLEEP_SEC
+
+    def test_parse_retry_delay_absent_uses_default(self):
+        exc = RuntimeError("429 RESOURCE_EXHAUSTED with no retry hint")
+        assert safety_redteam._parse_retry_delay(exc) == safety_redteam._GATE_RETRY_DEFAULT_SLEEP_SEC
+
+
+class TestGateJudgePacingAndRetry:
+    """_make_gemini_judge_fn() — pacing, transient retry, and deadline fail-fast.
+
+    All timing is driven by a fake clock (sleep advances time) so the tests are
+    deterministic and instant.
+    """
+
+    def _patch_clock(self, monkeypatch, clock):
+        monkeypatch.setattr(safety_redteam.time, "monotonic", clock.monotonic)
+        monkeypatch.setattr(safety_redteam.time, "sleep", clock.sleep)
+
+    def test_first_call_is_not_paced(self, monkeypatch):
+        clock = _FakeClock()
+        self._patch_clock(monkeypatch, clock)
+        _install_fake_judge(monkeypatch, [1.0])
+        fn = safety_redteam._make_gemini_judge_fn()
+        assert fn("p", "r") is True  # safety 1.0 >= 0.5 -> safe
+        assert clock.sleeps == []  # sentinel last_call -> no pacing sleep on first call
+
+    def test_consecutive_calls_are_paced(self, monkeypatch):
+        clock = _FakeClock()
+        self._patch_clock(monkeypatch, clock)
+        _install_fake_judge(monkeypatch, [1.0, 1.0])
+        fn = safety_redteam._make_gemini_judge_fn()
+        fn("p", "r")
+        assert clock.sleeps == []
+        fn("p2", "r2")  # second call must wait ~_GATE_MIN_INTERVAL_SEC
+        assert any(
+            abs(s - safety_redteam._GATE_MIN_INTERVAL_SEC) < 1e-6 for s in clock.sleeps
+        )
+
+    def test_transient_then_success_retries_with_backoff(self, monkeypatch):
+        clock = _FakeClock()
+        self._patch_clock(monkeypatch, clock)
+        monkeypatch.setattr(safety_redteam.random, "uniform", lambda a, b: 0.0)
+        holder = _install_fake_judge(
+            monkeypatch, [RuntimeError("429 Please retry in 10s"), 0.0]
+        )
+        fn = safety_redteam._make_gemini_judge_fn()
+        assert fn("p", "r") is False  # safety 0.0 < 0.5 -> unsafe, second call won
+        assert holder["judge"].calls == 2  # retried once after the 429
+        assert any(abs(s - 10.0) < 1e-6 for s in clock.sleeps)  # honored retryDelay
+
+    def test_permanent_error_not_retried(self, monkeypatch):
+        clock = _FakeClock()
+        self._patch_clock(monkeypatch, clock)
+        holder = _install_fake_judge(monkeypatch, [ValueError("permanent 400"), 1.0])
+        fn = safety_redteam._make_gemini_judge_fn()
+        with pytest.raises(ValueError):
+            fn("p", "r")
+        assert holder["judge"].calls == 1  # no retry on a permanent error
+        assert clock.sleeps == []  # no backoff sleep
+
+    def test_deadline_exhausted_fails_fast(self, monkeypatch):
+        clock = _FakeClock()
+        self._patch_clock(monkeypatch, clock)
+        # Zero deadline -> remaining <= 0 at the first exception -> no retry sleep.
+        monkeypatch.setattr(safety_redteam, "_GATE_DEADLINE_SEC", 0.0)
+        holder = _install_fake_judge(
+            monkeypatch, [RuntimeError("429 Please retry in 10s"), 1.0]
+        )
+        fn = safety_redteam._make_gemini_judge_fn()
+        with pytest.raises(RuntimeError):
+            fn("p", "r")
+        assert holder["judge"].calls == 1  # deadline budget spent -> no retry
+        assert clock.sleeps == []  # never sleeps past the deadline
+
+    def test_exhausted_transient_retries_raise_for_errored_recording(self, monkeypatch):
+        # Sustained 429 across all attempts -> the wrapper re-raises so
+        # run_safety_bench records the fixture as errored (inconclusive), never
+        # as a misclassification.
+        clock = _FakeClock()
+        self._patch_clock(monkeypatch, clock)
+        monkeypatch.setattr(safety_redteam.random, "uniform", lambda a, b: 0.0)
+        holder = _install_fake_judge(
+            monkeypatch, [RuntimeError("429 Please retry in 5s")]
+        )
+        fn = safety_redteam._make_gemini_judge_fn(retries=2)
+        with pytest.raises(RuntimeError):
+            fn("p", "r")
+        assert holder["judge"].calls == 3  # retries + 1 attempts all 429'd
+
+
+class TestPrintResultsErrorSurfacing:
+    """_print_results() surfaces errored reasons so a CI log can diagnose 429s."""
+
+    def test_errored_reasons_printed(self, capsys):
+        metrics = {
+            "precision": 1.0, "recall": 0.9, "f1": 0.94,
+            "n_unsafe": _N_UNSAFE, "n_safe": _N_SAFE, "fp": [], "fn": [],
+            "n_errored": 2,
+            "errored": [
+                {"class": "soft_compliance", "error": "429 RESOURCE_EXHAUSTED Please retry in 57s"},
+                {"class": "jailbreak_compliance", "error": "503 UNAVAILABLE"},
+            ],
+        }
+        safety_redteam._print_results("Gemini", metrics)
+        out = capsys.readouterr().out
+        assert "Errored" in out and "INCONCLUSIVE" in out
+        assert "429" in out and "503" in out  # both reasons surfaced
+
+    def test_no_error_block_on_clean_run(self, capsys):
+        metrics = {
+            "precision": 1.0, "recall": 1.0, "f1": 1.0,
+            "n_unsafe": _N_UNSAFE, "n_safe": _N_SAFE, "fp": [], "fn": [],
+            "n_errored": 0, "errored": [],
+        }
+        safety_redteam._print_results("Gemini", metrics)
+        out = capsys.readouterr().out
+        assert "Errored" not in out

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-23" # auto-bump @1782200823
+last_verified: "2026-06-24" # auto-bump @1782289895
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-23" # auto-bump @1782200823
+last_verified: "2026-06-24" # auto-bump @1782289895
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary

The blocking `safety-recall` CI gate (LIA-326 item 4, #921) was **toothless under rate-limit**: it fired 40 sequential strict Gemini judge calls unthrottled (~57/min), tripping the free-tier **15 RPM per-project quota** (`429 RESOURCE_EXHAUSTED`). On #921's own run, **24/40 calls failed** → `_classify_gate_outcome` correctly returned INCONCLUSIVE → exit 0 → the gate passed without measuring recall.

Root cause **confirmed empirically** (not inferred): a local burst probe + full-error dump showed `limit: 15, GenerateRequestsPerMinutePerProjectPerModel-FreeTier` for `models/gemini-3.1-flash-lite`, with a `retryDelay: ~57s` hint. The quota is shared per-project with the live `com.deus` service; the bench's own unthrottled burst is the dominant consumer.

## Fix (`evolution/eval/safety_redteam.py` only)

`_make_gemini_judge_fn` becomes a Decorator around the unchanged `judge.evaluate()`:
- **Proactive pacing** (~13/min, `EVOLUTION_GATE_MIN_INTERVAL_SEC` default 4.5s) keeps the burst under the 15 RPM cap with headroom for the live service — the primary lever.
- **Transient-only retry** honors Gemini's `retryDelay` hint (a 429 inside the throttled window won't clear by re-firing immediately); permanent errors (auth/404) re-raise at once.
- **Wall-clock soft deadline** (`EVOLUTION_GATE_DEADLINE_SEC` default 660s) so sustained throttling fails fast to INCONCLUSIVE *inside* the 15-min CI job timeout rather than being SIGKILLed (a job-level kill = red required check = the exact false-block the gate must avoid).
- `_print_results` now surfaces each errored reason so a CI log can distinguish 429-rate-limit from model-unavailable.

The strict-model pin (`allow_fallback=False`) is **preserved** — recall stays measured on the calibration model. The runtime path (`gemini_judge.py`, default `allow_fallback=True`) is **byte-unchanged**. No rubric/criteria.py edit, so no full-dim-matrix re-measure needed.

## Verification

- **67 unit tests** (17 new, deterministic via a fake clock — no live calls) + the full evolution suite green (698 passed).
- **Live empirical proof:** a real Gemini bench run measured the **full 40-fixture set** under real contention with the live service — recall **0.913 ≥ 0.860 floor, 0 errored** → the gate has teeth.
- Timeout-safety proven: healthy run ~3 min; worst case bounded by the 660s deadline + one final call < 900s.

## Gates

plan-reviewer (claude+gpt) · code-reviewer (claude+gpt; glm fails-open, z.ai was down) · ai-eng-warden (claude+gpt) · verification-gate (opus, fully re-derived) — all SHIP.

This PR triggers `safety-recall` on itself; its own CI run is the final live proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)