### PR TITLE
fix(memory): pin intent-classify models with keep_alive (LIA-377)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,11 @@ DEUS_VAULT_PATH=
 # DEUS_INTENT_MODEL=gemma4:e2b
 # Intent-classify HTTP timeout in seconds (default 10):
 # DEUS_INTENT_TIMEOUT=10
+# Ollama keep_alive duration for the intent-classify models (LIA-377, default
+# 10m). This classify path is the only caller of gemma4:e2b/e4b, so unrelated
+# Ollama model churn evicts them between calls, paying a ~9-11s cold-load tax
+# on nearly every invocation without this pin:
+# DEUS_INTENT_KEEP_ALIVE=10m
 
 # === Integrations ===
 # Linear project management MCP (host-side Claude Code + container agents).

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -231,14 +231,14 @@ def _intent_timeout() -> float:
 def _intent_keep_alive() -> str:
     """Resolve the intent-classify keep_alive duration (Ollama duration string).
 
-    DEUS_INTENT_KEEP_ALIVE overrides; default 10m. This classify path is the
-    only caller of gemma4:e2b, so unrelated Ollama model churn (e.g. a local
-    benchmark loading other models) evicts it between calls, paying a ~9-11s
-    cold-load tax on nearly every invocation (LIA-377). 10m survives typical
-    inter-query gaps without pinning long enough to raise eviction odds for
-    concurrent consumers on this shared machine.
+    DEUS_INTENT_KEEP_ALIVE (LIA-377) overrides; default 10m. This classify
+    path is the only caller of gemma4:e2b, so unrelated Ollama model churn
+    (e.g. a local benchmark loading other models) evicts it between calls,
+    paying a ~9-11s cold-load tax on nearly every invocation. 10m survives
+    typical inter-query gaps without pinning long enough to raise eviction
+    odds for concurrent consumers on this shared machine.
     """
-    return os.environ.get("DEUS_INTENT_KEEP_ALIVE", "").strip() or "10m"
+    return os.environ.get("DEUS_INTENT_KEEP_ALIVE", "").strip() or "10m"  # LIA-377
 
 
 def _classify_ollama(query: str, model: str) -> str | None:

--- a/scripts/memory_query.py
+++ b/scripts/memory_query.py
@@ -228,6 +228,19 @@ def _intent_timeout() -> float:
     return v if v > 0 else 10.0
 
 
+def _intent_keep_alive() -> str:
+    """Resolve the intent-classify keep_alive duration (Ollama duration string).
+
+    DEUS_INTENT_KEEP_ALIVE overrides; default 10m. This classify path is the
+    only caller of gemma4:e2b, so unrelated Ollama model churn (e.g. a local
+    benchmark loading other models) evicts it between calls, paying a ~9-11s
+    cold-load tax on nearly every invocation (LIA-377). 10m survives typical
+    inter-query gaps without pinning long enough to raise eviction odds for
+    concurrent consumers on this shared machine.
+    """
+    return os.environ.get("DEUS_INTENT_KEEP_ALIVE", "").strip() or "10m"
+
+
 def _classify_ollama(query: str, model: str) -> str | None:
     """Classify a query as 'procedural'/'factual' via one local Ollama model.
 
@@ -256,6 +269,7 @@ def _classify_ollama(query: str, model: str) -> str | None:
         "stream": False,
         "think": False,  # gemma4 returns empty under a JSON schema without this (ollama-quirks.md)
         "options": {"temperature": 0},
+        "keep_alive": _intent_keep_alive(),
     }).encode()
 
     try:

--- a/scripts/tests/test_memory_query.py
+++ b/scripts/tests/test_memory_query.py
@@ -444,9 +444,10 @@ class _FakeResp:
 class _FakeConn:
     def __init__(self, resp):
         self._resp = resp
+        self.sent_body = None
 
     def request(self, *a, **k):
-        pass
+        self.sent_body = k.get("body")
 
     def getresponse(self):
         return self._resp
@@ -481,6 +482,14 @@ class TestClassifyIntent:
     def test_unknown_label_returns_none(self):
         assert self._classify(200, _ollama_body({"intent": "banana"})) is None
 
+    def test_payload_includes_keep_alive(self, monkeypatch):
+        monkeypatch.delenv("DEUS_INTENT_KEEP_ALIVE", raising=False)
+        conn = _FakeConn(_FakeResp(200, _ollama_body({"intent": "factual"})))
+        with patch("http.client.HTTPConnection", return_value=conn):
+            mq.classify_intent("does not matter")
+        sent = json.loads(conn.sent_body)
+        assert sent["keep_alive"] == mq._intent_keep_alive()
+
 
 class TestIntentTimeout:
     def test_default_when_unset(self, monkeypatch):
@@ -498,6 +507,22 @@ class TestIntentTimeout:
     def test_valid_override(self, monkeypatch):
         monkeypatch.setenv("DEUS_INTENT_TIMEOUT", "3.5")
         assert mq._intent_timeout() == 3.5
+
+
+class TestIntentKeepAlive:
+    """LIA-377: keep_alive pin for the intent-classify models."""
+
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("DEUS_INTENT_KEEP_ALIVE", raising=False)
+        assert mq._intent_keep_alive() == "10m"
+
+    def test_blank_falls_back(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_KEEP_ALIVE", "   ")
+        assert mq._intent_keep_alive() == "10m"
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("DEUS_INTENT_KEEP_ALIVE", "5m")
+        assert mq._intent_keep_alive() == "5m"
 
 
 class TestIntentModels:


### PR DESCRIPTION
## Summary
- `memory_retrieval_hook.py` (5s Claude Code UserPromptSubmit timeout) was timing out because `gemma4:e2b`/`e4b` — the only callers of the intent-classify path — get evicted from Ollama by unrelated model churn between calls
- Measured live before the fix: two consecutive real `/api/generate` calls to `gemma4:e2b` showed `load_duration` 8.58s then 11.05s, with actual inference only ~0.15-0.35s both times — confirming eviction (not compute contention) as the cost driver
- Adds a `keep_alive` field (default `10m`, `DEUS_INTENT_KEEP_ALIVE` override) to the classify payload so Ollama holds the model resident across the typical inter-query gap; 10m rather than a longer pin to limit added collision odds with the same concurrent-benchmark process that caused the original eviction on this shared 36GB machine
- Verified post-fix: sequential `classify_intent()` calls completed in 0.68s-1.2s (no cold-load spike), with `ollama ps` confirming `e2b` stayed resident with an active keep-alive window across the calls

## Test plan
- [x] `python3 -m pytest scripts/tests/test_memory_query.py -q` → 77 passed (73 existing + 4 new: `TestIntentKeepAlive` default/blank/override + one payload-assertion test confirming `keep_alive` is actually sent)
- [x] Live smoke test against real Ollama confirmed the fix (see measured timings above)
- [x] plan-reviewer SHIP (claude+gpt, 2 rounds — round 1 REVISE: dropped a settings.json timeout bump that didn't cover the diagnosed cold-load cases, lowered keep_alive default 30m→10m)
- [x] code-reviewer SHIP (claude+gpt+glm)
- [x] verification-gate SHIP

Closes LIA-377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)