### PR TITLE
fix(evolution): apply think:false body key to qwen3 judge models (qwen3.5 parse fix)

### DIFF
--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -58,12 +58,18 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
     """Synchronous Ollama generate call."""
     # Suppress model "thinking" for structured output — otherwise the thinking
     # preamble slows the call and can corrupt the JSON-grammar response. The
-    # mechanism is family-specific: Qwen uses the /no_think prompt suffix; Gemma4
-    # (the default OLLAMA_MODEL) uses the "think": false request-body key. Prior
-    # to this fix the default judge ran with thinking ON and no suppression.
-    # Scoped to gemma4 specifically — the only Gemma we run — rather than all
-    # "gemma*" so earlier variants aren't sent a key they may not support.
-    full_prompt = f"{prompt}\n/no_think" if "qwen" in model.lower() else prompt
+    # real control is the Ollama "think": false request-body key, used for the
+    # two thinking-capable judge families we run: Gemma4 (the default
+    # OLLAMA_MODEL) and Qwen3. Qwen3 ALSO keeps the older /no_think prompt suffix
+    # for qwen3.0 compat, but the suffix alone is insufficient: qwen3.5+ ignores
+    # it (a qwen3.0-era soft switch) and returns an EMPTY response under the
+    # strict `format` schema — a silent parse failure. The body key is what
+    # actually suppresses thinking on qwen3.5+; the suffix is harmless
+    # belt-and-suspenders for qwen3.0.
+    # Both predicates are scoped to specific families (gemma4, qwen3) rather than
+    # bare "gemma"/"qwen" so non-thinking variants (gemma2/3, qwen2.5, qwen-embed)
+    # aren't sent a key/suffix they don't support.
+    full_prompt = f"{prompt}\n/no_think" if "qwen3" in model.lower() else prompt
     payload = {
         "model": model,
         "prompt": full_prompt,
@@ -86,7 +92,7 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
             "seed": 42,
         },
     }
-    if "gemma4" in model.lower():
+    if "gemma4" in model.lower() or "qwen3" in model.lower():
         payload["think"] = False
     body = json.dumps(payload).encode()
     req = urllib.request.Request(

--- a/evolution/tests/test_ollama_judge.py
+++ b/evolution/tests/test_ollama_judge.py
@@ -32,14 +32,21 @@ def test_gemma4_suppresses_thinking_via_body_key():
     assert "/no_think" not in body["prompt"]
 
 
-def test_qwen_suppresses_thinking_via_prompt_suffix():
-    # Qwen keeps the /no_think prompt-suffix mechanism and no body-level key.
-    captured = {}
-    with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
-        _call_ollama("rate this response", model="qwen3:4b")
-    body = captured["body"]
-    assert body["prompt"].endswith("/no_think")
-    assert "think" not in body
+def test_qwen3_suppresses_thinking_via_both_mechanisms():
+    # Qwen3 gets BOTH controls: the body-level "think": false key (the real
+    # control — qwen3.5+ ignores the /no_think suffix and returns an empty
+    # response under the strict format schema) AND the /no_think prompt suffix
+    # (harmless belt-and-suspenders for qwen3.0 compat). Covers both the older
+    # qwen3.0 (suffix originally validated in LIA-186) and qwen3.5 (the variant
+    # the suffix alone left broken).
+    for model in ("qwen3:4b", "qwen3.5:4b"):
+        captured = {}
+        with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+            _call_ollama("rate this response", model=model)
+        body = captured["body"]
+        assert body["prompt"].endswith("/no_think"), f"{model} missing suffix"
+        assert body.get("think") is False, f"{model} missing think key"
+        assert "think" not in body.get("options", {})
 
 
 def test_non_thinking_model_sends_no_controls():
@@ -61,3 +68,18 @@ def test_earlier_gemma_variants_excluded_from_think_key():
         with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
             _call_ollama("rate this response", model=model)
         assert "think" not in captured["body"], f"{model} should not get think key"
+
+
+def test_earlier_qwen_variants_excluded_from_controls():
+    # Boundary canary: both the think key and the /no_think suffix are scoped to
+    # qwen3 only. Non-thinking qwen variants (qwen2.5, hypothetical qwen-embed)
+    # must receive NEITHER — guards against widening the predicate to a bare
+    # "qwen" substring, which would send a thinking control to a model that has
+    # no thinking mode to suppress.
+    for model in ("qwen2:7b", "qwen2.5:7b", "qwen-embed:0.6b"):
+        captured = {}
+        with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+            _call_ollama("rate this response", model=model)
+        body = captured["body"]
+        assert "think" not in body, f"{model} should not get think key"
+        assert "/no_think" not in body["prompt"], f"{model} should not get suffix"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-24" # auto-bump @1782294549
+last_verified: "2026-06-25" # auto-bump @1782378941
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-24" # auto-bump @1782296949
+last_verified: "2026-06-25" # auto-bump @1782378941
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Problem

The Ollama evolution judge (`evolution/judge/ollama_judge.py`) suppresses model "thinking" — a reasoning preamble that voids the strict JSON-grammar `format` response — via two family-specific mechanisms set in LIA-186 (#708):

- **gemma4** → `payload["think"] = False` (Ollama request-body key)
- **qwen** → `/no_think` prompt suffix, no body key

`qwen3.5` (released after LIA-186) **ignores the `/no_think` suffix** — it is a qwen3.0-era soft switch — so under the strict `format` schema it returns an **empty `response`** (eval_count>0, response=""), which `_parse_result` treats as a parse error. Net effect: **qwen3.5 is silently unusable as a judge.**

Surfaced during LIA-331 step 3, where qwen3.5 was the intended diverse co-judge and returned nothing until the body key was applied.

## Fix

Extend the body-key predicate to `qwen3` (the thinking-capable family) so qwen3.5+ is suppressed via the mechanism it actually honors. Keep the `/no_think` suffix for qwen3.0 compat (additive — the qwen3.0 path validated in LIA-186 is untouched).

Both predicates are scoped to specific families (`gemma4`, `qwen3`) rather than bare `gemma`/`qwen`, so non-thinking variants (gemma2/3, qwen2.5, qwen-embed) receive **neither** control — matching the existing gemma4-specificity rationale (don't send a thinking control to a model with no thinking mode).

```python
full_prompt = f"{prompt}\n/no_think" if "qwen3" in model.lower() else prompt
...
if "gemma4" in model.lower() or "qwen3" in model.lower():
    payload["think"] = False
```

## Verification

- **Unit:** 35 passed (`test_ollama_judge.py` + `test_ollama_judge_model_override.py` + `test_judge_registry.py`). New: qwen3 case loops `qwen3:4b` + `qwen3.5:4b` (both controls); boundary canary asserts `qwen2:7b`/`qwen2.5:7b`/`qwen-embed` get **neither** control.
- **Live (the actual fix outcome):** patched `_call_ollama` on `qwen3.5:4b` → non-empty valid JSON, `parse_error=False` (was empty → parse-error before).
- **n=200:** scored qwen3.5:4b through `think:false` → **0 parse-fails**.

## Risk

qwen3.0 now also receives `think:false` in addition to its suffix. `think` is the canonical Ollama control for thinking-capable models; the suffix only ever mattered for thinking-capable qwen, so the key is always valid there. Strictly additive — cannot remove the suffix path that worked. (qwen3.0 not pulled locally; verified on qwen3.5.)

Python-only; judge default stays `gemma4:e4b` so the live service is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)