### PR TITLE
fix(ingress): don't kill the OAuth refresh timer on a port-conflict retry (LIA-363)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-13" # auto-bump @1783962743
+last_verified: "2026-07-13" # auto-bump @1783974306
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-07-03" # auto-bump @1783068612
+last_verified: "2026-07-13" # auto-bump @1783974306
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -654,6 +654,66 @@ describe('credential-proxy', () => {
         restore();
       }
     });
+
+    // Regression for LIA-363: the EADDRINUSE retry loop calls server.close()
+    // before re-listening. If the 'close' cleanup listener is registered before
+    // the first bind attempt, that retry-close clears proactiveRefreshTimer, so
+    // the proxy binds on a later attempt with proactive refresh permanently dead.
+    it('does NOT clear the proactive timer when a port conflict forces a retry', async () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'dynamic-creds-token-valid-test',
+            refreshToken: 'dynamic-refresh',
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          },
+        }),
+      );
+
+      // Occupy an ephemeral port so the proxy's first bind attempt hits
+      // EADDRINUSE and enters the retry path.
+      const blocker = http.createServer();
+      const busyPort = await new Promise<number>((resolve) => {
+        blocker.listen(0, '127.0.0.1', () =>
+          resolve((blocker.address() as AddressInfo).port),
+        );
+      });
+
+      const { restore, calls } = collectIntervals();
+      const clearSpy = vi.spyOn(global, 'clearInterval');
+      try {
+        // Start the proxy on the occupied port (do not await — it will not
+        // resolve until we free the port and its retry binds).
+        const proxyPromise = startCredentialProxy(busyPort);
+
+        // Free the port shortly after the first (failing) bind attempt so the
+        // 2s retry succeeds.
+        await new Promise<void>((resolve) => setTimeout(resolve, 200));
+        await new Promise<void>((resolve) => blocker.close(() => resolve()));
+
+        const server = await proxyPromise;
+        proxyServer = server;
+
+        const proactive = calls.find((c) => c.delay === PROACTIVE_INTERVAL_MS);
+        expect(proactive).toBeDefined();
+
+        // The retry's server.close() must NOT have cleared the proactive timer.
+        const clearedDuringRetry = clearSpy.mock.calls.map((c) => c[0]);
+        expect(clearedDuringRetry).not.toContain(proactive!.handle);
+
+        // And a real shutdown still clears it.
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        proxyServer = undefined;
+        const clearedAfterClose = clearSpy.mock.calls.map((c) => c[0]);
+        expect(clearedAfterClose).toContain(proactive!.handle);
+      } finally {
+        clearSpy.mockRestore();
+        restore();
+        if (blocker.listening) {
+          await new Promise<void>((resolve) => blocker.close(() => resolve()));
+        }
+      }
+    }, 10000);
   });
 
   describe('request bounds (LIA-236)', () => {

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -485,17 +485,21 @@ export function startCredentialProxy(
       });
     });
 
-    server.on('close', () => {
-      clearInterval(rateLimitCleanupInterval);
-      if (proactiveRefreshTimer) clearInterval(proactiveRefreshTimer);
-    });
-
     let retries = 0;
     const maxRetries = 10;
     const retryDelay = 2000;
 
     const tryListen = () => {
       server.listen(port, host, () => {
+        // Register the shutdown cleanup only AFTER a successful bind. Doing it
+        // earlier means the EADDRINUSE retry's server.close() (below) fires the
+        // 'close' listener and clears proactiveRefreshTimer, so the proxy then
+        // binds on a later attempt with proactive OAuth refresh permanently
+        // dead — the exact "next-morning 401" class the timer prevents (LIA-363).
+        server.on('close', () => {
+          clearInterval(rateLimitCleanupInterval);
+          if (proactiveRefreshTimer) clearInterval(proactiveRefreshTimer);
+        });
         logger.info(
           { port, host, authMode, credentialsPath: CREDENTIALS_PATH },
           'Credential proxy started',


### PR DESCRIPTION
## What

Roadmap step 2, PR 3 of 3 from the 2026-07-03 system audit (V2 re-confirmed live). Fixes a silent, permanent loss of proactive OAuth refresh after any port-conflict startup retry.

`src/credential-proxy.ts` registered its `server.on('close')` cleanup — which clears `proactiveRefreshTimer` — **before** the first `listen()` attempt. On an EADDRINUSE conflict (e.g. a service restart where the old process still briefly holds the port), the retry path calls `server.close()`, which fires that `'close'` listener and permanently clears the refresh timer. The proxy then binds on a later retry running with proactive refresh dead — reintroducing the "next-morning 401" token-expiry class the timer exists to prevent (worst on non-macOS hosts, which have no launchd backstop).

## How

Move the `server.on('close')` registration **inside** the successful `listen` callback, so the retry's `server.close()` has no listener to fire. The listener attaches exactly once, on the single successful bind; a genuine shutdown still clears both the rate-limit and refresh timers.

## Review trail

- Plan-reviewer SHIP (claude + gpt).
- Code-reviewer SHIP (claude + gpt + glm) — native reviewer independently confirmed single-registration correctness and no lost cleanup on real shutdown.
- Verification-gate SHIP — ran tsc + the regression test (drives a real EADDRINUSE retry with an actual bound socket) + full suite (1953).
- **Regression test proven discriminating:** it fails against the old listener ordering and passes with the fix.
- Follow-up filed (LIA-387): the retries-exhausted `reject` path also doesn't clear the (unref'd) timers — pre-existing, out of scope here.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>