### PR TITLE
chore(eval): bump stale judge model default to claude-sonnet-5

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -44,7 +44,7 @@ The judge model scores agent responses. Configured in `judge_model.py`.
 | 1 | GeminiJudge | `GEMINI_API_KEY` in `.env` |
 | 2 | ClaudeProxyJudge (fallback) | Credential proxy on localhost:3001. Currently blocked by Anthropic OAuth auth issue. |
 
-Override the judge model name with `DEEPEVAL_JUDGE_MODEL` (default: `claude-sonnet-4-5`).
+Override the judge model name with `DEEPEVAL_JUDGE_MODEL` (default: `claude-sonnet-5`).
 
 ## Concurrency
 
@@ -106,7 +106,7 @@ Convention: `test_{name}.py` loads `datasets/{name}.jsonl`. The warmup fixture a
 | `DEUS_EVAL_CONCURRENT` | auto | Parallel warmup workers |
 | `CREDENTIAL_PROXY_PORT` | `3001` | Credential proxy port |
 | `GEMINI_API_KEY` | (none) | For GeminiJudge |
-| `DEEPEVAL_JUDGE_MODEL` | `claude-sonnet-4-5` | Judge model name override |
+| `DEEPEVAL_JUDGE_MODEL` | `claude-sonnet-5` | Judge model name override |
 
 ## Architecture Notes
 

--- a/eval/judge_model.py
+++ b/eval/judge_model.py
@@ -43,4 +43,4 @@ def make_judge(model: Optional[str] = None) -> DeepEvalBaseLLM:
     except NoProviderAvailableError:
         # Last resort: Claude proxy (kept for legacy compatibility)
         from evolution.judge.providers.claude_proxy import ClaudeProxyJudge
-        return ClaudeProxyJudge(model=model or os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5"))
+        return ClaudeProxyJudge(model=model or os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-5"))

--- a/evolution/judge/providers/claude_proxy.py
+++ b/evolution/judge/providers/claude_proxy.py
@@ -8,7 +8,7 @@ from ..base import BaseJudge, JudgeResult
 from ..provider import JudgeProvider
 
 PROXY_BASE_URL = os.environ.get("CREDENTIAL_PROXY_URL", "http://localhost:3001")
-CLAUDE_JUDGE_MODEL = os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5")
+CLAUDE_JUDGE_MODEL = os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-5")
 
 
 class ClaudeProxyRuntimeJudge(BaseJudge):

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-07-18" # auto-bump @1784327653
+last_verified: "2026-07-26" # auto-bump @1785083397
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-19" # auto-bump @1784444178
+last_verified: "2026-07-26" # auto-bump @1785083397
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary
- Update the stale `DEEPEVAL_JUDGE_MODEL` fallback default from `claude-sonnet-4-5` to the current `claude-sonnet-5` in code (`eval/judge_model.py`, `evolution/judge/providers/claude_proxy.py`) and docs (`eval/README.md`)
- Per user request: only sonnet/opus model IDs were touched; haiku references and the intentionally-historical `scripts/spikes/lia397_credential_proxy_billing_spike.*` files (pinned to `claude-opus-4-8` as a billing-spike record) were left as-is
- A companion private/gitignored file (`src/private/orchestrator/{model-router,config,sandcastle-runner}.ts` + tests) was updated locally outside this PR, per repo policy that private code is never shipped in a public PR

## Test plan
- [x] plan-reviewer SHIP (claude + gpt backends)
- [x] code-reviewer SHIP (claude + gpt backends)
- [x] `grep -rn "claude-sonnet-4-5" evolution/ eval/` returns empty
- [x] `pytest evolution/tests/test_judge_registry.py` — 25/26 pass (1 unrelated pre-existing failure: local Ollama config value mismatch, not touched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)