### PR TITLE
feat(preflight): SessionStart hook warns on concurrent-session collisions (LIA-284)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,11 @@
             "type": "command",
             "command": "bash -c 'python3 \"${CLAUDE_PROJECT_DIR:-.}/scripts/linear_pending_hook.py\"'",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'python3 \"${CLAUDE_PROJECT_DIR:-.}/scripts/session_preflight_hook.py\"'",
+            "timeout": 8
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: python3 scripts/drift_check.py --all --base origin/${{ github.base_ref }}
 
       - name: Pattern tests (Python)
-        run: python3 -m pytest scripts/tests/test_drift_check.py scripts/tests/test_prune_warden_backups.py scripts/tests/test_session_preflight.py -v
+        run: python3 -m pytest scripts/tests/test_drift_check.py scripts/tests/test_prune_warden_backups.py scripts/tests/test_session_preflight.py scripts/tests/test_session_preflight_hook.py -v
 
       - name: Warden review tests
         # Regression-protect the provider-agnostic warden co-gate engine: the gpt +

--- a/scripts/session_preflight.py
+++ b/scripts/session_preflight.py
@@ -326,6 +326,16 @@ PROBES = [
     probe_recent_uncommitted,
 ]
 
+# The two probes that can produce a CRITICAL (blocking) finding -- both are local
+# (git/filesystem) and fast. --critical-only runs exactly these, skipping the
+# advisory WARNING probes: probe_open_pr_for_branch makes a network `gh pr list`
+# call, so a session-start gate that only surfaces CRITICAL collisions avoids that
+# latency entirely rather than waiting on a timeout.
+CRITICAL_PROBES = [
+    probe_live_session_same_tree,
+    probe_branch_in_another_worktree,
+]
+
 
 # --------------------------------------------------------------------------- #
 # orchestration
@@ -387,6 +397,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--self-pid", type=int, default=None, help="This session's pid, excluded from checks"
     )
+    parser.add_argument(
+        "--critical-only",
+        action="store_true",
+        help="Run only the CRITICAL (blocking) probes; skip advisory WARNING probes "
+        "(notably the network gh-PR check). Used by the session-start hook.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
     parser.add_argument("--compact", action="store_true", help="Compact JSON (strip nulls)")
     parser.add_argument("--select", default=None, help="Comma-separated field projection")
@@ -403,9 +419,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"USAGE: {exc}", file=sys.stderr)
         return USAGE_ERROR
 
+    probes = CRITICAL_PROBES if args.critical_only else PROBES
     try:
         findings: list[Finding] = []
-        for probe in PROBES:
+        for probe in probes:
             findings.extend(probe(ctx))
     except Exception as exc:  # pragma: no cover - defensive last resort
         print(f"INTERNAL: {exc}", file=sys.stderr)

