### PR TITLE
feat(multi-agent): wire orchestrator into message loop + subagent one-shot (LIA-127)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-06-26" # auto-bump @1782488844
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-06-26" # auto-bump @1782488844
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-26" # auto-bump @1782425875
+last_verified: "2026-06-26" # auto-bump @1782488844
 governs:
   - src/
   - evolution/

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -1023,3 +1023,240 @@ describe('startMessageLoop', () => {
     expect(mockGetNewMessages.mock.calls.length).toBeLessThanOrEqual(2);
   });
 });
+
+// ── LIA-127: multi-agent dispatch wiring ─────────────────────────────────────
+describe('multi-agent dispatch (DEUS_MULTI_AGENT)', () => {
+  const TASK_BLOCK =
+    'do this\n```deus-tasks\n' +
+    JSON.stringify([
+      {
+        id: 'a',
+        role: 'researcher',
+        goal: 'g',
+        backstory: '',
+        prompt: 'research X',
+        mode: 'read',
+      },
+    ]) +
+    '\n```';
+
+  afterEach(() => {
+    delete process.env.DEUS_MULTI_AGENT;
+  });
+
+  it('flag-on + valid block → dispatches via orchestrator and sends the aggregate', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // The sub-agent run emits output + a DONE marker.
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({
+        type: 'output_text',
+        text: 'found the answer [STATUS:DONE]',
+      });
+      return { status: 'success', result: 'found the answer [STATUS:DONE]' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true);
+    // The aggregated multi-agent reply was sent (task id + status + output).
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✓ a: done'),
+    );
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('found the answer'),
+    );
+  });
+
+  it('flag-off + same block → single-agent path unchanged (no regression)', async () => {
+    delete process.env.DEUS_MULTI_AGENT; // flag OFF
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // Single-agent backend echoes a plain reply — NOT a multi-agent aggregate.
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'single agent reply' });
+      return { status: 'success', result: 'single agent reply' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true);
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('single agent reply'),
+    );
+    // No multi-agent formatting was produced.
+    expect(channel.sendMessage).not.toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✓ a: done'),
+    );
+  });
+
+  it('flag-on + blocked by injection scanner → NOT dispatched (security guard)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // Scanner flags the prompt as a blocked injection attempt.
+    mockScanForInjection.mockReturnValue({
+      blocked: true,
+      triggered: true,
+      score: 1,
+      matches: ['ignore previous instructions'],
+    });
+    let dispatched = false;
+    activeRunTurn = async (_ctx, _session, sink) => {
+      dispatched = true;
+      await sink({ type: 'output_text', text: 'should not run [STATUS:DONE]' });
+      return { status: 'success', result: 'x' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // consumed, no retry
+    expect(dispatched).toBe(false); // sub-agents never ran
+    expect(channel.sendMessage).not.toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✓ a: done'),
+    );
+  });
+
+  it('flag-on + malformed block → parse-error notice, no rollback', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({
+        content: '```deus-tasks\n{not valid json\n```',
+        timestamp: 'ts-1',
+      }),
+    ]);
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // consumed, no retry
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining("couldn't parse"),
+    );
+    // Cursor advanced to ts-1, not rolled back to ts-prev.
+    expect(state.setLastAgentTimestamp).toHaveBeenLastCalledWith(
+      'group@g.us',
+      'ts-1',
+    );
+  });
+
+  it('flag-on + all subagents blocked (status error) → reports reasons and consumes (no loop)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // Subagent run errors → BLOCKED → all-blocked → OrchestratorResult.status 'error'.
+    activeRunTurn = async () => ({
+      status: 'error',
+      result: null,
+      error: 'container crashed',
+    });
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    // Work ran (side effects possible) → consume + report, never loop.
+    expect(result).toBe(true);
+    // Cursor stays advanced (NOT rolled back) so the block isn't re-dispatched.
+    expect(state.setLastAgentTimestamp).toHaveBeenLastCalledWith(
+      'group@g.us',
+      'ts-1',
+    );
+    // The blocked reason is reported to the user.
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✗ a: blocked'),
+    );
+  });
+
+  it('flag-on + delivery failure after a completed run → still consumes (no duplicate re-dispatch)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    // Delivery fails — must NOT trigger a re-dispatch (would re-run write tasks).
+    channel.sendMessage = vi.fn(async () => {
+      throw new Error('send failed');
+    });
+    mockFindChannel.mockReturnValue(channel as any);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'done [STATUS:DONE]' });
+      return { status: 'success', result: 'done [STATUS:DONE]' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as any,
+      queue: makeQueue() as any,
+      channels: [channel as any],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // consumed despite delivery failure
+    expect(state.setLastAgentTimestamp).toHaveBeenLastCalledWith(
+      'group@g.us',
+      'ts-1', // not rolled back
+    );
+  });
+});

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -49,6 +49,13 @@ import {
 import { GroupQueue } from './group-queue.js';
 import { parseImageReferences } from './image.js';
 import { logger } from './logger.js';
+import {
+  MultiAgentOrchestrator,
+  parseTaskBlock,
+  formatMultiAgentResult,
+  MALFORMED_TASK_BLOCK,
+  type OrchestratorResult,
+} from './multi-agent/index.js';
 import { findChannel, formatMessages } from './router.js';
 import { RouterState, getAvailableGroups } from './router-state.js';
 import { isTriggerAllowed, loadSenderAllowlist } from './sender-allowlist.js';
@@ -460,8 +467,6 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       }, IDLE_TIMEOUT);
     };
 
