### PR TITLE
fix(memory): conflict-resolution model - resolved_at + 3-way invalidate (LIA-338)

### DIFF
--- a/evolution/tests/test_memory_indexer_contradiction_commit.py
+++ b/evolution/tests/test_memory_indexer_contradiction_commit.py
@@ -89,3 +89,192 @@ def test_detected_conflict_persists_across_connection_close(tmp_path, monkeypatc
         "pending_conflicts row must persist after the connection closes — "
         "detect_contradictions must commit at the write site"
     )
+
+
+# ── LIA-338: resolution-model completeness (resolved_at + 3-way --newer) ──────
+
+
+def _seed_conflict(mi, tmp_path, older_id=1, newer_id=2):
+    """Seed two atoms + one unresolved pending_conflicts row. Returns the
+    conflict id. Atom paths point under tmp_path and do NOT exist, so
+    invalidate_atom's file-rewrite branch is skipped (DB-only, no fixture files).
+    """
+    db = mi.open_db()
+    for aid, when, text in (
+        (older_id, "2026-06-01", "Older atom text."),
+        (newer_id, "2026-06-25", "Newer atom text."),
+    ):
+        db.execute(
+            "INSERT INTO entries (id, path, date, chunk, type) VALUES (?, ?, ?, ?, 'atom')",
+            [aid, str(tmp_path / f"atom_{aid}.md"), when, text],
+        )
+    db.execute(
+        "INSERT INTO pending_conflicts (older_id, newer_id, older_text, newer_text, created_at) "
+        "VALUES (?, ?, ?, ?, '2026-06-25')",
+        [older_id, newer_id, "Older atom text.", "Newer atom text."],
+    )
+    cid = db.execute(
+        "SELECT id FROM pending_conflicts WHERE older_id = ? AND newer_id = ?",
+        [older_id, newer_id],
+    ).fetchone()[0]
+    db.commit()
+    db.close()
+    return cid
+
+
+def _conflict_row(mi, cid):
+    db = mi.open_db()
+    row = db.execute(
+        "SELECT resolved, resolution, resolved_at FROM pending_conflicts WHERE id = ?",
+        [cid],
+    ).fetchone()
+    db.close()
+    return row  # (resolved, resolution, resolved_at)
+
+
+def _expired(mi, atom_id):
+    db = mi.open_db()
+    row = db.execute("SELECT expired_at FROM entries WHERE id = ?", [atom_id]).fetchone()
+    db.close()
+    return row[0]
+
+
+def test_resolved_at_null_until_invalidate_older(tmp_path, monkeypatch):
+    """Default --invalidate-conflict expires the OLDER atom, stamps resolved_at,
+    and leaves the newer atom intact. resolved_at is NULL until resolution."""
+    mi = _import_memory_indexer()
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+    cid = _seed_conflict(mi, tmp_path)
+
+    assert _conflict_row(mi, cid) == (0, None, None), "fresh conflict: unresolved, resolved_at NULL"
+
+    mi.cmd_invalidate_conflict(cid)
+
+    resolved, resolution, resolved_at = _conflict_row(mi, cid)
+    assert resolved == 1 and resolution == "invalidated"
+    assert resolved_at is not None, "resolved_at must be stamped on invalidate"
+    assert _expired(mi, 1) is not None, "older atom must be soft-deleted"
+    assert _expired(mi, 2) is None, "newer atom must be untouched"
+
+
+def test_invalidate_conflict_newer_branch(tmp_path, monkeypatch):
+    """--newer expires the NEWER atom, records resolution=invalidated_newer, and
+    leaves the older atom intact (closes the one-directional gap, LIA-338)."""
+    mi = _import_memory_indexer()
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+    cid = _seed_conflict(mi, tmp_path)
+
+    mi.cmd_invalidate_conflict(cid, newer=True)
+
+    resolved, resolution, resolved_at = _conflict_row(mi, cid)
+    assert resolved == 1 and resolution == "invalidated_newer"
+    assert resolved_at is not None
+    assert _expired(mi, 2) is not None, "newer atom must be soft-deleted"
+    assert _expired(mi, 1) is None, "older atom must be untouched"
+
+
+def test_dismiss_sets_resolved_at(tmp_path, monkeypatch):
+    """Dismiss stamps resolved_at and touches no atom."""
+    mi = _import_memory_indexer()
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+    cid = _seed_conflict(mi, tmp_path)
+
+    mi.cmd_dismiss_conflict(cid)
+
+    resolved, resolution, resolved_at = _conflict_row(mi, cid)
+    assert resolved == 1 and resolution == "dismissed" and resolved_at is not None
+    assert _expired(mi, 1) is None and _expired(mi, 2) is None
+
+
+def test_dismiss_is_noop_on_already_resolved(tmp_path, monkeypatch):
+    """Re-dismissing an already-resolved row must NOT overwrite resolved_at —
+    guards the migration invariant that historical rows keep their value
+    (here: NULL) instead of being stamped with today's date."""
+    mi = _import_memory_indexer()
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+    cid = _seed_conflict(mi, tmp_path)
+
+    # Simulate a historical resolved row: resolved=1 but resolved_at NULL.
+    db = mi.open_db()
+    db.execute(
+        "UPDATE pending_conflicts SET resolved = 1, resolution = 'dismissed', resolved_at = NULL "
+        "WHERE id = ?",
+        [cid],
+    )
+    db.commit()
+    db.close()
+
+    mi.cmd_dismiss_conflict(cid)  # must be a no-op
+
+    resolved, resolution, resolved_at = _conflict_row(mi, cid)
+    assert resolved == 1 and resolution == "dismissed"
+    assert resolved_at is None, "re-dismiss must not stamp a historical NULL row"
+
+
+def test_cli_dispatch_invalidate_conflict_newer(tmp_path, monkeypatch):
+    """End-to-end through main(): argv --invalidate-conflict <id> --newer wires
+    into cmd_invalidate_conflict(id, newer=True)."""
+    mi = _import_memory_indexer()
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+    cid = _seed_conflict(mi, tmp_path)
+
+    monkeypatch.setattr(
+        sys, "argv",
+        ["memory_indexer.py", "--invalidate-conflict", str(cid), "--newer"],
+    )
+    mi.main()
+
+    resolved, resolution, _ = _conflict_row(mi, cid)
+    assert resolved == 1 and resolution == "invalidated_newer"
+    assert _expired(mi, 2) is not None and _expired(mi, 1) is None
+
+
+def test_newer_without_invalidate_conflict_errors(tmp_path, monkeypatch):
+    """--newer alone is rejected (parser.error → SystemExit), never silently
+    ignored."""
+    import pytest
+
+    mi = _import_memory_indexer()
+    monkeypatch.setattr(mi, "DB_PATH", tmp_path / "mem.db")
+    monkeypatch.setattr(sys, "argv", ["memory_indexer.py", "--newer"])
+    with pytest.raises(SystemExit):
+        mi.main()
+
+
+def test_migration_adds_resolved_at_to_old_table(tmp_path, monkeypatch):
+    """An existing pending_conflicts table without resolved_at gains it on
+    open_db(), and the pre-existing resolved row keeps resolved_at NULL (no
+    fabricated timestamp)."""
+    import sqlite3
+
+    db_path = tmp_path / "mem.db"
+    monkeypatch.setattr(_import_memory_indexer(), "DB_PATH", db_path)
+
+    # Simulate a pre-LIA-338 DB: old schema, one already-resolved row.
+    raw = sqlite3.connect(db_path)
+    raw.execute(
+        "CREATE TABLE pending_conflicts ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, older_id INTEGER NOT NULL, "
+        "newer_id INTEGER NOT NULL, older_text TEXT, newer_text TEXT, "
+        "created_at TEXT NOT NULL, resolved INTEGER DEFAULT 0, resolution TEXT, "
+        "UNIQUE(older_id, newer_id))"
+    )
+    raw.execute(
+        "INSERT INTO pending_conflicts (older_id, newer_id, created_at, resolved, resolution) "
+        "VALUES (10, 11, '2026-06-10', 1, 'dismissed')"
+    )
+    raw.commit()
+    raw.close()
+
+    mi = _import_memory_indexer()
+    db = mi.open_db()  # runs the idempotent ALTER migration
+    cols = [r[1] for r in db.execute("PRAGMA table_info(pending_conflicts)").fetchall()]
+    assert "resolved_at" in cols, "migration must add resolved_at to an old table"
+    val = db.execute(
+        "SELECT resolved_at FROM pending_conflicts WHERE older_id = 10"
+    ).fetchone()[0]
+    assert val is None, "historical resolved row must stay NULL (no fabricated timestamp)"
+    db.close()
+
+    # Idempotent: a second open_db() (re-running the ALTER) must not raise.
+    mi.open_db().close()

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-25" # auto-bump @1782378941
+last_verified: "2026-06-25" # auto-bump @1782400340
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-25" # auto-bump @1782378941
+last_verified: "2026-06-25" # auto-bump @1782400340
 governs:
   - src/
   - evolution/

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -473,9 +473,19 @@ def open_db() -> sqlite3.Connection:
             created_at  TEXT NOT NULL,
             resolved    INTEGER DEFAULT 0,
             resolution  TEXT,
