### PR TITLE
feat(memory): cold-source retention + summary-to-source backlink (LIA-374)

### DIFF
--- a/.claude/skills/compress/skill.md
+++ b/.claude/skills/compress/skill.md
@@ -152,6 +152,17 @@ After saving the session log:
    Run: `python3 ~/deus/scripts/memory_indexer.py --extract "<full path to saved log>"`
    If the script fails, skip silently.
 
+4b. **Archive the source transcript + stamp the backlink** (always, best-effort — LIA-374):
+   Run: `python3 ~/deus/scripts/transcript_archive.py --cwd "$PWD" --json --best-effort`
+   - On `"ok": true`: append `source_transcript: <sha256>` as a new frontmatter line in the
+     just-saved session log (before the closing `---`). Idempotent: if the log already has a
+     `source_transcript:` line, leave it unchanged (safe on /compress retries).
+   - On `"ok": false`: do NOT block the flow — but surface it in the final Confirm line
+     (alongside the indexing/atom-extraction results, which already report operational
+     outcomes), e.g. `⚠ source transcript NOT archived: <error>`. Never silently swallow
+     the failure. (The Decision Receipt itself stays a pure rendering of saved data.)
+   - Restore later via `deus recall --source "<session-log path>"` (byte-exact source).
+
 5. **Delete today's checkpoint** (always):
    Run: `find "$VAULT/Checkpoints" -name "$(date +%Y-%m-%d)-*.md" -delete 2>/dev/null`
 
@@ -177,4 +188,4 @@ After saving the session log:
    `decisions[]` recorded AND no PR/merge this session; in that case the Confirm line still
    reports the save. This is the comprehension digest; the operational Confirm line is separate.
 
-Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, atom extraction result, and whether a session retrospective was triggered (home mode only — report "retrospective triggered (background)" or "retrospective skipped: <reason>").
+Confirm with the filename saved, number of pending tasks carried forward, redaction result (standard mode only), indexing result, atom extraction result, source-transcript archival status if it failed, and whether a session retrospective was triggered (home mode only — report "retrospective triggered (background)" or "retrospective skipped: <reason>").

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1287,6 +1287,12 @@ $STARTUP_INSTRUCTION"
     shift
     exec python3 "$SCRIPT_DIR/scripts/analyze_token_efficiency.py" "$@"
     ;;
+  recall)
+    # Decompress-back-to-source for a /compress session log (LIA-374):
+    # deus recall --source <session-log.md|sha256> [--out <path>]
+    shift
+    exec python3 "$SCRIPT_DIR/scripts/recall_source.py" "$@"
+    ;;
   preflight)
     # Read-only concurrent-session collision check for the current git tree
     # (LIA-284). Pure pass-through to the detector: exec inherits PWD so it

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -128,6 +128,7 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 |----------|---------|-------------|
 | `DEUS_VAULT_PATH` | — | Vault directory path for session logs and memory |
 | `DEUS_DB` | `~/.deus/memory.db` | Memory indexer SQLite database override |
