### PR TITLE
docs(wardens): add taste-pass plan-review rule

### DIFF
--- a/.claude/wardens/plan-review-rules.md
+++ b/.claude/wardens/plan-review-rules.md
@@ -138,6 +138,12 @@ Common traps:
 **Check:** For each function the plan references, has the actual signature been read and verified? Do the parameter names, types, and return types match what the plan assumes?
 **Rule:** Plans must verify the API surface they depend on by reading the source. Wrong method signatures, dead parameters, and phantom APIs are the #1 cause of multi-round plan-reviewer cycles. Read the function, then write the plan — not the reverse.
 
+## taste-pass
+**Severity:** warning
+**Applies when:** Plan changes product user-facing surfaces — chat/channel message formatting or templates, TUI panels, CLI/command output, web UI, or user-facing HTML artifacts. Repo documentation (README, CONTRIBUTING, `docs/`) is excluded — prose quality there is copy-writer territory, not taste elicitation.
+**Check:** Does the plan include a cheap reaction step — 3-4 divergent throwaway variants (mock, HTML artifact, sample output) for the user to react to — before committing to one design?
+**Rule:** For look-and-feel work, elicit taste before implementation: generate divergent variants at prototype cost, let the user react, then implement only the chosen direction. Skip when the change is backend-only, a mechanical refactor, or the user already specified the exact design.
+
 ---
 
 ## Remediation Details
@@ -214,3 +220,7 @@ Common traps:
 ### api-surface-verification
 **Cite:** RETRO-2026-05-11-02; Phase 5-6 postmortem (6 rounds caused by RuntimeRegistry.resolve() wrong signature, GroupQueue dead parameter)
 **Remediation:** For each referenced function, open the source file and read the actual signature. Update the plan to match the real parameter names, types, and return types. Add a "Verified signatures" note citing the file and line number for each function.
+
+### taste-pass
+**Cite:** map-vs-territory analysis (2026-07-04; durable copy in Session-Logs/2026-07-04/ after /compress) — unknown knowns (taste the user only recognizes on sight) are cheapest converted at prototype cost, not one-violation-each through the evolution feedback loop.
+**Remediation:** Add a pre-implementation step: produce 3-4 divergent throwaway variants of the user-facing surface (fake data is fine), present them for reaction, record the pick and why, then implement only the winner. The variants are disposable — do not wire up backend state to render them.


### PR DESCRIPTION
## What

Appends a warning-severity `taste-pass` rule + Remediation Details entry to `.claude/wardens/plan-review-rules.md`, following the file's documented append process. One file, +10 lines, markdown-only.

## Why

User-facing/design work involves "unknown knowns" — taste the user only recognizes on sight. Today that taste is learned one violation at a time through the evolution feedback loop (each miss becomes a feedback memory after the fact). Eliciting it *before* implementation is strictly cheaper: 3-4 divergent throwaway variants (mock, HTML artifact, sample output) for the user to react to, then implement only the winner.

Scope is deliberately tight: product user-facing surfaces only (chat/channel templates, TUI panels, CLI output, web UI, HTML artifacts). Repo docs are excluded (copy-writer territory). Skips for backend-only, mechanical-refactor, or user-already-specified-design changes. Severity `warning` — advisory, never blocks a plan.

Origin: map-vs-territory analysis session, 2026-07-04 (durable copy lands in vault Session-Logs on compress; this PR body is the standing anchor).

## Review trail

- plan-reviewer: claude SHIP (1 REVISE round — scope split into two single-concern PRs; this is PR A) + gpt backend SHIP
- code-reviewer: claude SHIP + gpt SHIP + glm SHIP
- ai-eng-warden: claude SHIP + gpt SHIP
- verification-gate: SHIP (1 file +10/-0, format matches siblings, no `.ts`/`patterns/` touched, `tsc` exit 0)

## Rollback

Single revert; advisory rules text with no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)