### PR TITLE
feat(agent-runner): observation masking for Deus-owned loops + Claude-path spike (LIA-378)

### DIFF
--- a/container/agent-runner/src/llama-cpp-backend.ts
+++ b/container/agent-runner/src/llama-cpp-backend.ts
@@ -27,6 +27,12 @@ import { fileURLToPath } from 'url';
 import { loadRegisteredContextFiles } from './context-registry.js';
 import { fetchMemoryContext } from './memory-retrieval-hook.js';
 import { DoomLoopDetector, normalizeArgs } from './doom-loop-detector.js';
+import {
+  maskStaleToolResults,
+  maskingEnabled,
+  maskKeepTurns,
+  maskMinBytes,
+} from './observation-masking.js';
 import { dispatchPreToolUseGate } from './pre-tool-use-hook.js';
 import {
   type AgentRuntimeId,
@@ -499,6 +505,17 @@ export async function runLlamaCppConversation(
       : prompt;
 
     try {
+      // Observation masking (LIA-378): the gentler lever runs BEFORE the
+      // token estimate, so proactive compaction (destructive) evaluates
+      // post-mask sizes and triggers less often. Dark by default.
+      if (maskingEnabled()) {
+        const { masked } = maskStaleToolResults(messages, {
+          keepRecentTurns: maskKeepTurns(),
+          minBytes: maskMinBytes(),
+        });
+        if (masked > 0)
+          log(`Observation masking: ${masked} stale tool result(s) masked`);
+      }
       const estTokens = estimateTokens(messages);
       const estPct = Math.round((estTokens / LLAMA_CPP_CONTEXT_WINDOW) * 100);
       if (estPct >= AUTO_COMPACT_PCT && messages.length > 2) {

--- a/container/agent-runner/src/observation-masking.test.ts
+++ b/container/agent-runner/src/observation-masking.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  MASKED_PLACEHOLDER,
+  maskStaleToolResults,
+  maskingEnabled,
+  maskKeepTurns,
+  maskMinBytes,
+} from './observation-masking.js';
+
+afterEach(() => {
+  delete process.env.DEUS_OBSERVATION_MASKING;
+  delete process.env.DEUS_MASK_KEEP_TURNS;
+  delete process.env.DEUS_MASK_MIN_BYTES;
+});
+
+type Msg = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content?: string | Array<Record<string, unknown>> | null;
+  tool_call_id?: string;
+};
+
+const BIG = 'x'.repeat(600);
+
+/** system + N user-turns, each: user → assistant → tool(BIG). */
+function conversation(turns: number): Msg[] {
+  const msgs: Msg[] = [{ role: 'system', content: 'sys' }];
+  for (let i = 0; i < turns; i++) {
+    msgs.push({ role: 'user', content: `q${i}` });
+    msgs.push({ role: 'assistant', content: `a${i}` });
+    msgs.push({ role: 'tool', tool_call_id: `t${i}`, content: BIG });
+  }
+  return msgs;
+}
+
+describe('env parsing', () => {
+  it('masking is OFF by default (dark ship)', () => {
+    expect(maskingEnabled()).toBe(false);
+    process.env.DEUS_OBSERVATION_MASKING = '1';
+    expect(maskingEnabled()).toBe(true);
+  });
+
+  it('keep-turns and min-bytes defaults and overrides', () => {
+    expect(maskKeepTurns()).toBe(3);
+    expect(maskMinBytes()).toBe(500);
+    process.env.DEUS_MASK_KEEP_TURNS = '5';
+    process.env.DEUS_MASK_MIN_BYTES = '100';
+    expect(maskKeepTurns()).toBe(5);
+    expect(maskMinBytes()).toBe(100);
+    process.env.DEUS_MASK_KEEP_TURNS = '0';
+    expect(maskKeepTurns()).toBe(3); // invalid → default
+  });
+});
+
+describe('maskStaleToolResults', () => {
+  it('masks tool results older than the keep-window, keeps recent ones', () => {
+    const msgs = conversation(5);
+    const { masked } = maskStaleToolResults(msgs, {
+      keepRecentTurns: 3,
+      minBytes: 500,
+    });
+    expect(masked).toBe(2); // turns 0,1 masked; 2,3,4 kept
+    expect(msgs[3].content).toBe(MASKED_PLACEHOLDER); // turn 0 tool
+    expect(msgs[6].content).toBe(MASKED_PLACEHOLDER); // turn 1 tool
+    expect(msgs[9].content).toBe(BIG); // turn 2 tool intact
+    expect(msgs[12].content).toBe(BIG);
+    expect(msgs[15].content).toBe(BIG);
+  });
+
+  it('never masks non-tool messages', () => {
+    const msgs = conversation(5);
+    maskStaleToolResults(msgs, { keepRecentTurns: 1, minBytes: 1 });
+    for (const m of msgs) {
+      if (m.role !== 'tool') expect(m.content).not.toBe(MASKED_PLACEHOLDER);
+    }
+  });
+
+  it('respects minBytes — small results stay', () => {
+    const msgs = conversation(5);
+    msgs[3].content = 'tiny'; // turn 0 tool result small
+    const { masked } = maskStaleToolResults(msgs, {
+      keepRecentTurns: 3,
+      minBytes: 500,
+    });
+    expect(masked).toBe(1); // only turn 1's big result
+    expect(msgs[3].content).toBe('tiny');
+  });
+
+  it('is idempotent — placeholders never re-masked or re-counted', () => {
+    const msgs = conversation(5);
+    const first = maskStaleToolResults(msgs, {
+      keepRecentTurns: 3,
+      minBytes: 500,
+    });
+    const second = maskStaleToolResults(msgs, {
+      keepRecentTurns: 3,
+      minBytes: 500,
+    });
+    expect(first.masked).toBe(2);
+    expect(second.masked).toBe(0);
+  });
+
+  it('skips non-string content untouched (array + null)', () => {
+    const msgs = conversation(4);
+    const arr = [{ type: 'text', text: BIG }];
+    msgs[3].content = arr; // turn 0 tool, array content
+    msgs[6].content = null; // turn 1 tool, null content
+    const { masked } = maskStaleToolResults(msgs, {
+      keepRecentTurns: 1,
+      minBytes: 1,
+    });
+    expect(msgs[3].content).toBe(arr);
+    expect(msgs[6].content).toBeNull();
+    expect(masked).toBe(1); // only turn 2's string result; turn 3 is kept (last 1)
+  });
+
+  it('handles fewer turns than the keep-window as a no-op', () => {
+    const msgs = conversation(2);
+    const { masked } = maskStaleToolResults(msgs, {
+      keepRecentTurns: 3,
+      minBytes: 1,
+    });
+    expect(masked).toBe(0);
+  });
+
+  it('fails open on malformed input (no throw, no mutation)', () => {
+    const weird = [{ role: 'tool' }, { role: 'tool', content: BIG }] as Msg[];
+    expect(() =>
+      maskStaleToolResults(weird, { keepRecentTurns: 1, minBytes: 1 }),
+    ).not.toThrow();
+    // No user turns at all → nothing is "older than the last K user turns".
+    expect(weird[1].content).toBe(BIG);
+  });
+});

--- a/container/agent-runner/src/observation-masking.ts
+++ b/container/agent-runner/src/observation-masking.ts
@@ -1,0 +1,91 @@
+/**
+ * Observation masking for Deus-owned message arrays (LIA-378, slice 1).
+ *
+ * Tool results dominate agent-loop context (measured: 53.5% of final-context
+ * tokens in the largest dispatches, re-billed ~47x over a dispatch); masking
+ * stale ones matches summarization solve-rates at ~half the cost
+ * (arXiv:2508.21433). This module applies ONLY where Deus owns the message
+ * history — today the llama-cpp backend. The Claude path has no owned array
+ * (see the LIA-378 spike); the openai backend keeps history server-side.
+ *
+ * Honesty note: masked llama-cpp content is NOT recoverable (the messages
+ * array is in-memory only; the LIA-374 cold store covers host transcripts,
+ * not container loops). The safety case is: flag OFF by default, keep-window,
+ * minBytes floor, and a placeholder that tells the model to re-run the tool.
+ *
+ * Turn counting matches the adjacent compactMessages() (llama-cpp-backend.ts):
+ * a turn is one `role === 'user'` message; tool results attach to the turn
+ * they follow. The two windows can never disagree about what "N turns" means.
+ */
+
+const DEFAULT_KEEP_TURNS = 3;
+const DEFAULT_MIN_BYTES = 500;
+
+/** Replacement text for a masked tool result — no retention claim. */
+export const MASKED_PLACEHOLDER =
+  '[tool result masked to save context — re-run the tool if its output is needed again]';
+
+/** Kill-switch: OFF by default (dark ship). LIA-378 */
+export function maskingEnabled(): boolean {
+  return process.env.DEUS_OBSERVATION_MASKING === '1'; // LIA-378
+}
+
+export function maskKeepTurns(): number {
+  const parsed = Number.parseInt(
+    process.env.DEUS_MASK_KEEP_TURNS || '', // LIA-378
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_KEEP_TURNS;
+}
+
+export function maskMinBytes(): number {
+  const parsed = Number.parseInt(
+    process.env.DEUS_MASK_MIN_BYTES || '', // LIA-378
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MIN_BYTES;
+}
+
+interface MaskableMessage {
+  role: string;
+  content?: string | Array<Record<string, unknown>> | null;
+}
+
+export interface MaskOpts {
+  keepRecentTurns: number;
+  minBytes: number;
+}
+
+/**
+ * Replace stale tool-result contents with MASKED_PLACEHOLDER, in place.
+ *
+ * A tool message is masked only when ALL hold: it precedes the last
+ * `keepRecentTurns` user messages; its content is a string (non-string =
+ * fail-open skip); it is at least `minBytes` bytes; and it isn't already the
+ * placeholder (idempotent). Never touches non-tool messages.
+ */
+export function maskStaleToolResults(
+  messages: MaskableMessage[],
+  opts: MaskOpts,
+): { masked: number } {
+  const userIndices: number[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    if (messages[i]?.role === 'user') userIndices.push(i);
+  }
+  if (userIndices.length <= opts.keepRecentTurns) return { masked: 0 };
+
+  // Everything before the first kept user turn is stale.
+  const cutoff = userIndices[userIndices.length - opts.keepRecentTurns];
+  let masked = 0;
+  for (let i = 0; i < cutoff; i += 1) {
+    const msg = messages[i];
+    if (msg?.role !== 'tool') continue;
+    const content = msg.content;
+    if (typeof content !== 'string') continue; // fail-open: arrays/null untouched
+    if (content === MASKED_PLACEHOLDER) continue; // idempotent
+    if (Buffer.byteLength(content, 'utf8') < opts.minBytes) continue;
+    msg.content = MASKED_PLACEHOLDER;
+    masked += 1;
+  }
+  return { masked };
+}

--- a/scripts/spikes/lia378_transcript_rewrite_spike.md
+++ b/scripts/spikes/lia378_transcript_rewrite_spike.md
@@ -1,0 +1,55 @@
+# Spike: Claude-path observation masking via transcript rewrite (LIA-378)
+
+**Date:** 2026-07-05 · **Verdict: VIABLE** — the Claude CLI reconstructs resumed
+context from the on-disk transcript JSONL with no caching or checksum; an edited
+`tool_result` is exactly what the resumed model sees.
+
+## Question
+
+The Claude backend has no Deus-owned message array (the SDK subprocess manages
+history), and PostToolUse hooks cannot rewrite built-in tool results
+(`updatedMCPToolOutput` is `mcp__*`-only — verified in LIA-379). The only
+plausible seam for masking stale tool results is rewriting the transcript JSONL
+**between turns** (no subprocess running; `resume`/`resumeSessionAt` rebuild
+history from disk). Does the CLI actually re-read mutated content, or does it
+cache/validate?
+
+## Method (synthetic scratch session — no personal data)
+
+1. Scratch dir with `probe.txt` containing a sentinel string
+   (`SENTINEL-CONTENT-ALPHA-7391`); `claude -p --model haiku "Read probe.txt,
+   reply READ DONE"` → transcript with one Read `tool_result` carrying the
+   sentinel (1 occurrence in the JSONL).
+2. **Probe A** — `claude -p --resume <sid> "quote the sentinel from the earlier
+   tool result, do not re-read"` against the ORIGINAL transcript →
+   `SENTINEL-CONTENT-ALPHA-7391` (baseline: resumed context carries the result).
+3. Edit the session JSONL in place: replace the sentinel with
+   `MASKED-PLACEHOLDER-BETA-0042` (content-only edit, structure untouched).
+4. **Probe B** — same resume prompt against the EDITED transcript →
+   `MASKED-PLACEHOLDER-BETA-0042`.
+
+The resumed model reproduced the edited placeholder, not the original content:
+history is re-read from disk on every resume, byte-for-byte, no integrity check
+blocking content-only edits.
+
+## Implications for slice 2 (Claude-path masking)
+
+- Mechanism: a between-turn pass (the container agent-runner's outer loop, after
+  a `query()` returns and before the next `resume`) rewrites stale `tool_result`
+  contents in the session transcript with a placeholder + pointer.
+- Losslessness: pair each rewrite with LIA-374-style content-addressed retention
+  of the pre-edit transcript (or of each evicted block) so the placeholder can
+  point at retained bytes — unlike llama-cpp's in-memory array, the Claude path
+  CAN be made lossless.
+- Cache economics caveat: editing early-transcript content invalidates the
+  prompt-cache prefix from the edit point on the next call — the rewrite should
+  batch (mask many results at once, e.g. at compaction-pressure thresholds)
+  rather than fire per turn, or the cache-write cost eats the savings.
+- Risks to design around: SDK version drift in JSONL schema (pin a structural
+  round-trip test), concurrent writes (only rewrite while no subprocess runs),
+  and `resultWasTruncated`-style metadata consistency.
+
+## Scope of this spike
+
+Read-only finding; nothing wired into production. Slice-2 scoping lives in
+LIA-378. Scratch session dirs deleted after the run.


### PR DESCRIPTION
## Summary

Token-efficiency slice 5 (final). Tool-result accumulation is **53.5% of final-context tokens** in the largest dispatches (session-measured: 63,639 of 118,997 mean tokens across the top-20 subagent transcripts), re-billed **~47x** over a dispatch's lifetime (independently matches #991). Masking stale tool results matches LLM-summarization solve-rates at ~half the cost ("The Complexity Trap", arXiv:2508.21433, SWE-bench).

Backend feasibility (verified): **openai** — not implementable (history lives server-side via `previous_response_id`); **llama-cpp** — Deus owns `messages[]` → implemented here; **Claude (production)** — no owned array; needs transcript rewrite → decisive spike executed here.

## Changes

- **`observation-masking.ts`** — pure module: masks `role:'tool'` string contents older than the last `DEUS_MASK_KEEP_TURNS` (3) user-turns — the SAME turn convention as the adjacent `compactMessages`, so the two windows can't disagree — and ≥ `DEUS_MASK_MIN_BYTES` (500). Idempotent; non-string content fail-open; in-place mutation. Placeholder makes **no retention claim** (plan-review catch: llama-cpp messages are in-memory; the LIA-374 cold store covers host transcripts only — masked content here is genuinely unrecoverable, so the safety case is the dark flag + keep-window + minBytes + re-run instruction).
- **`llama-cpp-backend.ts`** — masking runs immediately before the compaction estimate: the gentle lever fires first, the destructive one (compaction) triggers less often.
- **`DEUS_OBSERVATION_MASKING` ships OFF (dark).** ai-eng caveat adopted: each mask event edits early bytes and can thrash llama-server's KV-prefix cache (full re-prefill on local CPU inference could offset token savings) — **bench wall-clock latency before ever enabling**.

## Claude-path spike — VERDICT: VIABLE (`scripts/spikes/lia378_transcript_rewrite_spike.md`)

Synthetic scratch session; edited the session JSONL on disk (tool_result sentinel → placeholder); `claude -p --resume`:
- Probe A (original): model quotes `SENTINEL-CONTENT-ALPHA-7391`
- Probe B (edited): model quotes `MASKED-PLACEHOLDER-BETA-0042`

The CLI re-reads resumed history from disk byte-for-byte — no caching/checksum. Slice 2 (production Claude-path masking) is mechanically possible AND lossless when paired with LIA-374-style retention; the spike doc records the batching requirement (per-turn edits would bust the Anthropic prompt-cache prefix — mask in batches at pressure thresholds).

## Testing

TDD: 9 vitest red-first (keep-window user-turn counting, minBytes floor, idempotency, non-string array/null skip, under-window no-op, malformed fail-open, dark-default env parsing). Container suite 246/246; build, prettier, flag-lint clean.

## Reviews

plan-reviewer SHIP (2 rounds claude — incl. a losslessness-overclaim catch that reshaped the placeholder text; gpt) · code-reviewer SHIP (claude + gpt; glm COULD_NOT_RUN ×3 = fail-open tooling gap, tracked) · ai-eng-warden SHIP (claude + gpt) · verification-gate SHIP (all 8 claims fresh, incl. independent confirmation of the in-place-mutation mechanism the insertion-point claim rests on).

## Follow-ups (tracked in LIA-378 for slice 2)

Claude-path batched transcript-rewrite masking + retention pairing; llama-server KV-thrash latency bench; tool-name-bearing placeholder; content-aware masking tiers.

Linear: LIA-378

🤖 Generated with [Claude Code](https://claude.com/claude-code)