### PR TITLE
feat(sessions): add deterministic SessionEnd auto-save (no LLM turn)

### DIFF
--- a/scripts/auto_compress.py
+++ b/scripts/auto_compress.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Deterministic SessionEnd auto-save worker.
+
+Saves a mechanical (non-LLM) session record when a Claude Code session ends,
+without ever resuming the session as an agent -- the transcript is read only
+as structured JSONL *data* (turn/tool counts, timestamps, touched file
+paths), never as instructions for a model to act on.
+
+This is the direct fix for an earlier design that resumed the session via
+`claude -p --resume ... "/compress"` and could not be made safe:
+`--allowedTools` does not restrict the tool inventory (it only adds to
+whatever `~/.claude/settings.json` already allows -- confirmed empirically),
+and a `sandbox-exec` boundary left filesystem writes, inherited-environment
+secrets, and exfil-capable egress (e.g. Linear) all open. Removing the LLM
+turn removes the injection surface entirely: there is no tool-use loop for a
+hostile transcript to steer.
+
+Not the same feature as src/auto-compress.ts (WhatsApp/Telegram channel-
+session idle-save) -- unrelated, zero shared code, naming collision only.
+
+Extracted transcript strings (file paths, tool names) are treated as
+untrusted data end to end: sanitized (control characters stripped, length
+capped) before they ever reach a file, and tool names are bucketed against a
+known allowlist rather than reproduced verbatim.
+
+Checkpoints are deliberately NOT deleted here -- this worker never reads
+them, so it must never be the thing that destroys their content. See LIA-469
+for a separate, pre-existing gap in the interactive /compress skill's own
+(also unread) checkpoint deletion; this worker's correctness does not depend
+on that ticket being fixed.
+
+Exit code 0 = the mechanical log was written; non-zero = caller should retry.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+from stop_hook import _load_vault_root  # noqa: E402
+
+_MAX_FIELD_LEN = 300
+_MAX_FILES_SHOWN = 10
+_KNOWN_TOOLS = frozenset({
+    "Bash", "Read", "Write", "Edit", "MultiEdit", "Agent", "Skill",
+    "ToolSearch", "AskUserQuestion", "EnterWorktree", "ExitWorktree",
+    "Glob", "Grep", "WebFetch", "WebSearch", "NotebookEdit",
+})
+
+
+def _sanitize(s: str, max_len: int = _MAX_FIELD_LEN) -> str:
+    """Strip control characters (prevents frontmatter/YAML corruption and
+    fake-key injection into a spliced block) and cap length. Every string
+    extracted from a transcript is untrusted and must pass through this
+    before being templated into any file."""
+    cleaned = "".join(ch for ch in s if ch.isprintable())
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 1] + "…"
+    return cleaned
+
+
+def _bucket_tool_name(name: str) -> str:
+    """Known Claude Code tool names pass through; an MCP tool's `mcp__`
+    prefix is trusted as a namespace marker (assigned by the harness, not
+    transcript content), but everything AFTER that prefix is still
+    attacker-reachable transcript content and must be sanitized like any
+    other extracted string -- an exact `_KNOWN_TOOLS` match needs no
+    sanitizing (equality already constrains it to one of a small fixed set
+    of clean strings), but the `mcp__` branch does not have that guarantee.
+    Anything else buckets into `other` rather than reproducing an arbitrary
+    string verbatim."""
+    if name in _KNOWN_TOOLS:
+        return name
+    if name.startswith("mcp__"):
+        return _sanitize(name)
+    return "other"
+
+
+def extract_transcript_facts(transcript_path: str) -> dict:
+    """Parse the transcript JSONL as pure data -- never executed, never fed
+    to a model as instructions. Returns only counts/timestamps/file-paths."""
+    user_turns = 0
+    assistant_turns = 0
+    tool_counts: dict[str, int] = {}
+    file_paths: set[str] = set()
+    first_ts: str | None = None
+    last_ts: str | None = None
+
+    p = Path(transcript_path)
+    if not p.exists():
+        return {
+            "user_turns": 0,
+            "assistant_turns": 0,
+            "tool_counts": {},
+            "file_paths": [],
+            "first_ts": None,
+            "last_ts": None,
+        }
+
+    with p.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            t = obj.get("type")
+            if t == "user":
+                user_turns += 1
+            elif t == "assistant":
+                assistant_turns += 1
+            ts = obj.get("timestamp")
+            if isinstance(ts, str) and ts:
+                if first_ts is None:
+                    first_ts = ts
+                last_ts = ts
+            msg = obj.get("message")
+            content = msg.get("content") if isinstance(msg, dict) else None
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "tool_use":
+                        name = _bucket_tool_name(str(c.get("name", "")))
+                        tool_counts[name] = tool_counts.get(name, 0) + 1
+                        inp = c.get("input")
+                        if isinstance(inp, dict):
+                            fp = inp.get("file_path")
+                            if isinstance(fp, str) and fp:
+                                file_paths.add(_sanitize(fp))
+
+    return {
+        "user_turns": user_turns,
+        "assistant_turns": assistant_turns,
+        "tool_counts": tool_counts,
+        "file_paths": sorted(file_paths),
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+    }
+
+
+def render_log(session_id: str, cwd: str, facts: dict, sha256: str | None, date: str) -> str:
+    top_tools = sorted(facts["tool_counts"].items(), key=lambda kv: -kv[1])[:5]
+    tools_str = ", ".join(f"{name}:{count}" for name, count in top_tools) or "none"
+    files = facts["file_paths"][:_MAX_FILES_SHOWN]
+    extra = len(facts["file_paths"]) - len(files)
+    files_block = "\n".join(f"- {fp}" for fp in files) or "(none recorded)"
+    if extra > 0:
+        files_block += f"\n- (+{extra} more)"
+
+    tldr = (
+        f"Auto-saved (no LLM summary) -- {facts['user_turns']} user turns, "
+        f"{facts['assistant_turns']} assistant turns, top tools: {tools_str}. "
+        f"Time span: {facts['first_ts'] or 'unknown'} to {facts['last_ts'] or 'unknown'}."
+    )
+
+    lines = [
+        "---",
+        "type: session",
+        f"date: {date}",
+        "auto_generated: true",
+        "topics: []",
+        # json.dumps produces a double-quote-and-backslash-escaped string --
+        # a safe subset of YAML double-quoted scalar escaping -- so an
+        # embedded `"` (e.g. an unusual cwd) can't break out of the quotes.
+        f"project_path: {json.dumps(_sanitize(cwd))}",
+    ]
+    if sha256:
+        lines.append(f"source_transcript: {sha256}")
+    lines.append("tldr: |")
+    lines.append(f"  {tldr}")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "*Mechanically generated by the SessionEnd auto-save worker -- no "
+        "narrative summary, no decisions/key-learnings extracted. Run "
+        "`/compress` interactively on this session for a full write-up if "
+        "one is still wanted.*"
+    )
+    lines.append("")
+    lines.append("## Files touched (raw paths, unverified)")
+    lines.append("")
+    lines.append(files_block)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _run_child(argv: list[str], vault: Path, cwd: str, timeout: int) -> "subprocess.CompletedProcess[str]":
+    """Every child subprocess inherits the SAME already-resolved vault via
+    DEUS_VAULT_PATH -- the highest-priority tier of every downstream
+    resolver -- so it never independently re-resolves (and potentially
+    disagrees with) the vault this worker already picked."""
+    env = {**os.environ, "DEUS_VAULT_PATH": str(vault)}
+    return subprocess.run(
+        argv, cwd=cwd, env=env, timeout=timeout, capture_output=True, text=True,
+    )
+
+
+def run(session_id: str, transcript_path: str, cwd: str, timeout: int = 120) -> int:
+    vault = _load_vault_root(cwd=Path(cwd))
+    if vault is None:
+        print("auto_compress: no vault resolvable, aborting", file=sys.stderr)
+        return 1
+
+    facts = extract_transcript_facts(transcript_path)
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    log_dir = vault / "Session-Logs" / date
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"auto-{session_id[:8]}.md"
+
+    # Archive first, pinned to the EXACT transcript path (never --cwd
+    # auto-discovery, which could bind to a sibling session's transcript
+    # under concurrent same-cwd sessions).
+    sha256: str | None = None
+    try:
+        result = _run_child(
+            [
+                sys.executable, str(SCRIPTS_DIR / "transcript_archive.py"),
+                "--transcript", transcript_path, "--json", "--best-effort",
+            ],
+            vault, cwd, timeout,
+        )
+        if result.returncode == 0 and result.stdout:
+            payload = json.loads(result.stdout)
+            if payload.get("ok"):
+                sha256 = payload.get("sha256")
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, json.JSONDecodeError, OSError) as e:
+        print(f"auto_compress: archival step failed (non-fatal): {e}", file=sys.stderr)
+
+    log_path.write_text(render_log(session_id, cwd, facts, sha256, date), encoding="utf-8")
+
+    # Sync pending tasks (read-only against Linear -- no write path exists in
+    # sync_linear_pending.py; the automated worker never calls
+    # linear_createIssue/createComment or any other Linear write).
+    try:
+        _run_child(
+            [sys.executable, str(SCRIPTS_DIR / "sync_linear_pending.py"), "--write"],
+            vault, cwd, timeout,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError) as e:
+        print(f"auto_compress: pending sync failed (non-fatal): {e}", file=sys.stderr)
+
+    tldr_first_line = _sanitize(
+        f"Auto-saved: {facts['user_turns']} user + {facts['assistant_turns']} assistant turns"
+    )
+    try:
+        _run_child(
+            [
+                sys.executable, str(SCRIPTS_DIR / "sync_linear_pending.py"),
+                "--write-previous", f"{date}: {tldr_first_line}",
+            ],
+            vault, cwd, timeout,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError) as e:
+        print(f"auto_compress: previous-block update failed (non-fatal): {e}", file=sys.stderr)
+
+    # Index only -- --no-extract is required, not optional: bare --add
+    # defaults to running a real LLM atom-extraction call whose prompt
+    # naively concatenates the log content with zero escaping.
+    try:
+        _run_child(
+            [
+                sys.executable, str(SCRIPTS_DIR / "memory_indexer.py"),
+                "--add", str(log_path), "--no-extract",
+            ],
+            vault, cwd, timeout,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError) as e:
+        print(f"auto_compress: indexing failed (non-fatal): {e}", file=sys.stderr)
+
+    return 0 if log_path.exists() else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--transcript-path", required=True)
+    parser.add_argument("--cwd", required=True)
+    parser.add_argument("--timeout", type=int, default=120)
+    args = parser.parse_args()
+    return run(args.session_id, args.transcript_path, args.cwd, args.timeout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -100,6 +100,14 @@ def main():
         "credential_probe", [cred_probe], dry_run
     )
 