+            resolved_at TEXT DEFAULT NULL,
             UNIQUE(older_id, newer_id)
         )
     """)
+    # Migrate pre-existing pending_conflicts tables (LIA-338): add resolved_at so
+    # the review cadence becomes measurable. Historical resolved rows stay NULL
+    # on purpose — we never observed WHEN they were resolved, so inventing a
+    # timestamp would fabricate data. New resolutions stamp it going forward.
+    # Idempotent: ADD COLUMN raises OperationalError once the column exists.
+    try:
+        db.execute("ALTER TABLE pending_conflicts ADD COLUMN resolved_at TEXT DEFAULT NULL")
+    except sqlite3.OperationalError:
+        pass
     for col, definition in [
         ("privacy", "TEXT DEFAULT 'internal'"),
         ("temperature", "REAL DEFAULT 1.0"),
@@ -3194,13 +3204,18 @@ def cmd_resolve_conflicts():
         print(f"  OLDER (atom {older_id}): {older_text[:120]}")
         print(f"  NEWER (atom {newer_id}): {newer_text[:120]}")
         print(f"  → To invalidate older: --invalidate-conflict {cid}")
+        print(f"  → To invalidate newer: --invalidate-conflict {cid} --newer")
         print(f"  → To dismiss:          --dismiss-conflict {cid}")
         print()
     db.close()
 
 
-def cmd_invalidate_conflict(conflict_id: int):
-    """Invalidate the older atom in a conflict after user review."""
+def cmd_invalidate_conflict(conflict_id: int, newer: bool = False):
+    """Resolve a conflict by soft-deleting one of its atoms.
+
+    Default soft-deletes the OLDER atom (resolution='invalidated'); newer=True
+    soft-deletes the NEWER one (resolution='invalidated_newer').
+    """
     db = open_db()
     row = db.execute(
         "SELECT older_id, newer_id FROM pending_conflicts WHERE id = ? AND resolved = 0",
@@ -3211,24 +3226,41 @@ def cmd_invalidate_conflict(conflict_id: int):
         db.close()
         return
     older_id, newer_id = row
-    invalidate_atom(db, older_id, reason=f"superseded by atom {newer_id} (user-confirmed)")
+    if newer:
+        target_id, resolution = newer_id, "invalidated_newer"
+        reason = f"newer atom rejected vs atom {older_id} (user-confirmed)"
+    else:
+        target_id, resolution = older_id, "invalidated"
+        reason = f"superseded by atom {newer_id} (user-confirmed)"
+    # invalidate_atom commits internally; the conflict-row UPDATE below is a
+    # separate transaction (same shape as before this change — not atomic).
+    invalidate_atom(db, target_id, reason=reason)
     db.execute(
-        "UPDATE pending_conflicts SET resolved = 1, resolution = 'invalidated' WHERE id = ?",
-        [conflict_id],
+        "UPDATE pending_conflicts SET resolved = 1, resolution = ?, resolved_at = ? WHERE id = ?",
+        [resolution, local_now().strftime("%Y-%m-%d"), conflict_id],
     )
     db.commit()
     db.close()
 
 
 def cmd_dismiss_conflict(conflict_id: int):
-    """Dismiss a false-positive conflict."""
+    """Dismiss a false-positive conflict (no-op if already resolved).
+
+    The ``resolved = 0`` guard makes resolved_at write-once: re-dismissing an
+    already-resolved row must not overwrite its (possibly NULL, historical)
+    resolved_at with today's date.
+    """
     db = open_db()
-    db.execute(
-        "UPDATE pending_conflicts SET resolved = 1, resolution = 'dismissed' WHERE id = ?",
-        [conflict_id],
+    cur = db.execute(
+        "UPDATE pending_conflicts SET resolved = 1, resolution = 'dismissed', resolved_at = ? "
+        "WHERE id = ? AND resolved = 0",
+        [local_now().strftime("%Y-%m-%d"), conflict_id],
     )
     db.commit()
-    print(f"Conflict #{conflict_id} dismissed.")
+    if cur.rowcount:
+        print(f"Conflict #{conflict_id} dismissed.")
+    else:
+        print(f"Conflict #{conflict_id} not found or already resolved.")
     db.close()
 
 
@@ -4420,7 +4452,8 @@ def main() -> int:
     group.add_argument("--resolve-conflicts", action="store_true",
                        help="Show pending contradictions for review (no auto-invalidation)")
     group.add_argument("--invalidate-conflict", type=int, metavar="ID",
-                       help="Confirm and invalidate the older atom in conflict #ID")
+                       help="Confirm and invalidate the older atom in conflict #ID "
+                            "(add --newer to invalidate the newer atom instead)")
     group.add_argument("--dismiss-conflict", type=int, metavar="ID",
                        help="Dismiss conflict #ID as false positive")
     group.add_argument("--export", metavar="PATH",
@@ -4456,6 +4489,9 @@ def main() -> int:
                         help="Preview --prune changes without applying them")
     parser.add_argument("--reason", default="manual",
                         help="Reason for --invalidate (default: manual)")
+    parser.add_argument("--newer", action="store_true",
+                        help="With --invalidate-conflict: invalidate the NEWER atom "
+                             "instead of the older one (resolution=invalidated_newer)")
     parser.add_argument("--domain", metavar="DOMAIN",
                         help="Filter --query results by domain (dev/study/trading/personal/general)")
     parser.add_argument("--graph", action="store_true",
@@ -4477,6 +4513,11 @@ def main() -> int:
                              "(e.g. public,internal,private). Overrides --privacy. "
                              "Also reads from DEUS_MEMORY_PRIVACY env var.")
     args = parser.parse_args()
+
+    # --newer is a modifier for --invalidate-conflict; reject it standalone so
+    # it is never silently ignored (LIA-338).
+    if args.newer and args.invalidate_conflict is None:
+        parser.error("--newer requires --invalidate-conflict")
 
     # Warm up embedding provider before batch workloads when requested.
     # Only fires when the caller sets DEUS_EMBED_WARMUP=1 to avoid adding
@@ -4519,7 +4560,7 @@ def main() -> int:
         cmd_resolve_conflicts()
         return
     if args.invalidate_conflict is not None:
-        cmd_invalidate_conflict(args.invalidate_conflict)
+        cmd_invalidate_conflict(args.invalidate_conflict, newer=args.newer)
         return
     if args.dismiss_conflict is not None:
         cmd_dismiss_conflict(args.dismiss_conflict)


### PR DESCRIPTION
## Summary

LIA-338 Part 1 — completes the **resolution side** of the memory contradiction-detector (`scripts/memory_indexer.py`). Two structural defects, surfaced in the 2026-06-25 triage session, are fixed:

1. **One-directional resolution.** `--invalidate-conflict ID` could only invalidate the *older* atom. When the *newer* atom was the wrong one (e.g. a hallucinated atom), there was no CLI path — it required a manual `invalidate_atom()` call in a REPL.
2. **Value not measurable.** `pending_conflicts` had `created_at` but no `resolved_at`, so review cadence ("is the queue ever reviewed?") had no clean query.

## Changes

- **Migration:** add `resolved_at TEXT DEFAULT NULL` to `pending_conflicts` (in the `CREATE TABLE` + an idempotent `ALTER TABLE` in `try/except sqlite3.OperationalError`). Historical resolved rows stay **NULL on purpose** — we never observed when they were resolved, so stamping them would fabricate data.
- **3-way resolution:** `--invalidate-conflict ID --newer` invalidates the *newer* atom (`resolution=invalidated_newer`); default behavior unchanged. Guard rejects `--newer` without `--invalidate-conflict`.
- **Stamp `resolved_at`** on invalidate + dismiss, **write-once**: `cmd_invalidate_conflict` early-returns on already-resolved rows, and `cmd_dismiss_conflict` now updates `WHERE resolved = 0` (so re-dismissing a historical NULL row can't overwrite it).
- **7 new tests** in `evolution/tests/test_memory_indexer_contradiction_commit.py`.

## Out of scope (separate PRs per LIA-338)

- Detection-precision tuning (`detect_contradictions` / `_contradiction_prompt`) — needs the 78-pair fixture + a Gemini measurement.
- Review-cadence surfacing (`/compress` backlog count, auto-aging).

## Verification

- `python3 -m pytest evolution/tests/test_memory_indexer_contradiction_commit.py -v` → 8 passed.
- `python3 -m pytest evolution/tests/ -q` → **715 passed, 1 skipped**.
- Migration verified on the real `~/.deus/memory.db`: column added, **0 fabricated timestamps** among 91 resolved rows, 5 unresolved rows untouched.

## Gates

plan-reviewer, code-reviewer, ai-eng-warden (Claude + GPT + GLM where configured), and verification-gate all returned **SHIP**. The GPT code-reviewer caught a real bug mid-review (unguarded dismiss overwriting `resolved_at`) which was fixed + regression-tested before SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)