### PR TITLE
fix(scripts): make compression_benchmark robust to imperfect local-judge JSON

### DIFF
--- a/scripts/compression_benchmark.py
+++ b/scripts/compression_benchmark.py
@@ -183,11 +183,35 @@ Facts to verify:
 {json.dumps(batch, indent=2)}
 
 Output ONLY a JSON array of objects: {{"fact": "...", "status": "preserved|derivable|missing", "note": "..."}}"""
-        batch_results = parse_json(llm_call(prompt))
-        # Attach classification to each result
-        for r in batch_results:
-            r["classification"] = classifications.get(r.get("fact", ""), "supplementary")
-        all_results.extend(batch_results)
+        # The local judge occasionally emits imperfect JSON (bare-string array
+        # element, dict missing "fact"/"status", non-list root, or a totally
+        # unparseable response). Build results by iterating the INPUT batch so
+        # every fact gets exactly one well-formed verdict (stable denominator);
+        # any malformed/omitted judge entry backfills conservatively to "missing"
+        # (never inflates coverage). Guarantees fact/status/classification on
+        # every element -> all downstream indexing is safe.
+        try:
+            raw = parse_json(llm_call(prompt))
+        except ValueError:
+            raw = None
+        by_fact: dict[str, dict] = {}
+        if isinstance(raw, list):
+            for el in raw:
+                if isinstance(el, dict) and isinstance(el.get("fact"), str) and el["fact"]:
+                    status = el.get("status")
+                    if status not in ("preserved", "derivable", "missing"):
+                        status = "missing"
+                    el["status"] = status
+                    by_fact[el["fact"]] = el
+        for fact in batch:
+            r = by_fact.get(fact)
+            if not isinstance(r, dict):
+                # No valid verdict for this fact -> conservative "missing".
+                r = {"fact": fact, "status": "missing", "note": "no valid verdict returned"}
+            # by_fact entries were already normalized (valid status, fact == key),
+            # so both branches now guarantee fact + status here.
+            r["classification"] = classifications.get(fact, "supplementary")
+            all_results.append(r)
     return all_results
 
 

--- a/scripts/tests/test_compression_benchmark.py
+++ b/scripts/tests/test_compression_benchmark.py
@@ -463,3 +463,79 @@ def test_module_constants_are_paths():
     assert isinstance(cb.BENCHMARK_DIR, Path)
     assert isinstance(cb.GOLDEN_DIR, Path)
     assert isinstance(cb.RESULTS_LOG, Path)
+
+
+# == verify_facts robustness against malformed local-judge JSON ================
+
+_FACTS = [
+    {"fact": "A", "classification": "critical"},
+    {"fact": "B", "classification": "supplementary"},
+]
+
+
+def _verify_with(judge_output: str):
+    """Run verify_facts with llm_call mocked to return a canned judge string."""
+    with patch.object(cb, "llm_call", return_value=judge_output):
+        return cb.verify_facts(_FACTS, "compressed doc")
+
+
+def _status_of(results, fact):
+    return next(r["status"] for r in results if r["fact"] == fact)
+
+
+def test_verify_facts_wellformed_is_identity():
+    res = _verify_with('[{"fact":"A","status":"preserved"},{"fact":"B","status":"missing"}]')
+    assert len(res) == len(_FACTS)
+    assert _status_of(res, "A") == "preserved"
+    assert _status_of(res, "B") == "missing"
+    # classification preserved from input
+    assert next(r["classification"] for r in res if r["fact"] == "A") == "critical"
+
+
+def test_verify_facts_bare_string_element_backfills_missing():
+    res = _verify_with('["A", {"fact":"B","status":"preserved"}]')
+    assert len(res) == len(_FACTS)
+    assert _status_of(res, "A") == "missing"   # bare string not keyed
+    assert _status_of(res, "B") == "preserved"
+
+
+def test_verify_facts_dict_missing_status_is_missing():
+    res = _verify_with('[{"fact":"A"},{"fact":"B","status":"preserved"}]')
+    assert _status_of(res, "A") == "missing"
+    assert _status_of(res, "B") == "preserved"
+
+
+def test_verify_facts_dict_missing_fact_no_keyerror():
+    res = _verify_with('[{"status":"preserved"}]')
+    assert len(res) == len(_FACTS)
+    assert all(r["status"] == "missing" for r in res)
+    # every result has a usable fact key (no KeyError downstream)
+    assert {r["fact"] for r in res} == {"A", "B"}
+
+
+def test_verify_facts_unhashable_fact_no_typeerror():
+    # list-valued "fact" would TypeError as a dict key without the str guard
+    res = _verify_with('[{"fact":["x","y"],"status":"preserved"}]')
+    assert len(res) == len(_FACTS)
+    assert all(r["status"] == "missing" for r in res)
+
+
+def test_verify_facts_non_list_root_backfills_missing():
+    res = _verify_with('{"fact":"A","status":"preserved"}')
+    assert len(res) == len(_FACTS)
+    assert all(r["status"] == "missing" for r in res)
+
+
+def test_verify_facts_unparseable_no_crash():
+    res = _verify_with("total garbage, no json here at all")
+    assert len(res) == len(_FACTS)
+    assert all(r["status"] == "missing" for r in res)
+
+
+def test_verify_facts_len_invariant_and_score_runs():
+    # denominator invariant + downstream compute_weighted_score never raises
+    for out in ('["A"]', '{"x":1}', "garbage", '[{"status":"missing"}]'):
+        res = _verify_with(out)
+        assert len(res) == len(_FACTS)
+        s = cb.compute_weighted_score(res)  # must not raise on any shape
+        assert s["total"] == len(_FACTS)


### PR DESCRIPTION
## What
`scripts/compression_benchmark.py`'s `verify_facts` crashed mid-run whenever the local Ollama judge (`gemma4:e4b`) returned imperfect JSON. Observed live this session validating the vault slim — four distinct crash shapes:
- bare-string array element → `AttributeError: 'str' has no attribute 'get'`
- dict missing `status` → `KeyError('status')` (downstream in `compute_weighted_score`)
- list/dict-valued `fact` → `TypeError: unhashable type` (used as a dict key)
- non-list root, or totally unparseable response → uncaught `parse_json` `ValueError`

## How
Rebuild the per-batch results by iterating the **input `batch`**, not the judge output:
- wrap `parse_json(llm_call(...))` in `try/except ValueError`
- only key `by_fact` on a hashable **string** `fact`; normalize `status` to the valid enum, else `"missing"`
- every input fact gets exactly one verdict; any malformed/omitted judge entry backfills conservatively to `"missing"`

Result: stable denominator (`len(results) == len(facts)`), **never inflates coverage**, and every result dict is guaranteed `fact`+`status`+`classification` so all downstream indexing is safe. Well-formed judge output is unchanged (identity, modulo input ordering which all consumers ignore).

## Tests
8 new crash-path tests in `scripts/tests/test_compression_benchmark.py` (bare-string, missing-status, missing-fact, unhashable-fact, non-list root, unparseable, + the `len==len(facts)` invariant and a `compute_weighted_score`-never-raises check). Full file: **36 passed**.

## Verification (both halves)
verification-gate independently ran the ORIGINAL code (crashed on all 4 shapes) and the FIXED code (all handled, stable denominator, no inflation).

## Follow-ups (LIA-350)
- `extract_and_classify_facts` has the same unguarded `parse_json(llm_call(...))` — same fragility, out of this diff's scope.
- Surface a backfill counter in the summary so judge-unreliability isn't conflated with real coverage loss.
- (LIA-350 also covers the bigger design gap: retrieval-aware / linked-file coverage + behavioral test-set alignment.)

## Gates
plan-reviewer (claude+gpt) SHIP · code-reviewer (claude+gpt+glm) SHIP · verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)