### PR TITLE
feat(agent-runner): read-discipline nudges — sliced reads over full-file re-bills (LIA-379)

### DIFF
--- a/.claude/agents/ai-eng-warden.md
+++ b/.claude/agents/ai-eng-warden.md
@@ -76,7 +76,7 @@ Return a single markdown report. No preamble.
 - **Think like a token accountant for efficiency rules.** Estimate token cost of prompt changes. Flag gratuitous context.
 - **Tight output.** Target ≤60 lines in diff mode, ≤120 lines in audit mode. Focus on high-signal findings.
 - **Fail-closed on missing rules file.** If rules file doesn't exist, report "rules file missing" and stop.
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 ## Dismissal feedback
 

--- a/.claude/agents/architecture-snapshot.md
+++ b/.claude/agents/architecture-snapshot.md
@@ -73,7 +73,7 @@ Accuracy > completeness. A precise map of 80% of the system beats a vague map of
 
 ## Rules of engagement
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 - **Accuracy over coverage.** If you didn't read it, don't include it. Mark it in "What This Snapshot Doesn't Cover."
 - **No prescriptions.** Describe, don't prescribe. Don't write "you should refactor X."
 - **Concrete names only.** No "the service", "the handler". Use actual module and file names.

--- a/.claude/agents/brainstormer.md
+++ b/.claude/agents/brainstormer.md
@@ -26,7 +26,7 @@ Novelty > completeness. One surprising, well-reasoned idea is worth more than fi
 
 ### Step 2: Research
 
-1. **Internal:** Follow the three-stage code exploration protocol from `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Understand what's already built.
+1. **Internal:** Follow the three-stage code exploration protocol from `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Understand what's already built. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 2. **External:** Use WebSearch to find:
    - State-of-the-art approaches in industry and academia (last 12 months)
    - How similar systems solve this (MemGPT, LangChain, claude-mem, Cursor, etc.)

--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -32,7 +32,7 @@ You are a code exploration agent. Your job is to find information in the codebas
 
 ## Tool Selection Protocol
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 For stage 2, load codegraph via: `ToolSearch("select:mcp__codegraph__codegraph_context")`, then call `codegraph_context` with a description of what you're looking for. Follow up with `codegraph_callers`, `codegraph_trace`, or `codegraph_explore` if needed.
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -61,7 +61,7 @@ Return a single markdown report. No preamble.
 - **Tight output.** Target ≤50 lines. A long review is a signal/noise red flag.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/code-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
 - **Diff is authoritative.** If memory or docs contradict what's in the diff, trust the diff — memory is a snapshot, code is live.
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 ## Scope Memo
 

--- a/.claude/agents/doc-gardener.md
+++ b/.claude/agents/doc-gardener.md
@@ -15,7 +15,7 @@ actual codebase. You run weekly on a cron schedule.
 
 ## Code Exploration
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 ## Process
 

--- a/.claude/agents/general.md
+++ b/.claude/agents/general.md
@@ -23,6 +23,6 @@ You are a general-purpose agent. You handle research, code exploration, multi-st
 
 ## Tool Selection Protocol (code tasks)
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 For non-code tasks (research, writing, analysis), use whatever tools are appropriate.

--- a/.claude/agents/keystone.md
+++ b/.claude/agents/keystone.md
@@ -33,7 +33,7 @@ reliably walks a chain once it's been handed; it misses which chain to walk.
 ## At invocation, read these
 
 1. **Standards** — `~/deus/.claude/wardens/standards.md`. Quality floor and mindset.
-2. **Code Exploration protocol** — `~/deus/.claude/rules/core-behavioral-rules.md § Code Exploration`.
+2. **Code Exploration protocol** — `~/deus/.claude/rules/core-behavioral-rules.md § Code Exploration`. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
    Walk every link with codegraph-first evidence. Grep/Read only to confirm.
 
 No other rules file. The method below IS the ruleset.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -50,7 +50,7 @@ Return a single markdown report. No preamble, no "I'll review...".
 - **Stay in critique mode.** If asked to fix, respond: "out of scope for this agent — invoke the `Plan` subagent or implement directly."
 - **Keep it tight.** A useful review is ≤40 lines. Padding is noise.
 - **Fail-closed on missing rules file.** If `~/deus/.claude/wardens/plan-review-rules.md` doesn't exist, report "rules file missing — cannot review" and stop. Do not improvise rules.
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 - **Verify premises, not just rule compliance.** When the plan cites repo state as a problem (tracked files, unused deps, orphan files, cache drift, divergence between paths), run the verification commands yourself before approving. The `premise-verification` rule lists the minimum checks per premise type. A rule-compliant plan built on a false premise is REVISE, not SHIP.
 
 ## Scope Memo

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -36,7 +36,7 @@ BEFORE any grep, find, or Read-based exploration:
 2. Call codegraph_context with a description of what you're investigating — it composes search + node + callers + callees in one call
 3. For tracing call flows: use codegraph_trace (one call returns the full path)
 4. For blast radius analysis: use codegraph_impact
