### PR TITLE
fix(memory): re-embed nodes missing an embedding row (LIA-369)

### DIFF
--- a/scripts/memory_tree.py
+++ b/scripts/memory_tree.py
@@ -1089,7 +1089,27 @@ def build_tree(
         ).fetchone()
         # On rebuild, embeddings were just DELETEd — re-embed even if the
         # content_hash is unchanged, otherwise the vec table stays empty.
-        need_embed = rebuild or existing is None or existing[0] != ch
+        #
+        # LIA-369: also re-embed any node that has NO embedding row, regardless
+        # of content_hash. A transient embed failure otherwise leaves the node
+        # with an advanced content_hash but no embedding; keying need_embed on the
+        # hash alone would see existing[0] == ch next run and never retry, hiding
+        # the node from vector recall forever. Checking the embedding row directly
+        # covers both a failed embed and an unchanged node whose embed failed
+        # mid-rebuild, without corrupting content_hash (the atom->node join at
+        # ~:1376 depends on it).
+        has_embedding = True
+        if sqlite_vec is not None and existing is not None:
+            has_embedding = (
+                db.execute(
+                    "SELECT 1 FROM embeddings WHERE rowid = ?",
+                    (_rowid_for(entry["id"]),),
+                ).fetchone()
+                is not None
+            )
+        need_embed = (
+            rebuild or existing is None or existing[0] != ch or not has_embedding
+        )
         vec = None
         if need_embed and not skip_embed:
             try:
@@ -1098,6 +1118,18 @@ def build_tree(
             except Exception as exc:
                 print(f"WARN: embed failed for {entry['path']}: {exc}", file=sys.stderr)
                 vec = None
+                # LIA-369: drop any stale embedding row on failure. upsert_node
+                # only replaces the vec row when a NEW embedding is supplied, so
+                # for a content-CHANGED node whose embed fails the old row would
+                # otherwise persist — has_embedding would stay true, the retry
+                # would never fire, and a wrong-content vector would keep serving.
+                # Deleting it makes has_embedding false next run (guaranteed retry)
+                # and removes the stale vector.
+                if sqlite_vec is not None and existing is not None:
+                    db.execute(
+                        "DELETE FROM embeddings WHERE rowid = ?",
+                        (_rowid_for(entry["id"]),),
+                    )
         upsert_node(
             db,
             node_id=entry["id"],

--- a/scripts/tests/test_memory_tree.py
+++ b/scripts/tests/test_memory_tree.py
@@ -373,6 +373,58 @@ class TestBuild:
         counts2 = mt.build_tree(fake_vault, tmp_db)
         assert counts2["embedded"] == 0  # content_hash unchanged
 
+    @pytest.mark.skipif(mt.sqlite_vec is None, reason="sqlite_vec not available")
+    def test_embed_failure_retries_on_next_build(self, tmp_db, fake_vault, monkeypatch):
+        # LIA-369: a transient embed failure must not permanently exclude a node
+        # from vector recall — the next build must retry. Against the pre-fix code
+        # (need_embed keyed on content_hash only) the hash advances on failure and
+        # the retry never fires, so c2["embedded"] would be 0.
+        def boom(_text):
+            raise RuntimeError("ollama down")
+
+        monkeypatch.setattr(mt, "embed_text", boom)
+        c1 = mt.build_tree(fake_vault, tmp_db)
+        assert c1["embedded"] == 0
+        assert tmp_db.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0] == 0
+
+        monkeypatch.setattr(mt, "embed_text", StubEmbed())
+        c2 = mt.build_tree(fake_vault, tmp_db)
+        assert c2["embedded"] == 4  # the fix: every node re-embeds
+        assert tmp_db.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0] == 4
+
+    @pytest.mark.skipif(mt.sqlite_vec is None, reason="sqlite_vec not available")
+    def test_embed_failure_on_content_change_drops_stale_and_retries(
+        self, tmp_db, fake_vault, stub_embed, monkeypatch
+    ):
+        # LIA-369 (content-changed case): a node whose content changed and whose
+        # re-embed then fails must NOT keep serving its stale (old-content) vector
+        # forever. The fix deletes the stale embedding row on failure so the node
+        # both stops serving a wrong-content vector AND retries next build.
+        mt.build_tree(fake_vault, tmp_db)  # stub_embed succeeds → 4 embeddings
+        assert tmp_db.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0] == 4
+
+        movies = fake_vault / "Persona" / "taste" / "movies.md"
+        movies.write_text(
+            movies.read_text().replace(
+                "Liam's film taste — stylish crime, Nolan, Fincher; watches with roommates.",
+                "Completely different film taste description to change the content hash.",
+            ),
+            encoding="utf-8",
+        )
+
+        def boom(_text):
+            raise RuntimeError("ollama down")
+
+        monkeypatch.setattr(mt, "embed_text", boom)
+        mt.build_tree(fake_vault, tmp_db)
+        # Stale row for the changed node deleted → 3 remain (pre-fix: stays 4).
+        assert tmp_db.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0] == 3
+
+        monkeypatch.setattr(mt, "embed_text", StubEmbed())
+        c = mt.build_tree(fake_vault, tmp_db)
+        assert c["embedded"] == 1  # the changed node re-embeds (pre-fix: 0)
+        assert tmp_db.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0] == 4
+
     def test_rebuild_orphans_all(self, tmp_db, fake_vault, stub_embed, tmp_path, monkeypatch):
         # Redirect DB_PATH so _backup_db targets the temp file.
         monkeypatch.setattr(mt, "DB_PATH", Path(tmp_db.execute("PRAGMA database_list").fetchone()[2]))


### PR DESCRIPTION
## What

Audit step 3, PR-C. `memory_tree.py build_tree` keyed re-embedding on `content_hash` alone, so a transient `embed_text()` failure — which advanced the stored hash but wrote no vector — hid the node from vector recall **forever** (the next build sees the hash match and skips it).

## How

- `need_embed` now also fires when a node has **no embedding row**, regardless of hash — covers the transient-failure and mid-rebuild cases.
- On embed failure, **drop any stale embedding row** so a content-*changed* node stops serving its old-content vector and is guaranteed to retry next build.
- `content_hash` is left correct (the atom->node join `a.source_hash = n.content_hash` depends on it).

The gpt co-gate caught two flaws in earlier versions (no retry after `--rebuild`; then a stale-vector leak) — the final mechanism handles all three cases (new / rebuild-unchanged / content-changed).

## Verification

Two discriminating tests — both verified to FAIL against the unfixed code and pass with the fix. Full `test_memory_tree.py`: 161 passed. Native Opus + gpt code-review SHIP (glm fails open — z.ai balance exhausted).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>