### PR TITLE
feat(cli): add `deus deploy` — diff-driven conditional deploy

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -94,13 +94,30 @@ _build_and_restart() {
   fi
 }
 
+# >>> deploy-plan
+# `deus deploy`'s rebuild decision: read changed file paths (newline-separated) on stdin,
+# emit `build` if any touch src/ and/or `container` if any touch container/ OR
+# .claude/skills/. Both feed the agent image (build.sh stages skills/*/agent.ts; the
+# Dockerfile copies container/), so a MISSED `container` token would ship a STALE image
+# with the wrong tool profile — a security risk — hence anchored regexes (not substrings,
+# so docs/container-notes.md / mysrc/x.ts don't match) and over- never under-trigger.
+# grep/printf only, so it sources in isolation for scripts/tests/test_deus_cmd_deploy.py.
+_deploy_plan() {
+  local changed
+  changed="$(cat)"
+  printf '%s\n' "$changed" | grep -qE '^src/'                         && echo "build"
+  printf '%s\n' "$changed" | grep -qE '^(container/|\.claude/skills/)' && echo "container"
+  return 0  # force success: grep -q exits 1 when no token matched, which is not an error here
+}
+# <<< deploy-plan
+
 # Warn (never block) when the live tree drifts off main or behind origin/main, so
 # `deus <cmd>` doesn't silently ship stale behavior from a feature branch.
 # darwin/Linux only (date +%s, git); Windows port pending — project_windows_support.md
 _deus_freshness_check() {
   [[ "$OSTYPE" == darwin* || "$OSTYPE" == linux* ]] || return 0
-  # Skip for sync (does its own reporting) and help/no-arg paths.
-  case "$1" in sync|""|-h|--help|help) return 0 ;; esac
+  # Skip for sync/deploy (both do their own fetch + reporting) and help/no-arg paths.
+  case "$1" in sync|deploy|""|-h|--help|help) return 0 ;; esac
   git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1 || return 0
 
   local stamp_dir="$HOME/.config/deus" stamp now last
@@ -1292,6 +1309,91 @@ $STARTUP_INSTRUCTION"
     _build_and_restart
     echo "deus: synced to $sync_remote/main."
     ;;