-5. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified
+5. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 Codegraph has a pre-built index of every symbol in the codebase. Using grep instead is searching page-by-page when the book has an index.
 

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -55,7 +55,7 @@ Return a single markdown report. No preamble.
 
 ## Rules of engagement
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 - **Think like QA, not a developer.** "The function is well-structured" is irrelevant. "What happens when the input is empty?" is gold.
 - **Cite specific locations.** Every finding ties to a file path and line number, not vague generalities.
 - **Generate runnable scenarios.** Test descriptions should be specific enough that a developer can implement them without asking follow-up questions.

--- a/.claude/agents/threat-modeler.md
+++ b/.claude/agents/threat-modeler.md
@@ -58,7 +58,7 @@ Return a single markdown report. No preamble.
 
 ## Rules of engagement
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 - **Architecture only.** Code-level findings (injection in a specific function, missing sanitization) go to code-reviewer, not this report.
 - **STRIDE is the frame.** Every threat maps to: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, or Elevation of Privilege.
 - **Cite rule ids.** Every Blocking Gap ties to a specific rule from the rules file.

--- a/.claude/agents/wardens/enrichment-gate.md
+++ b/.claude/agents/wardens/enrichment-gate.md
@@ -22,7 +22,7 @@ You receive an issue title and description (may be empty or minimal). Your job i
 
 Before writing any scope, explore the codebase using internal tools first:
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage.
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
 
 **Additional context sources:**
 1. Read `.claude/codebase_map.md` if present -- file tree, key exports, architecture summary in ~800 tokens

--- a/.claude/rules/core-behavioral-rules.md
+++ b/.claude/rules/core-behavioral-rules.md
@@ -41,6 +41,7 @@
 - Three-stage protocol: (1) `search_code` or `codegraph_context` (the composite primary) for semantic candidates, (2) `codegraph_callers`/`codegraph_callees`/`codegraph_impact` for structural context (what connects to the candidates), (3) grep/read for exact confirmation. Skip stages when the answer is already known.
 - Before modifying any function, query `codegraph_callers` to know the blast radius. A change with 2 callers is not the same risk as a change with 50.
 - Never open-code `grep -r` or `find -name` as the first move -- semantic search identifies the landscape, structural queries map the connections, exact search confirms specifics.
+- Read re-bills its full byte size on every subsequent turn (measured: 81.6% of tool-result bytes in large subagent transcripts). Default to `offset`/`limit` or grep-then-read; read a file whole only when the task genuinely needs it entire — same rule as `patterns/general-code.md` § Context hygiene (LIA-379).
 - Codegraph-first is hook-enforced on the main thread (`.claude/settings.json`) and on gated subagents that carry their own frontmatter hook (code-explorer/general/planner/keystone). When authoring a `Workflow` (or dispatching a subagent that has no frontmatter hook) over a codegraph-indexed repo, bake the codegraph-first mandate INTO the `agent()` prompts -- such a `workflow-subagent` inherits no exploration hook (settings.json hooks reach only the main thread), so its prompt is the only lever.
 
 ## Memory & Context

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -39,6 +39,12 @@ import { createToolCallLogHook } from './tool-call-log.js';
 import { writeAvailableTools } from './available-tools-log.js';
 import { buildAllowedTools, computeTeamsNeeded } from './allowed-tools.js';
 import { subagentNudgeAppend } from './subagent-nudge.js';
