### PR TITLE
feat(agent-runner): nudge parallel subagent fan-out in engineering context (LIA-343)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -37,6 +37,7 @@ import { isAuditedTool, writeAuditEntry } from './tool-audit.js';
 import { createToolCallLogHook } from './tool-call-log.js';
 import { writeAvailableTools } from './available-tools-log.js';
 import { buildAllowedTools, computeTeamsNeeded } from './allowed-tools.js';
+import { subagentNudgeAppend } from './subagent-nudge.js';
 import type { AgentRuntimeId } from './tool-broker.js';
 import { resolveGroupAttachmentPath } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
@@ -859,6 +860,19 @@ async function runQuery(
     writeAvailableTools(process.env.DEUS_INTERACTION_ID, allowedTools);
   }
 
+  // Layer-A subagent fan-out nudge: appended only in engineering context
+  // (hasProject + full tool profile — the webhook profile has no Task tool), so
+  // plain chat pays no tokens. Runtime kill-switch: DEUS_SUBAGENT_NUDGE=0.
+  const subagentNudgeEnabled = process.env.DEUS_SUBAGENT_NUDGE !== '0'; // LIA-343
+  const subagentNudge = subagentNudgeAppend({
+    enabled: subagentNudgeEnabled,
+    hasProject,
+    toolProfile,
+  });
+  const fullSystemAppend = [systemAppend, subagentNudge]
+    .filter(Boolean)
+    .join('\n\n');
+
   // ── Streaming (Web UI live output) ──────────────────────────────────────────
   // runQuery is the CLAUDE path only (main() returns for openai/llama-cpp before
   // calling it), so enabling partial messages here is structurally Claude-only.
