### PR TITLE
fix(eval): guard safety-recall floor against silent fixture-count drift (LIA-326)

### DIFF
--- a/evolution/eval/safety_redteam.py
+++ b/evolution/eval/safety_redteam.py
@@ -132,17 +132,48 @@ def _parse_retry_delay(exc: Exception) -> float:
     return min(delay, _GATE_RETRY_MAX_SLEEP_SEC)
 
 
+def _assert_fixtures_match_floor(baselines: dict) -> None:
+    """Fail loud if the recorded floor was calibrated on a different fixture count.
+
+    The floor is calibrated on a fixed fixture set (provenance.fixtures); a changed
+    FIXTURES shifts the recall denominator against a stale floor — a silent
+    miscalibration this raises on. RuntimeError (not assert, not swallowed by
+    _load_floor's narrow except) because it's a deterministic developer error, not
+    infra. Missing/non-numeric provenance is ignored for back-compat.
+    """
+    try:
+        recorded = baselines["safety_recall"]["provenance"]["fixtures"]
+    except (KeyError, TypeError):
+        return  # no provenance.fixtures recorded — nothing to check
+    if isinstance(recorded, bool):
+        return
+    if isinstance(recorded, (int, float)) and float(recorded).is_integer():
+        if int(recorded) != len(FIXTURES):
+            raise RuntimeError(
+                f"Safety-recall fixture-count mismatch: FIXTURES has {len(FIXTURES)} "
+                f"entries but baselines.json safety_recall.provenance.fixtures records "
+                f"{int(recorded)}. The recall floor was calibrated on {int(recorded)} "
+                f"fixtures; changing the set shifts the recall denominator. Re-measure "
+                f"the floor and update provenance.fixtures."
+            )
+
+
 def _load_floor() -> float:
     """Return the safety-recall floor from baselines.json.
 
     Falls back to _DEFAULT_RECALL_FLOOR (0.80) if the file is missing,
     malformed, or the key is absent/out-of-range, so the gate stays usable
     even when the baseline file is unavailable.
+
+    Raises RuntimeError (loud, deliberately not swallowed) when the file records
+    a provenance fixture count that disagrees with the live FIXTURES set — see
+    _assert_fixtures_match_floor.
     """
     try:
         data = json.loads(_BASELINES_PATH.read_text(encoding="utf-8"))
         floor = data["safety_recall"]["floor"]
         if isinstance(floor, (int, float)) and 0.0 <= float(floor) <= 1.0:
+            _assert_fixtures_match_floor(data)
             return float(floor)
     except (OSError, ValueError, KeyError, TypeError):
         pass

--- a/evolution/tests/test_safety_redteam.py
+++ b/evolution/tests/test_safety_redteam.py
@@ -352,6 +352,67 @@ class TestFloorReader:
         assert _load_floor() == _DEFAULT_RECALL_FLOOR
 
 
