### PR TITLE
fix(orchestrator): serialize auto-compact self-dispatch via GroupQueue.enqueueTask (LIA-367)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783081643
+last_verified: "2026-07-03" # auto-bump @1783105295
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-07-03" # auto-bump @1783081643
+last_verified: "2026-07-03" # auto-bump @1783105295
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783088946
+last_verified: "2026-07-03" # auto-bump @1783105295
 governs:
   - src/
   - evolution/

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -278,6 +278,40 @@ describe('GroupQueue', () => {
     expect(taskCallCount).toBe(1);
   });
 
+  // --- Pending-queue task dedup (LIA-367: auto-compact self-dispatch) ---
+
+  it('rejects duplicate enqueue of a task already pending (not yet running)', async () => {
+    let resolveMessages: () => void;
+
+    const processMessages = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveMessages = resolve;
+      });
+      return true;
+    });
+    queue.setProcessMessagesFn(processMessages);
+
+    // Take the group's only slot with a message run, so a subsequently
+    // enqueued task goes onto pendingTasks rather than running immediately.
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+
+    const firstFn = vi.fn(async () => {});
+    queue.enqueueTask('group1@g.us', 'auto-compact', firstFn);
+
+    // A second enqueue with the same taskId while the first is still only
+    // pending (never ran) must be dropped, not queued twice.
+    const dupFn = vi.fn(async () => {});
+    queue.enqueueTask('group1@g.us', 'auto-compact', dupFn);
+
+    // Let the message run finish and the pending task drain.
+    resolveMessages!();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(firstFn).toHaveBeenCalledTimes(1);
+    expect(dupFn).not.toHaveBeenCalled();
+  });
+
   // --- Idle preemption ---
 
   it('does NOT preempt active container when not idle', async () => {

--- a/src/message-orchestrator.test.ts
+++ b/src/message-orchestrator.test.ts
@@ -291,6 +291,7 @@ function makeQueue() {
     closeStdin: vi.fn(),
     notifyIdle: vi.fn(),
     enqueueMessageCheck: vi.fn(),
+    enqueueTask: vi.fn(),
     sendMessage: vi.fn(() => false as boolean),
     registerProcess: vi.fn(),
   };
@@ -763,6 +764,36 @@ describe('processGroupMessages', () => {
       'group@g.us',
       'ts-1',
     );
+  });
+});
+
+// ── Auto-compact dispatch (LIA-367) ──────────────────────────────────────────
+// `result.contextStats`/`result.compactionEvent` never reach this callback in
+// production today — ContainerRuntime.runTurn's onOutput only forwards
+// output_text/activity/session/error/turn_complete, and RuntimeEvent has no
+// variant carrying them. This test pins that today's real event pipeline
+// never triggers the auto-compact dispatch (dead-code regression guard); the
+// serialization mechanism itself (enqueueTask dedup/queue/drain ordering) is
+// covered separately in group-queue.test.ts, where it's actually reachable.
+describe('auto-compact dispatch (LIA-367)', () => {
+  it('never calls queue.enqueueTask via the real event pipeline (contextStats is not forwarded)', async () => {
+    const state = makeState(MAIN_GROUP, 'ts-prev');
+    const channel = makeChannel();
+    mockFindChannel.mockReturnValue(channel as unknown as Channel);
+    mockGetMessagesSince.mockReturnValue([makeMsg({ timestamp: 'ts-1' })]);
+    const queue = makeQueue();
+
+    // defaultRunTurn is used (output_text + session + turn_complete) — the
+    // real shape the event pipeline can produce today.
+    const orchestrator = createMessageOrchestrator({
+      registry: makeRegistry(),
+      state: state as unknown as RouterState,
+      queue: queue as unknown as GroupQueue,
+      channels: [channel as unknown as Channel],
+    });
+
+    await orchestrator.processGroupMessages('group@g.us');
+    expect(queue.enqueueTask).not.toHaveBeenCalled();
   });
 });
 

--- a/src/message-orchestrator.ts
+++ b/src/message-orchestrator.ts
@@ -84,7 +84,6 @@ export interface OrchestratorDeps {
 export function createMessageOrchestrator(deps: OrchestratorDeps) {
   const { state, queue, registry, channels, ingressCaps } = deps;
   let messageLoopRunning = false;
-  const autoCompactFired = new Set<string>();
 
   async function runAgent(
     group: RegisteredGroup,
@@ -129,7 +128,6 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
         }
         clearSession(group.folder, backend);
         state.clearSession(group.folder, backend);
-        autoCompactFired.delete(group.folder);
         sessionRef = undefined;
       }
     }
@@ -494,6 +492,7 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
     await channel.setTyping?.(chatJid, true);
     let hadError = false;
     let outputSentToUser = false;
