### PR TITLE
docs: correct Teams/Outlook channel disposition (LIA-392)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,10 @@ Do not invent personal facts. Retrieve them or say what is missing.
 Single Node.js host process. No microservices.
 
 - Channels are skill-installed adapters such as WhatsApp, Telegram, Slack,
-  Discord, and Gmail.
+  Discord, Gmail, Teams, and Outlook. Teams and Outlook are wired and
+  unit-tested but not yet proven end-to-end against live Azure Bot Framework /
+  Microsoft Graph — planned, not ready for production traffic without that
+  verification.
 - Each conversation group runs in its own isolated container.
 - Deus owns the runtime/session/tool/context contract.
 - Claude is the default compatibility backend.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A personal AI that understands you - not just recalls things you've said. It lea
 
 3. **Picks up where you left off** - Context carries over between sessions. Start a project Monday, come back Thursday, and it knows where you left off.
 
-4. **Lives where you already are** - WhatsApp, Telegram, Slack, Discord, Gmail. Add only the ones you need. Your memory follows you across all of them.
+4. **Lives where you already are** - WhatsApp, Telegram, Slack, Discord, Gmail, Teams, Outlook. Add only the ones you need. Your memory follows you across all of them.
 
 5. **Private by default** - Runs on your machine in isolated containers. No cloud sync, no tracking, no data leaving your computer.
 
@@ -288,7 +288,7 @@ Select review wardens (`plan-reviewer`, `code-reviewer`, `ai-eng-warden`) can ru
 |---|---|---|---|---|---|
 | **Memory** | Understands you - indexes facts by meaning, recalls in context | Markdown files | Via OpenClaw | Full-text search + preference profiling | Conversation only |
 | **Learning** | Adapts at the personality level - tone, judgment, suggestions | No | No | Auto-creates & refines skills | No |
-| **Channels** | 5 (WhatsApp, Telegram, Slack, Discord, Gmail) | 10+ | Via OpenClaw | 15+ (WhatsApp, Telegram, Signal, Matrix...) | None |
+| **Channels** | 7 (WhatsApp, Telegram, Slack, Discord, Gmail, Teams, Outlook) | 10+ | Via OpenClaw | 15+ (WhatsApp, Telegram, Signal, Matrix...) | None |
 | **Isolation** | Container per conversation | Opt-in Docker | Landlock + seccomp | Per-session | None |
 | **LLM support** | Claude default, OpenAI/llama.cpp opt-in | Any provider | Any (via OpenClaw) | Any (10+ providers) | Claude only |
 | **Setup** | ~5 min | ~15 min | ~20 min | ~10 min | N/A |


### PR DESCRIPTION
## Summary
- The prior cleanup audit claimed Teams and Outlook had "zero router instantiation." False — both are fully wired (`channels/index.ts` imports them, `index.ts`'s registry loop instantiates every registered factory, `router.ts` dispatches via `ownsJid()`) and unit-tested, just not proven end-to-end against real Azure Bot Framework / Microsoft Graph (this environment has no credentials to run that).
- README.md: adds Teams/Outlook to the channel list and comparison-table count (5 → 7).
- AGENTS.md: extends the channel-architecture bullet with an explicit readiness caveat rather than either omitting them or silently claiming production-readiness.

Full corrected disposition + acceptance-criteria mapping recorded in a [Linear comment on LIA-392](https://linear.app/liams-private-workspace/issue/LIA-392/m05-decide-whether-to-ship-or-shelve-the-teams-and-outlook-providers#comment-b9b685d2). Issue stays open pending a future session with real credentials to complete the E2E acceptance criterion.

## Test plan
- [x] `git diff --stat` — exactly 2 files, README.md + AGENTS.md
- [x] Wiring claim grep-confirmed (`src/channels/index.ts`, `src/index.ts`, `src/router.ts`)
- [x] Both provider unit test suites pass: Teams 9/9, Outlook 10/10
- [x] Confirmed both test suites mock all external SDKs (no live E2E exists) — the "not yet proven end-to-end" claim is accurate, not underclaimed
- [x] Native code-reviewer + GPT + GLM co-gate — all SHIP
- [x] verification-gate — SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)