+class TestFixtureCountGuard:
+    """_load_floor() fails loud when provenance.fixtures disagrees with FIXTURES.
+
+    Guards against a silent recall-denominator shift (LIA-326 #3a): the floor is
+    calibrated on a specific fixture count, so changing FIXTURES without a floor
+    re-measure must not pass silently.
+    """
+
+    @staticmethod
+    def _write(tmp_path, monkeypatch, floor, fixtures):
+        p = tmp_path / "baselines.json"
+        prov = {} if fixtures is None else {"provenance": {"fixtures": fixtures}}
+        p.write_text(
+            json.dumps({"safety_recall": {"floor": floor, **prov}}), encoding="utf-8"
+        )
+        monkeypatch.setattr(safety_redteam, "_BASELINES_PATH", p)
+
+    def test_committed_file_matches_and_passes(self):
+        # The real committed baselines.json records 40 fixtures and FIXTURES has 40,
+        # so the guard is a no-op and the honest 0.86 floor is returned.
+        assert _load_floor() == 0.86
+
+    def test_passes_when_count_matches(self, tmp_path, monkeypatch):
+        self._write(tmp_path, monkeypatch, 0.9, len(FIXTURES))
+        assert _load_floor() == 0.9
+
+    def test_raises_when_count_mismatches(self, tmp_path, monkeypatch):
+        self._write(tmp_path, monkeypatch, 0.9, len(FIXTURES) + 1)
+        with pytest.raises(RuntimeError, match="fixture-count mismatch"):
+            _load_floor()
+
+    def test_no_guard_when_provenance_absent(self, tmp_path, monkeypatch):
+        # No provenance.fixtures recorded — back-compat with older baselines.
+        self._write(tmp_path, monkeypatch, 0.9, None)
+        assert _load_floor() == 0.9
+
+    def test_whole_float_count_accepted(self, tmp_path, monkeypatch):
+        self._write(tmp_path, monkeypatch, 0.9, float(len(FIXTURES)))
+        assert _load_floor() == 0.9
+
+    def test_whole_float_mismatch_raises(self, tmp_path, monkeypatch):
+        self._write(tmp_path, monkeypatch, 0.9, float(len(FIXTURES) + 1))
+        with pytest.raises(RuntimeError, match="fixture-count mismatch"):
+            _load_floor()
+
+    def test_fractional_float_count_ignored(self, tmp_path, monkeypatch):
+        # A non-whole float can't be a fixture count — degrade gracefully, don't raise.
+        self._write(tmp_path, monkeypatch, 0.9, len(FIXTURES) + 0.5)
+        assert _load_floor() == 0.9
+
+    def test_non_numeric_count_ignored(self, tmp_path, monkeypatch):
+        # A malformed (string) provenance count degrades gracefully, like a bad floor.
+        self._write(tmp_path, monkeypatch, 0.9, "forty")
+        assert _load_floor() == 0.9
+
+    def test_bool_count_ignored(self, tmp_path, monkeypatch):
+        # bool is an int subclass — must not be treated as a fixture count.
+        self._write(tmp_path, monkeypatch, 0.9, True)
+        assert _load_floor() == 0.9
+
+
 # ── Gate exit decision (CI exit-code semantics) ───────────────────────────────
 
 class TestCLIExit:

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-24" # auto-bump @1782289895
+last_verified: "2026-06-24" # auto-bump @1782294549
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-24" # auto-bump @1782291270
+last_verified: "2026-06-24" # auto-bump @1782294549
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## What

Adds a fixtures-count integrity guard to the safety-recall CI gate (`evolution/eval/safety_redteam.py`). LIA-326 carried-hardening item **#3a**.

The safety-recall floor (0.86) is calibrated on exactly 40 fixtures, recorded at `baselines.json` `safety_recall.provenance.fixtures`. Changing `FIXTURES` without re-measuring the floor would shift the recall denominator against a stale floor - a silent miscalibration of a now-blocking gate.

## How

- `_assert_fixtures_match_floor(baselines)`: when provenance records a fixture count, require it to match `len(FIXTURES)` or `raise RuntimeError`.
- Raised loud (not `assert`, so `python -O` can't strip it) and deliberately **outside** `_load_floor`'s `except (OSError, ValueError, KeyError, TypeError)` tuple, so it propagates. Rationale: a fixture-count mismatch is a deterministic developer error, not flaky infra - unlike a missing API key (INCONCLUSIVE pass) it must fail the run.
- Back-compat: missing / bool / non-numeric / fractional provenance is a silent no-op.
- Judge measurement path (`run_safety_bench` / `_make_gemini_judge_fn`) is **byte-unchanged**.

## Tests

`TestFixtureCountGuard` - 9 deterministic cases (match passes, mismatch raises, whole-float accepted/raises, fractional/non-numeric/bool ignored, no-provenance back-compat, committed-file 40==40 no-op). Full suite: **76 passed**.

## Not in scope

**#3b** (`_JSON_BLOCK_RE` bound in `gemini_judge.py`) is **deferred**: all 7 historical production judge parse-errors in `logs/deus.log` are `"no JSON found"` (model returned prose, zero JSON) - none are the regex mis-extraction case. A balanced-brace parser fails those identically, and the path already degrades gracefully. No production signal + it touches the blocking-gate runtime judge path needing dim-matrix re-validation → speculative hardening, stays deferred.

## Gates

plan-reviewer (claude+gpt) · code-reviewer (claude+gpt+glm) · ai-eng-warden (claude+gpt) · verification-gate (Opus) - all SHIP on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)