### PR TITLE
chore(deps): pin @commitlint/config-conventional to 21.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^21.1.0",
-        "@commitlint/config-conventional": "^21.2.0",
+        "@commitlint/config-conventional": "21.1.0",
         "@eslint/js": "^10.0.1",
         "@langchain/mcp-adapters": "^1.1.3",
         "@langchain/ollama": "^1.3.0",
@@ -400,14 +400,14 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
-      "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.1.0.tgz",
+      "integrity": "sha512-BIFl8xM+3SLy3jrblUC3wmQLCVbLty+++6o859BDCmybVrQdXmIWO+dlkGIbv/M2bBoC55wGuh0zGiw3TPjL1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.2.0",
-        "conventional-changelog-conventionalcommits": "^10.0.0"
+        "@commitlint/types": "^21.1.0",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -695,16 +695,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
-      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3751,16 +3741,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-parser": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^21.1.0",
-    "@commitlint/config-conventional": "^21.2.0",
+    "@commitlint/config-conventional": "21.1.0",
     "@eslint/js": "^10.0.1",
     "@langchain/mcp-adapters": "^1.1.3",
     "@langchain/ollama": "^1.3.0",


### PR DESCRIPTION
## Summary
- `deus-v2/dev`'s `package.json` allowed `@commitlint/config-conventional` to float to `^21.2.0`, which resolves to `21.2.0` and pulls in `conventional-changelog-conventionalcommits@10.2.1` -- an ESM-only package with no `require` export condition.
- commitlint's own `@commitlint/resolve-extends` still loads shareable configs via `require.resolve()`, so **every** commit-msg hook invocation on this branch currently crashes with `ERR_PACKAGE_PATH_NOT_EXPORTED` before validating the message, regardless of commit content.
- Pins to `21.1.0` exactly (matching what `main` already uses), whose own `conventional-changelog-conventionalcommits` dependency stays on the CJS-compatible `9.x` line.

Discovered while landing LIA-415 -- unrelated to that ticket's diff, but blocking, so fixing it as its own small commit rather than bundling it into a feature PR.

## Test plan
- [x] `npx --no -- commitlint` with a sample conventional-commit message now validates silently (previously crashed)
- [x] `npm run typecheck` passes (devDependency only, no runtime impact)
- [x] `git diff --stat` confirms only `package.json`/`package-lock.json` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)