### PR TITLE
feat(agent-runtimes): inject vault context when sessions open (LIA-416)

### DIFF
--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-07-13" # auto-bump @1783974306
+last_verified: "2026-07-16" # auto-bump @1784179570
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/agent-runtimes/deus-native-backend.ts
+++ b/src/agent-runtimes/deus-native-backend.ts
@@ -307,12 +307,16 @@ export class DeusNativeRuntime implements AgentRuntime {
 
       // Session-open injection fires only on a genuinely NEW session (once
       // per open lifecycle — a resumed turn never even calls
-      // loadSessionOpenContext) AND only when the group actually has
-      // CLAUDE.md content (systemMessage stays undefined otherwise). The
-      // returned SessionOpenRecord is an inspectable log consumed by tests,
-      // matching B2's own discarded-logs precedent here.
+      // loadSessionOpenContext) AND only when session-open content actually
+      // exists (systemMessage stays undefined otherwise). Awaited (LIA-416/
+      // D2): the loader now composes vault context whose recent-sessions
+      // provider is an async subprocess — the await occurs ONLY on this
+      // new-session branch, bounded by the vault pipeline's 5s subprocess
+      // timeout, and never blocks the process-wide event loop. The returned
+      // SessionOpenRecord is an inspectable log consumed by tests, matching
+      // B2's own discarded-logs precedent here.
       const sessionOpenMessage = isNewSession
-        ? loadSessionOpenContext(runContext).systemMessage
+        ? (await loadSessionOpenContext(runContext)).systemMessage
         : undefined;
 
       const model = buildProxyRoutedChatAnthropic(runContext);

--- a/src/agent-runtimes/lifecycle-events.test.ts
+++ b/src/agent-runtimes/lifecycle-events.test.ts
@@ -17,6 +17,8 @@ import {
   buildPromptLifecycleHook,
   type PromptEventRecord,
 } from './lifecycle-events.js';
+import { loadVaultContext } from './vault-context.js';
+import type { VaultContextResult } from './vault-context.js';
 import { defaultSession } from './types.js';
 import type {
   RuntimeEvent,
@@ -48,6 +50,11 @@ const harness = vi.hoisted(() => ({
   makeModel: null as null | (() => unknown),
   tools: [] as unknown[],
   captured: [] as Array<{ systemMessage: unknown; systemPrompt: unknown }>,
+  // LIA-416 (D2): what the mocked vault facade returns for a CONTROL-group
+  // call. undefined => "eligible, vault unavailable, no content" (the
+  // hermetic default — real config/vault/DB/subprocess must never be touched
+  // from this file). Non-control calls always get the real skip shape.
+  vaultContent: undefined as string | undefined,
 }));
 
 // Real langchain everywhere (createMiddleware, FakeToolCallingModel, tool,
@@ -111,6 +118,39 @@ vi.mock('./checkpointer.js', async (importOriginal) => {
   return {
     ...actual,
     getCheckpointer: () => actual.getCheckpointer(harness.checkpointerDbPath),
+  };
+});
+
+// LIA-416 (D2): hermetic vault-context facade — real config/vault/DB/
+// subprocess access must never happen from this file. A non-control call
+// delegates to the REAL loadVaultContext, which exits on the
+// non-control-group check before any I/O (verified: vault-context.ts's
+// eligibility exits run strictly before readConfig/resolveVault/fs/spawn),
+// so that branch stays genuinely hermetic. A control-group call returns
+// harness.vaultContent instead of touching the real vault. Wrapped in
+// `vi.fn` so tests can assert call counts directly (AC1/AC3/AC4).
+vi.mock('./vault-context.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./vault-context.js')>();
+  return {
+    ...actual,
+    loadVaultContext: vi.fn(
+      async (runContext: RunContext): Promise<VaultContextResult> => {
+        if (!runContext.isControlGroup) {
+          return actual.loadVaultContext(runContext);
+        }
+        const hasContent = harness.vaultContent !== undefined;
+        return {
+          content: harness.vaultContent,
+          record: {
+            eligible: true,
+            vaultAvailable: hasContent,
+            contextLoaded: hasContent,
+            loadedSections: hasContent ? (['vault-files'] as const) : [],
+            loadedVaultFiles: [],
+          },
+        };
+      },
+    ),
   };
 });
 
