### PR TITLE
feat(memory): local fallback chain for the procedure intent gate (LIA-342)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,20 @@ DEUS_VAULT_PATH=
 # Python binary for memory bridge (default: python3)
 # DEUS_PYTHON=python3
 
+# Procedure-memory recall + intent gate (opt-in; off by default).
+# Surface captured /learn-procedure nodes in recall (kill-switch = 0):
+# DEUS_PROCEDURE_MEMORY=0
+# Post-retrieval intent gate that drops a procedure from a FACTUAL query (LIA-337,
+# default on; 0 disables, keeping all surfaced procedures):
+# DEUS_PROCEDURE_INTENT_GATE=1
+# Ordered LOCAL classifier fallback chain, comma-separated (LIA-342, first that
+# answers wins; all-fail -> keep procedures):
+# DEUS_INTENT_MODELS=gemma4:e2b,gemma4:e4b
+# Legacy single-model override (back-compat; ignored when DEUS_INTENT_MODELS is set):
+# DEUS_INTENT_MODEL=gemma4:e2b
+# Intent-classify HTTP timeout in seconds (default 10):
+# DEUS_INTENT_TIMEOUT=10
+
 # === Integrations ===
 # Linear project management MCP (host-side Claude Code + container agents).
 # Generate at: Linear Settings → API → Personal API keys

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -138,7 +138,29 @@ ATOM_DIST_THRESHOLD = float(os.environ.get("DEUS_ATOM_DIST", "0"))
 # procedure candidate is actually present (post-retrieval), which bounds its
 # latency cost — most prompts never pay it.
 _INTENT_GATE_ENABLED = os.environ.get("DEUS_PROCEDURE_INTENT_GATE", "1").strip() != "0"  # LIA-337
