### PR TITLE
fix(evolution): eval-loop dormancy — empty GEMINI_API_KEY= value + Gemini model-id leak

### DIFF
--- a/evolution/config.py
+++ b/evolution/config.py
@@ -173,7 +173,13 @@ def load_api_key() -> str:
         if path.exists():
             for line in path.read_text().splitlines():
                 if line.startswith("GEMINI_API_KEY="):
-                    return line.split("=", 1)[1].strip()
+                    value = line.split("=", 1)[1].strip()
+                    # An empty value (leftover `GEMINI_API_KEY=` placeholder)
+                    # must behave like an absent key — returning "" makes
+                    # GeminiProvider.is_available() report a provider that can
+                    # never authenticate, silently disabling the eval loop.
+                    if value:
+                        return value
     key = os.environ.get("GEMINI_API_KEY", "")
     if not key:
         checked = ", ".join(str(p) for p in _ENV_SEARCH_PATHS)

--- a/evolution/reflexion/generator.py
+++ b/evolution/reflexion/generator.py
@@ -8,7 +8,6 @@ import json
 import re
 from typing import Optional
 
-from ..config import JUDGE_MODEL
 from ..generative import generate
 
 _REFLECTION_PROMPT = """Analyze this low-scoring AI interaction and extract an actionable lesson.
@@ -48,12 +47,15 @@ def generate_reflection(
     dims: Optional[dict] = None,
     rationale: str = "",
     tools_used: Optional[list[str]] = None,
-    model: str = JUDGE_MODEL,
+    model: Optional[str] = None,
     metrics: Optional[dict] = None,
 ) -> tuple[str, str]:
     """
     Generate a reflection for a low-scoring interaction.
     Returns (content, category).
+
+    ``model=None`` defers to the winning generative provider's own default —
+    a hardcoded Gemini id here 404s on non-Gemini providers (Ollama etc.).
     """
     formatted = _REFLECTION_PROMPT.format(
         prompt=prompt[:1500],
@@ -96,12 +98,15 @@ def generate_positive_reflection(
     dims: Optional[dict] = None,
     rationale: str = "",
     tools_used: Optional[list[str]] = None,
-    model: str = JUDGE_MODEL,
+    model: Optional[str] = None,
     metrics: Optional[dict] = None,
 ) -> tuple[str, str]:
     """
     Generate a positive pattern reflection for a high-scoring interaction.
     Returns (content, category).