+    # SessionEnd auto-save safety net: recovers queue entries a crashed/killed
+    # detached worker missed. Up to 3 entries x compress_sweep's own worker
+    # ceiling (120s default) + slack.
+    compress_sweep = str(SCRIPTS_DIR / "maintenance" / "compress_sweep.py")
+    results["compress_sweep"] = run_task(
+        "compress_sweep", [compress_sweep], dry_run, timeout=600,
+    )
+
     # ── Weekly tasks (Sunday or --weekly) ────────────────────────────────────
 
     if run_weekly:

--- a/scripts/maintenance/compress_sweep.py
+++ b/scripts/maintenance/compress_sweep.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Safety net for the SessionEnd auto-save queue (see ../session_end_hook.py and
+../auto_compress.py). Recovers entries a crashed/killed detached worker
+missed:
+
+- Stale `*.json` (queued_at older than the debounce window): process
+  synchronously via the same claim -> run -> outcome path the worker uses.
+- Orphaned `*.json.running` (older than 2x the worker's own belt window):
+  the worker that claimed it died mid-run; reset for retry.
+- `attempts >= 3`: give up, rename to `.failed`, print one stderr line
+  (surfaces in logs/maintenance.log for /review-logs).
+
+Capped at 3 entries per run to bound runtime and daily cost. Registered in
+scripts/maintenance.py's Daily section.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+from session_end_hook import (  # noqa: E402
+    QUEUE_DIR,
+    _debounce_minutes,
+    _worker_ceiling,
+    process_entry,
+)
+
+MAX_ENTRIES_PER_RUN = 3
+MAX_ATTEMPTS = 3
+
+
+def sweep(dry_run: bool = False) -> int:
+    if not QUEUE_DIR.exists():
+        print("compress_sweep: no queue dir, nothing to do")
+        return 0
+
+    debounce_s = _debounce_minutes() * 60
+    ceiling = _worker_ceiling()
+    running_stale_after = 2 * (debounce_s + ceiling)
+
+    now = time.time()
+    processed = 0
+
+    for running in sorted(QUEUE_DIR.glob("*.json.running")):
+        try:
+            age = now - running.stat().st_mtime
+        except OSError:
+            continue
+        if age <= running_stale_after:
+            continue
+        json_path = running.with_suffix("")
+        if dry_run:
+            print(f"compress_sweep: would recover orphaned {running.name}")
+            continue
+        try:
+            payload = json.loads(running.read_text())
+        except (json.JSONDecodeError, OSError):
+            running.unlink(missing_ok=True)
+            continue
+        payload["attempts"] = payload.get("attempts", 0) + 1
+        tmp = json_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, json_path)
+        running.unlink(missing_ok=True)
+        print(f"compress_sweep: recovered orphaned {running.name} -> attempts={payload['attempts']}")
+
+    entries = sorted(QUEUE_DIR.glob("*.json"))
+    for entry in entries:
+        if processed >= MAX_ENTRIES_PER_RUN:
+            print(f"compress_sweep: hit {MAX_ENTRIES_PER_RUN}-entry cap, {len(entries) - processed} remaining for next run")
+            break
+        try:
+            payload = json.loads(entry.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        try:
+            queued_age = now - entry.stat().st_mtime
+        except OSError:
+            continue
+        if queued_age <= debounce_s:
+            continue  # not stale yet -- the debounced worker still owns this
+
+        if payload.get("attempts", 0) >= MAX_ATTEMPTS:
+            failed = entry.with_suffix(".failed")
+            if not dry_run:
+                entry.rename(failed)
+            print(
+                f"compress_sweep: {entry.name} exceeded {MAX_ATTEMPTS} attempts, "
+                f"giving up (renamed to {failed.name})",
+                file=sys.stderr,
+            )
+            continue
+
+        if dry_run:
+            print(f"compress_sweep: would process stale {entry.name}")
+            processed += 1
+            continue
+
+        running = entry.with_suffix(".json.running")
+        try:
+            os.rename(entry, running)
+        except FileNotFoundError:
+            continue  # lost the race
+        process_entry(payload, running, ceiling)
+        processed += 1
+
+    print(f"compress_sweep: processed {processed} stale entr{'y' if processed == 1 else 'ies'}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true", help="Print what would happen; touch nothing.")
+    args = parser.parse_args(argv)
+    return sweep(args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -42,11 +42,12 @@ from stop_hook import (  # noqa: E402
     _load_vault_root,
 )
 
-QUEUE_DIR = Path(os.environ.get("DEUS_AUTO_COMPRESS_QUEUE_DIR", "~/.deus/compress_queue")).expanduser()
-LOG_PATH = Path(os.environ.get("DEUS_AUTO_COMPRESS_LOG", "~/.deus/auto_compress.log")).expanduser()
+QUEUE_DIR = Path(os.environ.get("DEUS_AUTO_COMPRESS_QUEUE_DIR", "~/.deus/compress_queue")).expanduser()  # #1079
+LOG_PATH = Path(os.environ.get("DEUS_AUTO_COMPRESS_LOG", "~/.deus/auto_compress.log")).expanduser()  # #1079
 
 
 def _debounce_minutes() -> float:
+    # DEUS_AUTO_COMPRESS_DEBOUNCE_MIN: #1079
     try:
         v = float(os.environ.get("DEUS_AUTO_COMPRESS_DEBOUNCE_MIN", "30"))
         return v if v > 0 else 30.0
@@ -55,6 +56,7 @@ def _debounce_minutes() -> float:
 
 
 def _worker_ceiling() -> int:
+    # DEUS_AUTO_COMPRESS_TIMEOUT: #1079
     try:
         v = int(os.environ.get("DEUS_AUTO_COMPRESS_TIMEOUT", "120"))
         return v if v > 0 else 120
@@ -123,7 +125,7 @@ def main() -> None:
 
     if _is_bg_session():
         return  # bg sessions have their own separate blocking Stop-gate
-    if os.environ.get("DEUS_AUTO_COMPRESS") == "0":
+    if os.environ.get("DEUS_AUTO_COMPRESS") == "0":  # #1079
         return  # opt-out
 
     session_id = data.get("session_id")

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+SessionEnd hook: enqueue + debounced worker for the deterministic auto-save
+mechanism (see auto_compress.py for what actually gets written and why the
+mechanism has no LLM turn / injection surface).
+
+Parent mode (the hook itself) must return fast and exit 0 always -- errors
+surface on stderr, never block Claude Code.
+
+Fires only for Claude Code sessions (SessionEnd is a Claude-Code-specific
+hook event; other backends get zero auto-save coverage under this design --
+a known, accepted scope limit, not a silent gap, consistent with
+docs/decisions/hook-dispatch-facade-correction.md's finding that hook
+*triggers* are Claude-Code-coupled).
+
+Input: SessionEnd JSON on stdin,
+  {"session_id", "transcript_path", "cwd", "hook_event_name", "reason"}
+
+Worker mode (--worker <session_id>): sleeps out the debounce window, then
+validates, claims, and runs auto_compress.py. The `com.deus.maintenance`
+daily sweep (scripts/maintenance/compress_sweep.py) is the safety net for
+anything a crashed/killed worker misses.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+from _time import utc_now  # noqa: E402
+from stop_hook import (  # noqa: E402
+    BG_COMPRESS_MIN_TURNS,
+    _compress_already_ran,
+    _count_transcript_turns,
+    _is_bg_session,
+    _load_vault_root,
+)
+
+QUEUE_DIR = Path(os.environ.get("DEUS_AUTO_COMPRESS_QUEUE_DIR", "~/.deus/compress_queue")).expanduser()
+LOG_PATH = Path(os.environ.get("DEUS_AUTO_COMPRESS_LOG", "~/.deus/auto_compress.log")).expanduser()
+
+
+def _debounce_minutes() -> float:
+    try:
+        v = float(os.environ.get("DEUS_AUTO_COMPRESS_DEBOUNCE_MIN", "30"))
+        return v if v > 0 else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _worker_ceiling() -> int:
+    try:
+        v = int(os.environ.get("DEUS_AUTO_COMPRESS_TIMEOUT", "120"))
+        return v if v > 0 else 120
+    except (TypeError, ValueError):
+        return 120
+
+
+def _entry_path(session_id: str) -> Path:
+    return QUEUE_DIR / f"{session_id}.json"
+
+
+def _log_line(payload: dict) -> None:
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(payload) + "\n")
+    except OSError:
+        pass
+
+
+def _enqueue(session_id: str, transcript_path: str, cwd: str) -> None:
+    QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+    entry = _entry_path(session_id)
+    tmp = entry.with_suffix(".json.tmp")
+    try:
+        # Sub-second precision matters: a session can reopen within the same
+        # wall-clock second the queue entry was written, and truncating to a
+        # whole second would silently mask that as "unchanged".
+        mtime = Path(transcript_path).stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    payload = {
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+        "cwd": cwd,
+        "queued_at": utc_now().isoformat(),
+        "transcript_mtime": mtime,
+        "attempts": 0,
+    }
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, entry)
+
+
+def _spawn_worker(session_id: str) -> None:
+    """A session ending multiple times in quick succession (re-enqueue on
+    each SessionEnd) spawns multiple concurrent sleeping worker processes for
+    the same session_id -- harmless, not a race: each re-reads the entry
+    after its own sleep, and only one wins the atomic os.rename claim in
+    _worker_body; every loser sees FileNotFoundError and exits as a no-op."""
+    subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), "--worker", session_id],
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def main() -> None:
+    """Fast parent path: validate, enqueue, spawn, return. Never raises past
+    __main__'s own guard -- a slow/failing hook must not block Claude Code."""
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except (json.JSONDecodeError, OSError):
+        return
+
+    if _is_bg_session():
+        return  # bg sessions have their own separate blocking Stop-gate
+    if os.environ.get("DEUS_AUTO_COMPRESS") == "0":
+        return  # opt-out
+
+    session_id = data.get("session_id")
+    transcript_path = data.get("transcript_path")
+    cwd = data.get("cwd")
+    if not session_id or not transcript_path or not cwd:
+        return
+
+    if _load_vault_root(cwd=Path(cwd)) is None:
+        return  # no vault resolvable -- avoid a wasted spawn
+
+    if _count_transcript_turns(transcript_path) < BG_COMPRESS_MIN_TURNS:
+        return  # trivial session
+
+    if _compress_already_ran(transcript_path):
+        return  # user already ran /compress interactively this session
+
+    _enqueue(session_id, transcript_path, cwd)
+    _spawn_worker(session_id)
+
+
+def _run_worker(session_id: str) -> None:
+    """Detached worker. Arms a wall-clock belt first (LIA-235 pattern) so a
+    hung child can't leave an orphan."""
+    ceiling = _worker_ceiling()
+    debounce_s = _debounce_minutes() * 60
+    timer = threading.Timer(debounce_s + ceiling + 120, os._exit, args=(0,))
+    timer.daemon = True
+    timer.start()
+    try:
+        _worker_body(session_id, debounce_s, ceiling)
+    finally:
+        timer.cancel()
+
+
+def _worker_body(session_id: str, debounce_s: float, ceiling: int) -> None:
+    time.sleep(debounce_s)
+
+    entry = _entry_path(session_id)
+    if not entry.exists():
+        return  # already claimed/processed by another worker or the sweep
+
+    try:
+        payload = json.loads(entry.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+
+    transcript_path = payload["transcript_path"]
+    try:
+        current_mtime = Path(transcript_path).stat().st_mtime
+    except OSError:
+        current_mtime = -1.0
+
+    if current_mtime != payload.get("transcript_mtime"):
+        # Session was re-opened after enqueue -- re-arm with fresh timestamps
+        # rather than compressing a still-live session. The re-opened
+        # session's own SessionEnd will re-spawn a worker when it truly ends;
+        # the daily sweep is the backstop if it never comes.
+        payload["queued_at"] = utc_now().isoformat()
+        payload["transcript_mtime"] = current_mtime
+        tmp = entry.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, entry)
+        return
+
+    if _compress_already_ran(transcript_path):
+        return  # user compressed manually while this worker was sleeping
+
+    running = entry.with_suffix(".json.running")
+    try:
+        os.rename(entry, running)
+    except FileNotFoundError:
+        return  # lost the claim race to another worker/the sweep
+
+    process_entry(payload, running, ceiling)
+
+
+def process_entry(payload: dict, running_path: Path, ceiling: int) -> None:
+    """Shared claim->run->outcome path, reused by the sweep for stale
+    recovery. `running_path` is the already-claimed `.json.running` file."""
+    t0 = time.time()
+    session_id = payload["session_id"]
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPTS_DIR / "auto_compress.py"),
+            "--session-id", session_id,
+            "--transcript-path", payload["transcript_path"],
+            "--cwd", payload["cwd"],
+            "--timeout", str(ceiling),
+        ],
+        timeout=ceiling + 10,
+        capture_output=True,
+        text=True,
+    )
+    duration_ms = int((time.time() - t0) * 1000)
+    success = result.returncode == 0
+
+    log_entry = {
+        "ts": utc_now().isoformat(),
+        "session_id": session_id,
+        "is_error": not success,
+        "duration_ms": duration_ms,
+    }
+    if not success and result.stderr:
+        log_entry["stderr"] = result.stderr[-500:]
+    _log_line(log_entry)
+
+    if success:
+        try:
+            running_path.unlink()
+        except OSError:
+            pass
+    else:
+        payload["attempts"] = payload.get("attempts", 0) + 1
+        json_path = running_path.with_suffix("")
+        tmp = json_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, json_path)
+        try:
+            running_path.unlink()
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    if "--worker" in sys.argv:
+        try:
+            _run_worker(sys.argv[sys.argv.index("--worker") + 1])
+        except Exception as e:
+            sys.stderr.write(f"[session-end-hook worker] {type(e).__name__}: {e}\n")
+    else:
+        try:
+            main()
+        except Exception as e:
+            sys.stderr.write(f"[session-end-hook] {type(e).__name__}: {e}\n")

