### PR TITLE
fix(security): fail-closed gh gate for external projects (LIA-361)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-11" # auto-bump @1783777889
+last_verified: "2026-07-13" # auto-bump @1783962743
 governs:
   - src/
   - evolution/

--- a/src/external-push-gate.test.ts
+++ b/src/external-push-gate.test.ts
@@ -58,13 +58,19 @@ describe('isPushOrMergeTool', () => {
     expect(isPushOrMergeTool('gh', ['--hostname=h', 'pr', 'merge'])).toBe(true);
   });
 
-  it('does NOT flag non-push gh subcommands (incl. pr close, which is not a merge)', () => {
+  it('does NOT flag gh read subcommands (pr view/list)', () => {
     expect(isPushOrMergeTool('gh', ['pr', 'view', '294'])).toBe(false);
     expect(isPushOrMergeTool('gh', ['pr', 'list'])).toBe(false);
+  });
+
+  it('fail-closed: flags gh subcommands not in the read allowlist (pr close, issue create)', () => {
+    // Tightened by LIA-361: the allowlist names only pr view|list|diff|status|
+    // checks as safe, so pr close (historically allowed) and issue create fall
+    // through to the default-gated branch.
     expect(isPushOrMergeTool('gh', ['pr', 'close', '294', '--merge'])).toBe(
-      false,
+      true,
     );
-    expect(isPushOrMergeTool('gh', ['issue', 'create'])).toBe(false);
+    expect(isPushOrMergeTool('gh', ['issue', 'create'])).toBe(true);
   });
 
   it('does not flag unrelated tools', () => {
@@ -152,5 +158,319 @@ describe('SENSITIVE_FILE_PATTERNS', () => {
   it('shadows git credential stores', () => {
     expect(SENSITIVE_FILE_PATTERNS).toContain('.git-credentials');
     expect(SENSITIVE_FILE_PATTERNS).toContain('.netrc');
+  });
+});
+
+// Independent oracle (authored from the LIA-361 spec, blind to the
+// implementation) — discriminating cases for the fail-closed allowlist gate.
+describe('isPushOrMergeTool — @oracle fail-closed allowlist spec', () => {
+  describe('non-gh tools', () => {
+    it('@oracle: deus-git-push is always a push regardless of args', () => {
+      expect(isPushOrMergeTool('deus-git-push', [])).toBe(true);
+      expect(isPushOrMergeTool('deus-git-push', ['--dry-run'])).toBe(true);
+    });
+
+    it('@oracle: non-gh, non-push tools are always allowed (bash, cat)', () => {
+      expect(isPushOrMergeTool('bash', ['-c', 'git push origin main'])).toBe(
+        false,
+      );
+      expect(isPushOrMergeTool('cat', ['/etc/passwd'])).toBe(false);
+      expect(isPushOrMergeTool('git', ['push', 'origin', 'main'])).toBe(false);
+    });
+  });
+
+  describe('gh: read allowlist (FALSE)', () => {
+    it('@oracle: gh pr view/list/diff/status/checks are reads', () => {
+      expect(isPushOrMergeTool('gh', ['pr', 'view', '294'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['pr', 'list'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['pr', 'diff', '294'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['pr', 'status'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['pr', 'checks', '294'])).toBe(false);
+    });
+
+    it('@oracle: gh issue view/list/status are reads', () => {
+      expect(isPushOrMergeTool('gh', ['issue', 'view', '1'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['issue', 'list'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['issue', 'status'])).toBe(false);
+    });
+
+    it('@oracle: gh repo/release/run/workflow view|list are reads', () => {
+      expect(isPushOrMergeTool('gh', ['repo', 'view'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['repo', 'list'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['release', 'view'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['release', 'list'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['run', 'view', '123'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['run', 'list'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['workflow', 'view', 'ci'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['workflow', 'list'])).toBe(false);
+    });
+
+    it('@oracle: gh search code|commits|issues|prs|repos are reads', () => {
+      expect(isPushOrMergeTool('gh', ['search', 'repos', 'foo'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['search', 'issues', '--author=x'])).toBe(
+        false,
+      );
+      expect(isPushOrMergeTool('gh', ['search', 'code', 'foo'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['search', 'commits', 'foo'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['search', 'prs', 'foo'])).toBe(false);
+    });
+
+    it('@oracle: an unknown gh search target fails closed (no wildcard)', () => {
+      expect(isPushOrMergeTool('gh', ['search', 'frobnicate'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['search'])).toBe(true);
+    });
+
+    it('@oracle: a value that literally reads "push" must not false-trigger', () => {
+      // "push" appears as a flag VALUE, not a subcommand token — must stay a read.
+      expect(isPushOrMergeTool('gh', ['pr', 'view', '--head', 'push'])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('gh: fail-closed tightening (now TRUE)', () => {
+    it('@oracle: gh pr close is now gated (intentional tightening)', () => {
+      expect(isPushOrMergeTool('gh', ['pr', 'close', '294'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['pr', 'close', '294', '--merge'])).toBe(
+        true,
+      );
+    });
+
+    it('@oracle: mutating/credential/execution gh subcommands are gated', () => {
+      expect(isPushOrMergeTool('gh', ['alias', 'set', 'x', 'y'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['alias', 'import', 'file'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['extension', 'install', 'x/y'])).toBe(
+        true,
+      );
+      expect(isPushOrMergeTool('gh', ['extension', 'exec', 'x'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['secret', 'set', 'FOO'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['gist', 'create', 'file.txt'])).toBe(
+        true,
+      );
+      expect(isPushOrMergeTool('gh', ['ssh-key', 'add', 'key.pub'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['gpg-key', 'add', 'key.asc'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['repo', 'delete', 'o/r'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['repo', 'create', 'x'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['release', 'create', 'v1'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['release', 'delete', 'v1'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['workflow', 'run', 'ci.yml'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['run', 'rerun', '123'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['run', 'cancel', '123'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['run', 'download', '123'])).toBe(true);
+    });
+
+    it('@oracle: unknown/typo gh subcommands default to gated (fail closed)', () => {
+      expect(isPushOrMergeTool('gh', ['frobnicate', 'x'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['prr', 'view'])).toBe(true); // typo of "pr"
+    });
+
+    it('@oracle: -X/--method are position-skipping value-flags when finding the subcommand', () => {
+      expect(isPushOrMergeTool('gh', ['-X', 'POST', 'pr', 'view', '1'])).toBe(
+        false,
+      );
+      expect(isPushOrMergeTool('gh', ['-X', 'POST', 'pr', 'merge', '1'])).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('gh api: unambiguous GET (FALSE)', () => {
+    it('@oracle: plain gh api reads with no method/body flags are allowed', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r/pulls'])).toBe(false);
+      expect(isPushOrMergeTool('gh', ['api', '/user'])).toBe(false);
+    });
+
+    it('@oracle: -q/--jq output filters are NOT body flags, still a read', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-q', '.name'])).toBe(
+        false,
+      );
+      expect(
+        isPushOrMergeTool('gh', ['api', 'repos/o/r', '--jq', '.name']),
+      ).toBe(false);
+    });
+  });
+
+  describe('gh api: mutating method flag (TRUE)', () => {
+    it('@oracle: -X VERB (spaced) selects a non-GET verb', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-X', 'PUT'])).toBe(
+        true,
+      );
+    });
+
+    it('@oracle: -XVERB (glued) selects a non-GET verb', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-XPUT'])).toBe(true);
+    });
+
+    it('@oracle: --method=verb (lowercase) selects a non-GET verb, case-insensitively', () => {
+      expect(
+        isPushOrMergeTool('gh', ['api', 'repos/o/r', '--method=put']),
+      ).toBe(true);
+    });
+
+    it('@oracle: --method VERB (spaced) selects a non-GET verb', () => {
+      expect(
+        isPushOrMergeTool('gh', ['api', 'repos/o/r', '--method', 'DELETE']),
+      ).toBe(true);
+    });
+
+    it('@oracle: a dangling -X/--method with no following value fails closed to TRUE', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-X'])).toBe(true);
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '--method'])).toBe(
+        true,
+      );
+    });
+
+    it('@oracle: an explicit -X GET stays a read', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-X', 'GET'])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('gh api: body/param flags (TRUE)', () => {
+    it('@oracle: -f key=value (spaced) is a body flag', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-f', 'k=v'])).toBe(
+        true,
+      );
+    });
+
+    it('@oracle: -fkey=value (glued shorthand) is a body flag', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-fk=v'])).toBe(true);
+    });
+
+    it('@oracle: --input - (stdin body) is a body flag', () => {
+      expect(
+        isPushOrMergeTool('gh', ['api', 'repos/o/r', '--input', '-']),
+      ).toBe(true);
+    });
+
+    it('@oracle: -F/--field/--raw-field and their =-forms are all body flags', () => {
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '-F', 'k=v'])).toBe(
+        true,
+      );
+      expect(
+        isPushOrMergeTool('gh', ['api', 'repos/o/r', '--field', 'k=v']),
+      ).toBe(true);
+      expect(isPushOrMergeTool('gh', ['api', 'repos/o/r', '--field=k=v'])).toBe(
+        true,
+      );
+      expect(
+        isPushOrMergeTool('gh', ['api', 'repos/o/r', '--raw-field', 'k=v']),
+      ).toBe(true);
+    });
+
+    it('@oracle: gh api graphql -f query=... is gated because the body arrives via -f', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          'graphql',
+          '-f',
+          'query=query { viewer { login } }',
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe('gh api: POSIX shorthand clustering (TRUE) — regression for the -i cluster bypass', () => {
+    // gh api exposes the boolean shorthand -i/--include; pflag lets it cluster
+    // in front of a value flag, so `-if k=v` == `-i -f k=v`. A string-prefix
+    // check on the raw token (`-if`) would miss the hidden -f/-X/-H entirely.
+    it('@oracle: -if k=v (clustered body flag) is gated', () => {
+      expect(isPushOrMergeTool('gh', ['api', '/user', '-if', 'k=v'])).toBe(
+        true,
+      );
+    });
+
+    it('@oracle: -ifk=v (clustered + glued body flag) is gated', () => {
+      expect(isPushOrMergeTool('gh', ['api', '/user', '-ifk=v'])).toBe(true);
+    });
+
+    it('@oracle: -iX PUT (clustered method flag) is gated', () => {
+      expect(isPushOrMergeTool('gh', ['api', '/user', '-iX', 'PUT'])).toBe(
+        true,
+      );
+    });
+
+    it('@oracle: -iXPUT (clustered + glued method flag) is gated', () => {
+      expect(isPushOrMergeTool('gh', ['api', '/user', '-iXPUT'])).toBe(true);
+    });
+
+    it('@oracle: -iH with a method-override header (clustered) is gated', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          '/user',
+          '-iH',
+          'X-HTTP-Method-Override: DELETE',
+        ]),
+      ).toBe(true);
+    });
+
+    it('@oracle: -i alone (boolean include, no value flag) stays a read', () => {
+      expect(isPushOrMergeTool('gh', ['api', '/user', '-i'])).toBe(false);
+    });
+
+    it('@oracle: -iq .name (include + jq read filter) stays a read', () => {
+      expect(isPushOrMergeTool('gh', ['api', '/user', '-iq', '.name'])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('gh api: -H/--header method-override (TRUE)', () => {
+    it('@oracle: -H VALUE (spaced) matching method-override is gated', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          'repos/o/r',
+          '-H',
+          'X-HTTP-Method-Override: DELETE',
+        ]),
+      ).toBe(true);
+    });
+
+    it('@oracle: -HVALUE (glued) matching method-override is gated', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          'repos/o/r',
+          '-HX-HTTP-Method-Override:PATCH',
+        ]),
+      ).toBe(true);
+    });
+
+    it('@oracle: --header=VALUE (=-form) matching method-override is gated', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          'repos/o/r',
+          '--header=X-HTTP-Method-Override:PUT',
+        ]),
+      ).toBe(true);
+    });
+
+    it('@oracle: every -H occurrence is checked, not just the first', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          'repos/o/r',
+          '-H',
+          'Accept: application/json',
+          '-H',
+          'X-HTTP-Method-Override: DELETE',
+        ]),
+      ).toBe(true);
+    });
+
+    it('@oracle: an ordinary header with no override match stays a read', () => {
+      expect(
+        isPushOrMergeTool('gh', [
+          'api',
+          'repos/o/r',
+          '-H',
+          'Accept: application/json',
+        ]),
+      ).toBe(false);
+    });
   });
 });

--- a/src/tool-proxy.ts
+++ b/src/tool-proxy.ts
@@ -49,16 +49,120 @@ function validateArg(arg: string): string | null {
   return null;
 }
 
-/** `gh` global flags that consume the following token as their value. */
-const GH_FLAGS_WITH_VALUE = new Set(['-R', '--repo', '--hostname']);
+/**
+ * `gh` global flags that consume the following token as their value. `-X` /
+ * `--method` are included so a method verb (e.g. the `PUT` in `-X PUT`) is not
+ * mistaken for a positional subcommand when reading the subcommand path.
+ */
+const GH_FLAGS_WITH_VALUE = new Set([
+  '-R',
+  '--repo',
+  '--hostname',
+  '-X',
+  '--method',
+]);
 
 /**
- * True if this tool invocation pushes to / publishes on a remote (git push, or
- * `gh pr merge`/`gh pr create`/`gh merge`). Detection is by SUBCOMMAND POSITION,
- * not substring — so `gh pr merge --help` or a branch literally named "push"
+ * `gh` subcommand paths that are known-safe READS: a first-position subcommand
+ * mapped to the exact set of allowed second-position subcommands. Anything not
+ * listed here is treated as gated — an allowlist, not a denylist, so a new or
+ * unknown `gh` subcommand (or an unknown `gh search` target) fails closed.
+ */
+const GH_READ_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
+  pr: new Set(['view', 'list', 'diff', 'status', 'checks']),
+  issue: new Set(['view', 'list', 'status']),
+  repo: new Set(['view', 'list']),
+  release: new Set(['view', 'list']),
+  run: new Set(['view', 'list']),
+  workflow: new Set(['view', 'list']),
+  search: new Set(['code', 'commits', 'issues', 'prs', 'repos']),
+};
+
+/**
+ * `gh api` shorthand flags that consume a value — either glued into the same
+ * token or taken from the following token. Needed to walk POSIX shorthand
+ * clusters (pflag): `-if k=v` means `-i -f k=v`, so a value flag hidden behind
+ * a boolean shorthand like `-i`/`--include` must not be missed. `X`=method,
+ * `f`/`F`=body param, `H`=header (mutation-relevant); `q`/`p`/`t`=read-only
+ * filters (they consume a value but do not mutate).
+ */
+const GH_API_VALUE_SHORTHANDS = new Set(['X', 'f', 'F', 'H', 'q', 'p', 't']);
+
+/**
+ * True if a `gh api` invocation can mutate GitHub state (so it must be gated).
+ * `gh api` defaults to GET (a read) and switches to POST when body params are
+ * added; an explicit method flag can select any verb. Fail-closed: anything not
+ * provably a plain GET is treated as mutating. A real shorthand-cluster walk
+ * (not string-prefix sniffing) handles glued (`-XPUT`), `=`-form
+ * (`--method=PUT`), dangling, AND POSIX-clustered (`-if k=v`, `-iX PUT`) forms,
+ * and scans every `-H`/`--header` value for an `X-HTTP-Method-Override`
+ * (defense-in-depth; GitHub REST v3 does not honor it, but the check is cheap).
+ */
+function ghApiIsMutating(args: string[]): boolean {
+  const isMutatingMethod = (v: string | undefined): boolean =>
+    v === undefined || v.trim().toUpperCase() !== 'GET';
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+
+    // --- long forms: --method / --field / --raw-field / --input / --header ---
+    if (a === '--method' || a.startsWith('--method=')) {
+      const v = a === '--method' ? args[++i] : a.slice('--method='.length);
+      if (isMutatingMethod(v)) return true;
+      continue;
+    }
+    if (
+      a === '--field' ||
+      a.startsWith('--field=') ||
+      a === '--raw-field' ||
+      a.startsWith('--raw-field=') ||
+      a === '--input' ||
+      a.startsWith('--input=')
+    ) {
+      return true; // request body present
+    }
+    if (a === '--header' || a.startsWith('--header=')) {
+      const v = a === '--header' ? args[++i] : a.slice('--header='.length);
+      if (v !== undefined && /method-override/i.test(v)) return true;
+      continue;
+    }
+
+    // --- POSIX shorthand cluster: -i, -X, -f, -if, -iX, -ifk=v, ... ---
+    if (a.length >= 2 && a[0] === '-' && a[1] !== '-') {
+      for (let j = 1; j < a.length; j++) {
+        const ch = a[j];
+        if (!GH_API_VALUE_SHORTHANDS.has(ch)) continue; // boolean flag (e.g. i)
+        // Value = rest of this token after ch, else the next token (consumed).
+        const glued = a.slice(j + 1);
+        const val = glued.length > 0 ? glued : args[++i];
+        if (ch === 'X') {
+          if (isMutatingMethod(val)) return true;
+        } else if (ch === 'f' || ch === 'F') {
+          return true; // request body present
+        } else if (ch === 'H') {
+          if (val !== undefined && /method-override/i.test(val)) return true;
+        }
+        // q/p/t are read-only filters; their value is consumed above. Either
+        // way the token's remainder was this flag's value — stop walking it.
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * True if this tool invocation must be gated as publish/mutate/execute-capable
+ * for an untrusted external project — i.e. it could push, merge, publish, mutate
+ * GitHub state, or execute code using the host's GitHub credentials. Detection
+ * is by SUBCOMMAND POSITION, not substring, so a branch literally named "push"
  * does not false-trip. Platform-neutral (tool names + arg tokens only).
  *
- * Note: `gh pr close` is NOT a merge (it closes without merging) and is allowed.
+ * Fail-closed allowlist for `gh`: only the read subcommands in
+ * `GH_READ_SUBCOMMANDS` (and a non-mutating `gh api` GET) are allowed through;
+ * every other subcommand — including `alias`/`extension` (which can persist an
+ * alias or install code that later runs with host creds), `secret`, `release`,
+ * `repo`, `pr merge|create|close`, and anything unknown — is gated (LIA-361).
  */
 export function isPushOrMergeTool(toolName: string, args: string[]): boolean {
   // The dedicated push tool is always a push.
@@ -76,8 +180,12 @@ export function isPushOrMergeTool(toolName: string, args: string[]): boolean {
       positional.push(a);
     }
     const [c0, c1] = positional;
-    if (c0 === 'merge') return true; // `gh merge` top-level alias
-    if (c0 === 'pr' && (c1 === 'merge' || c1 === 'create')) return true;
+    if (c0 === 'api') return ghApiIsMutating(args); // read GET allowed
+    const reads = c0 ? GH_READ_SUBCOMMANDS[c0] : undefined;
+    if (reads && c1 !== undefined && reads.has(c1)) {
+      return false; // known safe read
+    }
+    return true; // fail closed: unknown / mutating / exec-capable subcommand
   }
   return false;
 }


### PR DESCRIPTION
## What

Closes the `gh api` credential-escalation bypass found by the 2026-07-03 system audit (V2 re-audit re-confirmed it live on origin/main). Roadmap step 2, PR 1 of 3.

The tool-proxy push/merge gate only flagged `gh merge` / `gh pr merge|create` by subcommand position. `gh api -X PUT .../pulls/1/merge` — and `gh alias set`, `gh extension install`, `gh secret set`, etc. — matched none of the guarded tokens and ran with the host operator's real GitHub credentials from a **non-allowlisted external-project container**, bypassing `externalPushDenialReason` (the LIA-180 trust boundary).

## How

`isPushOrMergeTool`'s `gh` handling flips from a denylist (allow unless recognized-bad) to a **fail-closed allowlist**:
- Only explicit read subcommands (`pr/issue/repo/release/run/workflow view|list|…`, `gh search <code|commits|issues|prs|repos>`) and a provably-GET `gh api` pass through.
- Everything else — `alias`/`extension` (persist an alias / install code that later runs with host creds), `secret`, `pr merge|create|close`, and any unknown subcommand — is gated.
- `gh api` mutation detection uses a real **POSIX shorthand-cluster walk**, not string-prefix matching, so `-if k=v` / `-iX PUT` (a value flag hidden behind the boolean `-i`/`--include`), plus glued/`=`/dangling/long forms, are all caught. Defense-in-depth scan for an `X-HTTP-Method-Override` header.

Only untrusted external projects are affected: `externalPushDenialReason` still returns `null` for the home/control project and allowlisted external projects (unchanged).

## Review trail

- Plan-reviewer SHIP (2 rounds: round 1 REVISE caught `alias`/`extension` bypass → flipped to allowlist).
- **A round-1 code-reviewer BLOCK caught a real fail-open** (`gh api -if k=v` POSIX-cluster hid the value flag; verified executing a live POST against real `gh` v2.92.0) → fixed with the cluster walker → round-2 SHIP.
- 5 warden SHIPs: code-reviewer (claude+gpt+glm), ai-eng-warden (claude+gpt), verification-gate.
- Tests: independent oracle suite authored **blind to the implementation** + a regression block for the cluster bypass. Full suite green (1990); tsc clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>