+import { readDisciplineNudgeAppend } from './read-discipline-nudge.js';
+import {
+  ReadOversizeNudgeTracker,
+  createReadOversizeNudgeHook,
+  readOversizeMaxNudges,
+} from './read-oversize-nudge.js';
 import type { AgentRuntimeId } from './tool-broker.js';
 import { resolveGroupAttachmentPath } from './tool-broker.js';
 import { HookDispatchService } from './hook-dispatch-service.js';
@@ -835,6 +841,11 @@ async function runQuery(
   }
 
   const doomDetector = new DoomLoopDetector();
+  // Per-turn rate-limit state for the oversize-Read advisory (same lifecycle
+  // as doomDetector: fresh per runQuery call). LIA-379
+  const readOversizeTracker = new ReadOversizeNudgeTracker(
+    readOversizeMaxNudges(),
+  );
 
   // The OFFERED tool manifest for this dispatch (Claude backend). Hoisted to a
   // const so it can be both passed to query() AND captured for evolution
@@ -872,7 +883,14 @@ async function runQuery(
     hasProject,
     toolProfile,
   });
-  const fullSystemAppend = [systemAppend, subagentNudge]
+  // Read-discipline nudge: engineering context only, but NOT toolProfile-gated —
+  // Read exists on the webhook profile too and the measured cost is read volume,
+  // not the Task tool. Runtime kill-switch: DEUS_READ_DISCIPLINE_NUDGE=0.
+  const readDisciplineNudge = readDisciplineNudgeAppend({
+    enabled: process.env.DEUS_READ_DISCIPLINE_NUDGE !== '0', // LIA-379
+    hasProject,
+  });
+  const fullSystemAppend = [systemAppend, subagentNudge, readDisciplineNudge]
     .filter(Boolean)
     .join('\n\n');
 