+| `DEUS_TRANSCRIPT_ARCHIVE_DIR` | `~/.deus/archive/transcripts` | Content-addressed cold store for /compress source-transcript archives (LIA-374) |
 | `DEUS_MEMORY_TREE` | `0` | Enable memory-tree hooks/context loading when set to `1` |
 | `DEUS_MEMORY_TREE_DB` | `~/.deus/memory_tree.db` | Memory-tree SQLite database override |
 | `DEUS_AUTO_MEMORY_DIR` | — | Optional external auto-memory directory indexed under `auto-memory/` |

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-07-03" # auto-bump @1783088946
+last_verified: "2026-07-05" # auto-bump @1783200566
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-06-30" # auto-bump @1782820526
+last_verified: "2026-07-05" # auto-bump @1783200566
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/recall_source.py
+++ b/scripts/recall_source.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""recall_source.py — decompress a session log's archived source transcript (LIA-374).
+
+`deus recall --source <session-log.md | sha256>` reads the log's
+`source_transcript:` frontmatter key (stamped by /compress), locates the
+content-addressed archive (`transcript_archive._archive_dir()`), and writes
+the raw transcript bytes to stdout (or --out). The lossy summary stays the
+human-facing artifact; this is the decompress-back-to-source path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import transcript_archive as ta  # noqa: E402
+
+_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+_KEY_RE = re.compile(r"^source_transcript:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
+
+
+def _sha_from_source(source: str) -> str | None:
+    if _SHA_RE.match(source):
+        return source
+    path = Path(source).expanduser()
+    if not path.is_file():
+        return None
+    match = _KEY_RE.search(path.read_text(encoding="utf-8", errors="replace"))
+    return match.group(1) if match else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="recall_source",
+        description="Restore the raw transcript behind a /compress session log.",
+    )
+    parser.add_argument(
+        "--source",
+        required=True,
+        help="Session-log path (reads its source_transcript: key) or a bare sha256",
+    )
+    parser.add_argument("--out", help="Write to this path instead of stdout")
+    args = parser.parse_args(argv)
+
+    sha = _sha_from_source(args.source)
+    if sha is None:
+        print(
+            f"error: no source_transcript: key found in {args.source} "
+            "(log predates archival, or archival failed at /compress time)",
+            file=sys.stderr,
+        )
+        return 1
+
+    store = ta.archive_dir()
+    dest = next(
+        (p for s in (".jsonl.zst", ".jsonl.gz") if (p := store / f"{sha}{s}").exists()),
+        None,
+    )
+    if dest is None:
+        print(f"error: no archive for {sha} under {store}", file=sys.stderr)
+        return 1
+
+    raw = ta.decompress(dest)
+    if args.out:
+        Path(args.out).write_bytes(raw)
+        print(f"restored {len(raw)} bytes -> {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.buffer.write(raw)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_recall_source.py
+++ b/scripts/tests/test_recall_source.py
@@ -1,0 +1,73 @@
+"""Tests for scripts/recall_source.py (LIA-374 rank-1) — summary→source recall."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ta = _load("transcript_archive")
+rs = _load("recall_source")
+
+
+@pytest.fixture
+def archived(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEUS_TRANSCRIPT_ARCHIVE_DIR", str(tmp_path / "archive"))
+    transcript = tmp_path / "sess.jsonl"
+    transcript.write_text('{"type":"user"}\n{"type":"assistant"}\n', encoding="utf-8")
+    result = ta.archive(transcript)
+    return transcript, result
+
+
+class TestRecallSource:
+    def test_roundtrip_from_session_log(self, tmp_path, archived, capsysbinary):
+        transcript, result = archived
+        log = tmp_path / "log.md"
+        log.write_text(
+            f"---\ntype: session\ndate: 2026-07-05\nsource_transcript: {result['sha256']}\n---\nbody\n",
+            encoding="utf-8",
+        )
+        rc = rs.main(["--source", str(log)])
+        assert rc == 0
+        assert capsysbinary.readouterr().out == transcript.read_bytes()
+
+    def test_bare_sha_mode(self, archived, capsysbinary):
+        transcript, result = archived
+        rc = rs.main(["--source", result["sha256"]])
+        assert rc == 0
+        assert capsysbinary.readouterr().out == transcript.read_bytes()
+
+    def test_out_flag_writes_file(self, tmp_path, archived):
+        transcript, result = archived
+        out = tmp_path / "restored.jsonl"
+        rc = rs.main(["--source", result["sha256"], "--out", str(out)])
+        assert rc == 0
+        assert out.read_bytes() == transcript.read_bytes()
+
+    def test_missing_frontmatter_key_errors_clearly(self, tmp_path, capsys):
+        log = tmp_path / "log.md"
+        log.write_text("---\ntype: session\n---\nbody\n", encoding="utf-8")
+        rc = rs.main(["--source", str(log)])
+        assert rc == 1
+        assert "source_transcript" in capsys.readouterr().err
+
+    def test_missing_archive_errors_clearly(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("DEUS_TRANSCRIPT_ARCHIVE_DIR", str(tmp_path / "empty"))
+        rc = rs.main(["--source", "a" * 64])
+        assert rc == 1
+        assert "archive" in capsys.readouterr().err.lower()

--- a/scripts/tests/test_transcript_archive.py
+++ b/scripts/tests/test_transcript_archive.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/transcript_archive.py (LIA-374 rank-1).
+
+Content-addressed cold-source retention: archive session transcripts to
+~/.deus/archive/transcripts/<sha256>.jsonl.zst so lossy /compress summaries
+keep a decompress-back-to-source path. Best-effort mode never blocks.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ta = _load("transcript_archive")
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    d = tmp_path / "archive"
+    monkeypatch.setenv("DEUS_TRANSCRIPT_ARCHIVE_DIR", str(d))
+    return d
+
+
+@pytest.fixture
+def transcript(tmp_path):
+    t = tmp_path / "session.jsonl"
+    t.write_text('{"type":"user","text":"hello"}\n{"type":"assistant"}\n', encoding="utf-8")
+    return t
+
+
+class TestArchive:
+    def test_content_addressed_and_idempotent(self, store, transcript):
+        r1 = ta.archive(transcript)
+        assert r1["ok"] is True
+        dest1 = Path(r1["dest"])
+        assert dest1.exists()
+        assert dest1.name.startswith(r1["sha256"])
+        mtime = dest1.stat().st_mtime
+        r2 = ta.archive(transcript)  # second call: skip, same dest
+        assert r2["ok"] is True and r2["dest"] == r1["dest"]
+        assert Path(r2["dest"]).stat().st_mtime == mtime
+        assert r2["skipped"] is True
+
+    def test_sha_changes_with_content(self, store, transcript, tmp_path):
+        r1 = ta.archive(transcript)
+        other = tmp_path / "other.jsonl"
+        other.write_text("different\n", encoding="utf-8")
+        r2 = ta.archive(other)
+        assert r1["sha256"] != r2["sha256"]
+
+    def test_roundtrip_byte_equality(self, store, transcript):
+        r = ta.archive(transcript)
+        restored = ta.decompress(Path(r["dest"]))
+        assert restored == transcript.read_bytes()
+
+    def test_gzip_fallback_when_zstd_missing(self, store, transcript, monkeypatch):
+        monkeypatch.setattr(ta, "_zstd_bin", lambda: None)
+        r = ta.archive(transcript)
+        assert r["ok"] is True
+        assert r["dest"].endswith(".jsonl.gz")
+        assert ta.decompress(Path(r["dest"])) == transcript.read_bytes()
+
+    def test_best_effort_never_raises_on_missing_transcript(self, store, tmp_path):
+        r = ta.archive(tmp_path / "nope.jsonl", best_effort=True)
+        assert r["ok"] is False and "error" in r
+
+    def test_strict_mode_raises_on_missing_transcript(self, store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            ta.archive(tmp_path / "nope.jsonl")
+
+
+class TestResolve:
+    def test_resolves_via_session_registry(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "sessions"
+        projects = tmp_path / "projects"
+        sessions.mkdir()
+        cwd = "/Users/x/proj"
+        slug = cwd.replace("/", "-")
+        tdir = projects / slug
+        tdir.mkdir(parents=True)
+        (tdir / "sess-1.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions / "123.json").write_text(
+            json.dumps({"pid": 123, "sessionId": "sess-1", "cwd": cwd}), encoding="utf-8"
+        )
+        monkeypatch.setattr(ta, "_sessions_dir", lambda: sessions)
+        monkeypatch.setattr(ta, "_projects_dir", lambda: projects)
+        assert ta.resolve_transcript(cwd) == tdir / "sess-1.jsonl"
+
+    def test_falls_back_to_newest_jsonl(self, tmp_path, monkeypatch):
+        import os
+        import time
+
+        sessions = tmp_path / "sessions"
+        projects = tmp_path / "projects"
+        sessions.mkdir()
+        cwd = "/Users/x/proj"
+        tdir = projects / cwd.replace("/", "-")
+        tdir.mkdir(parents=True)
+        old = tdir / "old.jsonl"
+        new = tdir / "new.jsonl"
+        old.write_text("{}\n", encoding="utf-8")
+        new.write_text("{}\n", encoding="utf-8")
+        stale = time.time() - 1000
+        os.utime(old, (stale, stale))
+        monkeypatch.setattr(ta, "_sessions_dir", lambda: sessions)  # no registry match
+        monkeypatch.setattr(ta, "_projects_dir", lambda: projects)
+        assert ta.resolve_transcript(cwd) == new
+
+    def test_claude_session_id_wins_over_registry_and_mtime(
+        self, tmp_path, monkeypatch
+    ):
+        # Concurrent same-cwd sessions: CLAUDE_SESSION_ID must pin OUR
+        # transcript even when a sibling session's file is newer / registered.
+        sessions = tmp_path / "sessions"
+        projects = tmp_path / "projects"
+        sessions.mkdir()
+        cwd = "/Users/x/proj"
+        tdir = projects / cwd.replace("/", "-")
+        tdir.mkdir(parents=True)
+        (tdir / "ours.jsonl").write_text("{}\n", encoding="utf-8")
+        (tdir / "sibling.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions / "9.json").write_text(
+            json.dumps({"pid": 9, "sessionId": "sibling", "cwd": cwd}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(ta, "_sessions_dir", lambda: sessions)
+        monkeypatch.setattr(ta, "_projects_dir", lambda: projects)
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "ours")
+        assert ta.resolve_transcript(cwd) == tdir / "ours.jsonl"
+        monkeypatch.delenv("CLAUDE_SESSION_ID")
+        assert ta.resolve_transcript(cwd) == tdir / "sibling.jsonl"
+
+    def test_dotted_cwd_segments_encode_to_dashes(self, tmp_path, monkeypatch):
+        # Claude Code slugs map '.' to '-' as well: /x/.claude/wt -> -x--claude-wt.
+        sessions = tmp_path / "sessions"
+        projects = tmp_path / "projects"
+        sessions.mkdir()
+        cwd = "/x/.claude/worktrees/wt-1"
+        tdir = projects / "-x--claude-worktrees-wt-1"
+        tdir.mkdir(parents=True)
+        (tdir / "s.jsonl").write_text("{}\n", encoding="utf-8")
+        monkeypatch.setattr(ta, "_sessions_dir", lambda: sessions)
+        monkeypatch.setattr(ta, "_projects_dir", lambda: projects)
+        assert ta.resolve_transcript(cwd) == tdir / "s.jsonl"
+
+    def test_returns_none_when_nothing_found(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(ta, "_sessions_dir", lambda: tmp_path / "s")
+        monkeypatch.setattr(ta, "_projects_dir", lambda: tmp_path / "p")
+        assert ta.resolve_transcript("/no/such/cwd") is None
+
+
+class TestCli:
+    def test_json_best_effort_exit_zero_on_error(self, store, tmp_path, capsys):
+        rc = ta.main(["--transcript", str(tmp_path / "nope.jsonl"), "--json", "--best-effort"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["ok"] is False
+
+    def test_json_happy_path(self, store, transcript, capsys):
+        rc = ta.main(["--transcript", str(transcript), "--json"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["ok"] is True and out["sha256"] and out["dest"]
+
+    def test_missing_transcript_without_best_effort_is_clean_error(
+        self, store, tmp_path, capsys
+    ):
+        # Both CLI branches must degrade identically — no raw traceback.
+        rc = ta.main(["--transcript", str(tmp_path / "nope.jsonl")])
+        assert rc == 1
+        assert "transcript not found" in capsys.readouterr().err

--- a/scripts/transcript_archive.py
+++ b/scripts/transcript_archive.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""transcript_archive.py — content-addressed cold-source retention (LIA-374).
+
+`/compress` writes ~170x lossy session summaries while the byte-exact source
+(the Claude Code transcript JSONL) is orphaned under Claude Code's own
+retention. This archives the transcript into a content-addressed cold store
+(default `~/.deus/archive/transcripts/<sha256>.jsonl.zst`) so a summary's
+`source_transcript:` frontmatter key can always decompress back to source.
+
+Design: content-addressable store (the standard dedup/immutability pattern —
+same family as git objects): sha256-of-raw-bytes key, single flat directory,
+O(1) lookup, idempotent writes, append-only (no-db-deletion philosophy).
+Transcript resolution is an ordered fallback chain implemented as plain
+conditionals: session registry match → newest-mtime JSONL → explicit override.
+
+The store default lives under `~/.deus/` — deliberately OUTSIDE the
+Obsidian/OneDrive-synced vault (raw transcripts carry PII; only the sha
+reference enters the vault). Compression: zstd -19 via the CLI when present,
+gzip fallback otherwise (cross-platform default; flagged in the JSON output).
+`--best-effort` never raises and always exits 0 — archival must never block
+`/compress`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def archive_dir() -> Path:
+    """Public: the content-addressed store location (recall_source depends on it)."""
+    return Path(
+        os.environ.get(
+            "DEUS_TRANSCRIPT_ARCHIVE_DIR",  # LIA-374
+            "~/.deus/archive/transcripts",
+        )
+    ).expanduser()
+
+
+# Backward-compat private alias (early callers/tests used the underscore name).
+_archive_dir = archive_dir
+
+
+def _sessions_dir() -> Path:
+    return Path("~/.claude/sessions").expanduser()
+
+
+def _projects_dir() -> Path:
+    return Path("~/.claude/projects").expanduser()
+
+
+def _zstd_bin() -> str | None:
+    return shutil.which("zstd")
+
+
+def resolve_transcript(cwd: str) -> Path | None:
+    """Locate the current session's transcript for `cwd`.
+
+    Ordered fallback chain: (0) `CLAUDE_SESSION_ID` env → that exact
+    transcript (the repo's established disambiguator for concurrent
+    same-cwd sessions — see session_preflight's self-exclusion); (1) newest
+    session-registry entry whose cwd matches → `<projects>/<slug>/
+    <sessionId>.jsonl`; (2) newest `*.jsonl` in the slug dir. None when
+    nothing matches. Without (0), two live sessions on one cwd could get a
+    SIBLING session's transcript backlinked — ok:true, wrong source.
+
+    Slug encoding: Claude Code maps every non-alphanumeric character (both
+    `/` and `.`) to `-` — e.g. `/x/.claude/wt` → `-x--claude-wt`. A plain
+    `/`→`-` replace misses dotted segments and silently resolves nothing.
+    """
+    slug = re.sub(r"[^A-Za-z0-9-]", "-", cwd)
+    slug_dir = _projects_dir() / slug
+
+    own_session = os.environ.get("CLAUDE_SESSION_ID", "").strip()
+    if own_session:
+        own = slug_dir / f"{own_session}.jsonl"
+        if own.is_file():
+            return own
+
+    candidates: list[tuple[float, Path]] = []
+    sessions = _sessions_dir()
+    if sessions.is_dir():
+        for f in sessions.glob("*.json"):
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if data.get("cwd") != cwd or not data.get("sessionId"):
+                continue
+            transcript = slug_dir / f"{data['sessionId']}.jsonl"
+            if transcript.is_file():
+                candidates.append((f.stat().st_mtime, transcript))
+    if candidates:
+        return max(candidates)[1]
+
+    if slug_dir.is_dir():
+        jsonls = sorted(
+            slug_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True
+        )
+        if jsonls:
+            return jsonls[0]
+    return None
+
+
+def archive(transcript: Path, *, best_effort: bool = False) -> dict:
+    """Compress `transcript` into the content-addressed store.
+
+    Returns {"ok", "sha256", "dest", "skipped", "codec"} on success;
+    in best-effort mode failures return {"ok": False, "error": ...}
+    instead of raising.
+    """
+    try:
+        raw = Path(transcript).read_bytes()
+        sha = hashlib.sha256(raw).hexdigest()
+        store = archive_dir()
+        store.mkdir(parents=True, exist_ok=True)
+
+        for suffix in (".jsonl.zst", ".jsonl.gz"):
+            existing = store / f"{sha}{suffix}"
+            if existing.exists():
+                return {
+                    "ok": True,
+                    "sha256": sha,
+                    "dest": str(existing),
+                    "skipped": True,
+                    "codec": "zstd" if suffix.endswith("zst") else "gzip",
+                }
+
+        zstd = _zstd_bin()
+        if zstd:
+            dest = store / f"{sha}.jsonl.zst"
+            tmp = store / f".{sha}.tmp.zst"
+            subprocess.run(
+                [zstd, "-19", "-q", "-f", "-o", str(tmp), str(transcript)],
+                check=True,
+                capture_output=True,
+            )
+            tmp.rename(dest)
+            codec = "zstd"
+        else:
+            dest = store / f"{sha}.jsonl.gz"
+            tmp = store / f".{sha}.tmp.gz"
+            with gzip.open(tmp, "wb", compresslevel=9) as f:
+                f.write(raw)
+            tmp.rename(dest)
+            codec = "gzip"
+
+        return {
+            "ok": True,
+            "sha256": sha,
+            "dest": str(dest),
+            "skipped": False,
+            "codec": codec,
+        }
+    except Exception as e:  # noqa: BLE001 — best-effort must swallow everything
+        if best_effort:
+            return {"ok": False, "error": f"{type(e).__name__}: {e}"}
+        raise
+
+
+def decompress(dest: Path) -> bytes:
+    """Restore the raw transcript bytes from an archived file."""
+    dest = Path(dest)
+    if dest.suffix == ".zst":
+        zstd = _zstd_bin()
+        if not zstd:
+            raise RuntimeError("zstd binary required to decompress .zst archives")
+        proc = subprocess.run(
+            [zstd, "-d", "-q", "-c", str(dest)], check=True, capture_output=True
+        )
+        return proc.stdout
+    return gzip.decompress(dest.read_bytes())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="transcript_archive",
+        description="Archive a session transcript into the content-addressed cold store.",
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--cwd", help="Session cwd — resolve its transcript automatically")
+    src.add_argument("--transcript", help="Explicit transcript path")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--best-effort",
+        action="store_true",
+        help="Never fail: errors exit 0 with ok:false JSON (for /compress)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.transcript:
+        transcript: Path | None = Path(args.transcript)
+        if not transcript.is_file():
+            # Same clean-error shape as the --cwd branch — a raw traceback is
+            # not an acceptable CLI failure mode for user-supplied paths.
+            transcript = None
+            missing = f"transcript not found: {args.transcript}"
+    else:
+        transcript = resolve_transcript(args.cwd)
+        missing = f"no transcript found for cwd {args.cwd}"
+
+    if transcript is None:
+        result: dict = {"ok": False, "error": missing}
+    else:
+        result = archive(transcript, best_effort=args.best_effort)
+
+    if args.json:
+        print(json.dumps(result))
+    elif result["ok"]:
+        print(f"{result['sha256']}  {result['dest']}")
+    else:
+        print(f"error: {result['error']}", file=sys.stderr)
+
+    if not result["ok"] and not args.best_effort:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Token-efficiency slice 4 (the lossless substrate). `/compress` writes ~170x lossy session summaries while the byte-exact source — the Claude Code transcript — is orphaned under Claude Code's own retention (live measurement at PR time: **767MB / 1,874 uncompressed JSONL files** in ~/.claude/projects; zero compressed artifacts anywhere). A summary can outlive its source, and "decompress back to source" is gone forever. This ships the LIA-374 research's rank-1 "do first" idea: retain the source cheaply, address it by content, backlink the summary. It is also the safety substrate for observation masking (LIA-378 — placeholders point at retained bytes) and governance-safe compaction (LIA-381).

Prior art framing: the memory-hierarchy/demand-paging view (arXiv:2603.09023); verbatim sources beat extracted artifacts for agent recall (arXiv:2601.00821); the store design is the git-objects content-addressed family.

## Changes

- **`scripts/transcript_archive.py`** — content-addressed cold store: sha256-of-raw key, flat directory (O(1), no index), idempotent, append-only (no-db-deletion). Default `~/.deus/archive/transcripts` — deliberately **outside** the Obsidian/OneDrive-synced vault (raw transcripts carry PII; only the sha enters the vault). `zstd -19` CLI with gzip fallback (cross-platform, flagged in JSON); atomic tmp+rename. Resolution chain: `CLAUDE_SESSION_ID` (same-cwd concurrent-session disambiguation — ai-eng catch, mirrors session_preflight) → session registry cwd match → newest jsonl in the slug dir → `--transcript` override. Slug encoding maps ALL non-alphanumerics to `-` (dotted segments included — caught live: `.claude` in worktree paths broke a naive `/`-only replace). `--best-effort` always exits 0 with `ok:false` JSON — archival can never block /compress.
- **`scripts/recall_source.py` + `deus recall`** — `deus recall --source <session-log.md|sha> [--out <path>]`: reads the log's `source_transcript:` frontmatter, decompresses byte-exact.
- **`/compress` skill step 4b** — archive best-effort + stamp `source_transcript: <sha>` (idempotent on retries); failure surfaces in the final Confirm line (never silently swallowed; the Decision Receipt stays a pure rendering).
- **`docs/ENVIRONMENT.md`** — `DEUS_TRANSCRIPT_ARCHIVE_DIR` row.

## Live smoke (real transcript, evidence limited to hashes/sizes per PII rule)

```
archive: ok=true codec=zstd  |  3,955,925 bytes -> 546,172 bytes (7.2x)
recall --source <sha> --out …  ->  restored 3,955,925 bytes
sha256(restored) == archive key: True   (verification-gate re-ran independently: 4,186,917-byte
newer snapshot, restored sha256 == key, MATCH: yes)
```

## Testing

TDD: 19 pytest red-first — content-address idempotency, round-trip byte-equality, gzip fallback (PATH-stripped), registry/newest/dotted-slug/CLAUDE_SESSION_ID resolution, best-effort semantics, clean CLI errors on both branches, recall frontmatter/bare-sha/--out/missing-key/missing-archive. `bash -n` clean; flag-lint clean; prettier N/A (python/md/sh).

## Reviews

plan-reviewer SHIP (2 rounds claude + gpt) · code-reviewer SHIP (2 rounds claude; gpt + glm on final bytes) · ai-eng-warden SHIP (claude + gpt) · verification-gate SHIP (all 7 claims, fresh evidence).

## Notes / follow-ups

- Retention horizon: unbounded append-only accepted (disk cost ~250MB for the full historic corpus at zstd-19; consistent with no-db-deletion). Personal backfill of the 1,874 historic transcripts runs locally post-merge (not repo code).
- When an agent (not a human) consumes `deus recall` output, wrap it as stored-output per LIA-335 discipline — designed-in note for the LIA-378 consumer (ai-eng recommendation).

Linear: LIA-374

🤖 Generated with [Claude Code](https://claude.com/claude-code)