### PR TITLE
fix(channels): throw on send failure instead of swallowing it (LIA-359, LIA-360)

### DIFF
--- a/docs/decisions/error-discipline.md
+++ b/docs/decisions/error-discipline.md
@@ -188,6 +188,36 @@ TrueCourse flagged 13 `security/deterministic/sql-injection` HIGHs in `evolution
 
 PR #11 audited the remaining 10 non-evolution `sql-injection` HIGHs in `scripts/bench/store.py`, `scripts/memory_indexer.py`, and `scripts/memory_tree.py`; all confirmed structural-safe (vec0 dims from module int constants, ALTER TABLE col/coltype from literal tuple-lists, WHERE clauses joined from local literal-string fragments, DELETE FROM iterating a hard-coded schema list). Annotated with `# safe: <reason>` per the PR #9 convention. SQL injection backlog from the TrueCourse 2026-04-19 scan is closed.
 
+### Issue #220: provider-package plain-Error exemption
+
+LIA-359/LIA-360 (silent channel-send failures) converted every silent-loss
+`return` in `packages/mcp-telegram/src/telegram.ts`,
+`packages/mcp-discord/src/discord.ts`, `packages/mcp-gmail/src/gmail.ts`,
+`packages/mcp-outlook/src/outlook.ts`, and `packages/mcp-teams/src/teams.ts`
+into a throw. The ADR's Scope line lists `packages/*` as in-scope for the
+error taxonomy, but these 5 files throw plain `Error`, not a
+`RetryableError`/`UserError`/`FatalError` subclass, for the same reason
+`container/agent-runner/` (Issue #218 above) can't import `src/bootstrap.ts`:
+each package's `tsconfig.json` sets `rootDir: "./src"` with no path to the
+main `src/` tree, so `src/errors/index.ts` isn't reachable from `packages/*`.
+
+This isn't a new carve-out invented for this PR — all 5 files already threw
+plain `Error` for connection/config failures before this change (e.g.
+`telegram.ts:82`, `discord.ts:73`, `gmail.ts:228/256/285/311`). The new throw
+sites just extend that existing local convention to the previously-silent
+paths. Each new site carries a one-line comment pointing back to this
+addendum so the next reader doesn't mistake it for an oversight.
+
+A shared throwable-error primitive in `packages/mcp-channel-core` (which all
+5 packages already depend on via `@deus-ai/channel-core`) was considered and
+rejected as premature: `mcp-channel-core/src/response.ts` already exports a
+return-value-based error shape (`mcpError`/`McpErrorCode`/`withMcpError`) for
+MCP tool responses, but that's orthogonal to a *thrown* class for a
+provider's internal method — introducing one now for 5 call sites, with no
+second consumer, is the same YAGNI call the PR #6 addendum made for the
+stream-error installer. If a future change needs a shared thrown-error type
+across `packages/*`, add it then.
+
 ### Issue #218: bootstrap mirror discipline
 
 PR #2 (#215) shipped `src/bootstrap.ts`. PR #3 (#219) wired it into the agent-runner entry point — but `container/agent-runner/` has its own `tsconfig.json` and `node_modules` and cannot import from `src/`. The harness was duplicated as `container/agent-runner/src/bootstrap.ts`, with the only divergence being the logger: pino + `FatalError` discrimination in the main process, plain `console.error` in the container (which has no pino dep). Issue #218 was opened to track extracting both copies into a shared `packages/bootstrap` workspace.

--- a/packages/mcp-discord/src/discord.test.ts
+++ b/packages/mcp-discord/src/discord.test.ts
@@ -485,19 +485,30 @@ describe('DiscordProvider', () => {
       expect(mockChannelFetch).toHaveBeenCalledWith('9876543210');
     });
 
-    it('handles send failure gracefully', async () => {
+    it('throws on send failure instead of swallowing it', async () => {
       await provider.connect();
 
       mockChannelFetch.mockRejectedValueOnce(new Error('Channel not found'));
 
       await expect(
         provider.sendMessage('dc:1234567890123456', 'Will fail'),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow('Channel not found');
     });
 
-    it('does nothing when client is not initialized', async () => {
-      await provider.sendMessage('dc:1234567890123456', 'No client');
-      // No error, no API call
+    it('throws when the channel is not found or not text-based', async () => {
+      await provider.connect();
+
+      mockChannelFetch.mockResolvedValueOnce(null);
+
+      await expect(
+        provider.sendMessage('dc:1234567890123456', 'no channel'),
+      ).rejects.toThrow('Discord channel not found or not text-based');
+    });
+
+    it('throws when the client is not initialized', async () => {
+      await expect(
+        provider.sendMessage('dc:1234567890123456', 'No client'),
+      ).rejects.toThrow('Discord client not initialized');
       expect(mockChannelFetch).not.toHaveBeenCalled();
     });
 

--- a/packages/mcp-discord/src/discord.ts
+++ b/packages/mcp-discord/src/discord.ts
@@ -232,14 +232,16 @@ export class DiscordProvider implements ChannelProvider {
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
-    if (!this.client) return;
+    // plain Error: packages/* cannot import src/errors/ (see error-discipline.md Issue #220); matches this file's existing plain-Error convention
+    if (!this.client) throw new Error('Discord client not initialized');
     try {
       const channelId = chatId.replace(/^dc:/, '');
       const channel = await this.client.channels.fetch(channelId);
 
       if (!channel || !('send' in channel)) {
-        logger.warn({ chatId }, 'Discord channel not found or not text-based');
-        return;
+        throw new Error(
+          `Discord channel not found or not text-based: ${chatId}`,
+        );
       }
 
       const textChannel = channel as TextChannel;
@@ -252,7 +254,11 @@ export class DiscordProvider implements ChannelProvider {
         }
       }
     } catch (err) {
-      logger.error({ chatId, err }, 'Failed to send Discord message');
+      logger.debug(
+        { chatId, err },
+        'Discord send failed, rethrowing to caller',
+      );
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 

--- a/packages/mcp-gmail/src/gmail.test.ts
+++ b/packages/mcp-gmail/src/gmail.test.ts
@@ -99,4 +99,35 @@ describe('GmailProvider', () => {
       expect(chats).toEqual([]);
     });
   });
+
+  describe('sendMessage failure propagation', () => {
+    it('throws when gmail is not initialized', async () => {
+      await expect(provider.sendMessage('gmail:abc', 'hi')).rejects.toThrow(
+        'Gmail not initialized',
+      );
+    });
+
+    it('throws when there is no thread metadata for the reply', async () => {
+      (provider as any).gmail = { users: { messages: { send: vi.fn() } } };
+
+      await expect(provider.sendMessage('gmail:abc', 'hi')).rejects.toThrow(
+        'No thread metadata for reply',
+      );
+    });
+
+    it('throws when the underlying send fails', async () => {
+      const send = vi.fn().mockRejectedValue(new Error('quota exceeded'));
+      (provider as any).gmail = { users: { messages: { send } } };
+      (provider as any).threadMeta.set('abc', {
+        sender: 'a@b.com',
+        senderName: 'A',
+        subject: 'hi',
+        messageId: '<id@b.com>',
+      });
+
+      await expect(provider.sendMessage('gmail:abc', 'hi')).rejects.toThrow(
+        'quota exceeded',
+      );
+    });
+  });
 });

--- a/packages/mcp-gmail/src/gmail.ts
+++ b/packages/mcp-gmail/src/gmail.ts
@@ -134,17 +134,14 @@ export class GmailProvider implements ChannelProvider {
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
-    if (!this.gmail) {
-      logger.warn('Gmail not initialized');
-      return;
-    }
+    // plain Error: packages/* cannot import src/errors/ (see error-discipline.md Issue #220); matches this file's existing plain-Error convention
+    if (!this.gmail) throw new Error('Gmail not initialized');
 
     const threadId = chatId.replace(/^gmail:/, '');
     const meta = this.threadMeta.get(threadId);
 
     if (!meta) {
-      logger.warn({ chatId }, 'No thread metadata for reply, cannot send');
-      return;
+      throw new Error(`No thread metadata for reply, cannot send: ${chatId}`);
     }
 
     const subject = meta.subject.startsWith('Re:')
@@ -178,7 +175,8 @@ export class GmailProvider implements ChannelProvider {
       });
       logger.info({ to: meta.sender, threadId }, 'Gmail reply sent');
     } catch (err) {
-      logger.error({ chatId, err }, 'Failed to send Gmail reply');
+      logger.debug({ chatId, err }, 'Gmail send failed, rethrowing to caller');
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 

--- a/packages/mcp-outlook/src/outlook.test.ts
+++ b/packages/mcp-outlook/src/outlook.test.ts
@@ -93,12 +93,34 @@ describe('OutlookProvider', () => {
     });
   });
 
-  describe('sendMessage', () => {
-    it('is a no-op when not connected (no graph client)', async () => {
-      // No throw, no send — there is no conversation metadata and no client.
+  describe('sendMessage failure propagation', () => {
+    it('throws when not connected (no graph client)', async () => {
       await expect(
         provider.sendMessage('outlook:conv-123', 'hello'),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow('Outlook not initialized');
+    });
+
+    it('throws when there is no conversation metadata for the reply', async () => {
+      (provider as any).graph = { api: vi.fn() };
+
+      await expect(
+        provider.sendMessage('outlook:conv-123', 'hello'),
+      ).rejects.toThrow('No conversation metadata for reply');
+    });
+
+    it('throws when the underlying send fails', async () => {
+      const post = vi.fn().mockRejectedValue(new Error('graph API error'));
+      (provider as any).graph = { api: vi.fn(() => ({ post })) };
+      (provider as any).convMeta.set('conv-123', {
+        messageId: 'msg-1',
+        sender: 'a@b.com',
+        senderName: 'A',
+        subject: 'hi',
+      });
+
+      await expect(
+        provider.sendMessage('outlook:conv-123', 'hello'),
+      ).rejects.toThrow('graph API error');
     });
   });
 

--- a/packages/mcp-outlook/src/outlook.ts
+++ b/packages/mcp-outlook/src/outlook.ts
@@ -216,10 +216,8 @@ export class OutlookProvider implements ChannelProvider {
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
-    if (!this.graph) {
-      logger.warn('Outlook not initialized');
-      return;
-    }
+    // plain Error: packages/* cannot import src/errors/ (see error-discipline.md Issue #220); matches this file's existing plain-Error convention
+    if (!this.graph) throw new Error('Outlook not initialized');
 
     const conversationId = chatId.replace(/^outlook:/, '');
     const meta = this.convMeta.get(conversationId);
@@ -227,13 +225,11 @@ export class OutlookProvider implements ChannelProvider {
     // KNOWN LIMITATION: the reply target (a messageId in the conversation) is
     // populated only after a poll cycle has seen that conversation. A reply to a
     // thread received before this process started has no stored messageId, so we
-    // log and skip rather than send into the void.
+    // throw rather than send into the void.
     if (!meta) {
-      logger.warn(
-        { chatId },
-        'No conversation metadata for reply, cannot send (no prior inbound seen)',
+      throw new Error(
+        `No conversation metadata for reply, cannot send (no prior inbound seen): ${chatId}`,
       );
-      return;
     }
 
     try {
@@ -242,7 +238,11 @@ export class OutlookProvider implements ChannelProvider {
         .post({ comment: text });
       logger.info({ to: meta.sender, conversationId }, 'Outlook reply sent');
     } catch (err) {
-      logger.error({ chatId, err }, 'Failed to send Outlook reply');
+      logger.debug(
+        { chatId, err },
+        'Outlook send failed, rethrowing to caller',
+      );
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 

--- a/packages/mcp-teams/src/teams.test.ts
+++ b/packages/mcp-teams/src/teams.test.ts
@@ -95,12 +95,27 @@ describe('TeamsProvider', () => {
     });
   });
 
-  describe('sendMessage', () => {
-    it('is a no-op when no conversation reference exists', async () => {
-      // No prior inbound → no stored reference → log + skip, no throw.
+  describe('sendMessage failure propagation', () => {
+    it('throws when no conversation reference exists', async () => {
+      // No prior inbound → no stored reference — must throw, not swallow.
       await expect(
         provider.sendMessage('teams:conv-1', 'hello'),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow('No conversation reference for reply');
+    });
+
+    it('throws when the underlying send fails', async () => {
+      (provider as any).adapter = {
+        continueConversationAsync: vi
+          .fn()
+          .mockRejectedValue(new Error('bot framework error')),
+      };
+      (provider as any).conversationRefs.set('conv-1', {
+        conversation: { id: 'c1' },
+      });
+
+      await expect(
+        provider.sendMessage('teams:conv-1', 'hello'),
+      ).rejects.toThrow('bot framework error');
     });
   });
 

--- a/packages/mcp-teams/src/teams.ts
+++ b/packages/mcp-teams/src/teams.ts
@@ -176,13 +176,12 @@ export class TeamsProvider implements ChannelProvider {
     // KNOWN LIMITATION: Bot Framework proactive messaging needs a stored
     // conversation reference, captured only from a prior inbound activity. With
     // no reference (no prior inbound seen) there is no way to address the
-    // conversation, so we log and skip rather than fail loudly.
+    // conversation, so we throw rather than fail silently.
+    // plain Error: packages/* cannot import src/errors/ (see error-discipline.md Issue #220); matches this file's existing plain-Error convention
     if (!this.adapter || !ref) {
-      logger.warn(
-        { chatId },
-        'No conversation reference for reply, cannot send (no prior inbound seen)',
+      throw new Error(
+        `No conversation reference for reply, cannot send (no prior inbound seen): ${chatId}`,
       );
-      return;
     }
 
     try {
@@ -195,7 +194,8 @@ export class TeamsProvider implements ChannelProvider {
       );
       logger.info({ chatId }, 'Teams message sent');
     } catch (err) {
-      logger.error({ chatId, err }, 'Failed to send Teams message');
+      logger.debug({ chatId, err }, 'Teams send failed, rethrowing to caller');
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 

--- a/packages/mcp-telegram/src/telegram.test.ts
+++ b/packages/mcp-telegram/src/telegram.test.ts
@@ -225,6 +225,24 @@ describe('TelegramProvider', () => {
     });
   });
 
+  describe('sendMessage failure propagation', () => {
+    it('throws when the bot is not initialized', async () => {
+      await expect(provider.sendMessage('tg:123', 'hi')).rejects.toThrow(
+        'Telegram bot not initialized',
+      );
+    });
+
+    it('throws when the underlying send fails', async () => {
+      await provider.connect();
+      const bot = (provider as any).bot;
+      bot.api.sendMessage.mockRejectedValue(new Error('network down'));
+
+      await expect(provider.sendMessage('tg:123', 'hi')).rejects.toThrow(
+        'network down',
+      );
+    });
+  });
+
   describe('basic operations', () => {
     it('reports connected after successful connect', async () => {
       await provider.connect();

--- a/packages/mcp-telegram/src/telegram.ts
+++ b/packages/mcp-telegram/src/telegram.ts
@@ -493,7 +493,8 @@ export class TelegramProvider implements ChannelProvider {
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
-    if (!this.bot) return;
+    // plain Error: packages/* cannot import src/errors/ (see error-discipline.md Issue #220); matches this file's existing plain-Error convention
+    if (!this.bot) throw new Error('Telegram bot not initialized');
     try {
       const numericId = chatId.replace(/^tg:/, '');
       if (text.length <= MAX_MESSAGE_LENGTH) {
@@ -508,7 +509,11 @@ export class TelegramProvider implements ChannelProvider {
         }
       }
     } catch (err) {
-      logger.error({ chatId, err }, 'Failed to send Telegram message');
+      logger.debug(
+        { chatId, err },
+        'Telegram send failed, rethrowing to caller',
+      );
+      throw err instanceof Error ? err : new Error(String(err));
     }
   }
 

--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-06-27" # auto-bump @1782574645
+last_verified: "2026-07-03" # auto-bump @1783088946
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-06-30" # auto-bump @1782820526
+last_verified: "2026-07-03" # auto-bump @1783088946
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-06-30" # auto-bump @1782820526
+last_verified: "2026-07-03" # auto-bump @1783088946
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783081643
+last_verified: "2026-07-03" # auto-bump @1783088946
 governs:
   - src/
   - evolution/

--- a/src/channels/mcp-adapter.test.ts
+++ b/src/channels/mcp-adapter.test.ts
@@ -160,6 +160,29 @@ describe('McpChannelAdapter', () => {
     });
   });
 
+  it('should throw a RetryableError when send_message returns isError', async () => {
+    mockCallTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: 'text', text: 'provider not connected' }],
+    });
+
+    const adapter = new McpChannelAdapter(makeOpts());
+    await expect(adapter.sendMessage('123@c.us', 'hi')).rejects.toThrow(
+      'send_message failed: provider not connected',
+    );
+  });
+
+  it('should resolve when send_message succeeds', async () => {
+    mockCallTool.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'Message sent.' }],
+    });
+
+    const adapter = new McpChannelAdapter(makeOpts());
+    await expect(
+      adapter.sendMessage('123@c.us', 'hi'),
+    ).resolves.toBeUndefined();
+  });
+
   it('should handle disconnect gracefully', async () => {
     const adapter = new McpChannelAdapter(makeOpts());
     await adapter.connect();

--- a/src/channels/mcp-adapter.ts
+++ b/src/channels/mcp-adapter.ts
@@ -10,6 +10,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 
+import { RetryableError } from '../errors/index.js';
 import { logger } from '../logger.js';
 import type {
   Channel,
@@ -139,10 +140,18 @@ export class McpChannelAdapter implements Channel {
   }
 
   async sendMessage(jid: string, text: string): Promise<void> {
-    await this.client.callTool({
+    const result = await this.client.callTool({
       name: 'send_message',
       arguments: { chat_id: jid, text },
     });
+    if (result.isError) {
+      const msg = Array.isArray(result.content)
+        ? result.content.map((c) => ('text' in c ? c.text : '')).join(' ')
+        : 'unknown error';
+      throw new RetryableError(`send_message failed: ${msg}`, {
+        context: { jid, channel: this.name },
+      });
+    }
   }
 
   isConnected(): boolean {


### PR DESCRIPTION
## Summary
- Telegram, Discord, Gmail, Outlook, and Teams providers converted every outbound send failure (not-initialized guard, missing metadata, transport error) into a logged no-op and resolved normally — a dropped reply looked identical to a delivered one.
- The shared `McpChannelAdapter.sendMessage` discarded the MCP `callTool` result without checking `isError`, so even a provider that did throw couldn't surface the failure to the host.
- Both layers now throw. This revives the existing LIA-286 delivery-failure fallback (`trySend` already handles a rejection; it just never received one before).
- Scope grew from the original 3-provider draft to 5 (added Outlook and Teams, which share the identical bug via the same `McpChannelAdapter`) plus a third silent-loss site in Discord found during plan review.
- Added a "provider-package plain-Error exemption" addendum to `docs/decisions/error-discipline.md` documenting why these 5 packages throw plain `Error` instead of the `src/errors/` taxonomy (cross-package import boundary, same constraint as the existing Issue #218 precedent).

## Test plan
- [x] Per-provider unit tests (telegram/discord/gmail/outlook/teams) asserting `sendMessage` rejects on not-initialized state and on underlying send failure
- [x] `mcp-adapter.test.ts`: new tests for `isError: true` → throws `RetryableError`, and success path still resolves
- [x] Root `npx vitest run`: 1940/1940 passed
- [x] Per-package `npx vitest run` for all 5 providers: green (one pre-existing unrelated `discord.test.ts` failure confirmed via `git stash` to reproduce on the unmodified baseline)
- [x] `npx tsc --noEmit` at root: clean
- [x] Plan-reviewer + code-reviewer co-gate (claude + gpt + glm backends): all SHIP

Closes LIA-359, LIA-360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>