@@ -1012,6 +1030,9 @@ async function runQuery(
           hooks.push(createDoomLoopHook(doomDetector));
           if (process.env.DEUS_TOOL_SIZE_LOG !== '0')
             hooks.push(createToolSizeLogHook());
+          if (process.env.DEUS_READ_OVERSIZE_NUDGE !== '0')
+            // LIA-379
+            hooks.push(createReadOversizeNudgeHook(readOversizeTracker));
           // LIA-154: structured per-call capture for evolution tool observability
           if (process.env.DEUS_TOOL_CALL_LOG !== '0')
             hooks.push(createToolCallLogHook());
@@ -1055,8 +1076,7 @@ async function runQuery(
         const evType = ev?.type as string | undefined;
         if (evType === 'content_block_delta') {
           const delta = ev?.delta as
-            | { type?: string; text?: string }
-            | undefined;
+            { type?: string; text?: string } | undefined;
           if (delta?.type === 'text_delta' && delta.text)
             pushPartial(delta.text);
         } else if (evType === 'content_block_start') {

--- a/container/agent-runner/src/read-discipline-nudge.test.ts
+++ b/container/agent-runner/src/read-discipline-nudge.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  READ_DISCIPLINE_NUDGE,
+  readDisciplineNudgeAppend,
+} from './read-discipline-nudge.js';
+
+describe('readDisciplineNudgeAppend', () => {
+  it('is silent when the kill-switch is off', () => {
+    expect(
+      readDisciplineNudgeAppend({ enabled: false, hasProject: true }),
+    ).toBe('');
+  });
+
+  it('is silent on plain chat (no project mounted)', () => {
+    expect(
+      readDisciplineNudgeAppend({ enabled: true, hasProject: false }),
+    ).toBe('');
+  });
+
+  it('appends the nudge in engineering context', () => {
+    expect(readDisciplineNudgeAppend({ enabled: true, hasProject: true })).toBe(
+      READ_DISCIPLINE_NUDGE,
+    );
+  });
+
+  it('nudge text keeps its load-bearing guidance', () => {
+    expect(READ_DISCIPLINE_NUDGE).toContain('offset/limit');
+    expect(READ_DISCIPLINE_NUDGE).toContain('Grep');
+    expect(READ_DISCIPLINE_NUDGE).toContain('Read a file in full only when');
+  });
+});

--- a/container/agent-runner/src/read-discipline-nudge.ts
+++ b/container/agent-runner/src/read-discipline-nudge.ts
@@ -1,0 +1,58 @@
+/**
+ * Read-discipline nudge (LIA-379).
+ *
+ * Read is the dominant tool-result cost: 81.6% of tool-result bytes in the 20
+ * largest subagent transcripts (mean 12,086 B/call), and every byte is re-read
+ * on each subsequent turn of the session. This appends a short, static
+ * instruction steering the model toward grep-then-slice (offset/limit) reads by
+ * default, reserving whole-file reads for tasks that genuinely need them.
+ * Advisory only — no truncation, no forced tool behavior change. Pure module,
+ * mirroring `subagent-nudge.ts`.
+ */
+
+/**
+ * The instruction appended to the system prompt in engineering context.
+ * Own cost: ~150 tokens, once per engineering-context turn in the cached
+ * system-prompt prefix — vs the mean 12KB (~3k-token) full Reads it deters.
+ */
+export const READ_DISCIPLINE_NUDGE = `## Read discipline
+
+Reading a file re-bills its full byte size on every later turn of the session.
+Before a Read, prefer this order:
+  1. When searching for something specific, Grep for the symbol/string first,
+     then Read only the surrounding lines with offset/limit.
+  2. If you already read a file this session and it hasn't changed, don't
+     re-read it — refer back to what you saw.
+  3. Read a file in full only when the task genuinely needs the whole thing:
+     a small config, a file you must edit end-to-end, or a review that
+     requires complete context.
+This restates "Context hygiene" — full Reads out of habit are the single
+largest token cost in agent sessions; a slice usually does.`;
+
+export interface ReadDisciplineNudgeOpts {
+  /** Runtime kill-switch (DEUS_READ_DISCIPLINE_NUDGE !== '0'); read at the call site. */
+  enabled: boolean;
+  /**
+   * Engineering context — an external project is mounted at /workspace/project.
+   * Unlike subagent-nudge, NOT gated on toolProfile: Read exists on both the
+   * 'full' and 'webhook' profiles, and the measured problem is file-reading
+   * volume, not the Task tool.
+   */
+  hasProject: boolean;
+}
+
+/**
+ * Returns the nudge text when it should be appended, else an empty string.
+ *
+ * Appended only when BOTH hold:
+ *  - `enabled`    — the kill-switch is on (default)
+ *  - `hasProject` — engineering context (plain chat has no project files worth
+ *                   disciplining reads over, so it pays no tokens)
+ */
+export function readDisciplineNudgeAppend(
+  opts: ReadDisciplineNudgeOpts,
+): string {
+  const { enabled, hasProject } = opts;
+  if (!enabled || !hasProject) return '';
+  return READ_DISCIPLINE_NUDGE;
+}

--- a/container/agent-runner/src/read-oversize-nudge.test.ts
+++ b/container/agent-runner/src/read-oversize-nudge.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  READ_OVERSIZE_NUDGE,
+  ReadOversizeNudgeTracker,
+  createReadOversizeNudgeHook,
+  readOversizeMaxNudges,
+  readOversizeThresholdBytes,
+} from './read-oversize-nudge.js';
+
+const THRESHOLD_ENV = 'DEUS_READ_OVERSIZE_THRESHOLD_BYTES';
+const MAX_ENV = 'DEUS_READ_OVERSIZE_NUDGE_MAX';
+
+afterEach(() => {
+  delete process.env[THRESHOLD_ENV];
+  delete process.env[MAX_ENV];
+});
+
+describe('readOversizeThresholdBytes', () => {
+  it('returns the default when the env is unset', () => {
+    expect(readOversizeThresholdBytes()).toBe(20_000);
+  });
+
+  it('returns a valid positive override', () => {
+    process.env[THRESHOLD_ENV] = '5000';
+    expect(readOversizeThresholdBytes()).toBe(5000);
+  });
+
+  it.each(['not-a-number', '0', '-5'])(
+    'falls back to the default on invalid value %s',
+    (value) => {
+      process.env[THRESHOLD_ENV] = value;
+      expect(readOversizeThresholdBytes()).toBe(20_000);
+    },
+  );
+});
+
+describe('readOversizeMaxNudges', () => {
+  it('returns the default when the env is unset', () => {
+    expect(readOversizeMaxNudges()).toBe(3);
+  });
+
+  it('returns a valid positive override', () => {
+    process.env[MAX_ENV] = '1';
+    expect(readOversizeMaxNudges()).toBe(1);
+  });
+
+  it.each(['abc', '0', '-1'])(
+    'falls back to the default on invalid value %s',
+    (value) => {
+      process.env[MAX_ENV] = value;
+      expect(readOversizeMaxNudges()).toBe(3);
+    },
+  );
+});
+
+describe('ReadOversizeNudgeTracker', () => {
+  it('nudges once per key, never on repeat', () => {
+    const tracker = new ReadOversizeNudgeTracker(3);
+    expect(tracker.shouldNudge('/a.ts')).toBe(true);
+    expect(tracker.shouldNudge('/a.ts')).toBe(false);
+  });
+
+  it('stops after the cap even for brand-new keys', () => {
+    const tracker = new ReadOversizeNudgeTracker(2);
+    expect(tracker.shouldNudge('/a.ts')).toBe(true);
+    expect(tracker.shouldNudge('/b.ts')).toBe(true);
+    expect(tracker.shouldNudge('/c.ts')).toBe(false);
+  });
+});
+
+function readEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    tool_name: 'Read',
+    tool_input: { file_path: '/workspace/project/big.ts' },
+    tool_response: 'x'.repeat(100),
+    tool_use_id: 'tu_1',
+    ...overrides,
+  };
+}
+
+// The hook's second positional arg pins the threshold so these tests are
+// independent of process.env.
+describe('createReadOversizeNudgeHook', () => {
+  const opts = { signal: new AbortController().signal };
+
+  it('ignores non-Read tools regardless of size', async () => {
+    const hook = createReadOversizeNudgeHook(
+      new ReadOversizeNudgeTracker(),
+      10,
+    );
+    const out = await hook(
+      readEvent({
+        tool_name: 'Bash',
+        tool_response: 'x'.repeat(10_000),
+      }) as never,
+      undefined,
+      opts,
+    );
+    expect(out).toEqual({});
+  });
+
+  it('is silent below the threshold', async () => {
+    const hook = createReadOversizeNudgeHook(
+      new ReadOversizeNudgeTracker(),
+      101,
+    );
+    const out = await hook(readEvent() as never, undefined, opts);
+    expect(out).toEqual({});
+  });
+
+  it('fires exactly at the threshold, not one byte under', async () => {
+    const at = createReadOversizeNudgeHook(new ReadOversizeNudgeTracker(), 100);
+    const under = createReadOversizeNudgeHook(
+      new ReadOversizeNudgeTracker(),
+      101,
+    );
+    const fired = await at(readEvent() as never, undefined, opts);
+    const silent = await under(readEvent() as never, undefined, opts);
+    expect(fired).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: READ_OVERSIZE_NUDGE,
+      },
+    });
+    expect(silent).toEqual({});
+  });
+
+  it('dedups repeat oversize reads of the same file', async () => {
+    const hook = createReadOversizeNudgeHook(
+      new ReadOversizeNudgeTracker(),
+      10,
+    );
+    const first = await hook(readEvent() as never, undefined, opts);
+    const second = await hook(readEvent() as never, undefined, opts);
+    expect(first).not.toEqual({});
+    expect(second).toEqual({});
+  });
+
+  it('fires for distinct files until the cap, then stops', async () => {
+    const hook = createReadOversizeNudgeHook(
+      new ReadOversizeNudgeTracker(2),
+      10,
+    );
+    const a = await hook(
+      readEvent({ tool_input: { file_path: '/a.ts' } }) as never,
+      undefined,
+      opts,
+    );
+    const b = await hook(
+      readEvent({ tool_input: { file_path: '/b.ts' } }) as never,
+      undefined,
+      opts,
+    );
+    const c = await hook(
+      readEvent({ tool_input: { file_path: '/c.ts' } }) as never,
+      undefined,
+      opts,
+    );
+    expect(a).not.toEqual({});
+    expect(b).not.toEqual({});
+    expect(c).toEqual({});
+  });
+
+  it('falls back to tool_use_id when tool_input is malformed, without throwing', async () => {
+    const hook = createReadOversizeNudgeHook(
+      new ReadOversizeNudgeTracker(),
+      10,
+    );
+    const first = await hook(
+      readEvent({ tool_input: undefined }) as never,
+      undefined,
+      opts,
+    );
+    const second = await hook(
+      readEvent({ tool_input: undefined }) as never,
+      undefined,
+      opts,
+    );
+    expect(first).not.toEqual({});
+    expect(second).toEqual({}); // same tool_use_id key dedups
+  });
+});

