### PR TITLE
fix(orchestrator): surface terminal agent-run failures to the chat user (LIA-371)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783105295
+last_verified: "2026-07-03" # auto-bump @1783105781
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-07-03" # auto-bump @1783105295
+last_verified: "2026-07-03" # auto-bump @1783105781
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783105295
+last_verified: "2026-07-03" # auto-bump @1783105781
 governs:
   - src/
   - evolution/

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 import { GroupQueue } from './group-queue.js';
+import { logger } from './logger.js';
 
 // Mock config to control concurrency limit
 vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/deus-test-data',
   MAX_CONCURRENT_CONTAINERS: 2,
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
 }));
 
 // Mock fs operations used by sendMessage/closeStdin
@@ -184,6 +195,7 @@ describe('GroupQueue', () => {
 
   it('stops retrying after MAX_RETRIES and resets', async () => {
     let callCount = 0;
+    const onTerminalFailure = vi.fn();
 
     const processMessages = vi.fn(async () => {
       callCount++;
@@ -191,24 +203,65 @@ describe('GroupQueue', () => {
     });
 
     queue.setProcessMessagesFn(processMessages);
+    queue.setOnTerminalFailure(onTerminalFailure);
     queue.enqueueMessageCheck('group1@g.us');
 
     // Run through all 5 retries (MAX_RETRIES = 5)
     // Initial call
     await vi.advanceTimersByTimeAsync(10);
     expect(callCount).toBe(1);
+    expect(onTerminalFailure).not.toHaveBeenCalled();
 
     // Retry 1: 5000ms, Retry 2: 10000ms, Retry 3: 20000ms, Retry 4: 40000ms, Retry 5: 80000ms
     const retryDelays = [5000, 10000, 20000, 40000, 80000];
     for (let i = 0; i < retryDelays.length; i++) {
       await vi.advanceTimersByTimeAsync(retryDelays[i] + 10);
       expect(callCount).toBe(i + 2);
+      if (i < retryDelays.length - 1) {
+        expect(onTerminalFailure).not.toHaveBeenCalled();
+      }
     }
+
+    // Terminal failure notice fires exactly once, on the 6th (final) call.
+    expect(onTerminalFailure).toHaveBeenCalledTimes(1);
+    expect(onTerminalFailure).toHaveBeenCalledWith('group1@g.us');
 
     // After 5 retries (6 total calls), should stop — no more retries
     const countAfterMaxRetries = callCount;
     await vi.advanceTimersByTimeAsync(200000); // Wait a long time
     expect(callCount).toBe(countAfterMaxRetries);
+    expect(onTerminalFailure).toHaveBeenCalledTimes(1); // still just once
+  });
+
+  it('does not propagate if onTerminalFailure callback throws', async () => {
+    const processMessages = vi.fn(async () => false);
+    queue.setProcessMessagesFn(processMessages);
+    queue.setOnTerminalFailure(() => {
+      throw new Error('boom');
+    });
+    queue.enqueueMessageCheck('group1@g.us');
+
+    await vi.advanceTimersByTimeAsync(10);
+    const delays = [5000, 10000, 20000, 40000, 80000];
+    for (const d of delays) {
+      await vi.advanceTimersByTimeAsync(d + 10);
+    }
+
+    // Discriminates the actual try/catch in scheduleRetry: without it, an
+    // uncaught throw is absorbed by runForGroup's outer catch instead, which
+    // logs a different message ('Error processing messages for group') and
+    // silently kicks off a fresh retry cycle rather than completing the
+    // terminal-retry branch cleanly.
+    expect(logger.error).toHaveBeenCalledWith(
+      { groupJid: 'group1@g.us', err: expect.any(Error) },
+      'onTerminalFailure callback threw',
+    );
+
+    // The group must remain usable after a throwing callback — a fresh
+    // message check starts a new retry cycle rather than being wedged.
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    expect(processMessages).toHaveBeenCalledTimes(7); // 6 + 1 fresh call
   });
 
   // --- Waiting groups get drained when slots free up ---

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -33,6 +33,7 @@ export class GroupQueue {
   private waitingGroups: string[] = [];
   private processMessagesFn: ((groupJid: string) => Promise<boolean>) | null =
     null;
+  private onTerminalFailureFn: ((groupJid: string) => void) | null = null;
   private shuttingDown = false;
 
   private getGroup(groupJid: string): GroupState {
@@ -57,6 +58,10 @@ export class GroupQueue {
 
   setProcessMessagesFn(fn: (groupJid: string) => Promise<boolean>): void {
     this.processMessagesFn = fn;
+  }
+
+  setOnTerminalFailure(fn: (groupJid: string) => void): void {
+    this.onTerminalFailureFn = fn;
   }
 
   enqueueMessageCheck(groupJid: string): void {
@@ -268,6 +273,11 @@ export class GroupQueue {
         'Max retries exceeded, dropping messages (will retry on next incoming message)',
       );
       state.retryCount = 0;
+      try {
+        this.onTerminalFailureFn?.(groupJid);
+      } catch (err) {
+        logger.error({ groupJid, err }, 'onTerminalFailure callback threw');
+      }
       return;
     }
 

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -16,6 +16,7 @@ import type {
   RunResult,
   RuntimeEventSink,
 } from './agent-runtimes/types.js';
+import { logger } from './logger.js';
 
 // ── Module mocks (hoisted) ───────────────────────────────────────────────────
 
@@ -294,6 +295,7 @@ function makeQueue() {
     enqueueTask: vi.fn(),
     sendMessage: vi.fn(() => false as boolean),
     registerProcess: vi.fn(),
+    setOnTerminalFailure: vi.fn(),
   };
 }
 
@@ -794,6 +796,53 @@ describe('auto-compact dispatch (LIA-367)', () => {
 
     await orchestrator.processGroupMessages('group@g.us');
     expect(queue.enqueueTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('terminal-failure notice wiring', () => {
+  it('wires queue.setOnTerminalFailure to send a notice via the resolved channel', async () => {
+    const state = makeState(MAIN_GROUP);
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    const queue = makeQueue();
+
+    createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    expect(queue.setOnTerminalFailure).toHaveBeenCalledTimes(1);
+    const registeredCallback = queue.setOnTerminalFailure.mock.calls[0][0];
+
+    await registeredCallback('group@g.us');
+
+    expect(mockFindChannel).toHaveBeenCalledWith([channel], 'group@g.us');
+    expect(channel.sendMessage).toHaveBeenCalledWith(
+      'group@g.us',
+      'I hit an error processing that — please try again.',
+    );
+  });
+
+  it('is a no-op when no channel owns the JID', async () => {
+    const state = makeState(MAIN_GROUP);
+    mockFindChannel.mockReturnValue(undefined);
+    const queue = makeQueue();
+
+    createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [],
+    });
+
+    const registeredCallback = queue.setOnTerminalFailure.mock.calls[0][0];
+    expect(() => registeredCallback('group@g.us')).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { groupJid: 'group@g.us' },
+      'No channel owns JID, cannot send terminal-failure notice',
+    );
   });
 });
 

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -83,6 +83,29 @@ export interface OrchestratorDeps {
 
 export function createMessageOrchestrator(deps: OrchestratorDeps) {
   const { state, queue, registry, channels, ingressCaps } = deps;
+
+  queue.setOnTerminalFailure((groupJid) => {
+    const channel = findChannel(channels, groupJid);
+    if (!channel) {
+      logger.warn(
+        { groupJid },
+        'No channel owns JID, cannot send terminal-failure notice',
+      );
+      return;
+    }
+    channel
+      .sendMessage(
+        groupJid,
+        'I hit an error processing that — please try again.',
+      )
+      .catch((err) =>
+        logger.warn(
+          { groupJid, err },
+          'Failed to send terminal-failure notice',
+        ),
+      );
+  });
+
   let messageLoopRunning = false;
 
   async function runAgent(

--- a/src/orchestrator-caps-phase4.oracle.test.ts
+++ b/src/orchestrator-caps-phase4.oracle.test.ts
@@ -349,6 +349,7 @@ function makeQueue() {
     enqueueMessageCheck: vi.fn(),
     sendMessage: vi.fn(() => false as boolean),
     registerProcess: vi.fn(),
+    setOnTerminalFailure: vi.fn(),
   };
 }
 


### PR DESCRIPTION
## Summary
- Persistent backend errors (auth expiry, container crash, dead session) previously failed completely silently: the user saw the typing indicator flick on and off through ~2.5 minutes of hidden exponential-backoff retries, then total silence, with no way to distinguish "thinking" from "broken."
- Adds `GroupQueue.setOnTerminalFailure` (mirrors the existing `processMessagesFn` single-slot callback pattern), fired once from `scheduleRetry`'s terminal-retry branch after `MAX_RETRIES` (5) is exhausted, wrapped in try/catch so a misbehaving callback can't destabilize the retry state machine.
- Wired in `message-orchestrator.ts` to resolve the channel via the existing `findChannel` helper and send a terse notice via `channel.sendMessage(...).catch(...)` — matching the precedent already set by `session-commands.ts` for slash-command failures, and using `.catch` (not bare await) since `channel.sendMessage` now throws on delivery failure per the just-merged #983.

## Review process
Went through 3 code-reviewer rounds during development, each fixing a real finding:
1. GPT backend flagged a fragile `.resolves.not.toThrow()` matcher in a test — fixed to a plain await.
2. code-reviewer mutation-tested the resulting test and proved it didn't actually discriminate whether the try/catch was present (an uncaught throw is silently absorbed by a different catch block, quietly starting a fresh retry cycle) — fixed by mocking `logger` and asserting the specific log message; independently re-verified via my own mutation test (removed the try/catch, confirmed the test fails, restored).
3. Minor missing assertion on the "no channel resolves" no-op path — added.

Final state: plan-reviewer SHIP (native + GPT), code-reviewer SHIP (native + GPT + GLM), verification-gate SHIP with full command evidence.

## Note on merge order
This PR and #367 (auto-compact concurrency fix, separate PR) both touch `message-orchestrator.test.ts`'s `makeQueue()` test helper (different new keys) and the top of `createMessageOrchestrator`. Whichever merges second will need a small rebase to reconcile both.

## Test plan
- [x] `npx tsc --noEmit && npx tsc` — clean
- [x] `npx vitest run` — 109 files, 1943 tests, 0 failures
- [x] New tests: `group-queue.test.ts` (terminal-failure fires once, only after final retry; throwing callback doesn't propagate — mutation-tested), `message-orchestrator.test.ts` (wiring resolves channel + sends notice; no-op + logs warning when unresolvable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)