### PR TITLE
fix(tui): remove redundant borrow in format! arg (clippy 1.97)

### DIFF
--- a/tui/src/ui.rs
+++ b/tui/src/ui.rs
@@ -239,7 +239,7 @@ fn render_session_picker(frame: &mut Frame, app: &App, area: Rect) {
         let label = Span::styled(
             format!(
                 " {} {} ",
-                &session.label,
+                session.label,
                 crate::app::model_display(&session.model)
             ),
             if is_selected {


### PR DESCRIPTION
## Summary
- The GitHub Actions runner's Rust toolchain updated to clippy 1.97, whose new `useless_borrows_in_formatting` lint fails `cargo clippy -- -D warnings` (the `test-tui` required check) on every PR.
- One-line fix: drop the redundant `&` on `session.label` in the session-picker `format!` call (`tui/src/ui.rs:242`). No behavior change — `format!` captures display args by reference internally.

## Verification
- `cargo clippy -- -D warnings` (exact CI invocation) exit 0, `cargo fmt -- --check` clean, `cargo test` 166 passed / 0 failed.
- Repo-wide scan for other formatting-macro bare borrows: only false positives (function args, a required unsized-slice borrow at `app.rs:2122`).
- Local toolchain is clippy 1.95 (lint can't fire locally) — this PR's own `test-tui` run on clippy 1.97 is the authoritative proof.

## Review
plan-reviewer (trivial-bypass, stated judgment), code-reviewer SHIP on claude+gpt+glm backends, verification-gate SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)