### PR TITLE
fix(auto-compress): anchor capture window to a persisted watermark, not now()

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-06-27" # auto-bump @1782546750
+last_verified: "2026-07-03" # auto-bump @1783081643
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-06-27" # auto-bump @1782546750
+last_verified: "2026-07-03" # auto-bump @1783081643
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783068612
+last_verified: "2026-07-03" # auto-bump @1783081643
 governs:
   - src/
   - evolution/

--- a/src/auto-compress.test.ts
+++ b/src/auto-compress.test.ts
@@ -19,9 +19,16 @@ vi.mock('./solutions/index.js', () => ({
 }));
 
 const mockGetMessagesSince = vi.fn<() => NewMessage[]>();
+const mockGetAutoCompressWatermark = vi.fn<() => string | undefined>();
+const mockSetAutoCompressWatermark = vi.fn();
 vi.mock('./db.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
-  return { ...actual, getMessagesSince: mockGetMessagesSince };
+  return {
+    ...actual,
+    getMessagesSince: mockGetMessagesSince,
+    getAutoCompressWatermark: mockGetAutoCompressWatermark,
+    setAutoCompressWatermark: mockSetAutoCompressWatermark,
+  };
 });
 
 const mockFireAndForget = vi.fn();
@@ -66,6 +73,11 @@ function makeMessage(overrides: Partial<NewMessage> = {}): NewMessage {
 describe('autoCompressSession', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // vi.restoreAllMocks() (afterEach below) only restores vi.spyOn mocks to
+    // their original implementation — it doesn't clear a custom
+    // mockImplementation set on a plain vi.fn() like mockWriteFileSync, so a
+    // throwing override from one test can otherwise leak into the next.
+    mockWriteFileSync.mockReset();
   });
 
   afterEach(() => {
@@ -158,6 +170,71 @@ describe('autoCompressSession', () => {
     await expect(
       autoCompressSession(makeGroup(), 'test@jid', 8),
     ).rejects.toThrow('EACCES: permission denied');
+  });
+
+  it('anchors to lastUsed - 2x idle hours when no watermark exists yet (bootstrap fallback)', async () => {
+    mockResolveVaultPath.mockReturnValue('/tmp/vault');
+    mockGetAutoCompressWatermark.mockReturnValue(undefined);
+    mockGetMessagesSince.mockReturnValue([makeMessage()]);
+
+    const lastUsed = '2026-05-10T00:00:00.000Z';
+    const idleHours = 8;
+    await autoCompressSession(makeGroup(), 'test@jid', idleHours, lastUsed);
+
+    const expectedSince = new Date(
+      new Date(lastUsed).getTime() - idleHours * 2 * 3_600_000,
+    ).toISOString();
+    expect(mockGetMessagesSince).toHaveBeenCalledWith(
+      'test@jid',
+      expectedSince,
+      expect.any(String),
+      500,
+      true,
+    );
+  });
+
+  it('anchors to the persisted watermark when one exists, ignoring lastUsed', async () => {
+    mockResolveVaultPath.mockReturnValue('/tmp/vault');
+    const watermark = '2026-06-01T12:00:00.000Z';
+    mockGetAutoCompressWatermark.mockReturnValue(watermark);
+    mockGetMessagesSince.mockReturnValue([makeMessage()]);
+
+    await autoCompressSession(
+      makeGroup(),
+      'test@jid',
+      8,
+      '2026-01-01T00:00:00.000Z',
+    );
+
+    expect(mockGetMessagesSince).toHaveBeenCalledWith(
+      'test@jid',
+      watermark,
+      expect.any(String),
+      500,
+      true,
+    );
+  });
+
+  it('advances the watermark to the max captured message timestamp minus 1 second', async () => {
+    mockResolveVaultPath.mockReturnValue('/tmp/vault');
+    mockGetAutoCompressWatermark.mockReturnValue(undefined);
+    // getMessagesSince always re-sorts ascending (db.ts) before returning —
+    // reflect that real contract here rather than scrambled order.
+    mockGetMessagesSince.mockReturnValue([
+      makeMessage({ timestamp: '2026-05-12T09:00:00.000Z' }),
+      makeMessage({ timestamp: '2026-05-12T10:00:00.000Z' }),
+      makeMessage({ timestamp: '2026-05-12T10:05:00.000Z' }),
+    ]);
+
+    await autoCompressSession(makeGroup(), 'test@jid', 8);
+
+    const expectedWatermark = new Date(
+      new Date('2026-05-12T10:05:00.000Z').getTime() - 1_000,
+    ).toISOString();
+    expect(mockSetAutoCompressWatermark).toHaveBeenCalledWith(
+      'test@jid',
+      expectedWatermark,
+    );
   });
 });
 