+
+    ``model=None`` defers to the winning provider's default model (see
+    ``generate_reflection``).
     """
     formatted = _POSITIVE_PROMPT.format(
         prompt=prompt[:1500],

--- a/evolution/reflexion/principles.py
+++ b/evolution/reflexion/principles.py
@@ -12,7 +12,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from ..config import JUDGE_MODEL
 from ..generative import generate
 from ..ilog.interaction_log import get_recent
 from ..storage import get_storage
@@ -54,7 +53,7 @@ Write 3-5 numbered principles (under 200 words total). Each must be: one sentenc
 def extract_principles(
     domain: Optional[str] = None,
     top_k: int = 5,
-    model: str = JUDGE_MODEL,
+    model: Optional[str] = None,
     min_new: int = 5,
     force: bool = False,
 ) -> Optional[str]:

--- a/evolution/tests/test_config.py
+++ b/evolution/tests/test_config.py
@@ -85,3 +85,60 @@ def test_repo_env_no_key_falls_through_to_user(tmp_path, monkeypatch):
     monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
 
     assert load_api_key() == "user-fallback-key"
+
+
+def test_empty_value_falls_through_to_user_env(tmp_path, monkeypatch):
+    """Case 6: Empty `GEMINI_API_KEY=` in repo .env, real key in user-level .env → user-level wins.
+
+    Regression for issue #1006: an empty value was returned as "" instead of
+    falling through, silently disabling the eval loop.
+    """
+    repo_env = tmp_path / ".env"
+    _write_env(repo_env, "")
+
+    user_env = tmp_path / "user" / ".env"
+    _write_env(user_env, "user-real-key")
+
+    monkeypatch.setattr(config_mod, "CONFIG_ENV", repo_env)
+    monkeypatch.setattr(config_mod, "USER_CONFIG_ENV", user_env)
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    assert load_api_key() == "user-real-key"
+
+
+def test_empty_value_falls_through_to_env_var(tmp_path, monkeypatch):
+    """Case 7: Empty value in both .env files, env var set → env-var value returned."""
+    repo_env = tmp_path / ".env"
+    _write_env(repo_env, "")
+    user_env = tmp_path / "user" / ".env"
+    _write_env(user_env, "")
+
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+    monkeypatch.setenv("GEMINI_API_KEY", "envvar-real-key")
+
+    assert load_api_key() == "envvar-real-key"
+
+
+def test_empty_value_everywhere_raises(tmp_path, monkeypatch):
+    """Case 8: Empty value in repo .env, nothing else → RuntimeError (same as absent)."""
+    repo_env = tmp_path / ".env"
+    _write_env(repo_env, "")
+    user_env = tmp_path / "missing" / ".env"
+
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    with pytest.raises(RuntimeError):
+        load_api_key()
+
+
+def test_whitespace_only_value_treated_as_empty(tmp_path, monkeypatch):
+    """Case 9: Whitespace-only value strips to empty → same fallthrough as Case 6."""
+    repo_env = tmp_path / ".env"
+    _write_env(repo_env, "   ")
+
+    user_env = tmp_path / "user" / ".env"
+    _write_env(user_env, "user-ws-key")
+
+    monkeypatch.setattr(config_mod, "_ENV_SEARCH_PATHS", [repo_env, user_env])
+
+    assert load_api_key() == "user-ws-key"

--- a/evolution/tests/test_reflexion_generator.py
+++ b/evolution/tests/test_reflexion_generator.py
@@ -95,3 +95,64 @@ def test_generate_positive_reflection_includes_metrics(capture_prompt):
         metrics={"tests_passed": 12},
     )
     assert 'Task metrics: {"tests_passed": 12}' in capture_prompt[0]
+
+
+# ── Model default pass-through (issue #1006) ─────────────────────────────────
+
+
+@pytest.fixture
+def capture_model(monkeypatch):
+    """Replace the LLM call with a capture that records the model kwarg."""
+    captured = []
+
+    def fake_generate(prompt, **kwargs):
+        captured.append(kwargs.get("model", "MISSING"))
+        return "- What went wrong: x\n- Next time: y\n- Category: reasoning"
+
+    monkeypatch.setattr("evolution.reflexion.generator.generate", fake_generate)
+    return captured
+
+
+def test_generate_reflection_default_model_is_none(capture_model):
+    """Regression #1006: no Gemini model id may leak to non-Gemini providers."""
+    from evolution.reflexion.generator import generate_reflection
+
+    generate_reflection(prompt="p", response="r", score=0.3)
+    assert capture_model == [None]
+
+
+def test_generate_positive_reflection_default_model_is_none(capture_model):
+    from evolution.reflexion.generator import generate_positive_reflection
+
+    generate_positive_reflection(prompt="p", response="r", score=0.9)
+    assert capture_model == [None]
+
+
+def test_generate_reflection_explicit_model_passes_through(capture_model):
+    from evolution.reflexion.generator import generate_reflection
+
+    generate_reflection(prompt="p", response="r", score=0.3, model="my-model")
+    assert capture_model == ["my-model"]
+
+
+def test_extract_principles_default_model_is_none(monkeypatch):
+    """Regression #1006: extract_principles shares the same generate() path and
+    must not default to a Gemini model id either."""
+    import evolution.reflexion.principles as principles_mod
+
+    captured = []
+
+    def fake_generate(prompt, **kwargs):
+        captured.append(kwargs.get("model", "MISSING"))
+        return "1. Always test the fallthrough path with a mocked provider chain."
+
+    fake_row = {"prompt": "p", "response": "r", "judge_score": 0.9}
+    monkeypatch.setattr(principles_mod, "generate", fake_generate)
+    monkeypatch.setattr(principles_mod, "get_recent", lambda **kw: [dict(fake_row)] * 3)
+    monkeypatch.setattr(principles_mod, "save_reflection", lambda **kw: None)
+    monkeypatch.setattr(principles_mod, "_record_extraction", lambda *a, **kw: None)
+
+    result = principles_mod.extract_principles(force=True)
+
+    assert result is not None
+    assert captured == [None]

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-06-26" # auto-bump @1782487369
+last_verified: "2026-07-11" # auto-bump @1783777889
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-05" # auto-bump @1783199380
+last_verified: "2026-07-11" # auto-bump @1783777889
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary
Fixes the two silent-dormancy defects reported in #1006:

1. **`load_api_key()` returned an empty `.env` value.** A leftover `GEMINI_API_KEY=` placeholder line was returned as `""` instead of falling through, so `GeminiProvider.is_available()` won provider selection with an unusable key — the eval loop sat at 0 judged interactions with no surface symptom. Empty (or whitespace-only) values now behave exactly like an absent key: continue scanning later `.env` paths, then the env var, then the existing `RuntimeError`. All 8 existing call sites (6 files) already handle the absent-key convention.
2. **Gemini model-id leak into non-Gemini providers.** `generate_reflection`, `generate_positive_reflection`, and `extract_principles` defaulted `model=JUDGE_MODEL` (`models/gemini-3.1-flash-lite`), which 404s when a non-Gemini provider (e.g. Ollama) wins `generate()`'s selection. All three now default `model=None`, deferring to the winning provider's own `default_model` — the same convention every generative provider already implements.

Note: `GEN_MODEL` and `JUDGE_MODEL` currently share the same default literal, so Gemini-path behavior is unchanged by coincidence of defaults; documenting here intentionally.

## Tests
- 4 new `load_api_key` regression cases (empty→user .env, empty→env var, empty everywhere→RuntimeError, whitespace-only).
- 4 new model-default cases (both reflection functions + `extract_principles` capture `model=None`; explicit override passes through).
- Mutation-proven red-green: the new tests fail against the pre-fix code with exactly the targeted symptoms.
- Full evolution suite: 723 passed, 1 skipped.

## Review
plan-reviewer SHIP (2 rounds, claude+gpt backends), code-reviewer SHIP (2 rounds, claude+gpt+glm), verification-gate SHIP (round 1 REVISE caught the `principles.py` sibling defect — closed in round 2).

Closes #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)