### PR TITLE
fix(memory): confirm file absence before orphaning a tree node (LIA-336)

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -171,6 +171,18 @@ _AUDIT_PATH = Path(os.environ.get(
 # silently wiping live data — see 2026-04-15 incident). `--force` bypasses.
 REBUILD_MIN_RETENTION = 0.5
 
+# Orphan-sweep false-positive guard (LIA-336). The orphan sweeps decide from a
+# single in-memory walk snapshot, but a concurrent rewrite of a tracked file —
+# vault files are written via Path.write_text (truncate-in-place, NOT atomic),
+# and /compress + parallel sessions rewrite CLAUDE.md — can make a live file
+# momentarily unreadable (OSError) or truncated (no `id:` yet) exactly when the
+# walk observes it, dropping a live node from the walk and soft-orphaning it.
+# Before orphaning a candidate we re-confirm absence on disk across a few spaced
+# retries; any single observation that the file is still tracked aborts the
+# orphan. Module-level so tests can set the delay to 0.
+ORPHAN_CONFIRM_RETRIES = 3
+ORPHAN_CONFIRM_DELAY_S = 0.05
+
 
 def is_external_namespace(path: str) -> bool:
     """True if path belongs to an external population (e.g. auto-memory/)."""
@@ -916,6 +928,43 @@ def iter_tree_files(vault: Path) -> list[Path]:
     return files
 
 
+def _confirm_orphan(path: Path, *, require_id: bool) -> bool:
+    """Confirm a tracked file is genuinely gone before orphaning its node (LIA-336).
+
+    A node becomes an orphan candidate when its file is absent from an in-memory
+    walk, but a concurrent rewrite can make a *live* file momentarily unreadable
+    (OSError) or truncated (no `id:` yet) during that walk. We re-check the
+    filesystem up to ORPHAN_CONFIRM_RETRIES times, spaced by ORPHAN_CONFIRM_DELAY_S,
+    and return True (safe to orphan) ONLY if every attempt confirms the file is
+    gone. A single observation that the file is still tracked returns False early.
+
+    Pattern: bounded retry with early-exit on confirmed-present. O(retries) reads,
+    paid only per orphan candidate (≈0 in steady state).
+
+    require_id=True  — mirror iter_tree_files membership: a clean read AND `id:`
+      present. A file persistently missing its `id:` is a real de-list (still
+      orphaned); a truncated read that momentarily hides `id:` is not.
+    require_id=False — pure existence check (for the existence-triggered sweeps).
+
+    OSError on every retry maps to "absent" intentionally: a file unreadable for
+    the whole window (e.g. revoked permissions, genuine deletion) should orphan.
+    """
+    for attempt in range(ORPHAN_CONFIRM_RETRIES):
+        try:
+            if require_id:
+                head = path.read_text(encoding="utf-8", errors="replace")[:4096]
+                still_tracked = bool(parse_frontmatter(head).get("id"))
+            else:
+                still_tracked = path.exists()
+        except OSError:
+            still_tracked = False
+        if still_tracked:
+            return False
+        if attempt < ORPHAN_CONFIRM_RETRIES - 1:
+            time.sleep(ORPHAN_CONFIRM_DELAY_S)
+    return True
+
+
 # ── Build ─────────────────────────────────────────────────────────────────────
 
 def build_tree(
@@ -1085,6 +1134,10 @@ def build_tree(
         if is_external_namespace(npath):
             continue
         if npath not in path_to_id:
+            # LIA-336: re-confirm before orphaning (see _confirm_orphan). The root
+            # is admitted by iter_tree_files without an id check → existence only.
+            if not _confirm_orphan(vault / npath, require_id=(npath != "MEMORY_TREE.md")):
+                continue
             db.execute(
                 "UPDATE nodes SET orphaned_at = ?, orphan_reason = 'missing_file' WHERE id = ?",
                 (now_iso, nid),
@@ -1863,7 +1916,9 @@ def autofix_tree(db: sqlite3.Connection, vault: Path) -> dict[str, int]:
     for (nid, npath, _) in active:
         if is_external_namespace(npath):
             continue
-        if not (vault / npath).exists():
+        # LIA-336: re-confirm before orphaning. This sweep is existence-based
+        # (no id check), so require_id=False mirrors the original .exists() test.
+        if _confirm_orphan(vault / npath, require_id=False):
             db.execute(
                 "UPDATE nodes SET orphaned_at = ?, orphan_reason = 'missing_file' WHERE id = ?",
                 (now_iso, nid),
@@ -2021,6 +2076,13 @@ def reindex_external(
     ).fetchall()
     for (nid, npath) in ext_active:
         if npath not in walked_paths:
+            # LIA-336: a rename-gap during rglob can briefly hide a live file;
+            # confirm it's truly gone on disk before orphaning. ns_path was built
+            # as EXTERNAL_NAMESPACE + rel_to_ext, so strip the prefix to recover
+            # the path under external_dir.
+            ext_file = external_dir / npath[len(EXTERNAL_NAMESPACE):]
+            if not _confirm_orphan(ext_file, require_id=False):
+                continue
             db.execute(
                 "UPDATE nodes SET orphaned_at = ?, orphan_reason = 'missing_file' WHERE id = ?",
                 (now_iso, nid),

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -390,6 +390,31 @@ class TestBuild:
         counts = mt.build_tree(fake_vault, tmp_db)
         assert counts["orphaned"] == 1
 
+    def test_transient_walk_miss_does_not_orphan(
+        self, tmp_db, fake_vault, stub_embed, monkeypatch
+    ):
+        """LIA-336: a file present on disk but missing from one walk (concurrent
+        rewrite) must NOT be orphaned — _confirm_orphan re-reads it and aborts."""
+        mt.build_tree(fake_vault, tmp_db)
+        monkeypatch.setattr(mt, "ORPHAN_CONFIRM_DELAY_S", 0)
+        movies = fake_vault / "Persona" / "taste" / "movies.md"
+        assert movies.exists()  # still on disk — only the walk "missed" it
+
+        real_iter = mt.iter_tree_files
+
+        def _iter_minus_movies(vault):
+            return [p for p in real_iter(vault) if p != movies]
+
+        monkeypatch.setattr(mt, "iter_tree_files", _iter_minus_movies)
+        counts = mt.build_tree(fake_vault, tmp_db)
+
+        assert counts["orphaned"] == 0
+        active = tmp_db.execute(
+            "SELECT 1 FROM nodes WHERE path = ? AND orphaned_at IS NULL",
+            ("Persona/taste/movies.md",),
+        ).fetchone()
+        assert active is not None  # node still live, not soft-deleted
+
     def test_rebuild_aborts_when_vault_shrinks(
         self, tmp_db, fake_vault, stub_embed, tmp_path, monkeypatch
     ):
@@ -445,6 +470,50 @@ class TestBuild:
         mt.build_tree(fake_vault, tmp_db, rebuild=True)
         audit = (tmp_path / "audit.jsonl").read_text().strip().splitlines()
         assert any('"action": "rebuild"' in line for line in audit)
+
+
+# ── Confirm-orphan guard (LIA-336) ──────────────────────────────────────────────
+
+class TestConfirmOrphan:
+    """Frozen oracle for _confirm_orphan: confirm-before-orphan guard against
+    false-orphaning a live file mid-rewrite. Returns True => safe to orphan."""
+
+    @pytest.fixture(autouse=True)
+    def _fast(self, monkeypatch):
+        monkeypatch.setattr(mt, "ORPHAN_CONFIRM_DELAY_S", 0)
+
+    def test_present_with_id_not_orphaned(self, tmp_path):  # row a
+        f = tmp_path / "n.md"
+        f.write_text("---\nid: abc\ndescription: d\n---\n", encoding="utf-8")
+        assert mt._confirm_orphan(f, require_id=True) is False
+
+    def test_absent_orphaned_require_id(self, tmp_path):  # row b
+        assert mt._confirm_orphan(tmp_path / "gone.md", require_id=True) is True
+
+    def test_persistent_no_id_orphaned(self, tmp_path):  # row c — real de-list
+        f = tmp_path / "n.md"
+        f.write_text("plain text, no frontmatter id\n", encoding="utf-8")
+        assert mt._confirm_orphan(f, require_id=True) is True
+
+    def test_transient_truncation_not_orphaned(self):  # row c' — the bug case
+        calls = {"n": 0}
+
+        class _Flaky:
+            def read_text(self, *a, **k):
+                calls["n"] += 1
+                # First read sees a truncated (mid-rewrite) file; retry sees id.
+                return "" if calls["n"] == 1 else "---\nid: abc\n---\n"
+
+        assert mt._confirm_orphan(_Flaky(), require_id=True) is False
+        assert calls["n"] >= 2  # proves it retried rather than orphaning on miss 1
+
+    def test_present_not_orphaned_existence(self, tmp_path):  # row d
+        f = tmp_path / "n.md"
+        f.write_text("x", encoding="utf-8")
+        assert mt._confirm_orphan(f, require_id=False) is False
+
+    def test_absent_orphaned_existence(self, tmp_path):  # row e
+        assert mt._confirm_orphan(tmp_path / "gone.md", require_id=False) is True
 
 
 # ── Retrieve ──────────────────────────────────────────────────────────────────
@@ -728,6 +797,35 @@ class TestReindexExternal:
         with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
             counts = mt.reindex_external(tmp_db, ext_dir)
         assert counts["orphaned"] == 1
+
+    def test_transient_rglob_miss_does_not_orphan(self, tmp_db, ext_dir, monkeypatch):
+        """LIA-336: a present file that rglob misses during one sweep (a rename
+        gap) must NOT be orphaned — _confirm_orphan re-checks it on disk. Mirrors
+        test_orphans_deleted_files but the file stays on disk."""
+        import pathlib
+
+        monkeypatch.setattr(mt, "ORPHAN_CONFIRM_DELAY_S", 0)
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
+            mt.reindex_external(tmp_db, ext_dir)
+
+        target = ext_dir / "feedback_test.md"
+        assert target.exists()  # still on disk; only the walk "misses" it
+
+        real_rglob = pathlib.Path.rglob
+
+        def _rglob_minus_target(self, pattern):
+            return (p for p in real_rglob(self, pattern) if p.name != "feedback_test.md")
+
+        monkeypatch.setattr(pathlib.Path, "rglob", _rglob_minus_target)
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
+            counts = mt.reindex_external(tmp_db, ext_dir)
+
+        assert counts["orphaned"] == 0
+        row = tmp_db.execute(
+            "SELECT 1 FROM nodes WHERE path = ? AND orphaned_at IS NULL",
+            ("auto-memory/feedback_test.md",),
+        ).fetchone()
+        assert row is not None  # live node preserved, not soft-deleted
 
     def test_reads_name_for_title(self, tmp_db, ext_dir):
         with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):


### PR DESCRIPTION
## Problem (LIA-336)
`memory_tree.py`'s orphan sweeps decide from a single in-memory walk snapshot. A concurrent rewrite of a tracked file — vault files are written via `Path.write_text` (truncate-in-place, **not** atomic; `memory_tree.py:1838,1920`, `memory_indexer.py:3381`), and `/compress` + parallel sessions rewrite `CLAUDE.md` — can make a live file momentarily **unreadable** (OSError) or **truncated** (no `id:` yet) exactly when the walk observes it. The live node falls out of the walk and is soft-orphaned (`orphan_reason='missing_file'`), dropping it from retrieval until a later rebuild. **Observed:** `CLAUDE.md` was falsely orphaned and hand-restored last session. This is the silent data-loss class the no-db-deletion / data-integrity rules exist to prevent.

## Fix
Add `_confirm_orphan(path, *, require_id)` — a **bounded-retry (3× / 0.05s) filesystem re-confirmation** before orphaning, applied at all three orphan sites:
- `build_tree` (`require_id` = `npath != "MEMORY_TREE.md"`; root is admitted without an id check)
- `autofix_tree` (`require_id=False` — preserves the original `.exists()` semantics)
- `reindex_external` (`require_id=False`; path reconstructed as `external_dir / npath[len(EXTERNAL_NAMESPACE):]`)

It aborts the orphan the moment any retry shows the file still tracked. `require_id=True` mirrors `iter_tree_files` membership: a **persistently** id-less file is still a real de-list (orphaned), but a **transient** truncation is not. OSError for the whole window maps to "absent" intentionally (a genuinely unreadable file should orphan).

## What this does NOT change
- Genuine deletions still orphan (existing `test_missing_file_gets_orphaned` / `test_orphans_deleted_files` unchanged).
- No retrieval/ranking code touched — **136-query benchmark identical before/after**: recall@k 0.765, mrr 0.636, abstain_accuracy 0.591, wrong_confident 0.0 (retrieval-sweep-gate).

## Tests
- `TestConfirmOrphan` — 6-case frozen oracle (require_id True/False × present/absent/truncated-transient/persistent-no-id).
- `test_transient_walk_miss_does_not_orphan` (build) + `test_transient_rglob_miss_does_not_orphan` (reindex) — a live file missed by one walk stays active.
- **151 pass** in `test_memory_tree.py`; **48 pass** across `test_memory_query` / `test_memory_tree_hook` / `test_memory_retrieval_hook`.

## Gates
plan-reviewer (claude+gpt) · code-reviewer (claude+gpt+glm) · ai-eng-warden (claude+gpt) · verification-gate (Opus) — all SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)