--- a/scripts/stop_hook.py
+++ b/scripts/stop_hook.py
@@ -26,11 +26,30 @@ from _time import local_now, utc_now  # noqa: E402
 # ── Config ────────────────────────────────────────────────────────────────────
 
 
-def _load_vault_root() -> Path | None:
-    """Resolve vault root from DEUS_VAULT_PATH env var or config.json."""
+def _load_vault_root(cwd: Path | None = None) -> Path | None:
+    """Resolve vault root: DEUS_VAULT_PATH env -> <cwd>/.deus/config.json
+    (per-instance override) -> ~/.config/deus/config.json (global fallback).
+
+    Matches the compress skill's own 3-tier resolution order
+    (.claude/skills/compress/skill.md). The per-instance tier is a STOP, not a
+    fall-through: if that file exists but has no usable vault_path, return
+    None rather than falling back to the global config -- a fall-through is
+    what would let one instance's resolver corrupt another instance's vault.
+    `cwd=None` (both existing call sites) preserves the prior 2-tier-only
+    behavior exactly.
+    """
     env_path = os.environ.get("DEUS_VAULT_PATH")
     if env_path:
         return Path(env_path).expanduser()
+    if cwd is not None:
+        instance_cfg = cwd / ".deus" / "config.json"
+        if instance_cfg.exists():
+            try:
+                cfg = json.loads(instance_cfg.read_text())
+            except (json.JSONDecodeError, OSError):
+                return None  # STOP -- do not fall through to global config
+            vp = cfg.get("vault_path")
+            return Path(vp).expanduser() if vp else None  # STOP either way
     cfg_path = Path("~/.config/deus/config.json").expanduser()
     if cfg_path.exists():
         try:

--- a/scripts/tests/test_auto_compress_queue.py
+++ b/scripts/tests/test_auto_compress_queue.py
@@ -1,0 +1,299 @@
+"""Tests for scripts/session_end_hook.py (enqueue + debounced worker) and
+scripts/maintenance/compress_sweep.py (the stale-entry safety net).
+
+All auto_compress.py subprocess dispatches are stubbed — these tests never
+invoke the real worker script.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+stop_hook = _load("stop_hook", _ROOT / "scripts" / "stop_hook.py")
+seh = _load("session_end_hook", _ROOT / "scripts" / "session_end_hook.py")
+sweep_mod = _load("compress_sweep", _ROOT / "scripts" / "maintenance" / "compress_sweep.py")
+
+
+@pytest.fixture(autouse=True)
+def isolate_queue_and_log(tmp_path, monkeypatch):
+    queue_dir = tmp_path / "compress_queue"
+    log_path = tmp_path / "auto_compress.log"
+    monkeypatch.setattr(seh, "QUEUE_DIR", queue_dir)
+    monkeypatch.setattr(seh, "LOG_PATH", log_path)
+    monkeypatch.setattr(sweep_mod, "QUEUE_DIR", queue_dir)
+    monkeypatch.delenv("CLAUDE_JOB_DIR", raising=False)
+    monkeypatch.delenv("DEUS_AUTO_COMPRESS", raising=False)
+
+
+@pytest.fixture
+def fake_vault(tmp_path, monkeypatch):
+    v = tmp_path / "vault"
+    v.mkdir()
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(v))
+    return v
+
+
+def _real_transcript(tmp_path, n_turns=6):
+    p = tmp_path / "transcript.jsonl"
+    lines = []
+    for i in range(n_turns):
+        lines.append(json.dumps({"type": "user" if i % 2 == 0 else "assistant", "timestamp": f"2026-01-01T00:0{i}:00Z"}))
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+# ── Parent-side enqueue gates ─────────────────────────────────────────────────
+
+def test_main_skips_bg_session(tmp_path, fake_vault, monkeypatch):
+    monkeypatch.setenv("CLAUDE_JOB_DIR", str(tmp_path))
+    transcript = _real_transcript(tmp_path)
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: json.dumps(
+        {"session_id": "s1", "transcript_path": str(transcript), "cwd": str(tmp_path)})})())
+    seh.main()
+    assert not seh.QUEUE_DIR.exists() or not list(seh.QUEUE_DIR.glob("*.json"))
+
+
+def test_main_skips_on_opt_out(tmp_path, fake_vault, monkeypatch):
+    monkeypatch.setenv("DEUS_AUTO_COMPRESS", "0")
+    transcript = _real_transcript(tmp_path)
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: json.dumps(
+        {"session_id": "s1", "transcript_path": str(transcript), "cwd": str(tmp_path)})})())
+    seh.main()
+    assert not seh.QUEUE_DIR.exists() or not list(seh.QUEUE_DIR.glob("*.json"))
+
+
+def test_main_skips_trivial_session(tmp_path, fake_vault, monkeypatch):
+    transcript = _real_transcript(tmp_path, n_turns=2)  # below BG_COMPRESS_MIN_TURNS
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: json.dumps(
+        {"session_id": "s1", "transcript_path": str(transcript), "cwd": str(tmp_path)})})())
+    seh.main()
+    assert not seh.QUEUE_DIR.exists() or not list(seh.QUEUE_DIR.glob("*.json"))
+
+
+def test_main_skips_when_no_vault(tmp_path, monkeypatch):
+    # Stub the resolver rather than just unsetting the env var -- the real
+    # dev machine's global ~/.config/deus/config.json would otherwise still
+    # resolve a real vault, defeating the test's intent.
+    monkeypatch.setattr(seh, "_load_vault_root", lambda cwd=None: None)
+    transcript = _real_transcript(tmp_path)
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: json.dumps(
+        {"session_id": "s1", "transcript_path": str(transcript), "cwd": str(tmp_path)})})())
+    seh.main()
+    assert not seh.QUEUE_DIR.exists() or not list(seh.QUEUE_DIR.glob("*.json"))
+
+
+def test_main_skips_when_compress_already_ran(tmp_path, fake_vault, monkeypatch):
+    p = tmp_path / "transcript.jsonl"
+    lines = [json.dumps({"type": "user", "timestamp": f"2026-01-01T00:0{i}:00Z"}) for i in range(6)]
+    lines.append(json.dumps({
+        "message": {"content": [{"type": "tool_use", "name": "Skill", "input": {"skill": "compress"}}]},
+    }))
+    p.write_text("\n".join(lines), encoding="utf-8")
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: json.dumps(
+        {"session_id": "s1", "transcript_path": str(p), "cwd": str(tmp_path)})})())
+    monkeypatch.setattr(seh, "_spawn_worker", lambda sid: pytest.fail("should not spawn"))
+    seh.main()
+    assert not seh.QUEUE_DIR.exists() or not list(seh.QUEUE_DIR.glob("*.json"))
+
+
+def test_main_enqueues_and_spawns_on_valid_session(tmp_path, fake_vault, monkeypatch):
+    transcript = _real_transcript(tmp_path)
+    spawned = []
+    monkeypatch.setattr(seh, "_spawn_worker", lambda sid: spawned.append(sid))
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: json.dumps(
+        {"session_id": "sess-abc", "transcript_path": str(transcript), "cwd": str(tmp_path)})})())
+    seh.main()
+    assert spawned == ["sess-abc"]
+    entry = seh.QUEUE_DIR / "sess-abc.json"
+    assert entry.exists()
+    payload = json.loads(entry.read_text())
+    assert payload["session_id"] == "sess-abc"
+    assert payload["attempts"] == 0
+
+
+def test_enqueue_overwrite_resets_queued_at(tmp_path):
+    seh._enqueue("s1", str(tmp_path / "t.jsonl"), str(tmp_path))
+    first = json.loads(seh._entry_path("s1").read_text())
+    time.sleep(0.01)
+    seh._enqueue("s1", str(tmp_path / "t.jsonl"), str(tmp_path))
+    second = json.loads(seh._entry_path("s1").read_text())
+    assert second["queued_at"] != first["queued_at"] or second["queued_at"] >= first["queued_at"]
+
+
+# ── Worker: claim race, mtime re-arm, success/failure ────────────────────────
+
+@pytest.fixture
+def stub_auto_compress_success(monkeypatch):
+    calls = []
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(argv, timeout=None, capture_output=True, text=True):
+        calls.append(argv)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(seh.subprocess, "run", _fake_run)
+    return calls
+
+
+@pytest.fixture
+def stub_auto_compress_failure(monkeypatch):
+    class _FakeCompleted:
+        returncode = 1
+        stdout = ""
+        stderr = "boom"
+
+    monkeypatch.setattr(seh.subprocess, "run", lambda *a, **k: _FakeCompleted())
+
+
+def test_worker_body_success_deletes_entry(tmp_path, stub_auto_compress_success):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    seh._enqueue("sid1", str(transcript), str(tmp_path))
+    seh._worker_body("sid1", debounce_s=0, ceiling=5)
+    assert not seh._entry_path("sid1").exists()
+    assert not seh._entry_path("sid1").with_suffix(".json.running").exists()
+    assert stub_auto_compress_success  # auto_compress.py was actually invoked
+
+
+def test_worker_body_failure_increments_attempts(tmp_path, stub_auto_compress_failure):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    seh._enqueue("sid1", str(transcript), str(tmp_path))
+    seh._worker_body("sid1", debounce_s=0, ceiling=5)
+    entry = seh._entry_path("sid1")
+    assert entry.exists()
+    payload = json.loads(entry.read_text())
+    assert payload["attempts"] == 1
+
+
+def test_worker_body_rearms_on_mtime_change(tmp_path, stub_auto_compress_success):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("v1", encoding="utf-8")
+    seh._enqueue("sid1", str(transcript), str(tmp_path))
+    time.sleep(0.02)
+    transcript.write_text("v2 -- session reopened", encoding="utf-8")  # mtime changes
+    seh._worker_body("sid1", debounce_s=0, ceiling=5)
+    assert not stub_auto_compress_success  # never invoked
+    entry = seh._entry_path("sid1")
+    assert entry.exists()  # re-armed, not claimed
+
+
+def test_worker_body_missing_entry_is_noop(tmp_path, stub_auto_compress_success):
+    seh._worker_body("nonexistent", debounce_s=0, ceiling=5)
+    assert not stub_auto_compress_success
+
+
+def test_worker_body_claim_race_only_one_proceeds(tmp_path, stub_auto_compress_success):
+    """Simulate: worker A claims (renames to .running); worker B then tries the
+    same entry and must lose the race (FileNotFoundError -> no-op)."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    seh._enqueue("sid1", str(transcript), str(tmp_path))
+
+    entry = seh._entry_path("sid1")
+    import os
+    running = entry.with_suffix(".json.running")
+    os.rename(entry, running)  # simulate worker A having already claimed it
+
+    # Worker B's body would find no entry.json at all now.
+    seh._worker_body("sid1", debounce_s=0, ceiling=5)
+    assert not stub_auto_compress_success
+    assert running.exists()  # worker A's claim untouched by B
+
+
+# ── Sweep ─────────────────────────────────────────────────────────────────────
+
+def test_sweep_recovers_orphaned_running(tmp_path, stub_auto_compress_success, monkeypatch):
+    seh.QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+    running = seh.QUEUE_DIR / "sid1.json.running"
+    running.write_text(json.dumps({
+        "session_id": "sid1", "transcript_path": str(tmp_path / "t.jsonl"),
+        "cwd": str(tmp_path), "queued_at": "x", "transcript_mtime": 0, "attempts": 0,
+    }), encoding="utf-8")
+    old_time = time.time() - 100000
+    import os
+    os.utime(running, (old_time, old_time))
+
+    sweep_mod.sweep(dry_run=False)
+    assert not running.exists()
+    recovered = seh.QUEUE_DIR / "sid1.json"
+    assert recovered.exists()
+    assert json.loads(recovered.read_text())["attempts"] == 1
+
+
+def test_sweep_gives_up_after_max_attempts(tmp_path):
+    seh.QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+    entry = seh.QUEUE_DIR / "sid1.json"
+    entry.write_text(json.dumps({
+        "session_id": "sid1", "transcript_path": str(tmp_path / "t.jsonl"),
+        "cwd": str(tmp_path), "queued_at": "x", "transcript_mtime": 0, "attempts": 3,
+    }), encoding="utf-8")
+    old_time = time.time() - 100000
+    import os
+    os.utime(entry, (old_time, old_time))
+
+    sweep_mod.sweep(dry_run=False)
+    assert not entry.exists()
+    assert (seh.QUEUE_DIR / "sid1.failed").exists()
+
+
+def test_sweep_caps_entries_per_run(tmp_path, stub_auto_compress_success):
+    seh.QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+    old_time = time.time() - 100000
+    import os
+    for i in range(5):
+        entry = seh.QUEUE_DIR / f"sid{i}.json"
+        entry.write_text(json.dumps({
+            "session_id": f"sid{i}", "transcript_path": str(tmp_path / "t.jsonl"),
+            "cwd": str(tmp_path), "queued_at": "x", "transcript_mtime": 0, "attempts": 0,
+        }), encoding="utf-8")
+        os.utime(entry, (old_time, old_time))
+
+    sweep_mod.sweep(dry_run=False)
+    remaining = list(seh.QUEUE_DIR.glob("*.json"))
+    processed = 5 - len(remaining)
+    assert processed == sweep_mod.MAX_ENTRIES_PER_RUN
+
+
+def test_sweep_dry_run_touches_nothing(tmp_path):
+    seh.QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+    entry = seh.QUEUE_DIR / "sid1.json"
+    entry.write_text(json.dumps({
+        "session_id": "sid1", "transcript_path": str(tmp_path / "t.jsonl"),
+        "cwd": str(tmp_path), "queued_at": "x", "transcript_mtime": 0, "attempts": 0,
+    }), encoding="utf-8")
+    old_time = time.time() - 100000
+    import os
+    os.utime(entry, (old_time, old_time))
+
+    sweep_mod.sweep(dry_run=True)
+    assert entry.exists()
+    payload = json.loads(entry.read_text())
+    assert payload["attempts"] == 0
+
+
+def test_sweep_no_queue_dir_is_noop():
+    assert sweep_mod.sweep(dry_run=False) == 0

