### PR TITLE
fix(memory): read full frontmatter for id, not a 4096-byte head (LIA-340)

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -904,6 +904,18 @@ def resolve_vault_path() -> Path:
     return Path("~/Desktop/אישי/Brain Dump/Second Brain/Deus").expanduser()
 
 
+def _frontmatter_id(path: Path) -> str | None:
+    """Return a markdown file's frontmatter ``id``, or None if absent.
+
+    Reads the whole file, not a fixed-size head: a frontmatter block whose
+    closing ``---`` fence falls past any truncation window (e.g. the large vault
+    CLAUDE.md) otherwise parses as unterminated and reports no ``id`` (LIA-340).
+    ``OSError`` propagates so each caller decides how an unreadable file is treated.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return parse_frontmatter(text).get("id")
+
+
 def iter_tree_files(vault: Path) -> list[Path]:
     """Yield markdown files that participate in the tree (have `id:` or are
     the root). We skip Session-Logs, Checkpoints, Atoms — those are owned by
@@ -919,11 +931,10 @@ def iter_tree_files(vault: Path) -> list[Path]:
         if p == root:
             continue
         try:
-            head = p.read_text(encoding="utf-8", errors="replace")[:4096]
+            has_id = _frontmatter_id(p) is not None
         except OSError:
             continue
-        fm = parse_frontmatter(head)
-        if fm.get("id"):
+        if has_id:
             files.append(p)
     return files
 
@@ -952,8 +963,7 @@ def _confirm_orphan(path: Path, *, require_id: bool) -> bool:
     for attempt in range(ORPHAN_CONFIRM_RETRIES):
         try:
             if require_id:
-                head = path.read_text(encoding="utf-8", errors="replace")[:4096]
-                still_tracked = bool(parse_frontmatter(head).get("id"))
+                still_tracked = bool(_frontmatter_id(path))
             else:
                 still_tracked = path.exists()
         except OSError:

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -515,6 +515,49 @@ class TestConfirmOrphan:
     def test_absent_orphaned_existence(self, tmp_path):  # row e
         assert mt._confirm_orphan(tmp_path / "gone.md", require_id=False) is True
 
+    def test_large_frontmatter_present_not_orphaned(self, tmp_path):  # LIA-340
+        # A frontmatter block whose closing `---` sits past a 4096-byte head:
+        # a truncated read leaves the fence unterminated, parse_frontmatter
+        # reports no id, and the node was falsely orphaned on every build
+        # (this is exactly how the vault CLAUDE.md got orphaned).
+        f = tmp_path / "big.md"
+        padding = "x" * 5000  # pushes the closing fence well past byte 4096
+        f.write_text(
+            f"---\nid: bigfm\ndescription: d\npadding: {padding}\n---\nbody\n",
+            encoding="utf-8",
+        )
+        fm_block = f.read_text(encoding="utf-8").split("---", 2)[1]
+        assert len(fm_block.encode("utf-8")) > 4096  # guard the fixture's premise
+        assert mt._confirm_orphan(f, require_id=True) is False
+
+
+class TestFrontmatterId:
+    """LIA-340: id extraction must read the whole frontmatter, not a 4096 head."""
+
+    def test_large_frontmatter_id_found(self, tmp_path):
+        f = tmp_path / "big.md"
+        f.write_text(
+            f"---\nid: bigfm\ndescription: d\npadding: {'x' * 5000}\n---\nbody\n",
+            encoding="utf-8",
+        )
+        assert mt._frontmatter_id(f) == "bigfm"
+
+    def test_no_id_returns_none(self, tmp_path):
+        f = tmp_path / "n.md"
+        f.write_text("plain text, no frontmatter\n", encoding="utf-8")
+        assert mt._frontmatter_id(f) is None
+
+    def test_iter_tree_files_admits_large_frontmatter(self, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "MEMORY_TREE.md").write_text("---\nid: root\n---\n", encoding="utf-8")
+        big = vault / "big.md"
+        big.write_text(
+            f"---\nid: bigfm\ndescription: d\npadding: {'x' * 5000}\n---\nbody\n",
+            encoding="utf-8",
+        )
+        assert big in mt.iter_tree_files(vault)
+
 
 # ── Retrieve ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Two functions in `scripts/memory_tree.py` truncated each file to its first **4096 bytes** before parsing the frontmatter `id:`:
- `iter_tree_files` (tree-walk membership)
- `_confirm_orphan(require_id=True)` (orphan confirmation)

`parse_frontmatter` requires a closed `---` fence. The vault **`CLAUDE.md`** (user-profile root) has a large frontmatter whose closing fence sits at byte **6586** — past the 4096 window. So the truncated head parsed as unterminated → no `id` → CLAUDE.md was **excluded from the tree walk and orphaned (`missing_file`) on every `build`**. It is the only node with >4KB frontmatter, so the only one affected — but it is the most load-bearing node (loaded every session; routes persona / cross-branch queries).

This is **not** the LIA-336 transient-rewrite race — it's a deterministic truncation bug in the same area.

## Fix

Add a `_frontmatter_id(path)` helper that reads the **whole file** and returns `parse_frontmatter(text).get("id")`; route both sites through it (DRY). `OSError` propagates so each caller keeps its own handling (`iter_tree_files`: `except OSError: continue`; `_confirm_orphan`: `except OSError: still_tracked=False`). The `require_id=False` existence path is unchanged.

Perf: `iter_tree_files` full-reads each vault `.md` per build, but that differs from the old `[:4096]` only for files >4KB (rare; Session-Logs/Checkpoints/Atoms are skipped). `_confirm_orphan` runs only per orphan candidate (~0 in steady state).

## Tests

- `_confirm_orphan` oracle for a >4KB-frontmatter node (the CLAUDE.md case).
- New `TestFrontmatterId`: helper returns the id past 4KB, returns None when absent, and `iter_tree_files` admits a large-frontmatter file.

## Verification

- `pytest scripts/tests/test_memory_tree.py` → **155 passed**.
- On the real `CLAUDE.md`: `_confirm_orphan(..., require_id=True)` now returns `False` and it is in `iter_tree_files`.
- `build` with the fix → `nodes: 32` (was 31), `orphaned: 0` (was 1); CLAUDE.md stays active.

Fixes LIA-340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)