### PR TITLE
fix(warden): lock verdict store against parallel-marks clobber (LIA-332)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 .claude/.commit-window
 # Warden verdict store + audit log (host-local runtime state; recreated on first mark)
 .claude/.warden-verdicts.json
+.claude/.warden-verdicts.json.lock
 .claude/.warden-log
 # Admin-merge gate markers (host-local; contain absolute worktree paths)
 .claude/.admin-merge-approved

--- a/scripts/tests/test_verdict_store_lock.py
+++ b/scripts/tests/test_verdict_store_lock.py
@@ -1,0 +1,95 @@
+"""Complementary unit tests for the LIA-332 verdict-store lock.
+
+These sit alongside the multiprocessing oracle in ``test_verdict_store_race.py``
+and cover what the oracle (POSIX-only, fork-based) does not:
+
+* a deterministic, CROSS-PLATFORM proof that the in-lock re-read MERGES a
+  concurrent writer's key (no multiprocessing timing dependence),
+* the ``fcntl is None`` no-op-lock branch (the Windows path, exercised on POSIX),
+* ``_clear_verdict`` preserving a sibling key while removing the target.
+
+Run:
+    python3 -m pytest scripts/tests/test_verdict_store_lock.py -v
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import codex_warden_hooks as h
+from warden_hooks import verdict_store as _vs
+
+
+@pytest.fixture
+def store_root(tmp_path, monkeypatch):
+    """Isolated verdict store under ``tmp_path/.claude`` (mirrors the oracle fixture)."""
+    cdir = tmp_path / ".claude"
+    cdir.mkdir()
+    monkeypatch.setattr(h, "_claude_marker_dir", lambda root: cdir)
+    monkeypatch.setattr(h, "_worktree_for_cwd", lambda cwd, root: tmp_path)
+    return tmp_path
+
+
+def _read_store(store_root: Path) -> dict:
+    path = store_root / ".claude" / ".warden-verdicts.json"
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+
+
+def test_inlock_reread_merges_concurrent_key(store_root, monkeypatch):
+    """The in-lock FRESH read merges a key a concurrent writer already committed.
+
+    Simulates the race deterministically: ``_read_verdicts_at`` (the read performed
+    INSIDE the lock) returns a store that already holds a sibling key — as if another
+    writer landed it just before our read. Our write must KEEP that sibling, not clobber
+    it. This is the cross-platform analogue of the multiprocessing oracle.
+    """
+    sibling = "code-reviewer@gpt"
+    ours = "code-reviewer@claude"
+
+    real_read = _vs._read_verdicts_at
+
+    def _read_with_sibling(path: Path) -> dict:
+        data = real_read(path)
+        data.setdefault(
+            sibling,
+            {"verdict": "SHIP", "ts": "2026-01-01T00:00:00Z", "reason": "concurrent", "source": "test"},
+        )
+        return data
+
+    monkeypatch.setattr(_vs, "_read_verdicts_at", _read_with_sibling)
+
+    _vs._write_verdict(store_root, ours, "SHIP", "ours")
+
+    data = _read_store(store_root)
+    assert ours in data, "our key was not written"
+    assert sibling in data, "concurrent sibling key was clobbered by our write"
+
+
+def test_write_still_works_when_fcntl_absent(store_root, monkeypatch):
+    """The ``fcntl is None`` no-op-lock branch (Windows path) still writes correctly."""
+    monkeypatch.setattr(_vs, "fcntl", None)
+
+    _vs._write_verdict(store_root, "code-reviewer@claude", "SHIP", "no-lock path")
+
+    data = _read_store(store_root)
+    assert data.get("code-reviewer@claude", {}).get("verdict") == "SHIP"
+
+
+def test_clear_preserves_sibling_key(store_root):
+    """Clearing one key leaves the others intact (no whole-store clobber on delete)."""
+    _vs._write_verdict(store_root, "code-reviewer", "SHIP", "cr")
+    _vs._write_verdict(store_root, "plan-reviewer", "SHIP", "pr")
+
+    # "code-reviewed" maps to "code-reviewer" via MARKER_NAMES.
+    h._clear_verdict("code-reviewed", store_root)
+
+    data = _read_store(store_root)
+    assert "code-reviewer" not in data, "target key was not cleared"
+    assert "plan-reviewer" in data, "sibling key was lost when clearing the target"

--- a/scripts/tests/test_verdict_store_race.py
+++ b/scripts/tests/test_verdict_store_race.py
@@ -1,0 +1,241 @@
+"""Oracle tests for LIA-332: verdict-store concurrent-write safety.
+
+Derived FROM THE SPEC (the LIA-332 bug report), blind to the implementation.
+Tests are RED against the current (unfixed) code and GREEN only once a
+cross-process lock is added to ``_write_verdict`` / ``_clear_verdict``.
+
+Run:
+    python3 -m pytest scripts/tests/test_verdict_store_race.py -v
+
+Oracle tagging convention (oracle-rules.md § oracle-tagged):
+    # @oracle LIA-332: <one-line spec reference>
+
+Setup notes for the implementer
+--------------------------------
+* These tests use ``multiprocessing.get_context("fork")`` (POSIX-only).
+  They are skipped on Windows via the ``skipif`` markers.
+* The ``store_root`` fixture patches ``h._claude_marker_dir`` to return a
+  temp ``.claude`` dir, exactly as ``test_phase3_cogate_oracle.py`` does.
+  The fork'd worker inherits the patched module state — no re-wiring needed.
+* ``_write_verdict`` also appends to ``.warden-log``; concurrent appends to
+  an O_APPEND file are atomic on POSIX, so the log is not part of any assertion.
+* The fix must NOT remove the ``if warden not in data: return`` guard in
+  ``_clear_verdict`` (invariant 2 regresses if it does).
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import codex_warden_hooks as h
+from warden_hooks import verdict_store as _vs
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Number of concurrent processes per round.  20 processes all racing to
+# read-modify-write the same file reliably exposes the clobber on current code.
+_RACE_PROCESSES = 20
+
+# Multiple rounds multiply exposure probability.  Even one round typically
+# drops 1–19 keys; three rounds make false-GREEN essentially impossible.
+_RACE_ROUNDS = 3
+
+
+# ---------------------------------------------------------------------------
+# Module-level worker (must be importable by name for the fork context)
+# ---------------------------------------------------------------------------
+
+def _worker_write_verdict(repo_root_str: str, warden_key: str) -> None:
+    """Fork worker: write one verdict using the inherited (monkeypatched) module state.
+
+    Called in a fork'd subprocess.  The subprocess inherits:
+      * ``_vs._entry`` bound to ``h`` (from the parent's ``bind_entry`` call)
+      * ``h._claude_marker_dir`` monkeypatched to return the temp .claude dir
+    No re-import or re-wiring needed.
+    """
+    _vs._write_verdict(
+        Path(repo_root_str), warden_key, "SHIP", f"oracle-race-{warden_key}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def store_root(tmp_path, monkeypatch):
+    """Isolated verdict store under ``tmp_path/.claude``.
+
+    Patches ``_claude_marker_dir`` on the live entry module so every
+    ``verdict_store`` call routes to ``tmp_path/.claude`` instead of
+    resolving the worktree via git.  Mirrors the harness pattern in
+    ``test_phase3_cogate_oracle.py``.
+    """
+    cdir = tmp_path / ".claude"
+    cdir.mkdir()
+    monkeypatch.setattr(h, "_claude_marker_dir", lambda root: cdir)
+    # Suppress the git-backed worktree derivation that would run in fork'd children.
+    monkeypatch.setattr(h, "_worktree_for_cwd", lambda cwd, root: tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 oracle — concurrent RMW preserves ALL keys
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fork() is POSIX-only; lock primitive is POSIX")
+def test_concurrent_writes_preserve_all_keys(store_root):
+    # @oracle LIA-332: N concurrent _write_verdict calls into the same store must land ALL N keys
+    #
+    # Contract (from spec):
+    #   If N processes each call _write_verdict(repo_root, "role@b{i}", "SHIP", ...)
+    #   concurrently into the SAME store, after all complete the store MUST contain
+    #   ALL N keys (none clobbered).
+    #
+    # Falsifies: the silent key-loss bug where the later writer's whole-dict
+    #   os.replace overwrites an earlier writer's key.  Concretely: two processes each
+    #   read {"A": ...}, each set their own key ("A"+"B{i}" or "A"+"B{j}"), and the
+    #   last os.replace wins — the other's key silently vanishes.  This was the live
+    #   failure mode: a code-reviewer@gpt SHIP vanished when it raced the claude
+    #   auto-mark.
+    #
+    # RED on current code:
+    #   _write_verdict reads the full dict, sets one key, writes the whole dict back
+    #   with os.replace.  Two (or more) concurrent writers each capture a stale
+    #   snapshot before the other has written; the later os.replace silently clobbers
+    #   earlier keys.  With 20 processes: typically 1–19 keys are lost per round.
+    #
+    # GREEN after fix:
+    #   A cross-process lock (e.g. fcntl.flock, lockfile, or any POSIX IPC primitive)
+    #   serialises the RMW so every writer's key survives.  The fix must not assume
+    #   any particular mechanism — this test asserts only observable state.
+
+    repo_root = store_root
+    ctx = multiprocessing.get_context("fork")
+    total_lost = 0
+
+    for round_idx in range(_RACE_ROUNDS):
+        # Fresh key set per round so rounds do not interfere with each other.
+        warden_keys = [
+            f"oracle-{round_idx}-warden{i}@gpt" for i in range(_RACE_PROCESSES)
+        ]
+
+        procs = [
+            ctx.Process(target=_worker_write_verdict, args=(str(repo_root), key))
+            for key in warden_keys
+        ]
+        # Start all at once to maximise concurrency.
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=30)
+            assert p.exitcode == 0, (
+                f"worker exited with code {p.exitcode} — subprocess crashed; "
+                "check that the fork'd module state is properly wired"
+            )
+
+        verdicts_path = store_root / ".claude" / ".warden-verdicts.json"
+        data: dict = {}
+        if verdicts_path.exists():
+            try:
+                data = json.loads(verdicts_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                pass  # partial/corrupt write — all keys from this round count as lost
+
+        missing = [k for k in warden_keys if k not in data]
+        total_lost += len(missing)
+
+    assert total_lost == 0, (
+        f"{total_lost} verdict key(s) clobbered across {_RACE_ROUNDS} rounds of "
+        f"{_RACE_PROCESSES} concurrent _write_verdict calls.\n"
+        "Root cause: the read-modify-write sequence (read dict → mutate one key → "
+        "os.replace whole dict) is not atomic across processes.  Each concurrent "
+        "writer captures a stale snapshot before others' writes land; the last "
+        "os.replace wins and all preceding writes lose their keys.\n"
+        "Fix: add a cross-process lock (e.g. fcntl.flock on a lockfile) around the "
+        "RMW in _write_verdict (and _clear_verdict) so writes are serialised.\n"
+        "This assertion is RED on the current code and GREEN once a lock is in place."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 oracle — clear-of-absent-key writes nothing
+# ---------------------------------------------------------------------------
+
+def test_clear_absent_key_writes_nothing(store_root):
+    # @oracle LIA-332: _clear_verdict for a key NOT present must not rewrite the file
+    #
+    # Contract (from spec):
+    #   Calling _clear_verdict for a marker whose warden key is NOT present in the
+    #   store must leave the file completely untouched: no new .bak-<stamp> backup
+    #   created, mtime unchanged.
+    #
+    # Falsifies: an implementation that removes or bypasses the ``if warden not in
+    #   data: return`` early-exit guard, causing an unnecessary write on every
+    #   no-op clear call.  Such a spurious write would (a) update mtime, (b)
+    #   create a .bak-<stamp> backup (because _write_atomic backs up before
+    #   overwriting), and (c) introduce unnecessary I/O and a write race surface.
+    #
+    # Expected GREEN on current code (the guard already exists).  Present to
+    # catch regressions if the fix refactors _clear_verdict and accidentally
+    # drops the early-exit.
+
+    repo_root = store_root
+    verdicts_path = store_root / ".claude" / ".warden-verdicts.json"
+    claude_dir = store_root / ".claude"
+
+    # Pre-populate the store with a key OTHER than "code-reviewer" (the key
+    # "code-reviewed" maps to via MARKER_NAMES).  The file must exist so the
+    # test is realistic: _clear_verdict reads the dict and finds the key absent.
+    initial_data = {
+        "some-other-warden": {
+            "verdict": "SHIP",
+            "ts": "2026-01-01T00:00:00Z",
+            "reason": "seed",
+            "source": "test",
+        }
+    }
+    verdicts_path.write_text(
+        json.dumps(initial_data, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    # Record filesystem state before the call.
+    # Use nanosecond mtime for precision (APFS / ext4 / tmpfs all support it).
+    mtime_ns_before = verdicts_path.stat().st_mtime_ns
+    bak_before: set[Path] = set(claude_dir.glob(".warden-verdicts.json.bak-*"))
+
+    # Sleep long enough that any write would produce a distinguishably later mtime.
+    time.sleep(0.05)
+
+    # "code-reviewed" → "code-reviewer" via real MARKER_NAMES.
+    # "code-reviewer" is NOT a key in initial_data, so _clear_verdict must return early.
+    h._clear_verdict("code-reviewed", repo_root)
+
+    mtime_ns_after = verdicts_path.stat().st_mtime_ns
+    bak_after: set[Path] = set(claude_dir.glob(".warden-verdicts.json.bak-*"))
+    new_baks = bak_after - bak_before
+
+    assert mtime_ns_after == mtime_ns_before, (
+        "_clear_verdict for an absent key rewrote .warden-verdicts.json "
+        "(mtime changed from "
+        f"{mtime_ns_before} to {mtime_ns_after}). "
+        "The no-op early-return guard (``if warden not in data: return``) was "
+        "bypassed or removed.  The fix must preserve this guard."
+    )
+    assert not new_baks, (
+        f"_clear_verdict for an absent key created unexpected backup file(s): "
+        f"{[str(p.name) for p in sorted(new_baks)]}. "
+        "_write_atomic creates a .bak-<stamp> copy before overwriting — a new "
+        "backup proves an unwanted write occurred.  The no-op guard must remain."
+    )

--- a/scripts/warden_hooks/verdict_store.py
+++ b/scripts/warden_hooks/verdict_store.py
@@ -23,11 +23,23 @@ Intra-capsule calls stay direct; only the 6 distinct entry-owned symbols
 
 from __future__ import annotations
 
+import contextlib
 import datetime as dt
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
+
+# OS-SPECIFIC (flagged per core-rules): fcntl is POSIX-only. The warden machinery
+# runs dev-host-only (macOS/Linux); on Windows fcntl is absent and the verdict-store
+# lock degrades to a NO-OP, which is correct because no concurrent marks occur there.
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows; warden never runs marks there
+    fcntl = None  # type: ignore[assignment]
+
+#: Sentinel distinguishing "key was absent" from a real value in locked mutations.
+_VERDICT_UNSET: Any = object()
 
 #: The live entry module (``codex_warden_hooks``), injected by :func:`bind_entry`
 #: at entry-module import time. Entry-owned helpers are resolved through this so
@@ -138,6 +150,53 @@ def _read_verdict(marker_name: str, repo_root: Path) -> str | None:
     return v if isinstance(v, str) else None
 
 
+@contextlib.contextmanager
+def _verdict_file_lock(path: Path):
+    """Exclusive cross-process lock guarding a read-modify-write of *path*.
+
+    Held on a SIDECAR lockfile (``<path>.lock``), not on *path* itself, so the
+    lock survives ``_write_atomic``'s ``os.replace`` (which swaps the target inode
+    while the lockfile's inode is untouched). NO-OP when ``fcntl`` is unavailable
+    (Windows) — see the import-site note; that branch is exercised in tests by
+    monkeypatching ``fcntl = None``.
+    """
+    if fcntl is None:  # Windows / no fcntl — no concurrent marks occur there
+        yield
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    # O_CREAT|O_RDWR (no O_TRUNC) = create-if-absent without truncating, the safe
+    # opener for a long-lived lockfile.
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _locked_verdict_update(path: Path, mutate: Callable[[dict[str, Any]], bool]) -> bool:
+    """Lock-guarded read-modify-write of the verdict store at *path*.
+
+    ``mutate(data) -> bool`` mutates the dict in place and returns whether it
+    changed anything. The store is re-read FRESH inside the lock, so a concurrent
+    writer's key (already on disk) is merged rather than clobbered. The write — and
+    its ``.bak`` backup — is skipped when ``mutate`` reports no change.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _verdict_file_lock(path):
+        data = _read_verdicts_at(path)
+        changed = mutate(data)
+        if changed:
+            _entry._write_atomic(
+                path, json.dumps(data, indent=2, sort_keys=True) + "\n"
+            )
+    return changed
+
+
 def _clear_verdict(marker_name: str, repo_root: Path) -> None:
     """Remove the *marker_name* entry from .warden-verdicts.json.
 
@@ -148,23 +207,34 @@ def _clear_verdict(marker_name: str, repo_root: Path) -> None:
     if not warden:
         return
     path = _verdicts_path(repo_root)
-    data = _read_verdicts(repo_root)
-    if warden not in data:
-        return
-    del data[warden]
+
+    def _pop(data: dict[str, Any]) -> bool:
+        # Absent key → no change → caller skips the write (no spurious .bak).
+        return data.pop(warden, _VERDICT_UNSET) is not _VERDICT_UNSET
+
     try:
-        _entry._write_atomic(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
+        _locked_verdict_update(path, _pop)
     except OSError:
         _entry._debug(f"_clear_verdict: failed to write {path}")
 
 
 def _write_verdict(repo_root: Path, warden: str, verdict: str, reason: str, source: str = "manual") -> None:
     path = _verdicts_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = _read_verdicts(repo_root)
+    # Submission time, not write time: under lock contention the actual write can lag.
     stamp = dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    data[warden] = {"verdict": verdict, "ts": stamp, "reason": reason, "source": source}
-    _entry._write_atomic(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+    def _set(data: dict[str, Any]) -> bool:
+        data[warden] = {
+            "verdict": verdict,
+            "ts": stamp,
+            "reason": reason,
+            "source": source,
+        }
+        return True
+
+    # Lock-guarded RMW: re-reads inside the lock so a concurrent writer's key is
+    # merged, not clobbered (LIA-332).
+    _locked_verdict_update(path, _set)
 
     log = _audit_log_path(repo_root)
     safe_reason = reason.replace("|", "/").replace("\n", " ").strip()


### PR DESCRIPTION
## What & why

PR2 of the **S-grade orchestration** push. Fixes LIA-332 — a parallel-marks clobber race in the warden verdict store (**HIGH blast radius**: every commit/plan/code gate reads `.warden-verdicts.json`).

### The bug (hit live on PR #937, twice)
`_write_verdict` / `_clear_verdict` read the whole `.warden-verdicts.json`, set/delete one key, and write the whole dict back. The read-modify-write isn't atomic across processes, so two concurrent writers each capture a snapshot, each set their own key, and the later `os.replace` drops the earlier writer's key. Live symptom: a `code-reviewer@gpt` SHIP silently vanished when it raced the Claude `code-reviewer` auto-mark, spuriously blocking the commit co-gate ("gpt not run yet").

## Fix (`scripts/warden_hooks/verdict_store.py`)
- **`_locked_verdict_update(path, mutate)`** — holds an exclusive `fcntl.flock` on a **sidecar** lockfile `<path>.lock` (a distinct inode, so the lock survives `_write_atomic`'s `os.replace`), **re-reads the store FRESH inside the lock** (merging any key a concurrent writer already committed), applies `mutate`, and writes only when something changed.
- `_write_verdict` and `_clear_verdict` route through it. `_clear_verdict` uses a sentinel so an absent-key clear writes nothing — preserves the prior no-op (no spurious `.bak`).
- **Cross-platform:** `fcntl` is POSIX; on Windows the lock degrades to a documented `_NoLock` no-op (the warden machinery runs dev-host-only, no concurrent marks there).
- `.gitignore`: added `.claude/.warden-verdicts.json.lock`.

## Tests
- **Independent oracle** (`test_verdict_store_race.py`, authored blind via `oracle-author` from the spec BEFORE the fix): `multiprocessing`, 3 rounds × 20 racing writers. **RED→GREEN** — 34/60 keys clobbered on the old code, **0** after. Plus a no-op-clear invariant guard.
- `test_verdict_store_lock.py`: deterministic (cross-platform) in-lock-merge proof, the `fcntl=None` no-op branch, clear-preserves-sibling.

### Verification & honesty
The full `scripts/tests/` run shows **5 failures, all PRE-EXISTING** — verified identical on baseline by stashing this change and re-running the same combo: 3 `test_warden_review` cross-test-isolation pollution + 2 `test_sync_agent_skills` `FileNotFoundError: AGENTS.md` env. **This change introduces zero new failures** and adds 5 passing tests. (The `test_warden_review` isolation bug deserves its own ticket — not in scope here.)

Note: warden Python tests aren't in CI yet (LIA-305), so CI here runs the JS/TS suite + lints, which this Python-only change doesn't touch.

## Rollback
Single `git revert` restores the pre-lock RMW. No schema change, no migration; `.bak`/`.lock` files are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)