--- a/src/auto-compress.ts
+++ b/src/auto-compress.ts
@@ -2,7 +2,11 @@ import path from 'path';
 
 import { ASSISTANT_NAME } from './config.js';
 import { consolidateSessionLog } from './consolidation-core.js';
-import { getMessagesSince } from './db.js';
+import {
+  getAutoCompressWatermark,
+  getMessagesSince,
+  setAutoCompressWatermark,
+} from './db.js';
 import { logger } from './logger.js';
 import { resolveVaultPath } from './solutions/index.js';
 import type { RegisteredGroup } from './types.js';
@@ -22,6 +26,7 @@ export async function autoCompressSession(
   group: RegisteredGroup,
   chatJid: string,
   effectiveIdleHours: number,
+  lastUsed?: string,
 ): Promise<void> {
   // Short-circuit before the DB query when there is nowhere to write.
   if (!resolveVaultPath()) {
@@ -29,10 +34,16 @@ export async function autoCompressSession(
     return;
   }
 
-  // 2× the idle window captures the full session including pre-idle activity
-  const sinceTimestamp = new Date(
-    Date.now() - effectiveIdleHours * 2 * 3_600_000,
-  ).toISOString();
+  // Anchor to the persisted watermark (last successful capture), not
+  // `now()`; only a chat with no prior capture falls back to the pre-fix
+  // `lastUsed - 2x idle` heuristic as a one-time bootstrap.
+  const watermark = getAutoCompressWatermark(chatJid);
+  const anchor = watermark
+    ? new Date(watermark).getTime()
+    : lastUsed
+      ? new Date(lastUsed).getTime() - effectiveIdleHours * 2 * 3_600_000
+      : Date.now() - effectiveIdleHours * 2 * 3_600_000;
+  const sinceTimestamp = new Date(anchor).toISOString();
 
   const messages = getMessagesSince(
     chatJid,
@@ -43,6 +54,10 @@ export async function autoCompressSession(
   );
 
   if (messages.length === 0) {
+    logger.info(
+      { group: group.name, chatJid },
+      'Auto-compress: no messages in window',
+    );
     return;
   }
 
@@ -83,6 +98,15 @@ tldr: |
   });
 
   if (savedPath) {
+    // WhatsApp message timestamps are second-resolution (whatsapp.ts:362),
+    // so subtract 1s to avoid excluding a same-second sibling message on the
+    // next capture. getMessagesSince re-sorts ascending, so the last element
+    // is the max timestamp.
+    const maxCapturedTs = messages[messages.length - 1].timestamp;
+    const newWatermark = new Date(
+      new Date(maxCapturedTs).getTime() - 1_000,
+    ).toISOString();
+    setAutoCompressWatermark(chatJid, newWatermark);
     logger.info(
       { group: group.name, path: savedPath },
       'Auto-compress: session saved',

--- a/src/consolidation-golden.test.ts
+++ b/src/consolidation-golden.test.ts
@@ -31,9 +31,13 @@ vi.mock('./solutions/index.js', () => ({
 }));
 
 const mockGetMessagesSince = vi.fn<() => NewMessage[]>();
+const mockGetAutoCompressWatermark = vi.fn<() => string | undefined>();
+const mockSetAutoCompressWatermark = vi.fn();
 vi.mock('./db.js', async (orig) => ({
   ...((await orig()) as Record<string, unknown>),
   getMessagesSince: mockGetMessagesSince,
+  getAutoCompressWatermark: mockGetAutoCompressWatermark,
+  setAutoCompressWatermark: mockSetAutoCompressWatermark,
 }));
 
 vi.mock('./logger.js', () => ({

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -7,6 +7,7 @@ import {
   deleteTask,
   getAllChats,
   getAllRegisteredGroups,
+  getAutoCompressWatermark,
   getConsecutiveFailCount,
   getLastFailTime,
   getMessagesSince,
@@ -18,6 +19,7 @@ import {
   logPipelineEvent,
   insertPipelineEventRow,
   getPipelineEvents,
+  setAutoCompressWatermark,
   setSession,
   setRegisteredGroup,
   storeChatMetadata,
@@ -941,5 +943,39 @@ describe('circuit breaker', () => {
       expect(lastTime).not.toBeNull();
       expect(getConsecutiveFailCount('issue-1', 'automerge_failed')).toBe(1);
     });
+  });
+});
+
+describe('auto-compress watermark', () => {
+  it('returns undefined for a chat with no watermark yet', () => {
+    expect(getAutoCompressWatermark('never-compressed@jid')).toBeUndefined();
+  });
+
+  it('round-trips a stored watermark', () => {
+    setAutoCompressWatermark('test@jid', '2026-05-12T10:00:00.000Z');
+    expect(getAutoCompressWatermark('test@jid')).toBe(
+      '2026-05-12T10:00:00.000Z',
+    );
+  });
+
+  it('overwrites rather than duplicates on repeated writes for the same chat_jid (ON CONFLICT upsert)', () => {
+    setAutoCompressWatermark('test@jid', '2026-05-12T10:00:00.000Z');
+    setAutoCompressWatermark('test@jid', '2026-05-12T11:00:00.000Z');
+
+    expect(getAutoCompressWatermark('test@jid')).toBe(
+      '2026-05-12T11:00:00.000Z',
+    );
+  });
+
+  it('keeps watermarks independent across different chat_jids', () => {
+    setAutoCompressWatermark('chat-a@jid', '2026-05-12T10:00:00.000Z');
+    setAutoCompressWatermark('chat-b@jid', '2026-05-12T20:00:00.000Z');
+
+    expect(getAutoCompressWatermark('chat-a@jid')).toBe(
+      '2026-05-12T10:00:00.000Z',
+    );
+    expect(getAutoCompressWatermark('chat-b@jid')).toBe(
+      '2026-05-12T20:00:00.000Z',
+    );
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -280,6 +280,16 @@ function createSchema(database: Database.Database): void {
     );
   `);
 
+  // Auto-compress capture watermark, keyed by chat — advanced from actual
+  // captured message timestamps (LIA-373), not session lifecycle or turn
+  // timing, so it has no dependency on how long an agent turn runs.
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS auto_compress_state (
+      chat_jid TEXT PRIMARY KEY,
+      last_captured_at TEXT NOT NULL
+    );
+  `);
+
   // Add allow_external_push column to projects (migration for existing DBs).
   // Default 0 = external projects cannot push/merge unless explicitly allowlisted.
   try {
@@ -601,7 +611,8 @@ export function createTask(
 
 export function getTaskById(id: string): ScheduledTask | undefined {
   return db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as
-    ScheduledTask | undefined;
+    | ScheduledTask
+    | undefined;
 }
 
 export function getAllTasks(): ScheduledTask[] {
@@ -924,6 +935,22 @@ export function getLastCompactedAt(
           .get(groupFolder)
   ) as { last_compacted_at: string | null } | undefined;
   return row?.last_compacted_at ?? undefined;
+}
+
+export function getAutoCompressWatermark(chatJid: string): string | undefined {
+  const row = db
+    .prepare(
+      'SELECT last_captured_at FROM auto_compress_state WHERE chat_jid = ?',
+    )
+    .get(chatJid) as { last_captured_at: string } | undefined;
+  return row?.last_captured_at;
+}
+
+export function setAutoCompressWatermark(chatJid: string, ts: string): void {
+  db.prepare(
+    `INSERT INTO auto_compress_state (chat_jid, last_captured_at) VALUES (?, ?)
+     ON CONFLICT(chat_jid) DO UPDATE SET last_captured_at = excluded.last_captured_at`,
+  ).run(chatJid, ts);
 }
 
 export function getAllSessions(): Record<string, RuntimeSession> {
@@ -1307,7 +1334,8 @@ export function getLastCompletedGateRun(
        ORDER BY finished_at DESC, rowid DESC LIMIT 1`,
     )
     .get(issueId, gateTo) as
-    { finished_at: string; verdict: string } | undefined;
+    | { finished_at: string; verdict: string }
+    | undefined;
 }
 
 export function upsertGateComment(

--- a/src/db.ts
+++ b/src/db.ts
@@ -611,8 +611,7 @@ export function createTask(
 
 export function getTaskById(id: string): ScheduledTask | undefined {
   return db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as
-    | ScheduledTask
-    | undefined;
+    ScheduledTask | undefined;
 }
 
 export function getAllTasks(): ScheduledTask[] {
@@ -1334,8 +1333,7 @@ export function getLastCompletedGateRun(
        ORDER BY finished_at DESC, rowid DESC LIMIT 1`,
     )
     .get(issueId, gateTo) as
-    | { finished_at: string; verdict: string }
-    | undefined;
+    { finished_at: string; verdict: string } | undefined;
 }
 
 export function upsertGateComment(

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -65,6 +65,8 @@ vi.mock('./db.js', () => ({
   setRegisteredGroup: vi.fn(),
   getLastCompactedAt: vi.fn(() => undefined),
   setLastCompactedAt: vi.fn(),
+  getAutoCompressWatermark: vi.fn(() => undefined),
+  setAutoCompressWatermark: vi.fn(),
 }));
 
 vi.mock('./container-runner.js', () => ({

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -115,7 +115,12 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
           'Session idle too long — starting fresh',
         );
         try {
-          await autoCompressSession(group, chatJid, effectiveIdleHours);
+          await autoCompressSession(
+            group,
+            chatJid,
+            effectiveIdleHours,
+            lastUsed,
+          );
         } catch (err) {
           logger.warn(
             { group: group.name, err },

--- a/src/orchestrator-caps-phase4.oracle.test.ts
+++ b/src/orchestrator-caps-phase4.oracle.test.ts
@@ -79,6 +79,8 @@ vi.mock('./db.js', () => ({
   setRegisteredGroup: vi.fn(),
   getLastCompactedAt: vi.fn(() => undefined),
   setLastCompactedAt: vi.fn(),
+  getAutoCompressWatermark: vi.fn(() => undefined),
+  setAutoCompressWatermark: vi.fn(),
 }));
 
 vi.mock('./container-runner.js', () => ({


### PR DESCRIPTION
## Summary

- Fixes LIA-373 (from the 2026-07-03 repo audit's silent-failure cluster): `auto-compress.ts` anchored its vault-capture window to `Date.now() - 2*idleHours` instead of the session's actual activity. Any absence longer than 2x the idle threshold (a weekend, a vacation) put the entire session outside the window, so nothing was captured before `clearSession` wiped it — a silent, permanent loss of the vault session log.
- Replaces the heuristic with a small persisted watermark (`auto_compress_state`: `chat_jid` -> `last_captured_at`), advanced from the actual captured messages' own timestamps (minus a 1s buffer, since WhatsApp timestamps are second-resolution) rather than session lifecycle or turn timing. A chat with no prior capture falls back to the old heuristic once, then is watermark-anchored forever after.
- Also fixes a pre-existing test-isolation gap in `auto-compress.test.ts` where a throwing `mockWriteFileSync` implementation could leak across tests (`vi.restoreAllMocks()` doesn't reset a plain `vi.fn()`'s custom implementation).

Design went through 5 rounds of adversarial plan review (independent claude + gpt backends) before landing on the watermark approach — two earlier designs (a fixed idle-hours multiplier, then a `sessions`-table `session_started_at` column) were rejected for real correctness gaps caught during review; both are documented inline in the code/plan for future readers.

## Test plan

- [x] `npx vitest run` — 1938/1938 tests pass across 109 files
- [x] `npx tsc --noEmit` — clean
- [x] New coverage: `auto-compress.test.ts` (bootstrap-fallback anchor, watermark-anchor precedence, watermark-advance-on-success), `db.test.ts` (upsert/`ON CONFLICT`, per-chat isolation)
- [x] Plan-review co-gate: SHIP (claude + gpt, 5 rounds)
- [x] Code-review co-gate: SHIP (claude + gpt + glm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)