### PR TITLE
fix(memory): repair entries_fts write-path drift (LIA-370)

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-07-15" # auto-bump @1784142175
+last_verified: "2026-07-16" # auto-bump @1784178260
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -290,10 +290,20 @@ def _backfill_fts(db: sqlite3.Connection) -> None:
     Silently skips if FTS5 is unavailable.
     """
     try:
-        fts_count = db.execute("SELECT COUNT(*) FROM entries_fts").fetchone()[0]
-        entries_count = db.execute("SELECT COUNT(*) FROM entries WHERE orphaned_at IS NULL").fetchone()[0]
-        if fts_count < entries_count:
-            # Insert active entries rows that don't yet have an FTS5 counterpart
+        # LIA-370(c): the old guard compared COUNT(entries_fts) < COUNT(active
+        # entries). Because stale rows from since-orphaned entries were never
+        # removed from entries_fts (fixed in (b)), fts_count stayed inflated and
+        # could sit >= the shrinking active count forever — so the guard never
+        # fired even when live atoms were genuinely missing from FTS. Gate on the
+        # real gap (active entries with no fts counterpart) instead.
+        missing = db.execute(
+            """
+            SELECT COUNT(*) FROM entries e
+            WHERE e.orphaned_at IS NULL
+            AND e.id NOT IN (SELECT rowid FROM entries_fts)
+            """
+        ).fetchone()[0]
+        if missing:
             db.execute("""
                 INSERT INTO entries_fts(rowid, chunk)
                 SELECT e.id, e.chunk FROM entries e
@@ -526,14 +536,80 @@ def entry_exists(db: sqlite3.Connection, path: str) -> bool:
     return row is not None
 
 
+def _fts_delete_entry(db: sqlite3.Connection, entry_id: int) -> None:
+    """Remove an entry's row from the derived entries_fts index (LIA-370(b)).
+
+    entries_fts is fts5 (no orphaned_at column), and the FTS search path had no
+    orphan filter, so a soft-deleted entry whose fts row lingered kept surfacing
+    as a live result and inflating the _backfill_fts count-guard. Per the
+    no-db-deletion ADR (Rule 6, amended) a derived index row may be hard-deleted
+    per-row; the entries row keeps its orphaned_at audit trail. Silent on missing
+    fts table.
+    """
+    try:
+        db.execute("DELETE FROM entries_fts WHERE rowid = ?", [entry_id])
+    except sqlite3.OperationalError:
+        pass
+
+
 def soft_delete_entries(db: sqlite3.Connection, path: str, reason: str = "re-indexed"):
     """Mark entries for a path as orphaned (soft-delete). See ADR: no-db-deletion.md."""
     now = utc_now().strftime("%Y-%m-%d %H:%M:%S")
+    ids = [
+        r[0]
+        for r in db.execute(
+            "SELECT id FROM entries WHERE path = ? AND orphaned_at IS NULL", [path]
+        ).fetchall()
+    ]
     db.execute(
         "UPDATE entries SET orphaned_at = ?, orphan_reason = ? WHERE path = ? AND orphaned_at IS NULL",
         [now, reason, path],
     )
+    for entry_id in ids:
+        _fts_delete_entry(db, entry_id)
     db.commit()
