### PR TITLE
fix(memory): cap MCP memory_recall payload server-side (LIA-344)

### DIFF
--- a/scripts/memory_mcp_server.py
+++ b/scripts/memory_mcp_server.py
@@ -52,6 +52,24 @@ except ImportError:
     _MCP_AVAILABLE = False
 
 
+def _int_env(name: str, default: int) -> int:
+    """Positive-int env override with a safe fallback (invalid/<=0 -> default)."""
+    try:
+        v = int(os.environ.get(name, ""))  # LIA-344
+    except ValueError:
+        return default
+    return v if v > 0 else default
+
+
+# LIA-344: bound the MCP recall payload server-side (the host hook caps at 4096,
+# but the MCP path returned recall()'s context uncapped with no k ceiling).
+# 8192 chars (~2k tok) exceeds the largest real procedure node (2,962) and a
+# typical k=3 body (~5 KB) while bounding the k=10 worst case (~57 KB). Both
+# env-overridable starting values, tunable post-ship on real MCP traffic.
+_MAX_CONTEXT_CHARS = _int_env("DEUS_MCP_RECALL_MAX_CHARS", 8192)  # LIA-344
+_K_MAX = _int_env("DEUS_MCP_RECALL_MAX_K", 10)  # LIA-344
+
+
 def memory_recall(query: str, k: int = 3, source: str = "mcp") -> dict:
     """Retrieve memory context for a query.
 
@@ -60,8 +78,12 @@ def memory_recall(query: str, k: int = 3, source: str = "mcp") -> dict:
 
     Args:
         query:  Natural-language query (e.g. "what is Liam's timezone?").
-        k:      Number of top results to return.
+        k:      Number of top results to return (LIA-344: clamped server-side to
+                1.._K_MAX, default ceiling 10).
         source: Identifier written to the retrieval log (default ``"mcp"``).
+
+    The formatted context is capped server-side to ``_MAX_CONTEXT_CHARS``
+    (LIA-344) so a caller cannot pull an unbounded payload.
 
     Returns:
         ``{"context": str, "paths": [str], "confidence": float, "fell_back": bool}``
@@ -73,7 +95,16 @@ def memory_recall(query: str, k: int = 3, source: str = "mcp") -> dict:
     # the default-off host hook — see docs/decisions/procedure-memory-default-on.md.
     proc_disabled = os.environ.get("DEUS_PROCEDURE_MEMORY", "").strip() == "0"
     exclude_kinds = None if proc_disabled else {"standard"}
-    return memory_query.recall(query, k=k, source=source, exclude_kinds=exclude_kinds)
+    # LIA-344: clamp k and cap the formatted context so an MCP caller cannot pull
+    # an unbounded payload (the sentinel framing survives — see _truncate_body).
+    k = min(max(1, k), _K_MAX)
+    return memory_query.recall(
+        query,
+        k=k,
+        source=source,
+        exclude_kinds=exclude_kinds,
+        max_context_chars=_MAX_CONTEXT_CHARS,
+    )
 
 
 def _run_mcp_server() -> None:

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -87,7 +87,22 @@ def _wrap_untrusted(body: str, *, label: str) -> str:
     ])
 
 
-def _format_context(results: list[dict], fell_back: bool) -> str:
+def _truncate_body(body: str, max_context_chars: int | None) -> str:
+    """Head-truncate a to-be-wrapped body to a char budget.
+
+    Applied to the FULL joined body (all results) exactly once, BEFORE
+    ``_wrap_untrusted``, so the untrusted framing header + both random sentinels
+    always survive — strictly stronger than the hook's post-wrap head-truncation
+    (LIA-335). Identity when uncapped (``None``) or already within budget.
+    """
+    if max_context_chars is None or len(body) <= max_context_chars:
+        return body
+    return body[:max_context_chars] + "\n=== [truncated] ==="
+
+
+def _format_context(
+    results: list[dict], fell_back: bool, *, max_context_chars: int | None = None
+) -> str:
     if fell_back or not results:
         return ""
     body_lines: list[str] = []
@@ -99,7 +114,9 @@ def _format_context(results: list[dict], fell_back: bool) -> str:
     if not body_lines:
         # All results unreadable: emit nothing rather than an empty wrapper.
         return ""
-    return _wrap_untrusted("\n".join(body_lines), label="may not be relevant to your task")
+    # Cap the single joined body ONCE (total bound, independent of k).
+    body = _truncate_body("\n".join(body_lines), max_context_chars)
+    return _wrap_untrusted(body, label="may not be relevant to your task")
 
 
 def _log_retrieval(
@@ -286,7 +303,7 @@ def _procedure_ids(db, result_ids: list[str]) -> set[str]:
     return {r[0] for r in rows}
 
 
-def _atom_fallback(query: str, k: int) -> str | None:
+def _atom_fallback(query: str, k: int, *, max_context_chars: int | None = None) -> str | None:
     """Best-effort fallback: query atoms when tree abstains. Returns None on any failure."""
     if ATOM_DIST_THRESHOLD <= 0:
         return None
@@ -316,7 +333,7 @@ def _atom_fallback(query: str, k: int) -> str | None:
         if not good:
             return None
 
-        body = "\n".join(f"- {tldr}" for tldr, _ in good)
+        body = _truncate_body("\n".join(f"- {tldr}" for tldr, _ in good), max_context_chars)
         return _wrap_untrusted(body, label="atom fallback")
     except Exception as exc:
         print(f"[deus] atom_fallback failed: {exc}", file=sys.stderr)
@@ -331,6 +348,7 @@ def recall(
     source: str = "unknown",
     concepts: list[str] | None = None,
     exclude_kinds: set[str] | None = None,
+    max_context_chars: int | None = None,
 ) -> dict:
     """Retrieve memory context for a query.
 