@@ -217,6 +257,8 @@ beforeEach(() => {
   harness.makeModel = singleCycleModel;
   harness.tools = [];
   harness.captured.length = 0;
+  harness.vaultContent = undefined;
+  vi.mocked(loadVaultContext).mockClear();
 });
 
 afterEach(() => {
@@ -412,6 +454,85 @@ describe('runTurn session-open lifecycle (AC1/AC4)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// LIA-416 (D2) — literal AC1/AC3/AC4 for the vault-context surface, through
+// REAL runTurn calls (the mocked loadVaultContext from './vault-context.js'
+// above, driven by harness.vaultContent — never the real vault/config/DB/
+// subprocess).
+// ---------------------------------------------------------------------------
+describe('runTurn vault-context session-open lifecycle (LIA-416 AC1/AC3/AC4)', () => {
+  it('invokes the vault surface once on a new control-group session and includes its content before the model call (AC1)', async () => {
+    const runtime = createDeusNativeRuntime(stubDeps);
+    harness.vaultContent = '=== VAULT: CLAUDE.md ===\nVault identity content.';
+
+    const result = await runtime.runTurn(
+      runCtx('vaultgroup', true),
+      defaultSession('', 'deus-native'),
+      () => {},
+    );
+
+    expect(result.status).toBe('success');
+    expect(vi.mocked(loadVaultContext)).toHaveBeenCalledTimes(1);
+    expect(harness.captured.length).toBeGreaterThan(0);
+    for (const call of harness.captured) {
+      expect(msgText(call.systemMessage)).toContain('Vault identity content.');
+    }
+  });
+
+  it('does not re-invoke the vault surface or re-inject its content on the resumed turn (AC4)', async () => {
+    const runtime = createDeusNativeRuntime(stubDeps);
+    harness.vaultContent = '=== VAULT: CLAUDE.md ===\nVault identity content.';
+
+    const result1 = await runtime.runTurn(
+      runCtx('vaultgroup', true),
+      defaultSession('', 'deus-native'),
+      () => {},
+    );
+    expect(vi.mocked(loadVaultContext)).toHaveBeenCalledTimes(1);
+    const sessionId1 = result1.sessionRef?.session_id;
+    expect(sessionId1).toBeTruthy();
+
+    harness.captured.length = 0;
+    const result2 = await runtime.runTurn(
+      runCtx('vaultgroup', true),
+      { backend: 'deus-native', session_id: sessionId1 as string },
+      () => {},
+    );
+
+    expect(result2.status).toBe('success');
+    // Literal once-per-session gating (AC3): the resumed turn must NOT call
+    // the facade again.
+    expect(vi.mocked(loadVaultContext)).toHaveBeenCalledTimes(1);
+    expect(harness.captured.length).toBeGreaterThan(0);
+    for (const call of harness.captured) {
+      expect(msgText(call.systemMessage)).not.toContain(
+        'Vault identity content.',
+      );
+    }
+  });
+
+  it('delegates to the real (ineligible) facade for a non-control group and injects no vault content', async () => {
+    const runtime = createDeusNativeRuntime(stubDeps);
+    harness.vaultContent = '=== VAULT: CLAUDE.md ===\nVault identity content.';
+
+    const result = await runtime.runTurn(
+      runCtx('nonvaultgroup', false),
+      defaultSession('', 'deus-native'),
+      () => {},
+    );
+
+    expect(result.status).toBe('success');
+    // The mock still records the call (it delegates to the real early-exit
+    // for non-control groups), but the delegated real facade must report
+    // ineligibility rather than the harness's fixture content leaking in.
+    for (const call of harness.captured) {
+      expect(msgText(call.systemMessage)).not.toContain(
+        'Vault identity content.',
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC2 — prompt middleware fires (and records) once per submitted prompt /
 // model-decision cycle, before the model call.
 // ---------------------------------------------------------------------------
@@ -474,9 +595,11 @@ describe('turn-complete lifecycle event (AC3)', () => {
 // fixture groups/ dir.
 // ---------------------------------------------------------------------------
 describe('loadSessionOpenContext (AC5)', () => {
-  it('loads a present group CLAUDE.md and records it', () => {
+  it('loads a present group CLAUDE.md and records it', async () => {
     writeGroupClaudeMd('groupa', 'Rule A content.');
-    const { systemMessage, record } = loadSessionOpenContext(runCtx('groupa'));
+    const { systemMessage, record } = await loadSessionOpenContext(
+      runCtx('groupa'),
+    );
     expect(systemMessage).toContain('Rule A content.');
     expect(record.sessionOpened).toBe(true);
     expect(record.groupClaudeMdLoaded).toBe(true);
@@ -484,8 +607,8 @@ describe('loadSessionOpenContext (AC5)', () => {
     expect(typeof record.timestamp).toBe('number');
   });
 
-  it('returns undefined cleanly (no throw) when no CLAUDE.md exists', () => {
-    const { systemMessage, record } = loadSessionOpenContext(
+  it('returns undefined cleanly (no throw) when no CLAUDE.md exists', async () => {
+    const { systemMessage, record } = await loadSessionOpenContext(
       runCtx('missinggroup'),
     );
     expect(systemMessage).toBeUndefined();
@@ -493,20 +616,22 @@ describe('loadSessionOpenContext (AC5)', () => {
     expect(record.globalClaudeMdLoaded).toBe(false);
   });
 
-  it('includes global CLAUDE.md for a non-main group (matching the container path’s main-vs-other mounting distinction)', () => {
+  it('includes global CLAUDE.md for a non-main group (matching the container path’s main-vs-other mounting distinction)', async () => {
     writeGroupClaudeMd('groupb', 'Group B rules.');
     writeGlobalClaudeMd('Global shared rules.');
-    const { systemMessage, record } = loadSessionOpenContext(runCtx('groupb'));
+    const { systemMessage, record } = await loadSessionOpenContext(
+      runCtx('groupb'),
+    );
     expect(systemMessage).toContain('Global shared rules.');
     expect(systemMessage).toContain('Group B rules.');
     expect(record.globalClaudeMdLoaded).toBe(true);
     expect(record.groupClaudeMdLoaded).toBe(true);
   });
 
-  it('EXCLUDES global CLAUDE.md for the main/control group', () => {
+  it('EXCLUDES global CLAUDE.md for the main/control group', async () => {
     writeGroupClaudeMd('maingroup', 'Main group rules.');
     writeGlobalClaudeMd('Global shared rules.');
-    const { systemMessage, record } = loadSessionOpenContext(
+    const { systemMessage, record } = await loadSessionOpenContext(
       runCtx('maingroup', true),
     );
     expect(systemMessage).toContain('Main group rules.');
@@ -514,9 +639,11 @@ describe('loadSessionOpenContext (AC5)', () => {
     expect(record.globalClaudeMdLoaded).toBe(false);
   });
 
-  it('global-only content still produces a session-open message for a non-main group', () => {
+  it('global-only content still produces a session-open message for a non-main group', async () => {
     writeGlobalClaudeMd('Global-only rules.');
-    const { systemMessage, record } = loadSessionOpenContext(runCtx('groupc'));
+    const { systemMessage, record } = await loadSessionOpenContext(
+      runCtx('groupc'),
+    );
     expect(systemMessage).toContain('Global-only rules.');
     expect(record.globalClaudeMdLoaded).toBe(true);
     expect(record.groupClaudeMdLoaded).toBe(false);

--- a/src/agent-runtimes/lifecycle-events.ts
+++ b/src/agent-runtimes/lifecycle-events.ts
@@ -5,17 +5,22 @@
  * `runTurn`-level LIFECYCLE (session-open / per-prompt / turn-complete), not
  * tool/model-call middleware substance. Two concerns live here:
  *
- * 1. **Session-open context loading** (`loadSessionOpenContext`): reads the
- *    group's own `groups/<folder>/CLAUDE.md` (and `groups/global/CLAUDE.md`
- *    for non-control groups, mirroring the container path's own main-vs-other
+ * 1. **Session-open context loading** (`loadSessionOpenContext`): composes
+ *    vault context (LIA-416/D2 — control group only, via
+ *    `vault-context.ts`'s `loadVaultContext` facade) with the group's own
+ *    `groups/<folder>/CLAUDE.md` (and `groups/global/CLAUDE.md` for
+ *    non-control groups, mirroring the container path's own main-vs-other
  *    distinction — `container-mounter.ts` mounts `/workspace/global`
  *    read-only only for non-main groups, and the container-side reader is
  *    `context-registry.ts`'s `GLOBAL RULES: CLAUDE.md` entry with
  *    `skipForControlGroup: true`). Called ONLY when the caller (`runTurn`)
- *    has already determined this is a genuinely NEW session
- *    (`sessionRef.session_id === ''`) — literal once-per-session gating: it
- *    runs once when a new runtime session opens and never repeats for the
- *    same open lifecycle. A resumed turn never calls this at all.
+ *    has already determined this is a genuinely NEW session — since
+ *    B4/LIA-404 that signal is REAL checkpointer-tuple existence
+ *    (`priorTuple === undefined` for the outgoing thread_id), NOT the
+ *    pre-B4 `sessionRef.session_id === ''` string check — literal
+ *    once-per-session gating: it runs once when a new runtime session opens
+ *    and never repeats for the same open lifecycle. A resumed turn (an
+ *    existing checkpointer tuple) never calls this at all.
  *
  * 2. **Prompt lifecycle hook** (`buildPromptLifecycleHook`): ONE middleware,
  *    TWO hooks with split responsibilities:
@@ -64,6 +69,7 @@ import {
 
 import type { RunContext } from './types.js';
 import { resolveGroupFolderPath } from '../group-folder.js';
+import { loadVaultContext, type VaultContextRecord } from './vault-context.js';
 
 /**
  * One inspectable record per session-open event, matching the
@@ -79,6 +85,11 @@ export interface SessionOpenRecord {
   /** Whether `groups/global/CLAUDE.md` was included (non-control groups
    *  only, and only when present with non-empty content). */
   globalClaudeMdLoaded: boolean;
+  /** LIA-416 (D2): outcome metadata from the vault-context surface —
+   *  eligibility/skip reason, vault availability, and WHICH ordered sections
+   *  and configured filenames contributed. Identifiers and booleans only,
+   *  never vault contents. */
+  vaultContext: VaultContextRecord;
   timestamp: number;
 }
 
@@ -96,31 +107,51 @@ function readContextFileIfPresent(filePath: string): string | undefined {
 
 /**
  * Loads the session-open context for a genuinely NEW session (the caller —
- * `runTurn` — decides that; this function is never called on a resumed
- * turn). Joins the present files into one system-role message string, or
- * returns `undefined` when neither exists — session-open injection is gated
- * on CONTENT PRESENCE as well as new-vs-resumed status.
+ * `runTurn` — decides that via checkpointer-tuple existence; this function is
+ * never called on a resumed turn). Joins the present parts into one
+ * system-role message string, or returns `undefined` when none exists —
+ * session-open injection is gated on CONTENT PRESENCE as well as
+ * new-vs-resumed status.
  *
- * Scope is deliberately group-scoped CLAUDE.md ONLY: `groups/<folder>/` is
- * the real, group-scoped source the container path bind-mounts as
- * `/workspace/group`, so reading it for THAT group's own session cannot leak
- * into another group's session. `groups/global/CLAUDE.md` is deliberately
- * shared across all non-main groups by the EXISTING container path's own
- * design — an existing pattern mirrored, not a new risk. AGENTS.md/
- * AI_AGENT_GUIDELINES.md/persona context and full `context-registry.ts`
- * parity stay explicitly out of scope (see deus-native-backend.ts's
- * non-goals).
+ * Composition order (LIA-416/D2) is general-before-specific: vault context
+ * first (personal identity/health/recent-memory — control group only, see
+ * vault-context.ts's eligibility rationale), then global CLAUDE.md
+ * (non-control groups only, unchanged), then group CLAUDE.md (most
+ * specific, unchanged). The vault content already carries the reference
+ * hook's own `=== ... ===` headers, so no wrapper header is added.
+ *
+ * Async solely because the vault pipeline's recent-sessions provider spawns
+ * `memory_indexer.py` asynchronously — the await occurs only on a genuine
+ * session open, and the existing global/group reads stay sync.
+ *
+ * Beyond vault context, scope is deliberately group-scoped CLAUDE.md ONLY:
+ * `groups/<folder>/` is the real, group-scoped source the container path
+ * bind-mounts as `/workspace/group`, so reading it for THAT group's own
+ * session cannot leak into another group's session. `groups/global/CLAUDE.md`
+ * is deliberately shared across all non-main groups by the EXISTING container
+ * path's own design — an existing pattern mirrored, not a new risk.
+ * AGENTS.md/AI_AGENT_GUIDELINES.md/persona context and full
+ * `context-registry.ts` parity stay explicitly out of scope (see
+ * deus-native-backend.ts's non-goals).
  */
-export function loadSessionOpenContext(runContext: RunContext): {
+export async function loadSessionOpenContext(runContext: RunContext): Promise<{
   systemMessage: string | undefined;
   record: SessionOpenRecord;
-} {
+}> {
   // Reused, not reimplemented: path-traversal-safe by construction
   // (ensureWithinBase inside group-folder.ts).
   const groupDir = resolveGroupFolderPath(runContext.groupFolder);
   const parts: string[] = [];
   let globalClaudeMdLoaded = false;
   let groupClaudeMdLoaded = false;
+
+  // Vault context FIRST (most general). The facade owns ALL eligibility/
+  // skip/fail-soft semantics — here it is one awaited call whose content is
+  // included only when non-empty, exactly like the file parts below.
+  const vault = await loadVaultContext(runContext);
+  if (vault.content !== undefined) {
+    parts.push(vault.content);
+  }
 
   // Global rules first (general), group rules second (specific) — non-control
   // groups only, mirroring container-mounter.ts's main-vs-other mounting
@@ -151,6 +182,7 @@ export function loadSessionOpenContext(runContext: RunContext): {
       sessionOpened: true,
       groupClaudeMdLoaded,
       globalClaudeMdLoaded,
+      vaultContext: vault.record,
       timestamp: Date.now(),
     },
   };

--- a/src/agent-runtimes/vault-context.test.ts
+++ b/src/agent-runtimes/vault-context.test.ts
@@ -1,0 +1,926 @@
+/**
+ * Unit + differential tests for the session-open vault-context surface
+ * (LIA-416 / D2, src/agent-runtimes/vault-context.ts).
+ *
+ * Every unit test injects the full seam set (paths, config, clock, env,
+ * spawn) so nothing here ever reads the real user vault, cache, config,
+ * memory database, or session logs — all filesystem work happens inside a
+ * per-test temp dir.
+ *
+ * The differential suite ("vault context parity (LIA-416 AC5)") is
+ * POSIX-only (the reference `vault_context_hook.py` declares macOS/Linux):
+ * it builds ONE real fixture, runs BOTH the TypeScript facade and the actual
+ * Python hook against it with an identical environment, and asserts literal
+ * output equality.
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import Database from 'better-sqlite3';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  loadVaultContext,
+  normalizeVaultAutoload,
+  MAX_SECTION_CHARS,
+  SEMANTIC_TTL_SECONDS,
+  type SpawnFn,
+  type SpawnedChildLike,
+  type VaultContextDeps,
+} from './vault-context.js';
+import type { RunContext } from './types.js';
+import { IS_WINDOWS } from '../platform.js';
+
+// Real repo scripts dir (this file lives at src/agent-runtimes/) —
+// realpath'd to mirror Python's `Path(__file__).resolve()`.
+const SCRIPTS_DIR = fs.realpathSync(
+  fileURLToPath(new URL('../../scripts', import.meta.url)),
+);
+
+let tmpRoot = '';
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'd2-vault-context-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function ctx(overrides: Partial<RunContext> = {}): RunContext {
+  return {
+    prompt: 'hello',
+    groupFolder: 'main',
+    chatJid: 'test@g.us',
+    isControlGroup: true,
+    ...overrides,
+  };
+}
+
+/** Fake spawn factory — scripts one child's behavior per call. */
+function fakeSpawn(script: {
+  stdout?: string;
+  emitError?: boolean;
+  neverClose?: boolean;
+  onKill?: () => void;
+  throwOnSpawn?: boolean;
+}): SpawnFn {
+  return () => {
+    if (script.throwOnSpawn) throw new Error('spawn EACCES');
+    let dataCb: ((chunk: Buffer | string) => void) | undefined;
+    let errorCb: ((...args: unknown[]) => void) | undefined;
+    let closeCb: ((...args: unknown[]) => void) | undefined;
+    const child: SpawnedChildLike = {
+      stdout: {
+        on: (event, cb) => {
+          if (event === 'data') dataCb = cb;
+        },
+      },
+      on: (event, cb) => {
+        if (event === 'error') errorCb = cb;
+        if (event === 'close') closeCb = cb;
+      },
+      kill: () => script.onKill?.(),
+    };
+    setTimeout(() => {
+      if (script.emitError) {
+        errorCb?.(new Error('spawn ENOENT'));
+        return;
+      }
+      if (script.stdout !== undefined) dataCb?.(Buffer.from(script.stdout));
+      if (!script.neverClose) closeCb?.(0);
+    }, 0);
+    return child;
+  };
+}
+
+/** Healthy memory_tree.db fixture — root node, one extra node, one edge. */
+function writeHealthyDb(dbPath: string): void {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  db.exec(
+    'CREATE TABLE nodes (path TEXT, orphaned_at TEXT); ' +
+      'CREATE TABLE edges (kind TEXT, expired_at TEXT);',
+  );
+  const insertNode = db.prepare(
+    'INSERT INTO nodes (path, orphaned_at) VALUES (?, NULL)',
+  );
+  insertNode.run('MEMORY_TREE.md');
+  insertNode.run('Atoms/example.md');
+  db.prepare(
+    "INSERT INTO edges (kind, expired_at) VALUES ('child', NULL)",
+  ).run();
+  db.close();
+}
+
+interface Fixture {
+  deps: VaultContextDeps;
+  vaultPath: string;
+  homeDir: string;
+  config: Record<string, unknown>;
+}
+
+/**
+ * Standard eligible-control-group fixture: real temp vault + home dirs,
+ * healthy DB, and inert defaults for every provider (no checkpoint, no
+ * cache, empty subprocess output) — individual tests turn sections on.
+ */
+function makeFixture(
+  configOverrides: Record<string, unknown> = {},
+  depOverrides: Partial<VaultContextDeps> = {},
+): Fixture {
+  const vaultPath = path.join(tmpRoot, 'vault');
+  const homeDir = path.join(tmpRoot, 'home');
+  fs.mkdirSync(vaultPath, { recursive: true });
+  fs.mkdirSync(path.join(homeDir, '.deus'), { recursive: true });
+  const dbPath = path.join(homeDir, '.deus', 'memory_tree.db');
+  writeHealthyDb(dbPath);
+  const config: Record<string, unknown> = {
+    vault_path: vaultPath,
+    ...configOverrides,
+  };
+  const deps: VaultContextDeps = {
+    readConfig: () => config,
+    resolveVault: () => vaultPath,
+    homeDir,
+    dbPath,
+    scriptsDir: SCRIPTS_DIR,
+    pythonBin: 'python3',
+    env: {},
+    now: Date.now,
+    spawnFn: fakeSpawn({ stdout: '' }),
+    recentTimeoutMs: 1000,
+    ...depOverrides,
+  };
+  return { deps, vaultPath, homeDir, config };
+}
+
+function writeVaultFile(
+  vaultPath: string,
+  name: string,
+  content: string,
+): void {
+  const full = path.join(vaultPath, name);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf-8');
+}
+
+function localDateString(ms: number): string {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Eligibility and skip semantics
+// ───────────────────────────────────────────────────────────────────────────
+describe('loadVaultContext eligibility', () => {
+  it('skips non-control groups without touching config, files, or subprocesses', async () => {
+    const result = await loadVaultContext(ctx({ isControlGroup: false }), {
+      readConfig: () => {
+        throw new Error('config must not be read on the skip path');
+      },
+      resolveVault: () => {
+        throw new Error('vault must not be resolved on the skip path');
+      },
+      spawnFn: fakeSpawn({ throwOnSpawn: true }),
+      env: {},
+    });
+    expect(result.content).toBeUndefined();
+    expect(result.record).toEqual({
+      eligible: false,
+      skipReason: 'non-control-group',
+      vaultAvailable: false,
+      contextLoaded: false,
+      loadedSections: [],
+      loadedVaultFiles: [],
+    });
+  });
+
+  it('skips when DEUS_VAULT_PRELOADED=1 (duplicate-prevention parity), all providers suppressed', async () => {
+    const result = await loadVaultContext(ctx(), {
+      readConfig: () => {
+        throw new Error('config must not be read on the preloaded path');
+      },
+      env: { DEUS_VAULT_PRELOADED: '1' },
+    });
+    expect(result.content).toBeUndefined();
+    expect(result.record.eligible).toBe(false);
+    expect(result.record.skipReason).toBe('already-preloaded');
+  });
+
+  it('a control-group RunContext with worktreePath remains eligible (no .git worktree skip)', async () => {
+    const { deps, vaultPath } = makeFixture();
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'identity content');
+    const result = await loadVaultContext(
+      ctx({ worktreePath: path.join(tmpRoot, 'some-worktree') }),
+      deps,
+    );
+    expect(result.record.eligible).toBe(true);
+    expect(result.content).toContain('=== VAULT: CLAUDE.md ===');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// vault_autoload normalization
+// ───────────────────────────────────────────────────────────────────────────
+describe('normalizeVaultAutoload', () => {
+  it('defaults to ["CLAUDE.md"] only when the key is absent', () => {
+    expect(normalizeVaultAutoload({})).toEqual(['CLAUDE.md']);
+  });
+
+  it('preserves configured order and an explicit empty array', () => {
+    expect(
+      normalizeVaultAutoload({ vault_autoload: ['b.md', 'a.md'] }),
+    ).toEqual(['b.md', 'a.md']);
+    expect(normalizeVaultAutoload({ vault_autoload: [] })).toEqual([]);
+  });
+
+  it('drops malformed/non-string entries without throwing', () => {
+    expect(
+      normalizeVaultAutoload({ vault_autoload: ['ok.md', 42, null, {}] }),
+    ).toEqual(['ok.md']);
+    expect(normalizeVaultAutoload({ vault_autoload: 'not-a-list' })).toEqual(
+      [],
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Vault-file provider
+// ───────────────────────────────────────────────────────────────────────────
+describe('vault file sections', () => {
+  it('loads the default CLAUDE.md when vault_autoload is absent', async () => {
+    const { deps, vaultPath } = makeFixture();
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'vault identity');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe('=== VAULT: CLAUDE.md ===\nvault identity');
+    expect(result.record.loadedVaultFiles).toEqual(['CLAUDE.md']);
+    expect(result.record.loadedSections).toEqual(['vault-files']);
+  });
+
+  it('loads multiple configured files preserving order', async () => {
+    const { deps, vaultPath } = makeFixture({
+      vault_autoload: ['second.md', 'Persona/INDEX.md'],
+    });
+    writeVaultFile(vaultPath, 'second.md', 'S');
+    writeVaultFile(vaultPath, 'Persona/INDEX.md', 'P');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe(
+      '=== VAULT: second.md ===\nS\n\n=== VAULT: Persona/INDEX.md ===\nP',
+    );
+    expect(result.record.loadedVaultFiles).toEqual([
+      'second.md',
+      'Persona/INDEX.md',
+    ]);
+  });
+
+  it('explicit empty vault_autoload loads no files but later providers still run', async () => {
+    const nowMs = Date.now();
+    const { deps, vaultPath, homeDir } = makeFixture(
+      { vault_autoload: [] },
+      { now: () => nowMs },
+    );
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'must not load');
+    const cpDir = path.join(vaultPath, 'Checkpoints');
+    writeVaultFile(
+      vaultPath,
+      path.join('Checkpoints', `${localDateString(nowMs)}-x.md`),
+      'checkpoint body',
+    );
+    expect(fs.existsSync(cpDir)).toBe(true);
+    fs.writeFileSync(
+      path.join(homeDir, '.deus', 'resume_semantic_cache.txt'),
+      'related things',
+      'utf-8',
+    );
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).not.toContain('must not load');
+    expect(result.record.loadedVaultFiles).toEqual([]);
+    expect(result.record.loadedSections).toEqual([
+      'checkpoint',
+      'semantic-cache',
+    ]);
+    expect(result.content).toBe(
+      '=== MID-SESSION CHECKPOINT ===\ncheckpoint body\n\n=== RELATED SESSIONS ===\nrelated things',
+    );
+  });
+
+  it('skips missing, empty, and unreadable files fail-soft', async () => {
+    const { deps, vaultPath } = makeFixture({
+      vault_autoload: ['missing.md', 'empty.md', 'unreadable.md', 'good.md'],
+    });
+    writeVaultFile(vaultPath, 'empty.md', '   \n  ');
+    // A directory where a file is expected: readFileSync throws (EISDIR) —
+    // the cross-platform "unreadable" case.
+    fs.mkdirSync(path.join(vaultPath, 'unreadable.md'));
+    writeVaultFile(vaultPath, 'good.md', 'good content');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe('=== VAULT: good.md ===\ngood content');
+    expect(result.record.loadedVaultFiles).toEqual(['good.md']);
+  });
+
+  it('truncates each file section to MAX_SECTION_CHARS', async () => {
+    const { deps, vaultPath } = makeFixture();
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'x'.repeat(MAX_SECTION_CHARS + 500));
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe(
+      `=== VAULT: CLAUDE.md ===\n${'x'.repeat(MAX_SECTION_CHARS)}`,
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Checkpoint provider
+// ───────────────────────────────────────────────────────────────────────────
+describe('checkpoint section', () => {
+  it('selects the newest same-day checkpoint by mtime', async () => {
+    const nowMs = Date.now();
+    const { deps, vaultPath } = makeFixture(
+      { vault_autoload: [] },
+      { now: () => nowMs },
+    );
+    const today = localDateString(nowMs);
+    writeVaultFile(vaultPath, `Checkpoints/${today}-early.md`, 'early');
+    writeVaultFile(vaultPath, `Checkpoints/${today}-late.md`, 'late');
+    const early = path.join(vaultPath, 'Checkpoints', `${today}-early.md`);
+    const late = path.join(vaultPath, 'Checkpoints', `${today}-late.md`);
+    fs.utimesSync(
+      early,
+      new Date(nowMs - 7200_000),
+      new Date(nowMs - 7200_000),
+    );
+    fs.utimesSync(late, new Date(nowMs - 600_000), new Date(nowMs - 600_000));
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe('=== MID-SESSION CHECKPOINT ===\nlate');
+    expect(result.record.loadedSections).toEqual(['checkpoint']);
+  });
+
+  it('contributes nothing when only other-day checkpoints exist', async () => {
+    const nowMs = Date.now();
+    const { deps, vaultPath } = makeFixture(
+      { vault_autoload: [] },
+      { now: () => nowMs },
+    );
+    const yesterday = localDateString(nowMs - 24 * 3600_000);
+    writeVaultFile(vaultPath, `Checkpoints/${yesterday}-old.md`, 'stale');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+    expect(result.record.contextLoaded).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Semantic-cache provider
+// ───────────────────────────────────────────────────────────────────────────
+describe('semantic cache section', () => {
+  function writeCache(
+    homeDir: string,
+    content: string,
+    ageSeconds: number,
+    nowMs: number,
+  ): void {
+    const cachePath = path.join(homeDir, '.deus', 'resume_semantic_cache.txt');
+    fs.writeFileSync(cachePath, content, 'utf-8');
+    const mtime = new Date(nowMs - ageSeconds * 1000);
+    fs.utimesSync(cachePath, mtime, mtime);
+  }
+
+  it('includes a fresh cache just inside the 4-hour boundary', async () => {
+    const nowMs = Date.now();
+    const { deps, homeDir } = makeFixture(
+      { vault_autoload: [] },
+      { now: () => nowMs },
+    );
+    writeCache(
+      homeDir,
+      '  related sessions text  ',
+      SEMANTIC_TTL_SECONDS - 60,
+      nowMs,
+    );
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe(
+      '=== RELATED SESSIONS ===\nrelated sessions text',
+    );
+    expect(result.record.loadedSections).toEqual(['semantic-cache']);
+  });
+
+  it('excludes the cache exactly at the boundary (age >= TTL)', async () => {
+    const nowMs = Date.now();
+    const { deps, homeDir } = makeFixture(
+      { vault_autoload: [] },
+      { now: () => nowMs },
+    );
+    writeCache(homeDir, 'stale', SEMANTIC_TTL_SECONDS, nowMs);
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+  });
+
+  it('excludes an empty cache file', async () => {
+    const nowMs = Date.now();
+    const { deps, homeDir } = makeFixture(
+      { vault_autoload: [] },
+      { now: () => nowMs },
+    );
+    writeCache(homeDir, '   \n ', 10, nowMs);
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Recent-sessions subprocess adapter
+// ───────────────────────────────────────────────────────────────────────────
+describe('recent sessions section', () => {
+  it('includes trimmed stdout under the RECENT SESSIONS header', async () => {
+    const { deps } = makeFixture(
+      { vault_autoload: [] },
+      { spawnFn: fakeSpawn({ stdout: '## Recent Sessions\n- one\n' }) },
+    );
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe(
+      '=== RECENT SESSIONS ===\n## Recent Sessions\n- one',
+    );
+    expect(result.record.loadedSections).toEqual(['recent-sessions']);
+  });
+
+  it('skips on empty stdout', async () => {
+    const { deps } = makeFixture(
+      { vault_autoload: [] },
+      { spawnFn: fakeSpawn({ stdout: '  \n ' }) },
+    );
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+  });
+
+  it('skips on spawn error event (missing Python) without failing other sections', async () => {
+    const { deps, vaultPath } = makeFixture(
+      {},
+      { spawnFn: fakeSpawn({ emitError: true }) },
+    );
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'still loads');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe('=== VAULT: CLAUDE.md ===\nstill loads');
+  });
+
+  it('skips when spawn itself throws synchronously', async () => {
+    const { deps } = makeFixture(
+      { vault_autoload: [] },
+      { spawnFn: fakeSpawn({ throwOnSpawn: true }) },
+    );
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+  });
+
+  it('kills and skips on timeout (5s reference behavior, shortened seam)', async () => {
+    let killed = false;
+    const { deps } = makeFixture(
+      { vault_autoload: [] },
+      {
+        spawnFn: fakeSpawn({
+          stdout: 'partial output before hang',
+          neverClose: true,
+          onKill: () => {
+            killed = true;
+          },
+        }),
+        recentTimeoutMs: 25,
+      },
+    );
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+    expect(killed).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Degraded memory health
+// ───────────────────────────────────────────────────────────────────────────
+describe('degraded memory health section', () => {
+  it('a healthy memory system stays silent', async () => {
+    const { deps, vaultPath } = makeFixture();
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'identity');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).not.toContain('MEMORY SYSTEM DEGRADED');
+    expect(result.record.loadedSections).toEqual(['vault-files']);
+  });
+
+  it('unconfigured vault returns the degraded banner ALONE (vault-missing exception)', async () => {
+    const { deps } = makeFixture({}, { resolveVault: () => null });
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toContain('=== MEMORY SYSTEM DEGRADED ===');
+    expect(result.content).toContain('  - vault path is not configured');
+    expect(result.content).toContain(
+      'vault unavailable: remount / grant Full Disk Access, then restart the session',
+    );
+    expect(result.record).toMatchObject({
+      eligible: true,
+      vaultAvailable: false,
+      contextLoaded: true,
+      loadedSections: ['degraded-memory-health'],
+      loadedVaultFiles: [],
+    });
+  });
+
+  it('non-directory vault reports "vault not mounted at <path>"', async () => {
+    const missing = path.join(tmpRoot, 'nonexistent-vault');
+    const { deps } = makeFixture({}, { resolveVault: () => missing });
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toContain(`  - vault not mounted at ${missing}`);
+    expect(result.record.vaultAvailable).toBe(false);
+  });
+
+  it.skipIf(IS_WINDOWS)(
+    'unwritable vault degrades but the pipeline still loads readable sections',
+    async () => {
+      const { deps, vaultPath } = makeFixture();
+      writeVaultFile(vaultPath, 'CLAUDE.md', 'still readable');
+      fs.chmodSync(vaultPath, 0o555);
+      try {
+        const result = await loadVaultContext(ctx(), deps);
+        expect(result.content).toContain(
+          `  - vault not writable at ${vaultPath} (grant Full Disk Access?)`,
+        );
+        expect(result.content).toContain(
+          '=== VAULT: CLAUDE.md ===\nstill readable',
+        );
+        expect(result.record.loadedSections).toEqual([
+          'degraded-memory-health',
+          'vault-files',
+        ]);
+      } finally {
+        fs.chmodSync(vaultPath, 0o755);
+      }
+    },
+  );
+
+  it('missing tree DB degrades with the rebuild remedy', async () => {
+    const { deps, homeDir } = makeFixture();
+    const dbPath = path.join(homeDir, '.deus', 'memory_tree.db');
+    fs.rmSync(dbPath);
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toContain(`  - memory tree DB missing at ${dbPath}`);
+    expect(result.content).toContain(
+      `rebuild tree: python3 ${path.join(SCRIPTS_DIR, 'memory_tree.py')} build`,
+    );
+    expect(result.content).toContain(
+      `verify: python3 ${path.join(SCRIPTS_DIR, 'memory_tree.py')} check`,
+    );
+  });
+
+  it('unopenable tree DB reports unreadable', async () => {
+    const { deps, homeDir } = makeFixture();
+    const dbPath = path.join(homeDir, '.deus', 'memory_tree.db');
+    fs.rmSync(dbPath);
+    fs.mkdirSync(dbPath); // a directory cannot be opened as a database
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toContain(
+      `  - memory tree DB unreadable at ${dbPath}`,
+    );
+  });
+
+  it('empty tree reports only the empty-tree line', async () => {
+    const { deps, homeDir } = makeFixture();
+    const dbPath = path.join(homeDir, '.deus', 'memory_tree.db');
+    const db = new Database(dbPath);
+    db.exec('DELETE FROM nodes; DELETE FROM edges;');
+    db.close();
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toContain(
+      '  - memory tree is empty (0 active nodes)',
+    );
+    expect(result.content).not.toContain('navigation root');
+    expect(result.content).not.toContain('0 edges');
+  });
+
+  it('missing root and zero edges degrade with their own lines and remedies', async () => {
+    const { deps, homeDir } = makeFixture();
+    const dbPath = path.join(homeDir, '.deus', 'memory_tree.db');
+    const db = new Database(dbPath);
+    db.exec(
+      "DELETE FROM nodes WHERE path = 'MEMORY_TREE.md'; DELETE FROM edges;",
+    );
+    db.close();
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toContain(
+      '  - navigation root MEMORY_TREE.md is missing from the tree',
+    );
+    expect(result.content).toContain(
+      '  - memory graph has 0 edges across 1 nodes (ranking dead)',
+    );
+    expect(result.content).toContain(
+      `lost root: python3 ${path.join(SCRIPTS_DIR, 'memory_tree.py')} scaffold-root --force --reindex`,
+    );
+  });
+
+  it('a schema/query error means "cannot determine" — no banner, session unaffected', async () => {
+    const { deps, homeDir, vaultPath } = makeFixture();
+    const dbPath = path.join(homeDir, '.deus', 'memory_tree.db');
+    const db = new Database(dbPath);
+    db.exec('DROP TABLE nodes;');
+    db.close();
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'unaffected');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe('=== VAULT: CLAUDE.md ===\nunaffected');
+  });
+
+  it('an unexpected health-probe exception is swallowed and other sections still load', async () => {
+    const { deps, vaultPath } = makeFixture(
+      {},
+      // dbPath alone missing is a DOCUMENTED degraded condition (produces a
+      // real banner, not an exception — Node's fs.existsSync(undefined)
+      // returns false rather than throwing on this runtime, verified). To
+      // exercise the outer catch-all's truly-UNEXPECTED-exception path, also
+      // break scriptsDir: once a real degraded line exists (from the missing
+      // DB), rendering calls `path.join(deps.scriptsDir, 'memory_tree.py')`,
+      // which throws a genuine TypeError for a non-string scriptsDir — the
+      // catch-all must swallow that and contribute no degraded section,
+      // matching the hook's try/except, while the vault file section still
+      // loads independently.
+      {
+        dbPath: undefined as unknown as string,
+        scriptsDir: undefined as unknown as string,
+      },
+    );
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'resilient');
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBe('=== VAULT: CLAUDE.md ===\nresilient');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Composition order + metadata
+// ───────────────────────────────────────────────────────────────────────────
+describe('composition and metadata', () => {
+  it('composes all sections in canonical order joined with \\n\\n and records exact metadata', async () => {
+    const nowMs = Date.now();
+    const { deps, vaultPath, homeDir } = makeFixture(
+      { vault_autoload: ['CLAUDE.md'] },
+      {
+        now: () => nowMs,
+        spawnFn: fakeSpawn({ stdout: 'recent output' }),
+      },
+    );
+    // Degrade health without breaking the vault: remove the tree DB.
+    fs.rmSync(path.join(homeDir, '.deus', 'memory_tree.db'));
+    writeVaultFile(vaultPath, 'CLAUDE.md', 'V');
+    writeVaultFile(
+      vaultPath,
+      `Checkpoints/${localDateString(nowMs)}-cp.md`,
+      'C',
+    );
+    fs.writeFileSync(
+      path.join(homeDir, '.deus', 'resume_semantic_cache.txt'),
+      'R',
+      'utf-8',
+    );
+
+    const result = await loadVaultContext(ctx(), deps);
+    const content = result.content!;
+    const order = [
+      '=== MEMORY SYSTEM DEGRADED ===',
+      '=== VAULT: CLAUDE.md ===',
+      '=== MID-SESSION CHECKPOINT ===',
+      '=== RECENT SESSIONS ===',
+      '=== RELATED SESSIONS ===',
+    ].map((header) => content.indexOf(header));
+    expect(order.every((idx) => idx >= 0)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+    expect(content).toContain(
+      '=== VAULT: CLAUDE.md ===\nV\n\n=== MID-SESSION CHECKPOINT ===\nC\n\n=== RECENT SESSIONS ===\nrecent output\n\n=== RELATED SESSIONS ===\nR',
+    );
+    expect(result.record).toEqual({
+      eligible: true,
+      vaultAvailable: true,
+      contextLoaded: true,
+      loadedSections: [
+        'degraded-memory-health',
+        'vault-files',
+        'checkpoint',
+        'recent-sessions',
+        'semantic-cache',
+      ],
+      loadedVaultFiles: ['CLAUDE.md'],
+    });
+  });
+
+  it('returns undefined content with a truthful record when nothing contributes', async () => {
+    const { deps } = makeFixture({ vault_autoload: [] });
+    const result = await loadVaultContext(ctx(), deps);
+    expect(result.content).toBeUndefined();
+    expect(result.record).toEqual({
+      eligible: true,
+      vaultAvailable: true,
+      contextLoaded: false,
+      loadedSections: [],
+      loadedVaultFiles: [],
+    });
+  });
+
+  it('environment vault path takes precedence over config through the real resolver', async () => {
+    const { resolveVaultPath } = await import('../container-mounter.js');
+    const envVault = path.join(tmpRoot, 'env-vault');
+    fs.mkdirSync(envVault, { recursive: true });
+    fs.writeFileSync(
+      path.join(envVault, 'CLAUDE.md'),
+      'from env vault',
+      'utf-8',
+    );
+    const { deps } = makeFixture(
+      { vault_path: path.join(tmpRoot, 'config-vault') },
+      {},
+    );
+    const original = process.env.DEUS_VAULT_PATH;
+    process.env.DEUS_VAULT_PATH = envVault;
+    try {
+      const result = await loadVaultContext(ctx(), {
+        ...deps,
+        resolveVault: (config) => resolveVaultPath(config),
+      });
+      expect(result.content).toContain('from env vault');
+    } finally {
+      if (original !== undefined) process.env.DEUS_VAULT_PATH = original;
+      else delete process.env.DEUS_VAULT_PATH;
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// AC5 — differential parity against the real scripts/vault_context_hook.py
+// ───────────────────────────────────────────────────────────────────────────
+const python3Available =
+  !IS_WINDOWS && spawnSync('python3', ['--version']).status === 0;
+
+describe.skipIf(!python3Available)('vault context parity (LIA-416 AC5)', () => {
+  const HOOK_PATH = path.join(SCRIPTS_DIR, 'vault_context_hook.py');
+
+  function runPythonHook(
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): string | undefined {
+    const res = spawnSync('python3', [HOOK_PATH], {
+      env: env as NodeJS.ProcessEnv,
+      cwd,
+      input: '{}',
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    expect(res.error).toBeUndefined();
+    const stdout = (res.stdout ?? '').trim();
+    if (!stdout) return undefined;
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput: { additionalContext: string };
+    };
+    return parsed.hookSpecificOutput.additionalContext;
+  }
+
+  /** Env shared by the TS subprocess adapter and the Python hook run. */
+  function buildChildEnv(homeDir: string, vaultPath: string) {
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      HOME: homeDir,
+      DEUS_VAULT_PATH: vaultPath,
+    };
+    delete env.DEUS_VAULT_PRELOADED;
+    delete env.DEUS_PYTHON;
+    return env;
+  }
+
+  it('full healthy fixture: TS content literally equals the hook additionalContext', async () => {
+    const homeDir = path.join(tmpRoot, 'home');
+    const vaultPath = path.join(tmpRoot, 'vault');
+    const cwd = path.join(tmpRoot, 'cwd'); // non-worktree CWD (no .git file)
+    fs.mkdirSync(path.join(homeDir, '.deus'), { recursive: true });
+    fs.mkdirSync(path.join(homeDir, '.config', 'deus'), { recursive: true });
+    fs.mkdirSync(cwd, { recursive: true });
+
+    const config = {
+      vault_path: vaultPath,
+      vault_autoload: ['CLAUDE.md', 'Persona/INDEX.md'],
+    };
+    fs.writeFileSync(
+      path.join(homeDir, '.config', 'deus', 'config.json'),
+      JSON.stringify(config),
+      'utf-8',
+    );
+
+    writeVaultFile(
+      vaultPath,
+      'CLAUDE.md',
+      '# Vault Identity\n\nParity test identity content.\n',
+    );
+    writeVaultFile(
+      vaultPath,
+      'Persona/INDEX.md',
+      'Persona index body.\n' + 'y'.repeat(MAX_SECTION_CHARS),
+    );
+
+    const nowMs = Date.now();
+    const today = localDateString(nowMs);
+    writeVaultFile(
+      vaultPath,
+      `Checkpoints/${today}-early.md`,
+      'EARLY checkpoint\n',
+    );
+    writeVaultFile(
+      vaultPath,
+      `Checkpoints/${today}-late.md`,
+      'LATE checkpoint\n',
+    );
+    fs.utimesSync(
+      path.join(vaultPath, 'Checkpoints', `${today}-early.md`),
+      new Date(nowMs - 7200_000),
+      new Date(nowMs - 7200_000),
+    );
+    fs.utimesSync(
+      path.join(vaultPath, 'Checkpoints', `${today}-late.md`),
+      new Date(nowMs - 300_000),
+      new Date(nowMs - 300_000),
+    );
+
+    // Deterministic session log for memory_indexer.py --recent 3. Both
+    // implementations invoke the SAME script with the SAME env, so whatever
+    // it renders (including nothing, if optional indexer deps are absent on
+    // this machine) must match literally on both sides.
+    writeVaultFile(
+      vaultPath,
+      'Session-Logs/2026-07-10/parity-session.md',
+      '---\ndate: 2026-07-10\ntldr: Parity fixture session.\ntopics: parity\ndecisions: Compare literally\n---\n\nBody.\n',
+    );
+
+    writeHealthyDb(path.join(homeDir, '.deus', 'memory_tree.db'));
+
+    fs.writeFileSync(
+      path.join(homeDir, '.deus', 'resume_semantic_cache.txt'),
+      'Related session A\nRelated session B\n',
+      'utf-8',
+    );
+
+    const childEnv = buildChildEnv(homeDir, vaultPath);
+
+    const tsResult = await loadVaultContext(ctx(), {
+      readConfig: () => config,
+      resolveVault: () => vaultPath,
+      homeDir,
+      dbPath: path.join(homeDir, '.deus', 'memory_tree.db'),
+      scriptsDir: SCRIPTS_DIR,
+      pythonBin: 'python3',
+      env: childEnv,
+      now: Date.now,
+      recentTimeoutMs: 15_000,
+    });
+    const pyContext = runPythonHook(childEnv, cwd);
+
+    expect(tsResult.content).toBeDefined();
+    expect(tsResult.content).toBe(pyContext);
+    // Sanity: the fixture actually exercised the vault/checkpoint/cache path.
+    expect(tsResult.content).toContain('=== VAULT: CLAUDE.md ===');
+    expect(tsResult.content).toContain(
+      '=== MID-SESSION CHECKPOINT ===\nLATE checkpoint',
+    );
+    expect(tsResult.content).toContain('=== RELATED SESSIONS ===');
+  }, 60_000);
+
+  it('degraded fixture (unavailable vault + missing tree DB): literal banner parity', async () => {
+    const homeDir = path.join(tmpRoot, 'home');
+    const missingVault = path.join(tmpRoot, 'not-a-vault');
+    const cwd = path.join(tmpRoot, 'cwd');
+    fs.mkdirSync(path.join(homeDir, '.deus'), { recursive: true });
+    fs.mkdirSync(path.join(homeDir, '.config', 'deus'), { recursive: true });
+    fs.mkdirSync(cwd, { recursive: true });
+    const config = { vault_path: missingVault };
+    fs.writeFileSync(
+      path.join(homeDir, '.config', 'deus', 'config.json'),
+      JSON.stringify(config),
+      'utf-8',
+    );
+
+    const childEnv = buildChildEnv(homeDir, missingVault);
+
+    const tsResult = await loadVaultContext(ctx(), {
+      readConfig: () => config,
+      resolveVault: () => missingVault,
+      homeDir,
+      dbPath: path.join(homeDir, '.deus', 'memory_tree.db'),
+      scriptsDir: SCRIPTS_DIR,
+      pythonBin: 'python3',
+      env: childEnv,
+      now: Date.now,
+      recentTimeoutMs: 15_000,
+    });
+    const pyContext = runPythonHook(childEnv, cwd);
+
+    // Banner despite the absent vault — the degraded-even-when-vault-missing
+    // exception, on both sides, byte-identical.
+    expect(tsResult.content).toBeDefined();
+    expect(tsResult.content).toBe(pyContext);
+    expect(tsResult.content).toContain('=== MEMORY SYSTEM DEGRADED ===');
+    expect(tsResult.content).toContain(
+      `  - vault not mounted at ${missingVault}`,
+    );
+    expect(tsResult.record.vaultAvailable).toBe(false);
+    expect(tsResult.record.loadedSections).toEqual(['degraded-memory-health']);
+  }, 60_000);
+});

--- a/src/agent-runtimes/vault-context.ts
+++ b/src/agent-runtimes/vault-context.ts
@@ -1,0 +1,585 @@
+/**
+ * Session-open vault context for the `deus-native` runtime (LIA-416 / D2).
+ *
+ * TypeScript surface mirroring `scripts/vault_context_hook.py` — the
+ * SessionStart hook that injects the personal vault (Second Brain) identity
+ * into host Claude Code sessions. `deus-native` never runs that hook (it is a
+ * Claude Code harness hook), so this module reproduces the same ordered
+ * context sections for the runtime's own session-open path:
+ *
+ *   1. `=== MEMORY SYSTEM DEGRADED ===`   (memory_health.py parity, TS port)
+ *   2. `=== VAULT: <filename> ===`        (one per configured autoload file)
+ *   3. `=== MID-SESSION CHECKPOINT ===`   (newest same-day checkpoint)
+ *   4. `=== RECENT SESSIONS ===`          (memory_indexer.py --recent 3,
+ *                                          spawned async — NOT ported)
+ *   5. `=== RELATED SESSIONS ===`         (fresh semantic resume cache)
+ *
+ * Design: one Facade (`loadVaultContext`) over an ordered pipeline of
+ * independent, fail-soft providers — a missing/empty/stale/unreadable/failed
+ * source contributes nothing and never prevents later providers from running.
+ * Contributed sections join with exactly `\n\n` (the reference hook's join).
+ *
+ * Eligibility (checked BEFORE any config/filesystem/DB/subprocess work):
+ * - Control group only (`runContext.isControlGroup === true`). The reference
+ *   hook targets the host developer's personal sessions, and the control
+ *   group is the only group whose container mount receives the complete
+ *   canonical vault (container-mounter.ts). Non-control groups get a
+ *   deliberately narrower surface — automatic injection there would broaden
+ *   disclosure of personal identity/checkpoints/session history beyond the
+ *   reference hook's scope.
+ * - `DEUS_VAULT_PRELOADED=1` skips everything (duplicate-prevention parity
+ *   with the hook's early return — including the degraded banner).
+ * - The hook's `.git`-is-a-file worktree skip is deliberately NOT copied: it
+ *   describes the host Claude Code process's CWD, whereas here a
+ *   `RunContext.worktreePath` is a task workspace attachment, not evidence
+ *   the session prompt already carries vault context.
+ *
+ * Once-per-session and prompt delivery are NOT this module's concern:
+ * `runTurn`'s checkpointer-existence gate decides when the session-open
+ * loader (and therefore this facade) runs, and `buildPromptLifecycleHook`
+ * delivers the composed string (lifecycle-events.ts).
+ */
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import Database from 'better-sqlite3';
+
+import type { RunContext } from './types.js';
+import { resolveVaultPath } from '../container-mounter.js';
+import { readDeusConfig } from '../checks.js';
+import { HOME_DIR, PROJECT_ROOT } from '../config.js';
+import { PYTHON_BIN } from '../platform.js';
+
+/** Per-section truncation cap — MAX_SECTION_CHARS in the reference hook. */
+export const MAX_SECTION_CHARS = 12000;
+/** Semantic-cache freshness window (seconds) — SEMANTIC_TTL in the hook. */
+export const SEMANTIC_TTL_SECONDS = 14400; // 4 hours
+/** `memory_indexer.py --recent 3` timeout (ms) — the hook's timeout=5. */
+export const RECENT_SESSIONS_TIMEOUT_MS = 5000;
+
+export type VaultContextSkipReason = 'non-control-group' | 'already-preloaded';
+
+export type VaultContextSection =
+  | 'degraded-memory-health'
+  | 'vault-files'
+  | 'checkpoint'
+  | 'recent-sessions'
+  | 'semantic-cache';
+
+/**
+ * Inspectable outcome metadata — section identifiers and configured
+ * filenames ONLY, never vault contents (privacy: this record may reach logs).
+ */
+export interface VaultContextRecord {
+  /** False only when a skip reason applied (never entered the pipeline). */
+  eligible: boolean;
+  skipReason?: VaultContextSkipReason;
+  /** Whether the resolved vault path existed and was a directory. */
+  vaultAvailable: boolean;
+  /** Whether ANY section contributed content. */
+  contextLoaded: boolean;
+  /** Contributing providers, in canonical output order. */
+  loadedSections: VaultContextSection[];
+  /** Configured autoload filenames that actually loaded, in order. */
+  loadedVaultFiles: string[];
+}
+
+export interface VaultContextResult {
+  content: string | undefined;
+  record: VaultContextRecord;
+}
+
+/**
+ * Minimal spawned-child shape — what the recent-sessions adapter needs from
+ * `child_process.spawn`'s return value, injectable for tests.
+ */
+export interface SpawnedChildLike {
+  stdout: {
+    on(event: 'data', cb: (chunk: Buffer | string) => void): unknown;
+  } | null;
+  on(event: 'error' | 'close', cb: (...args: unknown[]) => void): unknown;
+  kill(): unknown;
+}
+
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  options: {
+    stdio: ['ignore', 'pipe', 'ignore'];
+    env: Record<string, string | undefined>;
+  },
+) => SpawnedChildLike;
+
+/**
+ * Injectable seams. Every root path / process / clock dependency is
+ * overridable so unit tests never touch the real user vault, cache, config,
+ * memory database, or session logs. Production callers pass nothing.
+ */
+export interface VaultContextDeps {
+  /** Parsed ~/.config/deus/config.json (readDeusConfig — never throws). */
+  readConfig: () => Record<string, unknown>;
+  /** Vault resolution — env `DEUS_VAULT_PATH` precedence, then config. */
+  resolveVault: (config: Record<string, unknown>) => string | null;
+  /** Home dir — semantic-cache location (`<home>/.deus/resume_semantic_cache.txt`). */
+  homeDir: string;
+  /** Memory-tree DB (memory_health.py's DEFAULT_DB_PATH parity). */
+  dbPath: string;
+  /** Scripts dir — memory_indexer.py spawn + memory_tree.py remediation text. */
+  scriptsDir: string;
+  pythonBin: string;
+  /** Env consulted for DEUS_VAULT_PRELOADED and passed to the subprocess. */
+  env: Record<string, string | undefined>;
+  /** Clock (ms epoch) — checkpoint "today" + semantic-cache freshness. */
+  now: () => number;
+  spawnFn: SpawnFn;
+  /** Test seam only — production always uses RECENT_SESSIONS_TIMEOUT_MS. */
+  recentTimeoutMs: number;
+}
+
+function defaultDeps(): VaultContextDeps {
+  return {
+    readConfig: readDeusConfig,
+    resolveVault: (config) => resolveVaultPath(config),
+    homeDir: HOME_DIR,
+    dbPath: path.join(HOME_DIR, '.deus', 'memory_tree.db'),
+    scriptsDir: path.join(PROJECT_ROOT, 'scripts'),
+    pythonBin: PYTHON_BIN,
+    env: process.env,
+    now: Date.now,
+    spawnFn: spawn as unknown as SpawnFn,
+    recentTimeoutMs: RECENT_SESSIONS_TIMEOUT_MS,
+  };
+}
+
+// ── Providers (each fail-soft, each returns '' for "contributes nothing") ──
+
+/** Code-point-aware truncation — parity with Python's `content[:N]` slicing. */
+function truncateCodePoints(content: string, max: number): string {
+  if (content.length <= max) return content;
+  return Array.from(content).slice(0, max).join('');
+}
+
+/**
+ * `vault_autoload` normalization: default `["CLAUDE.md"]` ONLY when the key
+ * is absent; an explicit empty array stays empty; malformed/non-string
+ * entries contribute nothing rather than throwing.
+ */
+export function normalizeVaultAutoload(
+  config: Record<string, unknown>,
+): string[] {
+  if (!('vault_autoload' in config)) return ['CLAUDE.md'];
+  const raw = config['vault_autoload'];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((entry): entry is string => typeof entry === 'string');
+}
+
+/** One `=== VAULT: <fname> ===` section, or '' (missing/empty/unreadable). */
+function loadVaultFileSection(vaultPath: string, fname: string): string {
+  try {
+    // Node's utf8 decode substitutes U+FFFD for invalid sequences — same
+    // observable result as Python's errors="replace".
+    const raw = fs.readFileSync(path.join(vaultPath, fname), 'utf-8');
+    const content = truncateCodePoints(raw, MAX_SECTION_CHARS);
+    if (content.trim().length === 0) return '';
+    return `=== VAULT: ${fname} ===\n${content}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Newest same-day checkpoint (`Checkpoints/<YYYY-MM-DD>-*.md`, greatest
+ * mtime), or ''. "Today" is the LOCAL calendar date from the injected clock —
+ * parity with Python's `date.today()`.
+ */
+function loadCheckpointSection(vaultPath: string, nowMs: number): string {
+  try {
+    const d = new Date(nowMs);
+    const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    const cpDir = path.join(vaultPath, 'Checkpoints');
+    if (!fs.existsSync(cpDir) || !fs.statSync(cpDir).isDirectory()) return '';
+    const candidates = fs
+      .readdirSync(cpDir)
+      .filter((name) => name.startsWith(`${today}-`) && name.endsWith('.md'))
+      .map((name) => {
+        const full = path.join(cpDir, name);
+        return { full, mtimeMs: fs.statSync(full).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    if (candidates.length === 0) return '';
+    const content = fs.readFileSync(candidates[0].full, 'utf-8');
+    return content.trim().length > 0
+      ? `=== MID-SESSION CHECKPOINT ===\n${content}`
+      : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * `memory_indexer.py --recent 3` via async spawn — the reference hook's
+ * subprocess, reused rather than ported (the rendering logic lives in ONE
+ * place). Returns trimmed stdout, or '' on spawn error / timeout / empty
+ * output. Like the hook's `subprocess.run(check=False)`, trimmed stdout is
+ * used even when the process exits non-zero; stderr is ignored. The await
+ * blocks only this session-open turn — the spawn is asynchronous, so the
+ * process-wide event loop stays available to other groups/channels/backends.
+ */
+function loadRecentSessionsOutput(deps: VaultContextDeps): Promise<string> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: string) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    let child: SpawnedChildLike;
+    try {
+      child = deps.spawnFn(
+        deps.pythonBin,
+        [path.join(deps.scriptsDir, 'memory_indexer.py'), '--recent', '3'],
+        { stdio: ['ignore', 'pipe', 'ignore'], env: deps.env },
+      );
+    } catch {
+      finish('');
+      return;
+    }
+
+    let stdout = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    // Timeout parity: TimeoutExpired in the hook discards output entirely.
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // best-effort cleanup only
+      }
+      finish('');
+    }, deps.recentTimeoutMs);
+
+    child.on('error', () => {
+      clearTimeout(timer);
+      finish('');
+    });
+    child.on('close', () => {
+      clearTimeout(timer);
+      finish(stdout.trim());
+    });
+  });
+}
+
+/** Fresh (< 4h old, strictly) semantic resume cache section, or ''. */
+function loadSemanticCacheSection(deps: VaultContextDeps): string {
+  const cachePath = path.join(
+    deps.homeDir,
+    '.deus',
+    'resume_semantic_cache.txt',
+  );
+  try {
+    if (!fs.existsSync(cachePath)) return '';
+    const ageSeconds = (deps.now() - fs.statSync(cachePath).mtimeMs) / 1000;
+    if (ageSeconds >= SEMANTIC_TTL_SECONDS) return '';
+    const content = fs.readFileSync(cachePath, 'utf-8').trim();
+    return content ? `=== RELATED SESSIONS ===\n${content}` : '';
+  } catch {
+    return '';
+  }
+}
+
+// ── Degraded memory health (scripts/memory_health.py TS port) ──────────────
+
+/**
+ * Vault writability probe — memory_health.py's `_probe_vault_writable`.
+ * A create + unlink confirms the volume is mounted AND writable (`is_dir()`
+ * alone misses the macOS Full-Disk-Access case where reads work but writes
+ * silently fail). The probe filename is uniquely suffixed so independent
+ * sessions opening concurrently never collide; cleanup is always attempted.
+ */
+function probeVaultWritable(vaultPath: string | null): string {
+  if (vaultPath === null) return 'vault path is not configured';
+  let isDir: boolean;
+  try {
+    isDir = fs.statSync(vaultPath).isDirectory();
+  } catch {
+    isDir = false;
+  }
+  if (!isDir) return `vault not mounted at ${vaultPath}`;
+  const probe = path.join(
+    vaultPath,
+    `.deus-health-probe-${process.pid}-${Math.random().toString(36).slice(2, 10)}`,
+  );
+  let writable = true;
+  try {
+    fs.writeFileSync(probe, 'ok', 'utf-8');
+  } catch {
+    writable = false;
+  } finally {
+    try {
+      fs.unlinkSync(probe);
+    } catch {
+      // Always attempt cleanup; a failed unlink must not surface.
+    }
+  }
+  return writable
+    ? ''
+    : `vault not writable at ${vaultPath} (grant Full Disk Access?)`;
+}
+
+/**
+ * Catastrophic-only tree signals from a direct, READ-ONLY better-sqlite3
+ * read — memory_health.py's `_tree_health`, reusing the existing
+ * better-sqlite3 dependency instead of adding a second Python startup to the
+ * session-open path. A schema/query error means "cannot determine tree
+ * health" and returns [] (never blocks session opening).
+ */
+function treeHealthLines(dbPath: string): string[] {
+  if (!fs.existsSync(dbPath)) return [`memory tree DB missing at ${dbPath}`];
+  let db: InstanceType<typeof Database>;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  } catch {
+    return [`memory tree DB unreadable at ${dbPath}`];
+  }
+  try {
+    let nodes: number;
+    let edges: number;
+    let root: unknown;
+    try {
+      nodes = (
+        db
+          .prepare(
+            "SELECT COUNT(*) AS c FROM nodes WHERE orphaned_at IS NULL AND path NOT LIKE 'auto-memory/%'",
+          )
+          .get() as { c: number }
+      ).c;
+      edges = (
+        db
+          .prepare(
+            "SELECT COUNT(*) AS c FROM edges WHERE kind = 'child' AND expired_at IS NULL",
+          )
+          .get() as { c: number }
+      ).c;
+      root = db
+        .prepare(
+          "SELECT 1 AS one FROM nodes WHERE path = 'MEMORY_TREE.md' AND orphaned_at IS NULL",
+        )
+        .get();
+    } catch {
+      // Schema/probe error: "can't tell" — parity with the Python probe.
+      return [];
+    }
+    if (nodes === 0) return ['memory tree is empty (0 active nodes)'];
+    const lines: string[] = [];
+    if (root === undefined) {
+      lines.push('navigation root MEMORY_TREE.md is missing from the tree');
+    }
+    if (edges === 0) {
+      lines.push(
+        `memory graph has 0 edges across ${nodes} nodes (ranking dead)`,
+      );
+    }
+    return lines;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Loud DEGRADED banner rendering — memory_health.py's
+ * `render_degraded_section`, with the executable rendered via the
+ * platform-selected Python binary and the `memory_tree.py` path derived from
+ * the injected scripts dir (PROJECT_ROOT-based in production). On POSIX with
+ * the default `python3` binary the output is byte-identical to the Python
+ * reference; on Windows it is intentionally actionable (platform-native
+ * executable/path) rather than byte-identical.
+ */
+function renderDegradedSection(
+  lines: string[],
+  pythonBin: string,
+  memoryTreePath: string,
+): string {
+  const out = [
+    '=== MEMORY SYSTEM DEGRADED ===',
+    'Memory recall may be silently failing. Detected:',
+    ...lines.map((line) => `  - ${line}`),
+  ];
+  const blob = lines.join(' ').toLowerCase();
+  const remedies: string[] = [];
+  if (
+    blob.includes('not writable') ||
+    blob.includes('not mounted') ||
+    blob.includes('not configured')
+  ) {
+    remedies.push(
+      'vault unavailable: remount / grant Full Disk Access, then restart the session',
+    );
+  }
+  if (blob.includes('root')) {
+    remedies.push(
+      `lost root: ${pythonBin} ${memoryTreePath} scaffold-root --force --reindex`,
+    );
+  }
+  if (
+    blob.includes('db missing') ||
+    blob.includes('empty') ||
+    blob.includes('0 edges') ||
+    blob.includes('unreadable')
+  ) {
+    remedies.push(`rebuild tree: ${pythonBin} ${memoryTreePath} build`);
+  }
+  remedies.push(`verify: ${pythonBin} ${memoryTreePath} check`);
+  out.push('', 'Remediation:');
+  out.push(...remedies.map((r) => `  - ${r}`));
+  return out.join('\n');
+}
+
+/**
+ * Degraded section, or '' when healthy. Any unexpected health-provider
+ * exception is swallowed (contributes nothing, never blocks other providers)
+ * — parity with the hook's `_memory_degraded_section` catch-all.
+ */
+function memoryDegradedSection(
+  vaultPath: string | null,
+  deps: VaultContextDeps,
+): string {
+  try {
+    const lines: string[] = [];
+    const vaultProblem = probeVaultWritable(vaultPath);
+    if (vaultProblem) lines.push(vaultProblem);
+    lines.push(...treeHealthLines(deps.dbPath));
+    if (lines.length === 0) return '';
+    return renderDegradedSection(
+      lines,
+      deps.pythonBin,
+      path.join(deps.scriptsDir, 'memory_tree.py'),
+    );
+  } catch {
+    return '';
+  }
+}
+
+// ── Facade ──────────────────────────────────────────────────────────────────
+
+function skipResult(skipReason: VaultContextSkipReason): VaultContextResult {
+  return {
+    content: undefined,
+    record: {
+      eligible: false,
+      skipReason,
+      vaultAvailable: false,
+      contextLoaded: false,
+      loadedSections: [],
+      loadedVaultFiles: [],
+    },
+  };
+}
+
+/**
+ * Load the session-open vault context for `runContext` — the facade over the
+ * ordered provider pipeline (module doc comment). Returns `undefined`
+ * content when ineligible or when no provider contributes, plus an
+ * inspectable metadata record either way.
+ *
+ * `overrides` is a TEST seam only; production callers pass nothing.
+ */
+export async function loadVaultContext(
+  runContext: RunContext,
+  overrides?: Partial<VaultContextDeps>,
+): Promise<VaultContextResult> {
+  const deps: VaultContextDeps = { ...defaultDeps(), ...overrides };
+
+  // Eligibility exits — BEFORE any config/filesystem/DB/subprocess work.
+  if (!runContext.isControlGroup) return skipResult('non-control-group');
+  if (deps.env['DEUS_VAULT_PRELOADED'] === '1') {
+    return skipResult('already-preloaded');
+  }
+
+  const config = deps.readConfig();
+  const vaultPath = deps.resolveVault(config);
+
+  // Health first: a catastrophic memory failure must surface LOUDLY rather
+  // than silently nuke recall (the "memory died for 4 days" incident) —
+  // evaluated even when the vault itself is unavailable.
+  const degraded = memoryDegradedSection(vaultPath, deps);
+
+  const sections: string[] = [];
+  const loadedSections: VaultContextSection[] = [];
+  const loadedVaultFiles: string[] = [];
+  if (degraded) {
+    sections.push(degraded);
+    loadedSections.push('degraded-memory-health');
+  }
+
+  let vaultAvailable = false;
+  if (vaultPath !== null) {
+    try {
+      vaultAvailable = fs.statSync(vaultPath).isDirectory();
+    } catch {
+      vaultAvailable = false;
+    }
+  }
+
+  if (!vaultAvailable || vaultPath === null) {
+    // Degraded-banner-even-when-vault-missing exception: no context to
+    // inject, but do NOT fail silently when the health probe can explain it.
+    // (vaultAvailable can only be true when vaultPath !== null, but the
+    // `|| vaultPath === null` disjunct lets TS narrow vaultPath to `string`
+    // for every subsequent use below, instead of leaving it `string | null`.)
+    return {
+      content: sections.length > 0 ? sections.join('\n\n') : undefined,
+      record: {
+        eligible: true,
+        vaultAvailable: false,
+        contextLoaded: sections.length > 0,
+        loadedSections,
+        loadedVaultFiles,
+      },
+    };
+  }
+
+  for (const fname of normalizeVaultAutoload(config)) {
+    const section = loadVaultFileSection(vaultPath, fname);
+    if (section) {
+      sections.push(section);
+      loadedVaultFiles.push(fname);
+      if (!loadedSections.includes('vault-files')) {
+        loadedSections.push('vault-files');
+      }
+    }
+  }
+
+  const checkpoint = loadCheckpointSection(vaultPath, deps.now());
+  if (checkpoint) {
+    sections.push(checkpoint);
+    loadedSections.push('checkpoint');
+  }
+
+  const recentOutput = await loadRecentSessionsOutput(deps);
+  if (recentOutput) {
+    sections.push(`=== RECENT SESSIONS ===\n${recentOutput}`);
+    loadedSections.push('recent-sessions');
+  }
+
+  const semantic = loadSemanticCacheSection(deps);
+  if (semantic) {
+    sections.push(semantic);
+    loadedSections.push('semantic-cache');
+  }
+
+  return {
+    content: sections.length > 0 ? sections.join('\n\n') : undefined,
+    record: {
+      eligible: true,
+      vaultAvailable: true,
+      contextLoaded: sections.length > 0,
+      loadedSections,
+      loadedVaultFiles,
+    },
+  };
+}

--- a/src/container-mounter.ts
+++ b/src/container-mounter.ts
@@ -39,8 +39,20 @@ export interface VolumeMount {
 /**
  * Resolve the vault path from env var or config file.
  * Returns null if no vault is configured.
+ *
+ * Exported for reuse by the deus-native session-open vault-context loader
+ * (LIA-416, src/agent-runtimes/vault-context.ts) — one resolver, one
+ * precedence order, no duplication.
+ *
+ * `config` (optional): an already-parsed config object (e.g. from
+ * `readDeusConfig()`), so a caller that has read the config once can reuse
+ * that consistent snapshot. When omitted, the config file is read from disk
+ * exactly as before — existing callers are unchanged. Environment precedence
+ * (`DEUS_VAULT_PATH` first) is preserved in both modes.
  */
-function resolveVaultPath(): string | null {
+export function resolveVaultPath(
+  config?: Record<string, unknown>,
+): string | null {
   // 1. Environment variable
   const envPath = process.env.DEUS_VAULT_PATH;
   if (envPath) {
@@ -49,19 +61,25 @@ function resolveVaultPath(): string | null {
       : envPath;
     return path.resolve(resolved);
   }
-  // 2. Config file
-  const configPath = path.join(CONFIG_DIR, 'config.json');
-  try {
-    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    if (cfg.vault_path) {
-      const vp = cfg.vault_path as string;
-      const resolved = vp.startsWith('~')
-        ? path.join(HOME_DIR, vp.slice(1))
-        : vp;
-      return path.resolve(resolved);
+  // 2. Config (injected snapshot, or read from disk when not supplied)
+  let cfg: Record<string, unknown>;
+  if (config !== undefined) {
+    cfg = config;
+  } else {
+    const configPath = path.join(CONFIG_DIR, 'config.json');
+    try {
+      cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch {
+      // No config file or parse error
+      return null;
     }
-  } catch {
-    // No config file or parse error
+  }
+  const vp = cfg['vault_path'];
+  // A truthy non-string vault_path previously threw inside the try block and
+  // resolved to null — the type guard keeps that observable null result.
+  if (typeof vp === 'string' && vp) {
+    const resolved = vp.startsWith('~') ? path.join(HOME_DIR, vp.slice(1)) : vp;
+    return path.resolve(resolved);
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Adds a vault-context facade (`src/agent-runtimes/vault-context.ts`) that ports `scripts/vault_context_hook.py` to TypeScript: degraded memory health banner, ordered vault-autoload file sections, the newest same-day checkpoint, an async subprocess adapter for recent sessions (5s bounded, never blocks the event loop), and the semantic cache — composed in the same order as the Python reference.
- `loadSessionOpenContext` now awaits this facade and prepends its output (vault-first, then existing global/group `CLAUDE.md`) for eligible control-group sessions only, gated by the existing `priorTuple === undefined` once-per-session check in `runTurn` — no new gate is introduced. Injection is skipped for non-control groups and when `DEUS_VAULT_PRELOADED=1`, evaluated before any config/filesystem/subprocess work.
- Exports `resolveVaultPath` from `container-mounter.ts` with an optional parsed-config parameter so the facade can share one config read, without changing existing mount behavior or callers.

This is LIA-416 (D2) in the deus-v2 migration, stacked on `origin/deus-v2/dev` at LIA-401–LIA-407 (+ LIA-415's memory-retrieval middleware, rebased in). LIA-418 (D4, `context-registry.ts` parity) depends on this landing — it extends the same `loadSessionOpenContext` composition seam.

## Acceptance criteria
- [x] The session-open lifecycle invokes the vault-context surface.
- [x] Injected content is available before the session's first model call.
- [x] The injection runs once per opened session lifecycle.
- [x] Resume behavior follows the documented session-open semantics.
- [x] Tests compare the new surface with the expected `vault_context_hook.py` output.

## Review
- plan-reviewer: SHIP (native + gpt backend)
- code-reviewer: SHIP (native + gpt backend, round 2 — round 1 caught two real compile errors and a lint error, fixed and re-reviewed; glm backend COULD_NOT_RUN, fails open)
- verification-gate: SHIP — ran typecheck/lint/tests/pytest/drift-check first-hand, verified all 5 ACs against named passing tests including the real `vault_context_hook.py` differential parity tests

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (0 errors)
- [x] `npx vitest run src/agent-runtimes/lifecycle-events.test.ts src/agent-runtimes/vault-context.test.ts src/container-mounter.test.ts src/agent-runtimes/deus-native-backend.test.ts src/agent-runtimes/middleware-stack.test.ts` — 149/149 pass (confirms no interference with LIA-415)
- [x] `python3 -m pytest scripts/tests/test_memory_health.py` — 8/8 pass
- [x] `npm run drift-check` — clean (auto-bumped one drifted pattern, committed separately)
- [x] POSIX differential tests spawn the real `scripts/vault_context_hook.py` and assert literal content equality with the TypeScript output

🤖 Generated with [Claude Code](https://claude.com/claude-code)