### PR TITLE
feat(scripts): subagent fan-out measurement report (LIA-343 validation)

### DIFF
--- a/scripts/maintenance/subagent_fanout_report.py
+++ b/scripts/maintenance/subagent_fanout_report.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Report parallel-subagent fan-out per container run (LIA-343 validation).
+
+Counts subagent spawns per engineering-context run from the existing per-
+interaction tool-call logs written by `container/agent-runner/src/tool-call-log.ts`
+(LIA-154) at `groups/<group>/logs/tool-calls/<interaction_id>.jsonl`. One file =
+one run; each line is one tool call `{ts, name, ...}`.
+
+Used to validate the Layer-A subagent fan-out nudge: did the engineering agent
+start fanning out after the nudge shipped? Run with `--since <deploy-ISO>` to
+split runs into before/after the deploy boundary.
+
+Counting methodology:
+  - spawn        = a record with name in {"Task", "Agent"} (tool-call-log.ts:86
+                   groups 'Agent' || 'Task'; counting only "Task" undercounts).
+  - task_output  = a record with name == "TaskOutput" (a subagent's result-push,
+                   NOT a spawn) — tallied separately as corroborating evidence.
+  - logging_gap  = a run with task_outputs > 0 but spawns == 0: a subagent
+                   demonstrably ran but its spawn record was not logged. Surfaced
+                   explicitly so the report never reports a misleadingly clean 0.
+
+Read-only. Never modifies logs. Agent-native (see docs/decisions/printing-press-adoption.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_SCRIPTS_DIR))
+from _exit_codes import SUCCESS, ABSTAIN, USAGE_ERROR, INTERNAL_ERROR  # noqa: E402
+from _agent_io import agent_output, is_agent_context  # noqa: E402
+
+_REPO_ROOT = _SCRIPTS_DIR.parent
+_DEFAULT_GROUPS_DIR = _REPO_ROOT / "groups"
+
+SPAWN_NAMES = frozenset({"Task", "Agent"})
+TASK_OUTPUT_NAME = "TaskOutput"
+
+
+def summarize_run(records: list[dict], group: str, interaction_id: str) -> dict:
+    """Reduce one run's tool-call records to fan-out counts. Pure."""
+    spawns = 0
+    task_outputs = 0
+    first_ts = None
+    for rec in records:
+        name = rec.get("name")
+        if name in SPAWN_NAMES:
+            spawns += 1
+        elif name == TASK_OUTPUT_NAME:
+            task_outputs += 1
+        if first_ts is None and isinstance(rec.get("ts"), str):
+            first_ts = rec["ts"]
+    return {
+        "group": group,
+        "interaction_id": interaction_id,
+        "first_ts": first_ts,
+        "total_calls": len(records),
+        "spawns": spawns,
+        "task_outputs": task_outputs,
+        "logging_gap": task_outputs > 0 and spawns == 0,
+    }
+
+
+def aggregate(runs: list[dict]) -> dict:
+    """Aggregate run summaries. Pure."""
+    n = len(runs)
+    total_spawns = sum(r["spawns"] for r in runs)
+    return {
+        "runs": n,
+        "total_spawns": total_spawns,
+        "runs_with_spawn": sum(1 for r in runs if r["spawns"] > 0),
+        # Honest fan-out-occurred signal: any explicit spawn OR a TaskOutput.
+        "runs_with_subagent_activity": sum(
+            1 for r in runs if r["spawns"] > 0 or r["task_outputs"] > 0
+        ),
+        "logging_gaps": sum(1 for r in runs if r["logging_gap"]),
+        "mean_spawn_per_run": round(total_spawns / n, 3) if n else 0.0,
+    }
+
+
+def _parse_since(value: str) -> datetime:
+    """Parse an ISO-8601 cutoff into an aware UTC datetime. Raises ValueError."""
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _run_dt(run: dict) -> datetime | None:
+    ts = run.get("first_ts")
+    if not isinstance(ts, str):
+        return None
+    try:
+        return _parse_since(ts)
+    except ValueError:
+        return None
+
+
+def _load_records(path: Path) -> list[dict]:
+    """Load one interaction file, skipping blank/malformed lines."""
+    records: list[dict] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            records.append(obj)
+    return records
+
+
+def _iter_run_files(groups_dir: Path, groups_filter: set[str] | None):
+    """Yield (group, file) for every tool-calls JSONL under groups_dir."""
+    if not groups_dir.is_dir():
+        return
+    for group_dir in sorted(groups_dir.iterdir()):
+        if not group_dir.is_dir():
+            continue
+        group = group_dir.name
+        if groups_filter is not None and group not in groups_filter:
+            continue
+        tc_dir = group_dir / "logs" / "tool-calls"
+        if not tc_dir.is_dir():
+            continue
+        for f in sorted(tc_dir.glob("*.jsonl")):
+            yield group, f
+
+
+def build_report(
+    groups_dir: Path,
+    groups_filter: set[str] | None,
+    since: datetime | None,
+) -> dict:
+    """Collect run summaries per group, optionally split before/after `since`."""
+    by_group: dict[str, list[dict]] = {}
+    for group, f in _iter_run_files(groups_dir, groups_filter):
+        run = summarize_run(_load_records(f), group, f.stem)
+        by_group.setdefault(group, []).append(run)
+
+    report: dict = {"groups_dir": str(groups_dir), "groups": {}}
+    if since is not None:
+        report["since"] = since.isoformat()
+    for group, runs in sorted(by_group.items()):
+        if since is None:
+            report["groups"][group] = aggregate(runs)
+            continue
+        before, after, undated = [], [], []
+        for run in runs:
+            dt = _run_dt(run)
+            if dt is None:
+                undated.append(run)
+            elif dt < since:
+                before.append(run)
+            else:
+                after.append(run)
+        entry = {"before": aggregate(before), "after": aggregate(after)}
+        if undated:
+            entry["undated"] = aggregate(undated)
+        report["groups"][group] = entry
+    return report
+
+
+def _fmt_agg(a: dict) -> str:
+    return (
+        f"runs={a['runs']} spawns={a['total_spawns']} "
+        f"runs_with_spawn={a['runs_with_spawn']} "
+        f"subagent_activity={a['runs_with_subagent_activity']} "
+        f"logging_gaps={a['logging_gaps']} mean={a['mean_spawn_per_run']}"
+    )
+
+
+def _print_human(report: dict) -> None:
+    since = report.get("since")
+    print(f"Subagent fan-out report  (groups_dir={report['groups_dir']})")
+    if since:
+        print(f"Split at --since {since}")
+    if not report["groups"]:
+        print("  (no tool-call logs found)")
+        return
+    for group, data in report["groups"].items():
+        print(f"\n{group}")
+        if since:
+            for bucket in ("before", "after", "undated"):
+                if bucket in data:
+                    print(f"  {bucket:8} {_fmt_agg(data[bucket])}")
+        else:
+            print(f"  {_fmt_agg(data)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--groups-dir",
+        default=str(_DEFAULT_GROUPS_DIR),
+        help="Path to the groups/ directory (default: <repo>/groups).",
+    )
+    parser.add_argument(
+        "--groups",
+        default=None,
+        help="Comma-separated group names to include (default: all).",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="ISO-8601 cutoff; split runs into before/after (e.g. the deploy time).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON.")
+    parser.add_argument(
+        "--compact", action="store_true", help="Token-efficient JSON (strip nulls)."
+    )
+    parser.add_argument(
+        "--select", default=None, help="Comma-separated field paths to project."
+    )
+    args = parser.parse_args(argv)
+
+    since = None
+    if args.since is not None:
+        try:
+            since = _parse_since(args.since)
+        except ValueError:
+            print(f"error: --since is not a valid ISO-8601 timestamp: {args.since}", file=sys.stderr)
+            return USAGE_ERROR
+
+    groups_filter = None
+    if args.groups:
+        groups_filter = {g.strip() for g in args.groups.split(",") if g.strip()}
+
+    try:
+        report = build_report(Path(args.groups_dir), groups_filter, since)
+    except OSError as exc:
+        print(f"error: failed to read logs: {exc}", file=sys.stderr)
+        return INTERNAL_ERROR
+
+    use_json = args.json or is_agent_context()
+    out = agent_output(
+        report, use_json=use_json, compact=args.compact, select=args.select
+    )
+    if out is not None:
+        print(out)
+    else:
+        _print_human(report)
+
+    return SUCCESS if report["groups"] else ABSTAIN
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_subagent_fanout_report.py
+++ b/scripts/tests/test_subagent_fanout_report.py
@@ -1,0 +1,125 @@
+"""Tests for scripts/maintenance/subagent_fanout_report.py (LIA-343)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_MOD_PATH = (
+    Path(__file__).resolve().parent.parent / "maintenance" / "subagent_fanout_report.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("subagent_fanout_report", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+def _rec(name, ts="2026-06-28T10:00:00.000Z"):
+    return {"ts": ts, "name": name, "is_error": False}
+
+
+def test_summarize_run_counts_task_and_agent_as_spawns():
+    records = [
+        _rec("Task"),
+        _rec("Task"),
+        _rec("Agent"),
+        _rec("Bash"),
+        _rec("Read"),
+        _rec("Glob"),
+    ]
+    s = mod.summarize_run(records, "g", "g-1")
+    assert s["spawns"] == 3
+    assert s["total_calls"] == 6
+    assert s["task_outputs"] == 0
+    assert s["logging_gap"] is False
+    assert s["first_ts"] == "2026-06-28T10:00:00.000Z"
+
+
+def test_summarize_run_orphan_taskoutput_is_logging_gap():
+    # The real baseline anomaly: a subagent ran (TaskOutput) but no spawn logged.
+    records = [_rec("TaskOutput"), _rec("Bash"), _rec("Read")]
+    s = mod.summarize_run(records, "g", "g-1")
+    assert s["spawns"] == 0
+    assert s["task_outputs"] == 1
+    assert s["logging_gap"] is True
+
+
+def test_aggregate_counts_activity_and_gaps():
+    runs = [
+        {"spawns": 2, "task_outputs": 0, "logging_gap": False},  # fan-out
+        {"spawns": 0, "task_outputs": 1, "logging_gap": True},  # gap (activity)
+        {"spawns": 0, "task_outputs": 0, "logging_gap": False},  # no activity
+    ]
+    a = mod.aggregate(runs)
+    assert a["runs"] == 3
+    assert a["total_spawns"] == 2
+    assert a["runs_with_spawn"] == 1
+    assert a["runs_with_subagent_activity"] == 2  # spawn run + gap run
+    assert a["logging_gaps"] == 1
+    assert a["mean_spawn_per_run"] == round(2 / 3, 3)
+
+
+def test_aggregate_empty():
+    a = mod.aggregate([])
+    assert a["runs"] == 0
+    assert a["mean_spawn_per_run"] == 0.0
+
+
+def _write_run(groups_dir: Path, group: str, iid: str, recs: list[dict]):
+    d = groups_dir / group / "logs" / "tool-calls"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{iid}.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in recs), encoding="utf-8"
+    )
+
+
+def test_build_report_since_split(tmp_path):
+    gd = tmp_path / "groups"
+    # before the cutoff: no spawns
+    _write_run(gd, "linear-dispatch", "ld-1", [_rec("Bash", "2026-06-10T00:00:00Z")])
+    # after the cutoff: one Task spawn
+    _write_run(
+        gd,
+        "linear-dispatch",
+        "ld-2",
+        [_rec("Task", "2026-06-28T12:00:00Z"), _rec("Bash", "2026-06-28T12:00:01Z")],
+    )
+    report = mod.build_report(gd, None, mod._parse_since("2026-06-20T00:00:00Z"))
+    ld = report["groups"]["linear-dispatch"]
+    assert ld["before"]["runs"] == 1
+    assert ld["before"]["total_spawns"] == 0
+    assert ld["after"]["runs"] == 1
+    assert ld["after"]["total_spawns"] == 1
+
+
+def test_main_json_and_abstain(tmp_path, capsys):
+    # No tool-calls anywhere -> ABSTAIN, empty groups.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    rc = mod.main(["--groups-dir", str(empty), "--json"])
+    assert rc == mod.ABSTAIN
+    out = json.loads(capsys.readouterr().out)
+    assert out["groups"] == {}
+
+    # With data -> SUCCESS, valid JSON.
+    gd = tmp_path / "groups"
+    _write_run(gd, "linear-dispatch", "ld-1", [_rec("Task"), _rec("Bash")])
+    rc = mod.main(["--groups-dir", str(gd), "--json"])
+    assert rc == mod.SUCCESS
+    out = json.loads(capsys.readouterr().out)
+    assert out["groups"]["linear-dispatch"]["total_spawns"] == 1
+
+
+def test_main_bad_since_is_usage_error(tmp_path):
+    rc = mod.main(["--groups-dir", str(tmp_path), "--since", "not-a-date"])
+    assert rc == mod.USAGE_ERROR


### PR DESCRIPTION
## What

A read-only, agent-native CLI — `scripts/maintenance/subagent_fanout_report.py` — that measures whether the LIA-343 fan-out nudge (PR #965) actually increased parallel-subagent fan-out in engineering-context runs. The behavioral effect is the open validation item from #965; this is the tooling to read the signal off real traffic.

## How

Reads the existing per-interaction tool-call logs (`groups/<group>/logs/tool-calls/<id>.jsonl`, written by `container/agent-runner/src/tool-call-log.ts` / LIA-154 — no new instrumentation). One file = one run.

**Counting methodology (deliberately not naive `name=="Task"`):**
- **spawn** = `name in {"Task", "Agent"}` — `tool-call-log.ts:86` itself groups `'Agent' || 'Task'`, so counting only `"Task"` would undercount.
- **TaskOutput** (a subagent's result-push, not a spawn) is tallied separately as corroborating evidence a subagent ran.
- **logging_gap** = a run with `TaskOutput > 0` but `spawns == 0` — a subagent demonstrably ran but its spawn record wasn't logged. Surfaced explicitly so under-logged fan-out never reads as a clean `0`. (This is a real anomaly in the baseline data, caught during plan-review.)

`--since <ISO>` splits runs before/after the deploy boundary. Per-group breakdown (no fragile "is this engineering?" heuristic — the caller filters `--groups linear-dispatch`).

## Captured baseline (the "before")

- **linear-dispatch (engineering lane, nudge applies): 7 runs / 172 tool calls / 0 logged spawns / 1 logging_gap.** Mean 0.00 spawns/run — empirically confirms the under-reach the nudge targets.
- whatsapp_main (chat, nudge does NOT apply): 23 runs, 5 spawns — the chat agent already fans out occasionally on its own, which is *why* the nudge targets the engineering lane specifically.

Success signal for #965 = post-deploy engineering runs show spawns clearly above this. The `after` bucket is empty today; it fills as the Linear-dispatch pipeline runs real work, and re-running the same command later yields the verdict.

## Tests / verification

- `python3 -m pytest scripts/tests/test_subagent_fanout_report.py` — 7/7 (spawn counting, the orphan-TaskOutput logging_gap case, aggregate, `--since` split, `--json`, ABSTAIN).
- Real-data run reproduces the baseline exactly; verification-gate (Opus) independently re-derived the counts from the raw logs.
- Agent-native protocol: typed exit codes (`SUCCESS`/`ABSTAIN`/`USAGE_ERROR`/`INTERNAL_ERROR`), `--json`/`--compact`/`--select`, `DEUS_AGENT_NATIVE`.
- Wardens: plan-reviewer (claude+gpt), code-reviewer (claude+gpt; glm fails-open on a z.ai timeout), verification-gate (Opus) — all SHIP.

Read-only; no changes to the logger or the nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)