### PR TITLE
chore(codex-review): bump GPT reviewer default model to gpt-5.6-sol

### DIFF
--- a/scripts/codex_review.py
+++ b/scripts/codex_review.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Cross-family code-review ADVISORY via OpenAI GPT (codex CLI, subscription-billed).
 
-A different-family second opinion for a human reviewer — NOT a gate. Drives GPT-5.5
+A different-family second opinion for a human reviewer — NOT a gate. Drives GPT
 through `codex exec` (read-only sandbox) over a diff, with the Deus code-review rules as
 instructions and a strict `--output-schema` for structured per-file findings. Nothing
 auto-applies, auto-posts, or blocks a commit. (Rationale/alternatives: the plan
@@ -53,12 +53,12 @@ from _exit_codes import (  # noqa: E402
 )
 
 # ── Defaults ────────────────────────────────────────────────────────────────────
-DEFAULT_MODEL = "gpt-5.5"          # codex's own config.toml default; -m can override
+DEFAULT_MODEL = "gpt-5.6-sol"       # explicit override of codex's own config.toml default; -m can still override
 DEFAULT_SANDBOX = "read-only"       # never workspace-write / danger-full-access here
 DEFAULT_TIMEOUT = 300.0             # codex exec at high reasoning effort is slow
 DEFAULT_MAX_FILES = 20
 # Above this total diff size we fan out to one codex call per file instead of one
-# whole-diff call (a rough guard; GPT-5.5's context is large, so this is high).
+# whole-diff call (a rough guard; GPT's context is large, so this is high).
 WHOLE_DIFF_CHAR_LIMIT = 200_000
 # Synthetic path for non-diff content (cfg.is_diff=False): there is no real file path, but
 # the per-file results/merge keep keying on one. Wrapped in <> so it can't collide with a
@@ -251,7 +251,7 @@ def call_codex_exec(prompt: str, cfg: "CodexReviewConfig", cwd: str) -> CodexRes
             return CodexResult(
                 False, wall_s=cfg.timeout,
                 error=f"codex exec timed out after {cfg.timeout:.0f}s "
-                      "(GPT-5.5 high reasoning is slow; raise --timeout).",
+                      "(GPT high reasoning is slow; raise --timeout).",
             )
         wall = round(time.time() - t0, 2)
 
@@ -439,7 +439,7 @@ def review(diff: str, cfg: CodexReviewConfig, cwd: str, cross_context: str = "")
 # ── Human-readable rendering (the default; --json is the agent-native path) ───────
 BANNER = (
     "═══ ADVISORY: cross-family GPT second opinion — NOT a gate ═══\n"
-    "GPT-5.5 via your ChatGPT subscription (codex, read-only sandbox). LLM reviewers "
+    "GPT via your ChatGPT subscription (codex, read-only sandbox). LLM reviewers "
     "false-flag often; a human must triage every finding. Never auto-apply or gate on this."
 )
 

--- a/scripts/warden_review/backends/codex.py
+++ b/scripts/warden_review/backends/codex.py
@@ -30,7 +30,7 @@ _CODE_FROM_CATEGORY = {RATE_LIMIT: "rate_limit", AUTH_ERROR: "auth"}
 
 
 class CodexBackend(ModelReviewerBackend):
-    """Backend id ``gpt``: drives GPT (default gpt-5.6-sol) through the codex CLI."""
+    """Backend id ``gpt``: drives GPT (default codex_review.DEFAULT_MODEL) through the codex CLI."""
 
     def id(self) -> str:
         return BACKEND_GPT

--- a/scripts/warden_review/backends/codex.py
+++ b/scripts/warden_review/backends/codex.py
@@ -30,7 +30,7 @@ _CODE_FROM_CATEGORY = {RATE_LIMIT: "rate_limit", AUTH_ERROR: "auth"}
 
 
 class CodexBackend(ModelReviewerBackend):
-    """Backend id ``gpt``: drives GPT (default gpt-5.5) through the codex CLI."""
+    """Backend id ``gpt``: drives GPT (default gpt-5.6-sol) through the codex CLI."""
 
     def id(self) -> str:
         return BACKEND_GPT


### PR DESCRIPTION
## Summary
- Bumps `scripts/codex_review.py`'s `DEFAULT_MODEL` from `gpt-5.5` to `gpt-5.6-sol` (GA flagship, 2026-07-09). codex CLI on this host is already 0.144.3 (recognizes the new model id); `codex exec -m gpt-5.6-sol` confirmed callable.
- De-stales hardcoded "GPT-5.5" text in docstrings/comments/help/banner so they don't go stale on the next bump, and corrects the `DEFAULT_MODEL` comment (now an explicit override of codex's own config.toml default, not equal to it).
- Backend docstring in `scripts/warden_review/backends/codex.py` now defers to `codex_review.DEFAULT_MODEL` instead of hardcoding the model id, avoiding a second source of truth that would re-stale on the next bump.

Out of scope (documented, not oversights):
- `tui/src/backend/codex.rs`'s OpenAI model picker also lists `gpt-5.5` — the custom Rust TUI is already slated for archival (LIA-389), not worth extending.
- `scripts/nonumb.py:63` documents codex CLI's own upstream config default, a different concern from this repo's `DEFAULT_MODEL`.

Ports issue #1012 (documented as already shipped on the liam-cyberpro fork), rewritten independently for this repo rather than copied from the fork diff.

## Test plan
- [x] `pytest scripts/tests/test_codex_review.py scripts/tests/test_codex_warden.py scripts/tests/test_warden_review.py` — 112 passed
- [x] `codex exec -m gpt-5.6-sol` confirmed callable (real call, this session)
- [x] plan-reviewer (claude+gpt, 3 rounds to SHIP) and code-reviewer (claude, SHIP) both passed
- [x] `drift_check.py --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)