@@ -377,7 +395,7 @@ def recall(
             raw["trace"].append("intent_gate:unavailable")
 
     if raw["fell_back"]:
-        atom_context = _atom_fallback(query, k)
+        atom_context = _atom_fallback(query, k, max_context_chars=max_context_chars)
         if atom_context:
             raw["atom_fallback"] = True
             _log_retrieval(query, raw, source)
@@ -389,7 +407,9 @@ def recall(
                 "atom_fallback": True,
             }
 
-    context = _format_context(raw["results"], raw["fell_back"])
+    context = _format_context(
+        raw["results"], raw["fell_back"], max_context_chars=max_context_chars
+    )
     paths = [r["path"] for r in raw["results"]] if not raw["fell_back"] else []
 
     out = {

--- a/scripts/tests/test_memory_mcp_server.py
+++ b/scripts/tests/test_memory_mcp_server.py
@@ -51,7 +51,11 @@ class TestMemoryRecallTool:
             result = mms.memory_recall("what timezone?", k=5, source="test")
 
         mock_recall.assert_called_once_with(
-            "what timezone?", k=5, source="test", exclude_kinds={"standard"}
+            "what timezone?",
+            k=5,
+            source="test",
+            exclude_kinds={"standard"},
+            max_context_chars=mms._MAX_CONTEXT_CHARS,
         )
         assert result == FAKE_RECALL_RESULT
 
@@ -145,3 +149,48 @@ class TestServerName:
             mms._run_mcp_server()
 
         assert "deus-memory" in created_servers
+
+
+class TestMemoryRecallCap:
+    """LIA-344: server-side payload bound (k clamp + max_context_chars)."""
+
+    def test_forwards_max_context_chars(self):
+        with patch.object(mq, "recall", return_value=FAKE_RECALL_RESULT) as mock_recall:
+            mms.memory_recall("hello")
+        _, kwargs = mock_recall.call_args
+        assert kwargs["max_context_chars"] == mms._MAX_CONTEXT_CHARS
+
+    def test_clamps_large_k_to_ceiling(self):
+        with patch.object(mq, "recall", return_value=FAKE_RECALL_RESULT) as mock_recall:
+            mms.memory_recall("hello", k=9999)
+        _, kwargs = mock_recall.call_args
+        assert kwargs["k"] == mms._K_MAX
+
+    def test_clamps_non_positive_k_to_one(self):
+        with patch.object(mq, "recall", return_value=FAKE_RECALL_RESULT) as mock_recall:
+            mms.memory_recall("hello", k=0)
+        _, kwargs = mock_recall.call_args
+        assert kwargs["k"] == 1
+
+    def test_k_within_range_passes_through(self):
+        with patch.object(mq, "recall", return_value=FAKE_RECALL_RESULT) as mock_recall:
+            mms.memory_recall("hello", k=3)
+        _, kwargs = mock_recall.call_args
+        assert kwargs["k"] == 3
+
+
+class TestIntEnvGuard:
+    """LIA-344: env override parsing with safe fallback."""
+
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("DEUS_MCP_RECALL_MAX_CHARS", raising=False)
+        assert mms._int_env("DEUS_MCP_RECALL_MAX_CHARS", 8192) == 8192
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("DEUS_MCP_RECALL_MAX_CHARS", "5000")
+        assert mms._int_env("DEUS_MCP_RECALL_MAX_CHARS", 8192) == 5000
+
+    @pytest.mark.parametrize("bad", ["abc", "", "0", "-10", "3.5"])
+    def test_invalid_or_non_positive_falls_back(self, monkeypatch, bad):
+        monkeypatch.setenv("DEUS_MCP_RECALL_MAX_CHARS", bad)
+        assert mms._int_env("DEUS_MCP_RECALL_MAX_CHARS", 8192) == 8192

--- a/scripts/tests/test_memory_query.py
+++ b/scripts/tests/test_memory_query.py
@@ -581,3 +581,85 @@ class TestIntentChain:
         monkeypatch.setattr(mq, "_classify_ollama", fake)
         assert mq.classify_intent("q") == "factual"
         assert calls == ["m1"]
+
+
+class TestTruncateBody:
+    """LIA-344: single-pass body cap applied before untrusted-wrap."""
+
+    def test_none_is_passthrough(self):
+        body = "x" * 10000
+        assert mq._truncate_body(body, None) == body
+
+    def test_under_cap_is_identity(self):
+        body = "short body"
+        assert mq._truncate_body(body, 8192) == body
+
+    def test_over_cap_head_truncates_with_marker(self):
+        body = "y" * 5000
+        out = mq._truncate_body(body, 100)
+        assert out.startswith("y" * 100)
+        assert out.endswith("=== [truncated] ===")
+        assert len(out) == 100 + len("\n=== [truncated] ===")
+
+
+class TestFormatContextCap:
+    """LIA-344: _format_context bounds the JOINED body once, framing survives."""
+
+    def _results(self, n):
+        return [{"path": f"n{i}.md", "score": 0.5} for i in range(n)]
+
+    def test_cap_bounds_total_and_preserves_framing(self):
+        # Each node returns a large body; with 3 results an uncapped join would be
+        # ~9k chars. Cap the joined body to 500 and assert the total stays bounded.
+        with patch.object(mq, "_read_node_file", return_value="z" * 3000):
+            out = mq._format_context(self._results(3), False, max_context_chars=500)
+        # Untrusted framing header (line 1) + both sentinels survive.
+        assert out.startswith("=== Auto-retrieved memory")
+        assert out.count("<<<UNTRUSTED-MEMORY-") == 3  # header mention + open + close
+        assert "=== [truncated] ===" in out
+        # Bounded: body<=500 + wrapper overhead (~410 measured) -> comfortably <1200.
+        assert len(out) < 1200
+
+    def test_default_none_is_uncapped(self):
+        with patch.object(mq, "_read_node_file", return_value="z" * 3000):
+            out = mq._format_context(self._results(3), False)
+        assert "=== [truncated] ===" not in out
+        assert out.count("<<<UNTRUSTED-MEMORY-") == 3  # header mention + open + close
+
+
+class TestAtomFallbackCap:
+    """LIA-344: the atom-fallback path is also capped (security-relevant path)."""
+
+    def test_atom_fallback_body_is_capped(self, monkeypatch):
+        # Force the atom path to produce an oversized joined body, then cap it.
+        monkeypatch.setattr(mq, "ATOM_DIST_THRESHOLD", 1.0)
+
+        class _FakeMI:
+            def open_db(self):
+                return self
+
+            def execute(self, sql, *args):
+                class _Cur:
+                    def fetchone(_self):
+                        return (5,)
+
+                    def fetchall(_self):
+                        return [("A" * 4000, 0.1), ("B" * 4000, 0.2)]
+
+                return _Cur()
+
+            def close(self):
+                pass
+
+            def embed(self, _q):
+                return [0.0]
+
+            def serialize(self, _v):
+                return b""
+
+        monkeypatch.setitem(sys.modules, "memory_indexer", _FakeMI())
+        out = mq._atom_fallback("q", 5, max_context_chars=500)
+        assert out is not None
+        assert "=== [truncated] ===" in out
+        assert out.count("<<<UNTRUSTED-MEMORY-") == 3  # framing survives
+        assert len(out) < 1200


### PR DESCRIPTION
## What
Adds a server-side bound on the `deus-memory` MCP `memory_recall` payload (LIA-344). The host recall hook already caps at `MAX_CONTEXT_CHARS=4096`, but the MCP path returned `recall()`'s formatted context uncapped with no `k` ceiling — a caller could pull an unbounded payload.

## Measured (reproducible)
Over the live 164-node memory dir: worst-case k=10 body = 57,644 chars (~14.4k tok); k=3 worst = 29,748; largest real **procedure** node = 2,962; only 2/164 nodes exceed 8,192 (the MEMORY.md index + feedback_style.md). Live repro: uncapped k=10 ≈ 26–34k chars → capped `memory_recall` = 8,619 chars.

## How
- `_truncate_body` helper: head-truncate the **single joined body once** (total bound, independent of `k`) **before** `_wrap_untrusted`, so the LIA-335 untrusted framing header + both random sentinels always survive — strictly stronger than the hook's post-wrap truncation.
- Keyword-only `max_context_chars` threaded through `recall` / `_format_context` / `_atom_fallback`. Default `None` → **no change** to hook/CLI behavior.
- `memory_recall` clamps `k = min(max(1, k), _K_MAX)` and passes `_MAX_CONTEXT_CHARS`.
- Env-overridable `_MAX_CONTEXT_CHARS` (8192) / `_K_MAX` (10) with safe int-parse fallback (invalid/≤0 → default). 8192 chosen because it exceeds the largest real procedure body (2,962) and a typical k=3 body (~5 KB) while bounding the k=10 worst case.

## Tests
`scripts/tests/test_memory_query.py` + `test_memory_mcp_server.py`: `_truncate_body` (None/under/over-cap), `_format_context` cap + framing survival, `_atom_fallback` cap, `memory_recall` k-clamp + cap forwarding, `_int_env` guard. Full memory suites: 98 passed, 1 skipped; broader memory suite 619 passed, no regressions. flag_lint clean.

## Ceiling note
The cap bounds the body; the wrapper (header + 2 sentinels + footer) adds ~410 chars measured, so final payload ≈ 8,600. 8192/10 are env-overridable starting values, tunable post-ship.

## Accepted tradeoff / follow-ups
- Head-truncation drops the lowest-ranked tail first (results are score-sorted). In a k≥3 batch a lower-ranked result can be truncated mid-content rather than getting a per-result share. Acceptance is "bounded payload," not "fair per-result budget."
- Follow-up (ai-eng-warden recommendation): add a `truncated: bool` to the retrieval log so the post-ship tuning of the env knobs has real traffic data.

## Gates
plan-reviewer (claude+gpt) SHIP · code-reviewer (claude+gpt+glm) SHIP · ai-eng-warden (claude) SHIP · verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)