### PR TITLE
docs(skills): import wayfinder + research from mattpocock/skills

### DIFF
--- a/.claude/skills/ATTRIBUTION-mattpocock-skills.md
+++ b/.claude/skills/ATTRIBUTION-mattpocock-skills.md
@@ -1,6 +1,6 @@
 # Attribution — mattpocock/skills
 
-The following 12 host skills were imported into Deus from the open-source repo
+The following 14 host skills were imported into Deus from the open-source repo
 **[mattpocock/skills](https://github.com/mattpocock/skills)** (MIT-licensed):
 
 | Skill | Upstream path |
@@ -17,17 +17,28 @@ The following 12 host skills were imported into Deus from the open-source repo
 | `codebase-design` | `skills/engineering/codebase-design` |
 | `resolving-merge-conflicts` | `skills/engineering/resolving-merge-conflicts` |
 | `improve-codebase-architecture` | `skills/engineering/improve-codebase-architecture` |
+| `wayfinder` | `skills/engineering/wayfinder` |
+| `research` | `skills/engineering/research` |
 
-**Source:** `github.com/mattpocock/skills` @ commit `6eeb81b`
-(`6eeb81b5fcfeeb5bd531dd47ab2f9f2bbea27461`).
+**Source:** `github.com/mattpocock/skills` @ commit `ed37663`
+(`ed37663cc5fbef691ddfecd080dff42f7e7e350d`) as of the `wayfinder`/`research` addition — originally
+imported @ `6eeb81b` (2026-06-19).
 
 ## Adaptations from upstream
 
 The skill bodies are **byte-identical** to upstream. The only change is additive: Deus's
-`user_invocable: true` frontmatter field was added to the six user-only skills (`grill-me`,
-`grill-with-docs`, `teach`, `writing-great-skills`, `prototype`, `improve-codebase-architecture`
-— the ones carrying upstream's `disable-model-invocation: true`) for convention consistency.
-Invocation semantics are unchanged.
+`user_invocable: true` frontmatter field was added to the seven user-only skills (`grill-me`,
+`grill-with-docs`, `teach`, `writing-great-skills`, `prototype`, `improve-codebase-architecture`,
+`wayfinder` — the ones carrying upstream's `disable-model-invocation: true`) for convention
+consistency. Invocation semantics are unchanged. `research` carries no such flag upstream and gets
+no addition — it stays both user- and model-invocable, same class as `grilling`.
+
+Upstream's `agents/openai.yaml` files (OpenAI/ChatGPT-platform skill config, not applicable to
+Claude Code) are deliberately not copied. `wayfinder` and `research` are the first imported skills
+to carry an `agents/` directory upstream at all — the previously-imported skills never had one at
+import time, so there is no prior "omission" convention being followed here; the decision stands
+on its own merits: this content has zero function in Claude Code and isn't part of the skill's
+actual portable instructions.
 
 ### Notes for users
 
@@ -42,6 +53,84 @@ Invocation semantics are unchanged.
   session (after the fix is in) as a "what would have prevented this bug?" follow-up. That skill is
   now imported (see the table above), so the hand-off resolves. It depends on `/codebase-design` for
   its architecture vocabulary, which is also imported.
+- **`wayfinder` ships without Linear wiring.** Its own reference config skill,
+  `/setup-matt-pocock-skills` (not imported — see below), only ships GitHub/GitLab/local-markdown
+  tracker docs, no Linear one. Without that setup, `wayfinder` "default[s] to the local-markdown
+  tracker" per its own `SKILL.md`, which is fully functional standalone. Wiring it to Deus's actual
+  Linear pipeline is a separate, unscoped follow-up — not assumed to already work.
+- **`research` is the mechanism `wayfinder` uses for its `research`-type tickets** ("Resolved by a
+  `/research` subagent" — its own `SKILL.md`). It's independently useful outside `wayfinder` too:
+  a general-purpose "investigate a question against primary sources, write findings to a file"
+  primitive, distinct from Deus's own `/deep-research` (which classifies intent and fans out
+  lit-scout/brainstormer/NotebookLM specifically).
+
+## Evaluated, not imported
+
+Genuinely new upstream since the last sync (@ `6eeb81b`, as of `ed37663`): `code-review`,
+`to-spec`, `to-tickets` (plus `wayfinder`/`research`, imported above). `ask-matt`, `implement`, and
+`triage` are NOT new — all three already existed at `6eeb81b`; `ask-matt`/`implement` were simply
+never evaluated by the original 2026-06-19 import, and `triage` (along with upstream's now-vanished
+`to-issues`/`to-prd`, likely reworked into today's `to-tickets`/`to-spec`) was already explicitly
+evaluated and skipped by that import ("explicitly skipped triage/to-prd/to-issues (collide with
+Linear)" — its own session log). `setup-matt-pocock-skills` also predates this sync and remains
+unimported (see the `wayfinder` note above — its tracker docs don't cover Linear). All four
+skills below that could be mistaken for duplicates of an existing Deus skill (`code-review`,
+`to-tickets`, `to-spec`, `triage`) were read in FULL and diffed against their Deus-native
+counterpart before deciding — not skipped on name/territory alone.
+
+- **`code-review`** — name collision with Deus's own `/code-review` (a completely different
+  warden/dual-backend-gate system; see `.claude/wardens/code-review-rules.md`). Not imported as a
+  separate skill. Genuinely offers two ideas Deus's review lacks: a **Standards-vs-Spec two-axis
+  split** (conformance to documented conventions vs. faithfulness to the originating issue/PRD, run
+  as separate parallel sub-agent reviews so neither axis masks the other — Deus's own review checks
+  style/logic/security bugs, not spec conformance as a distinct axis) and a concrete **12-item
+  Fowler code-smell baseline checklist** (Mysterious Name, Duplicated Code, Feature Envy, Data
+  Clumps, Primitive Obsession, Repeated Switches, Shotgun Surgery, Divergent Change, Speculative
+  Generality, Message Chains, Middle Man, Refused Bequest) as an always-on fallback when a repo
+  documents no standards of its own. Worth grafting into Deus's existing `/code-review` skill as a
+  4th parallel agent — a real, well-specified follow-up, not done in this sync.
+- **`to-tickets`** — near-duplicate of Deus's own `/linear-slice` for the Linear-native path (same
+  tracer-bullet vertical-slice framing, same tracker-issue output). Not imported as a separate
+  skill. Has a genuine gap `linear-slice` lacks: an explicit **"wide refactor" exception** —
+  expand-contract sequencing (add the new form beside the old, migrate callers in blast-radius-
+  sized batches, then delete the old form) for mechanical, codebase-wide-blast-radius changes (a
+  column rename, a shared symbol retype) that can't be tracer-bulleted into independently-demoable
+  vertical slices. Also confirmed a real, not just theoretical, incompatibility: `to-tickets`
+  instructs applying the `ready-for-agent` triage label directly on publish — an analogous
+  incompatibility with Deus's actual gate contract, which uses a differently-named but equally
+  gate-owned label: `linear-slice`'s own `SKILL.md` states "Never apply a `Scoped` label... The
+  gate manages that label." Even absent the naming overlap, this skill cannot be
+  imported as-is against Deus's live Linear pipeline.
+- **`triage`** — read in full and compared against the actual documented Linear pipeline contract
+  (`Backlog → Todo → Ready for Agent → Agent Working → In Review → Done`, enrichment-gate/
+  bouncer-gate, both automated on state transitions). `triage`'s own state model
+  (`needs-triage`/`needs-info`/`ready-for-agent`/`ready-for-human`/`wontfix`, driven by a
+  conversational human-in-the-loop flow) does not map onto Deus's actual configured states or its
+  automated gate-driven flow — a confirmed, not assumed, state-model conflict. Not imported. Three
+  extractable ideas worth a dedicated follow-up evaluation against the REAL enrichment-gate
+  implementation (not read during this sync, so deliberately not blindly merged): a pre-triage
+  **redundancy check** ("is this already implemented — search by domain concept, not just the
+  request's wording"), a **verify-the-claim-before-grilling** step (reproduce a bug / confirm a PR
+  diff does what it claims before investing in further triage), and an **`.out-of-scope/`
+  rejected-request knowledge base** pattern (persist *why* a request was rejected so it doesn't get
+  silently re-proposed later).
+- **`to-spec`** — on full read, this is NOT redundant with anything Deus has: `linear-slice` only
+  decomposes an *already-existing* plan into tickets, nothing turns a conversation into a published
+  spec/PRD first. It shares `to-tickets`'s exact `ready-for-agent`-label conflict with Deus's gate
+  contract, so a safe import needs the same kind of Linear-specific adaptation `linear-slice` itself
+  already received (land in Backlog, let the enrichment gate own scope-writing, never apply a
+  gate-owned label directly) — real engineering, not a byte-identical copy. A concrete, well-scoped
+  candidate for a dedicated future skill (a Linear-adapted companion to `linear-slice`), not
+  bundled into this sync.
+- **`implement`** — genuinely novel (the execution counterpart to `wayfinder`'s "plan, don't do"
+  philosophy) but not requested, and Deus already has its own plan → build → review discipline
+  (Execution Gates, `core-behavioral-rules.md`) that a generic `/implement` would partially
+  duplicate. Worth a dedicated evaluation later, not bundled into this sync.
+- **`ask-matt`** — a router over mattpocock's *own* skill repo's inventory. Deus has its own
+  routing (`.mex/ROUTER.md`) and a materially different skill set — low standalone value here.
+- **`setup-matt-pocock-skills`** — not imported (see the `wayfinder` note above): its
+  tracker-config docs cover GitHub/GitLab/local-markdown only, no Linear, so importing it would not
+  by itself wire `wayfinder`/future skills to Deus's actual tracker.
 
 ## License
 

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: research
+description: Investigate a question against high-trust primary sources and capture the findings as a Markdown file in the repo. Use when the user wants a topic researched, docs or API facts gathered, or reading legwork delegated to a background agent.
+---
+
+Spin up a **background agent** to do the research, so you keep working while it reads.
+
+Its job:
+
+1. Investigate the question against **primary sources** — official docs, source code, specs, first-party APIs — not a secondary write-up of them. Follow every claim back to the source that owns it.
+2. Write the findings to a single Markdown file, citing each claim's source.
+3. Save it where the repo already keeps such notes; match the existing convention, and if there is none, put it somewhere sensible and say where.

--- a/.claude/skills/wayfinder/SKILL.md
+++ b/.claude/skills/wayfinder/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: wayfinder
+description: Plan a huge chunk of work — more than one agent session can hold — as a shared map of decision tickets on your issue tracker, and resolve them one at a time until the way to the destination is clear.
+disable-model-invocation: true
+user_invocable: true
+---
+
+A loose idea has arrived — too big for one agent session, and wrapped in fog: the way from here to the **destination** isn't visible yet. Wayfinding is about finding that way, not charging at the destination. This skill charts the way as a **shared map** on the repo's issue tracker, then works its **decision tickets** — questions whose resolution is a decision, not slices of a build to execute — one at a time until the route is clear.
+
+The destination varies per effort, and naming it is the first act of charting — it shapes every ticket. It might be a spec to hand off and iterate on, a decision to lock before planning starts, or a change made in place like a data-structure migration. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
+
+## Plan, don't do
+
+Wayfinder is **planning** by default: each ticket resolves a decision, and the map is done when the way is clear — nothing left to decide before someone goes and does the thing. The pull to just do the work is usually the signal you've reached the edge of the map and it's time to hand off. An effort can override this in its **Notes** — carrying execution into the map itself — but absent that, produce decisions, not deliverables.
+
+## Refer by name
+
+Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible; names read at a glance. The id and URL don't vanish — a name wraps its link — but they ride *inside* the name, never stand in for it.
+
+## The Map
+
+The map is a single issue on this repo's issue tracker, labelled `wayfinder:map` — the canonical artifact. Its tickets are child issues of the map.
+
+The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links.
+
+**Where the map, its child tickets, blocking, and frontier queries physically live is tracker-specific.** The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if not. Consult the tracker doc's "Wayfinding operations" section for how _this_ repo expresses them. If no tracker has been provided, default to the local-markdown tracker.
+
+### The map body
+
+The whole map at low resolution, loaded once per session. Open tickets are **not** listed — they are open child issues, found by query.
+
+```markdown
+## Destination
+
+<what reaching the end of this map looks like — the spec, decision, or change this effort is finding its way to. One or two lines; every session orients to it before choosing a ticket.>
+
+## Notes
+
+<domain; skills every session should consult; standing preferences for this effort>
+
+## Decisions so far
+
+<!-- the index — one line per closed ticket: enough to judge relevance, then zoom the link for the detail the ticket holds -->
+
+- [<closed ticket title>](link) — <one-line gist of the answer>
+
+## Not yet specified
+
+<!-- see "Fog of war": in-scope fog you can't ticket yet; graduates as the frontier advances -->
+
+## Out of scope
+
+<!-- see "Out of scope": work ruled beyond the destination; closed, never graduates -->
+```
+
+### Tickets
+
+Each ticket is a **child issue** of the map; the tracker's issue id is its identity. Its body is the question, sized to one 100K token agent session:
+
+```markdown
+## Question
+
+<the decision or investigation this ticket resolves>
+```
+
+Each ticket carries a `wayfinder:<type>` label — one of `research`, `prototype`, `grilling`, `task` (see [Ticket Types](#ticket-types)).
+
+A session **claims** a ticket by assigning it to the dev driving the map, **first**, before any work, so concurrent sessions skip it. That assignee _is_ the claim: an open, unassigned ticket is unclaimed.
+
+Blocking uses the tracker's **native** dependency relationship — essential because it renders the frontier _visually_ in the tracker's own UI, so the human sees what's takeable without opening the map. Only a tracker that lacks native blocking falls back to a body convention. A ticket is **unblocked** when every ticket blocking it is closed; the **frontier** is the open, unblocked, unclaimed children — the edge of the known.
+
+The answer isn't part of the body — it's recorded on resolution (see [Work through the map](#work-through-the-map)). Assets created while resolving a ticket are linked from the issue, not pasted in.
+
+## Ticket Types
+
+Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this).
+
+- **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
+- **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
+- **Grilling** (HITL): Conversation via the /grilling and /domain-modeling skills, one question at a time. The default case.
+- **Task** (HITL or AFK): Manual work that must happen before a *decision* can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that *does* rather than decides — and it earns its place by unblocking a decision, not by delivering the destination. The agent drives it alone where it can (AFK); otherwise it hands the human a precise checklist (HITL). Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
+
+## Fog of war
+
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** — the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets — one at a time, until the way to the destination is clear and no tickets remain.
+
+The map's **Not yet specified** section is where that dim view is written down: the suspected question, the area to revisit later. It's the undiscovered frontier _toward_ the destination — everything here is in scope, just not sharp enough to ticket. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
+
+**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now.
+
+- **Ticket when** the question is already sharp — even if it's blocked and you can't act on it yet.
+- **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces: it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it.
+
+**Not yet specified** excludes what's already decided (Decisions so far), what's already a live ticket, and what's out of scope (the next section).
+
+## Out of scope
+
+Fog only ever gathers _toward_ the destination. The destination fixes the scope, so work beyond it is **out of scope** — it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section on the map: work you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it here.
+
+Out-of-scope work never graduates — the frontier stops at the destination — so it returns only if the destination is redrawn, and then as a fresh effort, not a resumption.
+
+Ruling something out of scope is a scoping act, not a step on the route. When a ticket that already exists turns out to sit past the destination — mis-scoped in while charting, or exposed by a resolution — **close it** (a closed ticket is unambiguously off the frontier) and leave one line in the **Out of scope** section: the gist plus why it's out of scope, linking the closed ticket. It stays out of **Decisions so far**, which records the route actually walked — a scope boundary isn't a step on it.
+
+## Invocation
+
+Two modes. Either way, **never resolve more than one ticket per session** — with the exception of research tickets.
+
+### Chart the map
+
+User invokes with a loose idea.
+
+1. **Name the destination.** Run a `/grilling` and `/domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
+3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
+4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
+5. **Fire the research subagents.** For each `research` ticket you just created, spin up a `/research` subagent to resolve it in parallel, capturing its findings on a throwaway `research/<name>` branch with a context pointer from the ticket.
+6. Stop — charting is one session's work; it hand-resolves nothing.
+
+### Work through the map
+
+User invokes with a map (URL or number). A ticket is **optional** — without one, you pick the next decision, not the user.
+
+1. Load the **map** — the low-res view, not every ticket body.
+2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: assign it to yourself before any work.
+3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
+4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
+5. Add newly-surfaced tickets (create-then-wire); graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified** so it lives only as its new ticket. If the answer reveals a ticket — this one or another — sits beyond the destination, **rule it out of scope** rather than resolving it on the route. If the decision invalidates other parts of the map, update or delete those tickets.
+
+The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ renaming a repo-owned skill, update this table in the same change.
 | `/preserve` | Save durable memories from the current conversation |
 | `/project-settings` | View or modify external project memory settings |
 | `/prototype` | Build a throwaway prototype to validate a state model or UI direction |
+| `/research` | Investigate a question against primary sources; write findings to a file (background agent) |
 | `/resolving-merge-conflicts` | Disciplined resolution of an in-progress git merge/rebase conflict |
 | `/resume` | Load recent work and memory context |
 | `/review-logs` | Review Deus system health logs |
@@ -201,6 +202,7 @@ renaming a repo-owned skill, update this table in the same change.
 | `/update-skills` | Update installed skill branches from upstream |
 | `/use-local-whisper` | Switch voice transcription to local whisper.cpp |
 | `/wardens` | View, toggle, and configure warden quality gates |
+| `/wayfinder` | Chart a large effort as decision tickets on the issue tracker; resolve them one at a time |
 | `/writing-great-skills` | Reference for authoring predictable skills — leading words, progressive disclosure |
 | `/x-integration` | Set up or use X/Twitter integration |
 

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-07-05" # auto-bump @1783200566
+last_verified: "2026-07-23" # auto-bump @1784796016
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Imports `wayfinder` (charts a large effort as decision tickets on the issue tracker, resolves them one at a time) and its hard dependency `research` from `github.com/mattpocock/skills` @ `ed37663` (MIT) — already the source of 12 previously-imported Deus skills.
- Both byte-identical to upstream aside from `wayfinder`'s additive `user_invocable: true`, matching this repo's existing convention for upstream's `disable-model-invocation` skills.
- Surveys everything else new upstream since the last sync (@ `6eeb81b`) and records, with evidence not assumption, why 6 other skills aren't imported this round. 4 collision-adjacent ones (`code-review`, `to-tickets`, `triage`, `to-spec`) were read in full and diffed against their Deus-native counterparts rather than skipped on name alone — surfacing specific extractable ideas (a Standards/Spec review-axis split + a Fowler code-smell checklist; an expand-contract pattern for wide mechanical refactors `linear-slice` currently lacks) worth a dedicated follow-up, plus two confirmed hard incompatibilities with Deus's live Linear gate contract (both instruct applying a gate-owned label directly).

## Test plan
- [x] 3 rounds of plan-review SHIP — 2 rounds caught and fixed real premise errors (a wrong "8 skills are new since last import" count — only 5 are; and a false claim that omitting `wayfinder`'s `agents/` dir "matches" a prior import precedent that never existed), both independently re-verified before accepting the fix.
- [x] Byte-identity of both new `SKILL.md` files confirmed directly against upstream at the pinned commit (code-reviewer + verification-gate, independently).
- [x] `AGENTS.md` alphabetical placement confirmed.
- [x] `drift_check.py` — all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)