+    let pendingAutoCompact = false;
 
     // Swallow channel send failures so they never propagate as an onOutput
     // rejection (LIA-286); logs with orchestrator-layer context. The boolean
@@ -692,29 +691,18 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
         if (result.compactionEvent) {
           const resolvedBackend = registry.resolve(group);
           setLastCompactedAt(group.folder, resolvedBackend.name());
+          pendingAutoCompact = false;
         }
 
         if (
           result.contextStats?.autoCompact &&
           !result.compactionEvent &&
-          !autoCompactFired.has(group.folder)
+          !pendingAutoCompact
         ) {
-          autoCompactFired.add(group.folder);
+          pendingAutoCompact = true;
           logger.info(
             { group: group.name, pct: result.contextStats.pct },
-            'Auto-compact threshold reached, dispatching /compact',
-          );
-          runAgent(group, '/compact', chatJid, [], async () => {}).then(
-            () => {
-              autoCompactFired.delete(group.folder);
-            },
-            (err) => {
-              autoCompactFired.delete(group.folder);
-              logger.warn(
-                { group: group.name, err },
-                'Auto-compact dispatch failed',
-              );
-            },
+            'Auto-compact threshold reached, will dispatch /compact after this turn',
           );
         }
 
@@ -730,6 +718,16 @@ export function createMessageOrchestrator(deps: OrchestratorDeps) {
 
     await channel.setTyping?.(chatJid, false);
     if (idleTimer) clearTimeout(idleTimer);
+
+    // Deferred until the primary turn has fully returned (LIA-367): dispatching
+    // here — instead of un-awaited inside the onOutput callback above — means
+    // GroupQueue.enqueueTask always queues (state.active is still true) rather
+    // than racing a second container against this one on the same IPC dir.
+    if (pendingAutoCompact) {
+      queue.enqueueTask(chatJid, 'auto-compact', async () => {
+        await runAgent(group, '/compact', chatJid, [], async () => {});
+      });
+    }
 
     if (output === 'error' || hadError) {
       // If we already sent output to the user, don't roll back the cursor —


### PR DESCRIPTION
## Summary
- The `/compact` self-dispatch in `message-orchestrator.ts` fired `runAgent(group, '/compact', ...)` un-awaited, mid-callback, guarded only by a closure-scoped `Set<string>`. This bypassed `GroupQueue`'s one-container-per-group serialization entirely — a second container could spawn and race the primary turn's container on the same host IPC directory (neither call site sets `ipcRunKey`, so both resolve to the identical unscoped path).
- Reroutes the dispatch through the existing `GroupQueue.enqueueTask` primitive — the same pattern already used identically in `odysseus-server.ts` and `task-scheduler.ts` for "serialize a self-dispatch against the group's normal turn." The compact dispatch now only fires after the primary `runAgent` call has fully resolved, and because `GroupQueue.state.active` is still true at that point, `enqueueTask` always queues rather than running concurrently — `drainGroup` picks it up under full serialization once the primary container's state is cleanly reset.

## Important context: this specific race is currently unreachable in production
Traced the full data path for `result.contextStats`/`result.compactionEvent` (the fields that gate the dispatch): `ContainerRuntime.runTurn`'s `onOutput` only forwards `output_text/activity/session/error/turn_complete`; `RuntimeEvent` has no variant carrying `contextStats`/`compactionEvent` at all; `runAgent`'s `eventSink` only synthesizes `{status,result}`-shaped callback objects. So `result.contextStats?.autoCompact` is always `undefined` today — confirmed independently by an existing code comment at `src/config.ts:184-191` ("the runtime eventSink does not forward contextStats... tracked follow-up") and by `git log -S contextStats` showing zero commits ever wiring that forwarding path since the auto-compact feature was introduced (`a08d0e71`, LIA-94).

This means DEUS's own proactive auto-compact trigger has been silently inert since introduction — the SDK's own internal auto-compaction (a separate mechanism) still works, so nothing is on fire. This PR ships as cheap, precedented preventive hardening for a landmine that would activate the moment the forwarding gap closes (a follow-up ticket will track that separately) rather than as a fix for an actively-reproducing bug — flagging so reviewers don't expect an observable behavior change or an E2E repro.

## Test plan
- [x] `npx tsc --noEmit && npx tsc` — clean
- [x] `npx vitest run` — 109 files, 1942 tests, 0 failures
- [x] New tests: `message-orchestrator.test.ts` (regression-pin: real event pipeline never calls `queue.enqueueTask`, documenting current unreachability), `group-queue.test.ts` (pending-task dedup branch, previously only covered for running tasks)

## Note on merge order
This PR and #984 (silent agent-run failure notice, separate PR) both touch `message-orchestrator.test.ts`'s `makeQueue()` test helper (different new keys) and the top of `createMessageOrchestrator`. Whichever merges second will need a small rebase to reconcile both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)