+
+
+def gc_fts(db_path: Path = None) -> dict:
+    """One-time sweep of stale entries_fts rows for already-orphaned entries
+    (LIA-370(b) backfill). The forward fix stops NEW stale rows; this removes the
+    EXISTING ones. Backs up the DB first — WAL-checkpointed so the .bak captures
+    uncheckpointed commits (the -wal/-shm sidecars aren't copied). Idempotent: a
+    clean index deletes 0.
+    """
+    dbp = db_path or DB_PATH
+    if not dbp.exists():
+        return {"ok": False, "message": "no db"}
+    import shutil
+
+    ck = sqlite3.connect(dbp)
+    try:
+        ck.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.OperationalError:
+        pass
+    finally:
+        ck.close()
+    # Nanosecond-precision suffix so a quick idempotent rerun can't overwrite the
+    # pre-sweep backup (which holds the only rollback snapshot).
+    backup = dbp.with_suffix(
+        dbp.suffix + f".bak-{local_now().strftime('%Y%m%d-%H%M%S')}-{time.time_ns()}"
+    )
+    shutil.copy2(dbp, backup)
+
+    db = sqlite3.connect(dbp)
+    try:
+        cur = db.execute(
+            "DELETE FROM entries_fts WHERE rowid IN "
+            "(SELECT id FROM entries WHERE orphaned_at IS NOT NULL)"
+        )
+        deleted = cur.rowcount
+        db.commit()
+    except sqlite3.OperationalError:
+        # FTS5 unavailable — same condition the other entries_fts guards handle.
+        return {"ok": False, "backup": str(backup), "message": "no fts table"}
+    finally:
+        db.close()
+    return {"ok": True, "backup": str(backup), "fts_deleted": deleted}
 
 
 # ── Parsing ───────────────────────────────────────────────────────────────────
@@ -3600,6 +3676,14 @@ def cmd_extract(session_path: str, no_contradict: bool = False):
             )
             db.execute("INSERT INTO embeddings(rowid, embedding) VALUES (?, ?)",
                        [cur.lastrowid, serialize(vec)])
+            # LIA-370(a): the extract path was missing the entries_fts insert the
+            # non-extract path does (:747), so extracted atoms were never keyword-
+            # indexed — invisible to the BM25 keyword-rescue retrieval path.
+            try:
+                db.execute("INSERT INTO entries_fts(rowid, chunk) VALUES (?, ?)",
+                           [cur.lastrowid, atom["text"]])
+            except sqlite3.OperationalError:
+                pass
             new_atom_ids.append((cur.lastrowid, atom["text"], vec))
             new_count += 1
             print(f"  new atom [{domain}]: {atom['text'][:70]}")
@@ -4160,6 +4244,7 @@ def cmd_prune(dry_run: bool = False):
                     "UPDATE entries SET orphaned_at = ?, orphan_reason = ? WHERE id = ?",
                     [now, "file_deleted", entry_id],
                 )
+                _fts_delete_entry(db, entry_id)  # LIA-370(b)
             orphans += 1
 
     if not dry_run:
@@ -4438,6 +4523,8 @@ def main() -> int:
     group.add_argument("--health", action="store_true",
                        help="Print memory health report (atom quality, confidence, coverage trends) "
                             "and save a daily snapshot to ~/.deus/memory_health.jsonl (no API call)")
