### PR TITLE
fix(runtime): handle stream errors on tool-proxy req + container stdin (LIA-362, LIA-385)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-07-05" # auto-bump @1783199380
+last_verified: "2026-07-13" # auto-bump @1783974759
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-07-05" # auto-bump @1783199380
+last_verified: "2026-07-13" # auto-bump @1783974759
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-13" # auto-bump @1783974306
+last_verified: "2026-07-13" # auto-bump @1783974759
 governs:
   - src/
   - evolution/

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -314,6 +314,62 @@ describe('container-runner timeout behavior', () => {
 });
 
 // ---------------------------------------------------------------------------
+// container.stdin 'error' must not crash the host (LIA-385). stdin is a stream
+// distinct from the ChildProcess, so container.on('error') does not catch it;
+// an unhandled 'error' (EPIPE when the child exits before/while we write the
+// input) is a fatal uncaughtException that would take down the whole daemon.
+// The handler must log-and-swallow only — never abort a run that may be fine.
+// ---------------------------------------------------------------------------
+describe('container stdin error resilience (LIA-385)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a stdin EPIPE does not throw and the run still resolves from close', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // Let async setup (spawn + listener attach) run, as it would before a real
+    // child EPIPE.
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Child exits early: stdin emits 'error'. With no listener this is an
+    // uncaughtException; the fix attaches one, so this must be inert.
+    expect(() =>
+      fakeProc.stdin.emit(
+        'error',
+        Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }),
+      ),
+    ).not.toThrow();
+
+    // The run still completes via the normal output + close path with its
+    // true status — swallowing the stdin error must not abort or wedge it.
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'Done despite early stdin close',
+      newSessionId: 'session-epipe',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('success');
+    expect(result.newSessionId).toBe('session-epipe');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // parseBuffer must stay bounded (LIA-234). stdout/stderr accumulators are
 // capped at CONTAINER_MAX_OUTPUT_SIZE, but the stream parser's buffer was not:
 // a torn frame (START, never an END) or marker-free stdout noise could grow

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -517,6 +517,21 @@ export async function runContainerAgent(
     let stdoutTruncated = false;
     let stderrTruncated = false;
 
+    // If the child exits before/while we write the input JSON, stdin emits
+    // 'error' (EPIPE). container.stdin is a separate stream from the
+    // ChildProcess, so container.on('error') does NOT catch it; an unhandled
+    // stream 'error' is a fatal uncaught exception that would crash the whole
+    // host daemon (LIA-385). Log and swallow only: an early exit is not
+    // necessarily a failed run (a healthy agent-runner can exit early on an
+    // input parse error), and the existing 'close'/timeout handlers already
+    // resolve the run with its true status.
+    container.stdin.on('error', (err) => {
+      logger.warn(
+        { group: group.name, containerId: containerName, err },
+        'Container stdin write error (child likely exited early)',
+      );
+    });
+
     container.stdin.write(JSON.stringify(input));
     container.stdin.end();
 

--- a/src/tool-proxy.test.ts
+++ b/src/tool-proxy.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import http from 'http';
+import type { IncomingMessage, Server } from 'http';
+import type { AddressInfo } from 'net';
+
+// This test drives the request-stream 'error' path directly; it never reaches
+// auth/gate/registry logic, so these mocks only need to let startToolProxy bind.
+vi.mock('./config.js', () => ({ DEUS_PROXY_AUTH_ENABLED: false }));
+vi.mock('./db.js', () => ({
+  getProjectById: vi.fn(() => undefined),
+  getRegisteredGroupByFolder: vi.fn(() => undefined),
+}));
+vi.mock('./group-tokens.js', () => ({
+  validateGroupToken: vi.fn(() => 'test-group'),
+  isToolAllowedForToken: vi.fn(() => true),
+}));
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+vi.mock('./tool-registry.js', () => ({
+  loadRegistry: vi.fn(),
+  isAllowed: vi.fn(() => false),
+  getToolConfig: vi.fn(() => undefined),
+}));
+
+import { startToolProxy } from './tool-proxy.js';
+
+describe('tool-proxy request stream error resilience (LIA-362)', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it("attaches a req 'error' handler so a client mid-upload reset can't crash the host", async () => {
+    server = await startToolProxy(0);
+    const port = (server.address() as AddressInfo).port;
+
+    // The createServer handler runs first on each request and attaches its
+    // req.on('error') before any await; a second 'request' listener lets us
+    // capture that same IncomingMessage and emit 'error' on it. Without the
+    // fix's listener, emitting 'error' on an EventEmitter throws synchronously
+    // (the uncaught exception that crashes the daemon in production, LIA-362);
+    // with it, the emit is inert.
+    const captured = new Promise<IncomingMessage>((resolve) => {
+      server!.on('request', (req) => resolve(req));
+    });
+
+    const client = http.request({
+      host: '127.0.0.1',
+      port,
+      path: '/tool/whoami',
+      method: 'POST',
+    });
+    client.on('error', () => {}); // client-side ECONNRESET is expected/ignored
+    client.write('{}');
+    // Don't end() — keep the request in-flight while we drive the error.
+
+    const serverReq = await captured;
+    expect(() =>
+      serverReq.emit(
+        'error',
+        Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+      ),
+    ).not.toThrow();
+
+    client.destroy();
+
+    // The server must still be alive and answer a following request.
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        { host: '127.0.0.1', port, path: '/tool/whoami', method: 'POST' },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on('error', reject);
+      req.end('{}');
+    });
+    expect(status).toBeGreaterThan(0);
+  });
+});

