### PR TITLE
fix(admin-merge-gate): exclude known-advisory checks from plan-limited fallback

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -83,9 +83,12 @@ from warden_hooks.ci_status import (  # noqa: E402
     _CI_STATUS_NO_REQUIRED,
     _CI_STATUS_PENDING,
     _CI_STATUS_RED,
+    _KNOWN_ADVISORY_CHECK_NAMES,
     _branch_protection_plan_limited,
     _check_ci_status,
     _ci_block_reason,
+    _classify_checks,
+    _fetch_gh_checks_raw,
     _query_gh_checks,
 )
 

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -2287,6 +2287,87 @@ def test_check_ci_status_plan_limited_pending_blocks(monkeypatch):
     assert hooks._ci_block_reason("123", status, detail) is not None
 
 
+def test_check_ci_status_plan_limited_advisory_only_failure_is_excluded(monkeypatch):
+    # The discriminating case: a plan-limited repo where the ONLY non-green
+    # check is a known-advisory one (TrueCourse, cancelled — bucket "cancel",
+    # which is in _BUCKET_FAIL). Before the advisory-exclusion fallback this
+    # would incorrectly block; after it, the excluded check must not count.
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(
+            required_checks=None,
+            all_checks=[
+                {"bucket": "cancel", "name": "TrueCourse --diff vs main"},
+                {"bucket": "pass", "name": "ci"},
+            ],
+            protection_stdout=_PROTECTION_PLAN_LIMITED,
+            protection_rc=1,
+        ),
+    )
+    status, detail = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_GREEN
+    assert "plan-limited fallback" in detail
+
+
+def test_check_ci_status_plan_limited_advisory_exclusion_does_not_mask_real_failure(
+    monkeypatch,
+):
+    # @oracle: authored blind to the implementation from the ticket spec —
+    # excluding a known-advisory check must never mask a genuinely failing
+    # non-advisory check. A wrong GREEN here would let a merge land over red
+    # CI, so this is the dangerous-direction discriminator.
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(
+            required_checks=None,
+            all_checks=[
+                {"bucket": "cancel", "name": "TrueCourse --diff vs main"},
+                {"bucket": "fail", "name": "ci"},
+            ],
+            protection_stdout=_PROTECTION_PLAN_LIMITED,
+            protection_rc=1,
+        ),
+    )
+    status, detail = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_RED
+    assert "ci" in detail
+
+
+def test_check_ci_status_plan_limited_only_check_is_advisory_is_no_checks(monkeypatch):
+    # A PR whose ONLY check is the excluded advisory one — filtering must not
+    # produce a vacuous GREEN (set() <= _BUCKET_PASS is trivially true on an
+    # empty bucket set); it must classify as NO_CHECKS instead.
+    hooks = load_hooks()
+    monkeypatch.setattr(
+        hooks.subprocess,
+        "run",
+        _make_gh_run_split(
+            required_checks=None,
+            all_checks=[{"bucket": "cancel", "name": "TrueCourse --diff vs main"}],
+            protection_stdout=_PROTECTION_PLAN_LIMITED,
+            protection_rc=1,
+        ),
+    )
+    status, detail = hooks._check_ci_status("123")
+    assert status == hooks._CI_STATUS_NO_CHECKS
+    assert hooks._ci_block_reason("123", status, detail) is None
+
+
+def test_classify_checks_default_exclude_names_unchanged(monkeypatch):
+    # Regression guard: _classify_checks with exclude_names unset must be
+    # byte-identical to classifying the raw list (no filtering).
+    hooks = load_hooks()
+    checks = [{"bucket": "pass", "name": "ci"}, {"bucket": "fail", "name": "lint"}]
+    status, message, n = hooks._classify_checks(checks)
+    assert status == hooks._CI_STATUS_RED
+    assert "lint" in message
+    assert n == 2
+
+
 def test_check_ci_status_non_matching_403_stays_fail_closed(monkeypatch):
     # A 403 that is NOT the plan-limitation shape (e.g. a real auth/permission
     # denial) must NOT be treated as plan-limited — the substring gate must

