### PR TITLE
feat(multi-agent): route deus-tasks blocks to orchestrator on cold + warm turns (LIA-127)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -242,6 +242,11 @@ MAX_MESSAGE_LENGTH=50000
 # Hours of idle before resetting agent session (0=disabled)
 # SESSION_IDLE_RESET_HOURS=8
 
+# === Multi-agent (experimental) ===
+# Route ```deus-tasks blocks to the MultiAgentOrchestrator instead of the
+# single-agent path (LIA-127; default off). Needs real-container E2E before use.
+# DEUS_MULTI_AGENT=1
+
 # === Logging ===
 LOG_LEVEL=info
 # DEUS_TOOL_AUDIT_LOG=0

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-06-27" # auto-bump @1782546750
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-06-27" # auto-bump @1782546750
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-26" # auto-bump @1782425875
+last_verified: "2026-06-27" # auto-bump @1782546750
 governs:
   - src/
   - evolution/

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -72,10 +72,17 @@ vi.mock('./container-runner.js', () => ({
   writeGroupsSnapshot: vi.fn(),
 }));
 
-vi.mock('./router.js', () => ({
-  findChannel: vi.fn(),
-  formatMessages: vi.fn(() => 'formatted prompt'),
-}));
+vi.mock('./router.js', async () => {
+  // Keep the real stripInternalTags (used transitively by the multi-agent
+  // formatter) while stubbing the channel/format helpers.
+  const actual =
+    await vi.importActual<typeof import('./router.js')>('./router.js');
+  return {
+    ...actual,
+    findChannel: vi.fn(),
+    formatMessages: vi.fn(() => 'formatted prompt'),
+  };
+});
 
 vi.mock('./session-commands.js', () => ({
   handleSessionCommand: vi.fn(async () => ({ handled: false, success: false })),

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -157,7 +157,9 @@ import {
   extractSessionCommand,
 } from './session-commands.js';
 import { scanForInjection } from './guardrails/injection-scanner.js';
-import type { RegisteredGroup } from './types.js';
+import type { Channel, RegisteredGroup } from './types.js';
+import type { RouterState } from './router-state.js';
+import type { GroupQueue } from './group-queue.js';
 import { RuntimeRegistry } from './agent-runtimes/registry.js';
 
 const mockScanForInjection = vi.mocked(scanForInjection);
@@ -326,8 +328,8 @@ describe('processGroupMessages', () => {
     const queue = makeQueue();
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
       channels: [],
     });
 
@@ -339,14 +341,14 @@ describe('processGroupMessages', () => {
   it('returns true immediately when no missed messages', async () => {
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([]);
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -356,7 +358,7 @@ describe('processGroupMessages', () => {
   it('advances cursor then rolls back on agent error with no output sent', async () => {
     const state = makeState(MAIN_GROUP, 'ts-prev');
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async () => ({
@@ -367,9 +369,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -391,7 +393,7 @@ describe('processGroupMessages', () => {
   it('clears stale session on "No conversation found" error instead of persisting it', async () => {
     const state = makeState(MAIN_GROUP, 'ts-prev');
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     const mockClearSession = vi.mocked(clearSession);
@@ -410,9 +412,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -426,7 +428,7 @@ describe('processGroupMessages', () => {
   it('does NOT roll back cursor when output was already sent to the user', async () => {
     const state = makeState(MAIN_GROUP, 'ts-prev');
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -436,9 +438,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -459,16 +461,16 @@ describe('processGroupMessages', () => {
   it('skips non-main group when trigger is required but not present', async () => {
     const state = makeState(NON_MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([
       makeMsg({ content: 'just a regular message, no trigger' }),
     ]);
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -478,7 +480,7 @@ describe('processGroupMessages', () => {
   it('processes non-main group when trigger message is present', async () => {
     const state = makeState(NON_MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([
       makeMsg({ content: '@Deus please help' }),
     ]);
@@ -492,9 +494,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -505,7 +507,7 @@ describe('processGroupMessages', () => {
   it('main group processes messages without trigger check', async () => {
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([
       makeMsg({ content: 'no trigger here, just a regular message' }),
     ]);
@@ -519,9 +521,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -532,7 +534,7 @@ describe('processGroupMessages', () => {
   it('returns session command result without running agent when handled', async () => {
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([
       makeMsg({ content: '@Deus /compact' }),
     ]);
@@ -549,9 +551,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -562,7 +564,7 @@ describe('processGroupMessages', () => {
   it('sends agent output to the channel', async () => {
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -573,9 +575,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     await orchestrator.processGroupMessages('group@g.us');
@@ -588,7 +590,7 @@ describe('processGroupMessages', () => {
   it('strips <internal> blocks before sending to user', async () => {
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -602,9 +604,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     await orchestrator.processGroupMessages('group@g.us');
@@ -624,7 +626,7 @@ describe('processGroupMessages', () => {
     const channel = makeChannel();
     // Both the primary send and the fallback send fail.
     channel.sendMessage.mockRejectedValue(new Error('channel down'));
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -635,9 +637,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     // Agent succeeded, so the turn still reports success even though delivery
@@ -657,7 +659,7 @@ describe('processGroupMessages', () => {
     channel.sendMessage
       .mockRejectedValueOnce(new Error('rejected'))
       .mockResolvedValue(undefined);
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -668,9 +670,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     await orchestrator.processGroupMessages('group@g.us');
@@ -692,7 +694,7 @@ describe('processGroupMessages', () => {
     const channel = makeChannel();
     // Primary + fallback both fail: the user received nothing.
     channel.sendMessage.mockRejectedValue(new Error('channel down'));
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -702,9 +704,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -729,7 +731,7 @@ describe('processGroupMessages', () => {
     channel.sendMessage
       .mockRejectedValueOnce(new Error('rejected'))
       .mockResolvedValue(undefined);
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     activeRunTurn = async (_ctx, _session, sink) => {
@@ -739,9 +741,9 @@ describe('processGroupMessages', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -761,7 +763,7 @@ describe('injection scanner integration', () => {
   it('blocks message and prevents runTurn when injection is detected', async () => {
     const state = makeState(MAIN_GROUP, 'ts-prev');
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     mockScanForInjection.mockReturnValue({
@@ -780,9 +782,9 @@ describe('injection scanner integration', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -798,7 +800,7 @@ describe('injection scanner integration', () => {
   it('lets message through in logOnly mode even when triggered', async () => {
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
 
     mockScanForInjection.mockReturnValue({
@@ -818,9 +820,9 @@ describe('injection scanner integration', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: makeQueue() as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const result = await orchestrator.processGroupMessages('group@g.us');
@@ -842,8 +844,8 @@ describe('recoverPendingMessages', () => {
     const queue = makeQueue();
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
       channels: [],
     });
 
@@ -858,8 +860,8 @@ describe('recoverPendingMessages', () => {
     const queue = makeQueue();
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
       channels: [],
     });
 
@@ -883,7 +885,7 @@ describe('startMessageLoop', () => {
     });
 
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetNewMessages
       .mockReturnValueOnce({
         messages: [{ ...makeMsg(), chat_jid: 'group@g.us' }],
@@ -894,9 +896,9 @@ describe('startMessageLoop', () => {
     const queue = makeQueue();
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     const loopPromise = orchestrator.startMessageLoop();
@@ -914,7 +916,7 @@ describe('startMessageLoop', () => {
     vi.useFakeTimers();
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetNewMessages
       .mockReturnValueOnce({
         messages: [{ ...makeMsg(), chat_jid: 'group@g.us' }],
@@ -928,9 +930,9 @@ describe('startMessageLoop', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     orchestrator.startMessageLoop();
@@ -944,7 +946,7 @@ describe('startMessageLoop', () => {
     vi.useFakeTimers();
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetNewMessages
       .mockReturnValueOnce({
         messages: [{ ...makeMsg(), chat_jid: 'group@g.us' }],
@@ -958,9 +960,9 @@ describe('startMessageLoop', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     orchestrator.startMessageLoop();
@@ -973,7 +975,7 @@ describe('startMessageLoop', () => {
     vi.useFakeTimers();
     const state = makeState(MAIN_GROUP);
     const channel = makeChannel();
-    mockFindChannel.mockReturnValue(channel as any);
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
     mockGetNewMessages
       .mockReturnValueOnce({
         messages: [
@@ -989,9 +991,9 @@ describe('startMessageLoop', () => {
 
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
-      channels: [channel as any],
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
     });
 
     orchestrator.startMessageLoop();
@@ -1010,8 +1012,8 @@ describe('startMessageLoop', () => {
     const queue = makeQueue();
     const orchestrator = createMessageOrchestrator({
       registry: makeRegistry(),
-      state: state as any,
-      queue: queue as any,
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
       channels: [],
     });
 
@@ -1021,5 +1023,460 @@ describe('startMessageLoop', () => {
     await vi.advanceTimersByTimeAsync(10);
     // getNewMessages called once (from first loop), not twice
     expect(mockGetNewMessages.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});
+
+// ── LIA-127: multi-agent dispatch wiring ─────────────────────────────────────
+describe('multi-agent dispatch (DEUS_MULTI_AGENT)', () => {
+  const TASK_BLOCK =
+    'do this\n```deus-tasks\n' +
+    JSON.stringify([
+      {
+        id: 'a',
+        role: 'researcher',
+        goal: 'g',
+        backstory: '',
+        prompt: 'research X',
+        mode: 'read',
+      },
+    ]) +
+    '\n```';
+
+  afterEach(() => {
+    delete process.env.DEUS_MULTI_AGENT;
+  });
+
+  it('flag-on + valid block → dispatches via orchestrator and sends the aggregate', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // The sub-agent run emits output + a DONE marker.
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({
+        type: 'output_text',
+        text: 'found the answer [STATUS:DONE]',
+      });
+      return { status: 'success', result: 'found the answer [STATUS:DONE]' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true);
+    // The aggregated multi-agent reply was sent (task id + status + output).
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✓ a: done'),
+    );
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('found the answer'),
+    );
+  });
+
+  it('flag-off + same block → single-agent path unchanged (no regression)', async () => {
+    delete process.env.DEUS_MULTI_AGENT; // flag OFF
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // Single-agent backend echoes a plain reply — NOT a multi-agent aggregate.
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'single agent reply' });
+      return { status: 'success', result: 'single agent reply' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true);
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('single agent reply'),
+    );
+    // No multi-agent formatting was produced.
+    expect(channel.sendMessage).not.toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✓ a: done'),
+    );
+  });
+
+  it('flag-on + blocked by injection scanner → NOT dispatched (security guard)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // Scanner flags the prompt as a blocked injection attempt.
+    mockScanForInjection.mockReturnValue({
+      blocked: true,
+      triggered: true,
+      score: 1,
+      matches: ['ignore previous instructions'],
+    });
+    let dispatched = false;
+    activeRunTurn = async (_ctx, _session, sink) => {
+      dispatched = true;
+      await sink({ type: 'output_text', text: 'should not run [STATUS:DONE]' });
+      return { status: 'success', result: 'x' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // consumed, no retry
+    expect(dispatched).toBe(false); // sub-agents never ran
+    expect(channel.sendMessage).not.toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✓ a: done'),
+    );
+  });
+
+  it('flag-on + malformed block → parse-error notice, no rollback', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({
+        content: '```deus-tasks\n{not valid json\n```',
+        timestamp: 'ts-1',
+      }),
+    ]);
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // consumed, no retry
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining("couldn't parse"),
+    );
+    // Cursor advanced to ts-1, not rolled back to ts-prev.
+    expect(state.setLastAgentTimestamp).toHaveBeenLastCalledWith(
+      'group@g.us',
+      'ts-1',
+    );
+  });
+
+  it('flag-on + all subagents blocked (status error) → reports reasons and consumes (no loop)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    // Subagent run errors → BLOCKED → all-blocked → OrchestratorResult.status 'error'.
+    activeRunTurn = async () => ({
+      status: 'error',
+      result: null,
+      error: 'container crashed',
+    });
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    // Work ran (side effects possible) → consume + report, never loop.
+    expect(result).toBe(true);
+    // Cursor stays advanced (NOT rolled back) so the block isn't re-dispatched.
+    expect(state.setLastAgentTimestamp).toHaveBeenLastCalledWith(
+      'group@g.us',
+      'ts-1',
+    );
+    // The blocked reason is reported to the user.
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      expect.stringContaining('✗ a: blocked'),
+    );
+  });
+
+  it('flag-on + delivery failure after a completed run → still consumes (no duplicate re-dispatch)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    // Delivery fails — must NOT trigger a re-dispatch (would re-run write tasks).
+    channel.sendMessage = vi.fn(async () => {
+      throw new Error('send failed');
+    });
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: TASK_BLOCK, timestamp: 'ts-1' }),
+    ]);
+    activeRunTurn = async (_ctx, _session, sink) => {
+      await sink({ type: 'output_text', text: 'done [STATUS:DONE]' });
+      return { status: 'success', result: 'done [STATUS:DONE]' };
+    };
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: makeQueue() as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    const result = await orchestrator.processGroupMessages('group@g.us');
+
+    expect(result).toBe(true); // consumed despite delivery failure
+    expect(state.setLastAgentTimestamp).toHaveBeenLastCalledWith(
+      'group@g.us',
+      'ts-1', // not rolled back
+    );
+  });
+});
+
+// ── LIA-127: multi-agent warm-path routing (startMessageLoop, blocker #8) ─────
+// A ```deus-tasks block must reach the orchestrator (which lives only in
+// processGroupMessages) on a WARM turn too, not get piped into the single-agent
+// session. The interception finalizes the warm session (closeStdin) and routes to
+// the cold path via enqueueMessageCheck — instead of queue.sendMessage piping.
+describe('multi-agent warm-path routing (startMessageLoop)', () => {
+  const WARM_TASK_BLOCK =
+    'do this\n```deus-tasks\n' +
+    JSON.stringify([
+      {
+        id: 'a',
+        role: 'researcher',
+        goal: 'g',
+        backstory: '',
+        prompt: 'research X',
+        mode: 'read',
+      },
+    ]) +
+    '\n```';
+  const WARM_MALFORMED_BLOCK = '```deus-tasks\n{not valid json\n```';
+
+  afterEach(() => {
+    delete process.env.DEUS_MULTI_AGENT;
+  });
+
+  it('flag-on + warm container + valid block → closeStdin + enqueue, never pipes, cursor untouched', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetNewMessages
+      .mockReturnValueOnce({
+        messages: [
+          { ...makeMsg({ content: WARM_TASK_BLOCK }), chat_jid: 'group@g.us' },
+        ],
+        newTimestamp: 'ts-1',
+      })
+      .mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: WARM_TASK_BLOCK }),
+    ]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true); // warm container exists
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.closeStdin).toHaveBeenCalledWith('group@g.us');
+    expect(queue.enqueueMessageCheck).toHaveBeenCalledWith('group@g.us');
+    expect(queue.sendMessage).not.toHaveBeenCalled();
+    // Cursor left for processGroupMessages to advance (not touched here).
+    expect(state.setLastAgentTimestamp).not.toHaveBeenCalled();
+  });
+
+  it('flag-on + warm container + malformed block → closeStdin + enqueue (cold path emits the notice), never pipes', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetNewMessages
+      .mockReturnValueOnce({
+        messages: [
+          {
+            ...makeMsg({ content: WARM_MALFORMED_BLOCK }),
+            chat_jid: 'group@g.us',
+          },
+        ],
+        newTimestamp: 'ts-1',
+      })
+      .mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: WARM_MALFORMED_BLOCK }),
+    ]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true);
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Authorized block (valid OR malformed) finalizes the warm session and routes
+    // to the cold path — same as a valid block; the single parse-error notice
+    // fires in processGroupMessages, never here.
+    expect(queue.closeStdin).toHaveBeenCalledWith('group@g.us');
+    expect(queue.enqueueMessageCheck).toHaveBeenCalledWith('group@g.us');
+    expect(queue.sendMessage).not.toHaveBeenCalled();
+    expect(channel.sendMessage).not.toHaveBeenCalled();
+    expect(state.setLastAgentTimestamp).not.toHaveBeenCalled();
+  });
+
+  it('flag-on + warm container + ordinary message (no block) → pipes as before', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetNewMessages
+      .mockReturnValueOnce({
+        messages: [
+          { ...makeMsg({ content: 'just chatting' }), chat_jid: 'group@g.us' },
+        ],
+        newTimestamp: 'ts-1',
+      })
+      .mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: 'just chatting' }),
+    ]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true);
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.sendMessage).toHaveBeenCalled();
+    expect(queue.closeStdin).not.toHaveBeenCalled();
+    expect(queue.enqueueMessageCheck).not.toHaveBeenCalled();
+  });
+
+  it('flag-off + warm container + valid block → pipes as before (no interception)', async () => {
+    delete process.env.DEUS_MULTI_AGENT; // flag OFF
+    vi.useFakeTimers();
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetNewMessages
+      .mockReturnValueOnce({
+        messages: [
+          { ...makeMsg({ content: WARM_TASK_BLOCK }), chat_jid: 'group@g.us' },
+        ],
+        newTimestamp: 'ts-1',
+      })
+      .mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: WARM_TASK_BLOCK }),
+    ]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true);
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.sendMessage).toHaveBeenCalled();
+    expect(queue.closeStdin).not.toHaveBeenCalled();
+    expect(queue.enqueueMessageCheck).not.toHaveBeenCalled();
+  });
+
+  it('flag-on + non-main trigger-gated group + block WITHOUT trigger → not intercepted (accumulates as context)', async () => {
+    process.env.DEUS_MULTI_AGENT = '1';
+    vi.useFakeTimers();
+    const state = makeState(NON_MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    // Block present but NO trigger token → the trigger gate continues before the
+    // interception is reached, so the block must just accumulate.
+    mockGetNewMessages
+      .mockReturnValueOnce({
+        messages: [
+          { ...makeMsg({ content: WARM_TASK_BLOCK }), chat_jid: 'group@g.us' },
+        ],
+        newTimestamp: 'ts-1',
+      })
+      .mockReturnValue({ messages: [], newTimestamp: '' });
+    mockGetMessagesSince.mockReturnValue([
+      makeMsg({ content: WARM_TASK_BLOCK }),
+    ]);
+
+    const queue = makeQueue();
+    queue.sendMessage.mockReturnValue(true);
+
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    orchestrator.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(queue.closeStdin).not.toHaveBeenCalled();
+    expect(queue.enqueueMessageCheck).not.toHaveBeenCalled();
+    expect(queue.sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -49,6 +49,13 @@ import {
 import { GroupQueue } from './group-queue.js';
 import { parseImageReferences } from './image.js';
 import { logger } from './logger.js';
+import {
+  MultiAgentOrchestrator,
+  parseTaskBlock,
+  formatMultiAgentResult,
+  MALFORMED_TASK_BLOCK,
+  type OrchestratorResult,
+} from './multi-agent/index.js';
 import { findChannel, formatMessages } from './router.js';
 import { RouterState, getAvailableGroups } from './router-state.js';
 import { isTriggerAllowed, loadSenderAllowlist } from './sender-allowlist.js';
@@ -242,6 +249,25 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       logger.error({ group: group.name, err }, 'Agent error');
       return 'error';
     }
+  }
+
+  /**
+   * Authorized-sender subset eligible to carry a multi-agent task block. Shared by
+   * the cold-path dispatch and the warm-path interception so both gate on the same
+   * rule — an unauthorized sender's message must never become an executable block.
+   */
+  function eligibleSenderMessages(
+    messages: NewMessage[],
+    group: RegisteredGroup,
+    chatJid: string,
+    allowlist: ReturnType<typeof loadSenderAllowlist>,
+  ): NewMessage[] {
+    if (group.isControlGroup === true || group.requiresTrigger === false) {
+      return messages;
+    }
+    return messages.filter(
+      (m) => m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlist),
+    );
   }
 
   /**
@@ -460,8 +486,6 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
       }, IDLE_TIMEOUT);
     };
 
-    // FIXME(LIA-127): Wire MultiAgentOrchestrator dispatch behind DEUS_MULTI_AGENT=1 env gate. Orchestrator is built and tested (src/multi-agent/orchestrator.ts) but not connected to the message loop. See LIA-127 for implementation scope.
-
     await channel.setTyping?.(chatJid, true);
     let hadError = false;
     let outputSentToUser = false;
@@ -481,6 +505,115 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
         return false;
       }
     };
+
+    // LIA-127: multi-agent dispatch (behind DEUS_MULTI_AGENT). When the prompt
+    // carries a parseable ```deus-tasks block, fan out to MultiAgentOrchestrator
+    // instead of the single-agent path. Flag-off, no block, or an unparseable
+    // block (other than the explicit malformed-notice case) all leave the
+    // single-agent path below byte-identical.
+    if (process.env.DEUS_MULTI_AGENT === '1') {
+      const finishEarly = async (rollback: boolean, ret: boolean) => {
+        await channel.setTyping?.(chatJid, false);
+        if (idleTimer) clearTimeout(idleTimer);
+        if (rollback) {
+          state.setLastAgentTimestamp(chatJid, previousCursor);
+          state.save();
+        }
+        return ret;
+      };
+
+      // Parse from RAW message content, NOT `prompt`: formatMessages XML-escapes
+      // content (" → &quot;), which would break JSON.parse on the fenced block.
+      //
+      // Authorization: only AUTHORIZED senders' messages are eligible to carry a
+      // task block. A non-main group proceeds once ANY message has an authorized
+      // trigger, but an UNauthorized sender's accumulated message must not become an
+      // executable block — unlike the single-agent path (which treats other senders'
+      // messages as mere context), this path EXECUTES the block, incl. `write` tasks.
+      const eligible = eligibleSenderMessages(
+        missedMessages,
+        group,
+        chatJid,
+        loadSenderAllowlist(),
+      );
+      const rawContent = eligible.map((m) => m.content).join('\n');
+      const parsed = parseTaskBlock(rawContent);
+      if (parsed === MALFORMED_TASK_BLOCK) {
+        await trySend(
+          "I found a `deus-tasks` block but couldn't parse it — check the JSON and that each task has id/role/goal/prompt/mode.",
+          'multi-agent-parse-error',
+        );
+        // Message consumed; retrying won't fix malformed input. No rollback.
+        return finishEarly(false, true);
+      }
+      if (parsed) {
+        // Injection guard on the DECODED task fields — the text that actually
+        // reaches the container after JSON.parse + buildPrompt. Scanning the
+        // pre-decode chat prompt would MISS JSON-escape-obfuscated injections
+        // (e.g. "ignore previous instructions" scans clean but decodes to
+        // "ignore previous instructions" at the agent). Fail-open on scanner error.
+        const decoded = parsed
+          .map((t) => [t.role, t.goal, t.backstory, t.prompt].join('\n'))
+          .join('\n');
+        let maScan: ScanResult | undefined;
+        try {
+          maScan = scanForInjection(decoded, INJECTION_SCANNER_CONFIG);
+        } catch (err) {
+          logger.error(
+            { err },
+            'Injection scanner error (multi-agent) — failing open',
+          );
+        }
+        if (maScan?.blocked) {
+          logger.warn(
+            { group: group.name, score: maScan.score, matches: maScan.matches },
+            'Injection attempt blocked — multi-agent tasks NOT dispatched',
+          );
+          // Consumed, no retry (mirror runAgent's blocked→success semantics).
+          return finishEarly(false, true);
+        }
+        if (maScan?.triggered) {
+          logger.warn(
+            { group: group.name, score: maScan.score, matches: maScan.matches },
+            'Injection detected in multi-agent tasks (logOnly, passing through)',
+          );
+        }
+
+        logger.info(
+          { group: group.name, taskCount: parsed.length },
+          'Multi-agent dispatch',
+        );
+        let maResult: OrchestratorResult | undefined;
+        try {
+          const orchestrator = new MultiAgentOrchestrator(registry);
+          maResult = await orchestrator.dispatch(parsed, group);
+        } catch (err) {
+          // A throw means dispatch failed BEFORE running any task: topologicalSort
+          // (cyclic/dangling deps — both already caught at parse time) and
+          // registry.resolve run before execution; Promise.allSettled never rejects.
+          // So no work happened → safe to roll back and retry (transient/infra).
+          logger.warn({ group: group.name, err }, 'Multi-agent dispatch threw');
+          await trySend(
+            'Multi-agent dispatch failed — please try again.',
+            'multi-agent-error',
+          );
+          return finishEarly(true, false);
+        }
+        // Dispatch RETURNED → tasks ran and their side effects (incl. `write`)
+        // already happened. CONSUME regardless of status or delivery success:
+        // re-dispatching would re-run completed tasks (duplicate writes), and a
+        // valid all-blocked result (status 'error') must be REPORTED to the user
+        // with its blocked reasons, not silently looped. This mirrors the
+        // single-agent invariant "work done → consume; only retry if work didn't
+        // happen". (status 'error' conflates a deterministic all-blocked run with a
+        // transient infra failure that surfaced as BLOCKED; auto-retrying only the
+        // transient case would need the orchestrator to separate them.)
+        const reply = formatMultiAgentResult(maResult, parsed);
+        await trySend(reply, 'multi-agent-output');
+        return finishEarly(false, true);
+      }
+      // No block present → fall through to the single-agent path unchanged.
+    }
 
     const output = await runAgent(
       group,
@@ -753,6 +886,37 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
             );
             const messagesToSend =
               allPending.length > 0 ? allPending : groupMessages;
+
+            // LIA-127: multi-agent dispatch (behind DEUS_MULTI_AGENT). A
+            // ```deus-tasks block cannot be piped into a warm single-agent session
+            // — it must reach MultiAgentOrchestrator, which lives only in
+            // processGroupMessages. Mirror the authorized session-command
+            // interception above: finalize the warm session (closeStdin) and route
+            // to the cold path via enqueueMessageCheck, so BOTH cold and warm turns
+            // hit the one dispatch site. Placed AFTER the trigger gate (a
+            // non-triggered block in a trigger-gated group just accumulates as
+            // context, matching the cold path) and detected on the SAME pending set
+            // that would otherwise be piped, filtered to authorized senders. A
+            // non-null parse result (valid SubagentTask[] OR malformed — both
+            // truthy) means an authorized sender sent a block; the cold path then
+            // dispatches it or emits the single canonical parse-error notice. Do NOT
+            // advance the cursor — processGroupMessages pulls-since and consumes.
+            // closeStdin is a no-op when no container is active, so this branch also
+            // covers cold-start uniformly.
+            if (process.env.DEUS_MULTI_AGENT === '1') {
+              const maEligible = eligibleSenderMessages(
+                messagesToSend,
+                group,
+                chatJid,
+                loadSenderAllowlist(),
+              );
+              if (parseTaskBlock(maEligible.map((m) => m.content).join('\n'))) {
+                queue.closeStdin(chatJid);
+                queue.enqueueMessageCheck(chatJid);
+                continue;
+              }
+            }
+
             const formatted = formatMessages(messagesToSend, TIMEZONE);
 
             if (queue.sendMessage(chatJid, formatted)) {

--- a/src/multi-agent/index.ts
+++ b/src/multi-agent/index.ts
@@ -6,3 +6,8 @@ export type {
   SubagentStatus,
 } from './types.js';
 export { buildPrompt } from './prompt-templates.js';
+export {
+  parseTaskBlock,
+  formatMultiAgentResult,
+  MALFORMED_TASK_BLOCK,
+} from './message-bridge.js';

--- a/src/multi-agent/message-bridge.test.ts
+++ b/src/multi-agent/message-bridge.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the message↔orchestrator bridge (LIA-127):
+ * parseTaskBlock (validation pipeline) and formatMultiAgentResult
+ * (pure transform + deliverable-presence artifact verification).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseTaskBlock,
+  formatMultiAgentResult,
+  MALFORMED_TASK_BLOCK,
+} from './message-bridge.js';
+import type { OrchestratorResult, SubagentTask } from './types.js';
+
+const validBlock = (body: string) => '```deus-tasks\n' + body + '\n```';
+
+const TWO_TASKS = JSON.stringify([
+  {
+    id: 'a',
+    role: 'researcher',
+    goal: 'g',
+    backstory: '',
+    prompt: 'p',
+    mode: 'read',
+  },
+  {
+    id: 'synth',
+    role: 'writer',
+    goal: 'g2',
+    backstory: '',
+    prompt: 'p2',
+    mode: 'read',
+    contextFrom: ['a'],
+  },
+]);
+
+describe('parseTaskBlock', () => {
+  it('returns null when no block is present (falls through to single-agent)', () => {
+    expect(parseTaskBlock('just a normal prompt with no fence')).toBeNull();
+  });
+
+  it('parses a valid block into SubagentTask[]', () => {
+    const tasks = parseTaskBlock(`do this\n${validBlock(TWO_TASKS)}`);
+    expect(Array.isArray(tasks)).toBe(true);
+    expect((tasks as SubagentTask[]).map((t) => t.id)).toEqual(['a', 'synth']);
+  });
+
+  it('flags a present-but-invalid-JSON block as malformed', () => {
+    expect(parseTaskBlock(validBlock('{not json'))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('an XML-escaped block is malformed — callers MUST parse raw, not formatMessages output', () => {
+    // Regression guard (LIA-127): formatMessages XML-escapes content (" → &quot;).
+    // Parsing that escaped text fails JSON.parse → MALFORMED. The message loop must
+    // feed parseTaskBlock the RAW message content, never the escaped prompt.
+    const escaped = TWO_TASKS.replace(/"/g, '&quot;');
+    expect(parseTaskBlock(validBlock(escaped))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('flags an empty array as malformed', () => {
+    expect(parseTaskBlock(validBlock('[]'))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a task missing required fields', () => {
+    const bad = JSON.stringify([
+      { id: 'a', role: 'r', goal: 'g', mode: 'read' },
+    ]); // no prompt/backstory
+    expect(parseTaskBlock(validBlock(bad))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects an invalid mode', () => {
+    const bad = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'delete',
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(bad))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a task id with non-slug characters (chatJid/IPC-key safety)', () => {
+    const bad = JSON.stringify([
+      {
+        id: '../escape',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(bad))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects duplicate task ids', () => {
+    const dup = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+      },
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(dup))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a cyclic contextFrom graph (would deterministically throw in dispatch)', () => {
+    const cyclic = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+        contextFrom: ['b'],
+      },
+      {
+        id: 'b',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+        contextFrom: ['a'],
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(cyclic))).toBe(MALFORMED_TASK_BLOCK);
+  });
+
+  it('rejects a dangling contextFrom dependency', () => {
+    const dangling = JSON.stringify([
+      {
+        id: 'a',
+        role: 'r',
+        goal: 'g',
+        backstory: '',
+        prompt: 'p',
+        mode: 'read',
+        contextFrom: ['nonexistent'],
+      },
+    ]);
+    expect(parseTaskBlock(validBlock(dangling))).toBe(MALFORMED_TASK_BLOCK);
+  });
+});
+
+describe('formatMultiAgentResult', () => {
+  const tasks: SubagentTask[] = [
+    { id: 'a', role: 'r', goal: 'g', backstory: '', prompt: 'p', mode: 'read' },
+    { id: 'b', role: 'r', goal: 'g', backstory: '', prompt: 'p', mode: 'read' },
+  ];
+
+  it('renders done tasks with their output', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        { status: 'DONE', output: 'answer A' },
+        { status: 'DONE', output: 'answer B' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('✓ a: done');
+    expect(out).toContain('answer A');
+    expect(out).toContain('answer B');
+  });
+
+  it('flags a DONE task with EMPTY output as a no-deliverable concern (artifact verification)', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        { status: 'DONE', output: '   ' }, // explicit DONE but no deliverable
+        { status: 'DONE', output: 'real output' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('⚠ a: produced no deliverable');
+    expect(out).toContain('produced no deliverable'); // also surfaced in concerns
+    expect(out).not.toContain('✓ a: done');
+  });
+
+  it('renders blocked tasks with their reason', () => {
+    const res: OrchestratorResult = {
+      status: 'partial',
+      results: [
+        { status: 'DONE', output: 'ok' },
+        { status: 'BLOCKED', output: '', blockedReason: 'missing creds' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('✗ b: blocked — missing creds');
+  });
+
+  it('surfaces orchestrator concerns', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        { status: 'DONE_WITH_CONCERNS', output: 'x', concerns: ['flaky'] },
+        { status: 'DONE', output: 'y' },
+      ],
+      concerns: ['flaky'],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('**Concerns:**');
+    expect(out).toContain('- flaky');
+  });
+});

--- a/src/multi-agent/message-bridge.test.ts
+++ b/src/multi-agent/message-bridge.test.ts
@@ -220,4 +220,40 @@ describe('formatMultiAgentResult', () => {
     expect(out).toContain('**Concerns:**');
     expect(out).toContain('- flaky');
   });
+
+  it('strips <internal>...</internal> reasoning before delivery (no leak on the multi-agent path)', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        {
+          status: 'DONE',
+          output: '<internal>secret plan</internal>Visible answer A',
+        },
+        { status: 'DONE', output: 'answer B' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('Visible answer A');
+    expect(out).not.toContain('secret plan');
+    expect(out).not.toContain('<internal>');
+  });
+
+  it('treats an internal-only output as no deliverable (nothing visible after stripping)', () => {
+    const res: OrchestratorResult = {
+      status: 'success',
+      results: [
+        {
+          status: 'DONE',
+          output: '<internal>only reasoning, no answer</internal>',
+        },
+        { status: 'DONE', output: 'real output' },
+      ],
+      concerns: [],
+    };
+    const out = formatMultiAgentResult(res, tasks);
+    expect(out).toContain('⚠ a: produced no deliverable');
+    expect(out).not.toContain('only reasoning');
+    expect(out).not.toContain('✓ a: done');
+  });
 });

--- a/src/multi-agent/message-bridge.ts
+++ b/src/multi-agent/message-bridge.ts
@@ -6,6 +6,7 @@
  *  - formatMultiAgentResult does deliverable-presence artifact verification: a DONE task
  *    with empty output renders as a concern, never a silent success.
  */
+import { stripInternalTags } from '../router.js';
 import type { OrchestratorResult, SubagentTask } from './types.js';
 
 /** Sentinel: a deus-tasks fence was present but could not be parsed/validated. */
@@ -115,12 +116,18 @@ export function formatMultiAgentResult(
   const lines: string[] = [];
   const concerns = [...res.concerns];
 
+  // Strip <internal>...</internal> reasoning before anything reaches the user —
+  // mirrors the single-agent outbound path (message-orchestrator.ts) so the
+  // multi-agent path cannot leak internal content. A task whose output is
+  // ENTIRELY internal then reads as "produced no deliverable".
+  const visible = res.results.map((r) => stripInternalTags(r.output));
+
   res.results.forEach((r, i) => {
     const task = tasks[i];
     const label = task?.id ?? `task-${i + 1}`;
     const noDeliverable =
       (r.status === 'DONE' || r.status === 'DONE_WITH_CONCERNS') &&
-      !r.output.trim();
+      !visible[i].trim();
 
     if (r.status === 'BLOCKED') {
       lines.push(
@@ -140,9 +147,9 @@ export function formatMultiAgentResult(
   const header = lines.join('\n');
 
   const outputs = res.results
-    .map((r, i) => ({ r, task: tasks[i] }))
-    .filter(({ r }) => r.status !== 'BLOCKED' && r.output.trim())
-    .map(({ r, task }) => `### ${task?.id ?? 'task'}\n${r.output.trim()}`)
+    .map((r, i) => ({ r, out: visible[i], task: tasks[i] }))
+    .filter(({ r, out }) => r.status !== 'BLOCKED' && out.trim())
+    .map(({ out, task }) => `### ${task?.id ?? 'task'}\n${out.trim()}`)
     .join('\n\n');
 
   const concernBlock = concerns.length

--- a/src/multi-agent/message-bridge.ts
+++ b/src/multi-agent/message-bridge.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure message-layer ↔ MultiAgentOrchestrator helpers (no I/O).
+ *  - parseTaskBlock returns SubagentTask[] | null | MALFORMED_TASK_BLOCK — null means
+ *    NO block (caller falls through to single-agent), MALFORMED means present-but-invalid
+ *    (caller surfaces a notice instead of silently dropping or re-feeding raw JSON).
+ *  - formatMultiAgentResult does deliverable-presence artifact verification: a DONE task
+ *    with empty output renders as a concern, never a silent success.
+ */
+import type { OrchestratorResult, SubagentTask } from './types.js';
+
+/** Sentinel: a deus-tasks fence was present but could not be parsed/validated. */
+export const MALFORMED_TASK_BLOCK = 'malformed' as const;
+
+const TASK_BLOCK_RE = /```deus-tasks\s*\n([\s\S]*?)```/;
+
+const VALID_MODES = new Set(['read', 'write']);
+
+function isValidTask(value: unknown): value is SubagentTask {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = value as Record<string, unknown>;
+  // id is a slug: it flows into chatJid / IPC keys downstream, so constrain the
+  // charset to close any path/key-injection surface before it can matter.
+  if (typeof t.id !== 'string' || !/^[A-Za-z0-9_-]+$/.test(t.id)) return false;
+  if (typeof t.role !== 'string' || !t.role.trim()) return false;
+  if (typeof t.goal !== 'string' || !t.goal.trim()) return false;
+  if (typeof t.prompt !== 'string' || !t.prompt.trim()) return false;
+  if (typeof t.mode !== 'string' || !VALID_MODES.has(t.mode)) return false;
+  if (typeof t.backstory !== 'string') return false; // required by type; empty allowed
+  if (t.contextFrom !== undefined) {
+    if (!Array.isArray(t.contextFrom)) return false;
+    if (!t.contextFrom.every((c) => typeof c === 'string')) return false;
+  }
+  return true;
+}
+
+/**
+ * Parse a single ```deus-tasks fenced JSON block into a validated SubagentTask[].
+ *
+ * Returns:
+ *  - SubagentTask[]        when a block is present and fully valid
+ *  - null                  when NO block is present (caller falls through to single-agent)
+ *  - MALFORMED_TASK_BLOCK  when a block IS present but invalid (caller surfaces a notice)
+ */
+export function parseTaskBlock(
+  prompt: string,
+): SubagentTask[] | null | typeof MALFORMED_TASK_BLOCK {
+  // Fast pre-check: skip the O(n) regex on the common no-block prompt.
+  if (!prompt.includes('deus-tasks')) return null;
+  const match = TASK_BLOCK_RE.exec(prompt);
+  if (!match) return null; // no block → single-agent path
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1].trim());
+  } catch {
+    return MALFORMED_TASK_BLOCK;
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0)
+    return MALFORMED_TASK_BLOCK;
+  if (!parsed.every(isValidTask)) return MALFORMED_TASK_BLOCK;
+
+  const tasks = parsed as SubagentTask[];
+
+  // Cross-reference validation: unique ids, and every contextFrom id resolves.
+  const ids = new Set<string>();
+  for (const t of tasks) {
+    if (ids.has(t.id)) return MALFORMED_TASK_BLOCK; // duplicate id
+    ids.add(t.id);
+  }
+  for (const t of tasks) {
+    for (const dep of t.contextFrom ?? []) {
+      if (!ids.has(dep)) return MALFORMED_TASK_BLOCK; // dangling dependency
+    }
+  }
+
+  // Reject cyclic contextFrom graphs. dispatch's topologicalSort would throw a
+  // deterministic UserError on a cycle; catching it here makes a cyclic block a
+  // parse-time MALFORMED notice (consumed) instead of an infinite dispatch-retry
+  // loop. DFS three-color cycle detection.
+  const adj = new Map(tasks.map((t) => [t.id, t.contextFrom ?? []]));
+  const color = new Map<string, 0 | 1 | 2>(); // 0=unvisited 1=visiting 2=done
+  const hasCycle = (id: string): boolean => {
+    const c = color.get(id) ?? 0;
+    if (c === 1) return true;
+    if (c === 2) return false;
+    color.set(id, 1);
+    for (const dep of adj.get(id) ?? []) {
+      if (hasCycle(dep)) return true;
+    }
+    color.set(id, 2);
+    return false;
+  };
+  for (const t of tasks) {
+    if (hasCycle(t.id)) return MALFORMED_TASK_BLOCK;
+  }
+
+  return tasks;
+}
+
+/**
+ * Render an OrchestratorResult into one user-facing reply.
+ *
+ * Artifact verification (deliverable presence): a task reporting DONE /
+ * DONE_WITH_CONCERNS but with empty output is shown as a concern ("produced no
+ * deliverable"), never a silent ✓.
+ *
+ * `results` are positionally aligned to `tasks` (orchestrator aggregation maps
+ * tasks.map(t => results.get(t.id))), so index i pairs task i with result i.
+ */
+export function formatMultiAgentResult(
+  res: OrchestratorResult,
+  tasks: SubagentTask[],
+): string {
+  const lines: string[] = [];
+  const concerns = [...res.concerns];
+
+  res.results.forEach((r, i) => {
+    const task = tasks[i];
+    const label = task?.id ?? `task-${i + 1}`;
+    const noDeliverable =
+      (r.status === 'DONE' || r.status === 'DONE_WITH_CONCERNS') &&
+      !r.output.trim();
+
+    if (r.status === 'BLOCKED') {
+      lines.push(
+        `✗ ${label}: blocked — ${r.blockedReason ?? 'no reason given'}`,
+      );
+    } else if (noDeliverable) {
+      // A claimed-DONE task that emitted nothing is surfaced, never a silent ✓.
+      lines.push(`⚠ ${label}: produced no deliverable`);
+      concerns.push(`${label}: produced no deliverable`);
+    } else if (r.status === 'DONE_WITH_CONCERNS') {
+      lines.push(`⚠ ${label}: done with concerns`);
+    } else {
+      lines.push(`✓ ${label}: done`);
+    }
+  });
+
+  const header = lines.join('\n');
+
+  const outputs = res.results
+    .map((r, i) => ({ r, task: tasks[i] }))
+    .filter(({ r }) => r.status !== 'BLOCKED' && r.output.trim())
+    .map(({ r, task }) => `### ${task?.id ?? 'task'}\n${r.output.trim()}`)
+    .join('\n\n');
+
+  const concernBlock = concerns.length
+    ? `\n\n**Concerns:**\n${concerns.map((c) => `- ${c}`).join('\n')}`
+    : '';
+
+  return [header, outputs].filter(Boolean).join('\n\n') + concernBlock;
+}

--- a/src/multi-agent/orchestrator.test.ts
+++ b/src/multi-agent/orchestrator.test.ts
@@ -18,6 +18,7 @@ import type { SubagentTask, OrchestratorResult } from './types.js';
 import { MultiAgentOrchestrator } from './orchestrator.js';
 import { UserError } from '../errors/index.js';
 import { writeFileSync } from 'fs';
+import { join } from 'path';
 import { resolveGroupIpcPath } from '../group-folder.js';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
@@ -157,11 +158,12 @@ describe('MultiAgentOrchestrator', () => {
         'multi-agent-task-x',
       );
       // The _close sentinel was written into that run's input dir.
-      const wrote = vi
-        .mocked(writeFileSync)
-        .mock.calls.some(
-          (c) => typeof c[0] === 'string' && c[0].endsWith('/input/_close'),
-        );
+      const wrote = vi.mocked(writeFileSync).mock.calls.some(
+        // Cross-platform: production code uses path.join, so the separator is
+        // '\' on Windows — assert against the joined suffix, not a literal '/'.
+        (c) =>
+          typeof c[0] === 'string' && c[0].endsWith(join('input', '_close')),
+      );
       expect(wrote).toBe(true);
     });
   });

--- a/src/multi-agent/orchestrator.test.ts
+++ b/src/multi-agent/orchestrator.test.ts
@@ -17,11 +17,25 @@ import type { RegisteredGroup } from '../types.js';
 import type { SubagentTask, OrchestratorResult } from './types.js';
 import { MultiAgentOrchestrator } from './orchestrator.js';
 import { UserError } from '../errors/index.js';
+import { writeFileSync } from 'fs';
+import { resolveGroupIpcPath } from '../group-folder.js';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock fs + IPC-path resolution so the one-shot `_close` sentinel write never
+// touches the real filesystem during tests.
+vi.mock('fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+vi.mock('../group-folder.js', () => ({
+  resolveGroupIpcPath: vi.fn(
+    (folder: string, key: string) => `/ipc/${folder}/${key}`,
+  ),
 }));
 
 // ── Test helpers ───────────────────────────────────────────────────────
@@ -125,6 +139,30 @@ describe('MultiAgentOrchestrator', () => {
       expect(result.results.every((r) => r.status === 'DONE')).toBe(true);
       // Runtime should have been called for each task
       expect(runtime.runTurn).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('one-shot _close sentinel', () => {
+    it('writes a per-task _close sentinel on turn_complete so the container exits promptly', async () => {
+      const runtime = createMockRuntime('Done. [STATUS:DONE]');
+      const registry = createMockRegistry(runtime);
+      const orchestrator = new MultiAgentOrchestrator(registry);
+      const group = makeGroup({ folder: 'grp' });
+
+      await orchestrator.dispatch([makeTask({ id: 'task-x' })], group);
+
+      // IPC namespace keyed per-task (slug id) to avoid sibling collisions.
+      expect(resolveGroupIpcPath).toHaveBeenCalledWith(
+        'grp',
+        'multi-agent-task-x',
+      );
+      // The _close sentinel was written into that run's input dir.
+      const wrote = vi
+        .mocked(writeFileSync)
+        .mock.calls.some(
+          (c) => typeof c[0] === 'string' && c[0].endsWith('/input/_close'),
+        );
+      expect(wrote).toBe(true);
     });
   });
 

--- a/src/multi-agent/orchestrator.ts
+++ b/src/multi-agent/orchestrator.ts
@@ -15,7 +15,11 @@ import type {
   RuntimeEvent,
   RuntimeEventSink,
 } from '../agent-runtimes/types.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { UserError } from '../errors/index.js';
+import { resolveGroupIpcPath } from '../group-folder.js';
 import { logger } from '../logger.js';
 import { buildPrompt } from './prompt-templates.js';
 import type { RegisteredGroup } from '../types.js';
@@ -269,12 +273,16 @@ export class MultiAgentOrchestrator {
     priorOutputs: Map<string, SubagentResult>,
   ): Promise<SubagentResult> {
     const prompt = buildPrompt(task, priorOutputs);
+    const chatJid = `multi-agent-${task.id}`;
     const runContext = {
       prompt,
       groupFolder: group.folder,
-      chatJid: `multi-agent-${task.id}`,
+      chatJid,
       isControlGroup: false,
       isScheduledTask: false,
+      // Per-task IPC namespace (slug-only id → safe, unique key) so concurrent
+      // sibling subagents don't collide on the one-shot `_close` sentinel.
+      ipcRunKey: chatJid,
     };
 
     const outputParts: string[] = [];
@@ -285,6 +293,22 @@ export class MultiAgentOrchestrator {
       }
       if (event.type === 'error') {
         throw new Error(event.error);
+      }
+      // One-shot: signal the container to exit after its first result. Without
+      // this the container idles until IDLE_TIMEOUT (~30s) before runTurn
+      // resolves (container-runner resolves on exit). Mirrors the single-agent
+      // path and linear-dispatcher.executeAgentRun. Best-effort.
+      if (event.type === 'turn_complete') {
+        try {
+          const inputDir = path.join(
+            resolveGroupIpcPath(group.folder, chatJid),
+            'input',
+          );
+          fs.mkdirSync(inputDir, { recursive: true });
+          fs.writeFileSync(path.join(inputDir, '_close'), '');
+        } catch {
+          /* best-effort — close sentinel is an optimization, not correctness */
+        }
       }
     };
 


### PR DESCRIPTION
## What

Wires the dormant `MultiAgentOrchestrator` into the live message loop behind `DEUS_MULTI_AGENT=1` (**OFF by default — zero behavior change when unset**), so a `deus-tasks` block reaches the orchestrator on **both cold and warm turns**.

This is PR1 of the LIA-127 redo. It closes **blocker #8** (warm-turn bypass) from the [re-scope comment](https://linear.app/liams-private-workspace/issue/LIA-127).

## Why

`MultiAgentOrchestrator` was built but unwired. Last session's attempt (PR #953, closed) wired only the cold path; the GPT co-gate surfaced 8 defects (7 fixed). The crux that remained: `startMessageLoop` pipes warm-container turns straight into the single-agent session, so a `deus-tasks` block on a warm turn never reached the orchestrator (which lives only in `processGroupMessages`).

## How

- **Cold path** (`processGroupMessages`): parse an authorized `deus-tasks` block → injection-scan the **decoded** task fields → dispatch via `MultiAgentOrchestrator` → rollback-only-on-pre-execution-throw / consume-on-return.
- **Warm path** (`startMessageLoop`, blocker #8): intercept a block **after the trigger gate** and before the pipe — `closeStdin` + `enqueueMessageCheck` route it to the single orchestrator-dispatch site. Mirrors the existing **session-command interception** precedent. A non-triggered block in a trigger-gated group just accumulates as context (matches the cold path's trigger-then-dispatch order).
- **Shared `eligibleSenderMessages()`** helper applies the same authorized-sender filter to both paths (an unauthorized sender's block never becomes executable).
- `message-bridge.ts`: `parseTaskBlock` (validation + unique-id/dangling-dep/cycle checks) and `formatMultiAgentResult` (deliverable-presence verification).
- Orchestrator one-shot: per-task `ipcRunKey` + `_close` sentinel on `turn_complete` (avoids the ~30s `IDLE_TIMEOUT` hang on real `ContainerRuntime`).

## Tests

Cold-path dispatch (valid / flag-off / injection-blocked / malformed / all-blocked / delivery-failure) + **5 new warm-path routing cases** (valid block, malformed block, ordinary message, flag-off, non-main trigger-gated-without-trigger). Test casts tightened to `as unknown as <T>` to stay under the eslint cap.

## Verification

`npx tsc --noEmit` = 0 · `eslint . --max-warnings 220` = 0 (132) · `npx vitest run` = 1921 passed · root + skills `tsc` emit = 0. Reviewed by the warden co-gate: plan-reviewer (claude+gpt), code-reviewer (claude+gpt+glm), verification-gate (Opus) — all SHIP.

## Out of scope

- **Blocker #9** — real-container E2E. Required before the flag is enabled, but unsafe from a worktree (collides with the live `com.deus` service). A separate controlled step.
- PR1c (Opus LLM planner that emits the block) and PR1d (checkpoint/resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)