### PR TITLE
feat(skills): render a Decision Receipt at /compress (step 8)

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -157,4 +157,20 @@ After saving the session log:
 7. **Trigger session retrospective** (home mode only, background, opt-in):
    Read `branches/retrospective.md` for conditions and dispatch instructions. Skip silently if any check fails.
 
+8. **Render a Decision Receipt** (always, in the chat reply — home + external):
+   After the log is saved, render a short user-facing digest so the user can follow what
+   changed despite fast delivery — a RENDERING of the data already written (no new content):
+   - **Headline** = the saved log's `tldr` first line (the one-line outcome; it usually already
+     carries the main PR/issue reference).
+   - Up to **3 pivotal-decision bullets** = the saved `decisions[]` array, verbatim, each prefixed
+     `→`. The `decisions[]` strings carry no link field, so do NOT fabricate one; where this
+     session clearly maps a decision to a specific PR/issue, you may append that reference for
+     depth — otherwise render the string as-is.
+   - Optional single closing line WITHIN this receipt block: one open thread or "what's next"
+     (let the user drive). It is part of the receipt, before the operational Confirm line below.
+   Hard cap: **≤5 sentences AND ≤5 bullets, plain language, no deep technical detail** (depth
+   lives in the linked PRs/issues). Skip the receipt for a trivial session — one with no
+   `decisions[]` recorded AND no PR/merge this session; in that case the Confirm line still
+   reports the save. This is the comprehension digest; the operational Confirm line is separate.
+
 Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, atom extraction result, and whether a session retrospective was triggered (home mode only — report "retrospective triggered (background)" or "retrospective skipped: <reason>").

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-26" # auto-bump @1782497582
+last_verified: "2026-06-27" # auto-bump @1782510655
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What & why

Adds **step 8 — Render a Decision Receipt** to the `/compress` skill's post-save steps. `/compress` now closes with a short, plain-language digest in chat so the user can **follow what changed despite fast delivery** — the stated pain ("hard to follow key decisions/implementations since we ship so fast").

**It renders data `/compress` already writes** (no new artifact, no drift):
- **Headline** = the saved log's `tldr` first line.
- Up to **3 `→` pivotal bullets** = the saved `decisions[]` array, verbatim.
- Optional one-line close (open thread / what's next).
- Cap: **≤5 sentences AND ≤5 bullets**, plain language, depth via the linked PRs/issues.
- Skipped for trivial sessions (no `decisions[]` + no PR/merge); the operational Confirm line stays as the separate footer.

## Design
Co-designed with the user via the brainstormer. Key call: this is a **rendering** of existing `tldr`/`decisions[]` data, not a new content store — guarantees the chat digest and the vault record can't diverge (no duplication). The **portable essence is inlined** so any user benefits; the richer spec, examples, and the on-demand recap-phrase triggering live in the user's personal memory (already shipped, out of scope here).

## Review
Plan co-gate (claude+gpt) SHIP. Code co-gate **claude+gpt+glm all SHIP** after one REVISE round — the code round caught a real schema mismatch (`decisions[]` entries are ≤12-word strings with **no link field**, so the per-bullet PR-link mandate was corrected to an optional, never-fabricated reference). Prose-only skill doc; no executable code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)