--- a/src/tool-proxy.ts
+++ b/src/tool-proxy.ts
@@ -222,6 +222,14 @@ export function startToolProxy(
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
       const chunks: Buffer[] = [];
+      // A client that disconnects mid-upload (container killed mid-tool-call,
+      // docker stop, agent timeout) emits 'error' on the request stream; an
+      // unhandled stream 'error' is a fatal uncaught exception that would take
+      // down the whole host process, so swallow it here (LIA-362, mirrors the
+      // credential-proxy fix for LIA-236).
+      req.on('error', (err) => {
+        logger.debug({ err, url: req.url }, 'tool-proxy: request stream error');
+      });
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
         // ── Resolve caller's group folder ─────────────────────────────────


### PR DESCRIPTION
## What

Roadmap step 2, PR 2 of 3 from the 2026-07-03 system audit (V2 re-confirmed live). Closes two host-daemon crash paths that routine container teardown can trigger.

Two host-owned streams had no `'error'` listener, so an unhandled `'error'` event became a fatal `process.on('uncaughtException')` → `process.exit(1)` (`src/logger.ts`) that takes down the **entire host daemon serving every group** — not just the one request.

- **LIA-362 (tool-proxy):** a container killed mid-tool-call (agent timeout, `docker stop`) resets its socket, emitting `'error'` on the request stream. Adds `req.on('error')` (log + swallow) in the createServer handler — mirrors the LIA-236 fix the three sibling servers (credential-proxy, odysseus, ingress/gateway) already carry. This was the copy-paste-drift instance the audit flagged: the fix landed in one HTTP server and never propagated to tool-proxy.
- **LIA-385 (container-runner):** `container.stdin` is a stream distinct from the `ChildProcess`, so `container.on('error')` does NOT catch its EPIPE when the child exits before/while we write the input. Adds `container.stdin.on('error')` (log + swallow). **Swallow only — never kill or resolve the run early:** an early child exit isn't necessarily a failed run (a healthy agent-runner can exit on an input parse error), and the existing `close`/timeout handlers already resolve with the true status. (Filed by the V2 audit; it was the only high-severity finding nobody was tracking.)

## Notes

- Log level is intentionally asymmetric: stdin EPIPE at `warn` (rarer, more diagnostic), HTTP client abort at `debug` (routine) — matching each event's expected frequency.

## Review trail

- Plan-reviewer SHIP (claude + gpt, 2 rounds).
- Code-reviewer SHIP (claude + gpt + glm, 2 rounds) — round-1 warning (needless net.Server↔http.Server test cast) fixed; native reviewer independently confirmed handler placement/ordering and no wedge on the stdin path.
- Verification-gate SHIP — ran tsc + both crash regressions + full suite (1992).
- **Both tests proven discriminating:** each drives the real emitter (a real `IncomingMessage` captured off a live server; the fake child's `PassThrough` stdin) and is verified to throw against the unfixed code and be inert with the fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>