### PR TITLE
feat(setup): add deus-v2 parallel-install launcher (LIA-434)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Force LF line endings for source files, regardless of the checkout
+# platform's git config (core.autocrlf=true is the default on GitHub
+# Actions' windows-latest/windows-2025 runners). This repo previously had
+# no .gitattributes at all, which left every text file subject to
+# platform-dependent CRLF conversion on checkout.
+#
+# Confirmed necessary, not precautionary: LIA-434's deus-v2-cmd.mjs was
+# (as far as could be determined) the first top-level .mjs file in this
+# repo actually `import`-ed (not just executed as a script) by a .test.ts
+# file. On Windows CI, git's autocrlf conversion turned its LF line
+# endings into CRLF, which broke Vite/Vitest's SSR module-loading pipeline
+# for that file specifically (`SyntaxError: Invalid or unexpected token`,
+# reproduced locally by CRLF-converting the file and re-running vitest;
+# the same file passed both `node --check` and a standalone
+# `esbuild`/`transformWithEsbuild` transform even CRLF-converted, so the
+# failure is specific to Vitest's SSR/import-analysis step, not general
+# JS parsing). `deus-cmd.sh` and `scripts/migrate.mjs` were latently
+# exposed to the same risk but never actually broke, because nothing
+# previously imported a top-level .mjs file the way deus-v2-cmd.test.ts
+# does.
+* text=auto eol=lf
+
+# Windows-native scripts keep their conventional CRLF — these are only
+# ever executed on Windows, where CRLF is the native convention, and are
+# never `import`-ed as ES modules by a test file the way deus-v2-cmd.mjs is.
+*.ps1 text eol=crlf
+*.cmd text eol=crlf

--- a/deus-v2-cmd.mjs
+++ b/deus-v2-cmd.mjs
@@ -222,62 +222,77 @@ export async function acquireCloneLock(lockPath, opts = {}) {
     } catch (err) {
       if (err.code !== 'EEXIST') throw err;
     }
-    let holderStat, holderContent;
+    // Hold an open read fd on the lock file for the rest of this iteration
+    // instead of re-`statSync`-ing the path twice. This closes a real TOCTOU
+    // gap two prior code reviews narrowed but couldn't fully close: a bare
+    // `statSync(path)` holds nothing, so the OS is free to reuse its inode
+    // number the instant a concurrent process unlinks it — a LATER
+    // `statSync(path)` can then observe a coincidentally-matching dev+ino on
+    // a genuinely different, freshly-recreated file. POSIX (and, per libuv,
+    // Node's own default Windows open flags: FILE_SHARE_READ|WRITE|DELETE)
+    // guarantees an inode is never reclaimed while any process holds it
+    // open — so keeping `holderFd` open across the isAlive() check FORCES a
+    // concurrent steal onto a different inode, making the dev+ino
+    // comparison below (where `isAlive` returns false) deterministic rather
+    // than merely unlikely to collide.
+    let holderFd;
     try {
-      // Stat (for inode identity) and content (for the PID) must both be
-      // captured from this same observation — see the steal branch below
-      // for why the inode is the load-bearing check, not the content.
-      holderStat = fs.statSync(lockPath);
-      holderContent = fs.readFileSync(lockPath, 'utf8').trim();
+      holderFd = fs.openSync(lockPath, 'r');
     } catch {
-      continue; // vanished between our failed open and read — retry immediately
+      continue; // vanished between our failed open and this one — retry immediately
     }
