### PR TITLE
feat(skills): add Teams + Outlook channel stubs (LIA-310)

### DIFF
--- a/.claude/skills/add-msft-teams/SKILL.md
+++ b/.claude/skills/add-msft-teams/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: add-msft-teams
+description: Add Microsoft Teams as a channel. Can replace WhatsApp entirely or run alongside it. Uses the Azure Bot Service (Bot Framework) and requires a public HTTPS messaging endpoint.
+---
+
+# Add Microsoft Teams Channel
+
+> **Status:** Coming soon — this channel will be available as `@deus-ai/teams-mcp`. The MCP package is not yet available. In the meantime, the setup/registration phases below describe what the integration will look like, mirroring the other channel skills.
+
+Microsoft Teams is the chat-channel analog of Slack: a bot identity receives
+messages and posts replies. Unlike Slack's Socket Mode, the Teams bot uses the
+**Azure Bot Service (Bot Framework)**, which delivers activities to a **public
+HTTPS messaging endpoint** — so this channel depends on Deus's existing ingress
+gateway / tunnel to expose `/api/messages`.
+
+## Phase 1: Setup (Future)
+
+### Register the Azure app + bot (if needed)
+
+If the user doesn't have an Azure Bot, walk them through it. Quick summary of
+what's needed:
+
+1. In the [Azure Portal](https://portal.azure.com) → **Microsoft Entra ID** →
+   **App registrations** → **New registration**. Copy the **Application (client)
+   ID** and **Directory (tenant) ID**.
+2. **Certificates & secrets** → **New client secret** → copy the secret **value**
+   (shown once).
+3. Create an **Azure Bot** resource (Azure Bot Service). Link it to the app
+   registration above (the Microsoft App ID). Set the **messaging endpoint** to
+   your public URL: `https://your-domain.example.com/api/messages`.
+4. On the bot resource → **Channels** → enable the **Microsoft Teams** channel.
+5. Create a Teams app (Developer Portal for Teams / manifest) that references the
+   bot's App ID, then install it to a team or chat.
+
+> The messaging endpoint must be a **public HTTPS URL**. Deus already runs an
+> ingress gateway / tunnel — point the bot at that host's `/api/messages` path.
+> A local-only endpoint will not receive Bot Framework activities.
+
+### Configure environment
+
+Add to `.env` (use the values from the app registration — no personal tenant or
+domain values belong in this skill):
+
+```bash
+TEAMS_APP_ID=<your-application-client-id>
+TEAMS_APP_PASSWORD=<your-client-secret-value>
+TEAMS_TENANT_ID=<your-directory-tenant-id>
+```
+
+Channels auto-enable when their credentials are present — no extra configuration
+needed.
+
+Sync to container environment:
+
+```bash
+mkdir -p data/env && cp .env data/env/env
+```
+
+The container reads environment from `data/env/env`, not `.env` directly.
+
+## Phase 2: Registration (Future)
+
+### Get the conversation ID
+
+Tell the user:
+
+> 1. Add the bot to a Teams channel or chat (install the Teams app, then
+>    @mention the bot once so Teams creates a conversation reference).
+> 2. The conversation ID is the Bot Framework `conversation.id` for that
+>    channel/chat. The setup helper will capture it from the first inbound
+>    activity once the channel is live.
+>
+> The JID format for Deus is: `teams:<conversation-id>`
+
+### Register the channel
+
+The conversation ID, name, and folder name are needed. Use
+`npx tsx setup/index.ts --step register` with the appropriate flags.
+
+For a main channel (responds to all messages):
+
+```bash
+npx tsx setup/index.ts --step register -- --jid "teams:<conversation-id>" --name "<channel-name>" --folder "teams_main" --trigger "@${ASSISTANT_NAME}" --channel teams --no-trigger-required --is-main
+```
+
+For additional channels (trigger-only):
+
+```bash
+npx tsx setup/index.ts --step register -- --jid "teams:<conversation-id>" --name "<channel-name>" --folder "teams_<channel-name>" --trigger "@${ASSISTANT_NAME}" --channel teams
+```
+
+## Verify
+
+### Smoke test
+
+```bash
+npx tsx setup/index.ts --step smoke-test -- --channel teams
+```
+
+The smoke test checks: service running, registered group exists, DB write/read
+works, and channel connection appears in logs.
+
+> **Expected while this skill is a stub:** the smoke test will fail with a
+> "channel not registered / adapter not found" result until `@deus-ai/teams-mcp`
+> ships and the Teams channel factory is wired. That failure is the documented
+> state today, not a misconfiguration.
+
+Once the package is available and the smoke test passes, tell the user
+"Microsoft Teams channel is working." Then ask them to send a test message:
+
+> Send a message in your registered Teams channel to confirm real-time delivery.
+> - For main channel: any message works
+> - For non-main: @mention the bot
+
+## Troubleshooting
+
+### Bot not responding
+
+1. Check `TEAMS_APP_ID`, `TEAMS_APP_PASSWORD`, and `TEAMS_TENANT_ID` are set in
+   `.env` AND synced to `data/env/env`.
+2. Check the channel is registered:
+   `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'teams:%'"`
+3. For non-main channels: the message must include the trigger pattern.
+4. Service is running: `launchctl list | grep deus`.
+
+### Bot connected but not receiving messages
+
+1. Verify the messaging endpoint in the Azure Bot resource is your **public**
+   `https://.../api/messages` URL and is reachable from the internet.
+2. Verify the **Microsoft Teams** channel is enabled on the bot resource.
+3. Verify the Teams app (manifest) referencing the bot is installed in the
+   target team/chat.
+4. Check the ingress tunnel is up — a Bot Framework activity to an unreachable
+   endpoint is silently dropped by Azure.
+
+### Authorization / 401 from the Bot Framework
+
+1. Confirm the client secret **value** (not the secret ID) is in
+   `TEAMS_APP_PASSWORD`, and that it has not expired (Azure secrets expire).
+2. Confirm `TEAMS_TENANT_ID` matches the app registration's directory.
+3. Regenerate the secret in **Certificates & secrets** if in doubt, update
+   `.env`, sync `data/env/env`, and restart:
+   `launchctl kickstart -k gui/$(id -u)/com.deus`.
+
+## After Setup
+
+The Microsoft Teams channel will support:
+
+- **Team channels** — the bot must be installed in the team and @mentioned.
+- **Group chats** — the bot must be added to the chat.
+- **1:1 chats** — users can message the bot directly.
+- **Multi-channel** — can run alongside WhatsApp or other channels (auto-enabled
+  by credentials).
+
+## Known Limitations
+
+- **Public endpoint required** — unlike Slack's Socket Mode, the Bot Framework
+  pushes activities to a public HTTPS endpoint. Without the ingress tunnel
+  exposing `/api/messages`, the channel cannot receive messages.
+- **Threads / replies** — Teams reply chains will be delivered as flat messages
+  unless thread-aware routing is added (database schema, `NewMessage` type, and
+  `Channel.sendMessage` interface changes), the same limitation the Slack channel
+  documents.
+- **Adaptive Cards / attachments** — only text content is forwarded to the agent
+  in the initial integration. Adaptive Cards, files, and images are not handled.
+- **Secret expiry** — Azure client secrets expire; the channel will start
+  failing auth when the secret lapses, with no proactive warning until the
+  credential-probe maintenance script is extended to cover Teams.

--- a/.claude/skills/add-outlook/SKILL.md
+++ b/.claude/skills/add-outlook/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: add-outlook
+description: Add Outlook (Microsoft 365 email) integration to Deus. Can be configured as a tool (agent reads/sends mail when triggered) or as a full channel that polls the inbox. Uses the Microsoft Graph API and Azure AD OAuth.
+---
+
+# Add Outlook Integration
+
+> **Status:** Coming soon — this channel will be available as `@deus-ai/outlook-mcp`. The MCP package is not yet available. In the meantime, the setup/config phases below describe what the integration will look like, mirroring the Gmail skill.
+
+Outlook is the email-channel analog of Gmail, built on the **Microsoft Graph
+API**. It can run as a **tool** (read, send, search, draft) or as a full
+**channel** that polls the inbox and lets incoming mail trigger the agent.
+
+## Phase 1: Pre-flight (Future)
+
+### Ask the user
+
+Use `AskUserQuestion`:
+
+AskUserQuestion: Should incoming emails be able to trigger the agent?
+
+- **Yes** — Full channel mode: the agent listens on the Outlook inbox and
+  responds to incoming emails automatically.
+- **No** — Tool-only: the agent gets full Outlook tools (read, send, search,
+  draft) but won't monitor the inbox. No channel code is added.
+
+## Phase 2: Setup (Future)
+
+### Azure AD app registration
+
+Tell the user:
+
+> I need you to register an Azure AD application for Microsoft Graph:
+>
+> 1. Open https://portal.azure.com → **Microsoft Entra ID** → **App
+>    registrations** → **New registration**. Copy the **Application (client) ID**
+>    and **Directory (tenant) ID**.
+> 2. Go to **API permissions** → **Add a permission** → **Microsoft Graph** →
+>    **Delegated permissions**, and add: `Mail.Read`, `Mail.Send`,
+>    `Mail.ReadWrite`, `offline_access`, `User.Read`. Click **Grant admin
+>    consent** (or have a tenant admin grant it).
+> 3. For the OAuth flow, either add a **client secret** (Certificates & secrets)
+>    for the confidential flow, or enable the **device code flow** under
+>    **Authentication → Advanced settings → Allow public client flows**.
+>
+> Tell me the Application (client) ID and Directory (tenant) ID, or paste the
+> values here. Do not paste a client secret into chat — set it in `.env`.
+
+Store the app credentials (no personal values belong in this skill — these go in
+the user's local config):
+
+```bash
+mkdir -p ~/.outlook-mcp
+# Written by setup: ~/.outlook-mcp/app-credentials.json
+#   { "clientId": "...", "tenantId": "...", "clientSecret": "..." (optional) }
+```
+
+### OAuth authorization
+
+Tell the user:
+
+> I'm going to run Outlook authorization using the device-code flow. I'll print a
+> URL and a short code — open the URL, sign in to your Microsoft 365 account, and
+> enter the code. If you see a consent screen, approve the requested mail
+> permissions.
+
+The authorization caches the token to `~/.outlook-mcp/token.json` (with the
+`offline_access` refresh token so it renews without re-prompting). Verify with
+`ls ~/.outlook-mcp/token.json`.
+
+## Verify
+
+### Smoke test
+
+```bash
+npx tsx setup/index.ts --step smoke-test -- --channel outlook
+```
+
+The smoke test checks: service running, registered group exists, DB write/read
+works, and channel connection appears in logs.
+
+> **Expected while this skill is a stub:** the smoke test will fail with a
+> "channel not registered / adapter not found" result until `@deus-ai/outlook-mcp`
+> ships and the Outlook channel factory is wired. That failure is the documented
+> state today, not a misconfiguration.
+
+Once the package is available and the smoke test passes, tell the user "Outlook
+channel is working." Then, for channel mode, ask them to send a test email:
+
+> Send a test email to your connected Outlook account to confirm real-time
+> delivery. Check `logs/deus.log` for processing confirmation.
+
+## Troubleshooting
+
+### Outlook connection not responding
+
+Test the Graph token directly:
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r .accessToken ~/.outlook-mcp/token.json)" \
+  "https://graph.microsoft.com/v1.0/me" | jq '{displayName, mail, userPrincipalName}'
+```
+
+A `200` with your account details means the token is valid; a `401` means it
+expired or lacks scope.
+
+### OAuth token expired
+
+Re-authorize (the refresh token should renew automatically; force a fresh
+sign-in if it doesn't):
+
+```bash
+rm ~/.outlook-mcp/token.json
+# re-run the device-code authorization
+```
+
+### "insufficient privileges" / missing scope
+
+1. In **API permissions**, confirm `Mail.Read`, `Mail.Send`, `Mail.ReadWrite`,
+   `offline_access`, and `User.Read` are present.
+2. Click **Grant admin consent** — delegated permissions on some tenants require
+   admin approval.
+3. Delete `~/.outlook-mcp/token.json` and re-authorize so the new scopes are
+   included in the token.
+
+### Container can't access Outlook
+
+- The `~/.outlook-mcp` credentials directory must be mounted into the container
+  for the agent to use Outlook tools. That mount is added when
+  `@deus-ai/outlook-mcp` ships and the channel is wired — it does not exist yet
+  in this stub.
+- Check container logs: `cat groups/main/logs/container-*.log | tail -50`.
+
+### Emails not being detected (Channel mode only)
+
+- By default, the channel polls unread inbox messages:
+  `/me/mailFolders/Inbox/messages?$filter=isRead eq false`.
+- Check `logs/deus.log` for Graph polling errors (throttling returns HTTP 429
+  with a `Retry-After` header).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,9 @@ renaming a repo-owned skill, update this table in the same change.
 | `/add-linear` | Add Linear project management MCP integration (read/write issues, projects, cycles) |
 | `/add-listen-hotkey` | Add a global hotkey for `deus listen` |
 | `/add-llama-cpp` | Install and verify optional local `llama.cpp` generation |
+| `/add-msft-teams` | Add Microsoft Teams as a channel (Azure Bot Service / Bot Framework) |
 | `/add-ollama-tool` | Add Ollama as an MCP tool for local model calls |
+| `/add-outlook` | Add Outlook (Microsoft 365 email) as a tool or channel |
 | `/add-parallel` | Add Parallel AI MCP research tools |
 | `/add-pdf-reader` | Add PDF text extraction |
 | `/add-reactions` | Add WhatsApp emoji reaction support |

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-21" # auto-bump @1781990245
+last_verified: "2026-06-24" # auto-bump @1782291089
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

Adds two **doc-stub** channel-setup skills, mirroring the existing `add-slack` / `add-gmail` "Coming soon" pattern (LIA-310). No MCP adapter packages or runtime wiring — pure provisioning docs, same as every other channel skill today.

| File | Change |
|------|--------|
| `.claude/skills/add-msft-teams/SKILL.md` | NEW — Teams chat channel via Azure Bot Service / Bot Framework (public `/api/messages` endpoint, env-var creds `TEAMS_APP_ID`/`TEAMS_APP_PASSWORD`/`TEAMS_TENANT_ID`) |
| `.claude/skills/add-outlook/SKILL.md` | NEW — Outlook email channel via Microsoft Graph (OAuth device-code flow, `~/.outlook-mcp/`), tool-or-channel mode like Gmail |
| `AGENTS.md` | +2 rows in the Repo-owned host skills table (required in the same change) |

## Why doc-stubs

The `@deus-ai/teams-mcp` / `@deus-ai/outlook-mcp` packages don't exist yet, exactly like `@deus-ai/slack-mcp` / `@deus-ai/gmail-mcp`. Each skill's Verify section documents that **the smoke test is expected to fail** until its package ships and the channel factory is wired — so a reader doesn't misread the "channel not registered" error.

## Scope notes

- **No `src/` changes** — satisfies `patterns/skill-add.md` (CI rejects skill PRs touching `src/`).
- All endpoint/tenant references are **generic placeholders** — no personal Azure/tenant/domain values.
- `.agents/skills/` mirror is gitignored (regenerated by `scripts/sync_agent_skills.py`), so it's not in the diff.

## Verification

- `git diff` is docs-only; grep for personal values = clean.
- plan-reviewer (Claude + GPT) SHIP; code-reviewer (Claude + GPT) SHIP.
- Microsoft provisioning steps follow standard Entra ID app registration / Bot Framework / Graph mail flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)