+  deploy)
+    # Diff-driven conditional deploy of the live main tree. Like `deus sync` (ff-merge
+    # origin/main, non-destructive) but rebuilds ONLY what the incoming diff touched:
+    # host build + restart only when src/ changed; container rebuild only when container
+    # inputs changed. Codifies the post-merge-deploy + PRIVATE-WIPE-TRAP tribal knowledge
+    # in CLAUDE.md `git` key. See ADR: docs/decisions/live-command-freshness.md.
+    shift
+    deploy_dry_run=false
+    for arg in "$@"; do
+      case "$arg" in
+        --dry-run) deploy_dry_run=true ;;
+        *) echo "deus deploy: unknown option '$arg' (expected --dry-run)." >&2; exit 1 ;;
+      esac
+    done
+    # darwin/Linux only — Windows service restart + container build are unimplemented
+    # (same gap as _build_and_restart:85 / sync; project_windows_support.md).
+    if [[ "$OSTYPE" != darwin* && "$OSTYPE" != linux* ]]; then
+      echo "deus deploy: not supported on this platform yet (darwin/Linux only)." >&2
+      exit 1
+    fi
+    deploy_repo="$SCRIPT_DIR"
+    if ! git -C "$deploy_repo" rev-parse --git-dir >/dev/null 2>&1; then
+      echo "deus deploy: $deploy_repo is not a git repository." >&2; exit 1
+    fi
+    # Private-wipe guard: deploy builds the live tree IN PLACE (it never rsync/mirrors). A
+    # linked worktree lacks gitignored src/private/, so an in-place build there would emit
+    # a private-less dist/ over the live one (CLAUDE.md `git` key PRIVATE-WIPE TRAP). The
+    # `deus` symlink always points at the main tree, so this only trips on a raw
+    # `./deus-cmd.sh deploy` from inside a worktree — refuse exactly that case.
+    if [ "$(git -C "$deploy_repo" rev-parse --git-dir)" != "$(git -C "$deploy_repo" rev-parse --git-common-dir)" ]; then
+      echo "deus deploy: refusing to deploy from a linked worktree ($deploy_repo)." >&2
+      echo "  Run 'deus deploy' so it targets the live main tree, not a worktree." >&2
+      exit 1
+    fi
+    deploy_branch=$(git -C "$deploy_repo" symbolic-ref --short -q HEAD 2>/dev/null || echo "DETACHED")
+    if [ "$deploy_branch" != "main" ]; then
+      echo "deus deploy: live tree is on '$deploy_branch', not main." >&2
+      echo "  Switch the live tree to main first: git -C \"$deploy_repo\" checkout main" >&2
+      exit 1
+    fi
+    if ! git -C "$deploy_repo" diff --quiet || ! git -C "$deploy_repo" diff --cached --quiet; then
+      echo "deus deploy: live tree has uncommitted changes — commit or stash first." >&2
+      exit 1
+    fi
+    if ! git -C "$deploy_repo" remote get-url origin >/dev/null 2>&1; then
+      echo "deus deploy: no 'origin' remote configured." >&2; exit 1
+    fi
+    echo "Fetching origin..."
+    # Plain fetch updates refs/remotes/origin/main via the clone-default refspec, so the
+    # diff/merge below always see the freshest tip (no FETCH_HEAD-only ambiguity).
+    if ! git -C "$deploy_repo" fetch origin; then
+      echo "deus deploy: fetch failed." >&2; exit 1
+    fi
+    deploy_changed="$(git -C "$deploy_repo" diff --name-only HEAD origin/main)"
+    if [ -z "$deploy_changed" ]; then
+      echo "deus deploy: already up to date with origin/main — nothing to deploy."
+      exit 0
+    fi
+    # Compute the rebuild plan from the incoming diff BEFORE merging (post-merge it is empty).
+    deploy_plan="$(printf '%s\n' "$deploy_changed" | _deploy_plan)"
+    deploy_needs_build=false; deploy_needs_container=false
+    printf '%s\n' "$deploy_plan" | grep -qx build     && deploy_needs_build=true
+    printf '%s\n' "$deploy_plan" | grep -qx container && deploy_needs_container=true
+    deploy_count=$(printf '%s\n' "$deploy_changed" | grep -c .)
+    echo "Incoming: $deploy_count changed file(s) (HEAD..origin/main)."
+    echo "  host build + restart: $($deploy_needs_build && echo yes || echo 'no (no src/ change)')"
+    echo "  container rebuild:    $($deploy_needs_container && echo yes || echo 'no (no container/ or .claude/skills/ change)')"
+    if $deploy_dry_run; then
+      echo "deus deploy --dry-run: no changes applied."
+      exit 0
+    fi
+    if ! git -C "$deploy_repo" merge --ff-only origin/main; then
+      echo "deus deploy: cannot fast-forward (live tree diverged from origin/main)." >&2
+      echo "  Your main has local commits not on origin — merge or rebase manually." >&2
+      exit 1
+    fi
+    if $deploy_needs_build; then
+      _build_and_restart
+    fi
+    if $deploy_needs_container; then
+      echo "Rebuilding agent container..."
+      (cd "$deploy_repo" && ./container/build.sh) || { echo "deus deploy: container build failed." >&2; exit 1; }
+    fi
+    echo "deus: deployed to origin/main."
+    ;;
   pipeline)
     shift
     # cd required: config.ts evaluates PROJECT_ROOT from process.cwd() at import time
