### PR TITLE
fix(code-search): sweep orphaned rowids from vec/fts on reindex (LIA-368)

### DIFF
--- a/scripts/code_search.py
+++ b/scripts/code_search.py
@@ -623,11 +623,36 @@ def _index_file(
     if existing and existing[0] == file_hash:
         return 0, 1  # unchanged
 
-    # Soft-delete old chunks for this file
+    # Soft-delete old chunks for this file, and hard-delete their now-orphaned
+    # rows from the DERIVED index tables (LIA-368). chunks_vec/chunks_fts have no
+    # orphaned_at column and the search path draws its top-k*3 candidate pool
+    # straight from them BEFORE the orphan filter runs, so leaving stale rowids
+    # there means ~2/3 of every candidate list is dead. Per the no-db-deletion
+    # ADR (Rule 6, amended 2026-07-15) derived index tables may be hard-deleted
+    # per-row; the chunks row keeps its orphaned_at audit trail.
+    stale_rowids = [
+        r[0]
+        for r in db.execute(
+            "SELECT rowid FROM chunks WHERE file_path = ? AND orphaned_at IS NULL",
+            (rel_path,),
+        ).fetchall()
+    ]
     db.execute(
         "UPDATE chunks SET orphaned_at = ? WHERE file_path = ? AND orphaned_at IS NULL",
         (time.strftime("%Y-%m-%dT%H:%M:%S"), rel_path),
     )
+    if stale_rowids:
+        placeholders = ",".join("?" * len(stale_rowids))
+        if _fts_available(db):
+            db.execute(
+                f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders})",
+                stale_rowids,
+            )
+        if sqlite_vec is not None:
+            db.execute(
+                f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders})",
+                stale_rowids,
+            )
 
     chunks = chunk_file(content, rel_path)
     if not chunks:
@@ -1100,6 +1125,58 @@ ABSTAIN_QUERIES_NEAR = [
 ]
 
 
