### PR TITLE
feat(maintenance): morning memory report — daily "while you slept" digest (LIA-254)

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-20" # auto-bump @1781949213
+last_verified: "2026-06-24" # auto-bump @1782291270
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-24" # auto-bump @1782289895
+last_verified: "2026-06-24" # auto-bump @1782291270
 governs:
   - src/
   - evolution/

--- a/scripts/maintenance/morning_report.py
+++ b/scripts/maintenance/morning_report.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Morning memory report (LIA-254) — daily "while you slept" digest.
+
+At 07:00 (launchd/systemd/schtasks), summarize what changed overnight and
+deliver it to the CONTROL GROUP chat: memory growth since yesterday + the
+04:30 maintenance run's outcomes (any FAILED tasks or WARNs — a credential
+expiry, a judge-calibration regression, etc. surface here instead of sitting
+silently in a log nobody reads).
+
+Why host-side (not a scheduler agent task): both data sources are unreachable
+from a container — `logs/` is shadow-mounted empty for the control-group agent
+(container-mounter.ts, LIA-210) and ~/.deus/ is outside the project root. So
+this runs host-side (full fs access) and delivers via the same IPC file-drop
+mechanism auth-refresh.ts uses: write a schema-valid message file into the
+control group's IPC dir and the in-process watcher sends it to the chat.
+
+Read-only on its sources. Reading ~/.deus/memory_health.jsonl is NOT re-running
+`--health` — it's the persisted artifact the 04:30 run already wrote.
+
+Exit 0 on a successful delivery OR a benign skip (no control group registered
+yet, no data to report) — a benign skip is not a launchd failure. Exit nonzero
+only on an unexpected error so the scheduler's error log surfaces real breakage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+# A line is a real warning if it carries a WARN/REGRESSION token but is NOT a
+# count-summary like "credential_probe: 2 OK, 0 WARN, 0 skipped" or
+# "=== Done: 4 OK, 2 failed ===" (those contain "N OK" and a literal "0 WARN"
+# substring that must not be mistaken for an actual warning).
+_SUMMARY_RE = re.compile(r"\b\d+\s+OK\b")
+
+# __file__-relative so resolution is identical regardless of the scheduler's
+# cwd (Windows schtasks passes no working directory). Mirrors credential_probe.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _notify import macos_notify  # noqa: E402  (shared maintenance notifier)
+
+DATA_DIR = _REPO_ROOT / "data"
+STORE_DIR = _REPO_ROOT / "store"
+# Both default to fixed, cwd-independent paths; env overrides for tests/installs.
+DEFAULT_HEALTH = Path(
+    os.environ.get(  # LIA-254
+        "DEUS_MORNING_REPORT_HEALTH", str(Path("~/.deus/memory_health.jsonl").expanduser())
+    )
+)
+DEFAULT_MAINT_LOG = Path(
+    os.environ.get("DEUS_MORNING_REPORT_MAINT_LOG", str(_REPO_ROOT / "logs" / "maintenance.log"))  # LIA-254
+)
+
+
+def _read_health(path: Path) -> "tuple[dict | None, dict | None]":
+    """Return (latest, previous) health snapshots from the append-only JSONL.
+
+    Each line is one day's structured snapshot (memory_indexer --health). The
+    previous line enables overnight-delta reporting. Missing/malformed lines are
+    skipped; a missing file yields (None, None).
+    """
+    try:
+        lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    except OSError:
+        return None, None
+    # Scan from the END collecting the last two VALID snapshots, so a malformed
+    # trailing (or interior) line can't hide an otherwise-valid prior snapshot
+    # and silently drop the overnight delta.
+    snaps: list[dict] = []
+    for ln in reversed(lines):
+        try:
+            obj = json.loads(ln)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            snaps.append(obj)
+            if len(snaps) == 2:
+                break
+    if not snaps:
+        return None, None
+    return snaps[0], (snaps[1] if len(snaps) >= 2 else None)
+
+
+def _parse_last_maintenance_run(path: Path) -> "dict | None":
+    """Parse the LAST maintenance run block from the log, or None if no run.
+
+    Looks for the final `=== Deus maintenance — ... ===` header and reads from
+    there: collects `[name] FAILED/TIMEOUT/ERROR` task lines, any WARN/REGRESSION
+    lines, and the closing `=== Done: N OK, M failed ===` counts.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    lines = text.splitlines()
+    start = None
+    for i in range(len(lines) - 1, -1, -1):
+        if "=== Deus maintenance" in lines[i]:
+            start = i
+            break
+    if start is None:
+        return None
+    block = lines[start:]
+    header = lines[start].strip().strip("= ").strip()
+    failed: list[str] = []
+    warns: list[str] = []
+    ok = 0
+    done = None
+    for ln in block:
+        s = ln.strip()
+        # Task status lines look like "  [name] FAILED (exit 1)" / "[name] OK".
+        if s.startswith("[") and "]" in s:
+            verdict = s.split("]", 1)[1].strip()
+            name = s[1 : s.index("]")]
+            if verdict.startswith(("FAILED", "TIMEOUT", "ERROR")):
+                failed.append(name)
+        if (
+            ("WARN" in s or "REGRESSION" in s)
+            and not _SUMMARY_RE.search(s)
+            and s not in warns
+        ):
+            warns.append(s)
+        if s.startswith("=== Done:"):
+            done = s.strip("= ").strip()
+            # "Done: N OK, M failed" — regex is robust to format drift; a
+            # non-match leaves ok=0 rather than crashing on a split chain.
+            m = re.search(r"Done:\s*(\d+)\s*OK", done)
+            ok = int(m.group(1)) if m else 0
+    return {"ran": True, "header": header, "ok": ok, "failed": failed, "warns": warns, "done": done}
+
+
+def _fmt_delta(cur, prev, *, places: int = 0) -> str:
+    """Signed delta annotation like ' (+3)' / ' (-0.012)', or '' if no prior."""
+    if prev is None or not isinstance(cur, (int, float)) or not isinstance(prev, (int, float)):
+        return ""
+    d = cur - prev
+    if abs(d) < 0.0005:
+        return ""
+    return f" ({d:+.{places}f})"
+
+
+def _format_digest(latest: "dict | None", prev: "dict | None", maint: "dict | None", today: str) -> str:
+    """Build the concise, skimmable 'while you slept' digest. Pure function."""
+    out: list[str] = [f"🌙 While you slept — {today}"]
+
+    if latest:
+        atoms = latest.get("atoms")
+        conf = latest.get("avg_confidence")
+        d_atoms = _fmt_delta(atoms, (prev or {}).get("atoms"), places=0)
+        d_conf = _fmt_delta(conf, (prev or {}).get("avg_confidence"), places=3)
+        out.append(
+            f"Memory: {atoms} atoms{d_atoms} · avg confidence "
+            f"{conf:.3f}{d_conf}" if isinstance(conf, (int, float)) else f"Memory: {atoms} atoms{d_atoms}"
+        )
+        bits = []
+        for label, key in (("sessions", "sessions"), ("entities", "entities"), ("articles", "articles")):
+            v = latest.get(key)
+            if isinstance(v, int):
+                bits.append(f"{v} {label}")
+        stale = latest.get("articles_stale")
+        if isinstance(stale, int) and stale:
+            bits.append(f"{stale} stale")
+        if bits:
+            out.append("  " + " · ".join(bits))
+        snap_date = latest.get("date")
+        if snap_date and snap_date != today:
+            out.append(f"  ⚠️ health snapshot is from {snap_date} (no fresh 04:30 run?)")
+    else:
+        out.append("Memory: no health snapshot yet.")
+
+    if maint and maint.get("ran"):
+        failed = maint.get("failed") or []
+        line = f"Maintenance (04:30): {maint.get('ok', 0)} OK"
+        if failed:
+            line += f", {len(failed)} failed: {', '.join(failed)}"
+        out.append(line)
+        for w in maint.get("warns") or []:
+            out.append(f"  ⚠️ {w}")
+    else:
+        out.append("Maintenance: no overnight run found.")
+
+    return "\n".join(out)
+
+
+def _find_control_group(db_path: Path) -> "tuple[str, str] | None":
+    """(folder, jid) of the control group (registered_groups.is_main=1), or None."""
+    if not db_path.exists():
+        return None
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = con.execute(
+                "SELECT folder, jid FROM registered_groups WHERE is_main = 1 LIMIT 1"
+            ).fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return None
+    if not row or not row[0] or not row[1]:
+        return None
+    return str(row[0]), str(row[1])
+
+
+def _deliver(data_dir: Path, folder: str, jid: str, text: str, ts: int) -> bool:
+    """Drop a schema-valid IPC message file for the control group; the in-process
+    watcher picks it up and sends `text` to `jid`. Returns True on write success.
+
+    A control-group-FOLDER-sourced drop may target any jid (ipc.ts authorize),
+    and the watcher validates against IpcMessageFileSchema {type, chatJid?, text?}.
+    """
+    # Defense-in-depth: `folder` is DB-sourced (validated at insert), but this is
+    # a standalone host script building a filesystem path from it — reject any
+    # value that could escape data/ipc/ before writing.
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", folder):
+        return False
+    messages_dir = data_dir / "ipc" / folder / "messages"
+    try:
+        messages_dir.mkdir(parents=True, exist_ok=True)
+        payload = {"type": "message", "chatJid": jid, "text": text, "source": "morning-report"}
+        (messages_dir / f"morning-report-{ts}.json").write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        return True
+    except OSError:
+        return False
+
+
+def main(argv: "list[str] | None" = None, deliverer=_deliver, notifier=macos_notify,
+         now: "float | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--health", type=Path, default=DEFAULT_HEALTH)
+    parser.add_argument("--maint-log", type=Path, default=DEFAULT_MAINT_LOG)
+    parser.add_argument("--db", type=Path, default=STORE_DIR / "messages.db")
+    parser.add_argument("--data-dir", type=Path, default=DATA_DIR)
+    args = parser.parse_args(argv)
+
+    ts = int((now if now is not None else time.time()) * 1000)
+    latest, prev = _read_health(args.health)
+    maint = _parse_last_maintenance_run(args.maint_log)
+
+    # Nothing to report at all (fresh install, no run yet): benign skip.
+    if latest is None and maint is None:
+        print("morning_report: no health snapshot or maintenance log yet — nothing to report")
+        return 0
+
+    today = time.strftime("%Y-%m-%d", time.localtime(now if now is not None else time.time()))
+    digest = _format_digest(latest, prev, maint, today)
+
+    control = _find_control_group(args.db)
+    if control is None:
+        # No control group registered (fresh install): fall back to a desktop
+        # banner so the digest isn't silently lost, and skip cleanly.
+        print("morning_report: no control group registered — skipping chat delivery")
+        print(digest)
+        notifier("Deus morning report", digest)
+        return 0
+
+    folder, jid = control
+    if deliverer(args.data_dir, folder, jid, digest, ts):
+        print(f"morning_report: delivered to control group ({folder})")
+        return 0
+    print("morning_report: IPC delivery failed", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_morning_report.py
+++ b/scripts/tests/test_morning_report.py
@@ -1,0 +1,244 @@
+"""Tests for the morning memory report (scripts/maintenance/morning_report.py).
+
+Hermetic: health/maintenance sources are fixture files under tmp_path, the
+control-group DB is a throwaway sqlite file, and delivery is an injected
+recorder — nothing shells out, no Ollama, no real chat. The IPC delivery
+contract is asserted against the same shape the in-process watcher validates
+(IpcMessageFileSchema: {type, chatJid?, text?}).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1] / "maintenance" / "morning_report.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("morning_report", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["morning_report"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mr = _load()
+
+NOW = 1_750_000_000.0  # fixed epoch seconds for deterministic ts/date
+
+
+def _health(**kw) -> dict:
+    base = {"date": "2026-06-24", "atoms": 2949, "avg_confidence": 0.702,
+            "sessions": 811, "entities": 1513, "articles": 324, "articles_stale": 50}
+    base.update(kw)
+    return base
+
+
+# ── _read_health ──────────────────────────────────────────────────────────────
+
+def test_read_health_latest_and_prev(tmp_path: Path):
+    p = tmp_path / "h.jsonl"
+    p.write_text("\n".join(json.dumps(o) for o in [
+        _health(date="2026-06-22", atoms=2900),
+        _health(date="2026-06-23", atoms=2940),
+        _health(date="2026-06-24", atoms=2949),
+    ]))
+    latest, prev = mr._read_health(p)
+    assert latest["atoms"] == 2949 and prev["atoms"] == 2940  # last two only
+
+
+def test_read_health_recovers_prev_past_malformed_tail(tmp_path: Path):
+    # A corrupted trailing line must NOT drop the valid previous snapshot (the
+    # overnight delta would silently vanish). Scan-from-end skips it.
+    p = tmp_path / "h.jsonl"
+    p.write_text(
+        json.dumps(_health(date="2026-06-23", atoms=2900)) + "\n"
+        + json.dumps(_health(date="2026-06-24", atoms=2940)) + "\n"
+        + "{truncated write\n"
+    )
+    latest, prev = mr._read_health(p)
+    assert latest["atoms"] == 2940 and prev["atoms"] == 2900
+
+
+def test_read_health_missing_file(tmp_path: Path):
+    assert mr._read_health(tmp_path / "nope.jsonl") == (None, None)
+
+
+def test_read_health_skips_malformed(tmp_path: Path):
+    p = tmp_path / "h.jsonl"
+    p.write_text("{bad json\n" + json.dumps(_health()) + "\n")
+    latest, prev = mr._read_health(p)
+    assert latest["atoms"] == 2949 and prev is None
+
+
+# ── _parse_last_maintenance_run ─────────────────────────────────────────────────
+
+_LOG = """\
+=== Deus maintenance — 2026-06-23 04:30 ===
+
+── Daily ──
+  [memory_gc] OK
+  [health] OK
+=== Done: 5 OK, 0 failed ===
+
+=== Deus maintenance — 2026-06-24 04:30 ===
+
+── Daily ──
+  [memory_gc] OK
+  [credential_probe] running...
+    [codex] WARN — only 8min to expiry (refresher stalled?)
+    credential_probe: 2 OK, 0 WARN, 0 skipped
+  [credential_probe] FAILED (exit 1)
+  [health] OK
+── Weekly ──
+  [judge_calibration] running...
+    [WARN] quality Pearson 0.40 < 0.580 floor — local judge calibration REGRESSION
+  [judge_calibration] FAILED (exit 1)
+=== Done: 4 OK, 2 failed ===
+"""
+
+
+def test_parse_last_run_only_last_block(tmp_path: Path):
+    p = tmp_path / "maintenance.log"
+    p.write_text(_LOG)
+    m = mr._parse_last_maintenance_run(p)
+    assert m["ran"] is True
+    assert "2026-06-24" in m["header"]
+    assert set(m["failed"]) == {"credential_probe", "judge_calibration"}
+    assert m["ok"] == 4
+    # WARN/REGRESSION lines surfaced
+    assert any("expiry" in w for w in m["warns"])
+    assert any("REGRESSION" in w for w in m["warns"])
+    # ...but a healthy count-summary ("2 OK, 0 WARN, 0 skipped") is NOT a warning.
+    assert not any("skipped" in w for w in m["warns"])
+
+
+def test_parse_missing_log(tmp_path: Path):
+    assert mr._parse_last_maintenance_run(tmp_path / "nope.log") is None
+
+
+# ── _format_digest ──────────────────────────────────────────────────────────────
+
+def test_format_digest_deltas_and_warns():
+    latest = _health(atoms=2949, avg_confidence=0.702)
+    prev = _health(date="2026-06-23", atoms=2940, avg_confidence=0.690)
+    maint = {"ran": True, "ok": 4, "failed": ["credential_probe"],
+             "warns": ["[codex] WARN — only 8min to expiry"], "done": "Done: 4 OK, 1 failed"}
+    out = mr._format_digest(latest, prev, maint, "2026-06-24")
+    assert "+9" in out  # atom delta 2949-2940
+    assert "+0.012" in out  # confidence delta
+    assert "1 failed: credential_probe" in out
+    assert "⚠️" in out and "expiry" in out
+
+
+def test_format_digest_stale_snapshot_flagged():
+    latest = _health(date="2026-06-22")  # older than 'today'
+    out = mr._format_digest(latest, None, {"ran": True, "ok": 5, "failed": [], "warns": []}, "2026-06-24")
+    assert "2026-06-22" in out and "no fresh" in out
+
+
+def test_format_digest_no_data_fallbacks():
+    out = mr._format_digest(None, None, None, "2026-06-24")
+    assert "no health snapshot" in out and "no overnight run" in out
+
+
+# ── _find_control_group ─────────────────────────────────────────────────────────
+
+def _make_db(tmp_path: Path, *, with_main: bool) -> Path:
+    db = tmp_path / "messages.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE registered_groups (folder TEXT, jid TEXT, is_main INTEGER)")
+    con.execute("INSERT INTO registered_groups VALUES ('other','other@g.us',0)")
+    if with_main:
+        con.execute("INSERT INTO registered_groups VALUES ('main','main@g.us',1)")
+    con.commit()
+    con.close()
+    return db
+
+
+def test_find_control_group_present(tmp_path: Path):
+    assert mr._find_control_group(_make_db(tmp_path, with_main=True)) == ("main", "main@g.us")
+
+
+def test_find_control_group_absent(tmp_path: Path):
+    assert mr._find_control_group(_make_db(tmp_path, with_main=False)) is None
+
+
+def test_find_control_group_missing_db(tmp_path: Path):
+    assert mr._find_control_group(tmp_path / "nope.db") is None
+
+
+# ── _deliver ────────────────────────────────────────────────────────────────────
+
+def test_deliver_writes_schema_valid_ipc_file(tmp_path: Path):
+    ok = mr._deliver(tmp_path, "main", "main@g.us", "hello\nworld", ts=123)
+    assert ok is True
+    files = list((tmp_path / "ipc" / "main" / "messages").glob("*.json"))
+    assert len(files) == 1
+    payload = json.loads(files[0].read_text())
+    # IpcMessageFileSchema contract: type required; chatJid/text the carried fields.
+    assert payload["type"] == "message"
+    assert payload["chatJid"] == "main@g.us"
+    assert payload["text"] == "hello\nworld"
+
+
+def test_deliver_rejects_path_traversal_folder(tmp_path: Path):
+    # Defense-in-depth: a folder that could escape data/ipc/ is refused, no write.
+    assert mr._deliver(tmp_path, "../../etc", "j@g.us", "x", ts=1) is False
+    assert not (tmp_path / "ipc").exists()
+
+
+# ── main (injected deliverer/notifier) ──────────────────────────────────────────
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        return True
+
+
+def _setup_sources(tmp_path: Path, *, with_main=True):
+    health = tmp_path / "h.jsonl"
+    health.write_text(json.dumps(_health(date="2026-06-24")) + "\n")
+    log = tmp_path / "maintenance.log"
+    log.write_text(_LOG)
+    db = _make_db(tmp_path, with_main=with_main)
+    return ["--health", str(health), "--maint-log", str(log),
+            "--db", str(db), "--data-dir", str(tmp_path / "data")]
+
+
+def test_main_delivers_to_control_group(tmp_path: Path):
+    argv = _setup_sources(tmp_path, with_main=True)
+    deliver = _Recorder()
+    code = mr.main(argv=argv, deliverer=deliver, notifier=_Recorder(), now=NOW)
+    assert code == 0
+    assert len(deliver.calls) == 1
+    data_dir, folder, jid, text, ts = deliver.calls[0]
+    assert folder == "main" and jid == "main@g.us"
+    assert "While you slept" in text
+
+
+def test_main_no_control_group_skips_and_notifies(tmp_path: Path):
+    argv = _setup_sources(tmp_path, with_main=False)
+    deliver, notify = _Recorder(), _Recorder()
+    code = mr.main(argv=argv, deliverer=deliver, notifier=notify, now=NOW)
+    assert code == 0
+    assert deliver.calls == []        # no chat delivery
+    assert len(notify.calls) == 1     # desktop fallback instead
+
+
+def test_main_no_data_is_benign_skip(tmp_path: Path):
+    argv = ["--health", str(tmp_path / "nope.jsonl"),
+            "--maint-log", str(tmp_path / "nope.log"),
+            "--db", str(tmp_path / "nope.db"), "--data-dir", str(tmp_path / "data")]
+    deliver = _Recorder()
+    code = mr.main(argv=argv, deliverer=deliver, notifier=_Recorder(), now=NOW)
+    assert code == 0
+    assert deliver.calls == []

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import path from 'path';
+import { SCHEDULED_JOBS, buildScheduledJobPlist } from './service.js';
 
 /**
  * Tests for service configuration generation.
@@ -7,6 +8,62 @@ import path from 'path';
  * These tests verify the generated content of plist/systemd/nohup configs
  * without actually loading services.
  */
