### PR TITLE
feat(scripts): add session-collision preflight detector (LIA-284)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: python3 scripts/drift_check.py --all --base origin/${{ github.base_ref }}
 
       - name: Pattern tests (Python)
-        run: python3 -m pytest scripts/tests/test_drift_check.py scripts/tests/test_prune_warden_backups.py -v
+        run: python3 -m pytest scripts/tests/test_drift_check.py scripts/tests/test_prune_warden_backups.py scripts/tests/test_session_preflight.py -v
 
       - name: Warden review tests
         # Regression-protect the provider-agnostic warden co-gate engine: the gpt +

--- a/docs/decisions/printing-press-adoption.md
+++ b/docs/decisions/printing-press-adoption.md
@@ -38,6 +38,7 @@ The [cli-printing-press](https://github.com/mvanhorn/cli-printing-press) project
 | NOT_FOUND | 3 | UserError | Surface to user |
 | AUTH_ERROR | 4 | FatalError | Log + stop |
 | INTERNAL_ERROR | 5 | FatalError | Log + stop |
+| CONFLICT | 6 | (CLI-only) | Stop before write / re-check state |
 
 ### Phase 2: Host-Side Tool Proxy (future)
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-27" # auto-bump @1782574645
+last_verified: "2026-06-27" # auto-bump @1782578920
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/_exit_codes.py
+++ b/scripts/_exit_codes.py
@@ -4,6 +4,8 @@ Cross-references docs/decisions/error-discipline.md (TS four-class taxonomy):
   UserError  -> USAGE_ERROR(2), NOT_FOUND(3)
   FatalError -> AUTH_ERROR(4), INTERNAL_ERROR(5)
   ABSTAIN(1) is CLI-specific: "no result, not an error" -- no TS equivalent.
+  CONFLICT(6) is CLI-specific: "a precondition collided with concurrent state"
+    (e.g. another session already owns this checkout) -- no TS equivalent, like ABSTAIN.
 """
 
 SUCCESS = 0
@@ -12,4 +14,5 @@ USAGE_ERROR = 2
 NOT_FOUND = 3
 AUTH_ERROR = 4
 INTERNAL_ERROR = 5
+CONFLICT = 6
 RATE_LIMIT = 7

--- a/scripts/session_preflight.py
+++ b/scripts/session_preflight.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Read-only preflight: detect whether another session is already working this
+git checkout before you start writing to it (LIA-284, multi-session parallelism).
+
+Four probes against the current repo:
+  1. Another live Claude session on the same working tree   -> CRITICAL
+  2. The current branch checked out in another worktree     -> CRITICAL
+  3. An open PR already targeting the current branch         -> WARNING
+  4. Uncommitted files modified within the recency window    -> WARNING
+
+Any CRITICAL finding exits CONFLICT(6) so a caller/hook can stop before the first
+write; WARNING-only findings are advisory and exit SUCCESS(0).
+
+Agent-native protocol (docs/decisions/printing-press-adoption.md): --json / --compact
+/ --select, and DEUS_AGENT_NATIVE=1 auto-enables JSON.
+
+Cross-platform: liveness uses session ``updatedAt`` freshness (portable) plus, on POSIX,
+``os.kill(pid, 0)`` to confirm the pid is alive. On non-POSIX the pid check is skipped
+(liveness = updatedAt-only, slightly weaker, no functional loss). Self-exclusion uses
+``os.getpid()`` / ``os.getppid()`` (stdlib, identical on every platform) plus
+--self / --self-pid / CLAUDE_SESSION_ID -- deliberately NO /proc or sysctl ancestor walk
+(those are Linux-only / macOS-only and not portable).
+
+Design: a table-driven probe pipeline. Each probe is a pure function
+``probe(ctx) -> list[Finding]``; ``main()`` resolves the Context once, runs every probe,
+and maps the highest severity to the exit code. No GoF pattern applies at this scale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _exit_codes import (  # noqa: E402
+    CONFLICT,
+    INTERNAL_ERROR,
+    SUCCESS,
+    USAGE_ERROR,
+)
+from _agent_io import agent_output, is_agent_context  # noqa: E402
+
+DEFAULT_WINDOW_MIN = 30
+GIT_TIMEOUT = 10
+GH_TIMEOUT = 15
+
+CRITICAL = "CRITICAL"
+WARNING = "WARNING"
+
+
+class _UsageError(Exception):
+    """Caller-fixable precondition failure (e.g. not a git repo)."""
+
+
+@dataclass
+class Finding:
+    severity: str
+    code: str
+    detail: str
+
+    def as_dict(self) -> dict:
+        return {"severity": self.severity, "code": self.code, "detail": self.detail}
+
+
+@dataclass
+class Context:
+    toplevel: str
+    branch: str | None
+    window_min: int
+    self_session_ids: set[str]
+    self_pids: set[int]
+    now_ms: int
+
+
+# --------------------------------------------------------------------------- #
+# helpers (module-level so tests can monkeypatch them)
+# --------------------------------------------------------------------------- #
+def _run_git(args: list[str], cwd: str | None = None, timeout: int = GIT_TIMEOUT):
+    """Run a git command; return (returncode, stdout, stderr). Never raises."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except (OSError, ValueError, subprocess.SubprocessError):
+        # ValueError covers an embedded null byte in cwd (from a malformed session
+        # file's cwd field) -> treat as a failed probe and skip, never crash main().
+        return 1, "", "git invocation failed"
+
+
+def _git_toplevel(path: str) -> str | None:
+    rc, out, _ = _run_git(["rev-parse", "--show-toplevel"], cwd=path)
+    if rc != 0:
+        return None
+    top = out.strip()
+    return os.path.realpath(top) if top else None
+
+
+def _pid_alive(pid: int) -> bool:
+    """POSIX: os.kill(pid, 0). Non-POSIX: unknown -> assume alive (updatedAt gates)."""
+    if os.name != "posix":
+        return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # process exists, owned by another user
+    except OSError:
+        return True
+
+
+def _sessions_dir():
+    # The live session REGISTRY: ~/.claude/sessions/<pid>.json carries pid, cwd,
+    # status (busy/idle) and updatedAt, and the file is rewritten as a heartbeat
+    # while the session is alive. This is the liveness source -- NOT
+    # ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl, which are append-only
+    # conversation transcripts with no pid/cwd/liveness signal.
+    return os.path.join(os.path.expanduser("~"), ".claude", "sessions")
+
+
+def _load_sessions():
+    """Yield session dicts from ~/.claude/sessions/*.json; skip unreadable/malformed.
+
+    Each yielded dict gets a synthetic ``_mtime_ms`` (file mtime in ms): the JSON
+    ``updatedAt`` field only advances on a status transition and can lag many minutes
+    behind a long-busy session, whereas the file is rewritten as a heartbeat. Liveness
+    uses the fresher of the two so a busy session is not mistaken for abandoned.
+    """
+    d = _sessions_dir()
+    if not os.path.isdir(d):
+        return
+    for name in sorted(os.listdir(d)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(d, name)
+        try:
+            with open(path, encoding="utf-8") as fh:
+                data = json.load(fh)
+            mtime_ms = int(os.path.getmtime(path) * 1000)
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict):
+            data["_mtime_ms"] = mtime_ms
+            yield data
+
+
+def _resolve_window_min(cli_value: int | None) -> int:
+    """CLI flag wins; else env DEUS_PREFLIGHT_WINDOW_MIN (LIA-284); else default.
+
+    Guarded parse: non-int / <= 0 falls back to the default (mirrors the
+    ``Number.isFinite(n) && n > 0`` discipline for env-derived numbers).
+    """
+    if cli_value is not None and cli_value > 0:
+        return cli_value
+    raw = os.environ.get("DEUS_PREFLIGHT_WINDOW_MIN")  # LIA-284: multi-session preflight window
+    if raw:
+        try:
+            n = int(raw)
+        except ValueError:
+            n = 0
+        if n > 0:
+            return n
+    return DEFAULT_WINDOW_MIN
+
+
+# --------------------------------------------------------------------------- #
+# probes
+# --------------------------------------------------------------------------- #
+def probe_live_session_same_tree(ctx: Context) -> list[Finding]:
+    """A live session whose cwd resolves to this same working tree."""
+    findings: list[Finding] = []
+    window_ms = ctx.window_min * 60 * 1000
+    for s in _load_sessions():
+        sid = s.get("sessionId")
+        pid = s.get("pid")
+        cwd = s.get("cwd")
+        updated = s.get("updatedAt")
+        if not cwd or not isinstance(updated, int):
+            continue
+        if sid and sid in ctx.self_session_ids:
+            continue
+        if isinstance(pid, int) and pid in ctx.self_pids:
+            continue
+        if _git_toplevel(cwd) != ctx.toplevel:
+            continue
+        # Freshness = the more recent of the status timestamp and the heartbeat mtime
+        # (updatedAt lags a long-busy session; the file rewrite does not).
+        mtime_ms = s.get("_mtime_ms", 0)
+        last_active = updated if updated >= mtime_ms else mtime_ms
+        age_ms = ctx.now_ms - last_active
+        if age_ms > window_ms:
+            continue
+        if isinstance(pid, int) and not _pid_alive(pid):
+            continue
+        age_s = max(0, age_ms // 1000)
+        sid_disp = (sid or "?")[:8]
+        findings.append(
+            Finding(
+                CRITICAL,
+                "live_session_same_tree",
+                f"session {sid_disp} (pid {pid}) live on this tree, updated {age_s}s ago",
+            )
+        )
+    return findings
+
+
+def probe_branch_in_another_worktree(ctx: Context) -> list[Finding]:
+    """The current branch is checked out in a worktree other than this one."""
+    if not ctx.branch:
+        return []
+    rc, out, _ = _run_git(["worktree", "list", "--porcelain"], cwd=ctx.toplevel)
+    if rc != 0:
+        return []
+    findings: list[Finding] = []
+    path: str | None = None
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree ") :]
+        elif line.startswith("branch "):
+            ref = line[len("branch ") :]
+            branch = ref[len("refs/heads/") :] if ref.startswith("refs/heads/") else ref
+            if path and branch == ctx.branch:
+                rp = os.path.realpath(path)
+                if rp != ctx.toplevel:
+                    findings.append(
+                        Finding(
+                            CRITICAL,
+                            "branch_in_other_worktree",
+                            f"branch '{ctx.branch}' is checked out at {rp}",
+                        )
+                    )
+        elif line == "":
+            path = None
+    return findings
+
+
+def probe_open_pr_for_branch(ctx: Context) -> list[Finding]:
+    """An open PR already has this branch as its head (best-effort; gh optional)."""
+    if not ctx.branch:
+        return []
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "list", "--head", ctx.branch, "--state", "open", "--json", "number,title"],
+            cwd=ctx.toplevel,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []  # gh absent / timeout -> advisory probe, skip silently
+    if proc.returncode != 0:
+        return []
+    try:
+        prs = json.loads(proc.stdout or "[]")
+    except ValueError:
+        return []
+    findings: list[Finding] = []
+    for pr in prs if isinstance(prs, list) else []:
+        title = str(pr.get("title", ""))[:60]
+        findings.append(
+            Finding(
+                WARNING,
+                "open_pr_for_branch",
+                f"PR #{pr.get('number')} already targets '{ctx.branch}': {title}",
+            )
+        )
+    return findings
+
+
+def probe_recent_uncommitted(ctx: Context) -> list[Finding]:
+    """Uncommitted files modified within the window (someone may be editing now).
+
+    mtime-based, so it intentionally over-reports: ``git checkout -- <f>``, ``touch``,
+    or a rebuild that rewrites a file all bump mtime without a human edit. That is why
+    this is a WARNING (advisory, exit 0), never a CRITICAL.
+    """
+    rc, out, _ = _run_git(["status", "--porcelain"], cwd=ctx.toplevel)
+    if rc != 0:
+        return []
+    window_s = ctx.window_min * 60
+    now_s = ctx.now_ms / 1000
+    recent: list[str] = []
+    for line in out.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if " -> " in path:  # rename: "old -> new"
+            path = path.split(" -> ", 1)[1]
+        path = path.strip().strip('"')
+        full = os.path.join(ctx.toplevel, path)
+        try:
+            mtime = os.path.getmtime(full)
+        except OSError:
+            continue
+        if now_s - mtime <= window_s:
+            recent.append(path)
+    if not recent:
+        return []
+    sample = ", ".join(recent[:3])
+    more = f" (+{len(recent) - 3} more)" if len(recent) > 3 else ""
+    return [
+        Finding(
+            WARNING,
+            "recent_uncommitted_edits",
+            f"{len(recent)} uncommitted file(s) modified within {ctx.window_min}m: {sample}{more}",
+        )
+    ]
+
+
+PROBES = [
+    probe_live_session_same_tree,
+    probe_branch_in_another_worktree,
+    probe_open_pr_for_branch,
+    probe_recent_uncommitted,
+]
+
+
+# --------------------------------------------------------------------------- #
+# orchestration
+# --------------------------------------------------------------------------- #
+def _build_context(args) -> Context:
+    cwd = os.getcwd()
+    toplevel = _git_toplevel(cwd)
+    if toplevel is None:
+        raise _UsageError("not inside a git repository")
+    rc, out, _ = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=toplevel)
+    branch = out.strip() if rc == 0 else None
+    if branch in ("", "HEAD"):
+        branch = None  # detached HEAD -> branch probes are no-ops
+    self_ids: set[str] = set()
+    if args.self:
+        self_ids.add(args.self)
+    env_sid = os.environ.get("CLAUDE_SESSION_ID")
+    if env_sid:
+        self_ids.add(env_sid)
+    self_pids = {os.getpid(), os.getppid()}
+    if args.self_pid:
+        self_pids.add(args.self_pid)
+    return Context(
+        toplevel=toplevel,
+        branch=branch,
+        window_min=_resolve_window_min(args.window_min),
+        self_session_ids=self_ids,
+        self_pids=self_pids,
+        now_ms=int(time.time() * 1000),
+    )
+
+
+def _render_human(status: str, exit_code: int, findings: list[Finding]) -> str:
+    lines = [f"{f.severity}  {f.code}  {f.detail}" for f in findings]
+    if status == "CONFLICT":
+        lines.append(f"CONFLICT: another session may be working this tree (exit {exit_code})")
+    elif findings:
+        lines.append(f"OK with warnings: no blocking collision (exit {exit_code})")
+    else:
+        lines.append(f"OK: no concurrent-session collision detected (exit {exit_code})")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="session_preflight.py",
+        description="Detect concurrent-session collisions before writing to a checkout.",
+    )
+    parser.add_argument(
+        "--window-min",
+        type=int,
+        default=None,
+        help=f"Recency/liveness window in minutes (default {DEFAULT_WINDOW_MIN}; "
+        "env DEUS_PREFLIGHT_WINDOW_MIN)",
+    )
+    parser.add_argument(
+        "--self", dest="self", default=None, help="This session's sessionId, excluded from checks"
+    )
+    parser.add_argument(
+        "--self-pid", type=int, default=None, help="This session's pid, excluded from checks"
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output")
+    parser.add_argument("--compact", action="store_true", help="Compact JSON (strip nulls)")
+    parser.add_argument("--select", default=None, help="Comma-separated field projection")
+    args = parser.parse_args(argv)
+
+    use_json = args.json or is_agent_context()
+
+    try:
+        ctx = _build_context(args)
+    except _UsageError as exc:
+        if use_json:
+            print(json.dumps({"status": "ERROR", "exit_code": USAGE_ERROR, "error": str(exc)}))
+        else:
+            print(f"USAGE: {exc}", file=sys.stderr)
+        return USAGE_ERROR
+
+    try:
+        findings: list[Finding] = []
+        for probe in PROBES:
+            findings.extend(probe(ctx))
+    except Exception as exc:  # pragma: no cover - defensive last resort
+        print(f"INTERNAL: {exc}", file=sys.stderr)
+        return INTERNAL_ERROR
+
+    has_critical = any(f.severity == CRITICAL for f in findings)
+    exit_code = CONFLICT if has_critical else SUCCESS
+    status = "CONFLICT" if has_critical else ("WARN" if findings else "OK")
+
+    payload = {
+        "status": status,
+        "exit_code": exit_code,
+        "toplevel": ctx.toplevel,
+        "branch": ctx.branch,
+        "findings": [f.as_dict() for f in findings],
+    }
+
+    out = agent_output(payload, use_json=use_json, compact=args.compact, select=args.select)
+    print(out if out is not None else _render_human(status, exit_code, findings))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_session_preflight.py
+++ b/scripts/tests/test_session_preflight.py
@@ -1,0 +1,309 @@
+"""Tests for scripts/session_preflight.py — the concurrent-session collision detector.
+
+Each probe is a pure function over a Context, so the probe matrix is exercised by
+building a Context and monkeypatching the module-level git/session/pid helpers. The
+exit-code contract and agent-native output are exercised through ``main()``.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import session_preflight as sp  # noqa: E402
+from _exit_codes import CONFLICT, SUCCESS, USAGE_ERROR  # noqa: E402
+
+TOP = "/repo/top"
+NOW_MS = 1_000_000_000_000
+
+
+def _ctx(**over):
+    base = dict(
+        toplevel=TOP,
+        branch="feat/x",
+        window_min=30,
+        self_session_ids=set(),
+        self_pids=set(),
+        now_ms=NOW_MS,
+    )
+    base.update(over)
+    return sp.Context(**base)
+
+
+def _session(**over):
+    s = dict(sessionId="other-sid", pid=4242, cwd="/repo/top", updatedAt=NOW_MS - 1000)
+    s.update(over)
+    return s
+
+
+# ── _resolve_window_min ──────────────────────────────────────────────────────
+class TestResolveWindow:
+    def test_cli_value_wins(self, monkeypatch):
+        monkeypatch.setenv("DEUS_PREFLIGHT_WINDOW_MIN", "99")
+        assert sp._resolve_window_min(5) == 5
+
+    def test_env_used_when_no_cli(self, monkeypatch):
+        monkeypatch.setenv("DEUS_PREFLIGHT_WINDOW_MIN", "45")
+        assert sp._resolve_window_min(None) == 45
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-3", ""])
+    def test_bad_env_falls_back_to_default(self, monkeypatch, bad):
+        monkeypatch.setenv("DEUS_PREFLIGHT_WINDOW_MIN", bad)
+        assert sp._resolve_window_min(None) == sp.DEFAULT_WINDOW_MIN
+
+    def test_no_env_default(self, monkeypatch):
+        monkeypatch.delenv("DEUS_PREFLIGHT_WINDOW_MIN", raising=False)
+        assert sp._resolve_window_min(None) == sp.DEFAULT_WINDOW_MIN
+
+    def test_nonpositive_cli_ignored(self, monkeypatch):
+        monkeypatch.delenv("DEUS_PREFLIGHT_WINDOW_MIN", raising=False)
+        assert sp._resolve_window_min(0) == sp.DEFAULT_WINDOW_MIN
+
+
+# ── _run_git resilience ──────────────────────────────────────────────────────
+class TestRunGitResilience:
+    @pytest.mark.parametrize("exc", [OSError("boom"), ValueError("embedded null byte")])
+    def test_tolerates_subprocess_errors(self, monkeypatch, exc):
+        def raise_it(*a, **k):
+            raise exc
+
+        monkeypatch.setattr(sp.subprocess, "run", raise_it)
+        rc, out, err = sp._run_git(["status"])
+        assert rc == 1 and out == ""
+
+
+# ── probe_live_session_same_tree ─────────────────────────────────────────────
+class TestProbeLiveSession:
+    def _patch(self, monkeypatch, sessions, top_map=None, alive=True):
+        monkeypatch.setattr(sp, "_load_sessions", lambda: iter(sessions))
+        monkeypatch.setattr(sp, "_git_toplevel", lambda cwd: (top_map or {}).get(cwd, cwd))
+        monkeypatch.setattr(sp, "_pid_alive", lambda pid: alive)
+
+    def test_live_same_tree_is_critical(self, monkeypatch):
+        self._patch(monkeypatch, [_session()])
+        out = sp.probe_live_session_same_tree(_ctx())
+        assert len(out) == 1
+        assert out[0].severity == sp.CRITICAL
+        assert out[0].code == "live_session_same_tree"
+
+    def test_stale_session_ignored(self, monkeypatch):
+        old = _session(updatedAt=NOW_MS - 31 * 60 * 1000)  # outside 30m window
+        self._patch(monkeypatch, [old])
+        assert sp.probe_live_session_same_tree(_ctx()) == []
+
+    def test_dead_pid_ignored(self, monkeypatch):
+        self._patch(monkeypatch, [_session()], alive=False)
+        assert sp.probe_live_session_same_tree(_ctx()) == []
+
+    def test_stale_updatedat_but_fresh_heartbeat_is_live(self, monkeypatch):
+        # updatedAt is 40m old (outside the 30m window) but the file heartbeat mtime
+        # is recent -> a long-busy session must still be detected.
+        s = _session(updatedAt=NOW_MS - 40 * 60 * 1000)
+        s["_mtime_ms"] = NOW_MS - 5000
+        self._patch(monkeypatch, [s])
+        out = sp.probe_live_session_same_tree(_ctx())
+        assert len(out) == 1 and out[0].severity == sp.CRITICAL
+
+    def test_stale_both_timestamps_ignored(self, monkeypatch):
+        s = _session(updatedAt=NOW_MS - 40 * 60 * 1000)
+        s["_mtime_ms"] = NOW_MS - 40 * 60 * 1000
+        self._patch(monkeypatch, [s])
+        assert sp.probe_live_session_same_tree(_ctx()) == []
+
+    def test_different_tree_ignored(self, monkeypatch):
+        s = _session(cwd="/other/tree")
+        self._patch(monkeypatch, [s], top_map={"/other/tree": "/other/tree"})
+        assert sp.probe_live_session_same_tree(_ctx()) == []
+
+    def test_self_excluded_by_session_id(self, monkeypatch):
+        self._patch(monkeypatch, [_session(sessionId="me")])
+        assert sp.probe_live_session_same_tree(_ctx(self_session_ids={"me"})) == []
+
+    def test_self_excluded_by_pid(self, monkeypatch):
+        self._patch(monkeypatch, [_session(pid=777)])
+        assert sp.probe_live_session_same_tree(_ctx(self_pids={777})) == []
+
+    def test_missing_keys_skipped(self, monkeypatch):
+        self._patch(monkeypatch, [{"sessionId": "x"}, {"cwd": "/repo/top"}])  # no cwd / no updatedAt
+        assert sp.probe_live_session_same_tree(_ctx()) == []
+
+
+# ── probe_branch_in_another_worktree ─────────────────────────────────────────
+class TestProbeBranchWorktree:
+    def _porcelain(self, *blocks):
+        return 0, "\n\n".join(blocks) + "\n", ""
+
+    def test_branch_in_other_worktree_is_critical(self, monkeypatch):
+        out_txt = self._porcelain(
+            f"worktree {TOP}\nbranch refs/heads/main",
+            "worktree /repo/wt2\nbranch refs/heads/feat/x",
+        )
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: out_txt)
+        out = sp.probe_branch_in_another_worktree(_ctx())
+        assert len(out) == 1
+        assert out[0].code == "branch_in_other_worktree"
+        assert "/repo/wt2" in out[0].detail
+
+    def test_branch_only_in_current_top_not_flagged(self, monkeypatch):
+        out_txt = self._porcelain(f"worktree {TOP}\nbranch refs/heads/feat/x")
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: out_txt)
+        assert sp.probe_branch_in_another_worktree(_ctx()) == []
+
+    def test_detached_head_noop(self, monkeypatch):
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: (_ for _ in ()).throw(AssertionError("git should not run")))
+        assert sp.probe_branch_in_another_worktree(_ctx(branch=None)) == []
+
+    def test_git_failure_yields_nothing(self, monkeypatch):
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: (1, "", "boom"))
+        assert sp.probe_branch_in_another_worktree(_ctx()) == []
+
+
+# ── probe_open_pr_for_branch ─────────────────────────────────────────────────
+class TestProbeOpenPr:
+    def _patch_gh(self, monkeypatch, returncode=0, stdout="[]", raises=None):
+        class _Proc:
+            def __init__(self):
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = ""
+
+        def fake_run(*a, **k):
+            if raises:
+                raise raises
+            return _Proc()
+
+        monkeypatch.setattr(sp.subprocess, "run", fake_run)
+
+    def test_open_pr_is_warning(self, monkeypatch):
+        self._patch_gh(monkeypatch, stdout=json.dumps([{"number": 5, "title": "wip"}]))
+        out = sp.probe_open_pr_for_branch(_ctx())
+        assert len(out) == 1
+        assert out[0].severity == sp.WARNING
+        assert "#5" in out[0].detail
+
+    def test_gh_missing_skipped(self, monkeypatch):
+        self._patch_gh(monkeypatch, raises=FileNotFoundError("gh"))
+        assert sp.probe_open_pr_for_branch(_ctx()) == []
+
+    def test_no_prs_no_findings(self, monkeypatch):
+        self._patch_gh(monkeypatch, stdout="[]")
+        assert sp.probe_open_pr_for_branch(_ctx()) == []
+
+    def test_detached_head_noop(self, monkeypatch):
+        # gh must not even run when branch is None
+        monkeypatch.setattr(sp.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(AssertionError()))
+        assert sp.probe_open_pr_for_branch(_ctx(branch=None)) == []
+
+
+# ── probe_recent_uncommitted ─────────────────────────────────────────────────
+class TestProbeUncommitted:
+    def test_recent_edit_is_warning(self, monkeypatch, tmp_path):
+        f = tmp_path / "a.txt"
+        f.write_text("x")
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: (0, " M a.txt\n", ""))
+        out = sp.probe_recent_uncommitted(_ctx(toplevel=str(tmp_path)))
+        assert len(out) == 1
+        assert out[0].code == "recent_uncommitted_edits"
+
+    def test_old_edit_not_flagged(self, monkeypatch, tmp_path):
+        f = tmp_path / "a.txt"
+        f.write_text("x")
+        old = (NOW_MS / 1000) - 31 * 60  # 31 min old, window 30
+        os.utime(f, (old, old))
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: (0, " M a.txt\n", ""))
+        assert sp.probe_recent_uncommitted(_ctx(toplevel=str(tmp_path))) == []
+
+    def test_rename_uses_new_path(self, monkeypatch, tmp_path):
+        f = tmp_path / "new.txt"
+        f.write_text("x")
+        monkeypatch.setattr(sp, "_run_git", lambda *a, **k: (0, 'R  old.txt -> new.txt\n', ""))
+        out = sp.probe_recent_uncommitted(_ctx(toplevel=str(tmp_path)))
+        assert len(out) == 1
+
+
+# ── _pid_alive cross-platform ────────────────────────────────────────────────
+class TestPidAliveCrossPlatform:
+    def test_non_posix_assumes_alive(self, monkeypatch):
+        monkeypatch.setattr(sp.os, "name", "nt")
+        called = {"k": False}
+
+        def boom(*a):
+            called["k"] = True
+            raise AssertionError("os.kill must not run on non-posix")
+
+        monkeypatch.setattr(sp.os, "kill", boom)
+        assert sp._pid_alive(123456) is True
+        assert called["k"] is False
+
+    def test_posix_dead_pid(self, monkeypatch):
+        monkeypatch.setattr(sp.os, "name", "posix")
+
+        def raise_lookup(pid, sig):
+            raise ProcessLookupError()
+
+        monkeypatch.setattr(sp.os, "kill", raise_lookup)
+        assert sp._pid_alive(999999) is False
+
+    def test_posix_permission_error_means_alive(self, monkeypatch):
+        monkeypatch.setattr(sp.os, "name", "posix")
+
+        def raise_perm(pid, sig):
+            raise PermissionError()
+
+        monkeypatch.setattr(sp.os, "kill", raise_perm)
+        assert sp._pid_alive(1) is True
+
+
+# ── exit-code contract + agent-native output via main() ──────────────────────
+class TestMainContract:
+    def _patch_main(self, monkeypatch, findings):
+        monkeypatch.setattr(sp, "_build_context", lambda args: _ctx())
+        monkeypatch.setattr(sp, "PROBES", [lambda ctx: list(findings)])
+
+    def test_critical_exits_conflict(self, monkeypatch, capsys):
+        self._patch_main(monkeypatch, [sp.Finding(sp.CRITICAL, "c", "d")])
+        assert sp.main(["--json"]) == CONFLICT
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "CONFLICT"
+        assert payload["exit_code"] == CONFLICT
+
+    def test_warning_only_exits_success(self, monkeypatch, capsys):
+        self._patch_main(monkeypatch, [sp.Finding(sp.WARNING, "w", "d")])
+        assert sp.main(["--json"]) == SUCCESS
+        assert json.loads(capsys.readouterr().out)["status"] == "WARN"
+
+    def test_clean_exits_success(self, monkeypatch, capsys):
+        self._patch_main(monkeypatch, [])
+        assert sp.main(["--json"]) == SUCCESS
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "OK"
+        assert out["findings"] == []
+
+    def test_not_a_repo_is_usage_error(self, monkeypatch, capsys):
+        monkeypatch.setattr(sp, "_git_toplevel", lambda path: None)
+        monkeypatch.setenv("DEUS_AGENT_NATIVE", "0")
+        assert sp.main([]) == USAGE_ERROR
+
+    def test_agent_native_auto_json(self, monkeypatch, capsys):
+        self._patch_main(monkeypatch, [])
+        monkeypatch.setenv("DEUS_AGENT_NATIVE", "1")
+        assert sp.main([]) == SUCCESS  # no --json flag
+        json.loads(capsys.readouterr().out)  # parses => auto-JSON fired
+
+    def test_select_projects_fields(self, monkeypatch, capsys):
+        self._patch_main(monkeypatch, [])
+        sp.main(["--json", "--select", "status,exit_code"])
+        out = json.loads(capsys.readouterr().out)
+        assert set(out.keys()) == {"status", "exit_code"}
+
+    def test_human_output_when_not_json(self, monkeypatch, capsys):
+        self._patch_main(monkeypatch, [sp.Finding(sp.CRITICAL, "live_session_same_tree", "d")])
+        monkeypatch.setenv("DEUS_AGENT_NATIVE", "0")
+        assert sp.main([]) == CONFLICT
+        text = capsys.readouterr().out
+        assert "CONFLICT" in text and "exit 6" in text


### PR DESCRIPTION
## What

Adds `scripts/session_preflight.py` — a read-only preflight that detects whether another
session is already working a checkout before you start writing to it. Four probes against the
current repo:

| Probe | Severity |
|-------|----------|
| Another live session on the same working tree | CRITICAL |
| The current branch checked out in another worktree | CRITICAL |
| An open PR already targeting the current branch | WARNING |
| Uncommitted files modified within the recency window | WARNING |

Any CRITICAL exits `CONFLICT(6)` so a caller/hook can stop before the first write; advisory
WARNING findings exit `SUCCESS(0)`. Adds `CONFLICT = 6` to `scripts/_exit_codes.py` (CLI-only,
like ABSTAIN — no TS mirror) and documents it in the `printing-press-adoption.md` exit-code table.
Agent-native protocol: `--json` / `--compact` / `--select`, and `DEUS_AGENT_NATIVE=1` auto-JSON.

## Why

Two sessions writing the same branch produce an incoherent tree; concurrent Claude/Codex sessions
on shared checkouts are a recurring collision hazard (LIA-284, multi-session parallelism). This
automates the manual forensics (`git status` + `~/.claude/sessions/*.json` + file mtimes) into one
read-only pre-claim check.

## Liveness signal

A session is live when its heartbeat is within the window AND (on POSIX) its pid is alive.
Freshness uses the **fresher of** the JSON `updatedAt` field and the session file's mtime: the
`updatedAt` field only advances on a status transition and can lag many minutes behind a long-busy
session, whereas the file is rewritten as a heartbeat. The source is `~/.claude/sessions/<pid>.json`
(the live registry: pid/cwd/status/updatedAt) — deliberately NOT `~/.claude/projects/**/*.jsonl`,
which are append-only conversation transcripts with no pid/cwd/liveness signal.

## Alternatives considered

- **Advisory lock / PID file** — rejected: a crashed session leaves a stale lock that needs
  cleanup discipline; the detector would then either block falsely or require a reaper. The
  session registry is already maintained by the host, so a read-only check has nothing to clean up.
- **inotify / fsevents file-watch** — rejected: that is a long-running watcher, not a point-in-time
  preflight, and the APIs are platform-specific. The requirement is a cheap, stateless, read-only
  check run once before claiming work.

## Cross-platform (flagged)

Liveness freshness (`updatedAt`/mtime) is portable. On POSIX a secondary `os.kill(pid, 0)` confirms
the pid is alive; on non-POSIX that path is skipped (liveness = freshness-only, slightly weaker, no
functional loss). Self-exclusion uses stdlib `os.getpid()` / `os.getppid()` (identical on every
platform) plus `--self` / `--self-pid` / `CLAUDE_SESSION_ID` — deliberately NO `/proc` or `sysctl`
ancestor walk (those are Linux-only / macOS-only).

## Scope (deferred wiring)

Ships the portable detector + tests only, **intentionally unwired** — no SessionStart hook and no
`deus preflight` subcommand in this PR. Those are interface-specific follow-ons tracked under
**LIA-284**; this PR is the reusable core they will call.

## Tests

40 tests (`scripts/tests/test_session_preflight.py`), wired into the CI "Pattern tests (Python)"
step. Cover the probe matrix, the exit-code contract (CRITICAL=6 / WARNING-only=0 / clean=0 /
not-a-repo=2), self-exclusion (each mechanism), the window guard, cross-platform pid-skip, the
stale-`updatedAt`-but-fresh-heartbeat case, `_run_git` resilience (OSError/ValueError), and the
agent-native output (`--json` / `DEUS_AGENT_NATIVE` / `--select`).

> Re-authored canonically from scratch (clean-room from the spec); supersedes the closed #883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
