### PR TITLE
feat(cli): add deus preflight subcommand for concurrent-session detection (LIA-284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ See [AGENTS.md](AGENTS.md#commands-and-skills) for all available skills.
 | `deus backend` | Show active agent backend (`claude`, `codex`, `llama-cpp`) |
 | `deus backend set <name>` | Switch backend for all future sessions |
 | `deus sync` | Update the live install to `origin/main` (`deus sync upstream` for forks) |
+| `deus preflight` | Detect whether another live session is working the current git tree (read-only; exit 6 on collision) |
 
 For direct Codex CLI sessions outside the `deus` launcher, register Deus memory
 recall as an MCP tool through the repo launcher:

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1265,6 +1265,17 @@ $STARTUP_INSTRUCTION"
     shift
     exec python3 "$SCRIPT_DIR/scripts/analyze_token_efficiency.py" "$@"
     ;;
+  preflight)
+    # Read-only concurrent-session collision check for the current git tree
+    # (LIA-284). Pure pass-through to the detector: exec inherits PWD so it
+    # checks the invocation directory, forwards all flags, and propagates the
+    # detector's exit code (CONFLICT=6 on a CRITICAL collision, 2 if not a git
+    # repo, 0 otherwise). $SCRIPT_DIR (not $HOME/deus) so it works from any
+    # install path / worktree. The detector self-excludes via CLAUDE_SESSION_ID
+    # when set; pass --self <id> explicitly when running inside a session.
+    shift
+    exec python3 "$SCRIPT_DIR/scripts/session_preflight.py" "$@"
+    ;;
   sync)
     # Make the live install current with <remote>/main, non-destructively.
     #   deus sync            -> origin/main   (this repo's own remote)
@@ -1628,7 +1639,7 @@ $STARTUP_INSTRUCTION"
     esac
     ;;
   *)
-    echo "Usage: deus [claude|codex] [home|init|arch|auth|build|web|backend|gcal|listen|logs|model|provider|pipeline|solution|sweep|tui] [--agents]"
+    echo "Usage: deus [claude|codex] [home|init|arch|auth|build|web|backend|gcal|listen|logs|model|provider|pipeline|preflight|solution|sweep|tui] [--agents]"
     echo ""
     echo "  deus            Launch in current directory (external project mode if not ~/deus)"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
@@ -1655,6 +1666,7 @@ $STARTUP_INSTRUCTION"
     echo "  deus deploy     Diff-driven deploy (origin only): ff-merge origin/main + rebuild"
     echo "                    only what changed (host if src/, container if container/ or skills). --dry-run"
     echo "  deus pipeline   Pipeline event audit (LIA-XX | --failed | --active | --all)"
+    echo "  deus preflight  Check if another live session is working this git tree (read-only; exit 6 on collision)"
     echo "  deus solution   Manage solution atoms (list|search|add)"
     echo "  deus sweep      Run threshold calibration sweep against benchmark queries"
     echo "  deus tui        Interactive terminal UI (set tui_default=true in config to use by default)"


### PR DESCRIPTION
## What

Adds a `deus preflight` subcommand that runs the already-merged
`scripts/session_preflight.py` concurrent-session collision detector (#961)
against the current git tree. The thinnest first step from the
2026-06-27 session-preflight handoff — lets the detector be exercised by hand
before a SessionStart hook automates it.

```
$ deus preflight            # exit 6 if another live session owns this tree
$ deus preflight --json     # agent-native JSON
$ deus preflight --self <sessionId>   # exclude a known session
```

## How

Pure `exec` pass-through, modeled on the existing `usage)` case:

```sh
preflight)
  shift
  exec python3 "$SCRIPT_DIR/scripts/session_preflight.py" "$@"
  ;;
```

- `exec` inherits PWD → checks the invocation directory (verified: no global `cd` precedes the dispatch).
- Forwards every flag (`--self`/`--self-pid`/`--window-min`/`--json`/`--compact`/`--select`).
- Propagates the detector's exit code: `CONFLICT=6` on a CRITICAL collision, `2` if not a git repo, `0` otherwise.
- `$SCRIPT_DIR` (not `$HOME/deus`) so it works from any install path / worktree.
- Self-exclusion: the detector auto-reads `CLAUDE_SESSION_ID` when set; pass `--self <id>` explicitly when running inside a session (unset in the interactive Bash env).

## Files

- `deus-cmd.sh`: new `preflight)` case + dedicated help line + `preflight` added to the top-line command list.
- `README.md`: command-table row.

## Verification (reproduced first-hand)

| # | Check | Result |
|---|-------|--------|
| 1 | `zsh -n deus-cmd.sh` | clean (exit 0) |
| 2 | `cd /tmp && deus preflight --json` | exit 2, `{"status":"ERROR",...,"not inside a git repository"}` |
| 3 | `cd ~/deus && deus preflight` | exit 6, CRITICAL findings + `CONFLICT` line |
| 4 | `deus preflight --window-min 1 --json --select status,exit_code` | exit 0, projected JSON (1-min window filtered older sessions) |
| 5 | `deus badcmd` | help shows the new line + `preflight` in the top-line list |

Exit codes captured via `>file; echo $?` (not through a pipe — pipes mask exit codes).

## Cross-platform note

The bash/zsh wrapper is POSIX-only, consistent with `sync`/`deploy`/`usage` pending the TS CLI port (`deus-cmd.ps1` has no parity for these newer subcommands). The detector itself (`session_preflight.py`) is cross-platform Python.

## Out of scope (follow-ups, LIA-284)

- **SessionStart hook** auto-invocation (recommend WARN-not-block first; needs a real-invocation smoke test per code-review-rules.md; one concern per branch).
- The detection-vs-isolation other half of LIA-284.

## Wardens

- plan-reviewer: SHIP (claude + gpt)
- code-reviewer: SHIP (claude + gpt + glm)
- verification-gate: SHIP (Opus, reproduced all evidence first-hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)