--- a/container/agent-runner/src/read-oversize-nudge.ts
+++ b/container/agent-runner/src/read-oversize-nudge.ts
@@ -1,0 +1,114 @@
+/**
+ * Reactive oversize-Read nudge (LIA-379).
+ *
+ * When a Read response crosses a byte threshold, appends a one-line advisory
+ * via `additionalContext` steering FOLLOW-UP reads toward offset/limit or
+ * Grep. It never rewrites or truncates the Read result itself —
+ * `additionalContext` is append-only, and it is the only channel the SDK
+ * honors for built-in tools (`updatedMCPToolOutput` applies to mcp__* tools
+ * exclusively, verified against sdk.d.ts PostToolUseHookSpecificOutput).
+ *
+ * Rate-limited so it advises rather than nags: once per distinct file per
+ * turn, capped at a per-turn total. The tracker is constructed once per
+ * runQuery() call (same lifecycle as DoomLoopDetector), so limits reset each
+ * turn. The per-path dedup deliberately does NOT re-fire when the model
+ * paginates the same file with offset/limit — that is the compliant behavior
+ * being encouraged.
+ */
+
+import type {
+  HookCallback,
+  PostToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
+import { measureToolResponse } from './tool-size-measure.js';
+
+const DEFAULT_THRESHOLD_BYTES = 20_000;
+const DEFAULT_MAX_NUDGES_PER_TURN = 3;
+
+/** Byte threshold above which a Read result triggers the advisory. */
+export function readOversizeThresholdBytes(): number {
+  const parsed = Number.parseInt(
+    process.env.DEUS_READ_OVERSIZE_THRESHOLD_BYTES || '', // LIA-379
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_THRESHOLD_BYTES;
+}
+
+/** Per-turn cap on how many oversize advisories may fire. */
+export function readOversizeMaxNudges(): number {
+  const parsed = Number.parseInt(
+    process.env.DEUS_READ_OVERSIZE_NUDGE_MAX || '', // LIA-379
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_NUDGES_PER_TURN;
+}
+
+/**
+ * The one-line advisory appended after an oversize Read. Own cost: ~40 tokens
+ * per fire, ≤3 fires/turn by default (~120 tokens worst case) — vs the ≥20KB
+ * (~5k+ tokens) reads it targets, each re-billed every later turn.
+ */
+export const READ_OVERSIZE_NUDGE =
+  'This Read returned a large chunk of the file. If a follow-up read only ' +
+  'needs part of it, prefer Read with offset/limit or Grep — a full re-read ' +
+  're-bills the whole content again.';
+
+/**
+ * Per-turn rate-limit state: at most one nudge per distinct key (file path),
+ * capped at `maxNudges` total. `Set` over a count-map because dedup is a pure
+ * membership check — one bit of state per key is all the rule needs.
+ */
+export class ReadOversizeNudgeTracker {
+  private readonly nudgedKeys = new Set<string>();
+  private nudgeCount = 0;
+
+  constructor(
+    private readonly maxNudges: number = DEFAULT_MAX_NUDGES_PER_TURN,
+  ) {}
+
+  /** True exactly once per key, and never after the per-turn cap is spent. */
+  shouldNudge(key: string): boolean {
+    if (this.nudgeCount >= this.maxNudges) return false;
+    if (this.nudgedKeys.has(key)) return false;
+    this.nudgedKeys.add(key);
+    this.nudgeCount += 1;
+    return true;
+  }
+}
+
+function extractFilePath(toolInput: unknown): string | undefined {
+  const input = toolInput as Record<string, unknown> | undefined;
+  return typeof input?.file_path === 'string' ? input.file_path : undefined;
+}
+
+/**
+ * PostToolUse hook: fires only for Read results at/above the threshold, at
+ * most once per file per turn. Returns `{}` in every other case.
+ */
+export function createReadOversizeNudgeHook(
+  tracker: ReadOversizeNudgeTracker,
+  thresholdBytes: number = readOversizeThresholdBytes(),
+): HookCallback {
+  return async (input) => {
+    const hookInput = input as PostToolUseHookInput;
+    if (hookInput.tool_name !== 'Read') return {};
+
+    const { bytes } = measureToolResponse('Read', hookInput.tool_response);
+    if (bytes < thresholdBytes) return {};
+
+    const key =
+      extractFilePath(hookInput.tool_input) ?? hookInput.tool_use_id ?? '';
+    if (!tracker.shouldNudge(key)) return {};
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse' as const,
+        additionalContext: READ_OVERSIZE_NUDGE,
+      },
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Token-efficiency slice 1 of the 2026-07-04 deep-dive. **Read is 81.6% of tool-result bytes** in the 20 largest subagent transcripts (mean 12,086 B/call ≈ 3k tokens), and every byte is re-billed on each subsequent turn (~47x mean residency multiplier) — the single biggest measured token lever in Deus.

Advisory-only by design (no-regression constraint): verified against the SDK (`sdk.d.ts:1337-1341` + decompiled `cli.js`) that PostToolUse `updatedMCPToolOutput` applies only to `mcp__*` tools — built-in tool results cannot be rewritten, so there is no hard-cap option; the honored channels are the system-prompt append and `additionalContext`.

## Changes

- **`read-discipline-nudge.ts`** — static system-prompt append (mirrors `subagent-nudge.ts`): grep-then-slice order, don't re-read unchanged files, whole-file reads only when the task needs the entire file. Gated `hasProject` + `DEUS_READ_DISCIPLINE_NUDGE` (deliberately NOT toolProfile-gated: Read exists on the webhook profile too). Own cost: ~150 tok in the cached prefix.
- **`read-oversize-nudge.ts`** — PostToolUse hook: on Read results ≥ `DEUS_READ_OVERSIZE_THRESHOLD_BYTES` (default 20,000 — above the 12KB mean; targets the tail), appends a ~40-token `additionalContext` advisory, once per file per turn, ≤ `DEUS_READ_OVERSIZE_NUDGE_MAX` (default 3) per turn. Reuses `measureToolResponse` (LIA-347). Types via SDK `PostToolUseHookInput`.
- **`core-behavioral-rules.md`** — one Code Exploration bullet (what + why). Rule justification: targets the largest measured token cost; cross-referenced to `patterns/general-code.md` § Context hygiene to prevent wording drift. Note: the file's header says "800-token budget" but it already measured ~1,326 est. tokens pre-change — per the standing claude-md-gates precedent (preservation/coverage gates only, never size budgets) this is a stale comment, not a gate.
- **13 `explores_code: true` agent bodies** — same one-sentence addition. Rules-file content does NOT propagate to subagents (they receive only their own `.md` body; the `check_exploration_protocol` check is citation-string-only and not wired into CI), so the prompt body is the only lever.

## Hook smoke test (real invocation, compiled dist artifact)

In-process SDK hook (registered via `query()` options) — no settings.json/stdin contract exists for this hook class; the faithful real-invocation analog is invoking the compiled artifact with realistic `PostToolUseHookInput` events:

```
threshold = 20000
1 happy path (25KB Read):    fires additionalContext advisory
2 dedup same file:           {}
3 small Read (1KB):          {}
4 non-Read tool (25KB Bash): {}
5 malformed tool_input:      fires via tool_use_id fallback, no throw
6 object tool_response 30KB: fires, no throw
7 missing tool_response:     {} (0 bytes), no throw
SMOKE OK — no throws
```

Follow-up (non-blocking, from code review): a live `query()` run grepping the transcript for the nudge text would close the remaining SDK-delivery gap for in-process hooks.

## Testing

- 19 new vitest cases; agent-runner suite 223/223 green; `tsc --noEmit` clean; prettier clean; `flag_lint.py` clean (4 new `DEUS_*` flags cited).
- `index.ts:~1078` contains one incidental prettier rewrap (current prettier's output on an adjacent line; reverting it fails format-check).

## Reviews

plan-reviewer SHIP (4 rounds, claude + gpt) · code-reviewer SHIP (2 rounds, claude + gpt + glm) · ai-eng-warden SHIP (claude + gpt) · verification-gate SHIP (fresh evidence).

## Rollback

Env kill-switches only: `DEUS_READ_DISCIPLINE_NUDGE=0`, `DEUS_READ_OVERSIZE_NUDGE=0`; thresholds tunable via env without redeploy.

Linear: LIA-379

🤖 Generated with [Claude Code](https://claude.com/claude-code)