### PR TITLE
fix(memory): unify auto-memory dir resolution + fix feedback-recall read (LIA-341)

### DIFF
--- a/scripts/auto_memory_dir.py
+++ b/scripts/auto_memory_dir.py
@@ -1,0 +1,71 @@
+"""Single source of truth for the auto-memory directory.
+
+The auto-memory population (memory_indexer-promoted atoms, feedback, and
+procedures) lives in the Claude project memory dir. ``memory_indexer`` writes
+here, ``memory_tree`` indexes from here, ``memory_query`` reads node content
+from here, and ``standards_pack`` loads standard atoms from here. They MUST
+resolve the SAME directory or a node indexes under an ``auto-memory/`` namespace
+path that recall cannot read back (LIA-341) — the live symptom was
+``memory_query`` defaulting to a non-existent ``~/.deus/auto-memory`` and
+returning ``None`` for every promoted feedback node.
+
+Kept dependency-free (os + pathlib only) so SessionStart-critical importers like
+``standards_pack`` add no import weight.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+EXTERNAL_DIR_ENV = "DEUS_AUTO_MEMORY_DIR"
+
+
+def _encode_project_dir(project_dir: str) -> str:
+    """Encode a project path the way Claude Code names its project memory dir:
+    path separators become dashes, with a leading dash.
+
+    Windows ``CLAUDE_PROJECT_DIR`` uses backslashes, so collapse those first —
+    ``standards_pack``'s original encoding only replaced ``/`` and would leave a
+    Windows path with raw backslashes, silently missing the directory.
+    """
+    encoded = project_dir.replace("\\", "-").replace("/", "-")
+    if not encoded.startswith("-"):
+        encoded = "-" + encoded
+    return encoded
+
+
+def resolve_auto_memory_dir() -> Path:
+    """Resolve the canonical auto-memory directory.
+
+    Priority: explicit ``DEUS_AUTO_MEMORY_DIR`` override -> the
+    ``CLAUDE_PROJECT_DIR``-derived project memory dir -> this repo's project
+    memory dir (derived from the module's location) -> ``~/.deus/auto-memory``
+    fallback. Mirrors ``memory_indexer.py``'s promotion target. The two derived
+    steps only match when the candidate directory exists; otherwise resolution
+    falls through to the next step.
+    """
+    env = os.environ.get(EXTERNAL_DIR_ENV)
+    if env:
+        return Path(env).expanduser()
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if project_dir:
+        candidate = Path(
+            os.path.expanduser(
+                f"~/.claude/projects/{_encode_project_dir(project_dir)}/memory"
+            )
+        )
+        if candidate.is_dir():
+            return candidate
+
+    repo_root = Path(__file__).resolve().parent.parent
+    legacy = Path(
+        os.path.expanduser(
+            f"~/.claude/projects/{_encode_project_dir(repo_root.as_posix())}/memory"
+        )
+    )
+    if legacy.is_dir():
+        return legacy
+
+    return Path(os.path.expanduser("~/.deus/auto-memory"))

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -27,16 +27,17 @@ if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
 import memory_tree as mt  # noqa: E402
+from auto_memory_dir import resolve_auto_memory_dir  # noqa: E402
 
 LOG_FILE = Path(os.environ.get(
     "DEUS_RETRIEVAL_LOG",
     "~/.deus/memory_retrieval_log.jsonl",
 )).expanduser()
 
-AUTO_MEM_DIR = Path(os.environ.get(
-    mt.EXTERNAL_DIR_ENV,
-    "~/.deus/auto-memory",
-)).expanduser()
+# Shared resolver (LIA-341): the same dir memory_tree indexes into and
+# standards_pack reads. The old default `~/.deus/auto-memory` was a dir that
+# never exists, so recall returned None for every promoted auto-memory node.
+AUTO_MEM_DIR = resolve_auto_memory_dir()
 
 
 def _read_node_file(path: str) -> str | None:

--- a/scripts/standards_pack.py
+++ b/scripts/standards_pack.py
@@ -17,30 +17,15 @@ import re
 import sys
 from pathlib import Path
 
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from auto_memory_dir import resolve_auto_memory_dir  # noqa: E402
+
+
 def _default_auto_mem_dir() -> Path:
-    # 1. Explicit env override wins (matches memory_tree.EXTERNAL_DIR_ENV).
-    env = os.environ.get("DEUS_AUTO_MEMORY_DIR")
-    if env:
-        return Path(env)
-    # 2. Derive the per-project auto-memory dir from CLAUDE_PROJECT_DIR.
-    #    Mirrors memory_indexer.py promotion target (~/.claude/projects/<encoded>/memory).
-    #    Encoding: leading '-' + slashes replaced with '-'.
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if project_dir:
-        encoded = project_dir.replace("/", "-")
-        if not encoded.startswith("-"):
-            encoded = "-" + encoded
-        candidate = Path(os.path.expanduser(f"~/.claude/projects/{encoded}/memory"))
-        if candidate.is_dir():
-            return candidate
-    # 3. Derive from this script's filesystem location (repo_root/scripts/standards_pack.py).
-    repo_root = Path(__file__).resolve().parent.parent
-    encoded = repo_root.as_posix().replace("/", "-")
-    legacy = Path(os.path.expanduser(f"~/.claude/projects/{encoded}/memory"))
-    if legacy.is_dir():
-        return legacy
-    # 4. Final fallback (will trigger fail-loud warning in load_standards).
-    return Path(os.path.expanduser("~/.deus/auto-memory"))
+    # Must match memory_tree + memory_query — see auto_memory_dir.py (LIA-341).
+    return resolve_auto_memory_dir()
 
 
 AUTO_MEM_DIR = _default_auto_mem_dir()

--- a/scripts/tests/test_auto_memory_dir.py
+++ b/scripts/tests/test_auto_memory_dir.py
@@ -1,0 +1,78 @@
+"""Tests for the shared auto-memory dir resolver (LIA-341).
+
+Frozen expected values: each scenario asserts a concrete resolved path so an
+incorrectly-encoded directory key can't pass silently.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import auto_memory_dir as amd  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch, tmp_path):
+    # Detach from the real environment + home so derived/fallback paths are
+    # deterministic under tmp_path.
+    monkeypatch.delenv("DEUS_AUTO_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    return tmp_path
+
+
+def test_env_override_expands_tilde(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", "~/explicit")
+    assert amd.resolve_auto_memory_dir() == tmp_path / "explicit"
+
+
+def test_env_override_absolute_wins(monkeypatch, tmp_path):
+    target = tmp_path / "explicit-abs"
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(target))
+    assert amd.resolve_auto_memory_dir() == target
+
+
+def test_project_dir_derived_frozen_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/foo/bar")
+    target = tmp_path / ".claude" / "projects" / "-foo-bar" / "memory"
+    target.mkdir(parents=True)
+    assert amd.resolve_auto_memory_dir() == target
+
+
+def test_project_dir_derived_skipped_when_dir_absent(monkeypatch, tmp_path):
+    # CLAUDE_PROJECT_DIR set but its memory dir does not exist -> fall through
+    # to the ~/.deus/auto-memory fallback (the repo-derived dir won't exist
+    # under the tmp HOME either).
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/foo/bar")
+    assert amd.resolve_auto_memory_dir() == tmp_path / ".deus" / "auto-memory"
+
+
+def test_windows_backslash_encoding(monkeypatch, tmp_path):
+    win_proj = r"C:\Users\x"
+    encoded = amd._encode_project_dir(win_proj)
+    assert "\\" not in encoded  # no raw backslash survives the encoding
+    assert encoded == "-C:-Users-x"
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", win_proj)
+    target = tmp_path / ".claude" / "projects" / encoded / "memory"
+    target.mkdir(parents=True)
+    assert amd.resolve_auto_memory_dir() == target
+
+
+def test_fallback_when_nothing_resolves(tmp_path):
+    assert amd.resolve_auto_memory_dir() == tmp_path / ".deus" / "auto-memory"
+
+
+def test_standards_pack_delegates_to_resolver(monkeypatch, tmp_path):
+    import standards_pack
+
+    target = tmp_path / "deleg"
+    monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(target))
+    assert standards_pack._default_auto_mem_dir() == amd.resolve_auto_memory_dir()
+    assert standards_pack._default_auto_mem_dir() == target


### PR DESCRIPTION
## Problem

`memory_query` and `standards_pack` resolved the auto-memory directory **three different ways**:
- `standards_pack._default_auto_mem_dir()` resolved correctly (env → `CLAUDE_PROJECT_DIR`-derived → repo-root-derived → `~/.deus/auto-memory`).
- `memory_query.AUTO_MEM_DIR` defaulted to the **non-existent** `~/.deus/auto-memory`.

**Latent live bug (verified):** `memory_query._read_node_file('auto-memory/feedback_data_integrity.md')` returned **`None`** — recall could not read the content of the ~125 promoted feedback nodes that live in the Claude project memory dir. They ranked but their content was dropped from recall.

## Fix (PR-A of LIA-341)

- **NEW `scripts/auto_memory_dir.py`** — one dependency-free `resolve_auto_memory_dir()` (env override → `CLAUDE_PROJECT_DIR`-derived → repo-root-derived → `~/.deus/auto-memory` fallback). Adds the Windows-backslash encoding `standards_pack`'s original omitted.
- **`standards_pack.py`** — `_default_auto_mem_dir()` delegates to the shared resolver (removes ~20 duplicated lines). SessionStart-critical; behavior-identical on macOS/Linux.
- **`memory_query.py`** — `AUTO_MEM_DIR = resolve_auto_memory_dir()`, fixing the feedback-recall read.

This is a **bug fix, not retrieval-pipeline tuning** — it changes a broken default path to the correct one.

## Tests / verification

- `scripts/tests/test_auto_memory_dir.py` — 7 tests with frozen expected paths (env+tilde, project-derived `-foo-bar` key, skip-when-absent, Windows backslash → `-C:-Users-x`, fallback, delegation equality).
- 7 new + 185 existing memory tests pass.
- Live smoke: `_read_node_file('auto-memory/feedback_data_integrity.md')` now returns content (len 1203, was `None`); `standards_pack.load_standards()` still returns 4809 chars.

## Follow-up (PR-B)

Non-destructive single-file external admit (`reindex-external --add`) + `/learn-procedure` skill rewrite, so procedure capture works safely. Tracked in LIA-341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)