-    // FIXME(LIA-127): Wire MultiAgentOrchestrator dispatch behind DEUS_MULTI_AGENT=1 env gate. Orchestrator is built and tested (src/multi-agent/orchestrator.ts) but not connected to the message loop. See LIA-127 for implementation scope.
-
     await channel.setTyping?.(chatJid, true);
     let hadError = false;
     let outputSentToUser = false;
@@ -481,6 +486,120 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
         return false;
       }
     };
+
+    // LIA-127: multi-agent dispatch (behind DEUS_MULTI_AGENT). When the prompt
+    // carries a parseable ```deus-tasks block, fan out to MultiAgentOrchestrator
+    // instead of the single-agent path. Flag-off, no block, or an unparseable
+    // block (other than the explicit malformed-notice case) all leave the
+    // single-agent path below byte-identical.
+    if (process.env.DEUS_MULTI_AGENT === '1') {
+      const finishEarly = async (rollback: boolean, ret: boolean) => {
+        await channel.setTyping?.(chatJid, false);
+        // idleTimer is null here today (only started in runAgent's callback below);
+        // the guard keeps cleanup correct if a pre-dispatch timer is ever added.
+        if (idleTimer) clearTimeout(idleTimer);
+        if (rollback) {
+          state.setLastAgentTimestamp(chatJid, previousCursor);
+          state.save();
+        }
+        return ret;
+      };
+
+      // Parse from RAW message content, NOT `prompt`: formatMessages XML-escapes
+      // content (" → &quot;), which would break JSON.parse on the fenced block.
+      //
+      // Authorization: only AUTHORIZED senders' messages are eligible to carry a
+      // task block. A non-main group proceeds once ANY message has an authorized
+      // trigger, but an UNauthorized sender's accumulated message must not become an
+      // executable block — unlike the single-agent path (which treats other senders'
+      // messages as mere context), this path EXECUTES the block, incl. `write` tasks.
+      const maAllowlist = loadSenderAllowlist();
+      const eligible =
+        isMainGroup || group.requiresTrigger === false
+          ? missedMessages
+          : missedMessages.filter(
+              (m) =>
+                m.is_from_me ||
+                isTriggerAllowed(chatJid, m.sender, maAllowlist),
+            );
+      const rawContent = eligible.map((m) => m.content).join('\n');
+      const parsed = parseTaskBlock(rawContent);
+      if (parsed === MALFORMED_TASK_BLOCK) {
+        await trySend(
+          "I found a `deus-tasks` block but couldn't parse it — check the JSON and that each task has id/role/goal/prompt/mode.",
+          'multi-agent-parse-error',
+        );
+        // Message consumed; retrying won't fix malformed input. No rollback.
+        return finishEarly(false, true);
+      }
+      if (parsed) {
+        // Injection guard on the DECODED task fields — the text that actually
+        // reaches the container after JSON.parse + buildPrompt. Scanning the
+        // pre-decode chat prompt would MISS JSON-escape-obfuscated injections
+        // (e.g. "ignore previous instructions" scans clean but decodes to
+        // "ignore previous instructions" at the agent). Fail-open on scanner error.
+        const decoded = parsed
+          .map((t) => [t.role, t.goal, t.backstory, t.prompt].join('\n'))
+          .join('\n');
+        let maScan: ScanResult | undefined;
+        try {
+          maScan = scanForInjection(decoded, INJECTION_SCANNER_CONFIG);
+        } catch (err) {
+          logger.error(
+            { err },
+            'Injection scanner error (multi-agent) — failing open',
+          );
+        }
+        if (maScan?.blocked) {
+          logger.warn(
+            { group: group.name, score: maScan.score, matches: maScan.matches },
+            'Injection attempt blocked — multi-agent tasks NOT dispatched',
+          );
+          // Consumed, no retry (mirror runAgent's blocked→success semantics).
+          return finishEarly(false, true);
+        }
+        if (maScan?.triggered) {
+          logger.warn(
+            { group: group.name, score: maScan.score, matches: maScan.matches },
+            'Injection detected in multi-agent tasks (logOnly, passing through)',
+          );
+        }
+
+        logger.info(
+          { group: group.name, taskCount: parsed.length },
+          'Multi-agent dispatch',
+        );
+        let maResult: OrchestratorResult | undefined;
+        try {
+          const orchestrator = new MultiAgentOrchestrator(registry);
+          maResult = await orchestrator.dispatch(parsed, group);
+        } catch (err) {
+          // A throw means dispatch failed BEFORE running any task: topologicalSort
+          // (cyclic/dangling deps — both already caught at parse time) and
+          // registry.resolve run before execution; Promise.allSettled never rejects.
+          // So no work happened → safe to roll back and retry (transient/infra).
+          logger.warn({ group: group.name, err }, 'Multi-agent dispatch threw');
+          await trySend(
+            'Multi-agent dispatch failed — please try again.',
+            'multi-agent-error',
+          );
+          return finishEarly(true, false);
+        }
+        // Dispatch RETURNED → tasks ran and their side effects (incl. `write`)
+        // already happened. CONSUME regardless of status or delivery success:
+        // re-dispatching would re-run completed tasks (duplicate writes), and a
+        // valid all-blocked result (status 'error') must be REPORTED to the user
+        // with its blocked reasons, not silently looped. This mirrors the
+        // single-agent invariant "work done → consume; only retry if work didn't
+        // happen". (status 'error' conflates a deterministic all-blocked run with a
+        // transient infra failure that surfaced as BLOCKED; auto-retrying only the
+        // transient case would need the orchestrator to separate them.)
+        const reply = formatMultiAgentResult(maResult, parsed);
+        await trySend(reply, 'multi-agent-output');
+        return finishEarly(false, true);
+      }
+      // No block present → fall through to the single-agent path unchanged.
+    }
 
     const output = await runAgent(
       group,

--- a/src/multi-agent/index.ts
+++ b/src/multi-agent/index.ts
@@ -6,3 +6,8 @@ export type {
   SubagentStatus,
 } from './types.js';
 export { buildPrompt } from './prompt-templates.js';
+export {
+  parseTaskBlock,
+  formatMultiAgentResult,
+  MALFORMED_TASK_BLOCK,
+} from './message-bridge.js';

--- a/src/multi-agent/message-bridge.test.ts
+++ b/src/multi-agent/message-bridge.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the message↔orchestrator bridge (LIA-127):
+ * parseTaskBlock (validation pipeline) and formatMultiAgentResult
+ * (pure transform + deliverable-presence artifact verification).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseTaskBlock,
+  formatMultiAgentResult,
+  MALFORMED_TASK_BLOCK,
+} from './message-bridge.js';
+import type { OrchestratorResult, SubagentTask } from './types.js';
+
+const validBlock = (body: string) => '```deus-tasks\n' + body + '\n```';
+
+const TWO_TASKS = JSON.stringify([
+  {
+    id: 'a',
+    role: 'researcher',
+    goal: 'g',
+    backstory: '',
+    prompt: 'p',
+    mode: 'read',
+  },
+  {
+    id: 'synth',
+    role: 'writer',
+    goal: 'g2',
+    backstory: '',
+    prompt: 'p2',
+    mode: 'read',
+    contextFrom: ['a'],
+  },
+]);
+
+describe('parseTaskBlock', () => {
+  it('returns null when no block is present (falls through to single-agent)', () => {
+    expect(parseTaskBlock('just a normal prompt with no fence')).toBeNull();
+  });
+
+  it('parses a valid block into SubagentTask[]', () => {
+    const tasks = parseTaskBlock(`do this\n${validBlock(TWO_TASKS)}`);
+    expect(Array.isArray(tasks)).toBe(true);
+    expect((tasks as SubagentTask[]).map((t) => t.id)).toEqual(['a', 'synth']);
+  });
+
+  it('flags a present-but-invalid-JSON block as malformed', () => {
+    expect(parseTaskBlock(validBlock('{not json'))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('an XML-escaped block is malformed — callers MUST parse raw, not formatMessages output', () => {
+    // Regression guard (LIA-127): formatMessages XML-escapes content (" → &quot;).
+    // Parsing that escaped text fails JSON.parse → MALFORMED. The message loop must
+    // feed parseTaskBlock the RAW message content, never the escaped prompt.
+    const escaped = TWO_TASKS.replace(/"/g, '&quot;');
+    expect(parseTaskBlock(validBlock(escaped))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('flags an empty array as malformed', () => {
+    expect(parseTaskBlock(validBlock('[]'))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a task missing required fields', () => {
+    const bad = JSON.stringify([
+      { id: 'a', role: 'r', goal: 'g', mode: 'read' },
+    ]); // no prompt/backstory
+    expect(parseTaskBlock(validBlock(bad))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects an invalid mode', () => {
+    const bad = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'delete',
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(bad))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a task id with non-slug characters (chatJid/IPC-key safety)', () => {
+    const bad = JSON.stringify([
+      {
+        id: '../escape',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(bad))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects duplicate task ids', () => {
+    const dup = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+      },
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(dup))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a cyclic contextFrom graph (would deterministically throw in dispatch)', () => {
+    const cyclic = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+        contextFrom: ['b'],
+      },
+      {
+        id: 'b',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+        contextFrom: ['a'],
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(cyclic))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a dangling contextFrom dependency', () => {
+    const dangling = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+        contextFrom: ['nonexistent'],
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(dangling))).toBe(MALFORMED_TASK_BLOCK);
+  });
+});
+
+describe('formatMultiAgentResult', () => {
+  const tasks: SubagentTask[] = [
+    { id: 'a', role: 'r', goal: 'g', backstory: '', prompt: 'p', mode: 'read' },
+    { id: 'b', role: 'r', goal: 'g', backstory: '', prompt: 'p', mode: 'read' },
+  ];
+
+  it('renders done tasks with their output', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        { status: 'DONE', output: 'answer A' },
+        { status: 'DONE', output: 'answer B' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('✓ a: done');
+    expect(out).toContain('answer A');
+    expect(out).toContain('answer B');
+  });
+
+  it('flags a DONE task with EMPTY output as a no-deliverable concern (artifact verification)', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        { status: 'DONE', output: '   ' }, // explicit DONE but no deliverable
+        { status: 'DONE', output: 'real output' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('⚠ a: produced no deliverable');
+    expect(out).toContain('produced no deliverable'); // also surfaced in concerns
+    expect(out).not.toContain('✓ a: done');
+  });
+
+  it('renders blocked tasks with their reason', () => {
+    const res: OrchestratorResult = {
+      status: 'partial',
+      results: [
+        { status: 'DONE', output: 'ok' },
+        { status: 'BLOCKED', output: '', blockedReason: 'missing creds' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('✗ b: blocked — missing creds');
+  });
+
+  it('surfaces orchestrator concerns', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        { status: 'DONE_WITH_CONCERNS', output: 'x', concerns: ['flaky'] },
+        { status: 'DONE', output: 'y' },
+      ],
+      concerns: ['flaky'],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('**Concerns:**');
+    expect(out).toContain('- flaky');
+  });
+});

--- a/src/multi-agent/message-bridge.ts
+++ b/src/multi-agent/message-bridge.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure message-layer ↔ MultiAgentOrchestrator helpers (no I/O).
+ *  - parseTaskBlock returns SubagentTask[] | null | MALFORMED_TASK_BLOCK — null means
+ *    NO block (caller falls through to single-agent), MALFORMED means present-but-invalid
+ *    (caller surfaces a notice instead of silently dropping or re-feeding raw JSON).
+ *  - formatMultiAgentResult does deliverable-presence artifact verification: a DONE task
+ *    with empty output renders as a concern, never a silent success.
+ */
+import type { OrchestratorResult, SubagentTask } from './types.js';
+
+/** Sentinel: a deus-tasks fence was present but could not be parsed/validated. */
+export const MALFORMED_TASK_BLOCK = 'malformed' as const;
+
+const TASK_BLOCK_RE = /```deus-tasks\s*\n([\s\S]*?)```/;
+
+const VALID_MODES = new Set(['read', 'write']);
+
+function isValidTask(value: unknown): value is SubagentTask {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = value as Record<string, unknown>;
+  // id is a slug: it flows into chatJid / IPC keys downstream, so constrain the
+  // charset to close any path/key-injection surface before it can matter.
+  if (typeof t.id !== 'string' || !/^[A-Za-z0-9_-]+$/.test(t.id)) return false;
+  if (typeof t.role !== 'string' || !t.role.trim()) return false;
+  if (typeof t.goal !== 'string' || !t.goal.trim()) return false;
+  if (typeof t.prompt !== 'string' || !t.prompt.trim()) return false;
+  if (typeof t.mode !== 'string' || !VALID_MODES.has(t.mode)) return false;
+  if (typeof t.backstory !== 'string') return false; // required by type; empty allowed
+  if (t.contextFrom !== undefined) {
+    if (!Array.isArray(t.contextFrom)) return false;
+    if (!t.contextFrom.every((c) => typeof c === 'string')) return false;
+  }
+  return true;
+}
+
+/**
+ * Parse a single ```deus-tasks fenced JSON block into a validated SubagentTask[].
+ *
+ * Returns:
+ *  - SubagentTask[]        when a block is present and fully valid
+ *  - null                  when NO block is present (caller falls through to single-agent)
+ *  - MALFORMED_TASK_BLOCK  when a block IS present but invalid (caller surfaces a notice)
+ */
+export function parseTaskBlock(
+  prompt: string,
+): SubagentTask[] | null | typeof MALFORMED_TASK_BLOCK {
+  // Fast pre-check: skip the O(n) regex on the common no-block prompt.
+  if (!prompt.includes('deus-tasks')) return null;
+  const match = TASK_BLOCK_RE.exec(prompt);
+  if (!match) return null; // no block → single-agent path
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1].trim());
+  } catch {
+    return MALFORMED_TASK_BLOCK;
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0)
+    return MALFORMED_TASK_BLOCK;
+  if (!parsed.every(isValidTask)) return MALFORMED_TASK_BLOCK;
+
+  const tasks = parsed as SubagentTask[];
+
+  // Cross-reference validation: unique ids, and every contextFrom id resolves.
+  const ids = new Set<string>();
+  for (const t of tasks) {
+    if (ids.has(t.id)) return MALFORMED_TASK_BLOCK; // duplicate id
+    ids.add(t.id);
+  }
+  for (const t of tasks) {
+    for (const dep of t.contextFrom ?? []) {
+      if (!ids.has(dep)) return MALFORMED_TASK_BLOCK; // dangling dependency
+    }
+  }
+
+  // Reject cyclic contextFrom graphs. dispatch's topologicalSort would throw a
+  // deterministic UserError on a cycle; catching it here makes a cyclic block a
+  // parse-time MALFORMED notice (consumed) instead of an infinite dispatch-retry
+  // loop. DFS three-color cycle detection.
+  const adj = new Map(tasks.map((t) => [t.id, t.contextFrom ?? []]));
+  const color = new Map<string, 0 | 1 | 2>(); // 0=unvisited 1=visiting 2=done
+  const hasCycle = (id: string): boolean => {
+    const c = color.get(id) ?? 0;
+    if (c === 1) return true;
+    if (c === 2) return false;
+    color.set(id, 1);
+    for (const dep of adj.get(id) ?? []) {
+      if (hasCycle(dep)) return true;
+    }
+    color.set(id, 2);
+    return false;
+  };
+  for (const t of tasks) {
+    if (hasCycle(t.id)) return MALFORMED_TASK_BLOCK;
+  }
+
+  return tasks;
+}
+
+/**
+ * Render an OrchestratorResult into one user-facing reply.
+ *
+ * Artifact verification (deliverable presence): a task reporting DONE /
+ * DONE_WITH_CONCERNS but with empty output is shown as a concern ("produced no
+ * deliverable"), never a silent ✓.
+ *
+ * `results` are positionally aligned to `tasks` (orchestrator aggregation maps
+ * tasks.map(t => results.get(t.id))), so index i pairs task i with result i.
+ */
+export function formatMultiAgentResult(
+  res: OrchestratorResult,
+  tasks: SubagentTask[],
+): string {
+  const lines: string[] = [];
+  const concerns = [...res.concerns];
+
+  res.results.forEach((r, i) => {
+    const task = tasks[i];
+    const label = task?.id ?? `task-${i + 1}`;
+    const noDeliverable =
+      (r.status === 'DONE' || r.status === 'DONE_WITH_CONCERNS') &&
+      !r.output.trim();
+
+    if (r.status === 'BLOCKED') {
+      lines.push(
+        `✗ ${label}: blocked — ${r.blockedReason ?? 'no reason given'}`,
+      );
+    } else if (noDeliverable) {
+      // A claimed-DONE task that emitted nothing is surfaced, never a silent ✓.
+      lines.push(`⚠ ${label}: produced no deliverable`);
+      concerns.push(`${label}: produced no deliverable`);
+    } else if (r.status === 'DONE_WITH_CONCERNS') {
+      lines.push(`⚠ ${label}: done with concerns`);
+    } else {
+      lines.push(`✓ ${label}: done`);
+    }
+  });
+
+  const header = lines.join('\n');
+
+  const outputs = res.results
+    .map((r, i) => ({ r, task: tasks[i] }))
+    .filter(({ r }) => r.status !== 'BLOCKED' && r.output.trim())
+    .map(({ r, task }) => `### ${task?.id ?? 'task'}\n${r.output.trim()}`)
+    .join('\n\n');
+
+  const concernBlock = concerns.length
+    ? `\n\n**Concerns:**\n${concerns.map((c) => `- ${c}`).join('\n')}`
+    : '';
+
+  return [header, outputs].filter(Boolean).join('\n\n') + concernBlock;
+}

--- a/src/multi-agent/orchestrator.test.ts
+++ b/src/multi-agent/orchestrator.test.ts
@@ -17,11 +17,25 @@ import type { RegisteredGroup } from '../types.js';
 import type { SubagentTask, OrchestratorResult } from './types.js';
 import { MultiAgentOrchestrator } from './orchestrator.js';
 import { UserError } from '../errors/index.js';
+import { writeFileSync } from 'fs';
+import { resolveGroupIpcPath } from '../group-folder.js';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock fs + IPC-path resolution so the one-shot `_close` sentinel write never
+// touches the real filesystem during tests.
+vi.mock('fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+vi.mock('../group-folder.js', () => ({
+  resolveGroupIpcPath: vi.fn(
+    (folder: string, key: string) => `/ipc/${folder}/${key}`,
+  ),
 }));
 
 // ── Test helpers ───────────────────────────────────────────────────────
@@ -125,6 +139,30 @@ describe('MultiAgentOrchestrator', () => {
       expect(result.results.every((r) => r.status === 'DONE')).toBe(true);
       // Runtime should have been called for each task
       expect(runtime.runTurn).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('one-shot _close sentinel', () => {
+    it('writes a per-task _close sentinel on turn_complete so the container exits promptly', async () => {
+      const runtime = createMockRuntime('Done. [STATUS:DONE]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup({ folder: 'grp' });
+
+      await orchestrator.dispatch([makeTask({ id: 'task-x' })], group);
+
+      // IPC namespace keyed per-task (slug id) to avoid sibling collisions.
+      expect(resolveGroupIpcPath).toHaveBeenCalledWith(
+        'grp',
+        'multi-agent-task-x',
+      );
+      // The _close sentinel was written into that run's input dir.
+      const wrote = vi
+        .mocked(writeFileSync)
+        .mock.calls.some(
+          (c) => typeof c[0] === 'string' && c[0].endsWith('/input/_close'),
+        );
+      expect(wrote).toBe(true);
     });
   });
 

--- a/src/multi-agent/orchestrator.ts
+++ b/src/multi-agent/orchestrator.ts
@@ -15,7 +15,11 @@ import type {
   RuntimeEvent,
   RuntimeEventSink,
 } from '../agent-runtimes/types.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { UserError } from '../errors/index.js';
+import { resolveGroupIpcPath } from '../group-folder.js';
 import { logger } from '../logger.js';
 import { buildPrompt } from './prompt-templates.js';
 import type { RegisteredGroup } from '../types.js';
@@ -269,12 +273,16 @@ export class MultiAgentOrchestrator {
     priorOutputs: Map<string, SubagentResult>,
   ): Promise<SubagentResult> {
     const prompt = buildPrompt(task, priorOutputs);
+    const chatJid = `multi-agent-${task.id}`;
     const runContext = {
       prompt,
       groupFolder: group.folder,
-      chatJid: `multi-agent-${task.id}`,
+      chatJid,
       isControlGroup: false,
       isScheduledTask: false,
+      // Per-task IPC namespace (slug-only id → safe, unique key) so concurrent
+      // sibling subagents don't collide on the one-shot `_close` sentinel.
+      ipcRunKey: chatJid,
     };
 
     const outputParts: string[] = [];
@@ -285,6 +293,22 @@ export class MultiAgentOrchestrator {
       }
       if (event.type === 'error') {
         throw new Error(event.error);
+      }
+      // One-shot: signal the container to exit after its first result. Without
+      // this the container idles until IDLE_TIMEOUT (~30s) before runTurn
+      // resolves (container-runner resolves on exit). Mirrors the single-agent
+      // path and linear-dispatcher.executeAgentRun. Best-effort.
+      if (event.type === 'turn_complete') {
+        try {
+          const inputDir = path.join(
+            resolveGroupIpcPath(group.folder, chatJid),
+            'input',
+          );
+          fs.mkdirSync(inputDir, { recursive: true });
+          fs.writeFileSync(path.join(inputDir, '_close'), '');
+        } catch {
+          /* best-effort — close sentinel is an optimization, not correctness */
+        }
       }
     };
 


### PR DESCRIPTION
## What & why

PR1b of the **S-grade orchestration** push. Activates the previously-**dormant** `MultiAgentOrchestrator` (the "built but not wired" half flagged in the orchestration rating) behind `DEUS_MULTI_AGENT`, with a minimal explicit `deus-tasks` JSON-block syntax. Flag-off, no block, or an invalid block leaves the live single-agent path **byte-identical**.

> Scope note: originally planned as wiring-only. The code-review co-gate found the orchestrator's **real-container execution was broken** (subagents never one-shot), so — per explicit decision — PR1b was **expanded** to also fix that. The LLM planner (PR1c) and checkpoint/resume (PR1d) remain follow-ups.

## Wiring (`message-orchestrator.ts`, `multi-agent/message-bridge.ts`)
- **`parseTaskBlock`** — validation pipeline: required fields, `mode∈{read,write}`, slug-only ids (chatJid/IPC-key safety), unique ids, dangling-dep **and cycle** detection → `SubagentTask[] | null | MALFORMED`.
- Parses from **raw message content** (not the prompt — `formatMessages` XML-escapes `"`→`&quot;`, which breaks `JSON.parse`).
- **Authorization:** in a non-main group only *authorized* senders' messages are eligible to carry a block (an unauthorized sender's block must not execute when another user later triggers).
- **Injection guard** on the **decoded task fields** (scanning the pre-decode prompt would miss JSON-escape-obfuscated injections like `ignore…`).
- **Rollback semantics:** dispatch *throws* (pre-execution) → roll back + retry; dispatch *returns* (work done) → consume + report (success / partial / all-blocked reasons), never re-dispatch (avoids duplicate `write` side effects). Mirrors the single-agent "work done → consume" invariant.
- **`formatMultiAgentResult`** — deliverable-presence artifact verification: a claimed-DONE task with empty output is reported as a concern, not a silent ✓.

## One-shot fix (`multi-agent/orchestrator.ts` `executeTask`)
`executeTask` now writes a per-task `_close` IPC sentinel on `turn_complete` (keyed by the unique `chatJid`) so the container **exits promptly** instead of idling ~`IDLE_TIMEOUT` (~30s) before `runTurn` resolves. Mirrors the single-agent path and `linear-dispatcher.executeAgentRun`. **This was masked by mock-runtime tests** and surfaced by the co-gate.

## Review & verification
Hardened across **6 code-review co-gate rounds** (GPT backend) — each fix listed in the commit. Final: **claude + gpt + glm all SHIP**; plan-review claude+gpt SHIP.
- `npx vitest run` — **1916 pass** (109 files); `npx tsc --noEmit` + `npx tsc` clean.
- The `_close` one-shot **mechanism is unit-verified** (sentinel write asserted on `turn_complete`).

### ⚠️ Required before enabling the flag in production
A full real-container multi-agent E2E was **not** run here (it needs the proxy + a registered group + mounts, and would risk colliding with the live `com.deus` service). **The first deployment that sets `DEUS_MULTI_AGENT=1` must run a live smoke test** — a real 2-task `deus-tasks` block — and confirm both subagents complete and the aggregate reply arrives **without** the ~30s/task idle hang. **LIA-127 should not be marked Done until that passes.** Merging this only makes the flag *available* (off by default).

## Rollback
`DEUS_MULTI_AGENT` unset/`0` fully disables the path. Single `git revert` reverts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)