### PR TITLE
fix(multi-agent): kill silent-DONE in subagent status parsing (LIA-127)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-25" # auto-bump @1782400340
+last_verified: "2026-06-26" # auto-bump @1782425875
 governs:
   - src/
   - evolution/

--- a/src/multi-agent/orchestrator.test.ts
+++ b/src/multi-agent/orchestrator.test.ts
@@ -360,7 +360,7 @@ describe('MultiAgentOrchestrator', () => {
       expect(result.results[0].output).toContain('The answer is 42');
     });
 
-    it('defaults to DONE when no marker present', async () => {
+    it('missing marker with output → DONE_WITH_CONCERNS (unverified), not silent DONE', async () => {
       const runtime = createMockRuntime('Just some output without markers.');
       const registry = createMockRegistry(runtime);
       const orchestrator = new MultiAgentOrchestrator(registry);
@@ -368,10 +368,56 @@ describe('MultiAgentOrchestrator', () => {
 
       const result = await orchestrator.dispatch([makeTask()], group);
 
-      expect(result.results[0].status).toBe('DONE');
+      expect(result.results[0].status).toBe('DONE_WITH_CONCERNS');
       expect(result.results[0].output).toBe(
         'Just some output without markers.',
       );
+      expect(result.results[0].concerns).toEqual([
+        'no [STATUS] marker emitted — completion unverified',
+      ]);
+    });
+
+    it('missing marker with empty output → BLOCKED (no deliverable)', async () => {
+      const runtime = createMockRuntime('   ');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('BLOCKED');
+      expect(result.results[0].blockedReason).toBe(
+        'no deliverable and no status marker',
+      );
+    });
+
+    it('explicit [STATUS:DONE] with empty output is trusted as DONE', async () => {
+      const runtime = createMockRuntime('[STATUS:DONE]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('DONE');
+      expect(result.results[0].output).toBe('');
+    });
+
+    it('parses a marker buried before long trailing chatter (>200 chars)', async () => {
+      // Tail-200 scan would miss this; full-output last-match finds it.
+      const trailing = 'x'.repeat(400);
+      const runtime = createMockRuntime(
+        `The real answer. [STATUS:DONE] ${trailing}`,
+      );
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      expect(result.results[0].status).toBe('DONE');
+      expect(result.results[0].output).toContain('The real answer.');
+      expect(result.results[0].output).not.toContain('[STATUS:DONE]');
     });
 
     it('parses DONE_WITH_CONCERNS and extracts concerns', async () => {
@@ -403,6 +449,45 @@ describe('MultiAgentOrchestrator', () => {
 
       expect(result.results[0].status).toBe('BLOCKED');
       expect(result.results[0].blockedReason).toBe('missing credentials');
+    });
+  });
+
+  describe('missing-marker contract (dispatch-level)', () => {
+    it('surfaces the synthetic concern into OrchestratorResult.concerns and stays success', async () => {
+      const runtime = createMockRuntime('Findings, but no marker emitted.');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const result = await orchestrator.dispatch([makeTask()], group);
+
+      // DONE_WITH_CONCERNS counts toward done → blockedCount 0 → success.
+      expect(result.status).toBe('success');
+      expect(result.concerns).toContain(
+        'no [STATUS] marker emitted — completion unverified',
+      );
+    });
+
+    it('a no-marker (DONE_WITH_CONCERNS) dependency does NOT cascade-block its dependents', async () => {
+      // Both tasks get the same marker-less output; T2 depends on T1. T1 →
+      // DONE_WITH_CONCERNS must NOT block T2 (cascade guard blocks only on BLOCKED).
+      const runtime = createMockRuntime('Output without a marker.');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup();
+
+      const tasks = [
+        makeTask({ id: 'task-1', prompt: 'First' }),
+        makeTask({ id: 'task-2', prompt: 'Second', contextFrom: ['task-1'] }),
+      ];
+
+      const result = await orchestrator.dispatch(tasks, group);
+
+      // T2 ran (not skipped as blocked) → runtime called for both tasks.
+      expect(runtime.runTurn).toHaveBeenCalledTimes(2);
+      const t2 = result.results[1]; // results preserve task order (tasks.map at aggregation)
+      expect(t2.status).toBe('DONE_WITH_CONCERNS');
+      expect(t2.blockedReason).toBeUndefined();
     });
   });
 

--- a/src/multi-agent/orchestrator.ts
+++ b/src/multi-agent/orchestrator.ts
@@ -28,29 +28,55 @@ import type {
 const STATUS_MARKER_RE =
   /\[STATUS:(DONE_WITH_CONCERNS:[^\]]*|DONE|BLOCKED:[^\]]*)\]/;
 
+/** Synthetic concern raised when a sub-agent omits its instructed status marker. */
+const NO_MARKER_CONCERN = 'no [STATUS] marker emitted — completion unverified';
+
 function parseStatusMarker(
   rawOutput: string,
   taskId: string,
 ): Pick<SubagentResult, 'status' | 'concerns' | 'blockedReason'> & {
   cleanOutput: string;
 } {
-  const tail = rawOutput.slice(-200);
-  const match = STATUS_MARKER_RE.exec(tail);
+  // Scan the FULL output for the LAST [STATUS:...] marker. buildPrompt instructs the
+  // agent to end with exactly one marker; last-match is robust to trailing chatter that
+  // the previous tail-200 window silently dropped. STATUS_MARKER_RE has no `g` flag, so
+  // a fresh global copy is required for matchAll (a non-global regex never advances
+  // lastIndex). Same edge as the old tail-window: a post-marker quoted marker wins.
+  const matches = [
+    ...rawOutput.matchAll(new RegExp(STATUS_MARKER_RE.source, 'g')),
+  ];
+  const match = matches[matches.length - 1];
 
   if (!match) {
+    const trimmed = rawOutput.trim();
+    // The agent was told to emit a marker and did not. Never assume success — the old
+    // silent-DONE default masked truncated, errored, or non-compliant runs.
+    if (!trimmed) {
+      logger.warn(
+        { taskId },
+        'Subagent produced no output and no status marker — treating as BLOCKED',
+      );
+      return {
+        status: 'BLOCKED',
+        cleanOutput: '',
+        blockedReason: 'no deliverable and no status marker',
+      };
+    }
     logger.info(
       { taskId },
-      'No status marker found in subagent output — defaulting to DONE',
+      'No status marker in subagent output — DONE_WITH_CONCERNS (unverified)',
     );
-    return { status: 'DONE', cleanOutput: rawOutput };
+    return {
+      status: 'DONE_WITH_CONCERNS',
+      concerns: [NO_MARKER_CONCERN],
+      cleanOutput: trimmed,
+    };
   }
 
   const markerBody = match[1];
-  const markerStart = rawOutput.length - 200 + (match.index ?? 0);
-  const actualStart = Math.max(0, markerStart);
+  const idx = match.index ?? 0;
   const cleanOutput = (
-    rawOutput.slice(0, actualStart) +
-    rawOutput.slice(actualStart).replace(match[0], '')
+    rawOutput.slice(0, idx) + rawOutput.slice(idx + match[0].length)
   ).trim();
 
   if (markerBody === 'DONE') {


### PR DESCRIPTION
## What & why

Foundation slice (PR1a) of the **S-grade orchestration** push — hardens the in-process `MultiAgentOrchestrator` result contract **before** wiring it to the message loop (LIA-127), so the production path inherits real verification instead of the current regex-default-DONE.

### The bug (verified)
`buildPrompt` instructs every sub-agent to end with exactly one `[STATUS:...]` marker, but `parseStatusMarker`:
1. **defaulted a missing marker to `DONE`** — a sub-agent that truncated, errored mid-stream, or ignored the instruction was recorded as a successful deliverable (silent false-success);
2. **only scanned the tail-200 chars** — a marker followed by >200 chars of trailing text was missed → also fell to silent-DONE.

## Changes (`src/multi-agent/orchestrator.ts`)
- **Full-output last-match scan** via `matchAll` over a global copy of `STATUS_MARKER_RE` (the constant has no `/g`; a non-global regex must not be `exec`-looped). Absolute `match.index` replaces the tail-200 offset arithmetic.
- **Missing marker + empty output → `BLOCKED`** (`'no deliverable and no status marker'`).
- **Missing marker + output → `DONE_WITH_CONCERNS`** with a synthetic `'unverified'` concern (still counts toward done in aggregation, but surfaces the gap into `OrchestratorResult.concerns`).
- **Explicit `[STATUS:DONE]` + empty output stays trusted** (a write-task's deliverable is a commit, not text).

## Deferred to PR1b (wiring)
Mode-aware empty-deliverable check (thread `task.mode`) and filtering synthetic concerns out of downstream context injection — only observable once dispatch actually runs.

## Tests
Updated the stale `defaults to DONE` test; added unit cases (empty→BLOCKED, empty+DONE→trusted, marker-before-long-trailing-text) and two dispatch-level integration cases (synthetic concern surfaces in `OrchestratorResult.concerns`; a no-marker `DONE_WITH_CONCERNS` dep does **not** cascade-block dependents).

- `npx vitest run` — **1894 pass** (108 files)
- `npx tsc --noEmit` — clean

Scope: `src/multi-agent/` only (path is dormant — zero risk to the live single-agent path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)