-_INTENT_MODEL = os.environ.get("DEUS_INTENT_MODEL", "gemma4:e2b").strip() or "gemma4:e2b"  # LIA-337
+
+# LIA-342: ordered LOCAL fallback chain for intent classification. gemma4:e2b is
+# the validated primary; gemma4:e4b (the always-loaded entity/atom model) is the
+# fallback so a transient e2b outage does not silently disable the precision gate.
+# (Opus cloud tier is a separate follow-up — see LIA-342.)
+_DEFAULT_INTENT_MODELS = ("gemma4:e2b", "gemma4:e4b")
+
+
+def _intent_models() -> list[str]:
+    """Ordered local model chain (read at CALL time for test isolation).
+
+    DEUS_INTENT_MODELS (comma-separated) overrides; else the legacy single
+    DEUS_INTENT_MODEL (#957 back-compat) if set; else the e2b->e4b default pair.
+    """
+    raw = os.environ.get("DEUS_INTENT_MODELS", "").strip()  # LIA-342
+    if raw:
+        models = [m.strip() for m in raw.split(",") if m.strip()]
+        if models:
+            return models
+    legacy = os.environ.get("DEUS_INTENT_MODEL", "").strip()  # LIA-337 back-compat
+    if legacy:
+        return [legacy]
+    return list(_DEFAULT_INTENT_MODELS)
 
 _INTENT_PROMPT_TEMPLATE = (
     "You are an intent classifier. Decide whether the user's message is a request "
@@ -159,6 +181,20 @@ _INTENT_PROMPT_TEMPLATE = (
 )
 
 
+def _parse_intent(text: str | None) -> str | None:
+    """Parse a classifier's INNER JSON text into a validated label (LIA-342).
+
+    `text` is the model's own JSON string (e.g. '{"intent":"factual"}'). Strict
+    parse + label whitelist; any miss -> None (the caller's fail-safe keeps
+    procedures).
+    """
+    try:
+        intent = json.loads(text or "{}").get("intent")
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return None
+    return intent if intent in ("procedural", "factual") else None
+
+
 def _intent_timeout() -> float:
     """Resolve the intent-classify HTTP timeout (seconds), guarded against
     empty/non-numeric/non-positive env values (''/'abc'/'0' -> default 10)."""
@@ -170,15 +206,13 @@ def _intent_timeout() -> float:
     return v if v > 0 else 10.0
 
 
-def classify_intent(query: str) -> str | None:
-    """Classify a query as 'procedural' or 'factual' via a local Ollama model.
+def _classify_ollama(query: str, model: str) -> str | None:
+    """Classify a query as 'procedural'/'factual' via one local Ollama model.
 
-    Returns 'procedural', 'factual', or None when the classifier is unavailable
-    (Ollama down, timeout, non-200, unparseable body, or an unknown label). None
-    is the FAIL-SAFE signal: the caller keeps procedures surfacing (errs toward
-    recall — a dropped real procedure is worse than an occasional false-fire).
-    Mirrors the HTTP shape of memory_tree.generate_approach_angles. Monkey-patched
-    in tests.
+    Returns the label, or None when this model is unavailable (Ollama down,
+    timeout, non-200, unparseable body, or an unknown label) so the caller can
+    fall through to the next model in the chain. Mirrors the HTTP shape of
+    memory_tree.generate_approach_angles.
     """
     import http.client
     import json as _json
@@ -194,7 +228,7 @@ def classify_intent(query: str) -> str | None:
     # Neutralize the closing delimiter so a query can't escape the <user-query> frame.
     prompt = _INTENT_PROMPT_TEMPLATE.replace("__QUERY__", query.replace("</user-query>", " "))
     payload = _json.dumps({
-        "model": _INTENT_MODEL,
+        "model": model,
         "prompt": prompt,
         "format": "json",
         "stream": False,
@@ -210,15 +244,29 @@ def classify_intent(query: str) -> str | None:
         body = resp.read()
         conn.close()
         if resp.status != 200:
-            print(f"[deus] intent classify returned {resp.status}", file=sys.stderr)
+            print(f"[deus] intent classify ({model}) returned {resp.status}", file=sys.stderr)
             return None
         data = _json.loads(body)
-        parsed_resp = _json.loads(data.get("response", "") or "{}")
-        intent = parsed_resp.get("intent")
-        return intent if intent in ("procedural", "factual") else None
+        return _parse_intent(data.get("response", ""))  # unwrap Ollama envelope, then parse inner JSON
     except Exception as exc:
-        print(f"[deus] intent classify failed: {exc}", file=sys.stderr)
+        print(f"[deus] intent classify ({model}) failed: {exc}", file=sys.stderr)
         return None
+
+
+def classify_intent(query: str) -> str | None:
+    """Classify a query as 'procedural' or 'factual' via the local model chain.
+
+    Tries each model in _intent_models() in order (LIA-342: gemma4:e2b -> e4b by
+    default), returning the first successful classification. Returns None only
+    when EVERY tier is unavailable/unparseable — the FAIL-SAFE signal that makes
+    the caller keep procedures surfacing (a dropped real procedure is worse than
+    an occasional false-fire). Monkey-patched in tests.
+    """
+    for model in _intent_models():
+        verdict = _classify_ollama(query, model)
+        if verdict is not None:
+            return verdict
+    return None
 
 
 def _procedure_ids(db, result_ids: list[str]) -> set[str]:

--- a/scripts/tests/test_memory_query.py
+++ b/scripts/tests/test_memory_query.py
@@ -486,3 +486,98 @@ class TestIntentTimeout:
     def test_valid_override(self, monkeypatch):
         monkeypatch.setenv("DEUS_INTENT_TIMEOUT", "3.5")
         assert mq._intent_timeout() == 3.5
+
+
+class TestIntentModels:
+    """LIA-342: the ordered local model chain resolver."""
+
+    def test_default_pair(self, monkeypatch):
+        monkeypatch.delenv("DEUS_INTENT_MODELS", raising=False)
+        monkeypatch.delenv("DEUS_INTENT_MODEL", raising=False)
+        assert mq._intent_models() == ["gemma4:e2b", "gemma4:e4b"]
+
+    def test_models_env_override_and_strip(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_MODELS", "a, b , ,c")
+        assert mq._intent_models() == ["a", "b", "c"]
+
+    def test_legacy_single_model_backcompat(self, monkeypatch):
+        monkeypatch.delenv("DEUS_INTENT_MODELS", raising=False)
+        monkeypatch.setenv("DEUS_INTENT_MODEL", "foo:x")
+        assert mq._intent_models() == ["foo:x"]
+
+    def test_models_env_beats_legacy(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_MODELS", "p,q")
+        monkeypatch.setenv("DEUS_INTENT_MODEL", "ignored")
+        assert mq._intent_models() == ["p", "q"]
+
+    def test_blank_models_falls_through_to_default(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_MODELS", "  ,  ")
+        monkeypatch.delenv("DEUS_INTENT_MODEL", raising=False)
+        assert mq._intent_models() == ["gemma4:e2b", "gemma4:e4b"]
+
+
+class TestParseIntent:
+    """LIA-342: strict inner-JSON parse + label whitelist (shared by tiers)."""
+
+    def test_valid_factual(self):
+        assert mq._parse_intent('{"intent":"factual"}') == "factual"
+
+    def test_valid_procedural(self):
+        assert mq._parse_intent('{"intent":"procedural"}') == "procedural"
+
+    def test_unknown_label(self):
+        assert mq._parse_intent('{"intent":"banana"}') is None
+
+    def test_empty_and_none(self):
+        assert mq._parse_intent("") is None
+        assert mq._parse_intent(None) is None
+
+    def test_garbage(self):
+        assert mq._parse_intent("not json") is None
+
+
+class TestIntentChain:
+    """LIA-342: classify_intent walks the model chain, first hit wins, fail-safe None."""
+
+    def test_first_model_hit_skips_rest(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_MODELS", "m1,m2")
+        calls: list[str] = []
+
+        def fake(_query, model):
+            calls.append(model)
+            return "factual"
+
+        monkeypatch.setattr(mq, "_classify_ollama", fake)
+        assert mq.classify_intent("q") == "factual"
+        assert calls == ["m1"]  # m2 never tried
+
+    def test_falls_through_to_second(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_MODELS", "m1,m2")
+        calls: list[str] = []
+
+        def fake(_query, model):
+            calls.append(model)
+            return None if model == "m1" else "procedural"
+
+        monkeypatch.setattr(mq, "_classify_ollama", fake)
+        assert mq.classify_intent("q") == "procedural"
+        assert calls == ["m1", "m2"]
+
+    def test_all_fail_returns_none(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_MODELS", "m1,m2")
+        monkeypatch.setattr(mq, "_classify_ollama", lambda _q, _m: None)
+        assert mq.classify_intent("q") is None
+
+    def test_legacy_single_model_drives_chain(self, monkeypatch):
+        # End-to-end through classify_intent via the back-compat single-var path.
+        monkeypatch.delenv("DEUS_INTENT_MODELS", raising=False)
+        monkeypatch.setenv("DEUS_INTENT_MODEL", "m1")
+        calls: list[str] = []
+
+        def fake(_query, model):
+            calls.append(model)
+            return "factual"
+
+        monkeypatch.setattr(mq, "_classify_ollama", fake)
+        assert mq.classify_intent("q") == "factual"
+        assert calls == ["m1"]


### PR DESCRIPTION
## What

Adds an ordered **local fallback chain** `gemma4:e2b → gemma4:e4b` to the procedure-memory intent classifier (`scripts/memory_query.py`).

## Why

The intent gate (LIA-337, #957) used a single local model and returned `None` on **any** failure. Since `None` is the fail-safe (caller keeps procedures), a transient `gemma4:e2b` outage **silently disabled the precision gate** — every near-domain factual query would surface its procedure again. This adds a fallback: if e2b is unavailable, fall through to `gemma4:e4b` (already the always-loaded entity/atom model, ~free) before failing open.

## How

- `_intent_models()` — ordered chain from `DEUS_INTENT_MODELS` (default `gemma4:e2b,gemma4:e4b`); back-compat with the legacy single `DEUS_INTENT_MODEL`; read at call time.
- `_classify_ollama(query, model)` — the #957 `classify_intent` body, parameterized by model (keeps the `<user-query>` injection-hardening, `think:false`, temp 0 verbatim).
- `_parse_intent(text)` — shared strict inner-JSON parse + label whitelist.
- `classify_intent(query)` — walks the chain, first non-`None` wins, else `None`. **Fail-safe preserved at every tier** → caller keeps procedures (errs toward recall).
- Removed the now-dead `_INTENT_MODEL` constant; documented the env block in `.env.example`.

## Scope

Flag stays **opt-in** (`DEUS_PROCEDURE_MEMORY` off by default) — no default flip. The **Opus cloud tier is a deferred follow-up (LIA-342 PR-B)**: its transport needs host-side credential-proxy auth (the proxy 401s host calls without a per-container group token — `credential-proxy.ts:254-262`) plus an `anthropic-version` header; both verified and split out.

## Verification

- **67 tests pass** (`scripts/tests/test_memory_query.py` + `test_memory_retrieval_hook.py`); #957's `TestClassifyIntent` stays green.
- `flag_lint` green (`DEUS_INTENT_MODELS` documented).
- **Live smoke:** default chain classifies procedural/factual correctly; bogus primary (404) falls through to e4b and still classifies; all-bogus → `None` (procedures kept).

Co-gate: plan-reviewer, code-reviewer (claude+gpt+glm), ai-eng-warden (claude+gpt) — all SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)