### PR TITLE
feat(dispatch): soft turn budgets in delegated-agent prompts (LIA-380)

### DIFF
--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -32,7 +32,7 @@ You are a code exploration agent. Your job is to find information in the codebas
 
 ## Tool Selection Protocol
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379). Respect any budget stated in your dispatch prompt; when none is stated, treat ~15 turns as your soft budget and return partial findings plus what remains rather than grinding past it (LIA-380).
 
 For stage 2, load codegraph via: `ToolSearch("select:mcp__codegraph__codegraph_context")`, then call `codegraph_context` with a description of what you're looking for. Follow up with `codegraph_callers`, `codegraph_trace`, or `codegraph_explore` if needed.
 

--- a/.claude/agents/general.md
+++ b/.claude/agents/general.md
@@ -23,6 +23,6 @@ You are a general-purpose agent. You handle research, code exploration, multi-st
 
 ## Tool Selection Protocol (code tasks)
 
-- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
+- **Code exploration: three-stage protocol.** Follow `core-behavioral-rules.md § Code Exploration`: (1) `search_code` semantic, (2) codegraph structural, (3) grep/read confirm. Never start with grep/find/Read. If a stage's tools are unavailable (ToolSearch returns no results), skip to the next stage. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379). Respect any budget stated in your dispatch prompt; when none is stated, treat ~15 turns as your soft budget and return partial findings plus what remains rather than grinding past it (LIA-380).
 
 For non-code tasks (research, writing, analysis), use whatever tools are appropriate.

--- a/.claude/agents/keystone.md
+++ b/.claude/agents/keystone.md
@@ -33,7 +33,7 @@ reliably walks a chain once it's been handed; it misses which chain to walk.
 ## At invocation, read these
 
 1. **Standards** — `~/deus/.claude/wardens/standards.md`. Quality floor and mindset.
-2. **Code Exploration protocol** — `~/deus/.claude/rules/core-behavioral-rules.md § Code Exploration`. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
+2. **Code Exploration protocol** — `~/deus/.claude/rules/core-behavioral-rules.md § Code Exploration`. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379). Budget carve-out: keystone traces are EXPECTED to run long (full-chain evidence, ≥2 independent methods on load-bearing links) — treat any dispatch-prompt budget as advisory and never return INCONCLUSIVE merely to satisfy a turn count; finish the chain (LIA-380).
    Walk every link with codegraph-first evidence. Grep/Read only to confirm.
 
 No other rules file. The method below IS the ruleset.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -36,7 +36,7 @@ BEFORE any grep, find, or Read-based exploration:
 2. Call codegraph_context with a description of what you're investigating — it composes search + node + callers + callees in one call
 3. For tracing call flows: use codegraph_trace (one call returns the full path)
 4. For blast radius analysis: use codegraph_impact
-5. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379).
+5. Use Grep or Read ONLY to confirm specific line numbers or content that codegraph identified. Prefer sliced reads: `offset`/`limit` or grep-then-read; whole-file reads only when the task needs the entire file (LIA-379). Respect any budget stated in your dispatch prompt; when none is stated, treat ~15 turns as your soft budget and return partial findings plus what remains rather than grinding past it (LIA-380).
 
 Codegraph has a pre-built index of every symbol in the codebase. Using grep instead is searching page-by-page when the book has an index.
 

--- a/container/agent-runner/src/subagent-nudge.test.ts
+++ b/container/agent-runner/src/subagent-nudge.test.ts
@@ -46,4 +46,11 @@ describe('subagentNudgeAppend', () => {
     expect(SUBAGENT_NUDGE).toContain('Task');
     expect(SUBAGENT_NUDGE).toContain('Do NOT spawn');
   });
+
+  it('nudge text instructs a soft budget in each dispatch prompt (LIA-380)', () => {
+    expect(SUBAGENT_NUDGE).toContain('soft budget');
+    expect(SUBAGENT_NUDGE).toContain(
+      'return partial findings plus what remains',
+    );
+  });
 });

--- a/container/agent-runner/src/subagent-nudge.ts
+++ b/container/agent-runner/src/subagent-nudge.ts
@@ -22,7 +22,10 @@ Rule of thumb: worth spawning at ~3+ independent items; for 1-2, inline tools ar
 faster. Cap concurrent subagents at ~5-6 — more just serialize and add overhead.
 When you fan out, give each subagent ONLY the context it needs and one clear
 deliverable, run them in parallel in a single turn, then YOU read all results and
