### PR TITLE
feat(memory): surface review-backlog count in cmd_extract (LIA-338)

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-25" # auto-bump @1782400340
+last_verified: "2026-06-26" # auto-bump @1782487369
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -3650,6 +3650,12 @@ def cmd_extract(session_path: str, no_contradict: bool = False):
                 total_conflicts += len(conflicts)
             if total_conflicts:
                 print(f"  contradictions: {total_conflicts} conflict(s) logged for review (use --resolve-conflicts)")
+            # Standing-backlog reminder so the review queue can't silently rot (LIA-338).
+            backlog = db.execute(
+                "SELECT COUNT(*) FROM pending_conflicts WHERE resolved = 0"
+            ).fetchone()[0]
+            if backlog:
+                print(f"  review backlog: {backlog} unresolved conflict(s) pending (use --resolve-conflicts)")
         except Exception as e:
             print(f"  WARN: contradiction detection failed: {e}", file=sys.stderr)
 

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -2960,6 +2960,58 @@ def test_cmd_extract_sets_privacy(mi, fresh_vault, monkeypatch):
     db.close()
 
 
+def _extract_session(mi, fresh_vault, monkeypatch):
+    """Build a minimal session + stub atom extraction so cmd_extract reaches the
+    contradiction/backlog tail with exactly one new atom (and no real LLM calls:
+    a single new atom has no peers within L2<1.2, so detect_contradictions is a
+    no-op)."""
+    session = fresh_vault / "Session-Logs" / "2024-01-01" / "test.md"
+    session.parent.mkdir(parents=True, exist_ok=True)
+    session.write_text(
+        "---\ntype: session\ndate: 2024-01-01\ntopics: [dev]\ntldr: test\n"
+        "decisions:\n  - \"chose X\"\n---\n## Decisions Made\n- chose X\n"
+    )
+    monkeypatch.setattr(mi, "extract_atoms",
+                        lambda c: [{"text": "prefer dark mode always", "category": "preference"}])
+    monkeypatch.setattr(mi, "embed", lambda t: [0.1] * 768)
+    return session
+
+
+def test_cmd_extract_prints_review_backlog(mi, fresh_vault, monkeypatch, capsys):
+    """cmd_extract surfaces the standing unresolved-conflict backlog so the review
+    queue can't silently rot (LIA-338 item 2)."""
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO pending_conflicts (older_id, newer_id, older_text, newer_text, created_at, resolved) "
+        "VALUES (1, 2, 'old fact', 'new fact', '2024-01-01', 0)"
+    )
+    db.commit()
+    db.close()
+
+    session = _extract_session(mi, fresh_vault, monkeypatch)
+    mi.cmd_extract(str(session))
+
+    out = capsys.readouterr().out
+    assert "review backlog: 1 unresolved conflict(s) pending (use --resolve-conflicts)" in out
+
+
+def test_cmd_extract_no_backlog_line_when_clean(mi, fresh_vault, monkeypatch, capsys):
+    """No backlog reminder when every conflict is resolved (queue is clean)."""
+    db = mi.open_db()
+    db.execute(
+        "INSERT INTO pending_conflicts (older_id, newer_id, older_text, newer_text, created_at, resolved, resolution) "
+        "VALUES (1, 2, 'old fact', 'new fact', '2024-01-01', 1, 'dismissed')"
+    )
+    db.commit()
+    db.close()
+
+    session = _extract_session(mi, fresh_vault, monkeypatch)
+    mi.cmd_extract(str(session))
+
+    out = capsys.readouterr().out
+    assert "review backlog:" not in out
+
+
 def test_query_privacy_filter(mi, monkeypatch, capsys):
     db = mi.open_db()
     vec1 = mi.embed("public fact")


### PR DESCRIPTION
## What

Adds a standing **review-backlog reminder** to the `cmd_extract` tail in `scripts/memory_indexer.py`. After the existing per-run "N conflict(s) logged" print, it runs `SELECT COUNT(*) FROM pending_conflicts WHERE resolved = 0` and prints `review backlog: {n} unresolved conflict(s) pending (use --resolve-conflicts)` — only when `n > 0`.

## Why

`detect_contradictions` (`memory_indexer.py:2459`) **never auto-invalidates** — a CONTRADICT verdict only queues a `pending_conflicts` row for human review (`--resolve-conflict` / `--dismiss-conflict`). Nothing surfaced the *standing* queue, so it once sat **2 weeks / 78 items** deep before anyone noticed. This per-run reminder makes the backlog visible so it can't silently rot. (LIA-338 item 2 / review cadence.)

Purely additive stdout: read-only `SELECT COUNT`, inside the existing `if not no_contradict and new_atom_ids:` guard and its `try/except → WARN`. No change to detection or resolution logic.

## Item 1 was refuted (shipping nothing there)

The companion idea — tighten `_contradiction_prompt` to raise the ~6.6% precision — was measured **authoritatively on the real detector model** `gemini-3.1-flash-lite` (not the gemma4 proxy) against the 91 labeled pairs:

| variant | TP recall | FP cleared | precision |
|---|---|---|---|
| current (live) | **6/6** | 2/85 | **0.067** |
| c2 (strict + few-shot) | 4/6 | 25/85 | 0.062 |

c2 drops 2 real contradictions and lands *below* baseline precision; the detector is correctly a high-recall funnel with a human backstop. Recorded on LIA-338; no prompt change ships.

## Tests

- `test_cmd_extract_prints_review_backlog` — seeds one `resolved=0` row, asserts the line appears.
- `test_cmd_extract_no_backlog_line_when_clean` — seeds a `resolved=1` row, asserts the line is absent.
- Full `scripts/tests/test_memory_indexer.py`: **279 passed**.

Co-gate: claude + gpt + glm code-reviewer all SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)