### PR TITLE
fix(memory): exclude orphaned entries from FTS query (LIA-370)

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-07-11" # auto-bump @1783777889
+last_verified: "2026-07-15" # auto-bump @1784142175
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -1200,6 +1200,7 @@ def _fts_query(db: sqlite3.Connection, query: str, k: int) -> list[tuple[str, in
             JOIN entries e ON e.id = entries_fts.rowid
             WHERE entries_fts MATCH ?
               AND e.type != 'atom'
+              AND e.orphaned_at IS NULL
             ORDER BY entries_fts.rank
             LIMIT ?
             """,

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -372,6 +372,36 @@ def test_soft_delete_entries_marks_orphaned(mi):
     db.close()
 
 
+def test_fts_query_excludes_orphaned_entries(mi):
+    """LIA-370 (query-time bug): _fts_query must not return soft-deleted entries.
+
+    The non-atom FTS path filtered only `type != 'atom'`. A soft-delete leaves the
+    entries_fts row in place (the write-path drift fixed separately in PR-E), so an
+    orphaned entry surfaced as a live search result. Filtering `orphaned_at IS NULL`
+    fixes it at query time.
+    """
+    db = mi.open_db()
+    cur = db.execute(
+        "INSERT INTO entries (path, date, chunk, type) VALUES (?, ?, ?, ?)",
+        ["/test/orphan.md", "2024-01-01", "unmistakable zebra content", "frontmatter"],
+    )
+    rowid = cur.lastrowid
+    db.execute(
+        "INSERT INTO entries_fts(rowid, chunk) VALUES (?, ?)",
+        [rowid, "unmistakable zebra content"],
+    )
+    db.commit()
+    # Present while active.
+    assert any(p == "/test/orphan.md" for p, _ in mi._fts_query(db, "zebra", 10))
+    # soft_delete leaves the entries_fts row (current write-path behaviour), so this
+    # isolates the query-time filter: the orphaned entry must no longer surface.
+    mi.soft_delete_entries(db, "/test/orphan.md", reason="test")
+    assert all(
+        p != "/test/orphan.md" for p, _ in mi._fts_query(db, "zebra", 10)
+    ), "orphaned entry must not be returned by _fts_query"
+    db.close()
+
+
 # ── cmd_recent ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Audit step 3, PR-F (a query-time bug found while scoping LIA-370, split out to ship/revert cleanly).

`_fts_query` (the non-atom FTS search path) filtered only `type != 'atom'`. A soft-deleted entry whose `entries_fts` row still lingered (the write-path drift fixed separately in PR-E) therefore surfaced as a **live search result today**.

## How

Add `AND e.orphaned_at IS NULL` to `_fts_query`, matching the already-correct `_fts_atom_query`.

## Verification

New regression test `test_fts_query_excludes_orphaned_entries` — verified it FAILS with the clause removed and passes with it. Native Opus + gpt + glm code-review SHIP (confirmed both FTS search paths now filter orphans; no other leak).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>