-write one coherent answer. Synthesis is your job, not theirs.
+write one coherent answer. Synthesis is your job, not theirs. State an explicit
+soft budget in each subagent's prompt ("about N tool calls / M turns; if you hit
+it, return partial findings plus what remains") scaled to the deliverable — an
+unbounded dispatch tends to keep exploring well past diminishing returns.
 
 Do NOT spawn a subagent for:
   - a single-file read, a single tool call, or a quick lookup

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783105781
+last_verified: "2026-07-04" # auto-bump @1783196425
 governs:
   - src/
   - evolution/

--- a/src/linear-dispatcher.test.ts
+++ b/src/linear-dispatcher.test.ts
@@ -487,6 +487,17 @@ describe('buildScopedIssuePrompt XML escaping (LIA-113)', () => {
     );
   });
 
+  it('states the soft turn budget in the instructions block (LIA-380)', () => {
+    const prompt = buildScopedIssuePrompt('Title', 'LIA-1', 'desc', []);
+    const instructionsIdx = prompt.indexOf('<instructions>');
+    const budgetIdx = prompt.indexOf('soft budget of ~60 turns');
+    expect(instructionsIdx).toBeGreaterThanOrEqual(0);
+    expect(budgetIdx).toBeGreaterThan(instructionsIdx);
+    expect(prompt).toContain(
+      'report what remains rather than grinding past it',
+    );
+  });
+
   it('escapes the extracted scope block (markers are not authenticated)', () => {
     // extractScopeBlock returns the content between markers, but the markers are
     // a plain string match — the issue author can forge them. So the extracted

--- a/src/linear-dispatcher.ts
+++ b/src/linear-dispatcher.ts
@@ -517,7 +517,7 @@ export function buildScopedIssuePrompt(
   }
 
   parts.push(
-    `<instructions>\n${contextBlock}Read the scope block in the task description. Follow the implementation plan and satisfy all acceptance criteria.\n</instructions>`,
+    `<instructions>\n${contextBlock}Read the scope block in the task description. Follow the implementation plan and satisfy all acceptance criteria. Work within a soft budget of ~60 turns; if the task genuinely needs more, finish the current coherent step, commit what is done, and report what remains rather than grinding past it.\n</instructions>`,
   );
   return parts.join('\n\n');
 }

--- a/src/multi-agent/prompt-templates.test.ts
+++ b/src/multi-agent/prompt-templates.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { buildPrompt, SOFT_TURN_BUDGET } from './prompt-templates.js';
+import type { SubagentTask } from './types.js';
+
+// Mirrors STATUS_MARKER_RE in orchestrator.ts:32-33 (not exported). If the
+// orchestrator contract changes shape, the budget text's example marker must
+// change with it — this assertion is the drift alarm.
+const STATUS_MARKER_RE =
+  /\[STATUS:(DONE_WITH_CONCERNS:[^\]]*|DONE|BLOCKED:[^\]]*)\]/;
+
+function task(): SubagentTask {
+  return {
+    id: 't1',
+    role: 'researcher',
+    goal: 'find things',
+    backstory: '',
+    prompt: 'Find the things.',
+    mode: 'read',
+  };
+}
+
+describe('buildPrompt soft turn budget (LIA-380)', () => {
+  it('includes the soft budget block with the configured turn count', () => {
+    const prompt = buildPrompt(task());
+    expect(prompt).toContain(`soft budget of ~${SOFT_TURN_BUDGET} turns`);
+    expect(prompt).toContain('do not grind past the budget');
+  });
+
+  it('places the budget block after the task prompt and before the status contract', () => {
+    const prompt = buildPrompt(task());
+    const promptIdx = prompt.indexOf('Find the things.');
+    const budgetIdx = prompt.indexOf('soft budget');
+    const statusIdx = prompt.indexOf('End your response with exactly one');
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    expect(budgetIdx).toBeGreaterThan(promptIdx);
+    expect(statusIdx).toBeGreaterThan(budgetIdx);
+  });
+
+  it('budget text cites a DONE_WITH_CONCERNS example that satisfies the orchestrator marker regex', () => {
+    const prompt = buildPrompt(task());
+    const budgetLine = prompt
+      .split('\n')
+      .find((l) => l.includes('soft budget'));
+    expect(budgetLine).toBeDefined();
+    const match = budgetLine!.match(STATUS_MARKER_RE);
+    expect(match).not.toBeNull();
+    expect(match![1].startsWith('DONE_WITH_CONCERNS:')).toBe(true);
+  });
+
+  it('keeps the existing status-marker instructions intact', () => {
+    const prompt = buildPrompt(task());
+    expect(prompt).toContain('[STATUS:DONE]');
+    expect(prompt).toContain(
+      '[STATUS:DONE_WITH_CONCERNS:<concern1>;<concern2>]',
+    );
+    expect(prompt).toContain('[STATUS:BLOCKED:<reason>]');
+  });
+});

