### PR TITLE
fix(memory): non-destructive single-file auto-memory admit + /learn-procedure fix (LIA-341)

### DIFF
--- a/.claude/skills/learn-procedure/SKILL.md
+++ b/.claude/skills/learn-procedure/SKILL.md
@@ -22,7 +22,7 @@ future prompt's intent matches the procedure's `description`.
 - `/learn-this` → teaches the USER a topic and records what they LEARNED (`$VAULT/Learning/`).
 - `/preserve` → silently saves preferences/decisions/facts about the user (`$VAULT/CLAUDE.md`).
 - `/learn-procedure` → saves a HOW-TO the ASSISTANT should re-run: an executable, step-based
-  task workflow (`$VAULT/auto-memory/procedures/`).
+  task workflow (the auto-memory dir's `procedures/` subdir — see step 1).
 
 Never duplicate the same content across these. A procedure is steps-to-execute, not a fact
 about the user and not a lesson for the user. If a procedure relates to a learning record,
@@ -36,11 +36,17 @@ or facts/preferences (those go to `/preserve`).
 
 ## Steps
 
-### 1. Resolve the vault path
+### 1. Resolve the auto-memory directory
 
-Read `~/.config/deus/config.json` and use its `vault_path`. If `DEUS_VAULT_PATH` is set, use
-that instead. All paths below use `$VAULT` for this resolved path. (Same resolution as
-`/checkpoint`, `/compress`, `/preserve`, `/learn-this` — never hardcode a personal path.)
+A procedure is stored in the **auto-memory directory** — the same dir `memory_indexer`
+promotes atoms into and that `memory_query` reads node content back from (LIA-341). Resolve it
+with the shared resolver (never hardcode a path):
+
+```bash
+python3 -c "import sys; sys.path.insert(0,'$HOME/deus/scripts'); from auto_memory_dir import resolve_auto_memory_dir; print(resolve_auto_memory_dir())"
+```
+
+All paths below use `$AUTOMEM` for this resolved directory.
 
 ### 2. Distill the procedure from the conversation
 
@@ -54,11 +60,11 @@ a vague or unverified procedure is worse than none.
 
 ### 3. Author the procedure node
 
-Write the node per the **convention** below. The `description` is the ONLY text that is
-embedded for retrieval (the build path embeds `description` alone), so it must be rich and
-discriminative. The body steps feed keyword search only.
+Write the node per the **convention** below. The `description` is the primary text embedded
+for retrieval, so it must be rich and discriminative. The body steps feed keyword search and
+the auto-memory embedding source.
 
-**Procedure-node convention** — `$VAULT/auto-memory/procedures/<slug>.md`:
+**Procedure-node convention** — `$AUTOMEM/procedures/<slug>.md`:
 
 ```markdown
 ---
@@ -93,12 +99,12 @@ after the user explicitly confirms. Never write silently.
 
 ### 5. Write to the personal store
 
-Write the file to `$VAULT/auto-memory/procedures/<slug>.md`.
+Write the file to `$AUTOMEM/procedures/<slug>.md` (create the `procedures/` subdir if needed).
 
 **Security — personal store only:** procedure nodes are personal memory. Never write a
 procedure into a project/source repo, and never include credentials, tokens, or secrets in
-the steps (reference where a secret lives, don't inline it). The `$VAULT` is gitignored
-personal memory; a procedure must never enter a public repo.
+the steps (reference where a secret lives, don't inline it). `$AUTOMEM` is personal memory
+outside any source repo; a procedure must never enter a public repo.
 
 **Security — injection at capture time:** a procedure body is later re-injected into future
 sessions as recalled context. Treat the capture as a trust boundary: if the procedure was
@@ -112,9 +118,12 @@ action, rewrite it before the approval gate. Flag any such content to the user a
 ### 6. Index it
 
 ```bash
-python3 ~/deus/scripts/memory_tree.py build
+python3 ~/deus/scripts/memory_tree.py reindex-external --add "$AUTOMEM/procedures/<slug>.md"
 ```
-Incremental (~0.4s) — it discovers and embeds the new node. Confirm it ranks:
+This is a **non-destructive single-file admit**: it indexes only this one node. Do NOT use
+`memory_tree.py build` (it skips the `auto-memory/` external namespace entirely) and do NOT use
+the bare `reindex-external` (a global reindex that would risk orphaning the rest of the
+auto-memory population if pointed at the wrong dir). Confirm it ranks:
 ```bash
 python3 ~/deus/scripts/memory_tree.py query "<the procedure's trigger phrase>"
 ```

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-25" # auto-bump @1782385841
+last_verified: "2026-06-26" # auto-bump @1782428294
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(_SCRIPTS_DIR))
 from _exit_codes import SUCCESS, ABSTAIN, USAGE_ERROR, NOT_FOUND, AUTH_ERROR, INTERNAL_ERROR
 from _agent_io import is_agent_context, compact_json, select_fields
 from _time import local_now, utc_now  # noqa: E402
+from auto_memory_dir import resolve_auto_memory_dir  # noqa: E402
 
 
 def _utc_iso() -> str:
@@ -1985,6 +1986,116 @@ def _write_id_to_frontmatter(path: Path, new_id: str) -> None:
     path.write_text(updated, encoding="utf-8")
 
 
+def _index_external_file(
+    db: sqlite3.Connection,
+    path: Path,
+    ns_path: str,
+    *,
+    skip_embed: bool = False,
+) -> dict[str, int]:
+    """Upsert ONE external (auto-memory) file into the tree under ``ns_path``.
+
+    The per-file half of :func:`reindex_external`: read, parse, embed-if-needed,
+    upsert. Pure single-node work — it does NOT walk, track ``walked_paths``,
+    orphan-sweep, back up, or commit. Callers own those (the walk + sweep are
+    what make a full reindex destructive; keeping them out of here is what makes
+    the single-file admit non-destructive — LIA-341). Returns per-file counts.
+    """
+    c = {"indexed": 0, "embedded": 0, "skipped": 0, "id_written": 0}
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        c["skipped"] += 1
+        return c
+
+    fm = parse_frontmatter(content)
+    description = fm.get("description", "").strip()
+    if not description:
+        c["skipped"] += 1
+        return c
+
+    node_id = fm.get("id")
+    if not node_id:
+        node_id = make_id()
+        _write_id_to_frontmatter(path, node_id)
+        c["id_written"] += 1
+
+    title = fm.get("name") or path.stem
+    node_type = fm.get("type", "feedback")
+    embed_src = embedding_source(description, content)
+    ch = content_hash(embed_src)
+
+    existing = db.execute(
+        "SELECT content_hash FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    has_embedding = sqlite_vec is not None and db.execute(
+        "SELECT 1 FROM embeddings WHERE rowid = ?", (_rowid_for(node_id),)
+    ).fetchone() is not None
+    need_embed = existing is None or existing[0] != ch or not has_embedding
+
+    vec = None
+    if need_embed and not skip_embed:
+        try:
+            vec = embed_text(embed_src)
+            c["embedded"] += 1
+        except Exception as exc:
+            print(f"WARN: embed failed for {ns_path}: {exc}", file=sys.stderr)
+            vec = None
+
+    upsert_node(
+        db,
+        node_id=node_id,
+        path=ns_path,
+        title=title,
+        description=description,
+        level=0,
+        node_type=node_type,
+        embedding=vec,
+        content_hash_val=ch,
+        body_text=_body_from_content(content),
+        atom_kind=fm.get("atom_kind", "knowledge"),
+    )
+    c["indexed"] += 1
+    return c
+
+
+def reindex_external_one(
+    db: sqlite3.Connection,
+    external_dir: Path,
+    rel_path: str,
+    *,
+    skip_embed: bool = False,
+) -> dict[str, int]:
+    """Index a SINGLE auto-memory file without the orphan sweep (LIA-341).
+
+    Non-destructive: a resolved-containment guard plus one upsert — no orphan
+    sweep or ``_backup_db`` (nothing else can be lost); commits explicitly since
+    :func:`upsert_node` does not and this path bypasses :func:`reindex_external`'s
+    commit; raises ``FileNotFoundError`` (dir/file missing) or ``ValueError``
+    (``rel_path`` escapes ``external_dir`` via ``..`` or a symlink).
+    """
+    external_dir = external_dir.expanduser().resolve()
+    if not external_dir.is_dir():
+        raise FileNotFoundError(f"auto-memory dir not found: {external_dir}")
+
+    pr = (external_dir / rel_path).resolve(strict=False)
+    if not pr.is_relative_to(external_dir):
+        raise ValueError(f"{rel_path} is not under {external_dir}")
+    if not pr.exists():
+        raise FileNotFoundError(f"file not found: {pr}")
+
+    ns_path = EXTERNAL_NAMESPACE + str(pr.relative_to(external_dir))
+    counts = {"indexed": 0, "embedded": 0, "skipped": 0, "id_written": 0}
+    sub = _index_external_file(db, pr, ns_path, skip_embed=skip_embed)
+    for k, v in sub.items():
+        counts[k] += v
+    db.commit()
+    _emit_audit(
+        {"action": "reindex_external_one", "dir": str(external_dir), "file": ns_path, **counts}
+    )
+    return counts
+
+
 def reindex_external(
     db: sqlite3.Connection,
     external_dir: Path,
@@ -2023,60 +2134,9 @@ def reindex_external(
         ns_path = EXTERNAL_NAMESPACE + str(rel_to_ext)
         walked_paths.add(ns_path)
 
-        try:
-            content = p.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            counts["skipped"] += 1
-            continue
-
-        fm = parse_frontmatter(content)
-        description = fm.get("description", "").strip()
-        if not description:
-            counts["skipped"] += 1
-            continue
-
-        node_id = fm.get("id")
-        if not node_id:
-            node_id = make_id()
-            _write_id_to_frontmatter(p, node_id)
-            counts["id_written"] += 1
-
-        title = fm.get("name") or p.stem
-        node_type = fm.get("type", "feedback")
-        embed_src = embedding_source(description, content)
-        ch = content_hash(embed_src)
-
-        existing = db.execute(
-            "SELECT content_hash FROM nodes WHERE id = ?", (node_id,)
-        ).fetchone()
-        has_embedding = sqlite_vec is not None and db.execute(
-            "SELECT 1 FROM embeddings WHERE rowid = ?", (_rowid_for(node_id),)
-        ).fetchone() is not None
-        need_embed = existing is None or existing[0] != ch or not has_embedding
-
-        vec = None
-        if need_embed and not skip_embed:
-            try:
-                vec = embed_text(embed_src)
-                counts["embedded"] += 1
-            except Exception as exc:
-                print(f"WARN: embed failed for {ns_path}: {exc}", file=sys.stderr)
-                vec = None
-
-        upsert_node(
-            db,
-            node_id=node_id,
-            path=ns_path,
-            title=title,
-            description=description,
-            level=0,
-            node_type=node_type,
-            embedding=vec,
-            content_hash_val=ch,
-            body_text=_body_from_content(content),
-            atom_kind=fm.get("atom_kind", "knowledge"),
-        )
-        counts["indexed"] += 1
+        sub = _index_external_file(db, p, ns_path, skip_embed=skip_embed)
+        for k, v in sub.items():
+            counts[k] += v
 
     # Orphan external nodes no longer on disk.
     now_iso = _utc_iso()
@@ -3206,6 +3266,12 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("manifest", help="Generate thin manifest from all indexed nodes")
 
     p_ext = sub.add_parser("reindex-external", help="Index auto-memory files from DEUS_AUTO_MEMORY_DIR")
+    p_ext.add_argument(
+        "--add",
+        metavar="PATH",
+        help="Non-destructively index a SINGLE auto-memory file (resolved via the "
+        "shared resolver; no orphan sweep, unlike the bare full reindex)",
+    )
     p_ext.add_argument("--skip-embed", action="store_true", help="Skip embedding API calls")
     p_ext.add_argument("--json", action="store_true")
 
@@ -3387,6 +3453,26 @@ def main(argv: list[str] | None = None) -> int:
         return SUCCESS
 
     if args.cmd == "reindex-external":
+        if args.add:
+            # Non-destructive single-file admit: resolve the canonical dir
+            # ourselves (the safe path, unlike the destructive bare reindex).
+            try:
+                counts = reindex_external_one(
+                    db, resolve_auto_memory_dir(), args.add, skip_embed=args.skip_embed
+                )
+            except (FileNotFoundError, ValueError) as exc:
+                print(f"ABORT: {exc}", file=sys.stderr)
+                return USAGE_ERROR
+            if args.json:
+                print(json.dumps(counts, indent=2))
+            else:
+                print(
+                    f"reindex-external --add: indexed={counts['indexed']} "
+                    f"embedded={counts['embedded']} "
+                    f"id_written={counts['id_written']} "
+                    f"skipped={counts['skipped']}"
+                )
+            return SUCCESS
         ext_dir = os.environ.get(EXTERNAL_DIR_ENV)
         if not ext_dir:
             print(f"ABORT: {EXTERNAL_DIR_ENV} not set", file=sys.stderr)

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -841,6 +841,71 @@ class TestReindexExternal:
             counts = mt.reindex_external(tmp_db, ext_dir)
         assert counts["orphaned"] == 1
 
+    def test_reindex_external_one_adds_without_orphaning(self, tmp_db, ext_dir, tmp_path):
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
+            mt.reindex_external(tmp_db, ext_dir)
+        before = {
+            r[0] for r in tmp_db.execute(
+                "SELECT path FROM nodes WHERE orphaned_at IS NULL"
+            ).fetchall()
+        }
+        assert len(before) == 2  # feedback_test + project_test
+
+        (ext_dir / "procedure_new.md").write_text(
+            "---\nname: New proc\ndescription: A newly captured procedure\ntype: procedure\n---\nSteps\n"
+        )
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
+            counts = mt.reindex_external_one(tmp_db, ext_dir, "procedure_new.md")
+        assert counts["indexed"] == 1
+        after = {
+            r[0] for r in tmp_db.execute(
+                "SELECT path FROM nodes WHERE orphaned_at IS NULL"
+            ).fetchall()
+        }
+        assert before <= after and len(after) == 3  # originals untouched
+
+        # Persistence: a FRESH connection sees the committed node (proves the
+        # explicit db.commit() — a single-connection assert would pass without it).
+        db2 = mt.open_db(tmp_path / "tree.db")
+        try:
+            active = {
+                r[0] for r in db2.execute(
+                    "SELECT path FROM nodes WHERE orphaned_at IS NULL"
+                ).fetchall()
+            }
+        finally:
+            db2.close()
+        assert "auto-memory/procedure_new.md" in active
+        assert len(active) == 3
+
+    def test_reindex_external_one_rejects_escape(self, tmp_db, ext_dir, tmp_path):
+        # A ../ path that escapes external_dir is rejected (resolved containment),
+        # even though the target file exists.
+        (tmp_path / "outside.md").write_text(
+            "---\nname: x\ndescription: y\ntype: feedback\n---\n"
+        )
+        with pytest.raises(ValueError):
+            mt.reindex_external_one(tmp_db, ext_dir, "../outside.md")
+        assert tmp_db.execute(
+            "SELECT count(*) FROM nodes WHERE orphaned_at IS NULL"
+        ).fetchone()[0] == 0
+
+    def test_reindex_external_one_missing_file(self, tmp_db, ext_dir):
+        with pytest.raises(FileNotFoundError):
+            mt.reindex_external_one(tmp_db, ext_dir, "nonexistent.md")
+
+    def test_cli_add_dispatch(self, tmp_path, ext_dir, monkeypatch):
+        # Exercises the `reindex-external --add` CLI branch end to end: resolver
+        # via DEUS_AUTO_MEMORY_DIR, SUCCESS exit + --json, and the USAGE_ERROR path.
+        monkeypatch.setattr(mt, "DB_PATH", tmp_path / "cli.db")
+        monkeypatch.setenv("DEUS_AUTO_MEMORY_DIR", str(ext_dir))
+        with patch.object(mt, "embed_text", return_value=[0.1] * mt.EMBED_DIM):
+            rc = mt.main(["reindex-external", "--add", "feedback_test.md", "--json"])
+        assert rc == mt.SUCCESS
+        # A ../ escape returns USAGE_ERROR, not a crash.
+        rc_escape = mt.main(["reindex-external", "--add", "../escape.md"])
+        assert rc_escape == mt.USAGE_ERROR
+
     def test_transient_rglob_miss_does_not_orphan(self, tmp_db, ext_dir, monkeypatch):
         """LIA-336: a present file that rglob misses during one sweep (a rename
         gap) must NOT be orphaned — _confirm_orphan re-checks it on disk. Mirrors


### PR DESCRIPTION
## Summary (PR-B of LIA-341)

Makes `/learn-procedure` work **safely**. PR-A (#947) unified the auto-memory dir resolver; this adds a **non-destructive single-file admit** so capturing one procedure can never orphan the rest of the population — the failure mode that soft-deleted 125 nodes earlier this session when the destructive global `reindex-external` hit the wrong dir.

## Changes

**`scripts/memory_tree.py`**
- Extract `_index_external_file(db, path, ns_path, *, skip_embed) -> dict` — per-file upsert; does NOT walk, track `walked_paths`, sweep, back up, or commit.
- `reindex_external`'s loop calls it; **`walked_paths.add` + the orphan sweep stay in `reindex_external`** (the destructive parts). Byte-identical — guarded by the existing `test_orphans_deleted_files`.
- New `reindex_external_one` — **resolved-containment guard** (rejects `../`/symlink escapes), raises `FileNotFoundError`/`ValueError`, single upsert, **no sweep, no `_backup_db`, explicit `db.commit()`**.
- CLI `reindex-external --add PATH` — resolves via `resolve_auto_memory_dir()`, catches `(FileNotFoundError, ValueError)` → `USAGE_ERROR`, honors `--json`. Bare `reindex-external` **unchanged**.

**`.claude/skills/learn-procedure/SKILL.md`** — writes to the resolved auto-memory dir's `procedures/`, indexes via `--add` (not `build`/bare reindex).

## Tests / verification
- 4 new tests: adds-without-orphaning (+ cross-connection persistence proving the commit), escape-rejection, missing-file, CLI dispatch (`--add --json` → SUCCESS; `--add ../escape.md` → USAGE_ERROR).
- 13 reindex + 159 full `test_memory_tree.py` pass.
- Live integration on a **copy** of the live DB: `--add` took auto-memory active **134 → 135, zero orphans**.

Source PR with a SKILL.md companion (prose-only skill rule per `patterns/skill-add.md`). Pure Extract Method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)