+    group.add_argument("--gc-fts", action="store_true",
+                       help="Sweep stale entries_fts rows for already-orphaned entries (LIA-370 backfill; backs up first)")
     group.add_argument("--prune", action="store_true",
                        help="Enforce TTL expiry + clean orphan DB rows (no API call)")
     group.add_argument("--invalidate", metavar="PATH",
@@ -4547,6 +4634,9 @@ def main() -> int:
         return
     if args.health:
         cmd_health(save=not args.no_save)
+        return
+    if args.gc_fts:
+        print(json.dumps(gc_fts(), indent=2))
         return
     if args.prune:
         cmd_prune(dry_run=args.dry_run)

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -372,6 +372,105 @@ def test_soft_delete_entries_marks_orphaned(mi):
     db.close()
 
 
+# ── LIA-370: entries_fts write-path repair ──────────────────────────────────
+
+def test_cmd_extract_indexes_atom_into_fts(mi, fresh_vault, monkeypatch):
+    """LIA-370(a): a newly extracted atom must land in entries_fts so the BM25
+    keyword-rescue path can find it. The extract path previously skipped it."""
+    session = fresh_vault / "Session-Logs" / "2024-01-01" / "t.md"
+    session.parent.mkdir(parents=True, exist_ok=True)
+    session.write_text(
+        "---\ntype: session\ndate: 2024-01-01\ntldr: t\n---\n## Decisions Made\n- x\n"
+    )
+    monkeypatch.setattr(
+        mi, "extract_atoms", lambda c: [{"text": "unmistakable zebra fact", "category": "fact"}]
+    )
+    monkeypatch.setattr(mi, "embed", lambda t: [0.1] * 768)
+    # no_contradict=True keeps the test provider-independent (skips the
+    # detect_contradictions LLM path explicitly, not just incidentally).
+    mi.cmd_extract(str(session), no_contradict=True)
+    # Query via a RAW connection — mi.open_db() runs _backfill_fts, which would
+    # insert the atom itself and mask a missing direct insert. This isolates the
+    # extract-path insert (fix a), not the backfill (fix c).
+    import sqlite3 as _sqlite3
+
+    raw = _sqlite3.connect(mi.DB_PATH)
+    atom_id = raw.execute("SELECT id FROM entries WHERE type='atom' LIMIT 1").fetchone()[0]
+    assert (
+        raw.execute("SELECT COUNT(*) FROM entries_fts WHERE rowid = ?", [atom_id]).fetchone()[0]
+        == 1
+    ), "extracted atom must be indexed into entries_fts by cmd_extract itself"
+    raw.close()
+
+
+def test_soft_delete_removes_fts_row(mi):
+    """LIA-370(b): soft_delete_entries must remove the entry's entries_fts row."""
+    db = mi.open_db()
+    cur = db.execute(
+        "INSERT INTO entries (path, date, chunk, type) VALUES (?,?,?,?)",
+        ["/x/y.md", "2024-01-01", "some chunk", "frontmatter"],
+    )
+    rowid = cur.lastrowid
+    db.execute("INSERT INTO entries_fts(rowid, chunk) VALUES (?, ?)", [rowid, "some chunk"])
+    db.commit()
+    assert db.execute("SELECT COUNT(*) FROM entries_fts WHERE rowid=?", [rowid]).fetchone()[0] == 1
+    mi.soft_delete_entries(db, "/x/y.md", reason="test")
+    assert db.execute("SELECT COUNT(*) FROM entries_fts WHERE rowid=?", [rowid]).fetchone()[0] == 0
+    db.close()
+
+
+def test_backfill_fts_fires_despite_inflated_count(mi):
+    """LIA-370(c): _backfill_fts must fire when an active entry is missing from
+    FTS even though stale (orphaned) fts rows inflate the total count — the old
+    count-only guard would skip it."""
+    db = mi.open_db()
+    active = db.execute(
+        "INSERT INTO entries (path, date, chunk, type) VALUES (?,?,?,?)",
+        ["/active.md", "2024-01-01", "active chunk", "frontmatter"],
+    ).lastrowid
+    orphan = db.execute(
+        "INSERT INTO entries (path, date, chunk, type, orphaned_at) VALUES (?,?,?,?,?)",
+        ["/orphan.md", "2024-01-01", "orphan chunk", "frontmatter", "2020-01-01 00:00:00"],
+    ).lastrowid
+    db.execute("INSERT INTO entries_fts(rowid, chunk) VALUES (?, ?)", [orphan, "orphan chunk"])
+    db.commit()
+    assert db.execute("SELECT COUNT(*) FROM entries_fts WHERE rowid=?", [active]).fetchone()[0] == 0
+    mi._backfill_fts(db)
+    assert (
+        db.execute("SELECT COUNT(*) FROM entries_fts WHERE rowid=?", [active]).fetchone()[0] == 1
+    ), "active entry missing from FTS must be backfilled despite inflated count"
+    db.close()
+
+
+def test_gc_fts_sweeps_orphaned_fts_rows(mi):
+    """LIA-370(b) backfill: gc_fts removes EXISTING stale fts rows, backs up
+    first, and is idempotent."""
+    db = mi.open_db()
+    orphan = db.execute(
+        "INSERT INTO entries (path, date, chunk, type, orphaned_at) VALUES (?,?,?,?,?)",
+        ["/o.md", "2024-01-01", "o", "frontmatter", "2020-01-01 00:00:00"],
+    ).lastrowid
+    active = db.execute(
+        "INSERT INTO entries (path, date, chunk, type) VALUES (?,?,?,?)",
+        ["/a.md", "2024-01-01", "a", "frontmatter"],
+    ).lastrowid
+    db.execute("INSERT INTO entries_fts(rowid, chunk) VALUES (?, ?)", [orphan, "o"])
+    db.execute("INSERT INTO entries_fts(rowid, chunk) VALUES (?, ?)", [active, "a"])
+    db.commit()
+    db.close()
+
+    result = mi.gc_fts()
+    assert result["ok"] and result["fts_deleted"] == 1
+    from pathlib import Path as _P
+    assert _P(result["backup"]).exists()
+
+    db = mi.open_db()
+    rows = [r[0] for r in db.execute("SELECT rowid FROM entries_fts").fetchall()]
+    assert active in rows and orphan not in rows
+    db.close()
+    assert mi.gc_fts()["fts_deleted"] == 0  # idempotent
+
+
 def test_fts_query_excludes_orphaned_entries(mi):
     """LIA-370 (query-time bug): _fts_query must not return soft-deleted entries.
 
@@ -1341,8 +1440,15 @@ def test_fts_populated_on_add(mi, tmp_path, monkeypatch):
     assert fts_count >= entries_count
 
 
-def test_soft_delete_preserves_fts_rows(mi, tmp_path, monkeypatch):
-    """soft_delete_entries keeps FTS5 rows (they're derived, filtered via entry join)."""
+def test_soft_delete_removes_fts_rows(mi, tmp_path, monkeypatch):
+    """soft_delete_entries REMOVES the derived FTS5 rows (LIA-370(b)).
+
+    Previously they were left in place ('filtered at query time'), but the FTS
+    query path had no orphan filter (LIA-370 bonus), so stale rows surfaced as
+    live results AND inflated the _backfill_fts guard. Per the no-db-deletion
+    ADR (Rule 6, amended) the derived index rows are hard-deleted; the entries
+    rows keep their orphaned_at audit trail.
+    """
     session = tmp_path / "vault" / "Session-Logs" / "del-session.md"
     _make_session_file(session)
     monkeypatch.setattr(mi, "embed", lambda text: [0.0] * mi.EMBED_DIM)
@@ -1351,11 +1457,11 @@ def test_soft_delete_preserves_fts_rows(mi, tmp_path, monkeypatch):
 
     db = mi.open_db()
     before = db.execute("SELECT COUNT(*) FROM entries_fts").fetchone()[0]
+    assert before > 0
     mi.soft_delete_entries(db, str(session), reason="test")
     after = db.execute("SELECT COUNT(*) FROM entries_fts").fetchone()[0]
-    # FTS rows preserved — orphaned entries are filtered at query time, not at delete time
-    assert after == before
-    # Entry is soft-deleted
+    assert after < before  # the soft-deleted entry's FTS rows are gone
+    # Entry itself is soft-deleted (row preserved with orphaned_at).
     assert not mi.entry_exists(db, str(session))
 
 


### PR DESCRIPTION
## What

Audit step 3, PR-E. Three write-path defects left the memory keyword (FTS5) index out of sync with the `entries` table:
- **(a)** atoms from the extract path were never inserted into `entries_fts` — invisible to BM25 keyword-rescue retrieval.
- **(b)** soft-deleted entries left their `entries_fts` rows behind.
- **(c)** those never-removed stale rows inflated the `_backfill_fts` count-guard so it never fired, even when live atoms were genuinely missing.

## How

- (a) insert into `entries_fts` on extract (mirrors the non-extract path).
- (b) new `_fts_delete_entry` helper called in `soft_delete_entries` (ids captured before the UPDATE) and the `cmd_prune` orphan loop. Per the no-db-deletion ADR (Rule 6, amended in #1038).
- (c) gate `_backfill_fts` on the real missing-row anti-join, not the defeated count comparison.
- New idempotent `--gc-fts` sweep for the existing stale rows (WAL-checkpointed backup first).

## Verification

4 discriminating tests (a/b/c + gc_fts) verified FAIL unfixed / pass fixed; the stale `preserves_fts_rows` test was updated to the corrected `removes_fts_rows` contract. Native Opus code-review SHIP (3 rounds) + gpt SHIP. NOTE: `test_memory_indexer.py` isn't CI-gated yet (LIA-438) so these tests ran locally + in review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>