--- a/src/multi-agent/prompt-templates.ts
+++ b/src/multi-agent/prompt-templates.ts
@@ -1,5 +1,14 @@
 import type { SubagentTask, SubagentResult } from './types.js';
 
+/**
+ * Soft turn budget stated in every subagent prompt (LIA-380). Advisory only —
+ * nothing enforces it (SDK maxTurns deliberately unwired; a hard cut mid-task
+ * is a quality-regression risk). Budget-aware prompting cut agent cost ~31%
+ * at comparable accuracy in published benchmarks (arXiv:2511.17006); the
+ * local baseline motivating the 15-turn default is in the LIA-380 PR body.
+ */
+export const SOFT_TURN_BUDGET = 15;
+
 export function buildPrompt(
   task: SubagentTask,
   priorOutputs?: Map<string, SubagentResult>,
@@ -30,6 +39,14 @@ export function buildPrompt(
   }
 
   parts.push(task.prompt);
+  parts.push('');
+  // Budget frames the response; the status contract below stays last. The
+  // DONE_WITH_CONCERNS example must match orchestrator.ts STATUS_MARKER_RE —
+  // a bare [STATUS:DONE_WITH_CONCERNS] fails the regex and the orchestrator
+  // discards the summary with a synthetic "no marker" concern.
+  parts.push(
+    `Work within a soft budget of ~${SOFT_TURN_BUDGET} turns. If the task needs more, stop and report [STATUS:DONE_WITH_CONCERNS:budget exceeded;<what's done>;<what remains>] — do not grind past the budget.`,
+  );
   parts.push('');
   parts.push('End your response with exactly one of these status markers:');
   parts.push('- [STATUS:DONE] if you completed the task successfully');


### PR DESCRIPTION
## Summary

Token-efficiency slice 2 of the 2026-07-04 deep-dive. Dispatch cost scales ~linearly with turn count — the measured local baseline (session transcript analysis, 2026-07-04): the 20 largest subagent dispatches averaged **73.6 turns and 5.39M billed tokens for ~13k output tokens** (~386 input tokens paid per output token vs ~163 on the main thread). Published evidence: budget-aware planning cut cost **31.3%** at comparable accuracy (BATS, arXiv:2511.17006).

**Advisory-only by design** (no-regression constraint): SDK `maxTurns` exists but stays deliberately unwired — a hard mid-task cut is a quality-regression risk. Observe first; adherence is measurable via the existing `usage.jsonl` `num_turns` log (both sides of any before/after come from that same log).

## Changes

- **`src/multi-agent/prompt-templates.ts`** — exported `SOFT_TURN_BUDGET = 15` + budget block in `buildPrompt()`, after the task prompt and before the STATUS contract. The partial-return example uses the regex-valid `[STATUS:DONE_WITH_CONCERNS:budget exceeded;<what's done>;<what remains>]` form — plan review caught that a bare marker fails `STATUS_MARKER_RE` and the orchestrator would silently discard the agent's summary.
- **NEW `src/multi-agent/prompt-templates.test.ts`** — first-ever coverage of `buildPrompt()`'s rendered text, including a contract-drift assertion (the budget line's example marker must match a mirrored `STATUS_MARKER_RE`).
- **`src/linear-dispatcher.ts`** — ~60-turn soft budget in `buildScopedIssuePrompt`'s `<instructions>`. `buildIssuePrompt` (gate/enrichment + custom-labeled roles) deliberately exempt: budgeting review/gate runs risks under-review. Follow-up candidate: per-RoleSpec budget frontmatter key.
- **`container/agent-runner/src/subagent-nudge.ts`** — the fan-out agent now states a scaled soft budget in each child dispatch prompt.
- **4 agent bodies** — ~15-turn default self-budget for code-explorer/general/planner; **keystone gets a carve-out** (ai-eng-warden catch: exhaustive single-claim traces must finish the chain — never return INCONCLUSIVE to satisfy a turn count).

## Testing

TDD: new tests written red-first. Root: tsc clean, 110 files / 1,950 tests green. Container: 224 green. Prettier + flag-lint clean (no new env flags — text constants only).

## Reviews

plan-reviewer SHIP (2 rounds, claude+gpt) · code-reviewer SHIP (3 rounds claude; gpt+glm on final bytes) · ai-eng-warden SHIP (2 rounds claude; gpt) · verification-gate SHIP (fresh evidence).

## Follow-ups (tracked, non-blocking)

- Per-RoleSpec budget frontmatter key for custom-labeled implementation dispatches.
- Non-blocking adherence log line when actual turns exceed the stated budget ~3x (feeds Token Sentinel, LIA-356).
- Tune 15/60 defaults against `usage.jsonl` after a week.

Linear: LIA-380

🤖 Generated with [Claude Code](https://claude.com/claude-code)