--- a/scripts/tests/test_auto_compress_script.py
+++ b/scripts/tests/test_auto_compress_script.py
@@ -1,0 +1,304 @@
+"""Tests for scripts/auto_compress.py — the deterministic (no-LLM-turn)
+SessionEnd auto-save worker.
+
+No real subprocess/LLM calls: child dispatches are monkeypatched with a
+recording stub so tests assert on exact argv, never on live network/LLM
+behavior.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+stop_hook = _load("stop_hook", _ROOT / "scripts" / "stop_hook.py")
+ac = _load("auto_compress", _ROOT / "scripts" / "auto_compress.py")
+
+
+# ── extract_transcript_facts ─────────────────────────────────────────────────
+
+def _write_transcript(path: Path, lines: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(x) for x in lines), encoding="utf-8")
+
+
+def test_extract_facts_counts_turns_and_tools(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, [
+        {"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": "hi"}},
+        {
+            "type": "assistant", "timestamp": "2026-01-01T00:01:00Z",
+            "message": {"content": [
+                {"type": "tool_use", "name": "Bash", "input": {}},
+                {"type": "tool_use", "name": "Edit", "input": {"file_path": "/a/b.py"}},
+            ]},
+        },
+        {"type": "user", "timestamp": "2026-01-01T00:02:00Z", "message": {"content": "more"}},
+        {
+            "type": "assistant", "timestamp": "2026-01-01T00:03:00Z",
+            "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {}}]},
+        },
+    ])
+    facts = ac.extract_transcript_facts(str(transcript))
+    assert facts["user_turns"] == 2
+    assert facts["assistant_turns"] == 2
+    assert facts["tool_counts"] == {"Bash": 2, "Edit": 1}
+    assert facts["file_paths"] == ["/a/b.py"]
+    assert facts["first_ts"] == "2026-01-01T00:00:00Z"
+    assert facts["last_ts"] == "2026-01-01T00:03:00Z"
+
+
+def test_extract_facts_missing_transcript_returns_zeros(tmp_path):
+    facts = ac.extract_transcript_facts(str(tmp_path / "nope.jsonl"))
+    assert facts == {
+        "user_turns": 0, "assistant_turns": 0, "tool_counts": {},
+        "file_paths": [], "first_ts": None, "last_ts": None,
+    }
+
+
+def test_extract_facts_skips_malformed_lines(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("not json\n" + json.dumps({"type": "user"}) + "\n\n", encoding="utf-8")
+    facts = ac.extract_transcript_facts(str(transcript))
+    assert facts["user_turns"] == 1
+
+
+# ── tool-name bucketing + sanitization (the injected-content-safety layer) ──
+
+def test_bucket_tool_name_known_and_unknown():
+    assert ac._bucket_tool_name("Bash") == "Bash"
+    assert ac._bucket_tool_name("mcp__linear__linear_createIssue") == "mcp__linear__linear_createIssue"
+    assert ac._bucket_tool_name("SomeAdversarialToolName") == "other"
+
+
+def test_sanitize_strips_control_chars_and_caps_length():
+    dirty = "a\nb\rc" + "x" * 400
+    clean = ac._sanitize(dirty)
+    assert "\n" not in clean
+    assert "\r" not in clean
+    assert len(clean) <= 300
+
+
+def test_extract_facts_sanitizes_embedded_newline_in_file_path(tmp_path):
+    """Adversarial: a crafted file_path with an embedded newline + fake YAML
+    key must not survive into extracted data unsanitized — this is what
+    prevents frontmatter corruption in render_log."""
+    transcript = tmp_path / "t.jsonl"
+    evil_path = "/tmp/evil.py\nfake_key: not_really_a_yaml_key"
+    _write_transcript(transcript, [
+        {
+            "type": "assistant", "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"content": [{"type": "tool_use", "name": "Write", "input": {"file_path": evil_path}}]},
+        },
+    ])
+    facts = ac.extract_transcript_facts(str(transcript))
+    assert len(facts["file_paths"]) == 1
+    assert "\n" not in facts["file_paths"][0]
+
+
+# ── render_log: frontmatter stays well-formed under adversarial input ───────
+# (code-review round 1 caught two reproduced bugs here: _bucket_tool_name
+# returned mcp__-prefixed names verbatim/unsanitized, and an unescaped `"` in
+# project_path broke the quoted scalar — plain substring checks missed both.
+# The parser below is deliberately minimal/self-contained rather than a real
+# YAML library (pyyaml isn't a declared project dependency) — it parses
+# exactly render_log's own known, fixed key set as scalar `key: value` lines
+# plus the `tldr: |` block literal, which is sufficient to prove no extra
+# key was injected and no known key's value was overwritten by injected
+# content, without adding a new dependency for a test-only concern.)
+
+_FRONTMATTER_KEYS = {"type", "date", "auto_generated", "topics", "project_path", "source_transcript"}
+
+
+def _parse_frontmatter(text: str) -> dict:
+    lines = text.splitlines()
+    assert lines[0] == "---"
+    close_idx = lines[1:].index("---") + 1
+    body = lines[1:close_idx]
+
+    result = {}
+    i = 0
+    while i < len(body):
+        line = body[i]
+        if line == "tldr: |":
+            i += 1
+            # tldr's block-literal content is everything indented under it;
+            # a genuinely injected line would appear here at column 0
+            # instead (proving it broke out), which the caller can assert on.
+            block = []
+            while i < len(body) and (body[i].startswith("  ") or body[i] == ""):
+                block.append(body[i])
+                i += 1
+            result["tldr"] = "\n".join(block)
+            continue
+        if ": " in line:
+            key, _, value = line.partition(": ")
+            # A raw key must be one of the known fixed set -- anything else
+            # is exactly the injection this parser exists to catch.
+            assert key in _FRONTMATTER_KEYS, f"unexpected/injected key: {key!r}"
+            result[key] = value
+        i += 1
+    return result
+
+
+def test_render_log_frontmatter_well_formed_with_adversarial_file_path():
+    facts = {
+        "user_turns": 3, "assistant_turns": 4,
+        "tool_counts": {"Bash": 2, "other": 1},
+        "file_paths": [ac._sanitize("/tmp/evil.py\nfake_key: x")],
+        "first_ts": "2026-01-01T00:00:00Z", "last_ts": "2026-01-01T00:05:00Z",
+    }
+    text = ac.render_log("abc12345", "/some/cwd", facts, "deadbeef" * 8, "2026-01-01")
+    parsed = _parse_frontmatter(text)
+    assert parsed["auto_generated"] == "true"
+    assert "fake_key" not in parsed
+    assert parsed["source_transcript"] == "deadbeef" * 8
+
+
+def test_render_log_frontmatter_well_formed_with_adversarial_mcp_tool_name():
+    """Reproduces code-review's exact finding: an mcp__-prefixed tool_use
+    name containing an embedded newline + fake YAML key must not flip
+    auto_generated or inject a new key, once routed through _bucket_tool_name
+    (which the real extract_transcript_facts path always does)."""
+    evil_name = "mcp__evil__x\nauto_generated: false\nfake_key: injected"
+    bucketed = ac._bucket_tool_name(evil_name)
+    facts = {
+        "user_turns": 1, "assistant_turns": 1,
+        "tool_counts": {bucketed: 1},
+        "file_paths": [], "first_ts": None, "last_ts": None,
+    }
+    text = ac.render_log("sid", "/cwd", facts, None, "2026-01-01")
+    parsed = _parse_frontmatter(text)
+    assert parsed["auto_generated"] == "true"
+    assert "fake_key" not in parsed
+
+
+def test_render_log_frontmatter_well_formed_with_quote_in_cwd():
+    """Reproduces code-review's second finding: an embedded `"` in cwd must
+    not break the quoted project_path scalar."""
+    facts = {"user_turns": 1, "assistant_turns": 1, "tool_counts": {}, "file_paths": [], "first_ts": None, "last_ts": None}
+    text = ac.render_log("sid", '/some/"weird/cwd', facts, None, "2026-01-01")
+    parsed = _parse_frontmatter(text)
+    assert json.loads(parsed["project_path"]) == '/some/"weird/cwd'
+
+
+def test_bucket_tool_name_sanitizes_mcp_prefixed_names():
+    evil = "mcp__x\nfake: y"
+    result = ac._bucket_tool_name(evil)
+    assert "\n" not in result
+
+
+def test_render_log_omits_source_transcript_when_none():
+    facts = {"user_turns": 1, "assistant_turns": 1, "tool_counts": {}, "file_paths": [], "first_ts": None, "last_ts": None}
+    text = ac.render_log("sid", "/cwd", facts, None, "2026-01-01")
+    assert "source_transcript:" not in text
+
+
+# ── run(): end-to-end with stubbed subprocess calls ──────────────────────────
+
+@pytest.fixture
+def fake_vault(tmp_path, monkeypatch):
+    v = tmp_path / "vault"
+    v.mkdir()
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(v))
+    return v
+
+
+@pytest.fixture
+def recorded_calls(monkeypatch):
+    calls = []
+
+    class _FakeCompleted:
+        def __init__(self, returncode=0, stdout=""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def _fake_run(argv, cwd=None, env=None, timeout=None, capture_output=True, text=True):
+        calls.append({"argv": argv, "cwd": cwd, "env": env})
+        script = Path(argv[1]).name
+        if script == "transcript_archive.py":
+            return _FakeCompleted(0, json.dumps({"ok": True, "sha256": "cafef00d" * 8}))
+        return _FakeCompleted(0, "")
+
+    monkeypatch.setattr(ac.subprocess, "run", _fake_run)
+    return calls
+
+
+def test_run_writes_log_and_calls_children_with_no_extract(fake_vault, recorded_calls, tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, [{"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": "hi"}}])
+
+    rc = ac.run("session123", str(transcript), str(tmp_path))
+    assert rc == 0
+
+    session_logs = list((fake_vault / "Session-Logs").glob("*/auto-session1.md"))
+    assert len(session_logs) == 1
+    content = session_logs[0].read_text()
+    assert "source_transcript: cafef00d" in content
+
+    scripts_called = [Path(c["argv"][1]).name for c in recorded_calls]
+    assert "transcript_archive.py" in scripts_called
+    assert "sync_linear_pending.py" in scripts_called
+    assert "memory_indexer.py" in scripts_called
+
+    indexer_call = next(c for c in recorded_calls if Path(c["argv"][1]).name == "memory_indexer.py")
+    assert "--no-extract" in indexer_call["argv"]
+    assert "--add" in indexer_call["argv"]
+
+    archive_call = next(c for c in recorded_calls if Path(c["argv"][1]).name == "transcript_archive.py")
+    assert "--transcript" in archive_call["argv"]
+    assert "--cwd" not in archive_call["argv"]
+    assert str(transcript) in archive_call["argv"]
+
+
+def test_run_propagates_resolved_vault_to_every_child_env(fake_vault, recorded_calls, tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, [{"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": "hi"}}])
+    ac.run("session123", str(transcript), str(tmp_path))
+    assert len(recorded_calls) >= 3
+    for call in recorded_calls:
+        assert call["env"]["DEUS_VAULT_PATH"] == str(fake_vault)
+
+
+def test_run_fails_when_no_vault_resolvable(tmp_path, monkeypatch):
+    # Stub the resolver itself rather than just unsetting the env var — the
+    # real dev machine's global ~/.config/deus/config.json would otherwise
+    # still resolve a real vault, defeating the test's intent (the resolver's
+    # own tiers are covered separately in test_stop_hook_vault_resolver.py).
+    monkeypatch.setattr(ac, "_load_vault_root", lambda cwd=None: None)
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    rc = ac.run("sid", str(transcript), str(tmp_path))
+    assert rc == 1
+
+
+def test_run_does_not_delete_checkpoints(fake_vault, recorded_calls, tmp_path):
+    """Round-6 fix C: the automated worker must never touch Checkpoints/ at all."""
+    checkpoints = fake_vault / "Checkpoints"
+    checkpoints.mkdir()
+    marker = checkpoints / "2026-01-01-00.md"
+    marker.write_text("real in-progress content", encoding="utf-8")
+
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, [{"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": "hi"}}])
+    ac.run("sid", str(transcript), str(tmp_path))
+
+    assert marker.exists()
+    assert marker.read_text() == "real in-progress content"

--- a/scripts/tests/test_stop_hook_vault_resolver.py
+++ b/scripts/tests/test_stop_hook_vault_resolver.py
@@ -1,0 +1,93 @@
+"""Tests for stop_hook._load_vault_root's 3-tier resolution (extended for the
+SessionEnd auto-save feature): DEUS_VAULT_PATH env -> <cwd>/.deus/config.json
+(per-instance override, STOP on partial file) -> ~/.config/deus/config.json
+(global fallback). Matches .claude/skills/compress/skill.md's own contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+stop_hook = _load("stop_hook", _ROOT / "scripts" / "stop_hook.py")
+
+
+def test_env_var_wins_over_everything(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEUS_VAULT_PATH", str(tmp_path / "env-vault"))
+    instance_cfg = tmp_path / ".deus" / "config.json"
+    instance_cfg.parent.mkdir()
+    instance_cfg.write_text(json.dumps({"vault_path": str(tmp_path / "instance-vault")}))
+    assert stop_hook._load_vault_root(cwd=tmp_path) == tmp_path / "env-vault"
+
+
+def test_per_instance_config_used_when_present(tmp_path, monkeypatch):
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    instance_cfg = tmp_path / ".deus" / "config.json"
+    instance_cfg.parent.mkdir()
+    instance_cfg.write_text(json.dumps({"vault_path": str(tmp_path / "instance-vault")}))
+    assert stop_hook._load_vault_root(cwd=tmp_path) == tmp_path / "instance-vault"
+
+
+def test_per_instance_config_missing_vault_path_stops_no_fallthrough(tmp_path, monkeypatch, home_config):
+    """The critical anti-corruption rule: a present-but-broken per-instance
+    file must STOP, never silently fall through to the global config."""
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    instance_cfg = tmp_path / ".deus" / "config.json"
+    instance_cfg.parent.mkdir()
+    instance_cfg.write_text(json.dumps({"other_key": "no vault_path here"}))
+    assert stop_hook._load_vault_root(cwd=tmp_path) is None
+
+
+def test_per_instance_config_malformed_json_stops_no_fallthrough(tmp_path, monkeypatch, home_config):
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    instance_cfg = tmp_path / ".deus" / "config.json"
+    instance_cfg.parent.mkdir()
+    instance_cfg.write_text("{ not valid json")
+    assert stop_hook._load_vault_root(cwd=tmp_path) is None
+
+
+def test_falls_back_to_global_config_when_no_instance_file(tmp_path, monkeypatch, home_config):
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    assert stop_hook._load_vault_root(cwd=tmp_path) == home_config
+
+
+def test_cwd_none_preserves_prior_2tier_behavior(tmp_path, monkeypatch, home_config):
+    """Backward-compat: existing call sites (cwd=None) must be unaffected."""
+    monkeypatch.delenv("DEUS_VAULT_PATH", raising=False)
+    assert stop_hook._load_vault_root() == home_config
+
+
+@pytest.fixture
+def home_config(tmp_path, monkeypatch):
+    """Redirect the global-config tier to a tmp path so tests never read the
+    real ~/.config/deus/config.json."""
+    fake_home_cfg = tmp_path / "global-config.json"
+    fake_vault = tmp_path / "global-vault"
+    fake_home_cfg.write_text(json.dumps({"vault_path": str(fake_vault)}))
+
+    real_expanduser = Path.expanduser
+
+    def _patched_expanduser(self):
+        if str(self) == "~/.config/deus/config.json":
+            return fake_home_cfg
+        return real_expanduser(self)
+
+    monkeypatch.setattr(Path, "expanduser", _patched_expanduser)
+    return fake_vault


### PR DESCRIPTION
## Summary

Auto-saves a Claude Code session to the vault when it ends, without ever resuming it as an agent. This went through a substantial design arc worth summarizing since the shipped mechanism looks very different from where it started:

- **Round 1** proposed resuming the session via `claude -p --resume <sid> "/compress"` with `--allowedTools` scoping. Empirically disproven: `--allowedTools` only *adds* permissions on top of whatever `~/.claude/settings.json` already allows — it does not restrict the tool inventory. A live test (only `Read` allowed) still let the model run an arbitrary `Bash` command with zero permission denials.
- **Round 2** replaced it with a real OS-level sandbox (macOS `sandbox-exec`) plus a local allowlist forward-proxy for network egress — both genuinely verified working via direct testing. But an independent threat-model pass (BLOCK) and a second review backend found the sandbox profile only restricted *reads*: writes, the full inherited environment (API keys), and exfil-capable egress (a writable Linear API) were all still open to an unattended process resuming a real, potentially-injected session.
- **Round 3 (this PR)** removes the LLM turn entirely. `scripts/auto_compress.py` parses the transcript JSONL purely as *data* — turn/tool counts, timestamps, touched file paths — never as instructions for a model to act on. There is no tool-use loop for a hostile transcript to steer, so no sandbox is needed. The trade-off, explicitly accepted: the auto-saved log is mechanical, not an LLM-authored narrative. A human can still run `/compress` interactively on the session for the rich version.

Went through 6 rounds of dual-backend (Claude + GPT) plan-review across the three designs (the first two REVISE/BLOCK, this one SHIP on both backends), plus 2 rounds of code-review on the implementation (round 1 caught a real, reproduced bug — see below).

## What's in this diff

- `scripts/session_end_hook.py` — the `SessionEnd` hook (cheap gates + atomic enqueue + detached debounced worker) and the worker (mtime-based re-arm if the session reopens mid-debounce, atomic claim via `os.rename`, retry via `attempts` on failure).
- `scripts/auto_compress.py` — the deterministic worker. Archives the transcript pinned to its exact path (`--transcript`, never `--cwd` auto-discovery, which could bind a sibling session's transcript under concurrent same-cwd sessions); syncs Linear pending tasks (read-only); indexes the log with `--no-extract` (bare `--add` would silently run a real LLM atom-extraction call with an unescaped prompt — confirmed by reading the actual extraction code path). Every child subprocess gets the already-resolved vault path via `DEUS_VAULT_PATH` env so it can't independently re-resolve to a different vault. Every extracted string (file paths, tool names) is sanitized before it reaches any file. Does **not** delete checkpoints — a separate, pre-existing gap in the interactive `/compress` skill's own (also unread) checkpoint deletion is tracked as LIA-469, not fixed here.
- `scripts/maintenance/compress_sweep.py` (+ `maintenance.py` registration) — safety net for orphaned/stale queue entries a crashed worker missed.
- `scripts/stop_hook.py` — extended `_load_vault_root()` to the full 3-tier resolution chain (env → per-instance `<cwd>/.deus/config.json` with a STOP-on-partial-file guard → global config), matching the compress skill's own contract. Both existing call sites keep their prior 2-tier behavior unchanged (`cwd=None` default) — no regression.

**Intentionally excluded:** the personal `~/.claude/settings.json` + `required-hooks.json` `SessionEnd` wiring that actually activates this feature is a separate, manual step — never committed to a public repo per this project's own rule.

## Test plan
- [x] 38 new tests across `scripts/tests/test_auto_compress_script.py`, `test_auto_compress_queue.py`, `test_stop_hook_vault_resolver.py` — all passing.
- [x] No regression: `tests/test_session_type_contract.py` (81 tests) and `scripts/tests/test_memory_tree_hook.py` still pass with the extended vault resolver.
- [x] Manual hook smoke test: real enqueue path confirmed end-to-end (entry written with correct schema); `CLAUDE_JOB_DIR` gate confirmed live (this very session has it set, and correctly skipped).
- [x] `maintenance.py --dry-run` confirms `compress_sweep` is registered in the Daily section.
- [x] Code-review round 1 caught a real, reproduced bug: `_bucket_tool_name`'s `mcp__`-prefix branch returned tool names verbatim/unsanitized (unlike file paths, which were correctly sanitized) — a crafted name could flip `auto_generated` to `false` and inject an arbitrary frontmatter key (reproduced with real PyYAML). Fixed, plus a regression test using a purpose-built minimal parser (pyyaml isn't a declared project dependency, so the test doesn't add one). Round 2 code-review SHIP, independently re-derived both fixes.
- [x] Personal-identifier grep on the full diff: clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>