+
+describe('scheduled python jobs (LIA-254 generic refactor)', () => {
+  const maintenance = SCHEDULED_JOBS.find((j) => j.id === 'maintenance');
+  const morning = SCHEDULED_JOBS.find((j) => j.id === 'morning-report');
+
+  it('preserves the maintenance job spec (regression guard for the refactor)', () => {
+    // The 04:30 KB maintenance job is live-critical — the generic extraction
+    // must not drift its schedule, script, or id.
+    expect(maintenance).toEqual({
+      id: 'maintenance',
+      scriptRelPath: 'scripts/maintenance.py',
+      hour: 4,
+      minute: 30,
+      description: 'Deus KB maintenance',
+    });
+  });
+
+  it('registers the morning report at 07:00', () => {
+    expect(morning).toMatchObject({
+      id: 'morning-report',
+      scriptRelPath: 'scripts/maintenance/morning_report.py',
+      hour: 7,
+      minute: 0,
+    });
+  });
+
+  it('maintenance plist keeps the unchanged label/time/script/log paths', () => {
+    const plist = buildScheduledJobPlist(
+      maintenance!,
+      '/home/user/deus',
+      '/home/user',
+      '/usr/bin/python3',
+    );
+    expect(plist).toContain('<string>com.deus.maintenance</string>');
+    expect(plist).toContain('/home/user/deus/scripts/maintenance.py');
+    expect(plist).toContain('<integer>4</integer>'); // hour
+    expect(plist).toContain('<integer>30</integer>'); // minute
+    expect(plist).toContain('/home/user/deus/logs/maintenance.log');
+  });
+
+  it('morning-report plist targets 07:00 and its own script/log', () => {
+    const plist = buildScheduledJobPlist(
+      morning!,
+      '/home/user/deus',
+      '/home/user',
+      '/usr/bin/python3',
+    );
+    expect(plist).toContain('<string>com.deus.morning-report</string>');
+    expect(plist).toContain(
+      '/home/user/deus/scripts/maintenance/morning_report.py',
+    );
+    expect(plist).toContain('<integer>7</integer>'); // hour
+    expect(plist).toContain('<integer>0</integer>'); // minute
+    expect(plist).toContain('/home/user/deus/logs/morning-report.log');
+  });
+});
 
 // Helper: generate a plist string the same way service.ts does
 function generatePlist(

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -56,13 +56,16 @@ export async function run(_args: string[]): Promise<void> {
     setupLaunchd(projectRoot, nodePath, homeDir);
     setupLogReviewLaunchd(projectRoot, homeDir);
     setupOAuthRefreshLaunchd(projectRoot, nodePath, homeDir);
-    setupMaintenanceLaunchd(projectRoot, homeDir);
+    for (const spec of SCHEDULED_JOBS)
+      installScheduledJobLaunchd(projectRoot, homeDir, spec);
   } else if (platform === 'linux') {
     setupLinux(projectRoot, nodePath, homeDir);
-    setupMaintenanceLinux(projectRoot, homeDir);
+    for (const spec of SCHEDULED_JOBS)
+      installScheduledJobLinux(projectRoot, homeDir, spec);
   } else if (platform === 'windows') {
     setupWindows(projectRoot, nodePath, homeDir);
-    setupMaintenanceWindows(projectRoot, homeDir);
+    for (const spec of SCHEDULED_JOBS)
+      installScheduledJobWindows(projectRoot, spec);
   } else {
     emitStatus('SETUP_SERVICE', {
       SERVICE_TYPE: 'unknown',
@@ -830,34 +833,79 @@ function getWindowsPythonPath(): string {
   }
 }
 
-function setupMaintenanceLaunchd(projectRoot: string, homeDir: string): void {
-  const pythonPath = getPythonPath();
-  const plistPath = path.join(
-    homeDir,
-    'Library',
-    'LaunchAgents',
-    'com.deus.maintenance.plist',
-  );
+// ── Scheduled Python maintenance jobs ────────────────────────────────────────
+// Both the nightly KB maintenance (04:30) and the morning memory report (07:00)
+// are daily Python scripts scheduled per-OS. They differ ONLY in the spec below,
+// so the per-platform scheduling logic lives ONCE in the installScheduledJob*
+// helpers (parameterize-method extraction; was three near-identical
+// setupMaintenance* functions). A new daily job = one more SCHEDULED_JOBS entry.
 
-  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+export interface ScheduledJobSpec {
+  /** Canonical id: macOS label `com.deus.<id>`, linux unit `deus-<id>`,
+   *  windows task `Deus<PascalCase>`, log `logs/<id>.log`. */
+  id: string;
+  scriptRelPath: string; // POSIX-style relative path from the project root
+  hour: number;
+  minute: number;
+  description: string;
+}
+
+export const SCHEDULED_JOBS: ScheduledJobSpec[] = [
+  {
+    id: 'maintenance',
+    scriptRelPath: 'scripts/maintenance.py',
+    hour: 4,
+    minute: 30,
+    description: 'Deus KB maintenance',
+  },
+  {
+    id: 'morning-report',
+    scriptRelPath: 'scripts/maintenance/morning_report.py',
+    hour: 7,
+    minute: 0,
+    description: 'Deus morning memory report',
+  },
+];
+
+function jobTaskName(id: string): string {
+  return (
+    'Deus' +
+    id
+      .split('-')
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join('')
+  );
+}
+
+/** Pure: the launchd plist for a scheduled job. Exported for regression tests
+ *  (locks the maintenance job's label/time/paths across the generic refactor). */
+export function buildScheduledJobPlist(
+  spec: ScheduledJobSpec,
+  projectRoot: string,
+  homeDir: string,
+  pythonPath: string,
+): string {
+  const label = `com.deus.${spec.id}`;
+  const logPath = `${projectRoot}/logs/${spec.id}.log`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.deus.maintenance</string>
+    <string>${label}</string>
     <key>ProgramArguments</key>
     <array>
         <string>${pythonPath}</string>
-        <string>${projectRoot}/scripts/maintenance.py</string>
+        <string>${projectRoot}/${spec.scriptRelPath}</string>
     </array>
     <key>WorkingDirectory</key>
     <string>${projectRoot}</string>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>
-        <integer>4</integer>
+        <integer>${spec.hour}</integer>
         <key>Minute</key>
-        <integer>30</integer>
+        <integer>${spec.minute}</integer>
     </dict>
     <key>EnvironmentVariables</key>
     <dict>
@@ -867,32 +915,53 @@ function setupMaintenanceLaunchd(projectRoot: string, homeDir: string): void {
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>${projectRoot}/logs/maintenance.log</string>
+    <string>${logPath}</string>
     <key>StandardErrorPath</key>
-    <string>${projectRoot}/logs/maintenance.log</string>
+    <string>${logPath}</string>
     <key>RunAtLoad</key>
     <false/>
 </dict>
 </plist>`;
+}
 
-  fs.writeFileSync(plistPath, plist);
+function installScheduledJobLaunchd(
+  projectRoot: string,
+  homeDir: string,
+  spec: ScheduledJobSpec,
+): void {
+  const pythonPath = getPythonPath();
+  const label = `com.deus.${spec.id}`;
+  const plistPath = path.join(
+    homeDir,
+    'Library',
+    'LaunchAgents',
+    `${label}.plist`,
+  );
+
+  fs.writeFileSync(
+    plistPath,
+    buildScheduledJobPlist(spec, projectRoot, homeDir, pythonPath),
+  );
+  const when = `${String(spec.hour).padStart(2, '0')}:${String(spec.minute).padStart(2, '0')}`;
   try {
     execSync(`launchctl load ${JSON.stringify(plistPath)}`, {
       stdio: 'ignore',
     });
-    logger.info({ plistPath }, 'Maintenance job scheduled (daily 04:30)');
+    logger.info({ plistPath }, `${spec.description} scheduled (daily ${when})`);
   } catch {
-    logger.warn(
-      'launchctl load for maintenance failed (may already be loaded)',
-    );
+    logger.warn(`launchctl load for ${spec.id} failed (may already be loaded)`);
   }
 }
 
-function setupMaintenanceLinux(projectRoot: string, homeDir: string): void {
+function installScheduledJobLinux(
+  projectRoot: string,
+  homeDir: string,
+  spec: ScheduledJobSpec,
+): void {
   const serviceManager = getServiceManager();
   if (serviceManager !== 'systemd') {
     logger.info(
-      'No systemd — skipping maintenance timer (run scripts/maintenance.py manually or via cron)',
+      `No systemd — skipping ${spec.id} timer (run ${spec.scriptRelPath} manually or via cron)`,
     );
     return;
   }
@@ -903,53 +972,58 @@ function setupMaintenanceLinux(projectRoot: string, homeDir: string): void {
     ? '/etc/systemd/system'
     : path.join(homeDir, '.config', 'systemd', 'user');
   const systemctlPrefix = runningAsRoot ? 'systemctl' : 'systemctl --user';
+  const unitBase = `deus-${spec.id}`;
+  const logPath = `${projectRoot}/logs/${spec.id}.log`;
+  const when = `${String(spec.hour).padStart(2, '0')}:${String(spec.minute).padStart(2, '0')}`;
 
   fs.mkdirSync(unitDir, { recursive: true });
 
-  // Service unit
   const serviceUnit = `[Unit]
-Description=Deus KB maintenance
+Description=${spec.description}
 
 [Service]
 Type=oneshot
-ExecStart=${pythonPath} ${projectRoot}/scripts/maintenance.py
+ExecStart=${pythonPath} ${projectRoot}/${spec.scriptRelPath}
 WorkingDirectory=${projectRoot}
 Environment=HOME=${homeDir}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
-StandardOutput=append:${projectRoot}/logs/maintenance.log
-StandardError=append:${projectRoot}/logs/maintenance.log`;
+StandardOutput=append:${logPath}
+StandardError=append:${logPath}`;
 
-  // Timer unit
   const timerUnit = `[Unit]
-Description=Deus KB maintenance timer
+Description=${spec.description} timer
 
 [Timer]
-OnCalendar=*-*-* 04:30:00
+OnCalendar=*-*-* ${when}:00
 Persistent=true
 
 [Install]
 WantedBy=timers.target`;
 
-  fs.writeFileSync(path.join(unitDir, 'deus-maintenance.service'), serviceUnit);
-  fs.writeFileSync(path.join(unitDir, 'deus-maintenance.timer'), timerUnit);
+  fs.writeFileSync(path.join(unitDir, `${unitBase}.service`), serviceUnit);
+  fs.writeFileSync(path.join(unitDir, `${unitBase}.timer`), timerUnit);
 
   try {
     execSync(`${systemctlPrefix} daemon-reload`, { stdio: 'ignore' });
-    execSync(`${systemctlPrefix} enable deus-maintenance.timer`, {
+    execSync(`${systemctlPrefix} enable ${unitBase}.timer`, {
       stdio: 'ignore',
     });
-    execSync(`${systemctlPrefix} start deus-maintenance.timer`, {
+    execSync(`${systemctlPrefix} start ${unitBase}.timer`, {
       stdio: 'ignore',
     });
-    logger.info('Maintenance timer scheduled (daily 04:30)');
+    logger.info(`${spec.description} timer scheduled (daily ${when})`);
   } catch {
-    logger.warn('systemd maintenance timer setup failed');
+    logger.warn(`systemd ${spec.id} timer setup failed`);
   }
 }
 
-function setupMaintenanceWindows(projectRoot: string, _homeDir: string): void {
+function installScheduledJobWindows(
+  projectRoot: string,
+  spec: ScheduledJobSpec,
+): void {
   const pythonPath = getWindowsPythonPath();
-  const taskName = 'DeusMaintenance';
+  const taskName = jobTaskName(spec.id);
+  const when = `${String(spec.hour).padStart(2, '0')}:${String(spec.minute).padStart(2, '0')}`;
 
   try {
     // Delete existing task if present
@@ -961,10 +1035,9 @@ function setupMaintenanceWindows(projectRoot: string, _homeDir: string): void {
   try {
     // execFileSync drops the cmd.exe shell; /TR keeps inner quotes because
     // schtasks re-parses it as a command line (so paths with spaces survive).
-    const maintScript = path.win32.join(
+    const script = path.win32.join(
       projectRoot,
-      'scripts',
-      'maintenance.py',
+      ...spec.scriptRelPath.split('/'),
     );
     execFileSync(
       'schtasks',
@@ -973,20 +1046,20 @@ function setupMaintenanceWindows(projectRoot: string, _homeDir: string): void {
         '/TN',
         taskName,
         '/TR',
-        `"${pythonPath}" "${maintScript}"`,
+        `"${pythonPath}" "${script}"`,
         '/SC',
         'DAILY',
         '/ST',
-        '04:30',
+        when,
         '/F',
       ],
       { stdio: 'pipe' },
     );
-    logger.info('Windows Task Scheduler: maintenance scheduled (daily 04:30)');
+    logger.info(`Windows Task Scheduler: ${spec.id} scheduled (daily ${when})`);
   } catch (err) {
     logger.warn(
       { err },
-      'Windows Task Scheduler setup failed — run scripts/maintenance.py manually',
+      `Windows Task Scheduler setup failed — run ${spec.scriptRelPath} manually`,
     );
   }
 }


### PR DESCRIPTION
## What
A 07:00 daily **"while you slept" digest** delivered to the control-group chat: memory growth since yesterday + the prior 04:30 maintenance run's outcomes. PR #4 of a 6-PR recurring-task automation program.

Overnight maintenance failures (a credential expiry, a judge-calibration regression, a failed task) currently sit unread in `logs/maintenance.log`. This surfaces them — plus memory growth — in the chat each morning.

## Why host-side (not the handoff's "mirror doc-gardener-seed.ts")
The doc-gardener approach runs the report as a **container agent**, but both data sources are unreachable from a container: `logs/` is shadow-mounted to an *empty* dir for the control-group agent (`container-mounter.ts:137`, LIA-210 secret/PII guard) and `~/.deus/memory_health.jsonl` is outside the project root. So the report runs **host-side** (full fs access) and delivers via the same **IPC file-drop** mechanism `auth-refresh.ts:notifyFailure` uses — writes a schema-valid `{type:"message",chatJid,text}` JSON into `data/ipc/<controlFolder>/messages/`, which the in-process watcher sends to the chat.

## How
- **`scripts/maintenance/morning_report.py`** (new) — read-only digest from the persisted `~/.deus/memory_health.jsonl` (overnight delta from the last two snapshots) + the last `logs/maintenance.log` run (NOT a `--health` re-run). Deterministic formatting. `__file__`-relative paths (cwd-independent for Windows schtasks). Path-traversal guard on the DB-sourced folder; malformed-JSONL-tail recovery (last *valid* snapshots). **Benign exit-0 skip** on no-data / no-control-group (desktop-notify fallback); nonzero only on a real error (so the scheduler error log surfaces real breakage).
- **`setup/service.ts`** — parameterize-method refactor: a generic `SCHEDULED_JOBS` spec array + `installScheduledJob{Launchd,Linux,Windows}` + a pure exported `buildScheduledJobPlist`, replacing three near-identical `setupMaintenance*` functions, wiring **both** maintenance (04:30) and morning-report (07:00) across all three platforms. The live-critical 04:30 job is **provably unchanged**.
- **`setup/service.test.ts`** — regression guard: asserts the maintenance spec + its generated plist (label/time/script/log) are unchanged by the refactor.
- **`scripts/tests/test_morning_report.py`** (new) — 17 hermetic tests (fixture sources + injected deliverer/notifier; no Ollama, no chat).

## Verification
- `pytest` — **17 pass**; full `vitest` — **1889 pass (108 files)**; `tsc` clean.
- **Natural e2e against live data** (sandboxed `--data-dir`): produced a correct schema-valid IPC drop to the real control group — `🌙 While you slept — 2026-06-24 / Memory: 2949 atoms (+1) · avg confidence 0.702 / 811 sessions · 1513 entities · 324 articles · 50 stale / Maintenance (04:30): 7 OK`. This caught + fixed a false-WARN bug (a healthy `0 WARN` summary line) before review.
- `flag_lint` clean (2 `DEUS_MORNING_REPORT_*` reads cited `# LIA-254`).

## Gates
plan-reviewer (claude+gpt), code-reviewer (**claude+gpt+glm**) all **SHIP**; verification-gate (Opus) **SHIP**. The co-gate caught two real defects mid-review (a false-WARN summary match, and `_read_health` dropping a valid snapshot behind a malformed tail) — both fixed + regression-tested. No ai-eng gate (no `evolution/`/agent/prompt surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)