### PR TITLE
docs(rules): log plan deviations at discovery

### DIFF
--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -34,6 +34,7 @@
 - Before parallelizing, map independent vs dependent subtasks. Fan out only the independent ones with explicit output contracts and a reconcile step; never parallelize a dependency chain — plan→review→implement→test is sequential by necessity, agents on stale inputs produce stale outputs, and a subtask without full interface context hallucinates its contracts.
 - Default subagent model is Sonnet. Escalate to Opus only with stated reason.
 - Default to cross-platform. Flag OS-specific code loudly in PRs.
+- During planned implementation, log each forced deviation from the plan (edge case, wrong assumption, changed approach) as a `Deviation:` note in the session as it happens — each is a discovered unknown; capture at discovery, don't reconstruct later.
 - Chat responses always in English. Hebrew only inside artifacts.
 
 ## Code Exploration


### PR DESCRIPTION
## What

One bullet added to the `## Workflow` section of `.claude/rules/core-behavioral-rules.md`: during planned implementation, log each forced deviation from the plan (edge case, wrong assumption, changed approach) as a `Deviation:` note at the moment it is discovered.

## Why (rule-addition justification, per the file's own header requirement)

Deviations-from-plan are discovered unknowns and the highest-signal input the evolution loop never sees: today they dissolve into prose, and retrospectives + `/compress` can only mine what was written down. This rule creates the signal in-session at discovery time; the existing compress → session-log → retrospective pipeline consumes it unchanged. It is a writing discipline, not a mechanism — no new storage path (checked against `record_feedback`, session-retrospective deferred-task tracking, and `/compress`; none captures deviation-at-discovery).

Origin: map-vs-territory analysis session, 2026-07-04. Companion PR (same session, separate concern): #986.

## Token cost disclosure

The addition is ~50-55 tokens. The file's header claims an "800-token budget" but the file already measures ~985-1263 tokens pre-change (word- and char-based estimates) with no CI gate tracking it — pre-existing drift, disclosed here; the header is deliberately left untouched to keep this diff single-concern. A follow-up may trim the file or correct the header claim.

## Review trail

- plan-reviewer: claude SHIP (1 REVISE round — scope split into two single-concern PRs; this is PR B) + gpt backend SHIP
- code-reviewer: claude SHIP (warning: include token estimate in PR body — done above) + gpt SHIP + glm SHIP
- ai-eng-warden: claude SHIP (warning: pre-existing header-budget drift, follow-up suggested — disclosed above) + gpt SHIP
- verification-gate: SHIP (1 file +1/-0, single hunk in Workflow, no `.ts`/`patterns/`, `tsc` exit 0)

## Rollback

Single revert; advisory rules text with no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)