### PR TITLE
fix(agent-runner): measure model-facing tool-output size, not SDK internals (LIA-347)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -29,6 +29,7 @@ import { fileURLToPath } from 'url';
 
 import { bootstrap } from './bootstrap.js';
 import { loadRegisteredContextFiles } from './context-registry.js';
+import { measureToolResponse } from './tool-size-measure.js';
 import { createMemoryRetrievalHook } from './memory-retrieval-hook.js';
 import { runOpenAIConversation } from './openai-backend.js';
 import { runLlamaCppConversation } from './llama-cpp-backend.js';
@@ -442,11 +443,12 @@ function createToolSizeLogHook(): HookCallback {
   return async (input, _toolUseId, _context) => {
     try {
       const hookInput = input as PostToolUseHookInput;
-      const serialized =
-        typeof hookInput.tool_response === 'string'
-          ? hookInput.tool_response
-          : JSON.stringify(hookInput.tool_response ?? '');
-      const bytes = Buffer.byteLength(serialized, 'utf8');
+      // Measure the MODEL-FACING size: file-mutation tools embed full-file
+      // snapshots the model never receives (LIA-347, see tool-size-measure.ts).
+      const { bytes, stripped } = measureToolResponse(
+        hookInput.tool_name,
+        hookInput.tool_response,
+      );
       // Rough heuristic: ~3.7 bytes per token for mixed English+code. Phase A
       // uses this for relative comparison, not absolute budgeting.
       const approxTokens = Math.round(bytes / 3.7);
@@ -456,6 +458,7 @@ function createToolSizeLogHook(): HookCallback {
         tool_use_id: hookInput.tool_use_id,
         bytes,
         approx_tokens: approxTokens,
+        stripped,
       };
       fs.mkdirSync(path.dirname(logPath), { recursive: true });
       fs.appendFileSync(logPath, JSON.stringify(entry) + '\n');

--- a/container/agent-runner/src/tool-size-measure.test.ts
+++ b/container/agent-runner/src/tool-size-measure.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  NON_MODEL_FACING_FIELDS,
+  measureToolResponse,
+} from './tool-size-measure.js';
+
+describe('measureToolResponse', () => {
+  it('measures string responses as-is (Read/Bash path)', () => {
+    const text = 'hello world';
+    const { bytes, stripped } = measureToolResponse('Read', text);
+    expect(bytes).toBe(Buffer.byteLength(text, 'utf8'));
+    expect(stripped).toBe(false);
+  });
+
+  it('strips originalFile for Edit and shrinks the measured size', () => {
+    const resp = {
+      filePath: '/f.ts',
+      oldString: 'a',
+      newString: 'b',
+      originalFile: 'X'.repeat(50_000),
+      structuredPatch: [
+        {
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+          lines: ['-a', '+b'],
+        },
+      ],
+      userModified: false,
+      replaceAll: false,
+    };
+    const { bytes, stripped } = measureToolResponse('Edit', resp);
+    expect(stripped).toBe(true);
+    expect(bytes).toBeLessThan(1_000); // 50k originalFile excluded
+    // Model-facing fields retained.
+    const roundtrip = JSON.stringify({ ...resp, originalFile: undefined });
+    expect(bytes).toBeLessThan(Buffer.byteLength(JSON.stringify(resp), 'utf8'));
+    expect(roundtrip).toContain('structuredPatch');
+  });
+
+  it('strips originalFile AND content for Write', () => {
+    const resp = {
+      type: 'update',
+      filePath: '/f.ts',
+      content: 'C'.repeat(40_000),
+      originalFile: 'O'.repeat(40_000),
+      structuredPatch: [],
+    };
+    const { bytes, stripped } = measureToolResponse('Write', resp);
+    expect(stripped).toBe(true);
+    expect(bytes).toBeLessThan(1_000); // both full-file fields excluded
+  });
+
+  it('strips original_file AND updated_file for NotebookEdit, keeps new_source', () => {
+    const resp = {
+      new_source: 'print(1)',
+      cell_type: 'code',
+      language: 'python',
+      edit_mode: 'replace',
+      notebook_path: '/n.ipynb',
+      original_file: 'N'.repeat(60_000),
+      updated_file: 'U'.repeat(60_000),
+    };
+    const { bytes, stripped } = measureToolResponse('NotebookEdit', resp);
+    expect(stripped).toBe(true);
+    expect(bytes).toBeLessThan(1_000);
+  });
+
+  it('does NOT strip model-facing content on non-denylisted tools', () => {
+    // A Read-like result carries a model-facing `content` field — must be kept.
+    const resp = { filePath: '/f.ts', content: 'Z'.repeat(10_000) };
+    const { bytes, stripped } = measureToolResponse('Read', resp);
+    expect(stripped).toBe(false);
+    expect(bytes).toBe(Buffer.byteLength(JSON.stringify(resp), 'utf8'));
+  });
+
+  it('marks stripped=false when a denylisted tool lacks the fields', () => {
+    const resp = { filePath: '/f.ts', structuredPatch: [] };
+    const { stripped } = measureToolResponse('Edit', resp);
+    expect(stripped).toBe(false);
+  });
+
+  it('handles null/undefined without throwing', () => {
+    expect(() => measureToolResponse('Edit', null)).not.toThrow();
+    expect(() => measureToolResponse('Read', undefined)).not.toThrow();
+    expect(measureToolResponse('Edit', null).stripped).toBe(false);
+  });
+
+  it('does not mutate the input object', () => {
+    const resp = { originalFile: 'x', structuredPatch: [] };
+    measureToolResponse('Edit', resp);
+    expect(resp.originalFile).toBe('x'); // shallow-copied, not deleted in place
+  });
+
+  it('denylist covers exactly the allowed file-mutation tools', () => {
+    expect(Object.keys(NON_MODEL_FACING_FIELDS).sort()).toEqual([
+      'Edit',
+      'NotebookEdit',
+      'Write',
+    ]);
+  });
+});

--- a/container/agent-runner/src/tool-size-measure.ts
+++ b/container/agent-runner/src/tool-size-measure.ts
@@ -1,0 +1,72 @@
+/**
+ * Model-facing size measurement for the Headroom POC tool-size log (LIA-347).
+ *
+ * The PostToolUse hook only receives the SDK's structured `tool_response`, which
+ * for file-mutation tools embeds full-file snapshots the model NEVER receives
+ * (Edit: `originalFile`; Write: `originalFile` + `content`; NotebookEdit:
+ * `original_file` + `updated_file`). Naively `JSON.stringify`-ing the whole
+ * object over-counts those tools massively (Edit measured ~11.8k tok/call, ~32%
+ * of all reported container tool tokens were phantom). This module strips those
+ * non-model-facing fields, per tool, before measuring — so `tool-sizes.jsonl`
+ * tracks roughly what the model actually consumes. Read/Bash/Grep etc. carry
+ * genuinely model-facing content and are left byte-identical to before.
+ *
+ * Measurement only: this never alters what the model or the SDK sees.
+ */
+
+/**
+ * Fields present on a tool's `tool_response` that the model does NOT receive,
+ * keyed by tool name. Verified against @anthropic-ai/claude-agent-sdk
+ * sdk-tools.d.ts (FileEditOutput / FileWriteOutput / NotebookEditOutput) and
+ * scoped to the file-mutation tools actually allowed (allowed-tools.ts). Tools
+ * absent here are measured unchanged. MultiEdit is intentionally omitted: it has
+ * no output type in this SDK and is not an allowed tool.
+ */
+export const NON_MODEL_FACING_FIELDS: Record<string, readonly string[]> = {
+  Edit: ['originalFile'],
+  Write: ['originalFile', 'content'],
+  NotebookEdit: ['original_file', 'updated_file'],
+};
+
+export interface MeasuredResponse {
+  /** UTF-8 byte length of the model-facing portion of the tool response. */
+  bytes: number;
+  /** True when at least one non-model-facing field was excluded. */
+  stripped: boolean;
+}
+
+/**
+ * Measure the model-facing byte size of a tool response. String responses and
+ * tools with no denylist entry are measured as-is; file-mutation tools have
+ * their full-file fields removed first.
+ */
+export function measureToolResponse(
+  toolName: string,
+  toolResponse: unknown,
+): MeasuredResponse {
+  if (typeof toolResponse === 'string') {
+    return { bytes: Buffer.byteLength(toolResponse, 'utf8'), stripped: false };
+  }
+
+  const fields = NON_MODEL_FACING_FIELDS[toolName];
+  let value: unknown = toolResponse ?? '';
+  let stripped = false;
+
+  if (
+    fields &&
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value)
+  ) {
+    const copy = { ...(value as Record<string, unknown>) };
+    for (const field of fields) {
+      if (field in copy) {
+        delete copy[field];
+        stripped = true;
+      }
+    }
+    value = copy;
+  }
+
+  return { bytes: Buffer.byteLength(JSON.stringify(value), 'utf8'), stripped };
+}


### PR DESCRIPTION
## What
The Headroom-POC tool-size log (`createToolSizeLogHook`, `container/agent-runner/src/index.ts`) `JSON.stringify`'d the entire SDK `tool_response`. For file-mutation tools that object embeds full-file snapshots the **model never receives**:
- `FileEditOutput.originalFile` (whole original file)
- `FileWriteOutput.originalFile` + `content` (whole original + whole new file)
- `NotebookEditOutput.original_file` + `updated_file` (two whole-notebook copies)

Result: Edit measured ~11,814 tok/call and **~2.03M of 6.24M reported container "tool tokens" (32.5%) were phantom** — never sent to the model, never billed. This could mislead the Headroom Phase A compression decision.

## How
- New pure module `container/agent-runner/src/tool-size-measure.ts`: `measureToolResponse(toolName, resp)` strips the non-model-facing fields per tool (denylist scoped to the **three allowed file-mutation tools** — verified against `allowed-tools.ts`), then byte-measures. String responses and all other tools are byte-identical to before.
- `MultiEdit` deliberately omitted: no `MultiEditOutput` type in the SDK and not an allowed tool.
- `index.ts` uses it and records a `stripped` bool in each JSONL entry (consumed safely by `scripts/analyze_token_efficiency.py` via `d.get()`).
- **Measurement-only**: never alters what the model or SDK sees (`createToolSizeLogHook` still returns `{}`); zero real tokens/dollars change.

## Over-strip guard
Fields are stripped **only by tool name** (Edit/Write/NotebookEdit). A model-facing `content` on a Read-like result is never dropped — covered by a dedicated test.

## `gitDiff.patch` scoped out (deliberate)
`FileEditOutput`/`FileWriteOutput` also carry an optional `gitDiff.patch`, left unstripped: it's proportional to the edit size (≈ what the model sees), not a full-file dump, so not the phantom class this targets.

## Tests / verification
New `tool-size-measure.test.ts` (strip per tool, over-strip guard, null/array/no-mutation). Full agent-runner suite **201 passed** (`test-agent-runner` covers it); `tsc --noEmit` clean. Live both-halves probe: naive Edit 50,073 bytes → measured 55 bytes (stripped); Read-like object not stripped.

## Deploy note
Container change → rebuild the agent container (`./container/build.sh`) post-merge.

## Gates
plan-reviewer (claude+gpt) SHIP · code-reviewer (claude+gpt+glm) SHIP · verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)