### PR TITLE
feat(skills): add dual-warden pre-review step to /learn-procedure (3.5)

### DIFF
--- a/.claude/skills/learn-procedure/SKILL.md
+++ b/.claude/skills/learn-procedure/SKILL.md
@@ -92,6 +92,46 @@ python3 -c "import sys; sys.path.insert(0,'$HOME/deus/scripts'); import memory_t
 ```
 Pick a short hyphenated `<slug>` from the title.
 
+### 3.5 — Dual-warden pre-review (required)
+
+Before the approval gate, vet the drafted node with two INDEPENDENT reviewers and surface
+every verdict at step 4. The lenses are orthogonal: one judges whether the node is *needed*,
+the other whether it is *well-formed as recalled context*. Both are ADVISORY — they inform the
+human's keep/revise/abandon call and do NOT write the warden verdict store. Dispatch all three
+reviews CONCURRENTLY (the result-skeptic Agent call and the two `codex_warden` Bash calls are
+independent tool calls; order does not matter).
+
+1. **Relevancy — `result-skeptic` (Opus).** Is this worth persisting at all? Checks redundancy
+   with an existing skill/convention, single-incident overreach, and the enforcement-vs-recall
+   layer mismatch (a behavior that should be *enforced* by a skill or hook does not belong in a
+   recall-gated advisory node). Opus, because the keep/kill call is nuanced judgment. Pass the
+   rendered node AND the task/session context that motivated capturing it:
+   `Agent(subagent_type="result-skeptic", model="opus", prompt=<rendered node + why it was proposed>)`
+
+2. **Instruction quality — `ai-eng-warden`, TWO cross-family models.** A procedure node is recalled
+   context re-injected into future prompts, so review it on the AI-engineering axes: description
+   discriminativeness + negative scope, false-fire risk against adjacent intents, injection-safety
+   of the steps (neutral how-to, NEVER second-person imperative commands or secrets), token cost,
+   and flag-gating. `ai-eng-warden` is a DIFF role, so present the draft as a new-file diff and
+   review it through two CROSS-FAMILY backends (not Claude) for failure-mode diversity. Run WITHOUT
+   `--warden-mark` — these are advisory; marking would stamp `ai-eng-reviewed` against the procedure
+   draft and pollute a later code-review co-gate. Collect each verdict from stdout:
+   ```bash
+   DIFF=$(mktemp)
+   # git diff --no-index ALWAYS exits 1 on a new file — expected; the diff is still written.
+   git diff --no-index /dev/null <draft-temp-file> > "$DIFF" || true
+   python3 ~/deus/scripts/codex_warden.py --role ai-eng-warden --backend gpt --diff-file "$DIFF"
+   python3 ~/deus/scripts/codex_warden.py --role ai-eng-warden --backend glm --diff-file "$DIFF"
+   ```
+   Each `python3` warden call should exit 0 and print a verdict (SHIP / REVISE / BLOCK /
+   COULD_NOT_RUN). A non-zero exit or missing verdict FROM A WARDEN CALL (not the expected exit-1
+   from `git diff`) means the review did not run — fix the invocation and retry before step 4.
+
+At the approval gate (step 4), show all three verdicts (skeptic + the two ai-eng backends) verbatim
+alongside the rendered node. On any DON'T-SAVE / REVISE, do NOT silently loop: either revise the
+draft and re-run this step, or present the verdict to the user and let them decide keep / revise /
+abandon. The human approval gate is authoritative.
+
 ### 4. Human approval gate (required)
 
 Show the fully-rendered node (frontmatter + steps) and the target path. Write the file ONLY

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-26" # auto-bump @1782428294
+last_verified: "2026-06-26" # auto-bump @1782497582
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What & why

Adds a new **step 3.5 — Dual-warden pre-review (required)** to `.claude/skills/learn-procedure/SKILL.md`, inserted between drafting the node (step 3) and the human approval gate (step 4). Every `/learn-procedure` invocation now vets the drafted procedure node with two **advisory** reviewers before a human decides to persist it.

**Born from this session:** when proposing a procedure node, running two reviewers caught *orthogonal* real problems that neither found alone — and the lesson was to **enforce the vetting in the skill, not in recalled memory** (a recall-gated advisory only nudges; a skill step fires every time).

## The two lenses (orthogonal)
1. **Relevancy — `result-skeptic` (Opus):** is the node needed at all? Redundancy with an existing skill/convention, single-incident overreach, enforcement-vs-recall layer mismatch.
2. **Instruction quality — `ai-eng-warden` across two cross-family models (gpt + glm):** a procedure node is recalled context re-injected into future prompts, so it's reviewed on AI-eng axes — description discriminativeness + negative scope, false-fire risk, injection-safety of the steps, token cost, flag-gating.

## Correctness details (folded in via plan + code co-gates)
- `ai-eng-warden` is a **diff role**, so the draft is presented as a **new-file diff** (`git diff --no-index /dev/null <draft>`, which always exits 1 — `|| true`, documented) and reviewed with `--diff-file`.
- Runs **WITHOUT `--warden-mark`** — advisory only; marking would stamp `ai-eng-reviewed` against the procedure draft and pollute a later code-review co-gate.
- Reviews dispatch **concurrently** (independent tool calls; no verdict-store writes → no ordering constraint); `$(mktemp)` for the diff path (race-safe).
- Verdicts surface verbatim at the approval gate; the **human decision is authoritative** (no silent REVISE loop).

## Review
Plan co-gate (claude+gpt) SHIP after one REVISE round (caught the `--warden-mark`/advisory + parallel + expected-output fixes). Code co-gate **claude+gpt+glm all SHIP** after one REVISE round (caught the `git diff` exit-1 trap, the parallel-vs-sequential mismatch, and the fixed-path race). Prose-only skill doc; no executable code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)