### PR TITLE
docs: fix stale webui env docs + document deus web endpoint (LIA-393)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,10 +116,11 @@ ODYSSEUS_HTTP_TOKEN=
 ODYSSEUS_MAX_HISTORY_CHARS=24000
 # Auto-consolidate Web UI conversations into vault memory (LIA-295). ON by
 # default; set to 0 (or false) to disable. A conversation is saved + indexed
-# once it reaches MIN_TURNS user messages OR MIN_CHARS of transcript.
+# once it reaches MIN_TURNS user messages AND MIN_CHARS of transcript (both
+# thresholds must be crossed).
 DEUS_WEBUI_CONSOLIDATE=1
 DEUS_WEBUI_CONSOLIDATE_MIN_TURNS=3
-DEUS_WEBUI_CONSOLIDATE_MIN_CHARS=200
+DEUS_WEBUI_CONSOLIDATE_MIN_CHARS=500
 
 # === Evolution / Eval ===
 EMBEDDING_PROVIDER=auto

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A personal AI that understands you - not just recalls things you've said. It lea
 <details>
 <summary>And more</summary>
 
-- **Web UI** - Talk to Deus from a browser. `deus web` launches a local Open WebUI front-end - no chat platform required.
+- **Web UI** - Talk to Deus from a browser. `deus web` launches a local Open WebUI front-end - no chat platform required. The launcher itself lives in `deus-cmd.sh` (shell, not `src/`) and talks to Deus over an OpenAI-compatible `/v1/chat/completions` SSE endpoint (`src/odysseus-server.ts`).
 - **Voice** - Send a voice message and it transcribes and responds. Runs locally on Apple Silicon.
 - **Vision** - Send a photo or screenshot and it sees and responds to it.
 - **Calendar** - Reads and manages your Google Calendar. Ask what's coming up, or tell it to book something.


### PR DESCRIPTION
## Summary
- The prior cleanup audit claimed `MIN_TURNS`/`MIN_CHARS` were undocumented in `.env.example` — false, both were already there. Re-verification found the real gaps: `.env.example`'s `DEUS_WEBUI_CONSOLIDATE_MIN_CHARS` example value (200) was stale against the actual code default (500), and its comment said the trigger condition was "OR" when the gate logic (`webui-consolidation.ts:96-99`) requires both thresholds crossed (AND).
- README now names the `/v1/chat/completions` endpoint (`src/odysseus-server.ts`) `deus web` talks to and confirms `deus-cmd.sh` as the launcher's implementation location — the audit's actual ask, previously misread as an implementation gap when it was only documentation drift.

Full disposition + acceptance-criteria mapping recorded in a [Linear comment on LIA-393](https://linear.app/liams-private-workspace/issue/LIA-393/m06-correct-the-web-ui-documentation-and-configuration-examples#comment-ccb49cb4).

## Test plan
- [x] `git diff --stat` — exactly 2 files, `.env.example` + `README.md`
- [x] Corrected value (500) grep-confirmed against `src/webui-consolidation.ts:38`'s actual default
- [x] Corrected AND semantics grep-confirmed against `webui-consolidation.ts:96-99`'s actual gate logic
- [x] Native code-reviewer + GPT + GLM co-gate — all SHIP
- [x] verification-gate — SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)