### PR TITLE
feat(memory): cap the container /memory/query bridge (LIA-354)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-01" # auto-bump @1782914887
+last_verified: "2026-07-03" # auto-bump @1783068612
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-07-01" # auto-bump @1782914887
+last_verified: "2026-07-03" # auto-bump @1783068612
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -123,6 +123,7 @@ def _log_retrieval(
     query: str,
     result: dict,
     source: str,
+    context_chars: int = 0,
 ) -> None:
     prompt_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
     entry = {
@@ -132,6 +133,10 @@ def _log_retrieval(
         "fell_back": result["fell_back"],
         "paths": [r["path"] for r in result["results"]],
         "source": source,
+        # LIA-354: size of the FINAL formatted context (post-truncation) —
+        # `paths` reflects pre-truncation results, so without this a silent
+        # max_context_chars regression is invisible in the production log.
+        "context_chars": context_chars,
     }
     try:
         LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -349,6 +354,7 @@ def recall(
     concepts: list[str] | None = None,
     exclude_kinds: set[str] | None = None,
     max_context_chars: int | None = None,
+    exclude_paths: set[str] | None = None,
 ) -> dict:
     """Retrieve memory context for a query.
 
@@ -394,11 +400,23 @@ def recall(
         else:
             raw["trace"].append("intent_gate:unavailable")
 
+    # LIA-354: per-surface path blocklist (the container bridge passes the vault
+    # index files, which are useless to a container as fragments). Presentation-
+    # level filter: drops from the injected context AND the retrieval log (which
+    # records injected paths). No k-backfill; confidence stays as computed from
+    # the pre-filter result set. Ordering: intent gate first, blocklist second —
+    # a third results-filter belongs after this one.
+    if exclude_paths and raw["results"]:
+        kept = [r for r in raw["results"] if r["path"] not in exclude_paths]
+        if len(kept) < len(raw["results"]):
+            raw["trace"].append(f"path_blocklist:dropped={len(raw['results']) - len(kept)}")
+            raw["results"] = kept
+
     if raw["fell_back"]:
         atom_context = _atom_fallback(query, k, max_context_chars=max_context_chars)
         if atom_context:
             raw["atom_fallback"] = True
-            _log_retrieval(query, raw, source)
+            _log_retrieval(query, raw, source, context_chars=len(atom_context))
             return {
                 "context": atom_context,
                 "paths": [],
@@ -419,7 +437,7 @@ def recall(
         "fell_back": raw["fell_back"],
     }
 
-    _log_retrieval(query, raw, source)
+    _log_retrieval(query, raw, source, context_chars=len(context))
 
     return out
 
@@ -438,9 +456,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--source", default="cli", help="Source identifier for logging")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--context-only", action="store_true", help="Output only the context block")
+    parser.add_argument(
+        "--max-context-chars", type=int, default=None,
+        help="Head-truncate the formatted context to this many chars (default: uncapped)",
+    )
+    parser.add_argument(
+        "--exclude-paths", default="",
+        help="Comma-separated vault-relative paths to drop from results (default: none)",
+    )
 
     args = parser.parse_args(argv)
-    result = recall(args.query, k=args.k, abstain_threshold=args.abstain, source=args.source)
+    exclude = {p.strip() for p in args.exclude_paths.split(",") if p.strip()} or None
+    result = recall(
+        args.query,
+        k=args.k,
+        abstain_threshold=args.abstain,
+        source=args.source,
+        max_context_chars=args.max_context_chars,
+        exclude_paths=exclude,
+    )
 
     if args.context_only:
         print(result["context"])

--- a/scripts/tests/test_memory_query.py
+++ b/scripts/tests/test_memory_query.py
@@ -266,6 +266,18 @@ class TestLogging:
         assert "ts" in entries[0]
         assert "prompt_hash" in entries[0]
 
+    def test_log_records_final_context_chars(self, log_file, fake_vault):
+        # LIA-354: `paths` reflects pre-truncation results, so context_chars is
+        # the only production-auditable evidence that the cap actually applied.
+        with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            result = mq.recall("what timezone?", source="mcp")
+
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["context_chars"] == len(result["context"])
+        assert entry["context_chars"] > 0
+
     def test_log_survives_write_failure(self, monkeypatch):
         monkeypatch.setattr(mq, "LOG_FILE", Path("/nonexistent/dir/log.jsonl"))
         with patch.object(mt, "retrieve", return_value=FAKE_RETRIEVE_HIT), \
@@ -663,3 +675,70 @@ class TestAtomFallbackCap:
         assert "=== [truncated] ===" in out
         assert out.count("<<<UNTRUSTED-MEMORY-") == 3  # framing survives
         assert len(out) < 1200
+
+
+class TestPathBlocklist:
+    """LIA-354: per-surface exclude_paths filter (the container bridge drops the
+    vault index files, which are useless to a container as fragments)."""
+
+    def _run(self, fake, **kw):
+        with patch.object(mt, "retrieve", return_value=fake), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            return mq.recall("any query", source="test", **kw)
+
+    def test_excluded_path_dropped_from_context_paths_and_log(self, fake_vault, log_file):
+        fake = _fake_retrieve(FAKE_RETRIEVE_HIT["results"])
+        result = self._run(fake, exclude_paths={"CLAUDE.md"})
+        assert result["paths"] == ["INFRA.md"]
+        assert "name: Liam" not in result["context"]
+        assert "memory: vault" in result["context"]
+        assert "path_blocklist:dropped=1" in fake["trace"]
+        # The retrieval log records the paths actually injected (post-filter).
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["paths"] == ["INFRA.md"]
+
+    def test_all_excluded_yields_empty_context_not_fallback(self, fake_vault):
+        fake = _fake_retrieve(FAKE_RETRIEVE_HIT["results"])
+        result = self._run(fake, exclude_paths={"CLAUDE.md", "INFRA.md"})
+        assert result["context"] == ""
+        assert result["paths"] == []
+        assert not result["fell_back"]
+
+    def test_default_none_keeps_everything(self, fake_vault):
+        fake = _fake_retrieve(FAKE_RETRIEVE_HIT["results"])
+        result = self._run(fake)
+        assert result["paths"] == ["CLAUDE.md", "INFRA.md"]
+        assert not any(t.startswith("path_blocklist") for t in fake["trace"])
+
+
+class TestCLIBounds:
+    """LIA-354: the --max-context-chars / --exclude-paths flags the bridge passes."""
+
+    def test_max_context_chars_truncates_with_framing_intact(self, capsys, fake_vault):
+        fake = _fake_retrieve(FAKE_RETRIEVE_HIT["results"])
+        with patch.object(mt, "retrieve", return_value=fake), \
+             patch.object(mt, "open_db") as mock_db, \
+             patch.object(mq, "_read_node_file", return_value="z" * 3000):
+            mock_db.return_value.close = lambda: None
+            code = mq.main(["test query", "--context-only", "--max-context-chars", "200"])
+
+        assert code == 0
+        out = capsys.readouterr().out
+        # LIA-335: head-truncation — framing header + both sentinels survive.
+        assert out.startswith("=== Auto-retrieved memory")
+        assert out.count("<<<UNTRUSTED-MEMORY-") == 3  # header mention + open + close
+        assert "=== [truncated] ===" in out
+
+    def test_exclude_paths_flag_parsed_and_applied(self, capsys, fake_vault):
+        fake = _fake_retrieve(FAKE_RETRIEVE_HIT["results"])
+        with patch.object(mt, "retrieve", return_value=fake), \
+             patch.object(mt, "open_db") as mock_db:
+            mock_db.return_value.close = lambda: None
+            # Spaces around commas are tolerated (the parser strips them).
+            code = mq.main(["test query", "--json", "--exclude-paths", "CLAUDE.md, INFRA.md"])
+
+        assert code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["paths"] == []
+        assert out["context"] == ""

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -67,6 +67,31 @@ const MEMORY_QUERY_SCRIPT = path.join(
 );
 const MEMORY_QUERY_TIMEOUT_MS = 4_000;
 
+// LIA-354: server-side recall bounds for the container bridge — never read
+// from the request body (containers must not be able to lift their own cap).
+// 8192 mirrors the MCP server's _MAX_CONTEXT_CHARS (memory_mcp_server.py,
+// LIA-344 sizing). Env-read is lazy (per request) so overrides are testable
+// without module re-import; the cost is negligible next to the execFile.
+const MEMORY_QUERY_DEFAULT_MAX_CHARS = 8192;
+// Exact vault-relative paths — coupled to the index files living at the vault
+// ROOT. A vault reorg that moves them silently un-blocks them (no error).
+const MEMORY_QUERY_DEFAULT_EXCLUDE = 'CLAUDE.md,INFRA.md';
+
+/** Extra memory_query.py args enforcing the bridge cap + index-file blocklist. */
+function bridgeRecallBoundArgs(): string[] {
+  const rawCap = Number(process.env.DEUS_BRIDGE_RECALL_MAX_CHARS);
+  const cap =
+    Number.isInteger(rawCap) && rawCap > 0
+      ? rawCap
+      : MEMORY_QUERY_DEFAULT_MAX_CHARS;
+  const exclude = (
+    process.env.DEUS_BRIDGE_RECALL_EXCLUDE ?? MEMORY_QUERY_DEFAULT_EXCLUDE
+  ).trim();
+  const args = ['--max-context-chars', String(cap)];
+  if (exclude) args.push('--exclude-paths', exclude);
+  return args;
+}
+
 /* ── Rate limiter (in-process, keyed per authenticated group) ──────── */
 
 // 20/min per group: the /memory/query bucket is keyed on the authenticated
@@ -322,6 +347,7 @@ export function startCredentialProxy(
             sourceArg,
             '-k',
             kArg,
+            ...bridgeRecallBoundArgs(),
           ];
 
           execFile(

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -77,13 +77,15 @@ const MEMORY_QUERY_DEFAULT_MAX_CHARS = 8192;
 // ROOT. A vault reorg that moves them silently un-blocks them (no error).
 const MEMORY_QUERY_DEFAULT_EXCLUDE = 'CLAUDE.md,INFRA.md';
 
-/** Extra memory_query.py args enforcing the bridge cap + index-file blocklist. */
+/** Extra memory_query.py args enforcing the bridge cap + index-file blocklist (LIA-354). */
 function bridgeRecallBoundArgs(): string[] {
+  // LIA-354: config plumbing with a validated fallback, not a feature gate.
   const rawCap = Number(process.env.DEUS_BRIDGE_RECALL_MAX_CHARS);
   const cap =
     Number.isInteger(rawCap) && rawCap > 0
       ? rawCap
       : MEMORY_QUERY_DEFAULT_MAX_CHARS;
+  // LIA-354: per-surface blocklist override, same config-plumbing shape.
   const exclude = (
     process.env.DEUS_BRIDGE_RECALL_EXCLUDE ?? MEMORY_QUERY_DEFAULT_EXCLUDE
   ).trim();

--- a/src/memory-bridge.test.ts
+++ b/src/memory-bridge.test.ts
@@ -185,6 +185,10 @@ describe('memory bridge — POST /memory/query', () => {
         'bridge',
         '-k',
         '3',
+        '--max-context-chars',
+        '8192',
+        '--exclude-paths',
+        'CLAUDE.md,INFRA.md',
       ]),
       expect.objectContaining({ timeout: 4_000 }),
       expect.any(Function),
@@ -346,6 +350,81 @@ describe('memory bridge — POST /memory/query', () => {
       expect.arrayContaining(['--source', 'telegram', '-k', '10']),
       expect.objectContaining({ timeout: 4_000 }),
       expect.any(Function),
+    );
+  });
+
+  /* ── LIA-354: server-side recall cap + index-file blocklist ────────── */
+
+  function lastExecFileArgs(): string[] {
+    return mockExecFile.mock.lastCall?.[1] as string[];
+  }
+
+  it('respects env overrides for the cap and blocklist (LIA-354)', async () => {
+    vi.stubEnv('DEUS_BRIDGE_RECALL_MAX_CHARS', '4096');
+    vi.stubEnv('DEUS_BRIDGE_RECALL_EXCLUDE', 'STUDY.md');
+    try {
+      await memoryRequest(proxyPort, JSON.stringify({ query: 'test' }));
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(lastExecFileArgs()).toEqual(
+      expect.arrayContaining([
+        '--max-context-chars',
+        '4096',
+        '--exclude-paths',
+        'STUDY.md',
+      ]),
+    );
+  });
+
+  it('invalid cap env falls back to the 8192 default (LIA-354)', async () => {
+    vi.stubEnv('DEUS_BRIDGE_RECALL_MAX_CHARS', 'abc');
+    try {
+      await memoryRequest(proxyPort, JSON.stringify({ query: 'test' }));
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(lastExecFileArgs()).toEqual(
+      expect.arrayContaining(['--max-context-chars', '8192']),
+    );
+  });
+
+  it('empty blocklist env omits --exclude-paths but keeps the cap (LIA-354)', async () => {
+    vi.stubEnv('DEUS_BRIDGE_RECALL_EXCLUDE', '');
+    try {
+      await memoryRequest(proxyPort, JSON.stringify({ query: 'test' }));
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const args = lastExecFileArgs();
+    expect(args).toEqual(
+      expect.arrayContaining(['--max-context-chars', '8192']),
+    );
+    expect(args).not.toContain('--exclude-paths');
+  });
+
+  it('client body cannot lift the cap or blocklist (LIA-354)', async () => {
+    await memoryRequest(
+      proxyPort,
+      JSON.stringify({
+        query: 'test',
+        max_context_chars: 999999,
+        maxContextChars: 999999,
+        exclude_paths: '',
+      }),
+    );
+
+    // Server-side values, regardless of what the container sent.
+    expect(lastExecFileArgs()).toEqual(
+      expect.arrayContaining([
+        '--max-context-chars',
+        '8192',
+        '--exclude-paths',
+        'CLAUDE.md,INFRA.md',
+      ]),
     );
   });
 });


### PR DESCRIPTION
## Problem

The container memory bridge (`memory-retrieval-hook.ts` → `POST /memory/query` on the credential proxy → `execFile memory_query.py`) was the only uncapped `recall()` surface. LIA-344 (#975) capped the MCP server (8192 chars) and the host hook caps at 4096, but the bridge fires on ~99% of channel messages with no bound (mean ~3,705 tok, p90 ~12,003 tok from the production `container-claude` retrieval log). Additionally, the vault index files `CLAUDE.md`/`INFRA.md` — useless to containers as 4KB fragments — made up 14.2% of the bridge's injected paths (42.6% of non-abstained retrieval events injected at least one).

## Fix

- **`scripts/memory_query.py`**: new `--max-context-chars` / `--exclude-paths` CLI flags threaded into the existing LIA-344 truncation plumbing (`recall(max_context_chars=...)`). New `exclude_paths` kwarg filters results by exact vault-relative path after the LIA-337 intent gate, before both `_format_context` and `_log_retrieval` (so the log records the paths actually injected). The retrieval log gains an additive `context_chars` field — `paths` reflects pre-truncation results, so without it a silent cap regression is invisible in production.
- **`src/credential-proxy.ts`**: `bridgeRecallBoundArgs()` appends `--max-context-chars 8192` (env `DEUS_BRIDGE_RECALL_MAX_CHARS`) and `--exclude-paths CLAUDE.md,INFRA.md` (env `DEUS_BRIDGE_RECALL_EXCLUDE`) to the bridge execFile args. Values are server-side only — never read from the client request body, so a container cannot lift its own cap.
- **No container-side change** — the cap is enforced server-side; no container rebuild needed.

## Invariants

- **LIA-335 preserved**: truncation stays HEAD-truncation via the existing `_truncate_body`, applied before `_wrap_untrusted` — the untrusted framing header + both random sentinels always survive.
- **Byte-identical defaults**: `max_context_chars=None` / `exclude_paths=None` — the MCP server and host hook callers are untouched and behave identically.
- Blocklist is deliberately **bridge-scoped, not global** in `recall()`: host tests and the recall benchmark legitimately expect `CLAUDE.md`/`INFRA.md` as results. Per-surface config feeds the LIA-353 Context Budget Governor later.

## Verification

- `scripts/tests/test_memory_query.py`: 73/73 (new `TestPathBlocklist`, `TestCLIBounds`, `context_chars` logging test).
- `src/memory-bridge.test.ts`: 15/15 (default args, env overrides, invalid-env fallback, empty-blocklist, client-cannot-lift-cap).
- Full `npx vitest run` 1931/1931, `npx tsc --noEmit` clean, `npm run build` clean.
- Real CLI smoke: truncation marker + intact sentinel framing + blocklist honored + logged `context_chars` matches returned context length.
- Full pytest has 5 pre-existing failures (`test_sync_agent_skills.py` ×2, `test_warden_review.py` ×3) that reproduce identically on clean `origin/main` — environment/ordering artifacts unrelated to this diff.

Wardens: plan-reviewer SHIP (claude+gpt) · code-reviewer SHIP (claude+gpt+glm) · ai-eng-warden SHIP (claude+gpt) · verification-gate SHIP.

Closes LIA-354.

Rollback: single revert + redeploy — additive change gated entirely behind proxy-appended CLI flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)