+def gc_index(project_dir: Path | str | None = None) -> dict[str, Any]:
+    """Sweep orphaned rowids from the derived index tables (LIA-368 backfill).
+
+    The forward fix in ``_index_file`` stops NEW orphans accumulating; this
+    one-time (idempotent) sweep removes the EXISTING dead rowids in
+    ``chunks_vec``/``chunks_fts`` whose ``chunks`` row is orphaned or gone. A
+    timestamped ``.bak`` is written first (no-db-deletion ADR: backup before a
+    bulk derived-table operation). Safe to re-run — a clean index deletes 0.
+    """
+    dbp = _resolve_db_path(project_dir)
+    # Migrate a matching legacy shared DB into the per-project location first, as
+    # status()/search()/reindex() do — otherwise a user with an old index gets a
+    # false "No index found" and their stale derived rows go unswept. Key the
+    # migration root to the SAME project_dir _resolve_db_path used (reindex does
+    # this too) so a non-cwd project_dir arg migrates against the matching root.
+    _migrate_legacy_if_match(_project_root(project_dir), dbp)
+    if not dbp.exists():
+        return {"ok": False, "message": "No index found"}
+
+    # WAL-checkpoint before copying so the .bak captures uncheckpointed commits
+    # (shutil.copy2 copies only the main .db, not the -wal/-shm sidecars).
+    ck = sqlite3.connect(dbp)
+    try:
+        ck.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.OperationalError:
+        pass
+    finally:
+        ck.close()
+    # Nanosecond-precision suffix so a quick idempotent rerun can't overwrite
+    # the pre-sweep backup (which holds the only rollback snapshot).
+    backup = dbp.with_suffix(
+        dbp.suffix + f".bak-{time.strftime('%Y%m%dT%H%M%S')}-{time.time_ns()}"
+    )
+    shutil.copy2(dbp, backup)
+
+    db = _init_db(dbp)
+    result: dict[str, Any] = {"ok": True, "backup": str(backup)}
+    try:
+        # Live rowids = chunks rows that are still active.
+        live = "SELECT rowid FROM chunks WHERE orphaned_at IS NULL"
+        if _fts_available(db):
+            cur = db.execute(f"DELETE FROM chunks_fts WHERE rowid NOT IN ({live})")
+            result["fts_deleted"] = cur.rowcount
+        if sqlite_vec is not None:
+            cur = db.execute(f"DELETE FROM chunks_vec WHERE rowid NOT IN ({live})")
+            result["vec_deleted"] = cur.rowcount
+        db.commit()
+    finally:
+        db.close()
+    return result
+
+
 def generate_fixture(
     repo_dir: str | Path,
     output: str | Path | None = None,
@@ -1387,6 +1464,10 @@ def main() -> None:
     p_search.add_argument("-k", type=int, default=DEFAULT_TOP_K)
 
     sub.add_parser("status", help="Show index status")
+    sub.add_parser(
+        "gc-index",
+        help="Sweep orphaned rowids from the derived vec/fts index tables (LIA-368)",
+    )
 
     p_fixture = sub.add_parser("generate-fixture", help="Generate benchmark fixture from codebase")
     p_fixture.add_argument("directory", nargs="?", default=".")
@@ -1412,6 +1493,8 @@ def main() -> None:
         print(json.dumps(results, indent=2))
     elif args.command == "status":
         print(json.dumps(status(), indent=2))
+    elif args.command == "gc-index":
+        print(json.dumps(gc_index(), indent=2))
     elif args.command == "generate-fixture":
         items = generate_fixture(args.directory, output=args.output)
         print(json.dumps({"count": len(items), "output": args.output}, indent=2))

--- a/scripts/tests/test_code_search_cal_cache_bust.py
+++ b/scripts/tests/test_code_search_cal_cache_bust.py
@@ -127,3 +127,105 @@ def test_reindex_busts_cache_when_no_calibration_and_embed_unavailable(
         f"got {code_search._cal_cache!r}"
     )
     assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# LIA-368: orphaned rowids must be swept from the derived index tables
+# ---------------------------------------------------------------------------
+
+def test_reindex_sweeps_orphaned_fts_rowids(monkeypatch, tmp_path):
+    """Reindexing a changed file must DELETE the old chunks' rowids from
+    chunks_fts (derived), not just soft-delete the chunks rows. Pre-fix, the
+    stale fts rowids lingered and polluted the candidate pool."""
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "mod.py"
+    f.write_text("def alpha():\n    return 1\n")
+    db_path = tmp_path / "code_search.db"
+    _seed_db(db_path)
+    monkeypatch.setenv("DEUS_CODE_SEARCH_DB", str(db_path))
+
+    code_search.reindex(str(src))
+    db = sqlite3.connect(str(db_path))
+    fts_ok = code_search._fts_available(db)
+    if not fts_ok:
+        db.close()
+        pytest.skip("chunks_fts not available")
+    old_rowids = [
+        r[0]
+        for r in db.execute(
+            "SELECT rowid FROM chunks WHERE orphaned_at IS NULL"
+        ).fetchall()
+    ]
+    assert old_rowids
+    assert (
+        db.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0] == len(old_rowids)
+    )
+    db.close()
+
+    # Change the file so reindex re-chunks and soft-deletes the old chunks.
+    f.write_text("def beta():\n    return 2\n\ndef gamma():\n    return 3\n")
+    code_search.reindex(str(src))
+
+    db = sqlite3.connect(str(db_path))
+    orphaned = db.execute(
+        "SELECT COUNT(*) FROM chunks WHERE orphaned_at IS NOT NULL"
+    ).fetchone()[0]
+    assert orphaned == len(old_rowids)  # chunks rows preserved (soft-deleted)
+    placeholders = ",".join("?" * len(old_rowids))
+    stale_in_fts = db.execute(
+        f"SELECT COUNT(*) FROM chunks_fts WHERE rowid IN ({placeholders})", old_rowids
+    ).fetchone()[0]
+    assert stale_in_fts == 0, "orphaned rowids must be swept from chunks_fts"
+    live = db.execute(
+        "SELECT COUNT(*) FROM chunks WHERE orphaned_at IS NULL"
+    ).fetchone()[0]
+    assert db.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0] == live
+    db.close()
+
+
+def test_gc_index_sweeps_preexisting_orphan_rows(monkeypatch, tmp_path):
+    """The --gc-index backfill removes EXISTING orphan derived rowids and is
+    idempotent + backs up first."""
+    db_path = tmp_path / "code_search.db"
+    _seed_db(db_path)
+    monkeypatch.setenv("DEUS_CODE_SEARCH_DB", str(db_path))
+
+    db = code_search._init_db(db_path)
+    if not code_search._fts_available(db):
+        db.close()
+        pytest.skip("chunks_fts not available")
+    db.execute(
+        "INSERT INTO chunks (id, file_path, chunk_type, chunk_name, chunk_index, "
+        "content, content_hash, mtime) VALUES ('a','f.py','func','a',0,'x','h',0)"
+    )
+    live_rowid = db.execute("SELECT rowid FROM chunks WHERE id='a'").fetchone()[0]
+    db.execute(
+        "INSERT INTO chunks (id, file_path, chunk_type, chunk_name, chunk_index, "
+        "content, content_hash, mtime, orphaned_at) "
+        "VALUES ('b','f.py','func','b',0,'y','h2',0,'2020-01-01')"
+    )
+    dead_rowid = db.execute("SELECT rowid FROM chunks WHERE id='b'").fetchone()[0]
+    db.execute(
+        "INSERT INTO chunks_fts (rowid, chunk_name, content) VALUES (?,?,?)",
+        (live_rowid, "a", "x"),
+    )
+    db.execute(
+        "INSERT INTO chunks_fts (rowid, chunk_name, content) VALUES (?,?,?)",
+        (dead_rowid, "b", "y"),
+    )
+    db.commit()
+    db.close()
+
+    result = code_search.gc_index()
+    assert result["ok"]
+    assert Path(result["backup"]).exists()  # backup written first
+    assert result["fts_deleted"] == 1
+
+    db = sqlite3.connect(str(db_path))
+    rowids = [r[0] for r in db.execute("SELECT rowid FROM chunks_fts").fetchall()]
+    assert live_rowid in rowids and dead_rowid not in rowids
+    db.close()
+
+    # Idempotent: a clean index sweeps nothing.
+    assert code_search.gc_index()["fts_deleted"] == 0