--- a/scripts/session_preflight_hook.py
+++ b/scripts/session_preflight_hook.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""SessionStart hook: warn when another live session is already working this tree.
+
+Runs the concurrent-session collision detector (session_preflight.py) at every
+session start and, if a CRITICAL collision is found, surfaces it as a WARN banner
+via additionalContext. This is the auto-invocation half of LIA-284: the detector
+is otherwise dormant infrastructure -- this hook fires it "at the moment a session
+starts claiming work".
+
+Design (Enforcement Layer hook, host-enforced, SessionStart):
+- WARN, never block. The hook always exits 0; a false CRITICAL that blocked every
+  session would be worse than the collision it prevents. The output is context only.
+- Network-free: invokes the detector with --critical-only so the advisory probes
+  (notably the network gh-PR check) are skipped -- only the fast local CRITICAL
+  probes run, keeping session start snappy.
+- Self-exclusion via the SessionStart payload's session_id (matches the registry's
+  full-UUID sessionId field) so the starting session never flags itself.
+- Fail-safe silent: any error (bad stdin, detector missing, timeout, non-JSON) ->
+  emit nothing, exit 0. The hook must never break session start.
+- Tree-relative: the detector runs in the hook's cwd (the starting session's working
+  directory), so a session launched inside a worktree checks THAT worktree's tree, not
+  ~/deus -- the collision check always targets the tree the session will actually write to.
+
+Opt-out: DEUS_PREFLIGHT_HOOK=0 disables it.  # LIA-284
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_DETECTOR = _SCRIPTS_DIR / "session_preflight.py"
+
+# Bounded so a wedged detector can't hang session start. Keep BELOW the hook's
+# settings.json timeout (currently 8s) so this fail-safes before the harness
+# kills us -- if you tune the settings.json timeout, keep it > this constant.
+_DETECTOR_TIMEOUT = 6
+
+# Cap each finding line so an adversarial/long git branch name or realpath can't
+# bloat the injected context (a branch name is unbounded; a realpath ~PATH_MAX).
+_MAX_DETAIL_CHARS = 200
+
+
+def _emit(context: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": context,
+            }
+        },
+        sys.stdout,
+    )
+
+
+def _read_session_id() -> str:
+    """Best-effort: pull session_id from the SessionStart stdin payload."""
+    try:
+        raw = sys.stdin.read()
+    except (OSError, UnicodeDecodeError):
+        return ""
+    if not raw:
+        return ""
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return ""
+    # Field name is `session_id` (snake_case) -- the documented Claude Code hook
+    # input schema (docs/SDK_DEEP_DIVE.md: BaseHookInput = {session_id, ...}; also
+    # container/agent-runner reads hookInput.session_id). It matches the registry's
+    # full-UUID `sessionId` value, so --self excludes the starting session.
+    sid = data.get("session_id") if isinstance(data, dict) else None
+    return sid if isinstance(sid, str) else ""
+
+
+def _run_detector(session_id: str) -> "dict | None":
+    """Run session_preflight.py --critical-only --json; return parsed dict or None.
+
+    None on any failure (missing detector, timeout, crash, non-JSON) -> caller
+    emits nothing. The detector is invoked in the current working directory so it
+    checks the tree the session is actually starting in.
+    """
+    if not _DETECTOR.is_file():
+        return None
+    cmd = [sys.executable, str(_DETECTOR), "--critical-only", "--json"]
+    if session_id:
+        cmd += ["--self", session_id]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_DETECTOR_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    # The detector exits CONFLICT(6) on a collision and 0 when clear -- both carry
+    # valid JSON on stdout, so a non-zero return is expected, not an error.
+    try:
+        data = json.loads(proc.stdout or "")
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _banner(result: dict) -> "str | None":
+    """Build the WARN banner from a CONFLICT result, or None if not a conflict."""
+    if result.get("status") != "CONFLICT":
+        return None
+    findings = result.get("findings")
+    if not isinstance(findings, list) or not findings:
+        return None
+    toplevel = result.get("toplevel")
+    where = f" ({str(toplevel)[:_MAX_DETAIL_CHARS]})" if toplevel else ""
+    lines = [
+        f"⚠️ PREFLIGHT: {len(findings)} other live session(s) may be "
+        f"working this git tree{where}:"
+    ]
+    for f in findings:
+        detail = f.get("detail") if isinstance(f, dict) else None
+        if detail:
+            lines.append(f"  - {str(detail)[:_MAX_DETAIL_CHARS]}")
+    lines.append(
+        "  Pause before editing shared files; confirm with the user whether a "
+        "worktree is needed (see: deus preflight)."
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    if os.environ.get("DEUS_PREFLIGHT_HOOK") == "0":  # LIA-284 opt-out
+        # Still drain stdin so the producer never blocks on a full pipe.
+        try:
+            sys.stdin.read()
+        except (OSError, UnicodeDecodeError):
+            pass
+        return
+    session_id = _read_session_id()
+    result = _run_detector(session_id)
+    if result is None:
+        return
+    banner = _banner(result)
+    if banner:
+        _emit(banner)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:  # never break session start
+        sys.stderr.write(f"[session-preflight-hook] {e}\n")
+    sys.exit(0)

--- a/scripts/tests/test_session_preflight.py
+++ b/scripts/tests/test_session_preflight.py
@@ -307,3 +307,34 @@ class TestMainContract:
         assert sp.main([]) == CONFLICT
         text = capsys.readouterr().out
         assert "CONFLICT" in text and "exit 6" in text
+
+
+# ── --critical-only probe selection ──────────────────────────────────────────
+class TestCriticalOnly:
+    def test_flag_runs_only_critical_probes(self, monkeypatch, capsys):
+        ran = []
+        crit = lambda ctx: (ran.append("crit") or [])  # noqa: E731
+        warn = lambda ctx: (ran.append("warn") or [])  # noqa: E731
+        monkeypatch.setattr(sp, "_build_context", lambda args: _ctx())
+        monkeypatch.setattr(sp, "CRITICAL_PROBES", [crit])
+        monkeypatch.setattr(sp, "PROBES", [crit, warn])
+        sp.main(["--critical-only", "--json"])
+        assert ran == ["crit"]
+
+    def test_no_flag_runs_all_probes(self, monkeypatch, capsys):
+        ran = []
+        crit = lambda ctx: (ran.append("crit") or [])  # noqa: E731
+        warn = lambda ctx: (ran.append("warn") or [])  # noqa: E731
+        monkeypatch.setattr(sp, "_build_context", lambda args: _ctx())
+        monkeypatch.setattr(sp, "CRITICAL_PROBES", [crit])
+        monkeypatch.setattr(sp, "PROBES", [crit, warn])
+        sp.main(["--json"])
+        assert ran == ["crit", "warn"]
+
+    def test_network_probe_excluded_from_critical_set(self):
+        # main() selects CRITICAL_PROBES verbatim, so membership IS the guarantee
+        # that the network gh-PR probe (and the mtime probe) never run with the flag.
+        assert sp.probe_open_pr_for_branch not in sp.CRITICAL_PROBES
+        assert sp.probe_recent_uncommitted not in sp.CRITICAL_PROBES
+        assert sp.probe_live_session_same_tree in sp.CRITICAL_PROBES
+        assert sp.probe_branch_in_another_worktree in sp.CRITICAL_PROBES

--- a/scripts/tests/test_session_preflight_hook.py
+++ b/scripts/tests/test_session_preflight_hook.py
@@ -1,0 +1,200 @@
+"""Tests for scripts/session_preflight_hook.py — the SessionStart preflight hook.
+
+The hook is a thin, fail-safe wrapper around session_preflight.py: read the
+session_id from stdin, run the detector with --critical-only, and emit a WARN
+banner only on a CONFLICT. Every failure path must exit 0 and emit nothing. Tests
+drive main() with monkeypatched stdin + subprocess.
+"""
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import session_preflight_hook as hook  # noqa: E402
+
+
+def _stdin(monkeypatch, text):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(text))
+
+
+def _fake_proc(stdout, returncode=0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+# The real detector exists on disk; point _DETECTOR at it so .is_file() is True
+# without monkeypatching a method on an (immutable) Path instance.
+_REAL_DETECTOR = Path(_SCRIPTS_DIR) / "session_preflight.py"
+_MISSING_DETECTOR = Path(_SCRIPTS_DIR) / "does_not_exist_preflight.py"
+
+
+CONFLICT_JSON = json.dumps(
+    {
+        "status": "CONFLICT",
+        "exit_code": 6,
+        "toplevel": "/repo/top",
+        "findings": [
+            {"severity": "CRITICAL", "code": "live_session_same_tree", "detail": "session abc live"},
+            {"severity": "CRITICAL", "code": "branch_in_other_worktree", "detail": "branch x at /wt"},
+        ],
+    }
+)
+OK_JSON = json.dumps({"status": "OK", "exit_code": 0, "toplevel": "/repo/top", "findings": []})
+
+
+# ── _read_session_id ─────────────────────────────────────────────────────────
+class TestReadSessionId:
+    def test_extracts_session_id(self, monkeypatch):
+        _stdin(monkeypatch, json.dumps({"session_id": "uuid-123", "source": "startup"}))
+        assert hook._read_session_id() == "uuid-123"
+
+    def test_empty_stdin(self, monkeypatch):
+        _stdin(monkeypatch, "")
+        assert hook._read_session_id() == ""
+
+    def test_malformed_json(self, monkeypatch):
+        _stdin(monkeypatch, "{not json")
+        assert hook._read_session_id() == ""
+
+    def test_missing_field(self, monkeypatch):
+        _stdin(monkeypatch, json.dumps({"source": "resume"}))
+        assert hook._read_session_id() == ""
+
+    def test_non_dict_payload(self, monkeypatch):
+        _stdin(monkeypatch, json.dumps(["a", "b"]))
+        assert hook._read_session_id() == ""
+
+
+# ── _run_detector ────────────────────────────────────────────────────────────
+class TestRunDetector:
+    def test_passes_self_and_critical_only(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["timeout"] = kw.get("timeout")
+            return _fake_proc(OK_JSON)
+
+        monkeypatch.setattr(hook.subprocess, "run", fake_run)
+        monkeypatch.setattr(hook, "_DETECTOR", _REAL_DETECTOR)
+        hook._run_detector("uuid-9")
+        assert "--critical-only" in captured["cmd"]
+        assert "--json" in captured["cmd"]
+        assert "--self" in captured["cmd"] and "uuid-9" in captured["cmd"]
+        assert captured["timeout"] == hook._DETECTOR_TIMEOUT
+
+    def test_omits_self_when_blank(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return _fake_proc(OK_JSON)
+
+        monkeypatch.setattr(hook.subprocess, "run", fake_run)
+        monkeypatch.setattr(hook, "_DETECTOR", _REAL_DETECTOR)
+        hook._run_detector("")
+        assert "--self" not in captured["cmd"]
+
+    def test_conflict_returncode_still_parsed(self, monkeypatch):
+        # detector exits 6 on a real conflict -- non-zero is expected, not an error
+        monkeypatch.setattr(hook.subprocess, "run", lambda cmd, **kw: _fake_proc(CONFLICT_JSON, returncode=6))
+        monkeypatch.setattr(hook, "_DETECTOR", _REAL_DETECTOR)
+        assert hook._run_detector("x")["status"] == "CONFLICT"
+
+    def test_missing_detector_returns_none(self, monkeypatch):
+        monkeypatch.setattr(hook, "_DETECTOR", _MISSING_DETECTOR)
+        assert hook._run_detector("x") is None
+
+    def test_timeout_returns_none(self, monkeypatch):
+        def boom(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 6)
+
+        monkeypatch.setattr(hook.subprocess, "run", boom)
+        monkeypatch.setattr(hook, "_DETECTOR", _REAL_DETECTOR)
+        assert hook._run_detector("x") is None
+
+    def test_oserror_returns_none(self, monkeypatch):
+        def boom(cmd, **kw):
+            raise OSError("exec failed")
+
+        monkeypatch.setattr(hook.subprocess, "run", boom)
+        monkeypatch.setattr(hook, "_DETECTOR", _REAL_DETECTOR)
+        assert hook._run_detector("x") is None
+
+    def test_nonjson_stdout_returns_none(self, monkeypatch):
+        monkeypatch.setattr(hook.subprocess, "run", lambda cmd, **kw: _fake_proc("not json"))
+        monkeypatch.setattr(hook, "_DETECTOR", _REAL_DETECTOR)
+        assert hook._run_detector("x") is None
+
+
+# ── _banner ──────────────────────────────────────────────────────────────────
+class TestBanner:
+    def test_conflict_banner_lists_findings(self):
+        out = hook._banner(json.loads(CONFLICT_JSON))
+        assert out is not None
+        assert "PREFLIGHT" in out and "2 other live session" in out
+        assert "session abc live" in out and "branch x at /wt" in out
+        assert "/repo/top" in out
+        assert "deus preflight" in out
+
+    def test_non_conflict_returns_none(self):
+        assert hook._banner(json.loads(OK_JSON)) is None
+
+    def test_conflict_without_findings_returns_none(self):
+        assert hook._banner({"status": "CONFLICT", "findings": []}) is None
+
+    def test_findings_not_list_returns_none(self):
+        assert hook._banner({"status": "CONFLICT", "findings": "oops"}) is None
+
+
+# ── main() — end-to-end, always exits cleanly ────────────────────────────────
+class TestMain:
+    def test_conflict_emits_banner(self, monkeypatch, capsys):
+        _stdin(monkeypatch, json.dumps({"session_id": "me"}))
+        monkeypatch.setattr(hook, "_run_detector", lambda sid: json.loads(CONFLICT_JSON))
+        hook.main()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+        assert "PREFLIGHT" in payload["hookSpecificOutput"]["additionalContext"]
+
+    def test_clean_emits_nothing(self, monkeypatch, capsys):
+        _stdin(monkeypatch, json.dumps({"session_id": "me"}))
+        monkeypatch.setattr(hook, "_run_detector", lambda sid: json.loads(OK_JSON))
+        hook.main()
+        assert capsys.readouterr().out == ""
+
+    def test_detector_none_emits_nothing(self, monkeypatch, capsys):
+        _stdin(monkeypatch, json.dumps({"session_id": "me"}))
+        monkeypatch.setattr(hook, "_run_detector", lambda sid: None)
+        hook.main()
+        assert capsys.readouterr().out == ""
+
+    def test_optout_skips_detector(self, monkeypatch, capsys):
+        monkeypatch.setenv("DEUS_PREFLIGHT_HOOK", "0")
+        _stdin(monkeypatch, json.dumps({"session_id": "me"}))
+        called = {"k": False}
+
+        def boom(sid):
+            called["k"] = True
+            raise AssertionError("detector must not run when opted out")
+
+        monkeypatch.setattr(hook, "_run_detector", boom)
+        hook.main()
+        assert called["k"] is False
+        assert capsys.readouterr().out == ""
+
+    def test_self_id_threaded_to_detector(self, monkeypatch, capsys):
+        _stdin(monkeypatch, json.dumps({"session_id": "uuid-xyz"}))
+        seen = {}
+
+        def fake_detector(sid):
+            seen["sid"] = sid
+            return json.loads(OK_JSON)
+
+        monkeypatch.setattr(hook, "_run_detector", fake_detector)
+        hook.main()
+        assert seen["sid"] == "uuid-xyz"

--- a/tests/test_session_type_contract.py
+++ b/tests/test_session_type_contract.py
@@ -86,6 +86,11 @@ class TestProjectSettingsHooks:
         cmds = _extract_hook_commands_for_event(self.settings, "SessionStart")
         assert any("warden-shim" in c and "session-init" in c for c in cmds)
 
+    def test_session_start_has_preflight_hook(self):
+        # LIA-284: the concurrent-session collision warning must stay wired in.
+        cmds = _extract_hook_commands_for_event(self.settings, "SessionStart")
+        assert any("session_preflight_hook" in c for c in cmds)
+
     def test_user_prompt_submit_has_memory_retrieval(self):
         cmds = _extract_hook_commands_for_event(self.settings, "UserPromptSubmit")
         assert any("memory_retrieval" in c for c in cmds)


### PR DESCRIPTION
## What

Adds a **SessionStart hook** that auto-runs the `session_preflight.py` concurrent-session
collision detector and surfaces a CRITICAL collision as a WARN banner. This is the
auto-invocation half of LIA-284 detection — the detector was dormant infrastructure
(#963 made it manual via `deus preflight`; this makes it fire automatically at the
moment a session starts claiming work).

## How

- **`scripts/session_preflight.py`** — new `--critical-only` flag: runs only the two
  local CRITICAL probes (`live_session_same_tree`, `branch_in_another_worktree`), skipping
  the advisory WARNING probes — notably the network `gh pr list` probe — so the hook is
  network-free at session start. Default off → full 4-probe behavior byte-unchanged.
- **`scripts/session_preflight_hook.py`** (new) — the hook:
  - Reads `session_id` from the SessionStart stdin payload for self-exclusion (verified
    snake_case: `docs/SDK_DEEP_DIVE.md:533` `BaseHookInput = {session_id,...}` +
    `container/agent-runner/src/post-tool-use-observer.ts:45`).
  - Runs the detector via subprocess with `--critical-only --json --self <id>`, 6s timeout
    (kept below the 8s harness timeout so it fail-safes first).
  - Emits a length-capped (`_MAX_DETAIL_CHARS=200`) WARN banner via `additionalContext`
    **only on CONFLICT**; silent otherwise.
  - **Always exits 0** — fail-safe on every error path (bad stdin, missing detector,
    timeout, non-JSON). A false CRITICAL that blocked every session would be worse than
    the collision it prevents.
  - Opt-out: `DEUS_PREFLIGHT_HOOK=0`.
- **`.claude/settings.json`** — 3rd SessionStart hook entry, timeout 8.
- **`.github/workflows/ci.yml`** — runs the new hook test in "Pattern tests (Python)".
- **Tests** — 21 hook tests + `--critical-only` probe-selection tests + a settings.json
  wiring test in `tests/test_session_type_contract.py` (so the wiring can't be silently removed).

## Real-invocation smoke test (exact settings.json command, hook JSON on stdin)

Command: `bash -c 'python3 "${CLAUDE_PROJECT_DIR:-.}/scripts/session_preflight_hook.py"'`

| Path | Input | Result |
|------|-------|--------|
| CONFLICT | `{"session_id":"smoke-fake"}` from `~/deus` | exit 0, valid-JSON banner (below) |
| CLEAN | same, fresh `git init` tree | exit 0, empty stdout |
| OPT-OUT | `DEUS_PREFLIGHT_HOOK=0` | exit 0, empty stdout |
| ERROR | malformed stdin `{bad` | exit 0, no crash |

CONFLICT-path `additionalContext` (rendered):
```
⚠️ PREFLIGHT: 2 other live session(s) may be working this git tree (/Users/liam10play/deus):
  - session 8b85ef60 (pid 41689) live on this tree, updated 525s ago
  - session 5bfc3c57 (pid 90775) live on this tree, updated 748s ago
  Pause before editing shared files; confirm with the user whether a worktree is needed (see: deus preflight).
```
(Malformed stdin loses self-exclusion → over-warns, never crashes — the fail-safe direction.)

## Tests

`python3 -m pytest scripts/tests/test_session_preflight.py scripts/tests/test_session_preflight_hook.py tests/test_session_type_contract.py` → **127 passed**.

## Cross-platform / scope

Hook is portable Python (bash wrapper only invokes `python3`, consistent with the other
two SessionStart hooks). Out of scope: the *isolation* half of LIA-284 (assessed separately).

## Wardens

- plan-reviewer: SHIP (claude + gpt)
- code-reviewer: SHIP (claude + gpt + glm)
- ai-eng-warden: SHIP (claude + gpt) — context-injection surface bounded (200-char detail cap)
- verification-gate: SHIP (Opus, reproduced 127 tests + all 4 smoke paths first-hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)