--- a/scripts/warden_hooks/ci_status.py
+++ b/scripts/warden_hooks/ci_status.py
@@ -35,16 +35,16 @@ _BUCKET_PENDING = frozenset({"pending"})
 _BUCKET_FAIL = frozenset({"fail", "cancel"})
 
 
-def _query_gh_checks(
+def _fetch_gh_checks_raw(
     pr_ref: str, *, required_only: bool, timeout: int = 3, repo: str | None = None
-) -> tuple[str, str, int]:
-    """Run ``gh pr checks`` once and classify the result.
+) -> tuple[str | None, list[dict] | None, str]:
+    """Run ``gh pr checks`` once and return the raw parsed checks, unclassified.
 
-    Returns ``(status, message, num_checks)`` where status is one of the
-    ``_CI_STATUS_*`` constants and num_checks is how many checks were returned.
-    When *required_only* is set, the query is scoped with ``--required`` so the
-    gate sees only branch-protection-required checks. Failure to query defaults
-    to ``_CI_STATUS_ERROR`` so the caller blocks rather than falls open.
+    Returns ``(early_status, checks, message)``. ``early_status`` is ``None``
+    and ``checks`` is a non-empty list when there's something to classify.
+    Otherwise ``early_status`` is one of ``_CI_STATUS_ERROR``/
+    ``_CI_STATUS_NO_CHECKS`` (checks is ``None``) — a terminal result reached
+    before classification is possible.
 
     *repo* scopes the query to an explicit ``OWNER/REPO`` (via ``gh``'s own
     ``--repo`` flag) instead of letting ``gh`` resolve one from the current
@@ -69,11 +69,11 @@ def _query_gh_checks(
             check=False,
         )
     except FileNotFoundError:
-        return _CI_STATUS_ERROR, "gh CLI not found; cannot verify CI status", 0
+        return _CI_STATUS_ERROR, None, "gh CLI not found; cannot verify CI status"
     except subprocess.TimeoutExpired:
-        return _CI_STATUS_ERROR, f"gh pr checks timed out after {timeout}s", 0
+        return _CI_STATUS_ERROR, None, f"gh pr checks timed out after {timeout}s"
     except OSError as exc:
-        return _CI_STATUS_ERROR, f"gh pr checks failed: {exc}", 0
+        return _CI_STATUS_ERROR, None, f"gh pr checks failed: {exc}"
 
     if result.returncode not in (0, 1, 8):
         # Exit code 1 = some checks failed (still parseable).
@@ -82,22 +82,49 @@ def _query_gh_checks(
         stderr_snippet = result.stderr.strip()[:200]
         return (
             _CI_STATUS_ERROR,
+            None,
             f"gh pr checks exited {result.returncode}: {stderr_snippet}",
-            0,
         )
 
     raw = result.stdout.strip()
     if not raw:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
+        return _CI_STATUS_NO_CHECKS, None, "no checks found for this PR"
 
     try:
         checks = json.loads(raw)
     except json.JSONDecodeError:
-        return _CI_STATUS_ERROR, "gh pr checks returned unparseable output", 0
+        return _CI_STATUS_ERROR, None, "gh pr checks returned unparseable output"
 
     if not isinstance(checks, list):
-        return _CI_STATUS_ERROR, "gh pr checks returned unexpected JSON shape", 0
+        return _CI_STATUS_ERROR, None, "gh pr checks returned unexpected JSON shape"
 
+    if not checks:
+        return _CI_STATUS_NO_CHECKS, None, "no checks found for this PR"
+
+    return None, checks, ""
+
+
+def _classify_checks(
+    checks: list[dict], exclude_names: frozenset[str] = frozenset()
+) -> tuple[str, str, int]:
+    """Classify an already-fetched checks list into a ``_CI_STATUS_*`` result.
+
+    *exclude_names*: check names to drop before classification (e.g. checks
+    known to be advisory-only across this codebase's CI workflows, never
+    branch-protection-required). Empty (the default) is a no-op filter —
+    byte-identical to classifying the unfiltered list.
+
+    If filtering removes every check, re-checks emptiness explicitly and
+    returns ``_CI_STATUS_NO_CHECKS`` — without this, ``set() <= _BUCKET_PASS``
+    is vacuously true on an empty bucket set, which would otherwise produce a
+    false ``_CI_STATUS_GREEN`` from an empty check list.
+    """
+    if exclude_names:
+        checks = [
+            c
+            for c in checks
+            if isinstance(c, dict) and str(c.get("name", "")) not in exclude_names
+        ]
     if not checks:
         return _CI_STATUS_NO_CHECKS, "no checks found for this PR", 0
 
@@ -124,6 +151,35 @@ def _query_gh_checks(
     unknown = buckets - _BUCKET_PASS - _BUCKET_PENDING - _BUCKET_FAIL
     return _CI_STATUS_ERROR, f"unknown check buckets: {', '.join(sorted(unknown))}", n
 
+
+def _query_gh_checks(
+    pr_ref: str, *, required_only: bool, timeout: int = 3, repo: str | None = None
+) -> tuple[str, str, int]:
+    """Run ``gh pr checks`` once and classify the result.
+
+    Returns ``(status, message, num_checks)``. Thin wrapper over
+    ``_fetch_gh_checks_raw`` + ``_classify_checks`` — external signature and
+    behavior unchanged from before that split.
+    """
+    early_status, checks, message = _fetch_gh_checks_raw(
+        pr_ref, required_only=required_only, timeout=timeout, repo=repo
+    )
+    if early_status is not None or checks is None:
+        return early_status or _CI_STATUS_ERROR, message, 0
+    return _classify_checks(checks)
+
+
+# Checks known to be advisory-only across this codebase's CI workflows (never
+# branch-protection-required, confirmed via sliamh11/Deus's real
+# required_status_checks.contexts and documented at merge_train.py's "advisory
+# checks like TrueCourse never gate" comment, LIA-144). GitHub's own bucket
+# classification for a self-cancelled run of one of these is inconsistent
+# (pass vs cancel for what appears to be the same cancellation reason), so
+# name-based exclusion is more reliable than trusting the bucket when
+# computing the plan-limited fallback's "must be green" set. Staleness here is
+# fail-safe: a renamed check simply drops out of this set and reverts to
+# blocking, never to falsely allowing.
+_KNOWN_ADVISORY_CHECK_NAMES = frozenset({"TrueCourse --diff vs main"})
 
 _PLAN_LIMITATION_MESSAGE = "Upgrade to GitHub Pro or make this repository public"
 
@@ -202,26 +258,39 @@ def _check_ci_status(
 
     # No REQUIRED checks reported. Disambiguate against the unfiltered set:
     # genuinely zero checks → allowed through (unchanged behaviour); checks
-    # present but none required → ambiguous, fail closed.
-    all_status, all_message, all_n = _query_gh_checks(
+    # present but none required → ambiguous, fail closed. Fetch once here so
+    # both the unfiltered classification below and the plan-limited fallback's
+    # advisory-excluded classification see the identical snapshot — a second
+    # live `gh` call could observe a different bucket for the same check.
+    early_status, checks, early_message = _fetch_gh_checks_raw(
         pr_ref, required_only=False, timeout=timeout, repo=repo
     )
+    if early_status == _CI_STATUS_ERROR:
+        return early_status, early_message
+    if early_status == _CI_STATUS_NO_CHECKS or not checks:
+        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
+
+    all_status, all_message, all_n = _classify_checks(checks)
     if all_status == _CI_STATUS_ERROR:
         return all_status, all_message
-    if all_n == 0:
-        return _CI_STATUS_NO_CHECKS, "no checks found for this PR"
 
     # Structurally unknowable required-checks (private repo, no GitHub Pro):
     # branch protection cannot exist on this repo at all, so the ambiguity
     # this branch normally fails closed on doesn't apply. Fall back to the
-    # unfiltered result directly — strictly more conservative than real
-    # required-checks (demands every check green, not just a subset).
+    # unfiltered result — strictly more conservative than real required-checks
+    # (demands every check green, not just a subset) — except for checks
+    # known to be advisory-only, whose inconsistent cancel/pass bucketing
+    # would otherwise cause false blocks unrelated to real CI health.
     if _branch_protection_plan_limited(repo, "main", timeout):
+        filtered_status, filtered_message, filtered_n = _classify_checks(
+            checks, _KNOWN_ADVISORY_CHECK_NAMES
+        )
         return (
-            all_status,
-            f"{all_message} (plan-limited fallback: branch protection "
-            f"unavailable on this repo's plan tier — used all {all_n} "
-            f"check(s) instead of branch-protection-required ones)",
+            filtered_status,
+            f"{filtered_message} (plan-limited fallback: branch protection "
+            f"unavailable on this repo's plan tier — used {filtered_n} "
+            f"check(s), excluding known-advisory checks, instead of "
+            f"branch-protection-required ones)",
         )
 
     # Thread the unfiltered status through so the operator sees WHAT is


### PR DESCRIPTION
## Summary

Follow-up to #1055 (the plan-limited admin-merge-gate fallback). Live testing against real `sliamh11/deus-v2` PRs revealed the fallback was blocked far more often than intended: `gh pr checks --json bucket` classifies a cancelled `"TrueCourse --diff vs main"` run inconsistently — bucket `"cancel"` (treated as failing) on some PRs, `"pass"` on others, for what appears to be the same kind of self-cancellation. TrueCourse is a known, established advisory-only gate (documented at `merge_train.py`'s "advisory checks like TrueCourse never gate" comment, LIA-144, and confirmed absent from `sliamh11/Deus`'s real `required_status_checks.contexts`) — its inconsistent bucketing shouldn't drive a real block.

## Fix

Adds `_KNOWN_ADVISORY_CHECK_NAMES`, a small fixed set of check names excluded from the "must be green" computation, but **only** inside the plan-limited fallback branch — every other path (required-checks-resolve-normally, the non-plan-limited `NO_REQUIRED` ambiguous case) is unaffected. Staleness here is fail-safe: a renamed check simply drops out of the set and reverts to blocking, never to falsely allowing.

Splits `_query_gh_checks` into `_fetch_gh_checks_raw` (fetch+parse only) and `_classify_checks` (pure classification, now taking an `exclude_names` parameter) — this fixes a snapshot-consistency issue an earlier design had: re-querying `gh pr checks` a second time for the exclusion-filtered view could observe a different live snapshot than the one the surrounding guards were evaluated against. `_check_ci_status` now fetches the unfiltered checks list ONCE and classifies it TWICE (unfiltered for existing guards/messages, advisory-filtered only inside the plan-limited branch) — guaranteed same snapshot, zero added `gh` round-trips. `_classify_checks` also re-checks emptiness after filtering, returning `NO_CHECKS` rather than a vacuous `GREEN` from an empty bucket set trivially satisfying `set() <= _BUCKET_PASS`.

## Smoke test evidence (real PRs)

1. **3 real deus-v2 PRs previously falsely blocked** (#18, #21, #22) — now correctly allowed.
2. **A genuinely red PR** — still blocks, real failing check named in the message.
3. **A full-featured repo** (real branch protection) with a real red check — completely unaffected: identical message format, no "plan-limited fallback" text.

(Repo/PR identifiers genericized where appropriate per this repo's public-repo-generic convention; smoke-test commands are reproducible against the cited PR numbers.)

## Tests

- 4 new unit tests: advisory-only-failure excluded → GREEN; advisory exclusion does **not** mask a real failure → still RED (authored by an independent `oracle-author` agent blind to the implementation, from spec alone); only-check-is-advisory → `NO_CHECKS` not a vacuous `GREEN`; default `exclude_names` is byte-identical to before.
- `python3 -m pytest scripts/tests/test_codex_warden_hooks.py -v` → **303 passed**.
- `python3 scripts/drift_check.py --all --base origin/main` → clean.

## Provenance

3 plan-review rounds (Opus, round 3 SHIP — rounds 1-2 caught the snapshot-consistency issue and the vacuous-GREEN empty-filter edge case), fresh code-review (Opus SHIP + GPT co-gate SHIP; GLM co-gate unavailable, insufficient balance, fails open per policy), verification-gate (Opus SHIP, independently re-ran all tests and smoke tests, confirmed no residual approval-marker artifacts left by testing).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>