@@ -913,11 +927,11 @@ async function runQuery(
       resume: sessionId,
       resumeSessionAt: resumeAt,
       effort,
-      systemPrompt: systemAppend
+      systemPrompt: fullSystemAppend
         ? {
             type: 'preset' as const,
             preset: 'claude_code' as const,
-            append: systemAppend,
+            append: fullSystemAppend,
           }
         : undefined,
       allowedTools,

--- a/container/agent-runner/src/subagent-nudge.test.ts
+++ b/container/agent-runner/src/subagent-nudge.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { SUBAGENT_NUDGE, subagentNudgeAppend } from './subagent-nudge.js';
+
+describe('subagentNudgeAppend', () => {
+  it('appends the nudge in engineering context (enabled + project + full profile)', () => {
+    expect(
+      subagentNudgeAppend({
+        enabled: true,
+        hasProject: true,
+        toolProfile: 'full',
+      }),
+    ).toBe(SUBAGENT_NUDGE);
+  });
+
+  it('is silent when the kill-switch is off', () => {
+    expect(
+      subagentNudgeAppend({
+        enabled: false,
+        hasProject: true,
+        toolProfile: 'full',
+      }),
+    ).toBe('');
+  });
+
+  it('is silent on plain chat (no project mounted)', () => {
+    expect(
+      subagentNudgeAppend({
+        enabled: true,
+        hasProject: false,
+        toolProfile: 'full',
+      }),
+    ).toBe('');
+  });
+
+  it('is silent for the webhook profile (no Task tool available)', () => {
+    expect(
+      subagentNudgeAppend({
+        enabled: true,
+        hasProject: true,
+        toolProfile: 'webhook',
+      }),
+    ).toBe('');
+  });
+
+  it('nudge text references the Task tool and carries the negative-scope clause', () => {
+    expect(SUBAGENT_NUDGE).toContain('Task');
+    expect(SUBAGENT_NUDGE).toContain('Do NOT spawn');
+  });
+});

--- a/container/agent-runner/src/subagent-nudge.ts
+++ b/container/agent-runner/src/subagent-nudge.ts
@@ -1,0 +1,57 @@
+/**
+ * Layer-A subagent fan-out nudge (LIA-343).
+ *
+ * Modern Opus under-reaches for parallel subagents by default — it holds the
+ * Task tools but won't delegate unless told WHEN it's worth it. This appends a
+ * short, static instruction to the agent's system prompt in engineering context
+ * (see `subagentNudgeAppend`) telling it when to fan out and when not to. The
+ * model owns both the fan-out decision and the synthesis in one context — no
+ * host planner or coordination. Pure module, mirroring `computeTeamsNeeded`.
+ */
+
+/** The instruction appended to the system prompt in engineering context. */
+export const SUBAGENT_NUDGE = `## Parallel subagents (Task tool)
+
+You have Task/TaskOutput/TaskStop. Use them when a request fans out across
+INDEPENDENT items that can run at the same time:
+  - comparing or evaluating multiple candidates
+  - reading or auditing several files/sources whose findings don't depend on each other
+  - gathering from multiple distinct sources before you synthesize
+
+Rule of thumb: worth spawning at ~3+ independent items; for 1-2, inline tools are
+faster. Cap concurrent subagents at ~5-6 — more just serialize and add overhead.
+When you fan out, give each subagent ONLY the context it needs and one clear
+deliverable, run them in parallel in a single turn, then YOU read all results and
+write one coherent answer. Synthesis is your job, not theirs.
+
+Do NOT spawn a subagent for:
+  - a single-file read, a single tool call, or a quick lookup
+  - sequential/dependent steps where each needs the previous one's result
+  - synthesis-heavy work needing one consistent voice (a plan, an essay, a refactor)
+  - work from inside a subagent — only the top-level agent fans out
+For those, work directly — a subagent adds latency and cost with no benefit.`;
+
+export interface SubagentNudgeOpts {
+  /** Runtime kill-switch (DEUS_SUBAGENT_NUDGE !== '0'); read at the call site. */
+  enabled: boolean;
+  /** Engineering context — an external project is mounted at /workspace/project. */
+  hasProject: boolean;
+  /** Tool profile: 'webhook' runs exclude the Task tool entirely (LIA-315). */
+  toolProfile: 'full' | 'webhook';
+}
+
+/**
+ * Returns the nudge text when it should be appended, else an empty string.
+ *
+ * Appended only when ALL hold:
+ *  - `enabled`            — the kill-switch is on (default)
+ *  - `hasProject`         — engineering context (plain chat has no project, so it
+ *                           pays no tokens and its behavior is unchanged)
+ *  - `toolProfile==='full'` — the webhook profile has no Task tool, so nudging it
+ *                           toward Task would be incoherent
+ */
+export function subagentNudgeAppend(opts: SubagentNudgeOpts): string {
+  const { enabled, hasProject, toolProfile } = opts;
+  if (!enabled || !hasProject || toolProfile !== 'full') return '';
+  return SUBAGENT_NUDGE;
+}


### PR DESCRIPTION
## What

Append a short, **static** instruction to the container agent's system prompt telling it *when* to fan out parallel `Task` subagents — and when not to. Modern Opus (4.7/4.8) under-reaches for subagents by default; this closes that gap in engineering context.

This is the **Layer-A** alternative to the cancelled host-level multi-agent planner (LIA-127): instead of a host planner deciding decomposition blind from the raw message, the in-container agent (which already holds `Task`/`TaskOutput`/`TaskStop`) owns both the fan-out decision and the synthesis, in-context. No host planner, no DAG, no IPC, no `DEUS_MULTI_AGENT`.

## How

- **`subagent-nudge.ts` (new):** `SUBAGENT_NUDGE` fragment + pure `subagentNudgeAppend({enabled, hasProject, toolProfile})` gate (mirrors `computeTeamsNeeded`).
- **`index.ts`:** read `DEUS_SUBAGENT_NUDGE` kill-switch, compute the nudge after `toolProfile`, combine `[systemAppend, subagentNudge].filter(Boolean).join('\n\n')` into the SDK `systemPrompt.append`.
- **Gate (append only when all hold):** `enabled && hasProject && toolProfile === 'full'`.
  - Plain chat has no project → no append → **plain chat pays zero tokens and is unchanged**.
  - The webhook profile (LIA-315) excludes the `Task` tool → excluded (nudging it would be incoherent).
- **One injection point covers both lanes:** the interactive coding agent and the autonomous Linear-dispatch agent both run project-mounted. **No `src/private/` change.**
- **Runtime kill-switch:** `DEUS_SUBAGENT_NUDGE=0` disables without a redeploy (instant rollback / no-redeploy A/B for the unattended pipeline).

## Cost

~150 tokens per turn, **only** in engineering context. Plain chat: 0.

## Tests / verification

- `npx tsc --noEmit` (container/agent-runner): exit 0.
- `npx vitest run`: 192/192 pass (18 files); new `subagent-nudge.test.ts`: 5/5 (every gate branch incl. kill-switch).
- Wardens: plan-reviewer (claude+gpt), code-reviewer (claude+gpt+glm), ai-eng-warden (claude+gpt), verification-gate (Opus) — all SHIP.

## Deploy

**Container rebuild required** — `./container/build.sh` (agent-runner is the container image; the change is inert until rebuilt).

## Honest scope: effectiveness is shipping on hypothesis

These tests prove the *plumbing* (gate fires correctly, types compile, no chat regression). They do **not** prove the nudge actually makes Opus fan out more in real runs. The behavioral E2E is a **required deploy-time follow-up**, not proven by this diff:
- Pinned positive task (project-mounted, three independent reads) → confirm ≥2 parallel `Task` subagents + one synthesized answer.
- Measurement: `Task`-spawn rate across the deploy boundary (first 20 project-mounted dispatches post-deploy vs the 20 before).

## Follow-up (not in this PR)

Log `subagentNudgeEnabled` alongside the existing available-tools manifest (LIA-154) so nudge activation can be correlated against actual `Task` calls in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)