@@ -1538,6 +1640,8 @@ $STARTUP_INSTRUCTION"
     echo "  deus logs       Review system health logs (rotate|review|summary|pinned)"
     echo "  deus usage      Token-efficiency + cost report (--since|--project|--pricing|--json)"
     echo "  deus sync       Update live install to origin/main; 'sync upstream' for forks"
+    echo "  deus deploy     Diff-driven deploy (origin only): ff-merge origin/main + rebuild"
+    echo "                    only what changed (host if src/, container if container/ or skills). --dry-run"
     echo "  deus pipeline   Pipeline event audit (LIA-XX | --failed | --active | --all)"
     echo "  deus solution   Manage solution atoms (list|search|add)"
     echo "  deus sweep      Run threshold calibration sweep against benchmark queries"

--- a/scripts/tests/test_deus_cmd_deploy.py
+++ b/scripts/tests/test_deus_cmd_deploy.py
@@ -1,0 +1,115 @@
+"""Functional tests for `deus deploy`'s rebuild-decision logic.
+
+`deus-cmd.sh` is sourced into a running shell as the live CLI, so this suite
+verifies the `deploy)` wiring statically (matching the test_deus_sync convention)
+AND exercises the pure `_deploy_plan()` decision function for real: the function
+is wrapped in `# >>> deploy-plan` / `# <<< deploy-plan` sentinels so we extract
+it, source it in bash, and feed it sample diffs — testing the OUTCOME (which
+rebuild steps a diff triggers), not just string presence.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "deus-cmd.sh"
+
+
+def _extract_deploy_plan() -> str:
+    text = SCRIPT.read_text()
+    m = re.search(r"# >>> deploy-plan\n(.*?)# <<< deploy-plan", text, re.DOTALL)
+    assert m, "deploy-plan sentinel markers not found in deus-cmd.sh"
+    return m.group(1)
+
+
+def _run_plan(changed_files: str) -> list[str]:
+    """Source the extracted _deploy_plan and run it over a newline-separated list."""
+    func = _extract_deploy_plan()
+    # Pass the file list as a positional arg ($1), not interpolated into the script, so
+    # paths containing shell-special chars ($, `, !) stay literal and never get evaluated.
+    script = func + '\nprintf "%s" "$1" | _deploy_plan\n'
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", changed_files],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.split()
+
+
+# --- functional: the decision function over each bucket -----------------------
+
+
+def test_src_change_triggers_build_only():
+    assert _run_plan("src/index.ts") == ["build"]
+
+
+def test_private_src_change_triggers_build():
+    assert _run_plan("src/private/whatsapp.ts") == ["build"]
+
+
+def test_container_agent_runner_triggers_container_only():
+    assert _run_plan("container/agent-runner/broker.ts") == ["container"]
+
+
+def test_container_dockerfile_triggers_container_only():
+    assert _run_plan("container/Dockerfile") == ["container"]
+
+
+def test_skills_change_triggers_container_only():
+    # Skills are staged into the image by container/build.sh -> needs a rebuild.
+    assert _run_plan(".claude/skills/add-slack/agent.ts") == ["container"]
+
+
+def test_docs_only_triggers_nothing():
+    assert _run_plan("docs/DEVELOPMENT.md") == []
+
+
+def test_patterns_and_readme_only_triggers_nothing():
+    assert _run_plan("patterns/general-code.md\nREADME.md") == []
+
+
+def test_scripts_only_triggers_nothing():
+    # scripts/*.py run live from the tree — no host build needed.
+    assert _run_plan("scripts/maintenance/morning_report.py") == []
+
+
+def test_mixed_src_and_container_triggers_both_in_order():
+    assert _run_plan("src/a.ts\ncontainer/Dockerfile\ndocs/z.md") == ["build", "container"]
+
+
+def test_empty_diff_triggers_nothing():
+    assert _run_plan("") == []
+
+
+def test_substrings_do_not_misfire():
+    # Anchored regexes: paths that merely CONTAIN the words but are not under the
+    # governed directories must NOT trigger a rebuild.
+    assert _run_plan("docs/container-notes.md\nmysrc/x.ts\ntools/src-helper.md") == []
+
+
+# --- static: the deploy) arm wiring is present --------------------------------
+
+
+def test_deploy_arm_wiring_present():
+    text = SCRIPT.read_text()
+    # ff-only merge of origin/main (non-destructive, like sync).
+    assert 'git -C "$deploy_repo" merge --ff-only origin/main' in text
+    # Worktree guard = the private-wipe-trap encoding.
+    assert "rev-parse --git-common-dir" in text
+    # Plain fetch (robust tracking-ref update), diff before merge, dry-run.
+    assert 'git -C "$deploy_repo" fetch origin' in text
+    assert 'git -C "$deploy_repo" diff --name-only HEAD origin/main' in text
+    assert "deploy_dry_run" in text
+    # Conditional rebuild steps wired to the plan tokens.
+    assert "_deploy_plan" in text
+    assert "container/build.sh" in text
+    # Cross-platform guard mirrors sync / _build_and_restart.
+    assert '"$OSTYPE" != darwin*' in text
+
+
+def test_deploy_is_skipped_by_freshness_nag():
+    text = SCRIPT.read_text()
+    # deploy does its own fetch + report, so the drift nag should not double-fire.
+    assert "sync|deploy|" in text


### PR DESCRIPTION
## What

Adds a `deus deploy` subcommand to `deus-cmd.sh`: a **diff-driven conditional deploy** of the live `main` tree. Like `deus sync` it ff-merges `origin/main` (non-destructive), but it rebuilds **only what the incoming diff touched**:

| Incoming change | Action |
|---|---|
| any `src/` | host `npm run build` + `launchctl kickstart` |
| any `container/` or `.claude/skills/` | `./container/build.sh` (skills are staged into the image) |
| docs / patterns / scripts only | ff-merge only, no rebuild |

Codifies the post-merge-deploy + private-wipe-trap tribal knowledge this automation program has been running by hand into one guarded command. (Program PR #5 of 6.)

## Design

- **`_deploy_plan()`** — pure `grep`/`printf` decision (reads changed files on stdin, emits `build`/`container`). Anchored regexes (`^src/`, `^(container/|\.claude/skills/)`) so `docs/container-notes.md` / `mysrc/x.ts` don't misfire. Over- never under-triggers the security-relevant `container` token (a stale image falls through to the wrong tool profile). Wrapped in sentinel comments so it's sourced + unit-tested in isolation.
- **Worktree guard** (`git rev-parse --git-dir` != `--git-common-dir`) refuses deploying from a linked worktree — encodes the private-wipe trap: a fresh worktree lacks gitignored `src/private/`, so an in-place build there would emit a private-less `dist/`. The `deus` symlink always targets the main tree, so this only trips on a raw `./deus-cmd.sh deploy` from inside a worktree.
- Reuses `sync`'s on-main / clean-tree / `origin`-remote preflight; `git fetch origin` (robust tracking-ref update, no `FETCH_HEAD`-only ambiguity); diff computed **before** the merge; `--dry-run` previews the plan and exits.
- darwin/Linux only (mirrors `_build_and_restart` / `sync`; Windows port pending).

## Testing

- `scripts/tests/test_deus_cmd_deploy.py` — **13 tests**: functional coverage of every diff bucket (src/private/container/skills/docs/patterns/scripts/mixed/empty/substring-anti-misfire) via the extracted `_deploy_plan`, plus static wiring assertions.
- `bash -n deus-cmd.sh` clean; `flag_lint --base origin/main` clean (no new env reads).
- Clean-room e2e verified: container-only `--dry-run` reports correctly with no mutation; docs-only real deploy ff-merges + advances HEAD; running from a linked worktree refuses (exit 1).

## Gates
plan-reviewer (claude+gpt) SHIP · code-reviewer (claude+gpt+glm) SHIP · verification-gate (Opus) SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)