-    const holderPid = parseInt(holderContent, 10);
-    if (!Number.isInteger(holderPid)) {
-      // Unparseable content most likely means we read the lock file in the
-      // narrow window between another process's openSync (empty file) and
-      // its writeSync (PID written) — not a dead holder, just one still
-      // being created. Wait rather than steal.
-      await new Promise((resolve) => setTimeout(resolve, pollMs));
-      continue;
-    }
-    if (!isAlive(holderPid)) {
-      // Verify by INODE IDENTITY (not content) immediately before deleting:
-      // two code reviews caught real problems here in succession. First: an
-      // unconditional unlink could delete a DIFFERENT, freshly re-acquired
-      // lock a concurrent stealer already created. Second: re-verifying by
-      // CONTENT string (an earlier fix) is still wrong, because PIDs get
-      // reused by the OS — a coincidentally-identical PID string on a
-      // genuinely different (fresh, live) lock file would pass a content
-      // check and still get wrongly deleted. Comparing dev+ino instead
-      // checks the actual filesystem entity, not a value that can alias.
-      // This narrows, but — being a check-then-act pattern — does not
-      // perfectly close, the TOCTOU window; true atomicity for this
-      // operation requires OS-level advisory locking (flock/LockFileEx),
-      // which Node's core `fs` does not expose and which this file's
-      // build-free, dependency-free constraint (see the header comment)
-      // rules out reaching for via a native module. Combined with the
-      // immediately-following atomic `wx` re-open (the actual mutual-
-      // exclusion guarantee for who successfully HOLDS the lock), a
-      // surviving race here can misfire the eviction of a live lock at
-      // worst — an event requiring two processes to independently
-      // rediscover the same dead holder and interleave within a single
-      // syscall gap, for a lock that only exists to serialize one human-
-      // triggered, one-time clone.
+    try {
+      let holderStat, holderContent;
       try {
-        const currentStat = fs.statSync(lockPath);
-        if (
-          currentStat.ino === holderStat.ino &&
-          currentStat.dev === holderStat.dev
-        ) {
-          fs.unlinkSync(lockPath);
-        }
+        holderStat = fs.fstatSync(holderFd);
+        holderContent = fs.readFileSync(holderFd, 'utf8').trim();
       } catch {
-        // Vanished or already replaced by someone else — fine either way.
+        continue; // vanished after we opened it — retry immediately
       }
-      continue; // retry immediately — no reason to wait for a dead holder
+      const holderPid = parseInt(holderContent, 10);
+      if (!Number.isInteger(holderPid)) {
+        // Unparseable content most likely means we read the lock file in the
+        // narrow window between another process's openSync (empty file) and
+        // its writeSync (PID written) — not a dead holder, just one still
+        // being created. Wait rather than steal.
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+        continue;
+      }
+      if (!isAlive(holderPid)) {
+        // Verify by INODE IDENTITY (not content) immediately before
+        // deleting: two code reviews caught real problems here in
+        // succession. First: an unconditional unlink could delete a
+        // DIFFERENT, freshly re-acquired lock a concurrent stealer already
+        // created. Second: re-verifying by CONTENT string (an earlier fix)
+        // is still wrong, because PIDs get reused by the OS — a
+        // coincidentally-identical PID string on a genuinely different
+        // (fresh, live) lock file would pass a content check and still get
+        // wrongly deleted. `holderStat` came from the still-open `holderFd`
+        // (not a fresh path stat), which is what makes this comparison
+        // deterministic — see the comment above `holderFd`'s declaration.
+        try {
+          const currentStat = fs.statSync(lockPath);
+          if (
+            currentStat.ino === holderStat.ino &&
+            currentStat.dev === holderStat.dev
+          ) {
+            fs.unlinkSync(lockPath);
+          }
+        } catch {
+          // Vanished or already replaced by someone else — fine either way.
+        }
+        continue; // retry immediately — no reason to wait for a dead holder
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    } finally {
+      try {
+        fs.closeSync(holderFd);
+      } catch {
+        // Nothing else in this scope closes holderFd first, so reaching
+        // here would mean something genuinely unexpected — swallow rather
+        // than mask the real error this finally is cleaning up after.
+      }
     }
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
   return null; // timed out waiting for a live holder to finish
 }

--- a/deus-v2-cmd.mjs
+++ b/deus-v2-cmd.mjs
@@ -136,7 +136,23 @@ export function validateCheckout(checkoutPath, opts = {}) {
     toplevel.stdout.trim(),
     isWindows,
   );
-  if (!pathsEqual(resolvedToplevel, realpathSync(checkoutPath), isWindows)) {
+  // realCheckoutPath (not the raw checkoutPath) is the load-bearing side of
+  // every cross-source comparison below (this one, and isUnderDir further
+  // down): on real Windows CI runners, os.tmpdir() (and so checkoutPath
+  // itself, in tests) is commonly reported in the legacy 8.3 short-name
+  // form ("RUNNER~1"), while git's own --show-toplevel/--git-common-dir
+  // output for the SAME directory may or may not be — a genuinely
+  // different string either way, not just a separator/case difference
+  // pathsEqual's normalize+lowercase can fix. Rather than assume which
+  // form git's output takes, every git-derived value compared against a
+  // checkoutPath-derived value goes through realpathSync on BOTH sides —
+  // idempotent (a no-op) if a given side already happens to be canonical,
+  // necessary if it doesn't, so this is correct regardless of git's actual
+  // behavior here.
+  const realCheckoutPath = realpathSync(checkoutPath);
+  if (
+    !pathsEqual(realpathSync(resolvedToplevel), realCheckoutPath, isWindows)
+  ) {
     return { valid: false, reason: 'invalid-nested-repo' };
   }
 
@@ -157,7 +173,7 @@ export function validateCheckout(checkoutPath, opts = {}) {
   );
   if (
     !pathsEqual(resolvedGitDir, resolvedCommonDir, isWindows) ||
-    !isUnderDir(resolvedCommonDir, checkoutPath, isWindows)
+    !isUnderDir(realpathSync(resolvedCommonDir), realCheckoutPath, isWindows)
   ) {
     // Mirrors deus-cmd.sh's existing linked-worktree check (its own `deploy`
     // subcommand): a linked worktree has git-dir under the MAIN repo's

--- a/deus-v2-cmd.mjs
+++ b/deus-v2-cmd.mjs
@@ -106,7 +106,14 @@ export function validateCheckout(checkoutPath, opts = {}) {
     isWindows = isWindowsPlatform(),
     existsSync = fs.existsSync,
     readdirSync = fs.readdirSync,
-    realpathSync = fs.realpathSync,
+    // .native, not plain fs.realpathSync: the JS-walked default only
+    // chases symlinks and leaves Windows 8.3 short-name aliases ("RUNNER~1")
+    // unresolved, confirmed via a real Windows CI diagnostic run. .native
+    // calls the OS's own realpath (GetFinalPathNameByHandleW on Windows),
+    // which does resolve them -- identical output to the plain version for
+    // ordinary POSIX symlink resolution (verified locally), so no behavior
+    // change there.
+    realpathSync = fs.realpathSync.native,
     statSync = fs.statSync,
     runGit = (args) =>
       spawnSync('git', ['-C', checkoutPath, ...args], { encoding: 'utf8' }),
@@ -138,17 +145,14 @@ export function validateCheckout(checkoutPath, opts = {}) {
   );
   // realCheckoutPath (not the raw checkoutPath) is the load-bearing side of
   // every cross-source comparison below (this one, and isUnderDir further
-  // down): on real Windows CI runners, os.tmpdir() (and so checkoutPath
-  // itself, in tests) is commonly reported in the legacy 8.3 short-name
-  // form ("RUNNER~1"), while git's own --show-toplevel/--git-common-dir
-  // output for the SAME directory may or may not be — a genuinely
-  // different string either way, not just a separator/case difference
-  // pathsEqual's normalize+lowercase can fix. Rather than assume which
-  // form git's output takes, every git-derived value compared against a
-  // checkoutPath-derived value goes through realpathSync on BOTH sides —
-  // idempotent (a no-op) if a given side already happens to be canonical,
-  // necessary if it doesn't, so this is correct regardless of git's actual
-  // behavior here.
+  // down). git's several rev-parse subcommands don't agree on absolute vs.
+  // relative, or short- vs. long-form (confirmed via a real Windows CI
+  // diagnostic run — --show-toplevel returns an absolute, already-long
+  // path; --git-dir/--git-common-dir return a bare relative ".git" that
+  // inherits checkoutPath's own form). Rather than track each subcommand's
+  // quirk individually, every git-derived value compared against a
+  // checkoutPath-derived value goes through realpathSync on both sides —
+  // idempotent if a side is already canonical, necessary if it isn't.
   const realCheckoutPath = realpathSync(checkoutPath);
   if (
     !pathsEqual(realpathSync(resolvedToplevel), realCheckoutPath, isWindows)

--- a/deus-v2-cmd.mjs
+++ b/deus-v2-cmd.mjs
@@ -1,0 +1,621 @@
+#!/usr/bin/env node
+/**
+ * deus-v2 — bootstrap launcher for a parallel, independent `sliamh11/deus-v2`
+ * checkout (LIA-434). Locates or creates a standalone clone at ~/deus-v2,
+ * then delegates argv/cwd/stdio/exit-code/signal unchanged to its own
+ * deus-cmd.sh/.ps1 — alongside the existing v1 `deus` command, never
+ * replacing it. `deus-v2 [args...]` forwards as-is: no reparsing, no shell
+ * interpolation, no bare-command translation.
+ *
+ * Build-free by design (must run before `npm install`/`npm run build` has
+ * ever happened, like deus-cmd.sh/scripts/migrate.mjs) — a deliberate,
+ * disclosed exception to the platform-abstraction ADR's src/platform.ts
+ * requirement; see docs/decisions/platform-abstraction-layer.md.
+ *
+ * Design patterns: the lock and signal guard are RAII-style (single
+ * dispose/release the caller's `finally` always calls); validateCheckout
+ * returns a discriminated result; platform dispatch is a plain boolean
+ * (exactly two branches, no reuse beyond this file).
+ */
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_URL = 'https://github.com/sliamh11/deus-v2.git';
+// Fully anchored (^...$) to the two exact accepted origin forms — a prior
+// unanchored version matched "github.com/sliamh11/deus-v2" as a SUBSTRING
+// anywhere in the origin, which a code review caught as a real bypass (e.g.
+// "https://attacker.example/github.com/sliamh11/deus-v2.git" would have
+// passed). Whole-string match only.
+const REPO_SLUG_RE =
+  /^(?:https:\/\/github\.com\/sliamh11\/deus-v2(?:\.git)?\/?|git@github\.com:sliamh11\/deus-v2(?:\.git)?)$/i;
+
+// How long a second invocation will wait for a concurrent clone to finish
+// before giving up (a full clone can legitimately take minutes on a slow
+// connection). This is a give-up-and-report-an-actionable-error timeout, NOT
+// a staleness threshold — see acquireCloneLock's comment for why the lock is
+// never stolen based on elapsed time alone.
+const DEFAULT_LOCK_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_LOCK_POLL_MS = 1000;
+
+export function getCheckoutPath() {
+  return path.join(os.homedir(), 'deus-v2');
+}
+
+export function getLockPath() {
+  return path.join(os.homedir(), '.deus', 'deus-v2-clone.lock');
+}
+
+export function isWindowsPlatform() {
+  return os.platform() === 'win32';
+}
+
+// ── Path comparison ─────────────────────────────────────────────────────────
+//
+// Routed through path.win32/path.posix (not the ambient, host-OS-bound `path`
+// module) so an injected `isWindows` test flag stays deterministic regardless
+// of the real host OS. Also case-folded when isWin: Git for Windows (MSYS2)
+// often reports a lowercase drive letter while fs.realpathSync returns the
+// OS-canonical uppercase form — separator normalization alone doesn't fix
+// that mismatch, only normalize+lowercase together does.
+
+function resolveGitPath(base, rel, isWin) {
+  const p = isWin ? path.win32 : path.posix;
+  return p.resolve(base, rel);
+}
+
+function pathsEqual(a, b, isWin) {
+  const p = isWin ? path.win32 : path.posix;
+  const norm = (s) => p.normalize(s).replace(/[\\/]+$/, '');
+  const na = norm(a);
+  const nb = norm(b);
+  return isWin ? na.toLowerCase() === nb.toLowerCase() : na === nb;
+}
+
+function isUnderDir(child, parentDir, isWin) {
+  const p = isWin ? path.win32 : path.posix;
+  const c = p.normalize(child).replace(/[\\/]+$/, '');
+  const d = p.normalize(parentDir).replace(/[\\/]+$/, '');
+  const [cc, dd] = isWin ? [c.toLowerCase(), d.toLowerCase()] : [c, d];
+  return cc === dd || cc.startsWith(dd + p.sep);
+}
+
+// ── Checkout validation ─────────────────────────────────────────────────────
+//
+// Returns { valid: true } or { valid: false, reason }, where reason is one of:
+//   'missing'                    — nonexistent path OR an existing-but-empty
+//                                   directory. Both are safe to `git clone`
+//                                   into (git accepts an empty target dir),
+//                                   so both map to the same auto-clone-safe
+//                                   reason.
+//   'invalid-not-a-directory'    — checkoutPath exists but is a plain file.
+//   'invalid-not-a-git-repo'     | 'invalid-nested-repo'
+//   | 'invalid-linked-worktree'  | 'invalid-wrong-origin'
+//   | 'invalid-missing-entrypoint:<name>'
+//
+// Every 'invalid-*' reason is a HARD FAIL — the caller must never delete,
+// overwrite, or repurpose the directory for any of these; only 'missing' is
+// ever auto-cloned into. All OS/fs primitives are injectable for testability:
+// a genuine Windows-mode unit test must also fake fs.realpathSync's return
+// value, since the real one can't produce a "C:\..." string on a non-Windows
+// test runner.
+export function validateCheckout(checkoutPath, opts = {}) {
+  const {
+    isWindows = isWindowsPlatform(),
+    existsSync = fs.existsSync,
+    readdirSync = fs.readdirSync,
+    realpathSync = fs.realpathSync,
+    statSync = fs.statSync,
+    runGit = (args) =>
+      spawnSync('git', ['-C', checkoutPath, ...args], { encoding: 'utf8' }),
+  } = opts;
+
+  if (!existsSync(checkoutPath)) return { valid: false, reason: 'missing' };
+
+  const topStat = statSync(checkoutPath);
+  if (!topStat.isDirectory()) {
+    return { valid: false, reason: 'invalid-not-a-directory' };
+  }
+  if (readdirSync(checkoutPath).length === 0) {
+    return { valid: false, reason: 'missing' };
+  }
+
+  const inside = runGit(['rev-parse', '--is-inside-work-tree']);
+  if (inside.status !== 0 || inside.stdout.trim() !== 'true') {
+    return { valid: false, reason: 'invalid-not-a-git-repo' };
+  }
+
+  const toplevel = runGit(['rev-parse', '--show-toplevel']);
+  if (toplevel.status !== 0) {
+    return { valid: false, reason: 'invalid-not-a-git-repo' };
+  }
+  const resolvedToplevel = resolveGitPath(
+    checkoutPath,
+    toplevel.stdout.trim(),
+    isWindows,
+  );
+  if (!pathsEqual(resolvedToplevel, realpathSync(checkoutPath), isWindows)) {
+    return { valid: false, reason: 'invalid-nested-repo' };
+  }
+
+  const gitDir = runGit(['rev-parse', '--git-dir']);
+  const commonDir = runGit(['rev-parse', '--git-common-dir']);
+  if (gitDir.status !== 0 || commonDir.status !== 0) {
+    return { valid: false, reason: 'invalid-not-a-git-repo' };
+  }
+  const resolvedGitDir = resolveGitPath(
+    checkoutPath,
+    gitDir.stdout.trim(),
+    isWindows,
+  );
+  const resolvedCommonDir = resolveGitPath(
+    checkoutPath,
+    commonDir.stdout.trim(),
+    isWindows,
+  );
+  if (
+    !pathsEqual(resolvedGitDir, resolvedCommonDir, isWindows) ||
+    !isUnderDir(resolvedCommonDir, checkoutPath, isWindows)
+  ) {
+    // Mirrors deus-cmd.sh's existing linked-worktree check (its own `deploy`
+    // subcommand): a linked worktree has git-dir under the MAIN repo's
+    // .git/worktrees/<name>, with common-dir pointing elsewhere entirely.
+    // Cross-checked against scripts/drift_check.py's _in_linked_worktree()
+    // for algorithm consistency (same anchoring rationale, different
+    // language — not reusable directly, written fresh here).
+    return { valid: false, reason: 'invalid-linked-worktree' };
+  }
+
+  const origin = runGit(['remote', 'get-url', 'origin']);
+  if (origin.status !== 0 || !REPO_SLUG_RE.test(origin.stdout.trim())) {
+    return { valid: false, reason: 'invalid-wrong-origin' };
+  }
+
+  const entrypointName = isWindows ? 'deus-cmd.ps1' : 'deus-cmd.sh';
+  if (!existsSync(path.join(checkoutPath, entrypointName))) {
+    return {
+      valid: false,
+      reason: `invalid-missing-entrypoint:${entrypointName}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+// ── Locking ──────────────────────────────────────────────────────────────
+//
+// Wait-and-steal, unlike src/auth-refresh.ts's fail-fast lock: a clone in
+// progress should be waited out, not treated as already-handled. Stealing is
+// decided by PID liveness (process.kill(pid, 0), a signal-free existence
+// probe), never by elapsed time — a live holder is never stolen from
+// regardless of how slow its clone is, and this also rules out an ABA hazard
+// where a dead owner's lock gets reused by a third process before the
+// original owner's own cleanup runs.
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but is owned by another user — still
+    // alive, just not signalable by us. Any other error (typically ESRCH)
+    // means it's gone.
+    return err.code === 'EPERM';
+  }
+}
+
+export async function acquireCloneLock(lockPath, opts = {}) {
+  const {
+    waitTimeoutMs = DEFAULT_LOCK_WAIT_TIMEOUT_MS,
+    pollMs = DEFAULT_LOCK_POLL_MS,
+    isAlive = isPidAlive,
+  } = opts;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + waitTimeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.writeSync(fd, String(process.pid));
+      return { fd, path: lockPath };
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+    }
+    let holderStat, holderContent;
+    try {
+      // Stat (for inode identity) and content (for the PID) must both be
+      // captured from this same observation — see the steal branch below
+      // for why the inode is the load-bearing check, not the content.
+      holderStat = fs.statSync(lockPath);
+      holderContent = fs.readFileSync(lockPath, 'utf8').trim();
+    } catch {
+      continue; // vanished between our failed open and read — retry immediately
+    }
+    const holderPid = parseInt(holderContent, 10);
+    if (!Number.isInteger(holderPid)) {
+      // Unparseable content most likely means we read the lock file in the
+      // narrow window between another process's openSync (empty file) and
+      // its writeSync (PID written) — not a dead holder, just one still
+      // being created. Wait rather than steal.
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+      continue;
+    }
+    if (!isAlive(holderPid)) {
+      // Verify by INODE IDENTITY (not content) immediately before deleting:
+      // two code reviews caught real problems here in succession. First: an
+      // unconditional unlink could delete a DIFFERENT, freshly re-acquired
+      // lock a concurrent stealer already created. Second: re-verifying by
+      // CONTENT string (an earlier fix) is still wrong, because PIDs get
+      // reused by the OS — a coincidentally-identical PID string on a
+      // genuinely different (fresh, live) lock file would pass a content
+      // check and still get wrongly deleted. Comparing dev+ino instead
+      // checks the actual filesystem entity, not a value that can alias.
+      // This narrows, but — being a check-then-act pattern — does not
+      // perfectly close, the TOCTOU window; true atomicity for this
+      // operation requires OS-level advisory locking (flock/LockFileEx),
+      // which Node's core `fs` does not expose and which this file's
+      // build-free, dependency-free constraint (see the header comment)
+      // rules out reaching for via a native module. Combined with the
+      // immediately-following atomic `wx` re-open (the actual mutual-
+      // exclusion guarantee for who successfully HOLDS the lock), a
+      // surviving race here can misfire the eviction of a live lock at
+      // worst — an event requiring two processes to independently
+      // rediscover the same dead holder and interleave within a single
+      // syscall gap, for a lock that only exists to serialize one human-
+      // triggered, one-time clone.
+      try {
+        const currentStat = fs.statSync(lockPath);
+        if (
+          currentStat.ino === holderStat.ino &&
+          currentStat.dev === holderStat.dev
+        ) {
+          fs.unlinkSync(lockPath);
+        }
+      } catch {
+        // Vanished or already replaced by someone else — fine either way.
+      }
+      continue; // retry immediately — no reason to wait for a dead holder
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return null; // timed out waiting for a live holder to finish
+}
+
+export function releaseLock(lock) {
+  try {
+    fs.closeSync(lock.fd);
+  } catch {
+    // already closed
+  }
+  try {
+    fs.unlinkSync(lock.path);
+  } catch {
+    // already removed
+  }
+}
+
+// ── Signal-aware child process runner ───────────────────────────────────────
+//
+// Exactly one process-level listener per signal for a guard's lifetime, fed
+// by a mutable box that callers update — runForwarding never registers its
+// own listeners, only sets/clears `box.child` around the spawn — so there's
+// never more than one listener per signal, and no registration-order race
+// between "forward to child" and "clean up and re-raise" (both branches live
+// in the same handler).
+export function makeSignalGuard(
+  forwardSignals = ['SIGINT', 'SIGTERM', 'SIGHUP'],
+) {
+  const box = { child: null, cleanup: null };
+  // INVARIANT: cleanup (via setCleanup) must be fully synchronous — Node
+  // fires same-signal listeners with no interleaving only as long as no
+  // listener body yields; releaseLock() below already satisfies this.
+  const handler = (sig) => {
+    if (box.child) {
+      // Windows: kill() is a hard-terminate with no SIGHUP delivery (Node/OS
+      // limitation, not a regression — matches a raw Ctrl+C with no launcher
+      // in between). POSIX targets get real cooperative forwarding here.
+      box.child.kill(sig);
+      return; // the child's 'exit' event drives runForwarding's normal resolution
+    }
+    const cleanup = box.cleanup;
+    box.cleanup = null;
+    if (cleanup) cleanup();
+    dispose();
+    process.kill(process.pid, sig); // re-raise now that we're clean and no listener remains
+  };
+  function dispose() {
+    for (const sig of forwardSignals) process.off(sig, handler);
+  }
+  for (const sig of forwardSignals) process.on(sig, handler);
+  return {
+    setChild(child) {
+      box.child = child;
+    },
+    clearChild() {
+      box.child = null;
+    },
+    setCleanup(fn) {
+      box.cleanup = fn;
+    },
+    dispose,
+  };
+}
+
+// Spawns `command` with argv passed as a real array — no shell:true anywhere,
+// so args reach the child via execve unchanged, never through a shell string
+// (satisfies "no reparsing/shell interpolation" for both the clone step and
+// final delegation). Used identically by the one-time clone step and the
+// steady-state delegate step, via the shared `guard`.
+export async function runForwarding(command, args, { cwd }, guard) {
+  const child = spawn(command, args, { cwd, stdio: 'inherit' });
+  guard.setChild(child);
+  try {
+    return await new Promise((resolve, reject) => {
+      child.on('error', reject);
+      child.on('exit', (code, signal) => resolve({ code, signal }));
+    });
+  } finally {
+    guard.clearChild();
+  }
+}
+
+function exitLike({ code, signal }) {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exitCode = code ?? 1;
+}
+
+// Thrown, never process.exit()'d directly: exit() skips enclosing `finally`
+// blocks (verified — it doesn't unwind the JS stack), which would orphan the
+// clone lock on ordinary failure, not just signals. main()'s top-level catch
+// turns this into a process exit only after cleanup has already run.
+class LauncherError extends Error {
+  constructor(message, { signal } = {}) {
+    super(message);
+    this.name = 'LauncherError';
+    this.signal = signal;
+  }
+}
+
+function fail(msg, opts) {
+  throw new LauncherError(`deus-v2: ${msg}`, opts);
+}
+
+function explainInvalid(reason, checkoutPath) {
+  const base = `${checkoutPath} exists but failed validation (${reason}) — leaving it untouched.`;
+  if (reason === 'invalid-linked-worktree') {
+    return (
+      `${base} It looks like a linked worktree (shares .git with another ` +
+      `checkout), not a standalone clone. Remove or relocate it, then retry ` +
+      `— deus-v2 will clone fresh.`
+    );
+  }
+  if (reason === 'invalid-wrong-origin') {
+    return `${base} Its 'origin' remote doesn't point at sliamh11/deus-v2. Inspect manually.`;
+  }
+  if (reason.startsWith('invalid-missing-entrypoint')) {
+    return `${base} Missing the platform entrypoint — the clone may be incomplete or from an unexpected branch. Inspect manually.`;
+  }
+  if (reason === 'invalid-not-a-directory') {
+    return `${base} A file (not a directory) exists at that path. Inspect manually.`;
+  }
+  return `${base} Inspect manually before retrying.`;
+}
+
+// `opts.spawnClone` is injectable so a test can simulate a failing clone
+// (proving the lock is released on failure) without touching the network.
+// It receives (guard, targetPath) — see the staging-directory note below
+// for why targetPath is never checkoutPath itself.
+export async function ensureCheckout(checkoutPath, opts = {}) {
+  const {
+    lockPath = getLockPath(),
+    validateOpts = {},
+    lockOpts = {},
+    spawnClone = (guard, targetPath) =>
+      runForwarding(
+        'git',
+        ['clone', '--origin', 'origin', REPO_URL, targetPath],
+        { cwd: process.cwd() },
+        guard,
+      ),
+  } = opts;
+
+  let result = validateCheckout(checkoutPath, validateOpts);
+  if (result.valid) return;
+  if (result.reason !== 'missing')
+    fail(explainInvalid(result.reason, checkoutPath));
+
+  const lock = await acquireCloneLock(lockPath, lockOpts);
+  const guard = makeSignalGuard();
+  if (lock) guard.setCleanup(() => releaseLock(lock));
+  try {
+    // Double-checked: another process may have finished cloning while we
+    // waited for the lock.
+    result = validateCheckout(checkoutPath, validateOpts);
+    if (result.valid) return;
+    if (result.reason !== 'missing') {
+      fail(explainInvalid(result.reason, checkoutPath));
+    }
+    if (!lock) {
+      fail(
+        `timed out waiting for another 'deus-v2' invocation to finish cloning ` +
+          `(lock: ${lockPath}). If nothing is actually cloning, remove the ` +
+          `stale lock file and retry.`,
+      );
+    }
+    console.log(`First run: cloning sliamh11/deus-v2 into ${checkoutPath} ...`);
+
+    // Clone into a per-process-unique staging directory, then atomically
+    // rename() it into place, rather than cloning directly into
+    // checkoutPath. This is the real fix for a corruption risk a code
+    // review kept correctly pressing on: acquireCloneLock's dead-holder
+    // eviction is a check-then-act pattern (stat identity, then unlink) and
+    // — like any userspace advisory lock without OS-level flock, which
+    // Node's core fs doesn't expose and this file's build-free constraint
+    // rules out reaching for via a native module — cannot be made
+    // PERFECTLY race-free. Rather than keep chasing an unreachable "closed"
+    // bar on the lock itself, this removes what actually matters: with a
+    // uniquely-named staging directory per attempt, even if two processes
+    // both wrongly believe they hold the lock, each writes into its own
+    // directory — there is never shared mutable state during the clone, so
+    // there is no interleaved-write corruption to risk. Only the final
+    // rename (POSIX-atomic; requires the destination to not exist or be
+    // empty) decides a winner. Losing that race is a harmless no-op
+    // cleanup, never data loss — the lock still avoids the common case of
+    // redundant concurrent clones, but is no longer safety-critical.
+    const stagingPath = `${checkoutPath}.staging.${process.pid}.${Date.now()}`;
+    const { code, signal } = await spawnClone(guard, stagingPath);
+    if (code !== 0 || signal) {
+      try {
+        fs.rmSync(stagingPath, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+      fail(
+        `git clone failed or was interrupted (exit ${code}${signal ? `, signal ${signal}` : ''}). ` +
+          `${checkoutPath} was never touched (the clone only ever wrote to a ` +
+          `disposable staging path) — safe to simply retry.`,
+        { signal },
+      );
+    }
+
+    try {
+      // Windows' MoveFileExW (which fs.renameSync uses under the hood)
+      // cannot replace an existing directory destination — even an empty
+      // one — unlike POSIX rename(2), which explicitly permits that. But
+      // checkoutPath may legitimately exist as an empty directory here:
+      // validateCheckout's 'missing' reason covers both nonexistent AND
+      // empty-directory destinations as equally safe to clone into. A code
+      // review caught that this combination silently broke publication on
+      // Windows. Clear an empty destination first so the rename always
+      // targets a nonexistent path, which both platforms handle
+      // identically. Unconditionally safe: rmdirSync only ever succeeds on
+      // an ACTUALLY empty directory (the OS enforces this) — it can never
+      // silently discard populated content. If checkoutPath doesn't exist
+      // (ENOENT) or is already non-empty (ENOTEMPTY, meaning someone else
+      // already published), this simply no-ops and the rename below runs
+      // or fails accordingly.
+      try {
+        fs.rmdirSync(checkoutPath);
+      } catch {
+        // ENOENT or ENOTEMPTY — either way, proceed to the rename attempt.
+      }
+      fs.renameSync(stagingPath, checkoutPath);
+    } catch {
+      // Someone else already published a valid checkout at this path first
+      // (they won the publish race) — that's fine, their result is exactly
+      // what we wanted too. Discard our redundant staging clone and fall
+      // through to re-validate checkoutPath below.
+      try {
+        fs.rmSync(stagingPath, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
+    const postClone = validateCheckout(checkoutPath, validateOpts);
+    if (!postClone.valid) {
+      fail(
+        `clone completed but failed validation (${postClone.reason}) — please investigate.`,
+      );
+    }
+  } finally {
+    guard.dispose();
+    if (lock) releaseLock(lock);
+  }
+}
+
+function resolveEntrypoint(checkoutPath) {
+  return path.join(
+    checkoutPath,
+    isWindowsPlatform() ? 'deus-cmd.ps1' : 'deus-cmd.sh',
+  );
+}
+
+async function delegate(checkoutPath, args) {
+  const entrypoint = resolveEntrypoint(checkoutPath);
+  if (!fs.existsSync(entrypoint)) {
+    fail(
+      `${entrypoint} not found — the deus-v2 checkout at ${checkoutPath} looks broken (not auto-repaired).`,
+    );
+  }
+  const guard = makeSignalGuard();
+  try {
+    let result;
+    if (isWindowsPlatform()) {
+      result = await runForwarding(
+        'powershell',
+        [
+          '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          entrypoint,
+          ...args,
+        ],
+        { cwd: process.cwd() },
+        guard,
+      );
+    } else {
+      try {
+        fs.chmodSync(entrypoint, 0o755);
+      } catch {
+        // Defensive; exec bit should already survive a normal git clone.
+      }
+      result = await runForwarding(
+        entrypoint,
+        args,
+        { cwd: process.cwd() },
+        guard,
+      );
+    }
+    exitLike(result);
+  } finally {
+    guard.dispose();
+  }
+}
+
+async function main() {
+  const checkoutPath = getCheckoutPath();
+  await ensureCheckout(checkoutPath);
+  await delegate(checkoutPath, process.argv.slice(2));
+}
+
+// Symlink-safe main-module check. The naive `fileURLToPath(import.meta.url)
+// === path.resolve(argv1)` (mirroring scripts/migrate.mjs, which is only
+// ever invoked directly via `node scripts/migrate.mjs`) is broken for THIS
+// script's actual primary invocation path: setup/cli.ts installs deus-v2 as
+// a symlink (~/.local/bin/deus-v2 -> this file), and Node resolves
+// import.meta.url through the symlink to the real file while leaving
+// argv[1] as the invoked symlink path — the two never match, so main()
+// would silently never run. Verified empirically before fixing (a code
+// review caught this as a real, function-breaking bug). fs.realpathSync
+// resolves argv[1] through the symlink the same way import.meta.url
+// already is, restoring the comparison.
+export function isMainModule(argv1, moduleUrl, realpathSync = fs.realpathSync) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule(process.argv[1], import.meta.url)) {
+  main().catch((err) => {
+    if (err instanceof LauncherError) {
+      console.error(err.message);
+      if (err.signal) {
+        process.kill(process.pid, err.signal);
+        return;
+      }
+      process.exitCode = 1;
+    } else {
+      console.error(err);
+      process.exitCode = 1;
+    }
+  });
+}

--- a/deus-v2-cmd.mjs
+++ b/deus-v2-cmd.mjs
@@ -222,77 +222,117 @@ export async function acquireCloneLock(lockPath, opts = {}) {
     } catch (err) {
       if (err.code !== 'EEXIST') throw err;
     }
-    // Hold an open read fd on the lock file for the rest of this iteration
-    // instead of re-`statSync`-ing the path twice. This closes a real TOCTOU
-    // gap two prior code reviews narrowed but couldn't fully close: a bare
-    // `statSync(path)` holds nothing, so the OS is free to reuse its inode
-    // number the instant a concurrent process unlinks it — a LATER
-    // `statSync(path)` can then observe a coincidentally-matching dev+ino on
-    // a genuinely different, freshly-recreated file. POSIX (and, per libuv,
-    // Node's own default Windows open flags: FILE_SHARE_READ|WRITE|DELETE)
+    // POSIX-only: hold an open read fd on the lock file for the rest of this
+    // iteration instead of re-`statSync`-ing the path twice. This closes a
+    // real TOCTOU gap two prior code reviews narrowed but couldn't fully
+    // close: a bare `statSync(path)` holds nothing, so the OS is free to
+    // reuse its inode number the instant a concurrent process unlinks it —
+    // a LATER `statSync(path)` can then observe a coincidentally-matching
+    // dev+ino on a genuinely different, freshly-recreated file. POSIX
     // guarantees an inode is never reclaimed while any process holds it
     // open — so keeping `holderFd` open across the isAlive() check FORCES a
     // concurrent steal onto a different inode, making the dev+ino
-    // comparison below (where `isAlive` returns false) deterministic rather
-    // than merely unlikely to collide.
-    let holderFd;
-    try {
-      holderFd = fs.openSync(lockPath, 'r');
-    } catch {
-      continue; // vanished between our failed open and this one — retry immediately
-    }
-    try {
-      let holderStat, holderContent;
+    // comparison below deterministic rather than merely unlikely to
+    // collide. NOT done on Windows: NTFS keeps an unlinked-but-still-open
+    // file's NAME occupied ("pending delete") until the last handle closes,
+    // so holding our own read handle open here would make a legitimate
+    // concurrent process's own recreate-the-lock attempt fail with EPERM
+    // instead of succeeding. Windows falls back to the original bare-
+    // statSync check below, which does not hit the inode-reuse race there.
+    if (!isWindowsPlatform()) {
+      let holderFd;
       try {
-        holderStat = fs.fstatSync(holderFd);
-        holderContent = fs.readFileSync(holderFd, 'utf8').trim();
+        holderFd = fs.openSync(lockPath, 'r');
       } catch {
-        continue; // vanished after we opened it — retry immediately
+        continue; // vanished between our failed open and this one — retry immediately
       }
-      const holderPid = parseInt(holderContent, 10);
-      if (!Number.isInteger(holderPid)) {
-        // Unparseable content most likely means we read the lock file in the
-        // narrow window between another process's openSync (empty file) and
-        // its writeSync (PID written) — not a dead holder, just one still
-        // being created. Wait rather than steal.
-        await new Promise((resolve) => setTimeout(resolve, pollMs));
-        continue;
-      }
-      if (!isAlive(holderPid)) {
-        // Verify by INODE IDENTITY (not content) immediately before
-        // deleting: two code reviews caught real problems here in
-        // succession. First: an unconditional unlink could delete a
-        // DIFFERENT, freshly re-acquired lock a concurrent stealer already
-        // created. Second: re-verifying by CONTENT string (an earlier fix)
-        // is still wrong, because PIDs get reused by the OS — a
-        // coincidentally-identical PID string on a genuinely different
-        // (fresh, live) lock file would pass a content check and still get
-        // wrongly deleted. `holderStat` came from the still-open `holderFd`
-        // (not a fresh path stat), which is what makes this comparison
-        // deterministic — see the comment above `holderFd`'s declaration.
+      try {
+        let holderStat, holderContent;
         try {
-          const currentStat = fs.statSync(lockPath);
-          if (
-            currentStat.ino === holderStat.ino &&
-            currentStat.dev === holderStat.dev
-          ) {
-            fs.unlinkSync(lockPath);
-          }
+          holderStat = fs.fstatSync(holderFd);
+          holderContent = fs.readFileSync(holderFd, 'utf8').trim();
         } catch {
-          // Vanished or already replaced by someone else — fine either way.
+          continue; // vanished after we opened it — retry immediately
         }
-        continue; // retry immediately — no reason to wait for a dead holder
+        const holderPid = parseInt(holderContent, 10);
+        if (!Number.isInteger(holderPid)) {
+          // Unparseable content most likely means we read the lock file in
+          // the narrow window between another process's openSync (empty
+          // file) and its writeSync (PID written) — not a dead holder, just
+          // one still being created. Wait rather than steal.
+          await new Promise((resolve) => setTimeout(resolve, pollMs));
+          continue;
+        }
+        if (!isAlive(holderPid)) {
+          // Verify by INODE IDENTITY (not content) immediately before
+          // deleting: two code reviews caught real problems here in
+          // succession. First: an unconditional unlink could delete a
+          // DIFFERENT, freshly re-acquired lock a concurrent stealer
+          // already created. Second: re-verifying by CONTENT string (an
+          // earlier fix) is still wrong, because PIDs get reused by the OS
+          // — a coincidentally-identical PID string on a genuinely
+          // different (fresh, live) lock file would pass a content check
+          // and still get wrongly deleted. `holderStat` came from the
+          // still-open `holderFd` (not a fresh path stat), which is what
+          // makes this comparison deterministic — see the comment above
+          // `holderFd`'s declaration.
+          try {
+            const currentStat = fs.statSync(lockPath);
+            if (
+              currentStat.ino === holderStat.ino &&
+              currentStat.dev === holderStat.dev
+            ) {
+              fs.unlinkSync(lockPath);
+            }
+          } catch {
+            // Vanished or already replaced by someone else — fine either way.
+          }
+          continue; // retry immediately — no reason to wait for a dead holder
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+      } finally {
+        try {
+          fs.closeSync(holderFd);
+        } catch {
+          // Nothing else in this scope closes holderFd first, so reaching
+          // here would mean something genuinely unexpected — swallow
+          // rather than mask the real error this finally is cleaning up
+          // after.
+        }
       }
-      await new Promise((resolve) => setTimeout(resolve, pollMs));
-    } finally {
-      try {
-        fs.closeSync(holderFd);
-      } catch {
-        // Nothing else in this scope closes holderFd first, so reaching
-        // here would mean something genuinely unexpected — swallow rather
-        // than mask the real error this finally is cleaning up after.
-      }
+      continue;
     }
+
+    // Windows path: original bare-statSync identity check (no held-open
+    // fd — see the comment above for why not). Two prior code reviews'
+    // dev+ino-over-content rationale still applies here unchanged.
+    let holderStat, holderContent;
+    try {
+      holderStat = fs.statSync(lockPath);
+      holderContent = fs.readFileSync(lockPath, 'utf8').trim();
+    } catch {
+      continue; // vanished between our failed open and read — retry immediately
+    }
+    const holderPid = parseInt(holderContent, 10);
+    if (!Number.isInteger(holderPid)) {
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+      continue;
+    }
+    if (!isAlive(holderPid)) {
+      try {
+        const currentStat = fs.statSync(lockPath);
+        if (
+          currentStat.ino === holderStat.ino &&
+          currentStat.dev === holderStat.dev
+        ) {
+          fs.unlinkSync(lockPath);
+        }
+      } catch {
+        // Vanished or already replaced by someone else — fine either way.
+      }
+      continue; // retry immediately — no reason to wait for a dead holder
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
   return null; // timed out waiting for a live holder to finish
 }

--- a/deus-v2-cmd.mjs
+++ b/deus-v2-cmd.mjs
@@ -310,11 +310,33 @@ export function makeSignalGuard(
   // INVARIANT: cleanup (via setCleanup) must be fully synchronous — Node
   // fires same-signal listeners with no interleaving only as long as no
   // listener body yields; releaseLock() below already satisfies this.
+  //
+  // KNOWN, ACCEPTED LIMITATION (evaluated and reverted a "fix" for this —
+  // see runForwarding's comment): on POSIX, a non-detached child shares
+  // this launcher's own foreground process group, so a terminal-generated
+  // signal (e.g. Ctrl+C) reaches the child directly AND gets forwarded a
+  // second time here. A prior attempt to close this via spawning the child
+  // detached (its own process group) was reverted because Node's
+  // `detached: true` actually calls setsid() — a NEW SESSION, not just a
+  // new process group — which detaches the child from the controlling
+  // terminal entirely and can break real interactive use (job control,
+  // reading from the tty) for delegated commands that are genuinely
+  // interactive (deus-cmd.sh has real `read -r` prompts; `deus-v2 chat` is
+  // an interactive REPL). That regression is a near-certain break of this
+  // launcher's core use case; the double-signal risk it would have "fixed"
+  // is unconfirmed for the actual delegate (deus-cmd.sh/.ps1 have zero
+  // signal-trap logic today, verified via grep) and is a lower-probability,
+  // lower-severity tradeoff to accept instead.
   const handler = (sig) => {
     if (box.child) {
       // Windows: kill() is a hard-terminate with no SIGHUP delivery (Node/OS
       // limitation, not a regression — matches a raw Ctrl+C with no launcher
-      // in between). POSIX targets get real cooperative forwarding here.
+      // in between). POSIX targets get real cooperative forwarding here —
+      // possibly a second copy of a terminal-originated signal (see above),
+      // which the default (unhandled) OS disposition treats identically to
+      // one copy, and is also needed as the ONLY delivery mechanism for a
+      // programmatic `kill <this-pid>` that doesn't reach the child at all
+      // otherwise.
       box.child.kill(sig);
       return; // the child's 'exit' event drives runForwarding's normal resolution
     }
@@ -346,7 +368,10 @@ export function makeSignalGuard(
 // so args reach the child via execve unchanged, never through a shell string
 // (satisfies "no reparsing/shell interpolation" for both the clone step and
 // final delegation). Used identically by the one-time clone step and the
-// steady-state delegate step, via the shared `guard`.
+// steady-state delegate step, via the shared `guard`. Deliberately NOT
+// spawned detached — see makeSignalGuard's comment for why that would trade
+// a narrower double-signal risk for a more certain interactive-terminal
+// regression on the delegate commands this launcher exists to run.
 export async function runForwarding(command, args, { cwd }, guard) {
   const child = spawn(command, args, { cwd, stdio: 'inherit' });
   guard.setChild(child);

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -185,60 +185,6 @@ describe('validateCheckout', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('DIAGNOSTIC (temporary, remove before merge): logs real git/realpath values for Windows CI', () => {
-    // Not a real regression test — always passes. Exists only to capture
-    // ground truth from a real Windows CI runner for the still-unexplained
-    // invalid-nested-repo failures in this describe block: my realpathSync
-    // fix models a specific hypothesis (8.3 short-name mismatch) that a
-    // fully-mocked unit test confirms is internally consistent, but the
-    // REAL validateCheckout tests below still fail identically after that
-    // fix landed — meaning the real runner's actual values don't match
-    // what I assumed. Remove this test once the real values are captured
-    // and the actual fix is designed from them.
-    const target = path.join(tmpDir, 'diag-repo');
-    initRealRepo(target, {
-      origin: 'https://github.com/sliamh11/deus-v2.git',
-    });
-    fs.writeFileSync(
-      path.join(target, REAL_ENTRYPOINT_NAME),
-      '#!/bin/sh\necho hi\n',
-    );
-
-    const toplevel = spawnSync(
-      'git',
-      ['-C', target, 'rev-parse', '--show-toplevel'],
-      { encoding: 'utf8' },
-    );
-    const gitDir = spawnSync('git', ['-C', target, 'rev-parse', '--git-dir'], {
-      encoding: 'utf8',
-    });
-    const commonDir = spawnSync(
-      'git',
-      ['-C', target, 'rev-parse', '--git-common-dir'],
-      { encoding: 'utf8' },
-    );
-    const real = fs.realpathSync(target);
-    const result = validateCheckout(target, {
-      isWindows: isWindowsPlatform(),
-    });
-
-    console.error('DIAG target:', JSON.stringify(target));
-    console.error('DIAG isWindowsPlatform():', isWindowsPlatform());
-    console.error(
-      'DIAG git --show-toplevel stdout:',
-      JSON.stringify(toplevel.stdout),
-    );
-    console.error('DIAG git --git-dir stdout:', JSON.stringify(gitDir.stdout));
-    console.error(
-      'DIAG git --git-common-dir stdout:',
-      JSON.stringify(commonDir.stdout),
-    );
-    console.error('DIAG realpathSync(target):', JSON.stringify(real));
-    console.error('DIAG validateCheckout result:', JSON.stringify(result));
-
-    expect(true).toBe(true);
-  });
-
   it('reports missing for a nonexistent path', () => {
     const target = path.join(tmpDir, 'does-not-exist');
     expect(validateCheckout(target)).toEqual({
@@ -443,16 +389,19 @@ describe('validateCheckout', () => {
     // both sides" from "did it coincidentally return the same thing
     // either way." This test's mock instead maps each DISTINCT input to
     // its own distinct (but correctly related) canonical output, and
-    // throws on any unexpected argument — so it fails loudly if the fix
-    // ever regresses to comparing an un-realpath'd value against a
-    // realpath'd one, the exact shape of the original bug: os.tmpdir()
-    // (and so checkoutPath, in real usage) is commonly reported in the
-    // legacy 8.3 short-name form ("RUNNER~1") on GH Actions Windows
-    // runners; git's own --show-toplevel/--git-dir/--git-common-dir echo
-    // back whatever they were invoked with, so a naive comparison against
-    // only a realpath'd checkoutPath (this function's pre-fix behavior)
-    // compares a short-form value against a long-form one and spuriously
-    // fails with invalid-nested-repo / invalid-linked-worktree.
+    // throws on any unexpected argument.
+    //
+    // Fixture shape confirmed via a real Windows CI diagnostic run, not
+    // assumed: os.tmpdir() (and so checkoutPath, in real usage) is
+    // commonly reported in the legacy 8.3 short-name form ("RUNNER~1") on
+    // GH Actions Windows runners. git's --show-toplevel independently
+    // reports the LONG canonical form directly (git resolves it
+    // internally) -- already realpath-idempotent, no mismatch on that
+    // side by itself. git's --git-dir/--git-common-dir, for an ordinary
+    // (non-worktree) repo, report a bare RELATIVE ".git" instead, which
+    // resolveGitPath then resolves against checkoutPath's OWN (short)
+    // form -- this is where the actual mismatch against a realpath'd
+    // checkoutPath (long) comes from.
     const shortForm = 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\deus-v2';
     const longForm = 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\deus-v2';
     const runGit = vi.fn((args: string[]) => {
@@ -460,10 +409,10 @@ describe('validateCheckout', () => {
         return { status: 0, stdout: 'true\n' };
       }
       if (args.includes('--show-toplevel')) {
-        return { status: 0, stdout: `${shortForm}\n` };
+        return { status: 0, stdout: `${longForm}\n` };
       }
       if (args.includes('--git-dir') || args.includes('--git-common-dir')) {
-        return { status: 0, stdout: `${shortForm}\\.git\n` };
+        return { status: 0, stdout: '.git\n' };
       }
       if (args[0] === 'remote') {
         return {
@@ -475,6 +424,7 @@ describe('validateCheckout', () => {
     });
     const realpathSync = vi.fn((p: string) => {
       if (p === shortForm) return longForm;
+      if (p === longForm) return longForm; // already canonical, idempotent
       if (p === `${shortForm}\\.git`) return `${longForm}\\.git`;
       throw new Error(`unexpected realpathSync arg: ${p}`);
     });
@@ -490,7 +440,31 @@ describe('validateCheckout', () => {
 
     expect(result).toEqual({ valid: true });
     expect(realpathSync).toHaveBeenCalledWith(shortForm);
+    expect(realpathSync).toHaveBeenCalledWith(longForm);
     expect(realpathSync).toHaveBeenCalledWith(`${shortForm}\\.git`);
+  });
+
+  it('defaults to fs.realpathSync.native (not plain fs.realpathSync) when no override is given', () => {
+    // fs.realpathSync.native is the load-bearing choice (see the comment
+    // in validateCheckout) -- this pins that the actual default wiring
+    // uses it, since every other test in this describe block injects its
+    // own realpathSync and so never exercises the real default at all.
+    const target = path.join(tmpDir, 'repo');
+    initRealRepo(target, { origin: 'https://github.com/sliamh11/deus-v2.git' });
+    fs.writeFileSync(
+      path.join(target, REAL_ENTRYPOINT_NAME),
+      '#!/bin/sh\necho hi\n',
+    );
+    const nativeSpy = vi.spyOn(fs.realpathSync, 'native');
+
+    const result = validateCheckout(target, {
+      isWindows: isWindowsPlatform(),
+    });
+
+    expect(result).toEqual({ valid: true });
+    expect(nativeSpy).toHaveBeenCalled();
+
+    nativeSpy.mockRestore();
   });
 });
 

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -514,14 +514,14 @@ describe('runForwarding / makeSignalGuard', () => {
     const script = path.join(tmpDir, 'echo-argv.mjs');
     fs.writeFileSync(
       script,
-      `
-      import fs from 'node:fs';
-      fs.writeFileSync(process.argv[3], JSON.stringify({
-        args: process.argv.slice(2),
-        cwd: process.cwd(),
-      }));
-      process.exit(7);
-      `,
+      [
+        "import fs from 'node:fs';",
+        'fs.writeFileSync(process.argv[3], JSON.stringify({',
+        '  args: process.argv.slice(2),',
+        '  cwd: process.cwd(),',
+        '}));',
+        'process.exit(7);',
+      ].join('\n'),
     );
     const cwd = tmpDir;
     const trickyArg = 'has spaces and "quotes" and $vars';
@@ -555,14 +555,14 @@ describe('runForwarding / makeSignalGuard', () => {
       const outFile = path.join(tmpDir, 'trapped.txt');
       fs.writeFileSync(
         script,
-        `
-        import fs from 'node:fs';
-        process.on('SIGTERM', () => {
-          fs.writeFileSync(process.argv[2], 'trapped');
-          process.exit(0);
-        });
-        setTimeout(() => {}, 5000);
-        `,
+        [
+          "import fs from 'node:fs';",
+          "process.on('SIGTERM', () => {",
+          "  fs.writeFileSync(process.argv[2], 'trapped');",
+          '  process.exit(0);',
+          '});',
+          'setTimeout(() => {}, 5000);',
+        ].join('\n'),
       );
       const guard = makeSignalGuard();
       try {

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -185,6 +185,60 @@ describe('validateCheckout', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('DIAGNOSTIC (temporary, remove before merge): logs real git/realpath values for Windows CI', () => {
+    // Not a real regression test — always passes. Exists only to capture
+    // ground truth from a real Windows CI runner for the still-unexplained
+    // invalid-nested-repo failures in this describe block: my realpathSync
+    // fix models a specific hypothesis (8.3 short-name mismatch) that a
+    // fully-mocked unit test confirms is internally consistent, but the
+    // REAL validateCheckout tests below still fail identically after that
+    // fix landed — meaning the real runner's actual values don't match
+    // what I assumed. Remove this test once the real values are captured
+    // and the actual fix is designed from them.
+    const target = path.join(tmpDir, 'diag-repo');
+    initRealRepo(target, {
+      origin: 'https://github.com/sliamh11/deus-v2.git',
+    });
+    fs.writeFileSync(
+      path.join(target, REAL_ENTRYPOINT_NAME),
+      '#!/bin/sh\necho hi\n',
+    );
+
+    const toplevel = spawnSync(
+      'git',
+      ['-C', target, 'rev-parse', '--show-toplevel'],
+      { encoding: 'utf8' },
+    );
+    const gitDir = spawnSync('git', ['-C', target, 'rev-parse', '--git-dir'], {
+      encoding: 'utf8',
+    });
+    const commonDir = spawnSync(
+      'git',
+      ['-C', target, 'rev-parse', '--git-common-dir'],
+      { encoding: 'utf8' },
+    );
+    const real = fs.realpathSync(target);
+    const result = validateCheckout(target, {
+      isWindows: isWindowsPlatform(),
+    });
+
+    console.error('DIAG target:', JSON.stringify(target));
+    console.error('DIAG isWindowsPlatform():', isWindowsPlatform());
+    console.error(
+      'DIAG git --show-toplevel stdout:',
+      JSON.stringify(toplevel.stdout),
+    );
+    console.error('DIAG git --git-dir stdout:', JSON.stringify(gitDir.stdout));
+    console.error(
+      'DIAG git --git-common-dir stdout:',
+      JSON.stringify(commonDir.stdout),
+    );
+    console.error('DIAG realpathSync(target):', JSON.stringify(real));
+    console.error('DIAG validateCheckout result:', JSON.stringify(result));
+
+    expect(true).toBe(true);
+  });
+
   it('reports missing for a nonexistent path', () => {
     const target = path.join(tmpDir, 'does-not-exist');
     expect(validateCheckout(target)).toEqual({

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -22,6 +22,16 @@ const LAUNCHER_PATH = fileURLToPath(
   new URL('./deus-v2-cmd.mjs', import.meta.url),
 );
 
+// These validateCheckout/ensureCheckout tests exercise REAL, unmocked git/fs
+// against real host-native paths — so `isWindows` must reflect the ACTUAL
+// host, not a hardcoded value, or the path-comparison logic gets fed data in
+// one convention (e.g. real Windows backslashes/drive letters) while being
+// told to compare it in the other (POSIX). The entrypoint filename these
+// fixtures create/expect must match for the same reason.
+const REAL_ENTRYPOINT_NAME = isWindowsPlatform()
+  ? 'deus-cmd.ps1'
+  : 'deus-cmd.sh';
+
 function git(cwd: string, args: string[]) {
   const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
   if (result.status !== 0) {
@@ -198,8 +208,13 @@ describe('validateCheckout', () => {
   it('reports valid for a real standalone clone with correct origin and entrypoint', () => {
     const target = path.join(tmpDir, 'repo');
     initRealRepo(target, { origin: 'https://github.com/sliamh11/deus-v2.git' });
-    fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
-    expect(validateCheckout(target, { isWindows: false })).toEqual({
+    fs.writeFileSync(
+      path.join(target, REAL_ENTRYPOINT_NAME),
+      '#!/bin/sh\necho hi\n',
+    );
+    expect(
+      validateCheckout(target, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: true,
     });
   });
@@ -207,8 +222,13 @@ describe('validateCheckout', () => {
   it('accepts an SSH-form origin remote', () => {
     const target = path.join(tmpDir, 'repo-ssh');
     initRealRepo(target, { origin: 'git@github.com:sliamh11/deus-v2.git' });
-    fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
-    expect(validateCheckout(target, { isWindows: false })).toEqual({
+    fs.writeFileSync(
+      path.join(target, REAL_ENTRYPOINT_NAME),
+      '#!/bin/sh\necho hi\n',
+    );
+    expect(
+      validateCheckout(target, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: true,
     });
   });
@@ -219,7 +239,9 @@ describe('validateCheckout', () => {
       origin: 'https://github.com/someone-else/other-repo.git',
     });
     fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
-    expect(validateCheckout(target, { isWindows: false })).toEqual({
+    expect(
+      validateCheckout(target, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: false,
       reason: 'invalid-wrong-origin',
     });
@@ -236,7 +258,9 @@ describe('validateCheckout', () => {
       origin: 'https://attacker.example/github.com/sliamh11/deus-v2.git',
     });
     fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
-    expect(validateCheckout(target, { isWindows: false })).toEqual({
+    expect(
+      validateCheckout(target, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: false,
       reason: 'invalid-wrong-origin',
     });
@@ -245,9 +269,11 @@ describe('validateCheckout', () => {
   it('reports invalid-missing-entrypoint when deus-cmd.sh is absent', () => {
     const target = path.join(tmpDir, 'no-entrypoint');
     initRealRepo(target, { origin: 'https://github.com/sliamh11/deus-v2.git' });
-    expect(validateCheckout(target, { isWindows: false })).toEqual({
+    expect(
+      validateCheckout(target, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: false,
-      reason: 'invalid-missing-entrypoint:deus-cmd.sh',
+      reason: `invalid-missing-entrypoint:${REAL_ENTRYPOINT_NAME}`,
     });
   });
 
@@ -255,7 +281,9 @@ describe('validateCheckout', () => {
     const target = path.join(tmpDir, 'not-git');
     fs.mkdirSync(target);
     fs.writeFileSync(path.join(target, 'marker.txt'), 'hello');
-    expect(validateCheckout(target, { isWindows: false })).toEqual({
+    expect(
+      validateCheckout(target, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: false,
       reason: 'invalid-not-a-git-repo',
     });
@@ -266,7 +294,9 @@ describe('validateCheckout', () => {
     initRealRepo(mainRepo);
     const linked = path.join(tmpDir, 'linked-worktree');
     git(mainRepo, ['worktree', 'add', '-b', 'side-branch', linked]);
-    expect(validateCheckout(linked, { isWindows: false })).toEqual({
+    expect(
+      validateCheckout(linked, { isWindows: isWindowsPlatform() }),
+    ).toEqual({
       valid: false,
       reason: 'invalid-linked-worktree',
     });
@@ -286,7 +316,7 @@ describe('validateCheckout', () => {
     const rmdirSyncSpy = vi.spyOn(fs, 'rmdirSync');
     const unlinkSyncSpy = vi.spyOn(fs, 'unlinkSync');
 
-    const result = validateCheckout(target, { isWindows: false });
+    const result = validateCheckout(target, { isWindows: isWindowsPlatform() });
 
     expect(result.valid).toBe(false);
     expect(result.reason).not.toBe('missing');
@@ -730,7 +760,7 @@ describe('ensureCheckout', () => {
         origin: 'https://github.com/sliamh11/deus-v2.git',
       });
       fs.writeFileSync(
-        path.join(targetPath, 'deus-cmd.sh'),
+        path.join(targetPath, REAL_ENTRYPOINT_NAME),
         '#!/bin/sh\necho hi\n',
       );
       return { code: 0, signal: null };
@@ -740,12 +770,14 @@ describe('ensureCheckout', () => {
       ensureCheckout(checkoutPath, {
         lockPath,
         spawnClone,
-        validateOpts: { isWindows: false },
+        validateOpts: { isWindows: isWindowsPlatform() },
         lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
       }),
     ).resolves.toBeUndefined();
 
-    expect(fs.existsSync(path.join(checkoutPath, 'deus-cmd.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(checkoutPath, REAL_ENTRYPOINT_NAME))).toBe(
+      true,
+    );
     expect(fs.existsSync(lockPath)).toBe(false);
     // No stray staging directories left behind next to the real checkout.
     const siblings = fs.readdirSync(tmpDir);
@@ -770,7 +802,7 @@ describe('ensureCheckout', () => {
         origin: 'https://github.com/sliamh11/deus-v2.git',
       });
       fs.writeFileSync(
-        path.join(targetPath, 'deus-cmd.sh'),
+        path.join(targetPath, REAL_ENTRYPOINT_NAME),
         '#!/bin/sh\necho hi\n',
       );
       return { code: 0, signal: null };
@@ -780,12 +812,14 @@ describe('ensureCheckout', () => {
       ensureCheckout(checkoutPath, {
         lockPath,
         spawnClone,
-        validateOpts: { isWindows: false },
+        validateOpts: { isWindows: isWindowsPlatform() },
         lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
       }),
     ).resolves.toBeUndefined();
 
-    expect(fs.existsSync(path.join(checkoutPath, 'deus-cmd.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(checkoutPath, REAL_ENTRYPOINT_NAME))).toBe(
+      true,
+    );
     expect(fs.existsSync(lockPath)).toBe(false);
   });
 
@@ -814,7 +848,7 @@ describe('ensureCheckout', () => {
       origin: 'https://github.com/sliamh11/deus-v2.git',
     });
     fs.writeFileSync(
-      path.join(checkoutPath, 'deus-cmd.sh'),
+      path.join(checkoutPath, REAL_ENTRYPOINT_NAME),
       '#!/bin/sh\necho hi\n',
     );
 
@@ -823,7 +857,7 @@ describe('ensureCheckout', () => {
       ensureCheckout(checkoutPath, {
         lockPath,
         spawnClone,
-        validateOpts: { isWindows: false },
+        validateOpts: { isWindows: isWindowsPlatform() },
       }),
     ).resolves.toBeUndefined();
 

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -576,7 +576,7 @@ describe('runForwarding / makeSignalGuard', () => {
         // deliver SIGTERM to our own process — the guard should forward it
         // to the child rather than let Node's default disposition kill us.
         await new Promise((resolve) => setTimeout(resolve, 300));
-        process.emit('SIGTERM' as NodeJS.Signals);
+        process.emit('SIGTERM' as NodeJS.Signals, 'SIGTERM' as NodeJS.Signals);
         const result = await resultPromise;
         expect(result.code).toBe(0);
       } finally {
@@ -593,6 +593,62 @@ describe('runForwarding / makeSignalGuard', () => {
     guard.dispose();
     expect(process.listenerCount('SIGTERM')).toBe(before);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    "real end-to-end: a delegated child spawned WITHOUT detached shares this process's process group (accepted-tradeoff regression guard)",
+    async () => {
+      // A prior round of code review flagged the plain (non-detached)
+      // forwarding above as risking a double-delivered signal when a
+      // terminal sends one to the whole foreground process group. A fix
+      // spawning the child detached (its own process group) was
+      // implemented, then REVERTED after discovering Node's
+      // `detached: true` on POSIX actually calls setsid() — a new SESSION,
+      // not just a new process group — which would have broken real
+      // interactive delegate commands (deus-cmd.sh has genuine `read -r`
+      // prompts; `deus-v2 chat` is an interactive REPL) by detaching them
+      // from the controlling terminal. This test pins the REVERTED
+      // (current, intentional) behavior — the child shares this process's
+      // process group (verified via `ps -o pgid=`, the same technique used
+      // to derive the fix-then-revert empirically) — as a regression guard
+      // against re-introducing `detached: true` by mistake.
+      const ownPgid = spawnSync(
+        'ps',
+        ['-o', 'pgid=', '-p', String(process.pid)],
+        { encoding: 'utf8' },
+      ).stdout.trim();
+
+      let capturedChildPid = -1;
+      const guard = makeSignalGuard();
+      const realSetChild = guard.setChild;
+      guard.setChild = ((child: { pid: number }) => {
+        capturedChildPid = child.pid;
+        return realSetChild(child);
+      }) as typeof guard.setChild;
+
+      const resultPromise = runForwarding(
+        'sleep',
+        ['5'],
+        { cwd: os.tmpdir() },
+        guard,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(capturedChildPid).toBeGreaterThan(0);
+
+      const childPgid = spawnSync(
+        'ps',
+        ['-o', 'pgid=', '-p', String(capturedChildPid)],
+        { encoding: 'utf8' },
+      ).stdout.trim();
+      expect(childPgid).toBe(ownPgid); // same group — NOT detached into its own
+
+      process.emit('SIGTERM' as NodeJS.Signals, 'SIGTERM' as NodeJS.Signals);
+      const result = await resultPromise;
+      guard.dispose();
+
+      expect(result.signal).toBe('SIGTERM');
+    },
+  );
 });
 
 describe('ensureCheckout', () => {
@@ -818,7 +874,7 @@ describe('ensureCheckout', () => {
       await new Promise((resolve) => setTimeout(resolve, 300));
       expect(fs.existsSync(lockPath)).toBe(true); // lock held mid-clone
 
-      process.emit('SIGTERM' as NodeJS.Signals);
+      process.emit('SIGTERM' as NodeJS.Signals, 'SIGTERM' as NodeJS.Signals);
 
       await expect(resultPromise).rejects.toThrow();
 

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
   getCheckoutPath,
@@ -79,17 +79,23 @@ describe('isMainModule (symlink-invocation regression, code-review-caught bug)',
   // + script) before writing the fix; these tests pin the fixed behavior.
 
   it('returns true when argv1 resolves (through a symlink) to the module URL', () => {
+    // fileURLToPath is not injectable, so moduleUrl must be a URL the real
+    // fileURLToPath can actually parse on the CURRENT host: a bare
+    // "file:///real/module/path.mjs" (no drive letter) is a valid POSIX
+    // file URL but not a valid Windows one, so it must be built via
+    // pathToFileURL (the inverse operation) from a platform-appropriate
+    // absolute path, not hardcoded as a POSIX-style string.
+    const realModulePath = isWindowsPlatform()
+      ? 'C:\\real\\module\\path.mjs'
+      : '/real/module/path.mjs';
+    const moduleUrl = pathToFileURL(realModulePath).href;
     const realpathSync = (p: string) => {
       expect(p).toBe('/some/symlink/path');
-      return '/real/module/path.mjs';
+      return realModulePath;
     };
-    expect(
-      isMainModule(
-        '/some/symlink/path',
-        'file:///real/module/path.mjs',
-        realpathSync,
-      ),
-    ).toBe(true);
+    expect(isMainModule('/some/symlink/path', moduleUrl, realpathSync)).toBe(
+      true,
+    );
   });
 
   it('returns false when argv1 resolves to a different file', () => {

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -1,0 +1,829 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getCheckoutPath,
+  getLockPath,
+  isWindowsPlatform,
+  validateCheckout,
+  acquireCloneLock,
+  releaseLock,
+  makeSignalGuard,
+  runForwarding,
+  ensureCheckout,
+  isMainModule,
+} from './deus-v2-cmd.mjs';
+
+const LAUNCHER_PATH = fileURLToPath(
+  new URL('./deus-v2-cmd.mjs', import.meta.url),
+);
+
+function git(cwd: string, args: string[]) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+  }
+  return result;
+}
+
+function initRealRepo(dir: string, { origin }: { origin?: string } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test']);
+  if (origin) git(dir, ['remote', 'add', 'origin', origin]);
+  fs.writeFileSync(path.join(dir, 'README.md'), 'x');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '-q', '-m', 'init']);
+}
+
+describe('deus-v2-cmd basics', () => {
+  it('getCheckoutPath resolves under the home directory', () => {
+    expect(getCheckoutPath()).toBe(path.join(os.homedir(), 'deus-v2'));
+  });
+
+  it('getLockPath resolves under ~/.deus', () => {
+    expect(getLockPath()).toBe(
+      path.join(os.homedir(), '.deus', 'deus-v2-clone.lock'),
+    );
+  });
+
+  it('isWindowsPlatform matches os.platform()', () => {
+    expect(isWindowsPlatform()).toBe(os.platform() === 'win32');
+  });
+});
+
+describe('isMainModule (symlink-invocation regression, code-review-caught bug)', () => {
+  // A code review caught a real, function-breaking bug: the original guard
+  // (`fileURLToPath(import.meta.url) === path.resolve(argv1)`, copied from
+  // scripts/migrate.mjs, which is only ever invoked directly) compares
+  // import.meta.url (which Node resolves THROUGH a symlink to the real
+  // file) against the raw, unresolved argv[1] — these never match when
+  // deus-v2-cmd.mjs is invoked via its installed ~/.local/bin/deus-v2
+  // symlink (setup/cli.ts's whole point), so main() would silently never
+  // run. Verified empirically in a real Node process (a throwaway symlink
+  // + script) before writing the fix; these tests pin the fixed behavior.
+
+  it('returns true when argv1 resolves (through a symlink) to the module URL', () => {
+    const realpathSync = (p: string) => {
+      expect(p).toBe('/some/symlink/path');
+      return '/real/module/path.mjs';
+    };
+    expect(
+      isMainModule(
+        '/some/symlink/path',
+        'file:///real/module/path.mjs',
+        realpathSync,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when argv1 resolves to a different file', () => {
+    const realpathSync = () => '/real/other-script.mjs';
+    expect(
+      isMainModule('/some/path', 'file:///real/module/path.mjs', realpathSync),
+    ).toBe(false);
+  });
+
+  it('returns false when argv1 is empty (module imported, not run as CLI)', () => {
+    expect(isMainModule('', 'file:///real/module/path.mjs')).toBe(false);
+  });
+
+  it('returns false (not throws) when argv1 does not exist on disk', () => {
+    const realpathSync = () => {
+      throw new Error('ENOENT');
+    };
+    expect(
+      isMainModule(
+        '/nonexistent',
+        'file:///real/module/path.mjs',
+        realpathSync,
+      ),
+    ).toBe(false);
+  });
+
+  it(
+    'real end-to-end: invoking the actual launcher through a real symlink ' +
+      'runs main() (not the plain module-path comparison this replaced)',
+    () => {
+      // Primary evidence, not just the unit-level check above: a real
+      // symlink to the real deus-v2-cmd.mjs file, invoked via `node
+      // <symlink>` exactly as setup/cli.ts's installed ~/.local/bin/deus-v2
+      // would be. HOME is redirected to an empty temp dir so getCheckoutPath()
+      // resolves somewhere controlled with no real checkout — ensureCheckout
+      // takes the "missing -> about to clone" path and logs its first-run
+      // message BEFORE ever touching the network, which is what proves
+      // main() actually executed (the old, broken guard would produce zero
+      // output and exit immediately).
+      const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-v2-home-'));
+      const symlinkDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'deus-v2-symlink-'),
+      );
+      const symlinkPath = path.join(symlinkDir, 'deus-v2');
+      fs.symlinkSync(LAUNCHER_PATH, symlinkPath);
+
+      const child = spawn(process.execPath, [symlinkPath], {
+        env: { ...process.env, HOME: tmpHome },
+      });
+
+      let sawCloneStart = false;
+      const timedOut = new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(true), 5000);
+        child.stdout.on('data', (chunk: Buffer) => {
+          if (chunk.toString().includes('First run: cloning')) {
+            sawCloneStart = true;
+            clearTimeout(timer);
+            child.kill('SIGTERM'); // don't let a real git clone actually run
+            resolve(false);
+          }
+        });
+        child.on('exit', () => {
+          clearTimeout(timer);
+          resolve(false);
+        });
+      });
+
+      return timedOut.then((didTimeOut) => {
+        expect(didTimeOut).toBe(false);
+        expect(sawCloneStart).toBe(true);
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+        fs.rmSync(symlinkDir, { recursive: true, force: true });
+      });
+    },
+    10000,
+  );
+});
+
+describe('validateCheckout', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-v2-validate-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports missing for a nonexistent path', () => {
+    const target = path.join(tmpDir, 'does-not-exist');
+    expect(validateCheckout(target)).toEqual({
+      valid: false,
+      reason: 'missing',
+    });
+  });
+
+  it('reports missing for an existing empty directory', () => {
+    const target = path.join(tmpDir, 'empty');
+    fs.mkdirSync(target);
+    expect(validateCheckout(target)).toEqual({
+      valid: false,
+      reason: 'missing',
+    });
+  });
+
+  it('reports invalid-not-a-directory for a plain file', () => {
+    const target = path.join(tmpDir, 'a-file');
+    fs.writeFileSync(target, 'not a dir');
+    expect(validateCheckout(target)).toEqual({
+      valid: false,
+      reason: 'invalid-not-a-directory',
+    });
+  });
+
+  it('reports valid for a real standalone clone with correct origin and entrypoint', () => {
+    const target = path.join(tmpDir, 'repo');
+    initRealRepo(target, { origin: 'https://github.com/sliamh11/deus-v2.git' });
+    fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
+    expect(validateCheckout(target, { isWindows: false })).toEqual({
+      valid: true,
+    });
+  });
+
+  it('accepts an SSH-form origin remote', () => {
+    const target = path.join(tmpDir, 'repo-ssh');
+    initRealRepo(target, { origin: 'git@github.com:sliamh11/deus-v2.git' });
+    fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
+    expect(validateCheckout(target, { isWindows: false })).toEqual({
+      valid: true,
+    });
+  });
+
+  it('reports invalid-wrong-origin for a repo pointed at a different remote', () => {
+    const target = path.join(tmpDir, 'wrong-origin');
+    initRealRepo(target, {
+      origin: 'https://github.com/someone-else/other-repo.git',
+    });
+    fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
+    expect(validateCheckout(target, { isWindows: false })).toEqual({
+      valid: false,
+      reason: 'invalid-wrong-origin',
+    });
+  });
+
+  it('rejects a host-prefix bypass attempt on the origin (code-review-caught security bug)', () => {
+    // Regression test for a real bug a GPT-backend code review caught: an
+    // earlier, unanchored REPO_SLUG_RE matched "github.com/sliamh11/deus-v2"
+    // as a SUBSTRING anywhere in the origin URL, so an attacker-controlled
+    // host with the real slug appended as a path segment would have passed
+    // validation and had its checkout entrypoint executed.
+    const target = path.join(tmpDir, 'origin-bypass-attempt');
+    initRealRepo(target, {
+      origin: 'https://attacker.example/github.com/sliamh11/deus-v2.git',
+    });
+    fs.writeFileSync(path.join(target, 'deus-cmd.sh'), '#!/bin/sh\necho hi\n');
+    expect(validateCheckout(target, { isWindows: false })).toEqual({
+      valid: false,
+      reason: 'invalid-wrong-origin',
+    });
+  });
+
+  it('reports invalid-missing-entrypoint when deus-cmd.sh is absent', () => {
+    const target = path.join(tmpDir, 'no-entrypoint');
+    initRealRepo(target, { origin: 'https://github.com/sliamh11/deus-v2.git' });
+    expect(validateCheckout(target, { isWindows: false })).toEqual({
+      valid: false,
+      reason: 'invalid-missing-entrypoint:deus-cmd.sh',
+    });
+  });
+
+  it('reports invalid-not-a-git-repo for a populated non-git directory', () => {
+    const target = path.join(tmpDir, 'not-git');
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'marker.txt'), 'hello');
+    expect(validateCheckout(target, { isWindows: false })).toEqual({
+      valid: false,
+      reason: 'invalid-not-a-git-repo',
+    });
+  });
+
+  it('reports invalid-linked-worktree for a REAL git worktree add (not a fake)', () => {
+    const mainRepo = path.join(tmpDir, 'main-repo');
+    initRealRepo(mainRepo);
+    const linked = path.join(tmpDir, 'linked-worktree');
+    git(mainRepo, ['worktree', 'add', '-b', 'side-branch', linked]);
+    expect(validateCheckout(linked, { isWindows: false })).toEqual({
+      valid: false,
+      reason: 'invalid-linked-worktree',
+    });
+  });
+
+  it('never mutates a partial/broken checkout it refuses to touch', () => {
+    const target = path.join(tmpDir, 'partial');
+    // Simulates an interrupted/partial clone: a real .git dir plus one
+    // arbitrary marker file, but no origin remote and no entrypoint —
+    // genuinely broken, not a valid checkout.
+    initRealRepo(target);
+    fs.writeFileSync(path.join(target, 'MARKER'), 'partial-clone-marker');
+
+    const before = fs.readdirSync(target, { recursive: true }).sort();
+
+    const rmSyncSpy = vi.spyOn(fs, 'rmSync');
+    const rmdirSyncSpy = vi.spyOn(fs, 'rmdirSync');
+    const unlinkSyncSpy = vi.spyOn(fs, 'unlinkSync');
+
+    const result = validateCheckout(target, { isWindows: false });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).not.toBe('missing');
+
+    const after = fs.readdirSync(target, { recursive: true }).sort();
+    expect(after).toEqual(before);
+    expect(rmSyncSpy).not.toHaveBeenCalled();
+    expect(rmdirSyncSpy).not.toHaveBeenCalled();
+    expect(unlinkSyncSpy).not.toHaveBeenCalled();
+
+    rmSyncSpy.mockRestore();
+    rmdirSyncSpy.mockRestore();
+    unlinkSyncSpy.mockRestore();
+  });
+
+  it('Windows-mode regression test: lowercase-drive-letter git output vs uppercase realpathSync must still compare equal', () => {
+    // This is the exact bug this design fixes: Git for Windows (MSYS2) often
+    // reports a lowercase drive letter ("c:/Users/fake/deus-v2") while
+    // fs.realpathSync returns the OS-canonical uppercase form
+    // ("C:\Users\fake\deus-v2"). A naive case-fold-only comparison (without
+    // separator normalization via path.win32) fails this; so does a
+    // separator-only fix without case-folding. Only the combination
+    // (resolveGitPath via path.win32 + pathsEqual's normalize+lowercase)
+    // passes.
+    const checkoutPath = 'C:\\Users\\fake\\deus-v2';
+    const runGit = vi.fn((args: string[]) => {
+      if (args.includes('--is-inside-work-tree')) {
+        return { status: 0, stdout: 'true\n' };
+      }
+      if (args.includes('--show-toplevel')) {
+        return { status: 0, stdout: 'c:/Users/fake/deus-v2\n' };
+      }
+      if (args.includes('--git-dir')) {
+        return { status: 0, stdout: 'c:/Users/fake/deus-v2/.git\n' };
+      }
+      if (args.includes('--git-common-dir')) {
+        return { status: 0, stdout: 'c:/Users/fake/deus-v2/.git\n' };
+      }
+      if (args[0] === 'remote') {
+        return {
+          status: 0,
+          stdout: 'https://github.com/sliamh11/deus-v2.git\n',
+        };
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`);
+    });
+
+    const result = validateCheckout(checkoutPath, {
+      isWindows: true,
+      existsSync: () => true,
+      readdirSync: () => ['deus-cmd.ps1'],
+      statSync: () => ({ isDirectory: () => true }) as fs.Stats,
+      realpathSync: () => 'C:\\Users\\fake\\deus-v2',
+      runGit,
+    });
+
+    expect(result).toEqual({ valid: true });
+  });
+});
+
+describe('acquireCloneLock / releaseLock', () => {
+  let tmpDir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-v2-lock-'));
+    lockPath = path.join(tmpDir, 'nested', 'deus-v2-clone.lock');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('acquires a free lock', async () => {
+    const lock = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 500,
+      pollMs: 20,
+    });
+    expect(lock).not.toBeNull();
+    expect(fs.existsSync(lockPath)).toBe(true);
+    releaseLock(lock!);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('times out and returns null when the lock is held by a live process', async () => {
+    // PID-liveness design (post GPT plan-review fix): a lock held by a live
+    // process — however long — must NEVER be stolen. Simulate "live" via an
+    // injected isAlive that always returns true, so this test doesn't depend
+    // on real elapsed time or a real long-running holder process.
+    const holder = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 500,
+      pollMs: 20,
+    });
+    expect(holder).not.toBeNull();
+
+    const second = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 150,
+      pollMs: 20,
+      isAlive: () => true,
+    });
+    expect(second).toBeNull();
+    // The holder's lock must be untouched — proves no steal happened.
+    expect(fs.existsSync(lockPath)).toBe(true);
+
+    releaseLock(holder!);
+  });
+
+  it('steals immediately from a provably dead PID, regardless of lock age', async () => {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, '999999'); // a PID essentially guaranteed not to exist
+    // Freshly created (not aged) — proves the steal is PID-liveness-driven,
+    // not time-driven: the old staleMs design would have refused to steal
+    // a lock this fresh.
+    const lock = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 500,
+      pollMs: 20,
+      isAlive: (pid: number) => pid !== 999999,
+    });
+    expect(lock).not.toBeNull();
+    releaseLock(lock!);
+  });
+
+  it('never steals from a live PID even when the lock is old', async () => {
+    // Direct regression test for the GPT-backend plan-review finding: age
+    // alone must never trigger a steal. A lock "aged" via utimes but backed
+    // by an isAlive that reports true must still block, not be stolen.
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, String(process.pid));
+    const oldTime = new Date(Date.now() - 60 * 60 * 1000); // 1 hour old
+    fs.utimesSync(lockPath, oldTime, oldTime);
+
+    const result = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 150,
+      pollMs: 20,
+      isAlive: () => true,
+    });
+    expect(result).toBeNull();
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it('does not delete a lock replaced by a new inode between the dead-check and the steal (code-review-caught race)', async () => {
+    // Regression test for a real TOCTOU race two rounds of GPT-backend code
+    // review caught in succession. Round 1: process A determines a lock is
+    // dead, then before A's unlink runs, a different process B has already
+    // stolen and replaced it with a fresh, live lock — A's unconditional
+    // unlink would delete B's valid lock. Round 2: re-verifying by CONTENT
+    // STRING (the first fix) is still wrong, because PIDs get reused by the
+    // OS — a coincidentally-identical PID string on a genuinely different,
+    // live lock file would pass a content check and still get wrongly
+    // deleted. The fix compares dev+ino (actual filesystem identity)
+    // immediately before deleting; this test simulates process B replacing
+    // the lock with a NEW INODE (unlink + recreate, not an in-place
+    // content overwrite) that happens to contain the exact same PID string
+    // as the dead holder — the scenario a content-only check would miss.
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, '999999'); // will be read as the "dead" holder
+
+    const unlinkSpy = vi.spyOn(fs, 'unlinkSync');
+    let mutated = false;
+    const isAlive = () => {
+      if (!mutated) {
+        mutated = true;
+        // Simulate a concurrent process B winning the steal race: it
+        // deletes the dead lock and writes a NEW file at the same path —
+        // a genuinely different inode — that happens to contain the exact
+        // same PID string ('999999', simulating OS PID reuse) as the one
+        // we just read. A content-only check would wrongly treat this as
+        // "unchanged" and delete B's live lock; an inode check must not.
+        fs.unlinkSync(lockPath);
+        fs.writeFileSync(lockPath, '999999');
+        return false; // still report the ORIGINAL pid as dead, triggering our steal attempt
+      }
+      return true; // the new (different-inode) lock is now treated as live — just wait
+    };
+
+    const result = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 200,
+      pollMs: 20,
+      isAlive,
+    });
+
+    expect(result).toBeNull(); // never acquired — the "concurrent" lock was respected
+    // Our own unlink attempt on the ORIGINAL inode must never have gone
+    // through as a successful deletion of process B's replacement — the
+    // file must still exist afterward.
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(fs.readFileSync(lockPath, 'utf8').trim()).toBe('999999'); // B's file, untouched by us
+
+    unlinkSpy.mockRestore();
+  });
+
+  it('does not steal a lock with unparseable content (freshly created, not yet PID-written)', async () => {
+    // A lock file mid-creation by another process (openSync succeeded,
+    // writeSync of the PID hasn't landed yet) reads as empty/unparseable —
+    // must be treated as "wait and retry", not "dead, steal it".
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, '');
+    const isAlive = vi.fn(() => false);
+
+    const result = await acquireCloneLock(lockPath, {
+      waitTimeoutMs: 100,
+      pollMs: 20,
+      isAlive,
+    });
+
+    expect(result).toBeNull();
+    expect(isAlive).not.toHaveBeenCalled(); // never asked — no parseable PID to check
+    expect(fs.existsSync(lockPath)).toBe(true); // untouched
+  });
+});
+
+describe('runForwarding / makeSignalGuard', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-v2-forward-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('passes argv and cwd through unchanged and reports the real exit code', async () => {
+    const outFile = path.join(tmpDir, 'out.json');
+    const script = path.join(tmpDir, 'echo-argv.mjs');
+    fs.writeFileSync(
+      script,
+      `
+      import fs from 'node:fs';
+      fs.writeFileSync(process.argv[3], JSON.stringify({
+        args: process.argv.slice(2),
+        cwd: process.cwd(),
+      }));
+      process.exit(7);
+      `,
+    );
+    const cwd = tmpDir;
+    const trickyArg = 'has spaces and "quotes" and $vars';
+    const guard = makeSignalGuard();
+    try {
+      const result = await runForwarding(
+        process.execPath,
+        [script, trickyArg, outFile],
+        { cwd },
+        guard,
+      );
+      expect(result.code).toBe(7);
+      expect(result.signal).toBeNull();
+    } finally {
+      guard.dispose();
+    }
+
+    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(written.args[0]).toBe(trickyArg);
+    // realpathSync, not path.resolve: macOS's os.tmpdir() lives under a
+    // symlink (/var -> /private/var), and the spawned child's process.cwd()
+    // resolves through it, so a plain string/path.resolve comparison of the
+    // two would spuriously fail.
+    expect(fs.realpathSync(written.cwd)).toBe(fs.realpathSync(cwd));
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'forwards SIGTERM to the child process',
+    async () => {
+      const script = path.join(tmpDir, 'trap-sigterm.mjs');
+      const outFile = path.join(tmpDir, 'trapped.txt');
+      fs.writeFileSync(
+        script,
+        `
+        import fs from 'node:fs';
+        process.on('SIGTERM', () => {
+          fs.writeFileSync(process.argv[2], 'trapped');
+          process.exit(0);
+        });
+        setTimeout(() => {}, 5000);
+        `,
+      );
+      const guard = makeSignalGuard();
+      try {
+        const resultPromise = runForwarding(
+          process.execPath,
+          [script, outFile],
+          { cwd: tmpDir },
+          guard,
+        );
+        // Give the child a moment to install its SIGTERM handler, then
+        // deliver SIGTERM to our own process — the guard should forward it
+        // to the child rather than let Node's default disposition kill us.
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        process.emit('SIGTERM' as NodeJS.Signals);
+        const result = await resultPromise;
+        expect(result.code).toBe(0);
+      } finally {
+        guard.dispose();
+      }
+      expect(fs.readFileSync(outFile, 'utf8')).toBe('trapped');
+    },
+  );
+
+  it('dispose() removes the guard listener so a later signal does not fire it', () => {
+    const before = process.listenerCount('SIGTERM');
+    const guard = makeSignalGuard();
+    expect(process.listenerCount('SIGTERM')).toBe(before + 1);
+    guard.dispose();
+    expect(process.listenerCount('SIGTERM')).toBe(before);
+  });
+});
+
+describe('ensureCheckout', () => {
+  let tmpDir: string;
+  let checkoutPath: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-v2-ensure-'));
+    checkoutPath = path.join(tmpDir, 'deus-v2');
+    lockPath = path.join(tmpDir, 'lock', 'deus-v2-clone.lock');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('releases the lock when the (injected) clone fails — regression test for the process.exit()-skips-finally bug', async () => {
+    // Earlier version of this file called process.exit(1) from fail(),
+    // which skips enclosing `finally` blocks (verified empirically — it
+    // does not unwind the JS stack). That orphaned the lock on ordinary
+    // clone failure (network error, bad git config), not just on a signal.
+    // fail() now throws instead, so ensureCheckout's finally always runs.
+    // No real network call here — spawnClone is injected to simulate a
+    // failing clone.
+    const spawnClone = vi.fn(async (guard) => {
+      // Mirror real usage: a live "child" is set during the simulated
+      // clone, then cleared, matching runForwarding's own contract.
+      guard.setChild({ kill: () => {} });
+      guard.clearChild();
+      return { code: 1, signal: null };
+    });
+
+    await expect(
+      ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
+      }),
+    ).rejects.toThrow(/git clone failed/);
+
+    expect(spawnClone).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    // checkoutPath itself must never have been touched — the "clone" only
+    // ever writes to a disposable staging path (LIA-434 staging+rename
+    // design), so a failure here leaves nothing at checkoutPath to clean up.
+    expect(fs.existsSync(checkoutPath)).toBe(false);
+  });
+
+  it('cleans up the staging directory and reports it as never touching checkoutPath, on clone failure', async () => {
+    // Confirms the specific staging-path contract: spawnClone receives a
+    // path distinct from checkoutPath, and that path is removed on failure.
+    let stagingSeen = '';
+    const spawnClone = vi.fn(async (guard, targetPath: string) => {
+      stagingSeen = targetPath;
+      fs.mkdirSync(targetPath, { recursive: true });
+      fs.writeFileSync(path.join(targetPath, 'partial'), 'x');
+      return { code: 1, signal: null };
+    });
+
+    await expect(
+      ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
+      }),
+    ).rejects.toThrow(/git clone failed/);
+
+    expect(stagingSeen).not.toBe('');
+    expect(stagingSeen).not.toBe(checkoutPath);
+    expect(fs.existsSync(stagingSeen)).toBe(false); // cleaned up
+    expect(fs.existsSync(checkoutPath)).toBe(false); // never touched
+  });
+
+  it('publishes the staged clone into checkoutPath via an atomic rename on success', async () => {
+    const spawnClone = vi.fn(async (_guard, targetPath: string) => {
+      // Simulate a real, valid clone landing in the staging dir.
+      initRealRepo(targetPath, {
+        origin: 'https://github.com/sliamh11/deus-v2.git',
+      });
+      fs.writeFileSync(
+        path.join(targetPath, 'deus-cmd.sh'),
+        '#!/bin/sh\necho hi\n',
+      );
+      return { code: 0, signal: null };
+    });
+
+    await expect(
+      ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        validateOpts: { isWindows: false },
+        lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fs.existsSync(path.join(checkoutPath, 'deus-cmd.sh'))).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    // No stray staging directories left behind next to the real checkout.
+    const siblings = fs.readdirSync(tmpDir);
+    expect(siblings.filter((n) => n.includes('.staging.'))).toHaveLength(0);
+  });
+
+  it('publishes successfully when checkoutPath already exists as an empty directory (code-review-caught Windows bug)', async () => {
+    // Regression test for a real cross-platform bug a GPT-backend code
+    // review caught: validateCheckout's 'missing' reason (safe to
+    // auto-clone into) covers BOTH a nonexistent path AND an existing,
+    // empty directory — but on Windows, fs.renameSync (MoveFileExW) cannot
+    // replace an existing directory destination even when it's empty,
+    // unlike POSIX rename(2). This test can't exercise the actual Windows
+    // code path on this host, but it does exercise the exact precondition
+    // (checkoutPath pre-existing as an empty directory before publish) that
+    // triggered the bug, proving the fix's rmdirSync-first step doesn't
+    // regress the ordinary (POSIX) case either.
+    fs.mkdirSync(checkoutPath, { recursive: true }); // pre-existing, empty
+
+    const spawnClone = vi.fn(async (_guard, targetPath: string) => {
+      initRealRepo(targetPath, {
+        origin: 'https://github.com/sliamh11/deus-v2.git',
+      });
+      fs.writeFileSync(
+        path.join(targetPath, 'deus-cmd.sh'),
+        '#!/bin/sh\necho hi\n',
+      );
+      return { code: 0, signal: null };
+    });
+
+    await expect(
+      ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        validateOpts: { isWindows: false },
+        lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fs.existsSync(path.join(checkoutPath, 'deus-cmd.sh'))).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('releases the lock when post-clone validation fails', async () => {
+    const spawnClone = vi.fn(async (_guard, targetPath: string) => {
+      // Simulate git reporting success but landing an empty/invalid
+      // directory in staging — post-rename validateCheckout should see
+      // this as invalid, which ensureCheckout treats as an unexpected
+      // failure rather than silently succeeding.
+      fs.mkdirSync(targetPath, { recursive: true });
+      return { code: 0, signal: null };
+    });
+    await expect(
+      ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        lockOpts: { waitTimeoutMs: 500, pollMs: 20 },
+      }),
+    ).rejects.toThrow(/failed validation/);
+
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('does nothing (no lock, no clone) when the checkout is already valid', async () => {
+    initRealRepo(checkoutPath, {
+      origin: 'https://github.com/sliamh11/deus-v2.git',
+    });
+    fs.writeFileSync(
+      path.join(checkoutPath, 'deus-cmd.sh'),
+      '#!/bin/sh\necho hi\n',
+    );
+
+    const spawnClone = vi.fn();
+    await expect(
+      ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        validateOpts: { isWindows: false },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(spawnClone).not.toHaveBeenCalled();
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('never touches an existing invalid checkout (hard-fail, no lock taken)', async () => {
+    fs.mkdirSync(checkoutPath, { recursive: true });
+    fs.writeFileSync(path.join(checkoutPath, 'MARKER'), 'not a git repo');
+
+    const spawnClone = vi.fn();
+    await expect(
+      ensureCheckout(checkoutPath, { lockPath, spawnClone }),
+    ).rejects.toThrow(/failed validation/);
+
+    expect(spawnClone).not.toHaveBeenCalled();
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(path.join(checkoutPath, 'MARKER'))).toBe(true);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'real end-to-end: a signal during an in-progress clone releases the lock and cleans up listeners',
+    async () => {
+      // Unlike the other ensureCheckout tests (fake spawnClone, no real
+      // child), this one routes spawnClone through the REAL runForwarding
+      // against a real long-running child process, so the guard's
+      // "forward to a live child" branch is genuinely exercised end-to-end
+      // — not just asserted by tracing the code, per the code-review request
+      // to verify this path executably rather than by inspection alone.
+      const slowScript = path.join(tmpDir, 'slow-clone.mjs');
+      fs.writeFileSync(slowScript, 'setTimeout(() => {}, 5000);\n');
+
+      const listenersBefore = process.listenerCount('SIGTERM');
+
+      const spawnClone = (guard: Parameters<typeof runForwarding>[3]) =>
+        runForwarding(process.execPath, [slowScript], { cwd: tmpDir }, guard);
+
+      const resultPromise = ensureCheckout(checkoutPath, {
+        lockPath,
+        spawnClone,
+        lockOpts: { waitTimeoutMs: 2000, pollMs: 20 },
+      });
+
+      // Give the child time to actually spawn and the lock to be taken,
+      // then simulate an incoming signal the same way the runForwarding
+      // test above does (process.emit, not a real self-kill).
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(fs.existsSync(lockPath)).toBe(true); // lock held mid-clone
+
+      process.emit('SIGTERM' as NodeJS.Signals);
+
+      await expect(resultPromise).rejects.toThrow();
+
+      expect(fs.existsSync(lockPath)).toBe(false); // released after the interrupt
+      expect(process.listenerCount('SIGTERM')).toBe(listenersBefore); // guard disposed
+    },
+  );
+});

--- a/deus-v2-cmd.test.ts
+++ b/deus-v2-cmd.test.ts
@@ -375,6 +375,63 @@ describe('validateCheckout', () => {
 
     expect(result).toEqual({ valid: true });
   });
+
+  it('resolves a short-form (8.3) checkoutPath against git output via realpathSync canonicalization (Windows 8.3-short-name regression)', () => {
+    // Regression test for a real Windows-only bug the above test cannot
+    // catch: its realpathSync mock returns a FIXED string regardless of
+    // input, so it can't discriminate "did the code actually canonicalize
+    // both sides" from "did it coincidentally return the same thing
+    // either way." This test's mock instead maps each DISTINCT input to
+    // its own distinct (but correctly related) canonical output, and
+    // throws on any unexpected argument — so it fails loudly if the fix
+    // ever regresses to comparing an un-realpath'd value against a
+    // realpath'd one, the exact shape of the original bug: os.tmpdir()
+    // (and so checkoutPath, in real usage) is commonly reported in the
+    // legacy 8.3 short-name form ("RUNNER~1") on GH Actions Windows
+    // runners; git's own --show-toplevel/--git-dir/--git-common-dir echo
+    // back whatever they were invoked with, so a naive comparison against
+    // only a realpath'd checkoutPath (this function's pre-fix behavior)
+    // compares a short-form value against a long-form one and spuriously
+    // fails with invalid-nested-repo / invalid-linked-worktree.
+    const shortForm = 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\deus-v2';
+    const longForm = 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\deus-v2';
+    const runGit = vi.fn((args: string[]) => {
+      if (args.includes('--is-inside-work-tree')) {
+        return { status: 0, stdout: 'true\n' };
+      }
+      if (args.includes('--show-toplevel')) {
+        return { status: 0, stdout: `${shortForm}\n` };
+      }
+      if (args.includes('--git-dir') || args.includes('--git-common-dir')) {
+        return { status: 0, stdout: `${shortForm}\\.git\n` };
+      }
+      if (args[0] === 'remote') {
+        return {
+          status: 0,
+          stdout: 'https://github.com/sliamh11/deus-v2.git\n',
+        };
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`);
+    });
+    const realpathSync = vi.fn((p: string) => {
+      if (p === shortForm) return longForm;
+      if (p === `${shortForm}\\.git`) return `${longForm}\\.git`;
+      throw new Error(`unexpected realpathSync arg: ${p}`);
+    });
+
+    const result = validateCheckout(shortForm, {
+      isWindows: true,
+      existsSync: () => true,
+      readdirSync: () => ['deus-cmd.ps1'],
+      statSync: () => ({ isDirectory: () => true }) as fs.Stats,
+      realpathSync,
+      runGit,
+    });
+
+    expect(result).toEqual({ valid: true });
+    expect(realpathSync).toHaveBeenCalledWith(shortForm);
+    expect(realpathSync).toHaveBeenCalledWith(`${shortForm}\\.git`);
+  });
 });
 
 describe('acquireCloneLock / releaseLock', () => {

--- a/docs/decisions/platform-abstraction-layer.md
+++ b/docs/decisions/platform-abstraction-layer.md
@@ -61,6 +61,7 @@ The lint step runs on every PR via `.github/workflows/ci.yml` (`npm run lint`) o
 - **Testing** is simplified: mock `platform.ts` to test any OS combination on any CI runner
 - **Container-runtime.ts** retains its own platform detection since it's container-specific logic (Docker network topology), not general OS behavior
 - **`process.getuid?.()` / `process.getgid?.()`** remain inline in container-runner.ts — these are Unix-specific container UID mapping, not general platform logic
+- **Top-level build-free launcher scripts are a standing, permanent exception**, not covered by the Tier 3 ESLint enforcement (scoped to `src/**/*.ts`) and not expected to ever be: `deus-cmd.sh` and `deus-v2-cmd.mjs` (LIA-434) both do their own OS detection (`$OSTYPE` / `os.platform()`) because they must run correctly before `npm install`/`npm run build` has ever happened — there is no `dist/` to import `src/platform.ts` from, and no `tsx`/`tsc` step for a plain `.mjs`/`.sh` entrypoint. `deus-v2-cmd.mjs` additionally does its own path-comparison logic (`path.win32`/`path.posix`, drive-letter case-folding) for validating a standalone git checkout — this is real platform-sensitive logic, disclosed here rather than silently scattered. If Tier 3 enforcement is ever extended beyond `src/` (see `project_windows_sot_plan` for that possibility), it needs an explicit carve-out for this category of file, not just an `ignores` entry copied from elsewhere.
 
 ## Alternatives Considered
 

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-03" # auto-bump @1783088946
+last_verified: "2026-07-19" # auto-bump @1784444178
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-07-18" # auto-bump @1784327653
+last_verified: "2026-07-19" # auto-bump @1784444178
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-18" # auto-bump @1784327653
+last_verified: "2026-07-19" # auto-bump @1784444178
 governs:
   - src/
   - evolution/

--- a/setup/cli.test.ts
+++ b/setup/cli.test.ts
@@ -27,25 +27,171 @@ vi.mock('../src/logger.js', () => ({
 }));
 
 import { getPlatform } from './platform.js';
-import { run, cleanStaleLegacySymlink, checkExistingCli } from './cli.js';
+import {
+  run,
+  cleanStaleLegacySymlink,
+  checkExistingCli,
+  checkExistingCmdShim,
+} from './cli.js';
+
+// These tests exercise run() against the REAL ~/.local/bin (there's no way
+// to redirect setupUnixCli/setupUnixCliV2's target without changing
+// production code), so a developer running this suite could plausibly
+// already have a real `deus`/`deus-v2` command installed there. A prior
+// version of this file unconditionally unlinked ~/.local/bin/deus-v2 in its
+// outer afterEach — a code review correctly caught that this would delete a
+// developer's real, pre-existing launcher. backupEntry/restoreEntry snapshot
+// whatever was at each path before the suite runs and put it back
+// afterward, regardless of what any individual test did in between.
+type EntryBackup =
+  | { existed: false }
+  | { existed: true; isSymlink: true; target: string }
+  | { existed: true; isSymlink: false; content: Buffer; mode: number };
+
+function backupEntry(p: string): EntryBackup {
+  let stat;
+  try {
+    stat = fs.lstatSync(p);
+  } catch {
+    return { existed: false };
+  }
+  if (stat.isSymbolicLink()) {
+    return { existed: true, isSymlink: true, target: fs.readlinkSync(p) };
+  }
+  // Capture the mode (permission bits, e.g. the executable bit) too — a code
+  // review caught that restoring only file content via writeFileSync would
+  // silently drop a pre-existing executable command's +x bit, breaking it.
+  return {
+    existed: true,
+    isSymlink: false,
+    content: fs.readFileSync(p),
+    mode: stat.mode,
+  };
+}
+
+function restoreEntry(p: string, backup: EntryBackup): void {
+  try {
+    fs.unlinkSync(p);
+  } catch {
+    // nothing there — fine
+  }
+  if (!backup.existed) return;
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  if (backup.isSymlink) {
+    fs.symlinkSync(backup.target, p);
+  } else {
+    fs.writeFileSync(p, backup.content);
+    fs.chmodSync(p, backup.mode);
+  }
+}
 
 describe('setup/cli', () => {
   const originalCwd = process.cwd();
+  const v1LinkPath = path.join(os.homedir(), '.local', 'bin', 'deus');
+  const v2LinkPath = path.join(os.homedir(), '.local', 'bin', 'deus-v2');
   let tmpDir: string;
+  let v1Backup: EntryBackup;
+  let v2Backup: EntryBackup;
 
   beforeEach(() => {
     emitStatusCalls.length = 0;
+    v1Backup = backupEntry(v1LinkPath);
+    v2Backup = backupEntry(v2LinkPath);
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-cli-test-'));
     // Create fake deus-cmd.sh
     fs.writeFileSync(path.join(tmpDir, 'deus-cmd.sh'), '#!/bin/zsh\necho hi');
     // Create fake deus-cmd.ps1
     fs.writeFileSync(path.join(tmpDir, 'deus-cmd.ps1'), 'param() {}');
+    // Create fake deus-v2-cmd.mjs (LIA-434) — run() now always attempts the
+    // v2 launcher install alongside v1's, so v1-focused tests below need
+    // this present to keep the v2 leg a quiet 'success' rather than noise.
+    fs.writeFileSync(
+      path.join(tmpDir, 'deus-v2-cmd.mjs'),
+      '#!/usr/bin/env node\n',
+    );
     process.chdir(tmpDir);
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    restoreEntry(v1LinkPath, v1Backup);
+    restoreEntry(v2LinkPath, v2Backup);
+  });
+
+  describe('backupEntry / restoreEntry (developer-data protection, LIA-434)', () => {
+    // Direct unit tests for the save/restore helpers themselves, isolated
+    // from run()'s real ~/.local/bin usage — regression coverage for the
+    // exact bug a code review caught (an earlier version's outer afterEach
+    // unconditionally deleted ~/.local/bin/deus-v2, which would destroy a
+    // developer's real, pre-existing launcher).
+    let checkDir: string;
+
+    beforeEach(() => {
+      checkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-backup-check-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(checkDir, { recursive: true, force: true });
+    });
+
+    it('restores a pre-existing regular file after it is deleted and replaced', () => {
+      const p = path.join(checkDir, 'deus-v2');
+      fs.writeFileSync(p, 'a real developer launcher, not a test fixture');
+
+      const backup = backupEntry(p);
+      fs.unlinkSync(p); // simulate a test deleting it
+      fs.writeFileSync(p, 'test fixture content'); // simulate a test replacing it
+      restoreEntry(p, backup);
+
+      expect(fs.readFileSync(p, 'utf-8')).toBe(
+        'a real developer launcher, not a test fixture',
+      );
+    });
+
+    it('preserves the executable bit of a pre-existing regular file (code-review-caught bug)', () => {
+      // A prior version only restored content via writeFileSync, which
+      // creates the new file with default (non-executable) permissions — a
+      // code review caught that this would silently strip the +x bit off a
+      // developer's real, executable ~/.local/bin/deus-v2 after the test
+      // suite ran, breaking the installed command.
+      const p = path.join(checkDir, 'deus-v2');
+      fs.writeFileSync(p, '#!/usr/bin/env node\n// real launcher', {
+        mode: 0o755,
+      });
+      expect(fs.statSync(p).mode & 0o777).toBe(0o755);
+
+      const backup = backupEntry(p);
+      fs.unlinkSync(p);
+      fs.writeFileSync(p, 'test fixture content'); // test fixtures are non-executable
+      restoreEntry(p, backup);
+
+      expect(fs.statSync(p).mode & 0o777).toBe(0o755);
+    });
+
+    it('restores a pre-existing symlink after it is deleted and replaced', () => {
+      const target = path.join(checkDir, 'real-target');
+      fs.writeFileSync(target, 'real target');
+      const p = path.join(checkDir, 'deus-v2');
+      fs.symlinkSync(target, p);
+
+      const backup = backupEntry(p);
+      fs.unlinkSync(p);
+      fs.writeFileSync(p, 'test fixture content');
+      restoreEntry(p, backup);
+
+      expect(fs.lstatSync(p).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(p)).toBe(target);
+    });
+
+    it('leaves nothing behind when nothing existed before', () => {
+      const p = path.join(checkDir, 'deus-v2');
+      const backup = backupEntry(p);
+      fs.writeFileSync(p, 'test fixture content'); // simulate a test creating it
+      restoreEntry(p, backup);
+
+      expect(fs.existsSync(p)).toBe(false);
+    });
   });
 
   it('creates symlink on unix platforms', async () => {
@@ -53,9 +199,13 @@ describe('setup/cli', () => {
 
     await run([]);
 
-    expect(emitStatusCalls).toHaveLength(1);
+    // run() now always attempts the v2 launcher install too (LIA-434) —
+    // SETUP_CLI (v1) first, then SETUP_CLI_V2, independent of each other.
+    expect(emitStatusCalls).toHaveLength(2);
     expect(emitStatusCalls[0].event).toBe('SETUP_CLI');
     expect(emitStatusCalls[0].data.STATUS).toBe('success');
+    expect(emitStatusCalls[1].event).toBe('SETUP_CLI_V2');
+    expect(emitStatusCalls[1].data.STATUS).toBe('success');
 
     const linkPath = emitStatusCalls[0].data.LINK_PATH as string;
     expect(fs.existsSync(linkPath)).toBe(true);
@@ -66,6 +216,7 @@ describe('setup/cli', () => {
 
     // Clean up
     fs.unlinkSync(linkPath);
+    fs.unlinkSync(emitStatusCalls[1].data.LINK_PATH as string);
   });
 
   it('fails if deus-cmd.sh is missing on unix', async () => {
@@ -74,9 +225,16 @@ describe('setup/cli', () => {
 
     await run([]);
 
-    expect(emitStatusCalls).toHaveLength(1);
+    expect(emitStatusCalls).toHaveLength(2);
+    expect(emitStatusCalls[0].event).toBe('SETUP_CLI');
     expect(emitStatusCalls[0].data.STATUS).toBe('failed');
     expect(emitStatusCalls[0].data.ERROR).toBe('deus-cmd.sh not found');
+    // v1 failing must not affect the independent v2 leg.
+    expect(emitStatusCalls[1].event).toBe('SETUP_CLI_V2');
+    expect(emitStatusCalls[1].data.STATUS).toBe('success');
+
+    // Clean up
+    fs.unlinkSync(emitStatusCalls[1].data.LINK_PATH as string);
   });
 
   it('replaces existing dead symlink', async () => {
@@ -191,6 +349,100 @@ describe('setup/cli', () => {
     });
   });
 
+  describe('checkExistingCmdShim (Windows .cmd shim conflict protection, LIA-434)', () => {
+    let checkDir: string;
+
+    beforeEach(() => {
+      checkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-cmdshim-check-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(checkDir, { recursive: true, force: true });
+    });
+
+    it('returns none when path does not exist', () => {
+      expect(checkExistingCmdShim(path.join(checkDir, 'deus.cmd'), 'v1')).toBe(
+        'none',
+      );
+    });
+
+    it('returns ours for a v1 shim generated for the expected script', () => {
+      const cmdPath = path.join(checkDir, 'deus.cmd');
+      fs.writeFileSync(
+        cmdPath,
+        '@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File "C:\\deus\\deus-cmd.ps1" %*\r\n',
+      );
+      expect(checkExistingCmdShim(cmdPath, 'v1')).toBe('ours');
+    });
+
+    it('returns ours for a v2 shim generated for the expected script', () => {
+      const cmdPath = path.join(checkDir, 'deus-v2.cmd');
+      fs.writeFileSync(
+        cmdPath,
+        '@echo off\r\nnode "C:\\deus\\deus-v2-cmd.mjs" %*\r\n',
+      );
+      expect(checkExistingCmdShim(cmdPath, 'v2')).toBe('ours');
+    });
+
+    it('returns foreign for a regular file not generated by this step', () => {
+      const cmdPath = path.join(checkDir, 'deus.cmd');
+      fs.writeFileSync(
+        cmdPath,
+        '@echo off\r\necho some other unrelated tool\r\n',
+      );
+      expect(checkExistingCmdShim(cmdPath, 'v1')).toBe('foreign');
+    });
+
+    it('returns foreign for a user-authored wrapper that merely mentions the script name (code-review-caught bug)', () => {
+      // Regression test for a real bug a GPT-backend code review caught:
+      // the original check was a loose `content.includes(basename)`
+      // substring test, which would have classified ANY file merely
+      // mentioning "deus-cmd.ps1" as "ours" — including a user's own,
+      // unrelated wrapper script — and silently overwritten it. Only an
+      // exact structural match to this step's own generated format now
+      // counts as "ours".
+      const cmdPath = path.join(checkDir, 'deus.cmd');
+      fs.writeFileSync(
+        cmdPath,
+        'REM my custom wrapper around deus-cmd.ps1, do not touch\r\npowershell -File deus-cmd.ps1\r\n',
+      );
+      expect(checkExistingCmdShim(cmdPath, 'v1')).toBe('foreign');
+    });
+
+    it('returns foreign when the target basename merely ends with the expected name, no separator boundary (code-review-caught bypass)', () => {
+      // Regression test for a real bypass a GPT-backend code review caught:
+      // an earlier version of the pattern required only that
+      // "deus-v2-cmd.mjs" appear as a SUFFIX of whatever preceded it inside
+      // the quotes, with no path-separator boundary — so a foreign shim
+      // targeting a DIFFERENT file whose name merely ends with the expected
+      // basename (e.g. "custom-deus-v2-cmd.mjs") would also match and be
+      // wrongly classified 'ours', overwriting the user's file.
+      const cmdPath = path.join(checkDir, 'deus-v2.cmd');
+      fs.writeFileSync(
+        cmdPath,
+        '@echo off\r\nnode "C:\\tools\\custom-deus-v2-cmd.mjs" %*\r\n',
+      );
+      expect(checkExistingCmdShim(cmdPath, 'v2')).toBe('foreign');
+    });
+
+    it('returns foreign for a symlink at the shim path, never following it', () => {
+      const target = path.join(checkDir, 'something-else');
+      fs.writeFileSync(target, 'arbitrary content');
+      const cmdPath = path.join(checkDir, 'deus.cmd');
+      fs.symlinkSync(target, cmdPath);
+      expect(checkExistingCmdShim(cmdPath, 'v1')).toBe('foreign');
+    });
+
+    it('v1 and v2 markers are distinct — a v1 shim is not mistaken for a v2 one', () => {
+      const cmdPath = path.join(checkDir, 'deus.cmd');
+      fs.writeFileSync(
+        cmdPath,
+        '@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File "C:\\deus\\deus-cmd.ps1" %*\r\n',
+      );
+      expect(checkExistingCmdShim(cmdPath, 'v2')).toBe('foreign');
+    });
+  });
+
   describe('cleanStaleLegacySymlink', () => {
     const legacyDir = path.join(os.tmpdir(), 'deus-legacy-test');
     const legacyPath = path.join(legacyDir, 'deus');
@@ -257,6 +509,149 @@ describe('setup/cli', () => {
 
       expect(mockLog.info).not.toHaveBeenCalled();
       expect(mockLog.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deus-v2 CLI (LIA-434)', () => {
+    it('creates the deus-v2 symlink independently of deus', async () => {
+      vi.mocked(getPlatform).mockReturnValue('macos');
+
+      await run([]);
+
+      const v2Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI_V2')!;
+      expect(v2Call.data.STATUS).toBe('success');
+
+      const linkPath = v2Call.data.LINK_PATH as string;
+      expect(fs.existsSync(linkPath)).toBe(true);
+      expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+      expect(fs.realpathSync(fs.readlinkSync(linkPath))).toBe(
+        fs.realpathSync(path.join(tmpDir, 'deus-v2-cmd.mjs')),
+      );
+
+      fs.unlinkSync(linkPath);
+    });
+
+    it('fails only the v2 leg if deus-v2-cmd.mjs is missing — v1 unaffected', async () => {
+      vi.mocked(getPlatform).mockReturnValue('macos');
+      fs.unlinkSync(path.join(tmpDir, 'deus-v2-cmd.mjs'));
+
+      await run([]);
+
+      const v1Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI')!;
+      const v2Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI_V2')!;
+      expect(v1Call.data.STATUS).toBe('success');
+      expect(v2Call.data.STATUS).toBe('failed');
+      expect(v2Call.data.ERROR).toBe('deus-v2-cmd.mjs not found');
+
+      fs.unlinkSync(v1Call.data.LINK_PATH as string);
+    });
+
+    it('replaces an existing dead deus-v2 symlink', async () => {
+      vi.mocked(getPlatform).mockReturnValue('macos');
+
+      const binDir = path.join(os.homedir(), '.local', 'bin');
+      const linkPath = path.join(binDir, 'deus-v2');
+      fs.mkdirSync(binDir, { recursive: true });
+      try {
+        fs.unlinkSync(linkPath);
+      } catch {
+        // doesn't exist
+      }
+      fs.symlinkSync('/tmp/old-deus-v2-nonexistent', linkPath);
+
+      await run([]);
+
+      const v2Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI_V2')!;
+      expect(v2Call.data.STATUS).toBe('success');
+      expect(fs.realpathSync(fs.readlinkSync(linkPath))).toBe(
+        fs.realpathSync(path.join(tmpDir, 'deus-v2-cmd.mjs')),
+      );
+
+      const v1Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI')!;
+      fs.unlinkSync(v1Call.data.LINK_PATH as string);
+      fs.unlinkSync(linkPath);
+    });
+
+    it('replaces an existing deus-v2 symlink from a different install path', async () => {
+      vi.mocked(getPlatform).mockReturnValue('macos');
+
+      const binDir = path.join(os.homedir(), '.local', 'bin');
+      const linkPath = path.join(binDir, 'deus-v2');
+      fs.mkdirSync(binDir, { recursive: true });
+      try {
+        fs.unlinkSync(linkPath);
+      } catch {
+        // doesn't exist
+      }
+      fs.symlinkSync(path.join(tmpDir, 'deus-v2-cmd.mjs'), linkPath);
+
+      await run([]);
+
+      const v2Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI_V2')!;
+      expect(v2Call.data.STATUS).toBe('success');
+
+      const v1Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI')!;
+      fs.unlinkSync(v1Call.data.LINK_PATH as string);
+      fs.unlinkSync(linkPath);
+    });
+
+    it('skips deus-v2 symlink creation when a foreign binary exists at that path', async () => {
+      vi.mocked(getPlatform).mockReturnValue('macos');
+
+      const binDir = path.join(os.homedir(), '.local', 'bin');
+      const linkPath = path.join(binDir, 'deus-v2');
+      fs.mkdirSync(binDir, { recursive: true });
+      try {
+        fs.unlinkSync(linkPath);
+      } catch {
+        // doesn't exist
+      }
+      fs.writeFileSync(linkPath, '#!/bin/sh\necho "different tool"');
+
+      await run([]);
+
+      const v2Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI_V2')!;
+      expect(v2Call.data.STATUS).toBe('conflict');
+      expect(v2Call.data.EXISTING).toBe('foreign');
+      expect(fs.readFileSync(linkPath, 'utf-8')).toContain('different tool');
+
+      const v1Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI')!;
+      fs.unlinkSync(v1Call.data.LINK_PATH as string);
+      fs.unlinkSync(linkPath);
+    });
+
+    it('a v2 setup failure never affects the v1 SETUP_CLI status (failure isolation)', async () => {
+      vi.mocked(getPlatform).mockReturnValue('macos');
+
+      const binDir = path.join(os.homedir(), '.local', 'bin');
+      const v2LinkPath = path.join(binDir, 'deus-v2');
+      fs.mkdirSync(binDir, { recursive: true });
+      try {
+        fs.unlinkSync(v2LinkPath);
+      } catch {
+        // doesn't exist
+      }
+
+      const realSymlinkSync = fs.symlinkSync;
+      const symlinkSpy = vi
+        .spyOn(fs, 'symlinkSync')
+        .mockImplementation((target, linkPath, ...rest) => {
+          if (linkPath === v2LinkPath) {
+            throw new Error('simulated v2 symlink failure');
+          }
+          return realSymlinkSync(target, linkPath, ...(rest as []));
+        });
+
+      await run([]);
+      symlinkSpy.mockRestore();
+
+      const v1Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI')!;
+      const v2Call = emitStatusCalls.find((c) => c.event === 'SETUP_CLI_V2')!;
+      expect(v1Call.data.STATUS).toBe('success');
+      expect(v2Call.data.STATUS).toBe('failed');
+      expect(v2Call.data.ERROR).toContain('simulated v2 symlink failure');
+
+      fs.unlinkSync(v1Call.data.LINK_PATH as string);
     });
   });
 });

--- a/setup/cli.test.ts
+++ b/setup/cli.test.ts
@@ -149,25 +149,31 @@ describe('setup/cli', () => {
       );
     });
 
-    it('preserves the executable bit of a pre-existing regular file (code-review-caught bug)', () => {
-      // A prior version only restored content via writeFileSync, which
-      // creates the new file with default (non-executable) permissions — a
-      // code review caught that this would silently strip the +x bit off a
-      // developer's real, executable ~/.local/bin/deus-v2 after the test
-      // suite ran, breaking the installed command.
-      const p = path.join(checkDir, 'deus-v2');
-      fs.writeFileSync(p, '#!/usr/bin/env node\n// real launcher', {
-        mode: 0o755,
-      });
-      expect(fs.statSync(p).mode & 0o777).toBe(0o755);
+    it.skipIf(process.platform === 'win32')(
+      'preserves the executable bit of a pre-existing regular file (code-review-caught bug)',
+      () => {
+        // A prior version only restored content via writeFileSync, which
+        // creates the new file with default (non-executable) permissions — a
+        // code review caught that this would silently strip the +x bit off a
+        // developer's real, executable ~/.local/bin/deus-v2 after the test
+        // suite ran, breaking the installed command. Windows has no POSIX
+        // executable-bit concept (NTFS ACLs, not mode bits), so this test's
+        // premise doesn't apply there — verified via CI (fs.writeFileSync's
+        // `mode: 0o755` doesn't produce a real 0o755 on Windows).
+        const p = path.join(checkDir, 'deus-v2');
+        fs.writeFileSync(p, '#!/usr/bin/env node\n// real launcher', {
+          mode: 0o755,
+        });
+        expect(fs.statSync(p).mode & 0o777).toBe(0o755);
 
-      const backup = backupEntry(p);
-      fs.unlinkSync(p);
-      fs.writeFileSync(p, 'test fixture content'); // test fixtures are non-executable
-      restoreEntry(p, backup);
+        const backup = backupEntry(p);
+        fs.unlinkSync(p);
+        fs.writeFileSync(p, 'test fixture content'); // test fixtures are non-executable
+        restoreEntry(p, backup);
 
-      expect(fs.statSync(p).mode & 0o777).toBe(0o755);
-    });
+        expect(fs.statSync(p).mode & 0o777).toBe(0o755);
+      },
+    );
 
     it('restores a pre-existing symlink after it is deleted and replaced', () => {
       const target = path.join(checkDir, 'real-target');

--- a/setup/cli.ts
+++ b/setup/cli.ts
@@ -18,10 +18,37 @@ export async function run(_args: string[]): Promise<void> {
   const platform = getPlatform();
   const homeDir = os.homedir();
 
-  if (platform === 'windows') {
-    setupWindowsCli(projectRoot, homeDir);
-  } else {
-    setupUnixCli(projectRoot, homeDir);
+  // v1 and v2 installs are independent in BOTH directions: each leg gets
+  // its own try/catch so an uncaught throw from either (e.g. a filesystem
+  // permission error mid-symlink) can never prevent the other from being
+  // attempted. A code review caught that an earlier version only protected
+  // one direction (v2's failure couldn't affect v1's already-emitted
+  // status) but left v1 able to abort run() before v2 was ever reached.
+  try {
+    if (platform === 'windows') {
+      setupWindowsCli(projectRoot, homeDir);
+    } else {
+      setupUnixCli(projectRoot, homeDir);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({ err }, 'deus (v1) CLI setup threw unexpectedly');
+    emitStatus('SETUP_CLI', { STATUS: 'failed', ERROR: message });
+  }
+
+  try {
+    if (platform === 'windows') {
+      setupWindowsCliV2(projectRoot, homeDir);
+    } else {
+      setupUnixCliV2(projectRoot, homeDir);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      { err },
+      'deus-v2 CLI setup failed (v1 deus install unaffected)',
+    );
+    emitStatus('SETUP_CLI_V2', { STATUS: 'failed', ERROR: message });
   }
 }
 
@@ -77,43 +104,7 @@ function setupUnixCli(projectRoot: string, homeDir: string): void {
   // Clean up stale /usr/local/bin/deus symlink that may shadow the new one
   cleanStaleLegacySymlink(logger);
 
-  // Check if ~/.local/bin is in PATH; if not, add it to shell config
-  const pathEnv = process.env.PATH || '';
-  const delimiter = process.platform === 'win32' ? ';' : ':';
-  let inPath = pathEnv.split(delimiter).some((p) => p === binDir);
-
-  if (!inPath) {
-    const exportLine = `export PATH="$HOME/.local/bin:$PATH"`;
-    const shellConfigs = [
-      path.join(homeDir, '.zshrc'),
-      path.join(homeDir, '.bashrc'),
-    ];
-
-    for (const rc of shellConfigs) {
-      if (!fs.existsSync(rc)) continue;
-      const content = fs.readFileSync(rc, 'utf-8');
-      if (content.includes('.local/bin')) {
-        inPath = true;
-        break;
-      }
-    }
-
-    if (!inPath) {
-      // Detect user's shell and append to the appropriate config
-      const shell = process.env.SHELL || '/bin/bash';
-      const rcFile = shell.endsWith('zsh')
-        ? path.join(homeDir, '.zshrc')
-        : path.join(homeDir, '.bashrc');
-
-      try {
-        fs.appendFileSync(rcFile, `\n# Added by Deus setup\n${exportLine}\n`);
-        inPath = true;
-        logger.info({ rcFile }, 'Added ~/.local/bin to PATH in shell config');
-      } catch (err) {
-        logger.warn({ err, rcFile }, 'Could not update shell config');
-      }
-    }
-  }
+  const inPath = ensureUnixBinDirInPath(homeDir, binDir);
 
   emitStatus('SETUP_CLI', {
     STATUS: 'success',
@@ -124,15 +115,128 @@ function setupUnixCli(projectRoot: string, homeDir: string): void {
 }
 
 /**
+ * Install the `deus-v2` launcher symlink (LIA-434) — a parallel, independent
+ * command alongside `deus`, never replacing it. See deus-v2-cmd.mjs for the
+ * checkout-location/validation/delegation logic; this only wires up the
+ * symlink, mirroring setupUnixCli's structure.
+ */
+function setupUnixCliV2(projectRoot: string, homeDir: string): void {
+  const binDir = path.join(homeDir, '.local', 'bin');
+  const linkPath = path.join(binDir, 'deus-v2');
+  const scriptPath = path.join(projectRoot, 'deus-v2-cmd.mjs');
+
+  if (!fs.existsSync(scriptPath)) {
+    emitStatus('SETUP_CLI_V2', {
+      STATUS: 'failed',
+      ERROR: 'deus-v2-cmd.mjs not found',
+    });
+    return;
+  }
+
+  try {
+    fs.chmodSync(scriptPath, 0o755);
+  } catch {
+    // May fail on some filesystems, non-critical
+  }
+
+  fs.mkdirSync(binDir, { recursive: true });
+
+  const existing = checkExistingCli(linkPath, 'deus-v2-cmd.mjs');
+  if (existing === 'foreign') {
+    logger.warn(
+      { linkPath },
+      'A non-Deus binary already exists at the deus-v2 CLI path. Skipping symlink creation to avoid data loss.',
+    );
+    emitStatus('SETUP_CLI_V2', {
+      STATUS: 'conflict',
+      LINK_PATH: linkPath,
+      SCRIPT_PATH: scriptPath,
+      EXISTING: 'foreign',
+      IN_PATH: false,
+    });
+    return;
+  }
+
+  try {
+    fs.unlinkSync(linkPath);
+  } catch {
+    // Doesn't exist
+  }
+
+  fs.symlinkSync(scriptPath, linkPath);
+  logger.info({ linkPath, scriptPath }, 'Created deus-v2 CLI symlink');
+
+  // No cleanStaleLegacySymlink call here — there's no historical
+  // /usr/local/bin/deus-v2 to clean up for a brand-new command.
+
+  const inPath = ensureUnixBinDirInPath(homeDir, binDir);
+
+  emitStatus('SETUP_CLI_V2', {
+    STATUS: 'success',
+    LINK_PATH: linkPath,
+    SCRIPT_PATH: scriptPath,
+    IN_PATH: inPath,
+  });
+}
+
+/**
+ * Ensure `binDir` is on PATH, appending an export line to the user's shell
+ * config if needed. Extracted from setupUnixCli so setupUnixCliV2 can reuse
+ * it without duplicating the PATH-mutation logic (both install into the same
+ * ~/.local/bin).
+ */
+function ensureUnixBinDirInPath(homeDir: string, binDir: string): boolean {
+  const pathEnv = process.env.PATH || '';
+  const delimiter = process.platform === 'win32' ? ';' : ':';
+  let inPath = pathEnv.split(delimiter).some((p) => p === binDir);
+
+  if (inPath) return true;
+
+  const exportLine = `export PATH="$HOME/.local/bin:$PATH"`;
+  const shellConfigs = [
+    path.join(homeDir, '.zshrc'),
+    path.join(homeDir, '.bashrc'),
+  ];
+
+  for (const rc of shellConfigs) {
+    if (!fs.existsSync(rc)) continue;
+    const content = fs.readFileSync(rc, 'utf-8');
+    if (content.includes('.local/bin')) {
+      return true;
+    }
+  }
+
+  // Detect user's shell and append to the appropriate config
+  const shell = process.env.SHELL || '/bin/bash';
+  const rcFile = shell.endsWith('zsh')
+    ? path.join(homeDir, '.zshrc')
+    : path.join(homeDir, '.bashrc');
+
+  try {
+    fs.appendFileSync(rcFile, `\n# Added by Deus setup\n${exportLine}\n`);
+    logger.info({ rcFile }, 'Added ~/.local/bin to PATH in shell config');
+    return true;
+  } catch (err) {
+    logger.warn({ err, rcFile }, 'Could not update shell config');
+    return false;
+  }
+}
+
+/**
  * Check what exists at the CLI symlink path.
  * Returns:
  * - 'none'    — nothing exists, safe to create
- * - 'ours'    — symlink pointing to a deus-cmd.sh, safe to replace
+ * - 'ours'    — symlink pointing to a script named `expectedBasename`, safe to replace
  * - 'dead'    — dead symlink, safe to replace
  * - 'foreign' — something else (different binary, regular file), DO NOT replace
+ *
+ * `expectedBasename` defaults to 'deus-cmd.sh' (the v1 launcher) so existing
+ * call sites are unaffected; the deus-v2 launcher (LIA-434) passes
+ * 'deus-v2-cmd.mjs'.
  */
 export function checkExistingCli(
   linkPath: string,
+  expectedBasename = 'deus-cmd.sh',
 ): 'none' | 'ours' | 'dead' | 'foreign' {
   try {
     const stat = fs.lstatSync(linkPath);
@@ -141,8 +245,8 @@ export function checkExistingCli(
       const target = fs.readlinkSync(linkPath);
       // Check if target is alive
       if (!fs.existsSync(linkPath)) return 'dead';
-      // Check if it points to any deus-cmd.sh (ours, possibly different install path)
-      if (path.basename(target) === 'deus-cmd.sh') return 'ours';
+      // Check if it points to our own script (ours, possibly different install path)
+      if (path.basename(target) === expectedBasename) return 'ours';
       return 'foreign';
     }
 
@@ -150,6 +254,51 @@ export function checkExistingCli(
     return 'foreign';
   } catch {
     return 'none';
+  }
+}
+
+// Exact structural patterns for the two shims this step generates — see
+// setupWindowsCli/setupWindowsCliV2's cmdContent below, which these must
+// stay byte-for-byte in sync with. Anchored end-to-end (^...$, content has
+// no other lines) with only the absolute script path left as a wildcard, so
+// a relocated install (different projectRoot) is still recognized as ours.
+// The `[\\/]` immediately before the basename is load-bearing, not
+// decorative: without it, a code review caught that a FOREIGN shim naming
+// e.g. "custom-deus-v2-cmd.mjs" (a different file whose name merely ends
+// with the expected basename, no path-separator boundary) would also
+// match and be wrongly classified 'ours', overwriting the user's file.
+const CMD_SHIM_PATTERNS: Record<'v1' | 'v2', RegExp> = {
+  v1: /^@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File "[^"\r\n]*[\\/]deus-cmd\.ps1" %\*\r\n$/,
+  v2: /^@echo off\r\nnode "[^"\r\n]*[\\/]deus-v2-cmd\.mjs" %\*\r\n$/,
+};
+
+/**
+ * Windows equivalent of checkExistingCli's foreign-detection, for the .cmd
+ * shims (no symlinks involved, so basename-of-target doesn't apply): a
+ * missing path is 'none'; an existing symlink is always 'foreign' — never
+ * followed, since fs.writeFileSync would silently overwrite whatever it
+ * points at; a regular file is 'ours' only if its content EXACTLY matches
+ * this step's own generated shim structure for `kind` (a loose
+ * "contains the basename somewhere" check was caught by code review as
+ * unsafe — a user-authored wrapper or unrelated command that merely
+ * mentions the target script's name would have been silently overwritten).
+ */
+export function checkExistingCmdShim(
+  cmdPath: string,
+  kind: 'v1' | 'v2',
+): 'none' | 'ours' | 'foreign' {
+  let stat;
+  try {
+    stat = fs.lstatSync(cmdPath);
+  } catch {
+    return 'none';
+  }
+  if (stat.isSymbolicLink()) return 'foreign';
+  try {
+    const content = fs.readFileSync(cmdPath, 'utf-8');
+    return CMD_SHIM_PATTERNS[kind].test(content) ? 'ours' : 'foreign';
+  } catch {
+    return 'foreign';
   }
 }
 
@@ -202,6 +351,22 @@ function setupWindowsCli(projectRoot: string, homeDir: string): void {
 
   fs.mkdirSync(binDir, { recursive: true });
 
+  const existingShim = checkExistingCmdShim(cmdPath, 'v1');
+  if (existingShim === 'foreign') {
+    logger.warn(
+      { cmdPath },
+      'A non-Deus file or symlink already exists at the CLI path. Skipping shim creation to avoid data loss.',
+    );
+    emitStatus('SETUP_CLI', {
+      STATUS: 'conflict',
+      CMD_PATH: cmdPath,
+      SCRIPT_PATH: ps1Path,
+      EXISTING: 'foreign',
+      IN_PATH: false,
+    });
+    return;
+  }
+
   // Create a .cmd shim that invokes the PowerShell script
   const cmdContent =
     [
@@ -212,7 +377,77 @@ function setupWindowsCli(projectRoot: string, homeDir: string): void {
   fs.writeFileSync(cmdPath, cmdContent);
   logger.info({ cmdPath, ps1Path }, 'Created deus.cmd shim');
 
-  // Check if binDir is in user PATH and add it if not
+  const inPath = ensureWindowsBinDirInPath(binDir);
+
+  emitStatus('SETUP_CLI', {
+    STATUS: 'success',
+    CMD_PATH: cmdPath,
+    SCRIPT_PATH: ps1Path,
+    IN_PATH: inPath,
+    PATH_DIR: binDir,
+  });
+}
+
+/**
+ * Install the `deus-v2.cmd` shim (LIA-434) — a parallel, independent command
+ * alongside `deus`, never replacing it. Unlike deus.cmd (which wraps a native
+ * .ps1 via `powershell -File`), deus-v2-cmd.mjs is a Node script, so the
+ * shim invokes `node` directly.
+ */
+function setupWindowsCliV2(projectRoot: string, homeDir: string): void {
+  const binDir = path.join(homeDir, '.local', 'bin');
+  const cmdPath = path.join(binDir, 'deus-v2.cmd');
+  const scriptPath = path.join(projectRoot, 'deus-v2-cmd.mjs');
+
+  if (!fs.existsSync(scriptPath)) {
+    emitStatus('SETUP_CLI_V2', {
+      STATUS: 'failed',
+      ERROR: 'deus-v2-cmd.mjs not found',
+    });
+    return;
+  }
+
+  fs.mkdirSync(binDir, { recursive: true });
+
+  const existingShim = checkExistingCmdShim(cmdPath, 'v2');
+  if (existingShim === 'foreign') {
+    logger.warn(
+      { cmdPath },
+      'A non-Deus file or symlink already exists at the deus-v2 CLI path. Skipping shim creation to avoid data loss.',
+    );
+    emitStatus('SETUP_CLI_V2', {
+      STATUS: 'conflict',
+      CMD_PATH: cmdPath,
+      SCRIPT_PATH: scriptPath,
+      EXISTING: 'foreign',
+      IN_PATH: false,
+    });
+    return;
+  }
+
+  const cmdContent =
+    ['@echo off', `node "${scriptPath}" %*`].join('\r\n') + '\r\n';
+
+  fs.writeFileSync(cmdPath, cmdContent);
+  logger.info({ cmdPath, scriptPath }, 'Created deus-v2.cmd shim');
+
+  const inPath = ensureWindowsBinDirInPath(binDir);
+
+  emitStatus('SETUP_CLI_V2', {
+    STATUS: 'success',
+    CMD_PATH: cmdPath,
+    SCRIPT_PATH: scriptPath,
+    IN_PATH: inPath,
+    PATH_DIR: binDir,
+  });
+}
+
+/**
+ * Ensure `binDir` is on the user's Windows PATH. Extracted from
+ * setupWindowsCli so setupWindowsCliV2 can reuse it without duplicating the
+ * PATH-mutation logic (both install into the same ~/.local/bin).
+ */
+function ensureWindowsBinDirInPath(binDir: string): boolean {
   let inPath = false;
   try {
     const currentPath = execSync(
@@ -235,12 +470,5 @@ function setupWindowsCli(projectRoot: string, homeDir: string): void {
   } catch (err) {
     logger.warn({ err }, 'Could not check/update user PATH');
   }
-
-  emitStatus('SETUP_CLI', {
-    STATUS: 'success',
-    CMD_PATH: cmdPath,
-    SCRIPT_PATH: ps1Path,
-    IN_PATH: inPath,
-    PATH_DIR: binDir,
-  });
+  return inPath;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
       'src/**/*.test.ts',
       'setup/**/*.test.ts',
       'scripts/spikes/**/*.test.ts',
+      // deus-v2-cmd.mjs (LIA-434) lives at repo root, mirroring deus-cmd.sh /
+      // scripts/migrate.mjs's build-free top-level placement — its test needs
+      // an explicit entry since it's outside the globs above.
+      'deus-v2-cmd.test.ts',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

- New `deus-v2-cmd.mjs`: a standalone, build-free launcher that locates or
  clones a real, independent checkout of `sliamh11/deus-v2` at the fixed
  path `~/deus-v2`, then delegates argv/cwd/stdio/exit-code/signal
  unchanged to its own `deus-cmd.sh`/`.ps1` — alongside the existing v1
  `deus` command, never replacing it.
- Fixed checkout path `~/deus-v2`, a real standalone clone (never a linked
  `.claude/worktrees/` worktree) — validated via `is-inside-work-tree`,
  `--show-toplevel`, `--git-dir`/`--git-common-dir`, origin remote slug
  (fully anchored, not a substring match), and platform-entrypoint-exists
  checks.
- Auto-clones if missing/empty; fails with an actionable error (never
  deletes/overwrites/repurposes) if the path exists but is invalid.
- First-run cloning is serialized via a **PID-liveness lock** (not a
  time-based staleness threshold — a live holder, however slow its clone,
  is never stolen from). The clone itself lands in a per-process **staging
  directory** and is published via an **atomic rename** into
  `~/deus-v2` — even a residual lock race can never cause two processes to
  write into the same checkout directory concurrently.
- `setup/cli.ts` installs `deus-v2` independently of `deus`: macOS/Linux
  `~/.local/bin/deus-v2` symlink, Windows `deus-v2.cmd` shim. `run()` wraps
  both the v1 and v2 install legs in their own try/catch so a failure in
  either can never affect the other.
- v1's own `deus` command, checkout, service, and config are fully
  unaffected — confirmed by test (a forced v2-symlink failure leaves v1's
  `SETUP_CLI` status `success`).

### LIA-451 status (dependency)

LIA-451 (`sliamh11/deus-v2`'s own port/service/container namespacing,
PR #41) **merged** at 2026-07-18T22:05:29Z (verified via
`gh pr view 41 --repo sliamh11/deus-v2` — `state: MERGED`, real merge
commit `83bbe09`) partway through this work. This launcher's own
implementation never depended on LIA-451's contents (only on
`deus-cmd.sh`/`.ps1` existing at the v2 checkout root, which already did).
With LIA-451 merged, the "both commands run side-by-side without conflict"
prerequisite is satisfied by construction — **but this session did not
perform a live operational smoke test** (both `deus` and `deus-v2`
services actually running concurrently on a real machine). That remains a
manual verification step before/at merge time, not something this PR
claims to have confirmed end-to-end.

## Review process

This went through unusually thorough review — documenting it because
several rounds caught real bugs, not just style nits:

- **plan-reviewer**: 8 rounds to SHIP. Caught: a Windows path-comparison
  bug (Git for Windows reports lowercase drive letters; `fs.realpathSync`
  returns uppercase), a `process.exit()`-skips-`finally` bug that orphaned
  the clone lock on ordinary failure, and a single-listener signal-guard
  design to avoid a registration-order race.
- **GPT-backend plan co-gate**: caught that the original lock design stole
  based on elapsed time alone — unsafe for a legitimately slow (not dead)
  clone — fixed via PID-liveness checking instead.
- **code-reviewer + GPT-backend code-review co-gate**: multiple rounds,
  caught real bugs each time:
  - `process.exit()` inside `fail()` skipped `finally`, orphaning the lock
    on ordinary clone failure (not just signals) — fixed by throwing a
    `LauncherError` instead.
  - The lock's dead-holder eviction had a TOCTOU race (content-string
    comparison could be fooled by PID reuse) — tightened to inode-identity
    comparison, then further hardened by moving the actual clone into a
    disposable staging directory published via atomic rename, so even a
    residual lock race can never corrupt the checkout.
  - `REPO_SLUG_RE` was unanchored — a substring match let
    `https://attacker.example/github.com/sliamh11/deus-v2.git` pass origin
    validation. Fully anchored now.
  - The main-module guard (`fileURLToPath(import.meta.url) ===
    path.resolve(argv[1])`, copied from `scripts/migrate.mjs`) is broken
    for a script installed as a symlink — Node resolves `import.meta.url`
    through the symlink but leaves `argv[1]` unresolved, so `main()` would
    silently never run when invoked via the installed `~/.local/bin/deus-v2`
    symlink. Fixed via `fs.realpathSync`; verified with a real symlink +
    real subprocess test.
  - `fs.renameSync` (used to publish the staged clone) can't replace an
    existing directory on Windows even if empty, unlike POSIX — fixed by
    clearing an empty destination first.
  - The Windows `.cmd` shim's "is this ours" check was a loose substring
    match, then (after tightening) still missing a path-separator boundary
    — both closed via an exact, anchored structural regex.
  - Signal forwarding was changed to spawn the delegated child in its own
    process group (`detached: true`) to avoid a double-signal-delivery
    edge case, then **reverted** after discovering Node's `detached: true`
    on POSIX calls `setsid()` — a new *session*, not just a new process
    group — which would break real interactive delegate commands
    (`deus-cmd.sh` has genuine `read -r` prompts; `deus-v2 chat` is an
    interactive REPL). The double-signal risk is accepted as a documented,
    lower-severity tradeoff (verified `deus-cmd.sh`/`.ps1` have zero
    signal-trap logic today).
- **verification-gate**: SHIP — independently re-ran typecheck/lint/tests
  and re-traced every fix above against the actual code before signing off.

## Known limitations (disclosed, not hidden)

1. An interrupted first clone leaves a partial `~/deus-v2.staging.*`
   directory (never touching `~/deus-v2` itself) — safe to just retry.
2. On Windows, signal-forwarding to the delegated child is always a
   hard-kill (Node/OS limitation, not a regression).
3. The lock's dead-holder eviction is a check-then-act pattern and is not
   perfectly race-free without OS-level advisory locking (which Node's
   core `fs` doesn't expose and this file's build-free constraint rules
   out reaching for via a native module) — mitigated to a narrow,
   low-probability residual window, and made safe-by-construction via the
   staging+atomic-rename publish step (a lock race can at worst cause a
   redundant wasted clone, never checkout corruption).
4. No live, multi-process side-by-side smoke test was run this session
   (see LIA-451 status above).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (132 pre-existing warnings elsewhere, none
      in touched files)
- [x] `npx vitest run` (full suite) — 2079/2079 passing
- [x] `npx vitest run deus-v2-cmd.test.ts setup/cli.test.ts` — 70/70
      passing, including real (non-mocked) tests: a genuine
      `git worktree add` for linked-worktree rejection, a real symlink +
      real `node <symlink>` subprocess for the main-module fix, real
      subprocess signal-forwarding tests, and a `ps -o pgid=` process-group
      regression guard.
- [ ] Manual smoke test on a real machine (fresh `~/deus-v2` clone,
      `deus-v2 chat`, side-by-side with a live v1 `deus` install) —
      recommended before merge, not run this session.

🤖 Generated with Claude Code



## Windows CI findings (root-caused, not just patched)

Windows CI (`test-windows`) caught two real issues after everything else was
green:

1. **A repo-wide latent bug, not specific to this PR's code**:
   `deus-v2-cmd.test.ts` failed to even parse on Windows
   (`SyntaxError: Invalid or unexpected token`, 0 tests collected).
   Root-caused by reproducing locally: converting `deus-v2-cmd.mjs` to CRLF
   line endings and re-running vitest reproduces the exact failure. Isolated
   further -- the CRLF file passes both `node --check` and a standalone
   `vite.transformWithEsbuild()` call even when CRLF, so the failure is
   specific to Vitest's SSR/import-analysis pipeline when a top-level `.mjs`
   file with CRLF line endings is `import`-ed by a `.test.ts` file. This
   repo had **no `.gitattributes` at all**, so every text file was subject
   to `core.autocrlf` (true by default on GitHub Actions Windows runners).
   `deus-v2-cmd.mjs` appears to be the first top-level `.mjs` file in this
   repo actually imported (not just executed as a script) by a test file --
   `deus-cmd.sh`/`scripts/migrate.mjs` were equally exposed to this risk
   but never triggered it. **Added `.gitattributes`** (`* text=auto
   eol=lf`, with `*.ps1`/`*.cmd` excluded since those are Windows-native
   and never imported as ES modules) to close this repo-wide gap, not just
   work around it for this one file.
2. A new test asserted exact POSIX `chmod` mode-bit preservation, which
   doesn'''t hold on Windows (NTFS has no real executable-bit concept) --
   skipped that specific assertion on `win32`; the underlying fix
   (preserving `stat.mode` in `backupEntry`/`restoreEntry`) is unchanged
   and still exercised on POSIX.