### PR DESCRIPTION
## What

Audit step 3, PR-D. Reindexing a file soft-deleted its `chunks` rows but never removed the corresponding rowids from the derived `chunks_vec`/`chunks_fts` tables — so ~69% of every top-k*3 candidate pool was dead rows (drawn from the index BEFORE the orphan filter runs).

## How

- `_index_file`: capture the orphaned rowids (preceding SELECT), then `DELETE` them from `chunks_fts` (guarded `_fts_available`) and `chunks_vec` (guarded `sqlite_vec is not None`). The `chunks` rows keep their `orphaned_at` audit trail. Per the no-db-deletion ADR (Rule 6, amended in #1038).
- New idempotent `gc-index` CLI subcommand to sweep the EXISTING backlog: WAL-checkpoints + backs up the DB first (nanosecond-unique `.bak`), migrates a legacy DB like the other entrypoints, then deletes derived rowids whose `chunks` row is orphaned/absent.

## Verification

Reindex-sweep test verified FAILS unfixed / passes fixed; gc-index test asserts backup-first + idempotent. 24 code_search tests pass. Native Opus code-review SHIP (3 rounds — caught a legacy-migration gap + a WAL-backup gap + a backup-collision gap, all fixed) + gpt SHIP. This test file runs in CI (via #1039).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>