### PR TITLE
feat(odysseus): stream deus-native activity over SSE (LIA-432/G5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,249 +1,147 @@
-# LIA-428 — Build `deus` CLI chat on `deus-native`
+# LIA-432 — Stream Odysseus activity over SSE
 
-## Goal and constraints
+## File map and responsibilities
 
-Add a new `deus chat` subcommand that opens an interactive terminal conversation backed specifically by the registered `deus-native` `AgentRuntime`. Preserve the existing meanings of bare `deus`, `deus claude`, `deus codex`, and `deus openai`; they continue to launch the existing development CLIs. The new chat must survive at least two turns, persist and resume its backend-scoped LangGraph session across CLI processes, render normalized human-facing output rather than `RuntimeEvent`/transport frames, close cleanly, and expose the backend and session id through `/status`.
+| File | Change and responsibility |
+| ---- | ------------------------- |
+| `src/agent-runtimes/activity-broadcaster.ts` (new) | Define the exported activity envelope, process-local fan-out broadcaster, documented no-throw lifecycle, and `deus-native` runtime decorator so every registry-resolved caller shares one ordered event stream. |
+| `src/agent-runtimes/activity-broadcaster.test.ts` (new) | Unit-test schema mapping, global ordering, fan-out/isolation, decorator transparency, and broadcaster lifecycle, including safe publication after close. |
+| `src/odysseus-activity-stream.test.ts` (new) | Exercise the authenticated `/v1/activity` route over real HTTP streams, including multi-event/multi-client delivery, admission limits, abort cleanup, Odysseus-only shutdown, cross-cutting broadcaster ownership, keepalives, and reconnect-without-replay behavior. |
+| `src/odysseus-server.ts` (edited) | Add broadcaster dependency injection, the activity route and SSE formatter, independent activity-stream accounting, per-connection cleanup, and an explicit Odysseus stop helper that owns only the HTTP server and its activity-route subscriptions. |
+| `src/index.ts` (edited) | Construct and inject the shared broadcaster, decorate only the registered `deus-native` runtime, give the Odysseus server a single shutdown owner outside the generic webhook-server loop, and close the process-wide broadcaster only at the true end of shutdown. |
+| `src/agent-runtimes/deus-native-backend.test.ts` (extended) | Lock the decorator integration behavior for a `deus-native` error result that does not emit its own `error` event, without changing the downstream sink or `RunResult`. |
 
-This is a source-code feature rather than a skill because it must enter the host-owned `AgentRuntime`, credential-proxy, database-session, and CLI-launcher paths. The implementation must follow the backend-neutral UX rules in `AI_AGENT_GUIDELINES.md`: present as Deus, keep provider details out of ordinary chat output, preserve backend-scoped session semantics, and never move credentials into the client process.
+## 1. Scope summary
 
-## Decisions
+G5 adds an authenticated, localhost-only Odysseus SSE subscription that exposes live events emitted by `deus-native` turns, regardless of whether the turn originated from Odysseus chat, a normal channel handled by `src/message-orchestrator.ts`, a scheduled task in `src/task-scheduler.ts`, a Linear run in `src/linear-dispatcher.ts`, or the multi-agent path in `src/multi-agent/orchestrator.ts`. It defines a stable event contract, fans each event out to all connected clients, and handles disconnect/reconnect and shutdown cleanup. It does not build the Companion app or an activity-monitor UI; those remain separate tickets.
 
-### 1. CLI entry point: additive `deus chat`
+For LIA-352's Companion voice overlay, the `deus-native` `activity`, `tool_call`, `output_text`, `turn_complete`, and `error` events are sufficient to drive the progress/“thinking” animation states and completion signal, so G5 is a full, direct unblock. For LIA-64's activity-monitor TUI tab, the same stream supplies current activity text, tool invocations, usage, run/group identity, and completion/failure state for `deus-native` turns specifically, providing real and useful data to build the tab against; it does not supply “container status” for container-backed Claude, OpenAI, or llama-cpp turns because `deus-native` is a host-side, zero-container execution path and G5 intentionally does not instrument those runtimes (see Non-goals). The intended ticket reading is therefore that G5 ships `deus-native`-only activity now; if LIA-64 is later scoped to require container status or other activity for non-`deus-native` backends, that requires its own follow-up ticket and ADR against the container-backed runtime path and is explicitly not part of what G5 unblocks.
 
-Add a `chat)` dispatch arm to `deus-cmd.sh` near the existing compiled-TypeScript subcommands (`pipeline`, `solution`, and `tui`, currently around lines 1507–1530). It will execute `node "$SCRIPT_DIR/dist/cli/deus-native-chat-client.js"` without changing directory, so the client retains the user's original `process.cwd()` for `RunContext.cwd`. Update the usage block around lines 1730–1766. Mirror the same `chat` dispatch and help text in `deus-cmd.ps1` (its command switch starts around line 490) because repo-owned CLI commands are a cross-backend/cross-platform contract.
+Operationally, because Claude remains the default backend and `deus-native` is opt-in via `DEUS_AGENT_BACKEND`, `/v1/activity` is expected to remain silent for any group/session not running on `deus-native`; consumers for LIA-352 or LIA-64 must distinguish that expected backend-not-selected state from a broken stream.
 
-The command is named `deus chat`, not bare `deus` and not a new package `bin`, because:
+## 2. Event schema
 
-- bare `deus` and the `claude`/`codex` prefixes already have stable, unrelated meanings in `deus-cmd.sh` (prefix handling at lines 29–44 and the home launch arm at lines 788+);
-- `package.json` has no installed `bin` and the live command is the symlinked shell/PowerShell launcher, so adding an npm-only entry point would not satisfy “from the `deus` CLI”;
-- an options-object seam on the TypeScript client lets G2 add model-selection flags and G3 add a plan-mode toggle later without changing this dispatch shape.
+Add the exported contract beside the new broadcaster in a new `src/agent-runtimes/activity-broadcaster.ts` module. Keep it separate from the OpenAI-compatible `chunkFrame()` / `completionFrame()` schema in `src/odysseus-server.ts`: `/v1/chat/completions` must remain wire-compatible with OpenAI, while the activity endpoint is a Deus-owned observational contract.
 
-`deus chat` resumes the one recorded `deus-native` CLI thread by default. No new-session/session-picker command is part of LIA-428.
+Each SSE message will carry both an SSE `id:` line and an SSE `event:` line, followed by one JSON `data:` object with this shape:
 
-### 2. Architecture: thin client; runtime remains in the daemon
+| Field       | Shape                                                                                | Contract                                                                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | string                                                                               | `${streamId}:${sequence}`; exactly matches the SSE `id:` line.                                                                                                                                       |
+| `streamId`  | UUID string                                                                          | Random once per `RuntimeActivityBroadcaster` instance/process epoch. A change tells a reconnecting client that the server restarted and sequence values are from a new epoch.                        |
+| `sequence`  | positive integer                                                                     | Allocated once by the broadcaster before fan-out, monotonically increasing across every published activity event in that process. It is global to the broadcaster, not per client or per turn.       |
+| `type`      | `output_text \| activity \| tool_call \| usage \| session \| turn_complete \| error` | The discriminant and the value used in the SSE `event:` line.                                                                                                                                        |
+| `timestamp` | ISO-8601 string                                                                      | Server publication time, generated once before fan-out so all clients receive the same timestamp. Ordering is defined by `sequence`, not wall-clock time.                                            |
+| `runId`     | UUID string                                                                          | Minted once by the runtime decorator for each `AgentRuntime.runTurn()` call and reused for all of that turn's events, so consumers can correlate interleaved groups and identify the terminal event. |
+| `source`    | object                                                                               | `{ backend: 'deus-native', groupFolder: string, chatJid: string }`, taken from `AgentRuntime.name()` and `RunContext.groupFolder` / `RunContext.chatJid`; no prompt or filesystem path is exposed.   |
+| `payload`   | object                                                                               | Variant-specific fields copied from the existing `RuntimeEvent` without adding provider-specific frame fields.                                                                                       |
 
-Do **not** instantiate `DeusNativeRuntime`, `startCredentialProxy`, or `startToolProxy` in the short-lived CLI process. `src/index.ts:101–166` proves that the daemon initializes the database, starts the sole credential proxy, creates the shared in-memory group-token map indirectly used by the runtime, and registers `deus-native` with its live dependencies. A second process would mint a token in a different `src/group-tokens.ts` map, which the daemon proxy would reject, while starting a second proxy on fixed port 3001 would collide with the daemon. Booting the full host just to chat would also duplicate channels, schedulers, webhooks, and IPC watchers.
+The `RuntimeEvent` mapping from `src/agent-runtimes/types.ts` is exhaustive:
 
-Instead, add a small daemon-owned, loopback-only chat server after the runtime registry is initialized. On every daemon start it will:
+| `RuntimeEvent` variant | SSE `type`      | `payload`                                                                                                                                                                     |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `output_text`          | `output_text`   | `{ text }`                                                                                                                                                                    |
+| `activity`             | `activity`      | `{ text }`                                                                                                                                                                    |
+| `tool_call`            | `tool_call`     | `{ name, arguments }`                                                                                                                                                         |
+| `usage`                | `usage`         | `{ sessionId, provider, model, inputTokens, outputTokens, totalTokens }`; preserve `undefined` token semantics by omitting those keys in JSON rather than fabricating zeroes. |
+| `session`              | `session`       | `{ sessionRef }`                                                                                                                                                              |
+| `turn_complete`        | `turn_complete` | `{}`                                                                                                                                                                          |
+| `error`                | `error`         | `{ error }`                                                                                                                                                                   |
 
-1. generate a cryptographically random bearer token;
-2. listen on `127.0.0.1` with port `0` (an OS-assigned ephemeral port, so no new fixed-port/config/startup-collision surface is created);
-3. atomically write `{ version, pid, host, port, token }` to a discovery file under `CONFIG_DIR`, with user-only permissions (`0600`) and no token logging;
-4. accept only the exact versioned chat routes and require a constant-time bearer-token match, following the security pattern already used by `src/odysseus-server.ts:124–139, 300–335`;
-5. remove only its own discovery record and close the server during the existing `src/index.ts:168–176` graceful shutdown path.
+Only `deus-native` turns are included. Although `RuntimeEventSink` is shared by the Claude, OpenAI, llama-cpp, and deus-native implementations, the ticket explicitly asks for “deus-native activity,” and expanding this external contract to all backends would be backend-wide observability scope not required by G5. Coverage is nevertheless channel-agnostic: every group and invocation path using the `deus-native` registry entry is included. The event set does not expose prompt bodies or wire the test-only `ToolCallDecisionRecord`, `MemoryPassRecord`, `ModelCallRecord`, `SessionOpenRecord`, or `PromptEventRecord` arrays from `src/agent-runtimes/middleware-stack.ts` and `src/agent-runtimes/lifecycle-events.ts` into a new public contract.
 
-The client reads that discovery record and sends authenticated loopback requests. A missing/stale record, refused connection, protocol-version mismatch, or authentication failure becomes a concise “Deus service/chat endpoint is unavailable; rebuild/restart the service” message and a non-zero exit. There is deliberately no unsafe fallback that starts another proxy or reads provider credentials.
+For LIA-352, the `activity`, `tool_call`, `output_text`, `turn_complete`, and `error` variants are sufficient for the Companion voice overlay's progress/“thinking” states and completion signal, making this a full, direct unblock. For LIA-64, the schema provides current activity text, tool invocations, usage, response text, group/run identity, and completion/failure for `deus-native` turns only, which is a useful dataset for building the activity-monitor tab but cannot provide the ticket's “container status” for Claude/OpenAI/llama-cpp turns. G5 intentionally ships this `deus-native`-only contract now; any later requirement for container-backend activity or status belongs in a follow-up ticket and ADR for that runtime path, not in G5.
 
-The transport uses one request per turn and a newline-delimited JSON response internally, so normalized events can be delivered incrementally when a runtime provides them. Protocol JSON is an implementation detail and is never written directly to stdout/stderr. `deus-native` currently reports `tool_streaming: false` and emits its answer after buffered `agent.invoke()` processing (`deus-native-backend.ts:360–492`), so LIA-428 must not claim token-level streaming that does not exist today; the transport and renderer will still consume incremental events correctly when the runtime begins emitting them.
+The process-wide `streamId` plus broadcaster-wide `sequence` is stable across reconnects to the same running host because an event is numbered once, before every subscriber receives the identical envelope. A per-connection counter would not satisfy this: two clients or a reconnect could assign different IDs to the same runtime event. JavaScript's safe-integer range is ample for a process-lifetime counter; guard against overflow by refusing publication with a logged error rather than silently wrapping and violating ordering.
 
-### 3. Stable chat seam for G2/G3
+## 3. Fan-out mechanism
 
-**Design:** use an Adapter (`NativeChatSessionStore`) to isolate the existing `db.getSession`/`db.setSession` persistence API, a Facade/Controller to keep readline/HTTP concerns separate from `AgentRuntime` turn orchestration, and an anti-corruption/normalization boundary that converts `RuntimeEvent` into terminal-safe display events. These are structural seams, not algorithmic machinery: the controller reads and caches one backend-scoped session row, so there is no collection-processing or algorithmic-complexity tradeoff.
+Create `RuntimeActivityBroadcaster` in the new `src/agent-runtimes/activity-broadcaster.ts`. It will own a Node `EventEmitter`, `streamId`, the next sequence, and a closed flag. Its small API is `publish(runId: string, source: RuntimeActivitySource, event: RuntimeEvent): void`, `subscribe(handler: (envelope: RuntimeActivityEnvelope) => void): () => void`, `subscriberCount(): number` for lifecycle assertions, and idempotent `close(): void`. The decorator signature is `withRuntimeActivityBroadcast(runtime: AgentRuntime, broadcaster: RuntimeActivityBroadcaster): AgentRuntime`. This is the Observer pattern: the process-wide broadcaster is the subject, and each activity-route connection is an independently removable observer. Publication is O(number of current subscribers), which is the necessary cost of delivering one immutable envelope to every live client; lookup/removal state remains process-local and bounded by the five-connection admission cap.
 
-`src/cli/deus-native-chat.ts` will expose a testable controller rather than embedding readline, HTTP, database access, and runtime calls in one function:
+`publish()` constructs one immutable envelope and synchronously emits it to a snapshot of subscribers; subscription wrappers isolate listener/write failures so one disconnected client cannot throw into `AgentRuntime.runTurn()` or prevent delivery to other clients. Its exported doc comment must guarantee that `publish()` never throws because the broadcaster is closed: after `close()` marks the instance closed and removes its listeners, every later `publish()` is a safe no-op that allocates no ID/sequence and invokes no subscriber. A post-close `subscribe()` is likewise inert and returns a no-op unsubscribe. Sequence-overflow refusal logs metadata but does not throw into a producer. These shutdown semantics are defense in depth for a late event from a detached turn and preserve the decorator's downstream sink even after process-wide observation has ended. There is no external broker because Deus is a single host process and the consumers are HTTP connections in that same process.
 
-```ts
-export interface DeusNativeChatOptions {
-  cwd: string;
-  resume: true;
-}
+Do not extend `src/events/bus.ts` for this ticket. `EventBus.emit()` is an asynchronously and sequentially awaited pipeline-reaction bus with the `DeusEvent` taxonomy from `src/events/types.ts`; making every runtime token/tool event flow through it would let an SSE listener back-pressure the agent and would conflate the accepted pipeline event-hub contract in `docs/decisions/event-hub.md` with a high-frequency transport stream. The dedicated broadcaster is a best-effort observation seam with different lifecycle and delivery semantics.
 
-export interface NativeChatSessionStore {
-  get(groupFolder: string, backend: AgentRuntimeId): RuntimeSession | undefined;
-  set(groupFolder: string, session: RuntimeSession): void;
-}
+Add a `withRuntimeActivityBroadcast(runtime, broadcaster)` decorator in the same new module. In `src/index.ts`, construct one broadcaster at the composition root, wrap only `createDeusNativeRuntime(backendDeps)`, and register that decorated runtime through the existing `RuntimeRegistry.register()` call. Pass the same broadcaster through `OdysseusServerDeps` to `startOdysseusServer()`. The decorator creates a `runId` per `runTurn()`, tees every existing event to `publish()` before invoking the caller's original `RuntimeEventSink`, and otherwise preserves `name()`, `capabilities()`, `startOrResume()`, `close()`, downstream sink ordering, and the returned `RunResult`.
 
-export function createDeusNativeChatController(deps: {
-  runtime: AgentRuntime;
-  sessions: NativeChatSessionStore;
-}): DeusNativeChatController;
-```
+This single registry-boundary decorator covers the existing sinks in `message-orchestrator.ts`, `task-scheduler.ts`, `linear-dispatcher.ts`, `multi-agent/orchestrator.ts`, and `odysseus-server.ts` without editing each caller. Track whether an `error` event was observed; if the wrapped deus-native call returns `RunResult.status === 'error'` without emitting one (the current `DeusNativeRuntime.runTurn()` catch path does this), publish one broadcaster-only `RuntimeEvent`-shaped `error` envelope using `RunResult.error`. Do not inject that synthetic event into the caller's sink, which would change existing channel behavior. If the wrapped call unexpectedly throws, publish the same terminal error and rethrow so existing caller semantics remain intact.
 
-The controller takes a single `DeusNativeChatOptions` object and builds `RunContext` in one place. G2 can extend that object with its model selection and translate it into the runtime-supported model configuration; G3 can add a typed mode field and translate it into the runtime contract. LIA-428 will not add placeholder `model`, `planMode`, or arbitrary client-controlled `backendConfig` fields. This prevents premature UX and avoids exposing security-sensitive runtime configuration merely for future-proofing.
+## 4. New route
 
-Use fixed internal identity constants such as `CLI_CHAT_GROUP_FOLDER = "deus-native-cli"` and `CLI_CHAT_JID = "cli:deus-native"`. The group folder is synthetic and unregistered; `DeusNativeRuntime.runTurn` only uses `resolveGroup` for the `publicIngress` refusal (`deus-native-backend.ts:253–262`), so `undefined` follows the safe non-public-ingress path. The synthetic identity also prevents the CLI session from overwriting a channel group's backend-scoped session row. `isControlGroup` remains `false`; this ticket does not grant the terminal client control-group privileges.
+Add exactly one route to the `createOdysseusServer()` router in `src/odysseus-server.ts`:
 
-Add the same top-of-file non-goals style used by `deus-native-backend.ts:1–70` to the chat controller and server modules. The comment must name the deferred G2 model-selection UX and G3 plan-mode toggle explicitly and warn contributors not to add them in this ticket.
+- `GET /v1/activity` — long-lived deus-native activity SSE subscription.
 
-## Files and responsibilities
+All other methods on `/v1/activity` return the same `405` JSON shape as the existing route method gates. The route participates in the existing method-before-auth routing discipline, then reuses `extractBearer()` and `timingSafeEqualStr()` against the same validated `ODYSSEUS_HTTP_TOKEN`; no query-string token, cookie, alternate credential, or auth bypass is added. It remains reachable only through the existing `127.0.0.1` bind in `startOdysseusServer()`.
 
-### New source files
+Apply the existing module-level `isRateLimited(remoteAddr)` check to each initial connection and reconnection, just as for `/v1/models` and `/v1/chat/completions`; keepalives and delivered activity events do not consume additional rate-limit entries. Advertise a 15-second SSE retry delay so a single normally reconnecting client stays below `RATE_LIMIT_MAX = 5` per 60 seconds when it is not also making other Odysseus requests.
 
-- `src/cli/deus-native-chat.ts`
-  - Own `DeusNativeChatOptions`, fixed CLI identity constants, the injectable session-store interface, `createDeusNativeChatController`, and the normalized display-event type.
-  - Implement `start()`, `runTurn(prompt, options)`, `status()`, and `close()` around the real `AgentRuntime` contract.
-  - Convert every `RuntimeEvent` variant into a bounded, UI-safe display event; never expose the runtime union itself to the terminal module.
-  - Keep per-turn/session state in the controller only as a cache of the authoritative SQLite row; do not create a second persistence mechanism.
+Use a separate `activeActivitySse` counter, but cap it with the existing `MAX_CONCURRENT_SSE` value. Do not share the current `activeSse` counter: `/v1/activity` connections are intentionally long-lived, so five monitor clients could otherwise consume every slot indefinitely and make unrelated `/v1/chat/completions` streaming turns return `503`. The separate counter still bounds activity sockets to five without adding a new config surface. Reset it in `_resetServerStateForTest()` alongside `activeSse`, and return the existing `503 { error: 'too many concurrent streams' }` shape when its cap is reached.
 
-- `src/cli/deus-native-chat-server.ts`
-  - Start the authenticated ephemeral loopback server inside the daemon, manage the discovery file, validate method/path/body/version/auth, cap request size, and serialize a single in-flight turn for the fixed CLI session (reject a competing turn rather than interleave prompts in one LangGraph thread).
-  - Resolve `registry.get("deus-native")` explicitly rather than `registry.resolve(...)`; `deus chat` is this ticket's native surface and must not silently follow the channel/global default backend.
-  - Adapt `db.getSession`/`db.setSession` to `NativeChatSessionStore`, stream the controller's normalized display events, expose status, and call controller close on the close route.
-  - Export a server factory that listens on an injected/ephemeral port for hermetic tests; keep process exit and logging out of the core handler.
+The activity route only subscribes; it does not resolve a group, enqueue a `GroupQueue` task, touch `inFlight`, or trigger a turn.
 
-- `src/cli/deus-native-chat-client.ts`
-  - Be the compiled executable invoked by the shell/PowerShell launchers.
-  - Parse only LIA-428's current options, construct a `DeusNativeChatOptions` object with `cwd`, open a readline loop, and send non-empty prompts sequentially.
-  - Recognize local commands `/status`, `/exit`, and `/quit`. `/status` fetches diagnostic state; `/exit`, `/quit`, EOF/Ctrl-D, and SIGINT stop accepting input, make a best-effort authenticated close request, restore terminal state, and exit without clearing the stored session.
-  - Render only normalized display events and terminal prompts; never log request/response objects, bearer tokens, `RuntimeEvent.type`, `sessionRef`, or NDJSON framing.
+## 5. Connect, multiple events, and clean disconnect
 
-### Modified runtime/CLI files
+On admission, write status 200 with the existing SSE headers used by `handleChatCompletion()` — `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and `Connection: keep-alive` — then write `retry: 15000\n\n` to flush headers and establish the reconnect delay. Register the response with the broadcaster only after admission and header setup. Each published envelope is written with a dedicated activity-frame formatter that emits `id:`, `event:`, and JSON `data:` lines; do not reuse `writeSse()`, whose `data:`-only assumption and OpenAI frame input belong to `/v1/chat/completions`.
 
-- `src/index.ts`
-  - Start the native chat server after `registry.register(createDeusNativeRuntime(...))` at current lines 147–166, when the database, credential proxy, shared group-token state, queue dependencies, and registry are all live.
-  - Retain the returned server handle, close it/remove its discovery record in the existing signal shutdown function, and include startup failures in the daemon's normal fatal startup handling. Do not start any duplicate proxy or a second runtime registry.
+Reuse `KEEPALIVE_MS = 20_000`, but keep the activity timer running for the entire subscription and write the same comment frame `: ping\n\n` whenever the response remains writable. This differs from the chat path at `src/odysseus-server.ts:591-594`, which pings only until `firstTokenSeen` because that response ends with the turn. The activity stream may be quiet between unrelated turns and must keep intermediaries from treating that silence as a dead connection. Call `unref()` on the interval so it cannot pin process exit.
 
-- `deus-cmd.sh`
-  - Add the `deus chat` dispatch to the compiled client and update help. Preserve the original cwd and all existing prefix/home behavior.
+Give each connection one idempotent `finalize()` closure with a once flag, mirroring the `releaseSlot()` / `finalize()` discipline around `src/odysseus-server.ts:520-568`. In one place it must clear and null the keepalive interval, invoke and clear the broadcaster unsubscribe function, remove the response from the server's active-activity set, decrement `activeActivitySse` exactly once, detach any explicitly installed close/error handlers if needed, and optionally call `res.end()` only when the server is ending a still-writable response. Register client abort with `res.once('close', finalize)`; request/response error handling remains guarded by the server's existing handlers.
 
-- `deus-cmd.ps1`
-  - Add the equivalent `chat` dispatch/help entry so the source feature remains buildable and reachable on the Windows launcher as required by `docs/CROSS_PLATFORM.md`.
+For explicit shutdown, make the server own an idempotent `closeActivityStreams()` cleanup registered by `createOdysseusServer()`, and expose an idempotent `stopOdysseusServer(server): Promise<void>` helper that calls that cleanup before `server.close()` and resolves when the server close callback completes. Track the per-server cleanup/stop promise in module-private state rather than adding methods to Node's public `Server` type. Each active response receives a final SSE comment such as `: server shutdown\n\n`, then `res.end()`; its normal `close` event may call `finalize()` again, but the once flag makes that harmless. Also invoke the same activity-stream cleanup as a server `close` backstop. Draining those permanent responses before `server.close()` avoids waiting forever for long-lived SSE sockets.
 
-### Documentation required by the repo update rule
+Draining `/v1/activity` responses is not sufficient on its own: Node's `server.close()` callback does not fire until every open connection ends, including a still-streaming `/v1/chat/completions` turn (bounded elsewhere only by the 10-minute `ABSOLUTE_TURN_MS`). Since `stopOdysseusServer()` is now awaited in `src/index.ts`'s `shutdown()` before the queue/channel drain (see below), an unbounded wait here could starve that drain for far longer than typical process-manager grace periods. `stopOdysseusServer()` therefore races `server.close()`'s callback against a `ODYSSEUS_STOP_GRACE_MS = 10_000` timeout; if the grace period elapses first, it force-closes any remaining sockets via `server.closeIdleConnections()` / `closeAllConnections()` (Node >=18.2 APIs; this repo requires Node >=20) so the close callback — and therefore `stopOdysseusServer()` — resolves promptly regardless of what else is still open.
 
-- `AGENTS.md`
-  - Add `deus chat` to the stable Commands and Skills list and add the native CLI controller/server entry point to the architecture table so later agents do not rediscover the transport.
+Give the Odysseus server exactly one HTTP-server shutdown owner in `src/index.ts`: the live wiring declares `webhookServers: Server[]` at `src/index.ts:139`, closes every member in the generic loop at `src/index.ts:172`, pushes the ingress gateway and standalone Linear webhook servers at `src/index.ts:363` and `src/index.ts:562`, creates `odysseusServer` at `src/index.ts:476`, and currently pushes that same instance at `src/index.ts:481`. Remove/replace the `webhookServers.push(odysseusServer)` wiring at line 481 so the array contains only the other webhook servers; in `shutdown()`, `await stopOdysseusServer(odysseusServer)` when it exists before the generic `webhookServers` loop, and do not close that instance again in the loop. `stopOdysseusServer()` is therefore the sole closer of the Odysseus `Server`, avoiding a double `server.close()` while preserving generic shutdown for the gateway and Linear servers. Crucially, neither `closeActivityStreams()` nor `stopOdysseusServer()` closes the injected `RuntimeActivityBroadcaster`; they remove only activity-route subscriptions and close the Odysseus HTTP resource.
 
-- `docs/AGENT_DEUS_101.md`
-  - Add the client → authenticated daemon endpoint → `deus-native` controller → runtime/session-store flow to the detailed entrypoint map.
+The process-wide broadcaster remains owned by the `src/index.ts` composition root. Preserve the live shutdown sequence at `src/index.ts:171-178`, with this precise extension: stop Linear admission; await the dedicated Odysseus stop; close the other `webhookServers`; stop the ingress tunnel and proxy servers; `await queue.shutdown(10000)`; await every `channel.disconnect()`; then call `activityBroadcaster.close()` immediately before `process.exit(0)`. This is the latest process-wide shutdown boundary, after channels, scheduled work admitted through the queue, Linear dispatch, and channel-owned multi-agent work have all had their available shutdown/drain window. It matters because `GroupQueue.shutdown(_gracePeriodMs)` at `src/group-queue.ts:366-383` only sets `shuttingDown` and reports detached containers; it does not use the grace-period argument or await in-flight turns. Closing the broadcaster inside the earlier Odysseus stop would therefore let a non-Odysseus turn call the decorator's tee against a closed shared dependency during channel disconnection. Moving `close()` to the process tail preserves observation throughout that window, while the documented post-close no-op prevents any still-late detached turn from throwing or disrupting its original sink after the final close.
 
-- `docs/decisions/deus-native-cli-chat.md` and `docs/decisions/INDEX.md`
-  - Record the thin-client decision, why a second in-process CLI runtime/proxy is invalid, the ephemeral authenticated loopback/discovery-file boundary, the fixed synthetic session identity, and rollback (remove launcher arms, server startup, and discovery file handling). This is an architectural entrypoint and credential-boundary decision, so it should not live only in code comments.
+## 6. Reconnection behavior
 
-### Tests
+Choose fire-and-forward-only delivery: the server does not replay missed events and does not retain a ring buffer. A reconnect starts receiving events published after its new subscription. `Last-Event-ID` is accepted as an ordinary request header but deliberately ignored; clients compare their last `{ streamId, sequence }` with the next envelope. A matching `streamId` and a jump in `sequence` proves a gap; a changed `streamId` proves the host restarted and began a new ordering epoch. This meets the acceptance criterion, which requires documented and tested reconnection behavior but does not require lossless delivery, while avoiding in-memory retention of potentially sensitive `tool_call.arguments` and avoiding a new history-size/config contract.
 
-- `src/cli/deus-native-chat.test.ts`
-  - Controller and renderer unit tests with an injected fake runtime/session store.
+Document this behavior in the exported contract doc comment on `RuntimeActivityEnvelope` / `RuntimeActivityBroadcaster` in the new module and in the `handleActivityStream()` route doc comment in `src/odysseus-server.ts`. A new ADR is not required for this bounded, process-local transport addition: `docs/decisions/event-hub.md` already establishes the single-process boundary, and this plan explicitly preserves rather than changes that bus's semantics. If a later consumer requires durable replay across process restarts, that is a materially different persistence/privacy decision and should get its own ticket and ADR.
 
-- `src/cli/deus-native-chat-server.test.ts`
-  - Real ephemeral HTTP server tests with temporary discovery paths and fake controller/runtime dependencies.
+Set `retry: 15000` on connect as the server's SSE reconnection hint. Authentication remains mandatory on every reconnect; a client that cannot resend the bearer header will receive `401`, and the server must never fall back to query credentials.
 
-- `src/cli/deus-native-chat-client.test.ts`
-  - Scripted input/output tests against a fake transport for two prompts, status, EOF/SIGINT-safe cleanup behavior, and framing-free output.
+## 7. Test plan
 
-- `src/cli/deus-native-chat.integration.test.ts`
-  - Reuse the hermetic fake-model/real-checkpointer approach from `src/agent-runtimes/deus-native-checkpointer-integration.test.ts` and the dependency mocking conventions from `src/agent-runtimes/deus-native-backend.test.ts`; do not make live provider/network calls.
+Split HTTP coverage into a new sibling `src/odysseus-activity-stream.test.ts` rather than growing the already 927-line `src/odysseus-server.test.ts`. Follow the current test's style: mock the same side-effecting modules, call `createOdysseusServer(deps, TOKEN)`, listen on an ephemeral `127.0.0.1` port, and use real `http.request()` / `http.get()` streams. Give each test a fresh injected `RuntimeActivityBroadcaster`; teardown must stop the server/route subscriptions first and close the process-wide broadcaster last, matching production ownership. Add focused unit coverage in a new `src/agent-runtimes/activity-broadcaster.test.ts`, and extend the existing `src/agent-runtimes/deus-native-backend.test.ts` only for the registry/decorator integration behavior.
 
-- `scripts/tests/test_deus_cmd_native_chat.py`
-  - Structural launcher test proving `deus chat` reaches the compiled client and that existing bare/prefixed branches remain present. Follow the existing `scripts/tests/test_deus_cmd_backend_prefix.py`/`test_deus_cmd_print_identity.py` style rather than invoking the live daemon.
+Concrete cases, mapped to the acceptance criteria:
 
-If the PowerShell launcher has no comparable test harness, cover its dispatch text in the TypeScript/structural test or add a small platform-neutral source assertion alongside the shell assertion; do not require a live Windows service in CI.
+1. **Endpoint/auth/method contract (AC: endpoint exposed).** `GET /v1/activity` without or with an invalid bearer returns `401`; an authenticated non-GET returns `405`; an authenticated GET returns 200 with `text/event-stream`, `no-cache`, and `keep-alive`, plus the 15-second retry directive. Assert the same bearer token path is used and no query token is accepted.
+2. **Schema and global ordering (AC: documented schema/stable ordering).** Publish scripted `tool_call`, `usage`, `output_text`, and `turn_complete` events through the broadcaster. Parse SSE frames and assert exhaustive field shape, identical `id:`/JSON `id`, ISO timestamp, `backend: 'deus-native'`, group folder, JID, shared `runId`, one `streamId`, strictly increasing `sequence`, and correct variant payloads. A unit test publishes from two run IDs/groups and proves the single broadcaster sequence still establishes total publication order.
+3. **Multiple events on one connection (AC: receive multiple runtime events).** Hold one real GET open, publish at least three events after subscription, and resolve the test as soon as three complete SSE frames have arrived rather than waiting for connection end. Assert delivery order matches publication order.
+4. **Multi-client fan-out (AC: live fan-out).** Connect two authenticated clients before publishing, emit two events, and assert both clients receive byte-equivalent IDs/envelopes in the same order. Abort one, publish a third, and assert the remaining client still receives it while the aborted client has been unsubscribed.
+5. **Only deus-native, all deus-native callers (AC: data sufficient for LIA-352/LIA-64).** Unit-test `withRuntimeActivityBroadcast()` with a fake deus-native runtime: its downstream sink receives the original events unchanged and in order, while the broadcaster adds source/run metadata. Verify the production composition in `src/index.ts` wraps only the `createDeusNativeRuntime()` registration, leaving the Claude/OpenAI/llama-cpp registrations undecorated. In `deus-native-backend.test.ts`, cover a returned error with no emitted `error` and assert the broadcaster receives one terminal error without changing the original downstream sink or `RunResult`.
+6. **Client abort cleanup (AC: disconnect cleanly).** Spy on the activity keepalive's `clearInterval`, connect, assert `broadcaster.subscriberCount() === 1`, destroy the client request, wait for the response `close`, then assert subscriber count is zero, the interval was cleared, and a later publish causes no write/error. Reconnect and disconnect five-plus times sequentially to prove the separate activity admission counter is released rather than eventually returning `503`.
+7. **Server shutdown cleanup (AC: disconnect cleanly).** Keep two clients connected, `await stopOdysseusServer(server)`, and assert both clients observe end/close, the broadcaster has zero route subscribers, all keepalive handles were cleared, and the server close callback completes. Assert the broadcaster itself remains open; this catches both the otherwise easy deadlock where `server.close()` waits on permanent SSE responses and an accidental return to Odysseus-owned broadcaster shutdown.
+8. **Shared-broadcaster shutdown ordering (cross-cutting lifecycle oracle).** Subscribe a non-SSE recorder to the shared broadcaster, stop the Odysseus server, and then run a decorated fake deus-native runtime with a channel/task/Linear-shaped `RunContext` rather than an SSE client. Assert its events still publish to the recorder and its original downstream sink/`RunResult` remain unchanged during the window after `stopOdysseusServer()` resolves but before process-wide `close()`. Then close the broadcaster and run/publish again: assert no exception, no subscriber invocation or new envelope, and unchanged downstream sink/`RunResult`. In `activity-broadcaster.test.ts`, independently call `close()` twice followed by `publish()` and assert the same documented safe no-op guarantee. This directly proves both the ownership reordering and its defense-in-depth fallback for a detached late producer.
+9. **Fire-and-forward reconnection (AC: reconnection documented and tested).** Connect client A, receive sequence N, disconnect it, publish N+1 while no client is present, then reconnect client B with `Last-Event-ID: <streamId>:N`. Assert N+1 is not replayed; publish N+2 and assert B's first data event is N+2 with the same stream ID, making the gap detectable. A second test constructs a new broadcaster and proves its changed `streamId` identifies a restart epoch even though its numeric sequence restarts.
+10. **Keepalive behavior.** With fake timers or a captured interval callback, advance `KEEPALIVE_MS` both before and after a data event and assert `: ping` is written in both cases, then disconnect and prove advancing again writes nothing. This locks the intentional difference from chat's `!firstTokenSeen` keepalive condition.
+11. **Admission/rate behavior.** Assert reconnects consume the existing rate bucket, delivered events/pings do not, and the activity cap uses its own counter. Where the sixth same-address request is intercepted first by the five-per-minute rate limiter, unit-test the activity admission helper/counter directly or reset only the rate bucket between admissions; do not weaken or reorder auth/rate limiting merely to make the cap easier to test.
 
-## Turn and session lifecycle
+Run at minimum `npx vitest run src/agent-runtimes/activity-broadcaster.test.ts src/agent-runtimes/deus-native-backend.test.ts src/odysseus-server.test.ts src/odysseus-activity-stream.test.ts`, `npm run typecheck`, `npm run build`, and `git diff --check`. The implementation reviewer should also inspect the final producer-to-consumer wiring in `src/index.ts` so passing unit tests cannot mask an unwired facade.
 
-For each prompt, `DeusNativeChatController.runTurn` performs this exact sequence:
+## 8. Non-goals and explicit exclusions
 
-1. Build a `RunContext` with the prompt, client cwd, fixed synthetic `groupFolder` and `chatJid`, `isControlGroup: false`, and `stream: true`. No G2/G3 fields are supplied.
-2. Read `sessions.get(CLI_CHAT_GROUP_FOLDER, "deus-native")`, which the production adapter implements with `db.getSession(groupFolder, backend)` (`src/db.ts:757–789`). The explicit backend argument is load-bearing: sessions are backend-scoped and the CLI must never select the most-recent Claude/OpenAI row.
-3. When no row exists, call `runtime.startOrResume(runContext)`. Today this returns `defaultSession("", "deus-native")` (`deus-native-backend.ts:225–232`); passing that empty id into `runTurn` lets the runtime mint the real `crypto.randomUUID()` LangGraph `thread_id` (`deus-native-backend.ts:264–304`). Do not mint a competing CLI id.
-4. Call `runtime.runTurn(runContext, sessionRef, eventSink)`. Keep the returned/current `RuntimeSession` in memory for the next prompt in the same CLI process.
-5. If the sink receives a `session` event, immediately validate that its backend is `deus-native`, update current state, and persist it with `db.setSession(CLI_CHAT_GROUP_FOLDER, sessionRef)`. This matches the canonical event handling in `message-orchestrator.ts:191–207`.
-6. After `runTurn` returns success, validate and persist `RunResult.sessionRef` as well, matching the success path in `message-orchestrator.ts:268–271`. This second path is required today because `DeusNativeRuntime` echoes its minted/resumed id in `RunResult.sessionRef` (`deus-native-backend.ts:485–492`) and does not currently emit a `session` event.
-7. On the second prompt, reuse that non-empty `RuntimeSession`; the id doubles as the checkpointer `thread_id`, so LangGraph loads the first exchange. `db.setSession`'s same-id path updates `last_used_at` rather than creating a duplicate active row (`src/db.ts:791+`).
-8. On `/exit`, `/quit`, EOF, or SIGINT, the close route reloads the current `deus-native` row if necessary and calls `runtime.close(sessionRef)`. It does **not** call `db.clearSession`; `clearSession` soft-orphans rows (`src/db.ts:895+`) and would break resume. A later `deus chat` process repeats step 2, passes the stored id to `runTurn`, and resumes the same checkpointed message history.
+- No Companion application work, views, notifications, or client state management from LIA-352.
+- No activity-monitor UI, filtering UI, persistence, or visualization from LIA-64.
+- No replay database, ring buffer, durable event history, cross-process broker, or delivery guarantee beyond live best-effort fan-out.
+- No new authentication mode, token transport, config variable, non-local bind, CORS change, or query-string credential.
+- No changes to the existing `/v1/chat/completions` OpenAI chunk schema or conversation/session behavior from LIA-294/LIA-295.
+- No activity from Claude, OpenAI, or llama-cpp turns in G5.
+- No expansion of `RuntimeEvent`, no new tools, no prompt/body capture, and no promotion of middleware/lifecycle test records into public telemetry.
+- No change to GroupQueue serialization, scheduled-task behavior, Linear dispatch behavior, or existing channel sinks.
 
-If `runTurn` returns `status: "error"`, render a user-facing error and do not replace a valid stored session with an empty/foreign ref. If a session event was already persisted before a later failure, retain it: it remains the runtime's authoritative continuity marker. Transport disconnect after the daemon accepted a prompt does not cancel or roll back the host turn; if the turn finishes, its session result is persisted and the next invocation can resume, even if the departed client missed the output.
+**Rollback:** This is a single additive PR: the new module, route, and counter are additive, and the only production-sequencing change is moving Odysseus HTTP-server shutdown ownership out of the generic `webhookServers` loop into a dedicated `stopOdysseusServer()` call in `src/index.ts`; that ownership change reverts cleanly with a single-commit revert because nothing else depends on the new ownership shape.
 
-## Runtime-event and terminal rendering
+## 9. Open questions and risks
 
-The controller exhaustively switches on the `RuntimeEvent` union in `src/agent-runtimes/types.ts:62–88` and emits a smaller display-event union. The client exhaustively renders that display union:
-
-- `output_text`: write assistant text as chat content, preserving incremental chunks and adding terminal separation only at turn completion. Never print `{ type: "output_text", ... }` or JSON-stringify the event.
-- `tool_call`: render a compact feedback line such as `Using web_search…` or `Using web_fetch…`. Optionally include a single bounded, escaped summary of useful arguments (query/URL), but never dump arbitrary argument JSON; redact keys matching token/auth/secret/password and cap length. The current runtime emits tool invocations after its buffered invoke and has no tool-result event in the `RuntimeEvent` contract, so LIA-428 renders the available invocation feedback and does not invent tool-result semantics.
-- `activity`: render the supplied human-readable text as a subdued progress line, bounded to prevent terminal flooding. Do not expose it as a reasoning/protocol object.
-- `usage`: accumulate the latest provider/model/token values for diagnostics, but keep provider/model accounting out of ordinary assistant output. Undefined token counts remain “unavailable,” never fabricated as zero.
-- `session`: persist/update controller state; do not print it during ordinary turns. `/status` is the intentional diagnostic surface.
-- `turn_complete`: finish the assistant block, clear temporary activity state, and return to the prompt. Do not print an event name or sentinel.
-- `error`: emit one sanitized `Error: …` line to stderr and retain detailed structured data only in daemon logs. Do not dump stack traces, response bodies, proxy tokens, or transport frames.
-
-The internal daemon response may contain NDJSON records, but client tests must assert that output contains neither raw JSON/event discriminants (for example `{"type":`, `output_text`, `turn_complete`, or `sessionRef`) nor SSE/NDJSON delimiters. This directly enforces acceptance criterion 3 rather than relying on visual inspection.
-
-## Diagnostics/status
-
-Use `/status` as the explicit in-chat diagnostic command because it is discoverable during a session, does not overload the existing service-level `deus status` command on PowerShell, and keeps identifiers out of normal responses. The daemon status route returns structured internal data; the client renders only:
-
-```text
-Backend: deus-native
-Session: <full session id, or “not started” before the first successful turn>
-State:   resumed | new
-Output:  buffered | streaming
-```
-
-“Resumed” means a backend-matching row was loaded from SQLite at controller start; “new” means no row existed then. `Output` derives from `runtime.capabilities().tool_streaming`/the actual event mode and must report the current buffered limitation honestly. The full id is shown because the AC explicitly requires session identifiers through diagnostics; the startup banner may show only a short resume notice and must direct the user to `/status` for the full values.
-
-This exact text format and the compact tool-feedback line intentionally skip a throwaway visual-variant/reaction pass: they are minimal, plain functional terminal output with no visual hierarchy or high-cost design decision. Keep them unstyled beyond ordinary terminal separation; if G2/G3 later introduces interactive selection or mode affordances, those richer UX surfaces should receive their own taste pass.
-
-## Acceptance-criterion mapping
-
-| Acceptance criterion | Concrete implementation and proof |
-| --- | --- |
-| A user can start a deus-native chat from the `deus` CLI. | `deus-cmd.sh`/`deus-cmd.ps1` route `deus chat` to `src/cli/deus-native-chat-client.ts`; the daemon server resolves `registry.get("deus-native")`, whose live registration is in `src/index.ts:162–165`. Launcher/server tests prove the path is connected rather than a tested-but-unwired facade. |
-| At least two consecutive turns in one session. | The readline loop remains open; `createDeusNativeChatController.runTurn` caches and reuses the first `RunResult.sessionRef`. The integration test sends two prompts and asserts call 2 receives the same UUID and its real checkpointer state contains both messages, following the existing checkpointer integration assertions around lines 282–328. |
-| Model output and tool feedback are rendered without protocol framing. | The exhaustive runtime-event normalizer in `deus-native-chat.ts` and renderer in `deus-native-chat-client.ts` handle output/tool/activity/usage/session/complete/error separately. Renderer tests feed every variant and assert no raw event or transport JSON appears. |
-| The user can exit cleanly and resume the recorded session. | `/exit`, `/quit`, EOF, and SIGINT call the daemon close route and restore readline without `clearSession`. `db.getSession(..., "deus-native")` reloads the stored row on a new client/controller. The integration test closes, reconstructs controller/client state, sends a third prompt, and proves the same checkpointer thread resumes. |
-| Backend and session identifiers are available through diagnostics or status output. | `/status` calls the daemon status route and renders full `Backend: deus-native` and `Session: <id>` values; tests cover pre-first-turn and persisted/resumed states. |
-
-## Test plan and verification
-
-### Unit tests
-
-1. Controller start with no row calls `startOrResume`, passes its empty native ref to `runTurn`, persists the result ref, and reports “new.”
-2. A second `runTurn` on the same controller gets the first result's exact session id; reconstructing the controller over the same store loads that id and reports “resumed.”
-3. Both the `session` event path and final `RunResult.sessionRef` path persist; same-id writes are harmless; foreign-backend/empty result refs are rejected rather than corrupting the native row.
-4. `close()` calls the runtime with the current/persisted ref and never clears the store.
-5. Every `RuntimeEvent` variant maps exhaustively to the intended display behavior; usage absence remains unknown; tool arguments are bounded/redacted.
-6. Client loop handles two prompts, `/status`, `/exit`, EOF, and interrupt without overlapping requests or leaving the terminal prompt active.
-7. Server rejects wrong method/path/auth/version, oversized/malformed bodies, and concurrent turns; it never logs/returns the bearer token; discovery-file cleanup cannot delete a successor daemon's record. Because this endpoint can drive the host-side agent loop, derive the missing-token, wrong-token, and stale-discovery-record rejection cases independently from the security/transport specification through the repo's `oracle-author` gate and tag those cases `@oracle`; the implementation author must not weaken or rewrite those assertions to match the handler. Ordinary implementer-authored tests remain appropriate for low-blast-radius method/version/body validation.
-
-### Integration tests
-
-1. Start the daemon server factory on an ephemeral port with a real `DeusNativeRuntime` wired to the hermetic model/checkpointer harness used by `deus-native-checkpointer-integration.test.ts`; use a temporary/in-memory database.
-2. Client A sends turn 1 and turn 2. Assert the same runtime UUID is persisted and the second model boundary sees both user messages.
-3. Client A closes. Client B reads the same stored native row, `/status` reports resumed/backend/id, and turn 3 reaches the same checkpointer thread.
-4. Have the fake model produce a tool call. Assert the terminal sees readable tool feedback and assistant output, while raw `RuntimeEvent` and NDJSON strings never appear.
-5. Run the launcher structural test to prove the live `deus chat` command reaches the compiled client and the existing bare/Claude/Codex branches are unchanged.
-
-### Commands before claiming implementation complete
-
-```bash
-npx vitest run src/cli/deus-native-chat.test.ts src/cli/deus-native-chat-server.test.ts src/cli/deus-native-chat-client.test.ts src/cli/deus-native-chat.integration.test.ts
-npx vitest run src/agent-runtimes/deus-native-backend.test.ts src/agent-runtimes/deus-native-checkpointer-integration.test.ts
-python3 -m pytest scripts/tests/test_deus_cmd_native_chat.py scripts/tests/test_deus_cmd_backend_prefix.py scripts/tests/test_deus_cmd_print_identity.py
-zsh -n deus-cmd.sh
-npm run typecheck
-npm run build
-npm run lint
-npm test
-npm run drift-check
-git diff --check
-```
-
-On a machine with the configured Anthropic credential path and the service rebuilt/restarted, perform one manual smoke test: run `deus chat`, ask a tool-free question, ask a follow-up that depends on turn 1, run `/status`, exit, relaunch `deus chat`, and ask a resume-dependent question. Confirm daemon logs contain no discovery bearer token. Live-provider verification supplements but does not replace the hermetic tests.
-
-`patterns/general-code.md` was read from the repo-root `patterns/` directory as selected by `.mex/ROUTER.md`. Its implementation requirements are reflected here: every new TypeScript source file has an alongside unit test, the architectural/credential-boundary change is documented through the ADR index, commits use `type(scope): description` Conventional Commit format (for example `feat(cli): add deus-native chat`), and `npm run drift-check` runs before push. Implementation must begin on a feature branch, remain one logical PR, and must not commit or push without the user-approved commit message required by `AGENTS.md`.
-
-## Explicit non-goals
-
-The new module comments and implementation must state these non-goals in the same prominent style as `deus-native-backend.ts`:
-
-- No G2 model-selection UX: no `--model`, picker, model persistence, or provider switching.
-- No G3 plan-mode toggle: no `--plan`, `/plan`, mode prompt, or permission-profile change.
-- No change to bare `deus`, `deus claude`, `deus codex`, `deus openai`, `DEUS_CLI_AGENT`, or `DEUS_AGENT_BACKEND` behavior.
-- No new backend/runtime interface, no changes to `DeusNativeRuntime` session-minting/checkpointer semantics, and no second database/session store.
-- No expansion of the `deus-native` tool surface, shell/filesystem access, permission policy, control-group privilege, context loading, session compaction, or checkpoint cleanup.
-- No invented tool-result event or fake token streaming; render only the normalized events the runtime contract supplies today.
-- No multi-session picker, named conversations, `/new`, transcript export, history UI, or concurrent clients sharing one CLI thread.
-- No reuse/change of the Odysseus `/v1/chat/completions` semantics: that endpoint intentionally uses fresh non-persisted sessions and a control group (`src/odysseus-server.ts:527+`), which conflicts with LIA-428's persisted synthetic CLI session.
-
-## Risks and resolved/open questions
-
-- **Credential-proxy ownership — resolved:** use the already-running daemon. A separate CLI runtime is invalid because group tokens are process-local and port 3001 is already owned.
-- **CLI naming/compatibility — resolved:** additive `deus chat`; bare and prefixed commands remain unchanged.
-- **Transport authorization — implementation risk:** loopback alone is insufficient because another local process can connect. Use a fresh high-entropy bearer token, constant-time comparison, user-only discovery file, no token logging, request caps, and exact routes. The implementation needs security review because this endpoint can drive the host-side agent loop; widening native tools later must re-evaluate this boundary.
-- **Discovery-file races/staleness — implementation risk:** write atomically after listen, include pid/version/token, validate before use, and remove only a record still owned by the shutting-down server. A stale or mismatched record fails closed with an actionable error.
-- **Interrupted clients — known behavior:** the host turn may complete and persist after the terminal disconnects. This is preferable to corrupting/checkpoint-cancelling a LangGraph turn; tell the user on reconnect that the persisted session was resumed.
-- **Tool feedback granularity — contract limitation:** today's `RuntimeEvent` union exposes a tool invocation but not a separate tool-result event, and `deus-native` emits after buffered invoke. LIA-428 can truthfully show which tool was used, not live execution/result phases. Changing that contract belongs to a separately reviewed runtime ticket.
-- **One global CLI thread — deliberate LIA-428 limit:** the fixed synthetic group folder yields one resumable native CLI session. Named/multiple sessions and cwd-scoped session keys are future UX decisions; silently keying by cwd now would make resume behavior surprising and constrain G2/G3.
-- **Daemon availability/version skew — implementation risk:** the client cannot work safely without the daemon endpoint. Fail closed and tell the user to rebuild/restart; do not bootstrap a partial host or read credentials as a fallback.
-- **Platform file permissions — verification item:** use `CONFIG_DIR`/`path.join` and Node's user-only create mode; verify POSIX `0600` in tests and document that Windows relies on the user's profile-directory ACL plus the random token. If review finds that insufficient, replace only the transport/discovery implementation with a same-user named-pipe ACL without changing the controller/client options seam.
-- **Router/pattern compliance — resolved:** `.mex/ROUTER.md` resolves `patterns/general-code.md` relative to the repo root; that file is present and was read. Its alongside-unit-test, ADR-gate, Conventional Commit, one-logical-PR, and pre-push `npm run drift-check` requirements are captured in the file map, verification commands, and implementation-workflow note above.
+1. **Resolved scope limitation: backend-neutral observability.** G5 is `deus-native`-only. It fully unblocks LIA-352's progress/“thinking” and completion cues, while LIA-64 receives useful activity data only for `deus-native` turns; LIA-64's “container status” for container-backed Claude/OpenAI/llama-cpp turns is out of scope and requires a follow-up ticket and ADR if later required.
+2. **Emission timing in the current backend.** `DeusNativeRuntime.runTurn()` currently emits `tool_call`, `usage`, `output_text`, and `turn_complete` while processing the completed `agent.invoke()` result, so G5 forwards each event immediately when emitted but does not make LangGraph produce those events earlier during a long model/tool execution. Wiring `middleware-stack.ts` hooks into real-time progress would expand the runtime contract and is intentionally excluded; the plan reviewer should decide whether the ticket's word “live” requires a prerequisite/follow-up for earlier backend emission.
+3. **Browser client bearer headers.** Native `EventSource` cannot set an `Authorization` header in ordinary browsers. A Companion web renderer would need an authenticated `fetch()` streaming client or a trusted native/main-process bridge. Query tokens are not an acceptable workaround because they leak through URLs and would weaken the existing auth model.
+4. **Tool argument sensitivity and slow clients.** `tool_call.arguments` may contain user data. The localhost bearer boundary matches the existing Odysseus security model, and no replay buffer reduces retention, but implementation should close a client whose socket remains back-pressured rather than accumulating an unbounded Node response buffer. That disconnect is best-effort transport behavior and should be logged without the event payload.
+5. **Dedicated broadcaster versus `EventBus`.** The live tree has `src/events/bus.ts` even though there is no runtime-activity fan-out today. The dedicated broadcaster is intentional because its synchronous best-effort/high-frequency semantics differ from `EventBus.emit()`'s sequential awaited pipeline reactions. The reviewer should confirm this separation is preferable to broadening the accepted event-hub ADR before implementation.
+6. **Documentation durability.** This plan uses source contract comments rather than a new ADR because replay is explicitly absent and no cross-process architecture is introduced. If LIA-352/LIA-64 will be developed outside this repository or the schema is treated as a long-lived public API, promote the same contract into a dedicated docs page or ADR in that later consumer ticket without changing G5's runtime scope.

--- a/src/agent-runtimes/activity-broadcaster.test.ts
+++ b/src/agent-runtimes/activity-broadcaster.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  RuntimeActivityBroadcaster,
+  withRuntimeActivityBroadcast,
+  type RuntimeActivityEnvelope,
+  type RuntimeActivitySource,
+} from './activity-broadcaster.js';
+import type {
+  AgentRuntime,
+  RunContext,
+  RunResult,
+  RuntimeCapabilities,
+  RuntimeEvent,
+  RuntimeEventSink,
+  RuntimeSession,
+} from './types.js';
+
+const CAPS: RuntimeCapabilities = {
+  shell: false,
+  filesystem: false,
+  web: true,
+  multimodal: false,
+  handoffs: false,
+  persistent_sessions: true,
+  tool_streaming: false,
+};
+
+const SOURCE_A: RuntimeActivitySource = {
+  backend: 'deus-native',
+  groupFolder: 'group-a',
+  chatJid: 'a@g.us',
+};
+const SOURCE_B: RuntimeActivitySource = {
+  backend: 'deus-native',
+  groupFolder: 'group-b',
+  chatJid: 'b@g.us',
+};
+
+function collect(
+  broadcaster: RuntimeActivityBroadcaster,
+): RuntimeActivityEnvelope[] {
+  const received: RuntimeActivityEnvelope[] = [];
+  broadcaster.subscribe((envelope) => received.push(envelope));
+  return received;
+}
+
+describe('RuntimeActivityBroadcaster — schema and global ordering', () => {
+  it('publishes an exhaustive, correctly-shaped envelope for every RuntimeEvent variant', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const runId = 'run-1';
+
+    const events: RuntimeEvent[] = [
+      { type: 'tool_call', name: 'web_search', arguments: { query: 'x' } },
+      {
+        type: 'usage',
+        sessionId: 'sess-1',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      },
+      { type: 'output_text', text: 'hello' },
+      { type: 'turn_complete' },
+    ];
+    for (const event of events) broadcaster.publish(runId, SOURCE_A, event);
+
+    expect(received).toHaveLength(4);
+
+    // Shared runId, one streamId, strictly increasing sequence, id === `${streamId}:${sequence}`.
+    for (let i = 0; i < received.length; i++) {
+      const envelope = received[i];
+      expect(envelope.runId).toBe(runId);
+      expect(envelope.streamId).toBe(broadcaster.streamId);
+      expect(envelope.sequence).toBe(i + 1);
+      expect(envelope.id).toBe(`${broadcaster.streamId}:${i + 1}`);
+      expect(() => new Date(envelope.timestamp).toISOString()).not.toThrow();
+      expect(new Date(envelope.timestamp).toISOString()).toBe(
+        envelope.timestamp,
+      );
+      expect(envelope.source).toEqual(SOURCE_A);
+    }
+
+    expect(received[0]).toMatchObject({
+      type: 'tool_call',
+      payload: { name: 'web_search', arguments: { query: 'x' } },
+    });
+    expect(received[1]).toMatchObject({
+      type: 'usage',
+      payload: {
+        sessionId: 'sess-1',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      },
+    });
+    expect(received[2]).toMatchObject({
+      type: 'output_text',
+      payload: { text: 'hello' },
+    });
+    expect(received[3]).toMatchObject({
+      type: 'turn_complete',
+      payload: {},
+    });
+  });
+
+  it('preserves undefined token semantics by omitting usage keys rather than fabricating zeroes', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+
+    broadcaster.publish('run-1', SOURCE_A, {
+      type: 'usage',
+      sessionId: 'sess-1',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+    });
+
+    const payload = received[0].payload as Record<string, unknown>;
+    expect('inputTokens' in payload).toBe(false);
+    expect('outputTokens' in payload).toBe(false);
+    expect('totalTokens' in payload).toBe(false);
+    expect(payload.sessionId).toBe('sess-1');
+  });
+
+  it('maps session and error events to their documented payload shapes', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const sessionRef: RuntimeSession = {
+      backend: 'deus-native',
+      session_id: 'thread-1',
+    };
+
+    broadcaster.publish('run-1', SOURCE_A, {
+      type: 'session',
+      sessionRef,
+    });
+    broadcaster.publish('run-1', SOURCE_A, {
+      type: 'error',
+      error: 'boom',
+    });
+    broadcaster.publish('run-1', SOURCE_A, {
+      type: 'activity',
+      text: 'thinking',
+    });
+
+    expect(received[0]).toMatchObject({
+      type: 'session',
+      payload: { sessionRef },
+    });
+    expect(received[1]).toMatchObject({
+      type: 'error',
+      payload: { error: 'boom' },
+    });
+    expect(received[2]).toMatchObject({
+      type: 'activity',
+      payload: { text: 'thinking' },
+    });
+  });
+
+  it('establishes ONE total publication order across multiple run IDs and groups (global, not per-run, sequence)', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+
+    broadcaster.publish('run-A', SOURCE_A, { type: 'activity', text: '1' });
+    broadcaster.publish('run-B', SOURCE_B, { type: 'activity', text: '2' });
+    broadcaster.publish('run-A', SOURCE_A, { type: 'turn_complete' });
+    broadcaster.publish('run-B', SOURCE_B, { type: 'turn_complete' });
+
+    expect(received.map((e) => e.sequence)).toEqual([1, 2, 3, 4]);
+    expect(received.map((e) => e.runId)).toEqual([
+      'run-A',
+      'run-B',
+      'run-A',
+      'run-B',
+    ]);
+    expect(received.map((e) => e.source.groupFolder)).toEqual([
+      'group-a',
+      'group-b',
+      'group-a',
+      'group-b',
+    ]);
+    // All four share the one broadcaster streamId.
+    expect(new Set(received.map((e) => e.streamId)).size).toBe(1);
+  });
+
+  it('a fresh broadcaster instance has a different streamId (new ordering epoch)', () => {
+    const a = new RuntimeActivityBroadcaster();
+    const b = new RuntimeActivityBroadcaster();
+    expect(a.streamId).not.toBe(b.streamId);
+  });
+});
+
+describe('RuntimeActivityBroadcaster — subscribe/subscriberCount/isolation', () => {
+  it('subscriberCount reflects active subscribers and drops to zero after unsubscribe', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    expect(broadcaster.subscriberCount()).toBe(0);
+    const unsubscribe = broadcaster.subscribe(() => {});
+    expect(broadcaster.subscriberCount()).toBe(1);
+    unsubscribe();
+    expect(broadcaster.subscriberCount()).toBe(0);
+  });
+
+  it('fans out one envelope to every current subscriber, byte-equivalent', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const receivedA: RuntimeActivityEnvelope[] = [];
+    const receivedB: RuntimeActivityEnvelope[] = [];
+    broadcaster.subscribe((e) => receivedA.push(e));
+    broadcaster.subscribe((e) => receivedB.push(e));
+
+    broadcaster.publish('run-1', SOURCE_A, { type: 'turn_complete' });
+
+    expect(receivedA).toEqual(receivedB);
+    expect(receivedA).toHaveLength(1);
+  });
+
+  it('isolates a throwing subscriber — delivery to the remaining subscribers still happens', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received: RuntimeActivityEnvelope[] = [];
+    broadcaster.subscribe(() => {
+      throw new Error('broken subscriber');
+    });
+    broadcaster.subscribe((e) => received.push(e));
+
+    expect(() =>
+      broadcaster.publish('run-1', SOURCE_A, { type: 'turn_complete' }),
+    ).not.toThrow();
+    expect(received).toHaveLength(1);
+  });
+});
+
+describe('RuntimeActivityBroadcaster — close() lifecycle (safe no-op guarantee)', () => {
+  it('close() is idempotent, removes subscribers, and post-close publish()/subscribe() are safe no-ops', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    expect(broadcaster.subscriberCount()).toBe(1);
+
+    broadcaster.close();
+    expect(broadcaster.subscriberCount()).toBe(0);
+
+    // Post-close subscribe() is inert: returns a no-op unsubscribe, does not
+    // actually register a listener.
+    const lateReceived: RuntimeActivityEnvelope[] = [];
+    const unsubscribe = broadcaster.subscribe((e) => lateReceived.push(e));
+    expect(broadcaster.subscriberCount()).toBe(0);
+    expect(() => unsubscribe()).not.toThrow();
+
+    // Post-close publish() allocates no id/sequence and invokes no subscriber.
+    expect(() =>
+      broadcaster.publish('run-1', SOURCE_A, { type: 'turn_complete' }),
+    ).not.toThrow();
+    expect(received).toHaveLength(0);
+    expect(lateReceived).toHaveLength(0);
+  });
+
+  it('calling close() twice, then publish(), remains a documented safe no-op', () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+
+    broadcaster.close();
+    expect(() => broadcaster.close()).not.toThrow();
+    expect(() =>
+      broadcaster.publish('run-1', SOURCE_A, { type: 'turn_complete' }),
+    ).not.toThrow();
+
+    expect(received).toHaveLength(0);
+    expect(broadcaster.subscriberCount()).toBe(0);
+  });
+});
+
+// ── withRuntimeActivityBroadcast() decorator ────────────────────────────────
+
+function makeFakeRuntime(
+  script: (sink: RuntimeEventSink) => Promise<RunResult>,
+): AgentRuntime {
+  return {
+    name: () => 'deus-native',
+    capabilities: () => CAPS,
+    startOrResume: async (_ctx: RunContext) => ({
+      backend: 'deus-native',
+      session_id: 'stub',
+    }),
+    close: async (_sessionRef: RuntimeSession) => {},
+    runTurn: (
+      _runContext: RunContext,
+      _sessionRef: RuntimeSession,
+      sink: RuntimeEventSink,
+    ) => script(sink),
+  };
+}
+
+const RUN_CONTEXT: RunContext = {
+  prompt: 'hi',
+  groupFolder: 'group-a',
+  chatJid: 'a@g.us',
+  isControlGroup: false,
+};
+const SESSION_REF: RuntimeSession = {
+  backend: 'deus-native',
+  session_id: '',
+};
+
+describe('withRuntimeActivityBroadcast — decorator transparency', () => {
+  it('forwards name()/capabilities()/startOrResume()/close() to the wrapped runtime unchanged', async () => {
+    const runtime = makeFakeRuntime(async (sink) => {
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'ok' };
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    expect(decorated.name()).toBe('deus-native');
+    expect(decorated.capabilities()).toEqual(CAPS);
+    await expect(decorated.startOrResume(RUN_CONTEXT)).resolves.toEqual({
+      backend: 'deus-native',
+      session_id: 'stub',
+    });
+    await expect(decorated.close(SESSION_REF)).resolves.toBeUndefined();
+  });
+
+  it('the downstream sink receives the original events unchanged and in order, while the broadcaster adds source/run metadata', async () => {
+    const scriptedEvents: RuntimeEvent[] = [
+      { type: 'activity', text: 'thinking' },
+      { type: 'tool_call', name: 'web_search', arguments: { q: 'x' } },
+      { type: 'output_text', text: 'done' },
+      { type: 'turn_complete' },
+    ];
+    const runtime = makeFakeRuntime(async (sink) => {
+      for (const event of scriptedEvents) await sink(event);
+      return { status: 'success', result: 'done' };
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    const downstream: RuntimeEvent[] = [];
+    const result = await decorated.runTurn(RUN_CONTEXT, SESSION_REF, (e) => {
+      downstream.push(e);
+    });
+
+    expect(result).toEqual({ status: 'success', result: 'done' });
+    // Downstream sink: unchanged, in order.
+    expect(downstream).toEqual(scriptedEvents);
+
+    // Broadcaster: same events, in order, PLUS source/run metadata, and one
+    // shared runId across the whole turn.
+    expect(received.map((e) => e.type)).toEqual([
+      'activity',
+      'tool_call',
+      'output_text',
+      'turn_complete',
+    ]);
+    const runIds = new Set(received.map((e) => e.runId));
+    expect(runIds.size).toBe(1);
+    for (const envelope of received) {
+      expect(envelope.source).toEqual({
+        backend: 'deus-native',
+        groupFolder: 'group-a',
+        chatJid: 'a@g.us',
+      });
+    }
+  });
+
+  it('mints a distinct runId per runTurn() call', async () => {
+    const runtime = makeFakeRuntime(async (sink) => {
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'ok' };
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    await decorated.runTurn(RUN_CONTEXT, SESSION_REF, () => {});
+    await decorated.runTurn(RUN_CONTEXT, SESSION_REF, () => {});
+
+    expect(received).toHaveLength(2);
+    expect(received[0].runId).not.toBe(received[1].runId);
+  });
+
+  it('publishes ONE synthetic terminal error when RunResult.status is "error" without an emitted error event, and never injects it into the caller sink or changes RunResult', async () => {
+    const runtime = makeFakeRuntime(async (sink) => {
+      await sink({ type: 'activity', text: 'trying' });
+      return { status: 'error', result: null, error: 'downstream failure' };
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    const downstream: RuntimeEvent[] = [];
+    const result = await decorated.runTurn(RUN_CONTEXT, SESSION_REF, (e) => {
+      downstream.push(e);
+    });
+
+    expect(result).toEqual({
+      status: 'error',
+      result: null,
+      error: 'downstream failure',
+    });
+    // Caller's own sink never sees the synthetic error — only the real
+    // events the runtime actually emitted.
+    expect(downstream).toEqual([{ type: 'activity', text: 'trying' }]);
+
+    // Broadcaster sees the real event PLUS exactly one synthetic terminal
+    // error envelope carrying RunResult.error.
+    expect(received.map((e) => e.type)).toEqual(['activity', 'error']);
+    expect(received[1].payload).toEqual({ error: 'downstream failure' });
+  });
+
+  it('does not publish a synthetic error when the wrapped runtime already emitted one', async () => {
+    const runtime = makeFakeRuntime(async (sink) => {
+      await sink({ type: 'error', error: 'real error event' });
+      return { status: 'error', result: null, error: 'real error event' };
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    await decorated.runTurn(RUN_CONTEXT, SESSION_REF, () => {});
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe('error');
+  });
+
+  it('when the wrapped call throws, publishes the same terminal error and rethrows unchanged', async () => {
+    const runtime = makeFakeRuntime(async () => {
+      throw new Error('unexpected throw');
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received = collect(broadcaster);
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    await expect(
+      decorated.runTurn(RUN_CONTEXT, SESSION_REF, () => {}),
+    ).rejects.toThrow('unexpected throw');
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: 'error',
+      payload: { error: 'unexpected throw' },
+    });
+  });
+
+  it("isolates one disconnected subscriber's throw from AgentRuntime.runTurn() itself (defense in depth via publish())", async () => {
+    const runtime = makeFakeRuntime(async (sink) => {
+      await sink({ type: 'turn_complete' });
+      return { status: 'success', result: 'ok' };
+    });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    broadcaster.subscribe(() => {
+      throw new Error('simulated disconnected SSE client write failure');
+    });
+    const decorated = withRuntimeActivityBroadcast(runtime, broadcaster);
+
+    await expect(
+      decorated.runTurn(RUN_CONTEXT, SESSION_REF, () => {}),
+    ).resolves.toEqual({ status: 'success', result: 'ok' });
+  });
+});

--- a/src/agent-runtimes/activity-broadcaster.ts
+++ b/src/agent-runtimes/activity-broadcaster.ts
@@ -1,0 +1,316 @@
+/**
+ * Process-local fan-out broadcaster for `deus-native` runtime activity
+ * (LIA-432 / G5).
+ *
+ * Deus is a single host process; the consumers of this stream are HTTP (SSE)
+ * connections living in that same process — so this is deliberately NOT a
+ * message broker. It is the Observer pattern: `RuntimeActivityBroadcaster` is
+ * the subject, and each `/v1/activity` connection (see
+ * `src/odysseus-server.ts`) is an independently removable observer.
+ *
+ * This is intentionally separate from `src/events/bus.ts`. `EventBus.emit()`
+ * is an asynchronously and sequentially AWAITED pipeline-reaction bus over the
+ * `DeusEvent` taxonomy (`src/events/types.ts`); routing every runtime
+ * token/tool event through it would let a slow/disconnected SSE listener
+ * back-pressure the agent turn itself, and would conflate that accepted
+ * pipeline-event-hub contract (`docs/decisions/event-hub.md`) with a
+ * high-frequency, best-effort observation stream. This module's delivery is
+ * synchronous, isolated per-subscriber, and never throws into a producer.
+ *
+ * Reconnection contract: delivery is fire-and-forward ONLY. There is no
+ * replay buffer and no `Last-Event-ID` support — a reconnecting client only
+ * receives events published after it (re)subscribes. A stable `streamId`
+ * (minted once per broadcaster instance/process epoch) plus a broadcaster-
+ * wide, strictly increasing `sequence` (allocated once per published event,
+ * before fan-out, identical for every subscriber) lets a client detect a gap
+ * (same `streamId`, a jump in `sequence`) or a host restart (changed
+ * `streamId`). This avoids retaining potentially sensitive `tool_call`
+ * arguments in memory and avoids a new history-size/config contract. See
+ * PLAN.md §6 for the full rationale.
+ */
+import crypto from 'crypto';
+import { EventEmitter } from 'events';
+
+import type {
+  AgentRuntime,
+  AgentRuntimeId,
+  RunContext,
+  RunResult,
+  RuntimeEvent,
+  RuntimeEventSink,
+  RuntimeSession,
+} from './types.js';
+import { logger } from '../logger.js';
+
+const ACTIVITY_EVENT = 'activity';
+
+/**
+ * Identity of the runtime/turn that produced an envelope. `backend` is
+ * whatever `AgentRuntime.name()` reports for the wrapped runtime — in
+ * production (see `src/index.ts`) this decorator is only ever applied to the
+ * `deus-native` registration, so `backend` is always `'deus-native'` in
+ * practice, but the type stays the general `AgentRuntimeId` rather than an
+ * unsafe narrowing cast.
+ */
+export interface RuntimeActivitySource {
+  backend: AgentRuntimeId;
+  groupFolder: string;
+  chatJid: string;
+}
+
+/** Variant-specific fields copied from `RuntimeEvent`, one shape per `type`. */
+export type RuntimeActivityPayload =
+  | { text: string } // output_text | activity
+  | { name: string; arguments: Record<string, unknown> } // tool_call
+  | {
+      // usage — token fields are OMITTED (never fabricated as 0) when the
+      // originating RuntimeEvent carried `undefined`, preserving the
+      // "a model call happened but usage wasn't reported" distinction.
+      sessionId: string;
+      provider: string;
+      model: string;
+      inputTokens?: number;
+      outputTokens?: number;
+      totalTokens?: number;
+    }
+  | { sessionRef: RuntimeSession } // session
+  | Record<string, never> // turn_complete
+  | { error: string }; // error
+
+/**
+ * One immutable, fanned-out activity message. Carries both the SSE `id:`
+ * line (`${streamId}:${sequence}`) and the JSON body delivered as the SSE
+ * `data:` line; `type` doubles as the SSE `event:` line. See the module doc
+ * comment above for the ordering and reconnection contract this shape exists
+ * to support.
+ */
+export interface RuntimeActivityEnvelope {
+  /** `${streamId}:${sequence}` — exactly matches the SSE `id:` line. */
+  id: string;
+  /** Random once per `RuntimeActivityBroadcaster` instance/process epoch. */
+  streamId: string;
+  /**
+   * Allocated once by the broadcaster before fan-out, monotonically
+   * increasing across every published event in THIS process — global to the
+   * broadcaster, not per-client or per-turn.
+   */
+  sequence: number;
+  type: RuntimeEvent['type'];
+  /** Server publication time (ISO-8601), generated once before fan-out so
+   * every subscriber sees the identical timestamp. Ordering is defined by
+   * `sequence`, never by wall-clock time. */
+  timestamp: string;
+  /** Minted once per `AgentRuntime.runTurn()` call, shared by every event
+   * from that turn, so consumers can correlate interleaved groups/turns and
+   * identify the terminal event. */
+  runId: string;
+  source: RuntimeActivitySource;
+  payload: RuntimeActivityPayload;
+}
+
+/** Exhaustive `RuntimeEvent` → `RuntimeActivityPayload` mapping (PLAN.md §2). */
+function toPayload(event: RuntimeEvent): RuntimeActivityPayload {
+  switch (event.type) {
+    case 'output_text':
+      return { text: event.text };
+    case 'activity':
+      return { text: event.text };
+    case 'tool_call':
+      return { name: event.name, arguments: event.arguments };
+    case 'usage': {
+      const payload: {
+        sessionId: string;
+        provider: string;
+        model: string;
+        inputTokens?: number;
+        outputTokens?: number;
+        totalTokens?: number;
+      } = {
+        sessionId: event.sessionId,
+        provider: event.provider,
+        model: event.model,
+      };
+      if (event.inputTokens !== undefined)
+        payload.inputTokens = event.inputTokens;
+      if (event.outputTokens !== undefined)
+        payload.outputTokens = event.outputTokens;
+      if (event.totalTokens !== undefined)
+        payload.totalTokens = event.totalTokens;
+      return payload;
+    }
+    case 'session':
+      return { sessionRef: event.sessionRef };
+    case 'turn_complete':
+      return {};
+    case 'error':
+      return { error: event.error };
+  }
+}
+
+/**
+ * Process-wide, single-instance fan-out subject for `deus-native` runtime
+ * activity. Owns a Node `EventEmitter`, a random `streamId`, the next
+ * `sequence`, and a `closed` flag.
+ *
+ * `publish()` never throws — not for a closed broadcaster (a safe no-op that
+ * allocates no id/sequence and invokes no subscriber, documented defense in
+ * depth for a late event from a detached turn), not for a full sequence
+ * counter (refused with a logged error rather than silently wrapping and
+ * violating global ordering), and not for a subscriber handler that itself
+ * throws (isolated per-subscriber so one broken/disconnected client can
+ * never propagate into `AgentRuntime.runTurn()` or block delivery to the
+ * rest). `subscribe()` on a closed broadcaster is likewise inert and returns
+ * a no-op unsubscribe. `close()` is idempotent.
+ */
+export class RuntimeActivityBroadcaster {
+  readonly streamId: string = crypto.randomUUID();
+  private sequence = 0;
+  private closed = false;
+  private readonly emitter = new EventEmitter();
+
+  constructor() {
+    // Concurrent SSE subscribers (bounded by MAX_CONCURRENT_SSE in
+    // odysseus-server.ts, but still > EventEmitter's default cap of 10) are
+    // expected and not a leak — disable the default MaxListenersExceeded
+    // warning rather than raising an arbitrary higher cap.
+    this.emitter.setMaxListeners(0);
+  }
+
+  publish(
+    runId: string,
+    source: RuntimeActivitySource,
+    event: RuntimeEvent,
+  ): void {
+    if (this.closed) return;
+    if (this.sequence >= Number.MAX_SAFE_INTEGER) {
+      logger.error(
+        { streamId: this.streamId, runId, type: event.type },
+        'RuntimeActivityBroadcaster: sequence exhausted — refusing publish rather than wrapping and violating global ordering',
+      );
+      return;
+    }
+    this.sequence += 1;
+    const envelope: RuntimeActivityEnvelope = {
+      id: `${this.streamId}:${this.sequence}`,
+      streamId: this.streamId,
+      sequence: this.sequence,
+      type: event.type,
+      timestamp: new Date().toISOString(),
+      runId,
+      source,
+      payload: toPayload(event),
+    };
+    // `emitter.listeners()` returns a fresh array copy — a snapshot subscriber
+    // list — so a handler that unsubscribes mid-publish cannot affect this
+    // delivery pass. Each handler is invoked directly (not via `emit()`) and
+    // wrapped in its own try/catch, so one throwing/disconnected subscriber
+    // cannot stop delivery to the others (EventEmitter.emit would otherwise
+    // let a thrown exception abort the remaining listener calls).
+    const handlers = this.emitter.listeners(ACTIVITY_EVENT) as Array<
+      (envelope: RuntimeActivityEnvelope) => void
+    >;
+    for (const handler of handlers) {
+      try {
+        handler(envelope);
+      } catch (err) {
+        logger.warn(
+          { err, streamId: this.streamId },
+          'RuntimeActivityBroadcaster: subscriber threw (isolated, ignored)',
+        );
+      }
+    }
+  }
+
+  /** Returns an unsubscribe function. Inert (no-op unsubscribe) once closed. */
+  subscribe(handler: (envelope: RuntimeActivityEnvelope) => void): () => void {
+    if (this.closed) return () => {};
+    this.emitter.on(ACTIVITY_EVENT, handler);
+    return () => {
+      this.emitter.off(ACTIVITY_EVENT, handler);
+    };
+  }
+
+  /** Current subscriber count — exposed for lifecycle assertions/tests. */
+  subscriberCount(): number {
+    return this.emitter.listenerCount(ACTIVITY_EVENT);
+  }
+
+  /** Idempotent. Drops all subscribers; every later `publish()`/`subscribe()`
+   * becomes a documented safe no-op. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.emitter.removeAllListeners(ACTIVITY_EVENT);
+  }
+}
+
+/**
+ * Decorates `runtime` so every `runTurn()` call tees its `RuntimeEvent`
+ * stream to `broadcaster.publish()` — in addition to, never instead of, the
+ * caller's own `eventSink` — before forwarding to it. `name()`,
+ * `capabilities()`, `startOrResume()`, `close()`, downstream sink ordering,
+ * and the returned `RunResult` are all otherwise unchanged.
+ *
+ * A `deus-native` turn that returns `RunResult.status === 'error'` WITHOUT
+ * ever emitting a `RuntimeEvent` of `type: 'error'` (the current
+ * `DeusNativeRuntime.runTurn()` catch path does exactly this) still needs a
+ * terminal envelope so an activity-stream consumer can tell the turn ended
+ * in failure — so this decorator publishes ONE broadcaster-only synthetic
+ * `error` envelope from `RunResult.error` in that case. That synthetic event
+ * is never injected into the caller's own `eventSink` — doing so would
+ * change existing channel/task/Linear-dispatch behavior, which this ticket
+ * must not do. If the wrapped call unexpectedly throws, the same terminal
+ * error is published and the exception is rethrown unchanged, preserving the
+ * caller's existing throw semantics.
+ */
+export function withRuntimeActivityBroadcast(
+  runtime: AgentRuntime,
+  broadcaster: RuntimeActivityBroadcaster,
+): AgentRuntime {
+  return {
+    name: () => runtime.name(),
+    capabilities: () => runtime.capabilities(),
+    startOrResume: (runContext: RunContext) =>
+      runtime.startOrResume(runContext),
+    close: (sessionRef: RuntimeSession) => runtime.close(sessionRef),
+    async runTurn(
+      runContext: RunContext,
+      sessionRef: RuntimeSession,
+      eventSink: RuntimeEventSink,
+    ): Promise<RunResult> {
+      const runId = crypto.randomUUID();
+      const source: RuntimeActivitySource = {
+        backend: runtime.name(),
+        groupFolder: runContext.groupFolder,
+        chatJid: runContext.chatJid,
+      };
+      let sawErrorEvent = false;
+
+      const teeSink: RuntimeEventSink = async (event) => {
+        if (event.type === 'error') sawErrorEvent = true;
+        // Publish BEFORE invoking the caller's own sink, per the documented
+        // tee order — the broadcaster's delivery never depends on (or can be
+        // delayed by) the downstream sink's own work.
+        broadcaster.publish(runId, source, event);
+        await eventSink(event);
+      };
+
+      try {
+        const result = await runtime.runTurn(runContext, sessionRef, teeSink);
+        if (result.status === 'error' && !sawErrorEvent) {
+          broadcaster.publish(runId, source, {
+            type: 'error',
+            error: result.error || 'unknown error',
+          });
+        }
+        return result;
+      } catch (err) {
+        if (!sawErrorEvent) {
+          const message = err instanceof Error ? err.message : String(err);
+          broadcaster.publish(runId, source, { type: 'error', error: message });
+        }
+        throw err;
+      }
+    },
+  };
+}

--- a/src/agent-runtimes/deus-native-backend.test.ts
+++ b/src/agent-runtimes/deus-native-backend.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { ContainerRuntimeDeps } from './container-backend.js';
 import type { RuntimeEvent } from './types.js';
+import {
+  RuntimeActivityBroadcaster,
+  withRuntimeActivityBroadcast,
+  type RuntimeActivityEnvelope,
+} from './activity-broadcaster.js';
 
 // Hoisted mocks — no live network call, no live model call anywhere in this
 // file, matching every other spike/adapter test's hermeticity convention.
@@ -627,5 +632,77 @@ describe('DeusNativeBackend — memory retrieval wiring (D1/LIA-415)', () => {
       'telemetry',
       'prompt-lifecycle',
     ]);
+  });
+});
+
+// ── Activity broadcaster decorator integration (LIA-432/G5) ────────────────
+//
+// The decorator itself (event tee order, synthetic-error rules, downstream
+// sink transparency) is unit-tested against a FAKE runtime in
+// activity-broadcaster.test.ts. This block locks the one piece that requires
+// the REAL DeusNativeRuntime: its catch-path returns `RunResult.status ===
+// 'error'` WITHOUT ever calling `eventSink` with a `type: 'error'` event (see
+// the "runTurn returns error when the proxy token mint fails" case above) —
+// proving `withRuntimeActivityBroadcast` synthesizes exactly one terminal
+// broadcaster-only error for that real shape, without altering the original
+// downstream sink or RunResult.
+describe('DeusNativeBackend — activity broadcaster decorator integration (LIA-432/G5)', () => {
+  beforeEach(() => {
+    createAgentMock.mockReset();
+    invokeMock.mockReset();
+    detectAuthModeMock.mockReturnValue('api-key');
+    getOrCreateGroupTokenMock.mockReset();
+    getOrCreateGroupTokenMock.mockReturnValue('fake-proxy-token');
+  });
+
+  it('publishes one terminal broadcaster-only error envelope for a returned error with no emitted error event, without changing the downstream sink or RunResult', async () => {
+    getOrCreateGroupTokenMock.mockImplementation(() => {
+      throw new Error(
+        'getOrCreateGroupToken: folder is a publicIngress folder',
+      );
+    });
+
+    const backend = createDeusNativeRuntime(stubDeps);
+    const broadcaster = new RuntimeActivityBroadcaster();
+    const received: RuntimeActivityEnvelope[] = [];
+    broadcaster.subscribe((e) => received.push(e));
+    const decorated = withRuntimeActivityBroadcast(backend, broadcaster);
+
+    const events: RuntimeEvent[] = [];
+    const result = await decorated.runTurn(
+      {
+        prompt: 'test',
+        groupFolder: 'nonexistent',
+        chatJid: 'test@g.us',
+        isControlGroup: false,
+      },
+      { backend: 'deus-native', session_id: '' },
+      (event) => {
+        events.push(event);
+      },
+    );
+
+    // RunResult is unchanged from the undecorated behavior asserted above.
+    expect(result.status).toBe('error');
+    expect(result.result).toBeNull();
+    expect(result.error).toContain('publicIngress');
+    // DeusNativeRuntime's catch path never calls eventSink — the original
+    // downstream sink still sees zero events, decorator or not.
+    expect(events).toHaveLength(0);
+    expect(createAgentMock).not.toHaveBeenCalled();
+
+    // The broadcaster received exactly one synthetic terminal error, never
+    // injected into the caller's own sink (the empty `events` array above
+    // already proves the latter).
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe('error');
+    expect(received[0].payload).toMatchObject({
+      error: expect.stringContaining('publicIngress'),
+    });
+    expect(received[0].source).toEqual({
+      backend: 'deus-native',
+      groupFolder: 'nonexistent',
+      chatJid: 'test@g.us',
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import { GroupQueue } from './group-queue.js';
 import { startIpcWatcher } from './ipc.js';
 import { loadSkillIpcHandlers } from './skills/index.js';
 import { createMessageOrchestrator } from './message-orchestrator.js';
-import { startOdysseusServer } from './odysseus-server.js';
+import { startOdysseusServer, stopOdysseusServer } from './odysseus-server.js';
 import { nativeChatDiscoveryPath } from './cli/deus-native-chat.js';
 import {
   startNativeChatServer,
@@ -86,6 +86,10 @@ import { createClaudeRuntime } from './agent-runtimes/claude-backend.js';
 import { createOpenAIRuntime } from './agent-runtimes/openai-backend.js';
 import { createLlamaCppRuntime } from './agent-runtimes/llama-cpp-backend.js';
 import { createDeusNativeRuntime } from './agent-runtimes/deus-native-backend.js';
+import {
+  RuntimeActivityBroadcaster,
+  withRuntimeActivityBroadcast,
+} from './agent-runtimes/activity-broadcaster.js';
 import {
   initLinearContext,
   startLinearDispatcher,
@@ -142,6 +146,18 @@ async function main(): Promise<void> {
 
   const channels: Channel[] = [];
   const webhookServers: Server[] = [];
+  // LIA-432/G5: the Odysseus server has its OWN shutdown owner
+  // (stopOdysseusServer, below) — deliberately never pushed into
+  // `webhookServers`. A holder object (rather than a forward-declared `let`)
+  // so shutdown() can close over a mutable `.server` field: the closure is
+  // DEFINED before the server exists but only ever RUNS on a later signal,
+  // after `.server` is assigned further down — `let` here would satisfy that
+  // same ordering but trips `prefer-const` (assigned exactly once, so ESLint
+  // can't see the assignment must stay separate from the closure's earlier
+  // definition).
+  const odysseusServerHolder: { server: Server | undefined } = {
+    server: undefined,
+  };
   // Mutable shared registry: the ingress gateway dispatches by these handlers.
   // Empty in Phase 1 (gateway serves /health + 404s, no dispatch path); the
   // Phase-4 webhook channel (LIA-315) pushes its route after the gateway listens.
@@ -164,10 +180,23 @@ async function main(): Promise<void> {
       groupFolder: string,
     ) => queue.registerProcess(chatJid, proc, containerName, groupFolder),
   };
+  // LIA-432/G5: shared, process-wide activity broadcaster — constructed once
+  // at the composition root and wired ONLY into the deus-native registration
+  // below (Claude/OpenAI/llama-cpp stay undecorated; see PLAN.md §3). Also
+  // passed through OdysseusServerDeps below so `/v1/activity` subscribes to
+  // this SAME instance. Owned here for its whole lifetime — closed only at
+  // the true tail of shutdown(), after channels/queue/Linear have drained.
+  const activityBroadcaster = new RuntimeActivityBroadcaster();
+
   registry.register(createClaudeRuntime(backendDeps));
   registry.register(createOpenAIRuntime(backendDeps));
   registry.register(createLlamaCppRuntime(backendDeps));
-  registry.register(createDeusNativeRuntime(backendDeps));
+  registry.register(
+    withRuntimeActivityBroadcast(
+      createDeusNativeRuntime(backendDeps),
+      activityBroadcaster,
+    ),
+  );
   logger.info({ backends: registry.list() }, 'Backend registry initialized');
 
   // LIA-428 (G1): daemon-owned loopback endpoint for `deus chat`. The
@@ -191,6 +220,12 @@ async function main(): Promise<void> {
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutdown signal received');
     stopLinearDispatcher();
+    // LIA-432/G5: the Odysseus server's SOLE closer — stops it (draining any
+    // live /v1/activity responses first) before the generic webhookServers
+    // loop, which never contains this instance (see wiring below).
+    if (odysseusServerHolder.server) {
+      await stopOdysseusServer(odysseusServerHolder.server);
+    }
     for (const srv of webhookServers) srv.close();
     ingressTunnel?.stop();
     proxyServer.close();
@@ -199,6 +234,12 @@ async function main(): Promise<void> {
     await nativeChatServer.close();
     await queue.shutdown(10000);
     for (const ch of channels) await ch.disconnect();
+    // Latest process-wide shutdown boundary — after channels, scheduled work
+    // admitted through the queue, Linear dispatch, and channel-owned
+    // multi-agent work have all had their available shutdown/drain window
+    // (PLAN.md §5). The documented post-close no-op on the broadcaster
+    // protects any still-late detached turn from throwing here.
+    activityBroadcaster.close();
     process.exit(0);
   };
   process.on('SIGTERM', () => shutdown('SIGTERM'));
@@ -497,12 +538,15 @@ async function main(): Promise<void> {
   // Start the Odysseus /v1 web channel (no-op unless ODYSSEUS_HTTP_ENABLED=1).
   // Each web turn runs on its own fresh session (LIA-294); serializes through
   // GroupQueue on the main jid like the scheduler.
-  const odysseusServer = await startOdysseusServer({
+  odysseusServerHolder.server = await startOdysseusServer({
     queue,
     registry,
     registeredGroups: () => state.registeredGroups,
+    activityBroadcaster,
   });
-  if (odysseusServer) webhookServers.push(odysseusServer);
+  // LIA-432/G5: deliberately NOT pushed into `webhookServers` — stopOdysseusServer()
+  // in shutdown() above is this instance's sole closer, avoiding a double
+  // `server.close()` (see the `odysseusServerHolder` declaration earlier).
 
   // Start Linear subsystems (no-op if LINEAR_API_KEY not configured)
   const linearEnv = readEnvFile([

--- a/src/odysseus-activity-stream.test.ts
+++ b/src/odysseus-activity-stream.test.ts
@@ -1,0 +1,785 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+
+// ── Mock heavy / side-effecting modules (same approach as odysseus-server.test.ts) ──
+vi.mock('./config.js', () => ({
+  ODYSSEUS_HTTP_ENABLED: true,
+  ODYSSEUS_HTTP_PORT: 0,
+  INJECTION_SCANNER_CONFIG: { enabled: false, threshold: 0.7, logOnly: true },
+  PROJECT_ROOT: '/tmp/deus-test',
+}));
+vi.mock('./container-runner.js', () => ({
+  writeTasksSnapshot: vi.fn(),
+  writeGroupsSnapshot: vi.fn(),
+}));
+vi.mock('./db.js', () => ({ getAllTasks: vi.fn(() => []) }));
+vi.mock('./router-state.js', () => ({ getAvailableGroups: vi.fn(() => []) }));
+vi.mock('./env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
+vi.mock('./guardrails/injection-scanner.js', () => ({
+  scanForInjection: () => ({
+    blocked: false,
+    triggered: false,
+    score: 0,
+    matches: [] as string[],
+  }),
+}));
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import {
+  createOdysseusServer,
+  stopOdysseusServer,
+  _resetServerStateForTest,
+  type OdysseusServerDeps,
+} from './odysseus-server.js';
+import {
+  RuntimeActivityBroadcaster,
+  withRuntimeActivityBroadcast,
+  type RuntimeActivityEnvelope,
+  type RuntimeActivitySource,
+} from './agent-runtimes/activity-broadcaster.js';
+import type {
+  AgentRuntime,
+  RuntimeCapabilities,
+  RuntimeEvent,
+} from './agent-runtimes/types.js';
+
+const TOKEN = 'a'.repeat(48); // valid (>= MIN_TOKEN_LEN=32)
+const authHeaders = { Authorization: `Bearer ${TOKEN}` };
+const SOURCE: RuntimeActivitySource = {
+  backend: 'deus-native',
+  groupFolder: 'group-x',
+  chatJid: 'x@deus.local',
+};
+
+function makeDeps(
+  broadcaster?: RuntimeActivityBroadcaster,
+): OdysseusServerDeps {
+  return {
+    // /v1/activity never touches queue/registry/registeredGroups — minimal
+    // stubs that would throw loudly if the route regressed into using them.
+    queue: {
+      enqueueTask: () => {
+        throw new Error('activity route must never enqueue a GroupQueue task');
+      },
+      closeStdin: () => {},
+      notifyIdle: () => {},
+      isShuttingDown: () => false,
+    } as unknown as OdysseusServerDeps['queue'],
+    registry: {
+      resolve: () => {
+        throw new Error('activity route must never resolve a backend');
+      },
+    } as unknown as OdysseusServerDeps['registry'],
+    registeredGroups: () => ({}),
+    activityBroadcaster: broadcaster ?? new RuntimeActivityBroadcaster(),
+  };
+}
+
+// ── SSE frame parsing ────────────────────────────────────────────────────────
+interface ParsedFrame {
+  id?: string;
+  event?: string;
+  data?: string;
+  retry?: string;
+  comment?: string;
+  raw: string;
+}
+
+function parseFrame(raw: string): ParsedFrame {
+  const frame: ParsedFrame = { raw };
+  for (const line of raw.split('\n')) {
+    if (line === '') continue;
+    if (line.startsWith(': ')) {
+      frame.comment = line.slice(2);
+      continue;
+    }
+    const sep = line.indexOf(': ');
+    if (sep === -1) continue;
+    const key = line.slice(0, sep);
+    const value = line.slice(sep + 2);
+    if (key === 'id') frame.id = value;
+    else if (key === 'event') frame.event = value;
+    else if (key === 'data') frame.data = value;
+    else if (key === 'retry') frame.retry = value;
+  }
+  return frame;
+}
+
+/**
+ * A real `http.request()`-backed `/v1/activity` client that parses incoming
+ * SSE frames incrementally (buffered by the `\n\n` delimiter) and exposes
+ * them one at a time via `next()` — so a test can assert on frames as they
+ * arrive without ever waiting for the (permanent) connection to end.
+ */
+class ActivityClient {
+  req: http.ClientRequest;
+  statusCode?: number;
+  headers?: http.IncomingHttpHeaders;
+  closed = false;
+  opened: Promise<void>;
+  closedPromise: Promise<void>;
+
+  private buffer = '';
+  private frameQueue: ParsedFrame[] = [];
+  private waiters: Array<(f: ParsedFrame) => void> = [];
+  private openResolve!: () => void;
+  private closeResolve!: () => void;
+
+  constructor(opts: {
+    port: number;
+    path?: string;
+    headers?: Record<string, string>;
+  }) {
+    this.opened = new Promise((resolve) => {
+      this.openResolve = resolve;
+    });
+    this.closedPromise = new Promise((resolve) => {
+      this.closeResolve = resolve;
+    });
+    this.req = http.request(
+      {
+        method: 'GET',
+        path: opts.path ?? '/v1/activity',
+        hostname: '127.0.0.1',
+        port: opts.port,
+        headers: { ...authHeaders, ...opts.headers },
+      },
+      (res) => {
+        this.statusCode = res.statusCode;
+        this.headers = res.headers;
+        this.openResolve();
+        res.on('data', (chunk: Buffer) => this.onData(chunk.toString('utf-8')));
+        res.on('close', () => {
+          this.closed = true;
+          this.closeResolve();
+        });
+        res.on('error', () => {});
+      },
+    );
+    this.req.on('error', () => {}); // swallow ECONNRESET from destroy()
+    this.req.end();
+  }
+
+  private onData(chunk: string): void {
+    this.buffer += chunk;
+    let idx: number;
+    while ((idx = this.buffer.indexOf('\n\n')) !== -1) {
+      const rawFrame = this.buffer.slice(0, idx);
+      this.buffer = this.buffer.slice(idx + 2);
+      const parsed = parseFrame(rawFrame);
+      const waiter = this.waiters.shift();
+      if (waiter) waiter(parsed);
+      else this.frameQueue.push(parsed);
+    }
+  }
+
+  /** Resolves with the next complete SSE frame (data, comment/ping, or the
+   * connection-open `retry:` directive — always the first frame on a 200
+   * connection), in arrival order. Callers that don't care about the retry
+   * directive should discard it with one `next()` call right after `opened`. */
+  next(): Promise<ParsedFrame> {
+    const queued = this.frameQueue.shift();
+    if (queued) return Promise.resolve(queued);
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  destroy(): void {
+    this.req.destroy();
+  }
+}
+
+/** Discards the connection-open `retry: 15000` directive — always the first
+ * frame on a 200 connection — so a test can go straight to real data/ping
+ * frames via `next()` afterward. */
+async function discardRetry(c: ActivityClient): Promise<void> {
+  const frame = await c.next();
+  if (frame.retry === undefined) {
+    throw new Error(
+      'discardRetry(): expected the connection-open retry: directive as the first frame',
+    );
+  }
+}
+
+async function waitForSubscriberCount(
+  broadcaster: RuntimeActivityBroadcaster,
+  expected: number,
+): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (broadcaster.subscriberCount() === expected) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(
+    `broadcaster.subscriberCount() never reached ${expected} ` +
+      `(still ${broadcaster.subscriberCount()})`,
+  );
+}
+
+function statusRequest(options: {
+  method?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  port: number;
+}): Promise<{
+  statusCode: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: options.method ?? 'GET',
+        path: options.path ?? '/v1/activity',
+        hostname: '127.0.0.1',
+        port: options.port,
+        headers: options.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () =>
+          resolve({
+            statusCode: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers,
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+let server: Server;
+let port: number;
+let currentBroadcaster: RuntimeActivityBroadcaster | undefined;
+
+function listen(deps: OdysseusServerDeps): Promise<void> {
+  currentBroadcaster = deps.activityBroadcaster;
+  server = createOdysseusServer(deps, TOKEN);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      port = (server.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+}
+
+function client(opts?: { path?: string; headers?: Record<string, string> }) {
+  return new ActivityClient({ port, path: opts?.path, headers: opts?.headers });
+}
+
+beforeEach(() => {
+  _resetServerStateForTest();
+});
+
+afterEach(async () => {
+  // Stop the server / route subscriptions FIRST, then close the process-wide
+  // broadcaster last — matching production ownership order (PLAN.md §5).
+  if (server?.listening) {
+    await stopOdysseusServer(server);
+  }
+  currentBroadcaster?.close();
+  currentBroadcaster = undefined;
+});
+
+// ── Case 1: endpoint / auth / method contract ───────────────────────────────
+describe('GET /v1/activity — endpoint, auth, and method contract', () => {
+  it('rejects a missing bearer with 401', async () => {
+    await listen(makeDeps());
+    const r = await statusRequest({ port });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('rejects an invalid bearer with 401', async () => {
+    await listen(makeDeps());
+    const r = await statusRequest({
+      port,
+      headers: { Authorization: 'Bearer ' + 'z'.repeat(48) },
+    });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('rejects an authenticated non-GET with 405', async () => {
+    await listen(makeDeps());
+    const r = await statusRequest({
+      port,
+      method: 'POST',
+      headers: authHeaders,
+    });
+    expect(r.statusCode).toBe(405);
+  });
+
+  it('never accepts a query-string token as an auth bypass', async () => {
+    await listen(makeDeps());
+    const r = await statusRequest({
+      port,
+      path: `/v1/activity?token=${TOKEN}`,
+    });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('an authenticated GET is admitted with SSE headers and the 15s retry directive, using the same bearer path as every other route', async () => {
+    await listen(makeDeps());
+    const c = client();
+    await c.opened;
+    expect(c.statusCode).toBe(200);
+    expect(c.headers?.['content-type']).toContain('text/event-stream');
+    expect(c.headers?.['cache-control']).toContain('no-cache');
+    expect(c.headers?.['connection']).toContain('keep-alive');
+
+    const first = await c.next();
+    expect(first.retry).toBe('15000');
+
+    c.destroy();
+  });
+});
+
+// ── Case 3: multiple events on one connection ───────────────────────────────
+describe('multiple runtime events on one connection', () => {
+  it('delivers events in publication order, resolving as each arrives (not waiting for connection end)', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+    const c = client();
+    await c.opened;
+    await waitForSubscriberCount(broadcaster, 1);
+    await discardRetry(c);
+
+    broadcaster.publish('run-1', SOURCE, { type: 'activity', text: 'a' });
+    broadcaster.publish('run-1', SOURCE, {
+      type: 'tool_call',
+      name: 'web_search',
+      arguments: {},
+    });
+    broadcaster.publish('run-1', SOURCE, { type: 'turn_complete' });
+
+    const frames = [await c.next(), await c.next(), await c.next()];
+    expect(frames.map((f) => f.event)).toEqual([
+      'activity',
+      'tool_call',
+      'turn_complete',
+    ]);
+    // The test resolved via 3 delivered frames — the connection is still open.
+    expect(c.closed).toBe(false);
+
+    c.destroy();
+  });
+});
+
+// ── Case 4: multi-client fan-out ─────────────────────────────────────────────
+describe('multi-client fan-out', () => {
+  it('delivers byte-equivalent envelopes, in order, to every connected client; an aborted client stops receiving and is unsubscribed', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+    const a = client();
+    const b = client();
+    await Promise.all([a.opened, b.opened]);
+    await waitForSubscriberCount(broadcaster, 2);
+    await Promise.all([discardRetry(a), discardRetry(b)]);
+
+    broadcaster.publish('run-1', SOURCE, { type: 'activity', text: 'first' });
+    broadcaster.publish('run-1', SOURCE, { type: 'activity', text: 'second' });
+
+    const [a1, b1] = await Promise.all([a.next(), b.next()]);
+    const [a2, b2] = await Promise.all([a.next(), b.next()]);
+    expect(a1.data).toBe(b1.data);
+    expect(a2.data).toBe(b2.data);
+    expect(JSON.parse(a1.data!).payload.text).toBe('first');
+    expect(JSON.parse(a2.data!).payload.text).toBe('second');
+
+    a.destroy();
+    await waitForSubscriberCount(broadcaster, 1);
+
+    broadcaster.publish('run-1', SOURCE, { type: 'activity', text: 'third' });
+    const b3 = await b.next();
+    expect(JSON.parse(b3.data!).payload.text).toBe('third');
+
+    b.destroy();
+  });
+});
+
+// ── Case 6: client abort cleanup ─────────────────────────────────────────────
+describe('client abort cleanup', () => {
+  it('destroying the connection unsubscribes, clears the keepalive interval, and a later publish causes no write/error', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+    const c = client();
+    await c.opened;
+    await waitForSubscriberCount(broadcaster, 1);
+
+    const callsBefore = clearIntervalSpy.mock.calls.length;
+    c.destroy();
+    await waitForSubscriberCount(broadcaster, 0);
+    expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+
+    expect(() =>
+      broadcaster.publish('run-1', SOURCE, { type: 'turn_complete' }),
+    ).not.toThrow();
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('reconnecting and disconnecting six times sequentially never returns 503 — the separate admission counter is released each time (distinct from the 429 rate limiter)', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+
+    for (let i = 0; i < 6; i++) {
+      const c = client();
+      await c.opened;
+      // A leaked activeActivitySse slot would eventually manifest as 503;
+      // the 6th same-address attempt may legitimately hit the SEPARATE 429
+      // rate limiter instead (RATE_LIMIT_MAX=5/60s) — that is not the bug
+      // under test here.
+      expect(c.statusCode).not.toBe(503);
+      if (c.statusCode === 200) {
+        c.destroy();
+        await waitForSubscriberCount(broadcaster, 0);
+      } else {
+        c.destroy();
+      }
+    }
+  });
+});
+
+// ── Case 7: server shutdown cleanup ──────────────────────────────────────────
+describe('server shutdown cleanup (stopOdysseusServer)', () => {
+  it('draining two live connections: both observe close, broadcaster has zero route subscribers, keepalives cleared, close callback completes — the broadcaster itself stays open', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+    const a = client();
+    const b = client();
+    await Promise.all([a.opened, b.opened]);
+    await waitForSubscriberCount(broadcaster, 2);
+
+    const callsBefore = clearIntervalSpy.mock.calls.length;
+    await stopOdysseusServer(server);
+
+    await Promise.all([a.closedPromise, b.closedPromise]);
+    expect(broadcaster.subscriberCount()).toBe(0);
+    expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(server.listening).toBe(false);
+
+    // The broadcaster itself was never closed by stopOdysseusServer() — still
+    // open, still delivers to a fresh subscriber.
+    const recorded: RuntimeActivityEnvelope[] = [];
+    broadcaster.subscribe((e) => recorded.push(e));
+    broadcaster.publish('run-1', SOURCE, { type: 'turn_complete' });
+    expect(recorded).toHaveLength(1);
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('is idempotent — a second call resolves without re-invoking server.close() or throwing', async () => {
+    await listen(makeDeps());
+    await stopOdysseusServer(server);
+    await expect(stopOdysseusServer(server)).resolves.toBeUndefined();
+  });
+});
+
+// ── Case 8 (route part): shared-broadcaster shutdown ordering ───────────────
+describe('cross-cutting lifecycle: the shared broadcaster survives stopOdysseusServer()', () => {
+  const CAPS: RuntimeCapabilities = {
+    shell: false,
+    filesystem: false,
+    web: true,
+    multimodal: false,
+    handoffs: false,
+    persistent_sessions: true,
+    tool_streaming: false,
+  };
+
+  it('after stopOdysseusServer() resolves but before the process-wide close(), a decorated non-SSE (channel/task/Linear-shaped) turn still publishes; after close() it becomes a documented safe no-op without changing the downstream sink/RunResult', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+
+    // Stands in for whatever else the process-wide composition root
+    // subscribes to the SAME broadcaster (not an SSE client).
+    const recorded: RuntimeActivityEnvelope[] = [];
+    broadcaster.subscribe((e) => recorded.push(e));
+
+    const sseClient = client();
+    await sseClient.opened;
+    await waitForSubscriberCount(broadcaster, 2); // recorder + SSE route
+
+    await stopOdysseusServer(server);
+    await waitForSubscriberCount(broadcaster, 1); // only the recorder remains
+
+    const fakeRuntime: AgentRuntime = {
+      name: () => 'deus-native',
+      capabilities: () => CAPS,
+      startOrResume: async () => ({ backend: 'deus-native', session_id: 's' }),
+      close: async () => {},
+      runTurn: async (_ctx, _s, sink) => {
+        await sink({ type: 'turn_complete' });
+        return { status: 'success', result: 'ok' };
+      },
+    };
+    const decorated = withRuntimeActivityBroadcast(fakeRuntime, broadcaster);
+
+    // A channel/task/Linear-shaped RunContext — NOT an SSE client.
+    const downstream: RuntimeEvent[] = [];
+    const result = await decorated.runTurn(
+      {
+        prompt: 'scheduled task prompt',
+        groupFolder: 'group-x',
+        chatJid: 'task@deus.local',
+        isControlGroup: false,
+        isScheduledTask: true,
+      },
+      { backend: 'deus-native', session_id: '' },
+      (e) => {
+        downstream.push(e);
+      },
+    );
+
+    expect(result).toEqual({ status: 'success', result: 'ok' });
+    expect(downstream).toEqual([{ type: 'turn_complete' }]);
+    expect(recorded.map((e) => e.type)).toEqual(['turn_complete']);
+
+    // NOW simulate the process-wide tail-of-shutdown close().
+    broadcaster.close();
+    const downstream2: RuntimeEvent[] = [];
+    const result2 = await decorated.runTurn(
+      {
+        prompt: 'late task',
+        groupFolder: 'group-x',
+        chatJid: 'task@deus.local',
+        isControlGroup: false,
+      },
+      { backend: 'deus-native', session_id: '' },
+      (e) => {
+        downstream2.push(e);
+      },
+    );
+    expect(result2).toEqual({ status: 'success', result: 'ok' });
+    expect(downstream2).toEqual([{ type: 'turn_complete' }]); // downstream sink unaffected
+    expect(recorded).toHaveLength(1); // no new envelope reached the broadcaster
+
+    sseClient.destroy();
+  });
+});
+
+// ── Case 9: fire-and-forward reconnection ───────────────────────────────────
+describe('reconnection — fire-and-forward only, no replay', () => {
+  it('a reconnect does not receive events published while disconnected; Last-Event-ID is accepted but ignored', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+
+    const a = client();
+    await a.opened;
+    await waitForSubscriberCount(broadcaster, 1);
+    await discardRetry(a);
+    broadcaster.publish('run-1', SOURCE, { type: 'activity', text: 'N' });
+    const frameN = await a.next();
+    const envelopeN = JSON.parse(frameN.data!) as RuntimeActivityEnvelope;
+    expect(envelopeN.sequence).toBe(1);
+
+    a.destroy();
+    await waitForSubscriberCount(broadcaster, 0);
+
+    // Published while NO client is connected — must never be replayed.
+    broadcaster.publish('run-1', SOURCE, {
+      type: 'activity',
+      text: 'missed N+1',
+    });
+
+    const b = client({ headers: { 'Last-Event-ID': envelopeN.id } });
+    await b.opened;
+    expect(b.statusCode).toBe(200); // header accepted, not rejected
+    await waitForSubscriberCount(broadcaster, 1);
+    await discardRetry(b);
+
+    broadcaster.publish('run-1', SOURCE, { type: 'activity', text: 'N+2' });
+    const frameFirst = await b.next();
+    const envelopeFirst = JSON.parse(
+      frameFirst.data!,
+    ) as RuntimeActivityEnvelope;
+
+    // B's FIRST received event is N+2 (sequence 3) — the missed N+1
+    // (sequence 2) was never replayed. Same streamId (same process epoch),
+    // so the client can detect the gap via the sequence jump (1 → 3).
+    expect(envelopeFirst.sequence).toBe(3);
+    expect(envelopeFirst.streamId).toBe(envelopeN.streamId);
+
+    b.destroy();
+  });
+
+  it('a fresh broadcaster (simulating a host restart) has a different streamId and its own sequence restarting at 1', async () => {
+    const broadcaster1 = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster1));
+    const c1 = client();
+    await c1.opened;
+    await waitForSubscriberCount(broadcaster1, 1);
+    await discardRetry(c1);
+    broadcaster1.publish('run-1', SOURCE, { type: 'turn_complete' });
+    const envelope1 = JSON.parse(
+      (await c1.next()).data!,
+    ) as RuntimeActivityEnvelope;
+    expect(envelope1.sequence).toBe(1);
+    c1.destroy();
+    await stopOdysseusServer(server);
+
+    const broadcaster2 = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster2));
+    const c2 = client();
+    await c2.opened;
+    await waitForSubscriberCount(broadcaster2, 1);
+    await discardRetry(c2);
+    broadcaster2.publish('run-1', SOURCE, { type: 'turn_complete' });
+    const envelope2 = JSON.parse(
+      (await c2.next()).data!,
+    ) as RuntimeActivityEnvelope;
+
+    expect(envelope2.sequence).toBe(1); // sequence restarts on the new instance
+    expect(envelope2.streamId).not.toBe(envelope1.streamId); // new ordering epoch
+
+    c2.destroy();
+  });
+});
+
+// ── Case 10: keepalive behavior ──────────────────────────────────────────────
+describe('keepalive', () => {
+  function collectIntervalHandlers(): {
+    restore: () => void;
+    calls: Array<{ delay: number; fire: () => void }>;
+  } {
+    const calls: Array<{ delay: number; fire: () => void }> = [];
+    const spy = vi
+      .spyOn(global, 'setInterval')
+      .mockImplementation(
+        (
+          handler: (...handlerArgs: unknown[]) => void,
+          timeout?: number,
+          ...args: unknown[]
+        ) => {
+          calls.push({ delay: timeout ?? 0, fire: () => handler(...args) });
+          // Inert but shape-compatible handle: real code calls .unref() on it.
+          return {
+            unref: () => {},
+            ref: () => {},
+          } as unknown as ReturnType<typeof setInterval>;
+        },
+      );
+    return { restore: () => spy.mockRestore(), calls };
+  }
+
+  it('writes ": ping" both before and after a data event (unlike chat\'s firstTokenSeen-gated keepalive), and stops firing after disconnect', async () => {
+    const { restore, calls } = collectIntervalHandlers();
+    const broadcaster = new RuntimeActivityBroadcaster();
+    try {
+      await listen(makeDeps(broadcaster));
+      const c = client();
+      await c.opened;
+      await waitForSubscriberCount(broadcaster, 1);
+      await discardRetry(c);
+
+      const activityInterval = calls.find((call) => call.delay === 20_000);
+      expect(activityInterval).toBeDefined();
+
+      activityInterval!.fire(); // simulate a tick BEFORE any data event
+      const ping1 = await c.next();
+      expect(ping1.comment).toBe('ping');
+
+      broadcaster.publish('run-1', SOURCE, { type: 'turn_complete' });
+      const dataFrame = await c.next();
+      expect(dataFrame.event).toBe('turn_complete');
+
+      activityInterval!.fire(); // simulate a tick AFTER a data event — still pings
+      const ping2 = await c.next();
+      expect(ping2.comment).toBe('ping');
+
+      c.destroy();
+      await waitForSubscriberCount(broadcaster, 0);
+
+      // The interval is cleared on disconnect — firing the captured callback
+      // again must not throw (defensive) and must not reach a dead socket.
+      expect(() => activityInterval!.fire()).not.toThrow();
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ── Case 11: admission / rate behavior ───────────────────────────────────────
+describe('admission and rate-limit interaction', () => {
+  it('reconnects consume the existing rate-limit bucket (RATE_LIMIT_MAX=5/60s)', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+
+    for (let i = 0; i < 5; i++) {
+      const c = client();
+      await c.opened;
+      expect(c.statusCode).toBe(200);
+      c.destroy();
+      await waitForSubscriberCount(broadcaster, 0);
+    }
+    const sixth = client();
+    await sixth.opened;
+    expect(sixth.statusCode).toBe(429);
+    sixth.destroy();
+  });
+
+  it('delivered events and keepalive pings do not consume additional rate-limit entries', async () => {
+    const broadcaster = new RuntimeActivityBroadcaster();
+    await listen(makeDeps(broadcaster));
+
+    const c = client();
+    await c.opened; // 1st rate-bucket entry
+    await discardRetry(c);
+    for (let i = 0; i < 10; i++) {
+      broadcaster.publish('run-1', SOURCE, { type: 'activity', text: `e${i}` });
+      await c.next();
+    }
+    c.destroy();
+    await waitForSubscriberCount(broadcaster, 0);
+
+    // 4 more fresh connections (2nd..5th rate-bucket entries) — all still
+    // admitted, proving the 10 delivered events above consumed none of the
+    // rate-limit budget.
+    for (let i = 0; i < 4; i++) {
+      const c2 = client();
+      await c2.opened;
+      expect(c2.statusCode).toBe(200);
+      c2.destroy();
+      await waitForSubscriberCount(broadcaster, 0);
+    }
+  });
+
+  it('the activity admission cap uses its own counter, separate from the rate limiter (503, not 429, once MAX_CONCURRENT_SSE is reached)', async () => {
+    // isolates the 503 cap from the 429 rate limiter (both thresholds are 5)
+    // by advancing the faked Date between admissions so each connection's
+    // rate-bucket entry ages out of the 60s window before the next one — real
+    // timers/sockets are untouched, per PLAN.md §7 case 11's explicit
+    // instruction not to weaken or reorder auth/rate limiting to test this.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const broadcaster = new RuntimeActivityBroadcaster();
+    try {
+      await listen(makeDeps(broadcaster));
+      const clients: ActivityClient[] = [];
+      for (let i = 0; i < 5; i++) {
+        const c = client();
+        await c.opened;
+        expect(c.statusCode).toBe(200);
+        clients.push(c);
+        vi.setSystemTime(Date.now() + 61_000);
+      }
+
+      const sixth = client();
+      await sixth.opened;
+      expect(sixth.statusCode).toBe(503);
+
+      for (const c of clients) c.destroy();
+      sixth.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/odysseus-server.test.ts
+++ b/src/odysseus-server.test.ts
@@ -48,9 +48,11 @@ import {
   buildConversationPrompt,
   validateOdysseusToken,
   _resetServerStateForTest,
+  stopOdysseusServer,
   type OdysseusServerDeps,
 } from './odysseus-server.js';
 import type { RuntimeEventSink, RunResult } from './agent-runtimes/types.js';
+import { RuntimeActivityBroadcaster } from './agent-runtimes/activity-broadcaster.js';
 import type { RegisteredGroup } from './types.js';
 
 const TOKEN = 'a'.repeat(48); // valid (>= 32)
@@ -107,6 +109,11 @@ function makeDeps(opts?: {
       resolve: () => backend,
     } as unknown as OdysseusServerDeps['registry'],
     registeredGroups: () => groups,
+    // LIA-432/G5: OdysseusServerDeps now requires an injected broadcaster.
+    // This file doesn't exercise /v1/activity (see the dedicated
+    // odysseus-activity-stream.test.ts sibling) — a fresh instance per
+    // makeDeps() call is enough to satisfy the type.
+    activityBroadcaster: new RuntimeActivityBroadcaster(),
   };
 }
 
@@ -567,6 +574,71 @@ describe('SSE streaming', () => {
     expect(closeStdin).not.toHaveBeenCalled(); // 10s timer still pending
     await vi.advanceTimersByTimeAsync(10_001); // fire scheduleClose
     expect(closeStdin).toHaveBeenCalledWith(MAIN_JID);
+    vi.useRealTimers();
+  });
+});
+
+// ── stopOdysseusServer bounded force-close (LIA-432/G5) ─────────────────────
+// Node's `server.close()` callback does not fire until every open connection
+// ends — not just drained `/v1/activity` streams. Without a bound,
+// `stopOdysseusServer()` could hang on a still-open `/v1/chat/completions`
+// turn for up to ABSOLUTE_TURN_MS (10 minutes), starving the rest of
+// src/index.ts's shutdown() sequence (queue/channel drain), which now runs
+// AFTER the awaited Odysseus stop. This proves the grace-period force-close
+// keeps that bounded instead.
+describe('stopOdysseusServer — bounded force-close of a still-open chat stream', () => {
+  it('does not resolve while a /v1/chat/completions turn is still streaming, then force-closes and resolves once the grace period elapses', async () => {
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
+    });
+    let releaseHang: () => void = () => {};
+    const hang = new Promise<void>((r) => {
+      releaseHang = r;
+    });
+    const turn: TurnDriver = async (sink) => {
+      await sink({ type: 'output_text', text: 'partial' });
+      await hang; // never resolves on its own — models a live long-running turn
+      return { status: 'success', result: 'unreachable in this test' };
+    };
+    await listen(makeDeps({ turn }));
+
+    // Real socket I/O (only timer fns are faked, matching the container
+    // wind-down test above) — open the stream and wait for the first
+    // streamed chunk so the connection is genuinely established and open.
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(
+        {
+          method: 'POST',
+          path: '/v1/chat/completions',
+          hostname: '127.0.0.1',
+          port,
+          headers: authHeaders,
+        },
+        (res) => {
+          res.once('data', () => resolve());
+          res.on('error', () => {});
+        },
+      );
+      req.on('error', reject);
+      req.end(chatBody());
+    });
+
+    let stopSettled = false;
+    const stopPromise = stopOdysseusServer(server).then(() => {
+      stopSettled = true;
+    });
+
+    // Flush microtasks without advancing fake timers — the chat connection
+    // is still open, so server.close()'s callback must not have fired yet.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(10_001); // elapse ODYSSEUS_STOP_GRACE_MS
+    await stopPromise;
+    expect(stopSettled).toBe(true);
+
+    releaseHang();
     vi.useRealTimers();
   });
 });

--- a/src/odysseus-server.ts
+++ b/src/odysseus-server.ts
@@ -31,6 +31,10 @@ import {
   RuntimeEventSink,
   defaultSession,
 } from './agent-runtimes/types.js';
+import type {
+  RuntimeActivityBroadcaster,
+  RuntimeActivityEnvelope,
+} from './agent-runtimes/activity-broadcaster.js';
 import {
   INJECTION_SCANNER_CONFIG,
   ODYSSEUS_HTTP_ENABLED,
@@ -77,6 +81,12 @@ const rateLimitCleanupInterval = setInterval(() => {
 rateLimitCleanupInterval.unref();
 
 let activeSse = 0;
+// Separate from `activeSse` on purpose (LIA-432/G5): `/v1/activity` connections
+// are intentionally long-lived, so up to MAX_CONCURRENT_SSE monitor clients
+// could otherwise consume every slot indefinitely and make unrelated
+// `/v1/chat/completions` streaming turns return 503. Bounds activity sockets
+// to MAX_CONCURRENT_SSE without adding a new config surface.
+let activeActivitySse = 0;
 /** main jid → true while a turn is queued/running (one in-flight per jid). */
 const inFlight = new Set<string>();
 
@@ -99,12 +109,18 @@ export function _resetServerStateForTest(): void {
   rateBuckets.clear();
   inFlight.clear();
   activeSse = 0;
+  activeActivitySse = 0;
 }
 
 export interface OdysseusServerDeps {
   queue: GroupQueue;
   registry: RuntimeRegistry;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  // LIA-432/G5: shared, process-wide broadcaster injected from the
+  // composition root (src/index.ts) — the same instance the
+  // `deus-native` runtime decorator publishes into. `/v1/activity`
+  // subscribes to it; it never owns or closes it (see stopOdysseusServer).
+  activityBroadcaster: RuntimeActivityBroadcaster;
 }
 
 /**
@@ -150,6 +166,22 @@ function writeJson(res: ServerResponse, status: number, body: unknown): void {
 function writeSse(res: ServerResponse, frame: Record<string, unknown>): void {
   if (!res.writable) return;
   res.write(`data: ${JSON.stringify(frame)}\n\n`);
+}
+
+// LIA-432/G5: dedicated activity-frame formatter — deliberately NOT writeSse()
+// above, whose `data:`-only assumption and OpenAI chunk/completion frame input
+// belong to `/v1/chat/completions`. Every published RuntimeActivityEnvelope
+// carries both an SSE `id:` line and an `event:` line (the envelope's `type`)
+// in addition to the JSON `data:` line, per the activity contract documented
+// in src/agent-runtimes/activity-broadcaster.ts.
+function writeActivityFrame(
+  res: ServerResponse,
+  envelope: RuntimeActivityEnvelope,
+): void {
+  if (!res.writable) return;
+  res.write(`id: ${envelope.id}\n`);
+  res.write(`event: ${envelope.type}\n`);
+  res.write(`data: ${JSON.stringify(envelope)}\n\n`);
 }
 
 const MODELS_RESPONSE = {
@@ -281,6 +313,138 @@ export function buildConversationPrompt(body: unknown): string {
   );
 }
 
+// ── `/v1/activity` shutdown bookkeeping (LIA-432/G5) ────────────────────────
+//
+// Per-server state tracked in module-private WeakMaps (rather than adding
+// methods to Node's public `Server` type). Each entry in `responses` IS the
+// connection's own idempotent `finalize` closure (see `handleActivityStream`)
+// — storing the closure itself (not a wrapper) means `closeActivityStreamsFor`
+// and the connection's own `res.once('close', ...)` both ultimately invoke the
+// exact same once-guarded function, so no separate double-cleanup bookkeeping
+// is needed.
+interface ActivityStreamState {
+  responses: Set<(endResponse: boolean) => void>;
+  closed: boolean;
+}
+
+const activityStateByServer = new WeakMap<Server, ActivityStreamState>();
+const stopPromiseByServer = new WeakMap<Server, Promise<void>>();
+
+/** Idempotent: writes a final `: server shutdown` comment + ends every still-
+ * active `/v1/activity` response, then marks the per-server state closed so a
+ * later call (including the server's own `close` backstop) is a safe no-op. */
+function closeActivityStreamsFor(state: ActivityStreamState): void {
+  if (state.closed) return;
+  state.closed = true;
+  // Snapshot first: each `finalize(true)` call synchronously deletes itself
+  // from `state.responses`, so iterating the live Set while mutating it is
+  // avoided entirely.
+  for (const finalize of [...state.responses]) {
+    finalize(true);
+  }
+}
+
+/**
+ * `GET /v1/activity` — long-lived, authenticated deus-native activity SSE
+ * subscription (LIA-432/G5). Fans out every `RuntimeActivityEnvelope`
+ * published by the shared `RuntimeActivityBroadcaster` (see
+ * `src/agent-runtimes/activity-broadcaster.ts`) to every connected client for
+ * as long as the process/broadcaster stay alive. The route only subscribes —
+ * it never resolves a group, enqueues a `GroupQueue` task, touches
+ * `inFlight`, or triggers a turn, and it is reachable only through the same
+ * `127.0.0.1`-bound, bearer-authenticated server as every other Odysseus
+ * route (auth + rate limiting happen in the caller, before this is invoked).
+ *
+ * Delivery is fire-and-forward only: no replay buffer, no ring buffer. A
+ * reconnecting client receives only events published after its new
+ * subscription. `retry: 15000` (written on admission) is the server's SSE
+ * reconnect hint; `Last-Event-ID` is accepted as an ordinary request header
+ * but deliberately ignored — a client instead compares its last observed
+ * `{ streamId, sequence }` against the next envelope to detect a gap (same
+ * `streamId`, a jump in `sequence`) or a host restart (changed `streamId`).
+ *
+ * Keepalive intentionally differs from `/v1/chat/completions`'s
+ * `!firstTokenSeen`-gated ping (this file's `handleChatCompletion`, whose
+ * pings stop once the turn starts streaming because that response ends with
+ * the turn): the activity stream may sit quiet between unrelated turns and
+ * must keep intermediaries from treating that silence as a dead connection,
+ * so its keepalive runs unconditionally for the entire subscription.
+ */
+function handleActivityStream(
+  deps: OdysseusServerDeps,
+  res: ServerResponse,
+  state: ActivityStreamState,
+): void {
+  if (activeActivitySse >= MAX_CONCURRENT_SSE) {
+    writeJson(res, 503, { error: 'too many concurrent streams' });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  // Flush headers and establish the reconnect delay before registering with
+  // the broadcaster (admission + header setup happen first, per contract).
+  res.write('retry: 15000\n\n');
+
+  activeActivitySse++;
+  let sseCounted = true;
+
+  // Reused KEEPALIVE_MS, but — unlike the chat path — this timer runs for the
+  // ENTIRE subscription (never gated on "first event seen"). unref() so it
+  // can never pin process exit.
+  let keepaliveTimer: ReturnType<typeof setInterval> | null = setInterval(
+    () => {
+      if (res.writable) res.write(': ping\n\n');
+    },
+    KEEPALIVE_MS,
+  );
+  keepaliveTimer.unref();
+
+  // Registered only after admission + header setup, per contract.
+  let unsubscribe: (() => void) | null = deps.activityBroadcaster.subscribe(
+    (envelope) => writeActivityFrame(res, envelope),
+  );
+
+  // One idempotent finalize() per connection, mirroring the releaseSlot()/
+  // finalize() discipline `handleChatCompletion` already uses below. In one
+  // place it clears+nulls the keepalive interval, invokes+clears the
+  // broadcaster unsubscribe, removes itself from the server's active-activity
+  // set, and decrements activeActivitySse exactly once. `endResponse` is true
+  // only for the explicit-shutdown path (closeActivityStreamsFor), where a
+  // still-writable response is ended with a final comment frame.
+  let finalized = false;
+  const finalize = (endResponse: boolean): void => {
+    if (finalized) return;
+    finalized = true;
+    if (keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+      keepaliveTimer = null;
+    }
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+    state.responses.delete(finalize);
+    if (sseCounted) {
+      activeActivitySse = Math.max(0, activeActivitySse - 1);
+      sseCounted = false;
+    }
+    if (endResponse && res.writable) {
+      res.write(': server shutdown\n\n');
+      res.end();
+    }
+  };
+
+  state.responses.add(finalize);
+  // Client abort (or any other socket close) → finalize without ending an
+  // already-dead response. Request/response error handling remains guarded
+  // by the server's existing top-level res/req 'error' handlers.
+  res.once('close', () => finalize(false));
+}
+
 /**
  * Build the configured (not-yet-listening) HTTP server. Exported so tests drive
  * the handler directly on an ephemeral port without the enabled-gate.
@@ -289,7 +453,12 @@ export function createOdysseusServer(
   deps: OdysseusServerDeps,
   token: string,
 ): Server {
-  return createServer((req, res) => {
+  const activityState: ActivityStreamState = {
+    responses: new Set(),
+    closed: false,
+  };
+
+  const server = createServer((req, res) => {
     // Sub-tick TOCTOU guard: the socket can die between a res.writable check
     // and the synchronous write; an unhandled 'error' would crash the host.
     res.on('error', (err) =>
@@ -307,9 +476,10 @@ export function createOdysseusServer(
 
     const isChat = url === '/v1/chat/completions';
     const isModels = url === '/v1/models';
+    const isActivity = url === '/v1/activity';
 
     // Method gate BEFORE auth (closes OPTIONS/HEAD presence-leak).
-    if (!isChat && !isModels) {
+    if (!isChat && !isModels && !isActivity) {
       writeJson(res, 404, { error: 'not found' });
       return;
     }
@@ -321,8 +491,14 @@ export function createOdysseusServer(
       writeJson(res, 405, { error: 'method not allowed' });
       return;
     }
+    if (isActivity && method !== 'GET') {
+      writeJson(res, 405, { error: 'method not allowed' });
+      return;
+    }
 
-    // Auth — all routes, constant-time.
+    // Auth — all routes, constant-time. Same ODYSSEUS_HTTP_TOKEN bearer path
+    // as every other route; no query-string token, cookie, or alternate
+    // credential is accepted (LIA-432/G5 adds no new auth mode).
     const bearer = extractBearer(req);
     if (!bearer || !timingSafeEqualStr(bearer, token)) {
       logger.warn({ remoteAddr, url, status: 401 }, 'Odysseus auth rejected');
@@ -330,6 +506,10 @@ export function createOdysseusServer(
       return;
     }
 
+    // Same rate bucket as every other route, applied to every initial
+    // connection AND every reconnection; delivered activity events/pings are
+    // plain writes on an already-admitted connection and consume no
+    // additional rate-limit entries.
     if (isRateLimited(remoteAddr)) {
       writeJson(res, 429, { error: 'rate limit exceeded' });
       return;
@@ -337,6 +517,11 @@ export function createOdysseusServer(
 
     if (isModels) {
       writeJson(res, 200, MODELS_RESPONSE);
+      return;
+    }
+
+    if (isActivity) {
+      handleActivityStream(deps, res, activityState);
       return;
     }
 
@@ -367,6 +552,15 @@ export function createOdysseusServer(
       handleChatCompletion(deps, body, res, remoteAddr);
     });
   });
+
+  activityStateByServer.set(server, activityState);
+  // Backstop: if something ends the server directly (bypassing
+  // stopOdysseusServer), still drain any live /v1/activity responses instead
+  // of leaving them dangling — closeActivityStreamsFor's own `closed` guard
+  // makes this a no-op when stopOdysseusServer already ran it.
+  server.on('close', () => closeActivityStreamsFor(activityState));
+
+  return server;
 }
 
 /**
@@ -409,6 +603,75 @@ export function startOdysseusServer(
       resolve(server);
     });
   });
+}
+
+// Bounds how long stopOdysseusServer() can be blocked by a connection OTHER
+// than a drained /v1/activity stream — chiefly a still-open /v1/chat/completions
+// turn, which ABSOLUTE_TURN_MS otherwise only bounds at 10 minutes. Node's
+// `server.close()` callback does not fire until every open connection ends,
+// so without this bound, `await stopOdysseusServer()` in src/index.ts's
+// shutdown() (which now runs BEFORE the queue/channel drain — see PLAN.md §5)
+// could starve the rest of graceful shutdown for up to that long. Previously
+// (`webhookServers.push(odysseusServer)` + fire-and-forget `.close()`),
+// shutdown never awaited this at all, so this bound keeps the new behavior
+// strictly better than before rather than introducing a new hang risk.
+const ODYSSEUS_STOP_GRACE_MS = 10_000;
+
+/**
+ * Idempotent Odysseus HTTP-server shutdown owner (LIA-432/G5). Drains every
+ * live `/v1/activity` response (final `: server shutdown` comment + `res.end()`)
+ * BEFORE `server.close()`, so `server.close()`'s own callback isn't left
+ * waiting forever on a permanent SSE socket — then resolves once that close
+ * callback completes, or after `ODYSSEUS_STOP_GRACE_MS` elapses, whichever is
+ * first. If the grace period elapses first (a connection other than a drained
+ * activity stream is still open — e.g. a live `/v1/chat/completions` turn),
+ * this force-closes remaining sockets via `closeIdleConnections()`/
+ * `closeAllConnections()` (Node >=18.2; this repo requires Node >=20) so the
+ * rest of process-wide shutdown (queue/channel drain in `src/index.ts`) is
+ * never starved by one in-flight streaming turn. This is the SOLE closer of
+ * the Odysseus `Server`; the generic `webhookServers` shutdown loop in
+ * `src/index.ts` must not also call `.close()` on the same instance (double
+ * `server.close()`).
+ *
+ * Crucially, this closes only the Odysseus HTTP resource and its
+ * `/v1/activity` route subscriptions — it never closes the injected
+ * `RuntimeActivityBroadcaster` itself. That broadcaster is process-wide,
+ * owned by the `src/index.ts` composition root, and stays open through the
+ * rest of shutdown so a `deus-native` turn still in flight elsewhere
+ * (channel/task/Linear) can keep publishing until the process-wide
+ * `activityBroadcaster.close()` call at the true tail of shutdown.
+ *
+ * Repeated calls (including a redundant call after the server already closed
+ * some other way) return the SAME promise/resolution rather than re-invoking
+ * `server.close()`, which would reject on an already-closed server.
+ */
+export function stopOdysseusServer(server: Server): Promise<void> {
+  const cached = stopPromiseByServer.get(server);
+  if (cached) return cached;
+
+  const stopPromise = (async () => {
+    const state = activityStateByServer.get(server);
+    if (state) closeActivityStreamsFor(state);
+
+    const closePromise = new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+
+    const forceTimer = setTimeout(() => {
+      server.closeIdleConnections?.();
+      server.closeAllConnections?.();
+    }, ODYSSEUS_STOP_GRACE_MS);
+    forceTimer.unref();
+
+    try {
+      await closePromise;
+    } finally {
+      clearTimeout(forceTimer);
+    }
+  })();
+
+  stopPromiseByServer.set(server, stopPromise);
+  return stopPromise;
 }
 
 function handleChatCompletion(


### PR DESCRIPTION
## Summary

- Adds an authenticated `GET /v1/activity` SSE endpoint that fans out live `deus-native` runtime events (`activity`, `tool_call`, `output_text`, `usage`, `session`, `turn_complete`, `error`) to connected clients, giving LIA-352 (Deus Companion) and LIA-64 (activity monitor) real data to build against without implementing either.
- New `RuntimeActivityBroadcaster` (`src/agent-runtimes/activity-broadcaster.ts`): process-wide fan-out subject with a documented schema, a stable `streamId` + monotonic `sequence` for ordering, a no-throw/no-replay lifecycle, and a `withRuntimeActivityBroadcast()` decorator applied only to the `deus-native` registry entry (Claude/OpenAI/llama-cpp stay undecorated — intentionally deus-native-only scope).
- New `/v1/activity` route in `src/odysseus-server.ts`: same bearer auth + rate limiting as every other route, a dedicated `activeActivitySse` counter (capped by the existing `MAX_CONCURRENT_SSE`, kept separate from chat's `activeSse` so long-lived monitors can't starve chat streaming), an unconditional keepalive for the life of the subscription, and idempotent per-connection cleanup.
- Odysseus now has a single HTTP-server shutdown owner via the new `stopOdysseusServer()`, which drains `/v1/activity` responses before `server.close()` and bounds the wait (`ODYSSEUS_STOP_GRACE_MS = 10s`, force-closing via `closeAllConnections()` past that) so a still-open `/v1/chat/completions` turn can no longer block process-wide shutdown for up to `ABSOLUTE_TURN_MS` (10 min) — a real regression caught by code review and fixed before merge. `src/index.ts` wires this as the sole closer and moves `activityBroadcaster.close()` to the true tail of shutdown, after channel/queue/Linear/native-chat-server drain.
- Reconnection is fire-and-forward only (no replay, no ring buffer); `streamId` + `sequence` let a client detect a gap or a host restart.

Scope is intentionally `deus-native`-only: LIA-64's "container status" field needs the container-backed runtimes and is explicitly out of scope here (documented in `PLAN.md` as a follow-up).

This branch was rebased onto `origin/deus-v2/dev` mid-implementation to pick up LIA-415/416/428 and a commitlint dependency fix that landed concurrently; the merge was verified to preserve both sides' changes byte-for-byte in the three overlapping files (`index.ts`, `odysseus-server.ts`, `deus-native-backend.test.ts`).

## Review trail

- plan-reviewer: native SHIP (2 rounds) + gpt SHIP
- code-reviewer: native SHIP (2 rounds, after fixing the shutdown-hang regression) + gpt SHIP (glm COULD_NOT_RUN — insufficient API balance, fails open per policy)
- verification-gate: native SHIP, with an independent end-to-end SSE run (real server, real client, real decorated turn) confirming all four event types delivered in order with correct sequence/id, clean disconnect, and clean shutdown

## Test plan

- [x] `npx vitest run src/agent-runtimes/activity-broadcaster.test.ts src/agent-runtimes/deus-native-backend.test.ts src/odysseus-server.test.ts src/odysseus-activity-stream.test.ts` — 92/92 passing
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Manual end-to-end SSE run (real server + real client + real decorated turn) — all 4 event types received in order, clean disconnect, clean shutdown

Refs LIA-432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)