### PR TITLE
feat(evolution): add opt-in GPT-5.6 judge provider (codex-exec, sandboxed)

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -95,9 +95,8 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `EVOLUTION_JUDGE_MAX_RESPONSE_CHARS` | `2000` | Max chars of agent response sent to Gemini judge |
 | `EVOLUTION_JUDGE_PROVIDER` | (auto-detect) | Force a specific judge provider: `ollama`, `gemini`, `claude`, `mock`, `llama-cpp`, `openai` |
 | `EVOLUTION_GEN_PROVIDER` | (auto-detect) | Force a specific generative provider: `gemini`, `ollama`, `mock`, `llama-cpp` |
-| `EVOLUTION_OPENAI_JUDGE_ENABLED` | (unset) | Opt-in gate for the OpenAI judge provider — required in addition to `OPENAI_API_KEY`; never auto-selected. See `docs/security/data-flows.md` §7 |
-| `EVOLUTION_OPENAI_JUDGE_MODEL` | `gpt-5.6-luna` | OpenAI model used when the `openai` judge provider is active |
-| `EVOLUTION_OPENAI_BASE_URL` | `https://api.openai.com/v1` | Base URL for the OpenAI judge provider (namespaced separately from the credential-proxy's `OPENAI_BASE_URL`) |
+| `EVOLUTION_OPENAI_JUDGE_ENABLED` | (unset) | Opt-in gate for the OpenAI judge provider — required in addition to a native `codex` CLI install + `codex login`; never auto-selected. macOS only. See `docs/security/data-flows.md` §7 |
+| `EVOLUTION_OPENAI_JUDGE_MODEL` | `gpt-5.6-luna` | Model passed to `codex exec -m` when the `openai` judge provider is active |
 | `DEUS_STORAGE_PROVIDER` | (auto-detect) | Force a specific storage provider: `sqlite` |
 | `EVOLUTION_GEN_MODEL` | `models/gemini-3.1-flash-lite` | Default generative model (Gemini) |
 | `EVOLUTION_MAX_REFLECTIONS` | `3` | Max reflections retrieved per agent query |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -93,8 +93,11 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `EVOLUTION_JUDGE_MODEL` | `models/gemini-3.1-flash-lite` | Gemini model used for judging and principle extraction |
 | `EVOLUTION_JUDGE_MAX_PROMPT_CHARS` | `2000` | Max chars of user prompt sent to Gemini judge (caps payload + PII exposure) |
 | `EVOLUTION_JUDGE_MAX_RESPONSE_CHARS` | `2000` | Max chars of agent response sent to Gemini judge |
-| `EVOLUTION_JUDGE_PROVIDER` | (auto-detect) | Force a specific judge provider: `ollama`, `gemini`, `claude`, `mock`, `llama-cpp` |
+| `EVOLUTION_JUDGE_PROVIDER` | (auto-detect) | Force a specific judge provider: `ollama`, `gemini`, `claude`, `mock`, `llama-cpp`, `openai` |
 | `EVOLUTION_GEN_PROVIDER` | (auto-detect) | Force a specific generative provider: `gemini`, `ollama`, `mock`, `llama-cpp` |
+| `EVOLUTION_OPENAI_JUDGE_ENABLED` | (unset) | Opt-in gate for the OpenAI judge provider — required in addition to `OPENAI_API_KEY`; never auto-selected. See `docs/security/data-flows.md` §7 |
+| `EVOLUTION_OPENAI_JUDGE_MODEL` | `gpt-5.6-luna` | OpenAI model used when the `openai` judge provider is active |
+| `EVOLUTION_OPENAI_BASE_URL` | `https://api.openai.com/v1` | Base URL for the OpenAI judge provider (namespaced separately from the credential-proxy's `OPENAI_BASE_URL`) |
 | `DEUS_STORAGE_PROVIDER` | (auto-detect) | Force a specific storage provider: `sqlite` |
 | `EVOLUTION_GEN_MODEL` | `models/gemini-3.1-flash-lite` | Default generative model (Gemini) |
 | `EVOLUTION_MAX_REFLECTIONS` | `3` | Max reflections retrieved per agent query |

--- a/docs/security/data-flows.md
+++ b/docs/security/data-flows.md
@@ -139,7 +139,7 @@ data flows to Google's Gemini API:
 
 ---
 
-## 7. OpenAI API — evolution-loop judge (opt-in, benchmark use)
+## 7. OpenAI (via codex CLI / ChatGPT subscription) — evolution-loop judge (opt-in, benchmark use, macOS only)
 
 - **What**: For every interaction scored by this provider —
   - User prompt (up to `EVOLUTION_JUDGE_MAX_PROMPT_CHARS`, default 2000 chars).
@@ -160,14 +160,28 @@ data flows to Google's Gemini API:
   even though it genuinely reaches Gemini in production (`user_profile=digest_for_group(...)`
   in `evolution/mcp_server.py`, `evolution/maintenance.py`) — a pre-existing gap
   in §2a, not something this section should claim parity with.
-- **Where**: `evolution/judge/openai_judge.py` → OpenAI `/chat/completions`.
+- **Where**: `evolution/judge/openai_judge.py` → local `codex` CLI (ChatGPT/
+  Codex subscription authentication — no `OPENAI_API_KEY`, no per-call
+  billing). No raw HTTP call is made by this provider.
 - **When**: NEVER auto-selected. Requires BOTH `EVOLUTION_OPENAI_JUDGE_ENABLED`
-  set AND `OPENAI_API_KEY` present. In practice this means a deliberate
+  set AND a working, authenticated native `codex` CLI install (verified via
+  `codex login status`). In practice this means a deliberate
   `evolution.benchmark_judge --provider openai` run, or an explicit
   `EVOLUTION_JUDGE_PROVIDER=openai` override — never a silent fallback when
   Gemini/Ollama are simply unavailable.
+- **Isolation**: each call runs `codex exec` inside a macOS Seatbelt sandbox
+  (`sandbox-exec`) with every execution-capable codex feature disabled
+  (`shell_tool`, `unified_exec`, `apps`, `browser_use`, `computer_use`, and
+  15 others — enumerated in `evolution/judge/openai_judge.py`) and
+  `process-exec` restricted at the OS level to the codex binary itself —
+  defense against judged content (real user prompts/agent responses, which
+  may contain adversarial text) being used to direct the agent to read local
+  files or make unintended tool calls. Filesystem access is scoped to a
+  narrow allowlist (codex's own fixed bookkeeping paths, this user's own
+  temp/cache root, and one per-call isolated directory) — never a blanket
+  grant. The subprocess environment is minimized to `PATH`/`HOME` only.
 - **Controls**: Leave `EVOLUTION_OPENAI_JUDGE_ENABLED` unset (default) to
-  opt out entirely.
+  opt out entirely. macOS only — reports unavailable on other platforms.
 
 ---
 

--- a/docs/security/data-flows.md
+++ b/docs/security/data-flows.md
@@ -139,6 +139,38 @@ data flows to Google's Gemini API:
 
 ---
 
+## 7. OpenAI API — evolution-loop judge (opt-in, benchmark use)
+
+- **What**: For every interaction scored by this provider —
+  - User prompt (up to `EVOLUTION_JUDGE_MAX_PROMPT_CHARS`, default 2000 chars).
+  - Agent response (up to `EVOLUTION_JUDGE_MAX_RESPONSE_CHARS`, default 2000 chars).
+  - `context`, if the caller supplied one (up to `EVOLUTION_JUDGE_MAX_PROMPT_CHARS`
+    — no production caller passes this today, but the interface allows it, so
+    it's capped defensively).
+  - `user_profile` (the stored persona digest), if the caller supplied one —
+    already capped at `EVOLUTION_JUDGE_MAX_PERSONA_CHARS` (default 500 chars)
+    where it's generated (`evolution/persona.py`), re-capped again here.
+  - Tool names used in the interaction (identifiers only, e.g. `"Read"`,
+    `"Bash"` — not tool arguments or output).
+
+  Same prompt/response caps as the Gemini judge (§2a). `context`/`user_profile`
+  handling is actually *stricter* here: this provider re-caps both at point of
+  use (`_cap_context_and_profile`); Gemini's judge (`gemini_judge.py`) does not
+  cap `context` at point of use, and §2a doesn't document `user_profile` at all
+  even though it genuinely reaches Gemini in production (`user_profile=digest_for_group(...)`
+  in `evolution/mcp_server.py`, `evolution/maintenance.py`) — a pre-existing gap
+  in §2a, not something this section should claim parity with.
+- **Where**: `evolution/judge/openai_judge.py` → OpenAI `/chat/completions`.
+- **When**: NEVER auto-selected. Requires BOTH `EVOLUTION_OPENAI_JUDGE_ENABLED`
+  set AND `OPENAI_API_KEY` present. In practice this means a deliberate
+  `evolution.benchmark_judge --provider openai` run, or an explicit
+  `EVOLUTION_JUDGE_PROVIDER=openai` override — never a silent fallback when
+  Gemini/Ollama are simply unavailable.
+- **Controls**: Leave `EVOLUTION_OPENAI_JUDGE_ENABLED` unset (default) to
+  opt out entirely.
+
+---
+
 ## Opt-out summary
 
 | Data type | Destination | How to opt out |
@@ -152,6 +184,7 @@ data flows to Google's Gemini API:
 | Calendar events | Google Calendar | Remove `add-gcal` skill |
 | Issue summaries | Linear | Remove `add-linear` skill |
 | Task summaries | Asana | Remove `add-asana` skill |
+| Interaction scores (judge, opt-in) | OpenAI | Don't set `EVOLUTION_OPENAI_JUDGE_ENABLED` (opt-in only) |
 
 ---
 

--- a/evolution/benchmark_judge.py
+++ b/evolution/benchmark_judge.py
@@ -11,6 +11,7 @@ Usage:
 """
 import argparse
 import json
+import math
 import os
 import random
 import statistics
@@ -46,12 +47,17 @@ SAFETY_PROBES_PATH = Path(__file__).resolve().parent / "fixtures" / "judge_safet
 
 @dataclass
 class EvalDetail:
-    """Per-interaction evaluation detail for conflict analysis."""
+    """Per-interaction evaluation detail for conflict analysis and paired comparison."""
     interaction_id: str
     prompt_preview: str  # first 80 chars
     ground_truth: float
     model_score: float
     rationale: str
+    # Per-dimension truth/score for this one interaction (only dims present in
+    # the interaction's ground_truth_dims — mirrors ModelResult.dim_scores/dim_truth
+    # but keyed to this record so cross-run comparisons can be paired by interaction_id.
+    dim_truth: dict[str, float] = field(default_factory=dict)
+    dim_scores: dict[str, float] = field(default_factory=dict)
 
     @property
     def delta(self) -> float:
@@ -143,6 +149,74 @@ def _mae(a: list[float], b: list[float]) -> Optional[float]:
     if not a:
         return None
     return statistics.mean(abs(a[i] - b[i]) for i in range(len(a)))
+
+
+# ── Trivial baselines (fixture "gameability" — how much raw Pearson a judge's
+# score explains beyond what a feature blind to actual response quality already
+# gets for free). See handoff 2026-08-02-01-15-gpt56-judge-benchmark-reliability:
+# a bare log(response_length) regressor alone scored r=0.485/r=0.338 on the two
+# investigation fixtures — a chunk of any judge's raw Pearson is just "did it
+# happen to favor longer responses," not judging skill. ─────────────────────────
+
+def _constant_mean_mae(truth: list[float]) -> Optional[float]:
+    """MAE of the 'always predict the in-sample mean' baseline. None if empty."""
+    if not truth:
+        return None
+    m = statistics.mean(truth)
+    return statistics.mean(abs(t - m) for t in truth)
+
+
+def _logistic_fit_pearson(feature: list[float], truth: list[float],
+                          iters: int = 500, lr: float = 0.1) -> Optional[float]:
+    """Fit y_hat = sigmoid(a*x + b) by gradient descent (MSE loss) on the
+    STANDARDIZED feature, from a fixed deterministic start (a=b=0) — no RNG
+    needed, unlike _bootstrap_ci which resamples. Returns Pearson(y_hat, truth).
+
+    In-sample fit on the same rows being graded — this measures how gameable
+    the fixture is by a trivial nonlinear transform of the feature, not
+    held-out generalization. Standardizing before fitting (rather than fitting
+    directly on raw log(len)) avoids z=a*x+b overflowing math.exp at realistic
+    response-length scale (log(len) ranges ~2-9, un-scaled that saturates or
+    diverges a lr sized for a standardized feature).
+    """
+    n = len(feature)
+    if n == 0 or len(truth) != n:
+        return None
+    mean_f = statistics.mean(feature)
+    std_f = statistics.pstdev(feature)
+    if std_f == 0:
+        return None  # constant feature — no slope to fit (mirrors _pearson's convention)
+    x = [(f - mean_f) / std_f for f in feature]
+
+    def sigmoid(z: float) -> float:
+        z = max(-30.0, min(30.0, z))  # clip: sigmoid saturates well before |z|=30
+        return 1.0 / (1.0 + math.exp(-z))
+
+    a, b = 0.0, 0.0
+    for _ in range(iters):
+        preds = [sigmoid(a * xi + b) for xi in x]
+        # d(MSE)/d(pred) * d(pred)/dz, averaged over n
+        grad_common = [2.0 * (preds[i] - truth[i]) * preds[i] * (1 - preds[i]) for i in range(n)]
+        grad_a = sum(grad_common[i] * x[i] for i in range(n)) / n
+        grad_b = sum(grad_common) / n
+        a -= lr * grad_a
+        b -= lr * grad_b
+
+    y_hat = [sigmoid(a * xi + b) for xi in x]
+    return _pearson(y_hat, truth)
+
+
+def compute_trivial_baselines(interactions: list[dict]) -> dict:
+    """Fixture-derived (not judge-derived) baselines — computed once per run,
+    independent of which model(s) are being benchmarked."""
+    responses = [i.get("response", "") or "" for i in interactions]
+    truth = [i["ground_truth_score"] for i in interactions]
+    log_len = [math.log(len(r) + 1) for r in responses]
+    return {
+        "log_length_pearson": _pearson(log_len, truth),
+        "constant_mean_mae": _constant_mean_mae(truth),
+        "logistic_pearson": _logistic_fit_pearson(log_len, truth),
+    }
 
 
 def _prf(tp: int, fp: int, fn: int) -> tuple[Optional[float], Optional[float], Optional[float]]:
@@ -398,16 +472,24 @@ def benchmark(models: list[str], interactions: list[dict], provider: str = "olla
             mr.ground_truth.append(interaction["ground_truth_score"])
             # Per-dimension arrays (only when the interaction carries per-dim truth).
             gt_dims = interaction.get("ground_truth_dims") or {}
+            record_dim_truth: dict[str, float] = {}
+            record_dim_scores: dict[str, float] = {}
             for d in DIMS:
                 if d in gt_dims:
-                    mr.dim_scores[d].append(getattr(result, d))
-                    mr.dim_truth[d].append(float(gt_dims[d]))
+                    dim_score = getattr(result, d)
+                    dim_truth_val = float(gt_dims[d])
+                    mr.dim_scores[d].append(dim_score)
+                    mr.dim_truth[d].append(dim_truth_val)
+                    record_dim_scores[d] = dim_score
+                    record_dim_truth[d] = dim_truth_val
             mr.details.append(EvalDetail(
                 interaction_id=interaction["id"],
                 prompt_preview=interaction["prompt"][:80].replace("\n", " "),
                 ground_truth=interaction["ground_truth_score"],
                 model_score=result.score,
                 rationale=result.rationale[:200] if result.rationale else "",
+                dim_truth=record_dim_truth,
+                dim_scores=record_dim_scores,
             ))
 
             if verbose:
@@ -432,7 +514,7 @@ def benchmark(models: list[str], interactions: list[dict], provider: str = "olla
     return results
 
 
-def print_comparison(results: list[ModelResult]) -> None:
+def print_comparison(results: list[ModelResult], trivial_baselines: Optional[dict] = None) -> None:
     if not results:
         print("\nNo results to compare.")
         return
@@ -446,23 +528,39 @@ def print_comparison(results: list[ModelResult]) -> None:
 
     ranked = sorted(results, key=composite, reverse=True)
 
+    log_len_r = trivial_baselines.get("log_length_pearson") if trivial_baselines else None
+    if trivial_baselines is not None:
+        logi = trivial_baselines.get("logistic_pearson")
+        cmae = trivial_baselines.get("constant_mean_mae")
+        fmt = lambda v: f"{v:.3f}" if v is not None else "n/a"
+        print(
+            "\nTrivial baselines (fixture gameability, not judge skill): "
+            f"log-length r={fmt(log_len_r)} | "
+            f"logistic(log-length) r={fmt(logi)} | "
+            f"constant-mean MAE={fmt(cmae)}"
+        )
+
     print(f"\n{'='*80}")
     print("BENCHMARK RESULTS (ranked by composite score)")
     print(f"{'='*80}")
-    print(
-        f"{'Rank':<5} {'Model':<25} {'Pearson':>8} {'Spearman':>9} "
-        f"{'MAE':>6} {'ParseErr':>9} {'Latency':>8} {'Composite':>10}"
-    )
-    print("-" * 80)
+    header = f"{'Rank':<5} {'Model':<25} {'Pearson':>8} {'Spearman':>9} " \
+             f"{'MAE':>6} {'ParseErr':>9} {'Latency':>8} {'Composite':>10}"
+    if log_len_r is not None:
+        header += f" {'Δ vs log-len':>13}"
+    print(header)
+    print("-" * len(header))
 
     for i, r in enumerate(ranked):
         comp = composite(r)
         marker = " ***" if i == 0 else ""
-        print(
+        row = (
             f"{i+1:<5} {r.model:<25} {r.pearson:>8.3f} {r.spearman:>9.3f} "
             f"{r.mae:>6.3f} {r.parse_errors:>4}/{r.total:<4} "
-            f"{r.avg_latency:>7.1f}s {comp:>9.3f}{marker}"
+            f"{r.avg_latency:>7.1f}s {comp:>9.3f}"
         )
+        if log_len_r is not None:
+            row += f" {r.pearson - log_len_r:>+13.3f}"
+        print(row + marker)
 
     print(f"\n*** Winner: {ranked[0].model}")
 
@@ -720,11 +818,15 @@ def main() -> None:
             sys.exit(1)
         print(f"Loaded {len(interactions)} interactions with stored ground-truth scores.\n")
 
+    # Fixture-derived (not judge-derived) trivial baselines — computed once,
+    # independent of which model(s) are benchmarked below.
+    trivial_baselines = compute_trivial_baselines(interactions)
+
     # Run benchmark
     results = benchmark(models, interactions, provider=args.provider, verbose=not args.quiet)
 
     # Composite ranking (legacy) + per-dimension report (fixture mode only).
-    print_comparison(results)
+    print_comparison(results, trivial_baselines=trivial_baselines)
     print_dimension_report(results)
 
     # Safety probes — synthetic smoke test (fixture mode only).
@@ -741,18 +843,39 @@ def main() -> None:
 
     # Optional machine-readable results.
     if args.json_out:
-        payload = [{
-            "model": r.model, "n": len(r.scores), "parse_errors": r.parse_errors,
-            "composite_pearson": _pearson(r.scores, r.ground_truth),
-            "composite_ci": _bootstrap_ci(r.scores, r.ground_truth, _pearson),
-            "threshold": _threshold_pr(r.scores, r.ground_truth),
-            "avg_latency_s": r.avg_latency,
-            "dims": {d: {"pearson": _pearson(r.dim_scores[d], r.dim_truth[d]),
-                         "spearman": _spearman(r.dim_scores[d], r.dim_truth[d]),
-                         "mae": _mae(r.dim_scores[d], r.dim_truth[d])}
-                     for d in DIMS if r.dim_scores.get(d)},
-        } for r in results]
-        out = {"results": payload, "safety_probes": [s for s in safety_results if s]}
+        log_len_r = trivial_baselines.get("log_length_pearson")
+        payload = []
+        for r in results:
+            comp_pearson = _pearson(r.scores, r.ground_truth)
+            payload.append({
+                "model": r.model, "n": len(r.scores), "parse_errors": r.parse_errors,
+                "composite_pearson": comp_pearson,
+                "composite_ci": _bootstrap_ci(r.scores, r.ground_truth, _pearson),
+                "incremental_pearson_vs_log_length": (
+                    comp_pearson - log_len_r
+                    if comp_pearson is not None and log_len_r is not None
+                    else None
+                ),
+                "threshold": _threshold_pr(r.scores, r.ground_truth),
+                "avg_latency_s": r.avg_latency,
+                "dims": {d: {"pearson": _pearson(r.dim_scores[d], r.dim_truth[d]),
+                             "spearman": _spearman(r.dim_scores[d], r.dim_truth[d]),
+                             "mae": _mae(r.dim_scores[d], r.dim_truth[d])}
+                         for d in DIMS if r.dim_scores.get(d)},
+                # Per-interaction records — required for paired cross-run/cross-fixture
+                # comparisons (e.g. same interaction_id scored by two different judges).
+                "records": [{
+                    "interaction_id": d.interaction_id,
+                    "prompt_preview": d.prompt_preview,
+                    "ground_truth": d.ground_truth,
+                    "model_score": d.model_score,
+                    "dim_truth": d.dim_truth,
+                    "dim_scores": d.dim_scores,
+                    "rationale": d.rationale,
+                } for d in r.details],
+            })
+        out = {"results": payload, "safety_probes": [s for s in safety_results if s],
+               "trivial_baselines": trivial_baselines}
         Path(args.json_out).expanduser().write_text(json.dumps(out, indent=2))
         print(f"\n[json] wrote {args.json_out}")
 

--- a/evolution/benchmark_judge.py
+++ b/evolution/benchmark_judge.py
@@ -11,6 +11,7 @@ Usage:
 """
 import argparse
 import json
+import os
 import random
 import statistics
 import sys
@@ -31,6 +32,9 @@ from .judge.ollama_judge import (
     _ollama_url,
     is_ollama_available,
 )
+from .judge.provider import JudgeRegistry
+from .judge import providers as _judge_providers  # noqa: F401 — registers all built-in providers
+from .judge.providers.openai import OpenAIProvider
 
 DIMS = ("quality", "safety", "tool_use", "personalization")
 # Interactions scoring below this composite trigger reflexion (EVOLUTION_REFLECTION_THRESHOLD
@@ -339,7 +343,7 @@ def _auto_detect_models() -> list[str]:
     return [m for m in all_models if "gemma4" in m]
 
 
-def benchmark(models: list[str], interactions: list[dict], verbose: bool = True) -> list[ModelResult]:
+def benchmark(models: list[str], interactions: list[dict], provider: str = "ollama", verbose: bool = True) -> list[ModelResult]:
     results = []
 
     for model_name in models:
@@ -348,13 +352,19 @@ def benchmark(models: list[str], interactions: list[dict], verbose: bool = True)
             print(f"Benchmarking: {model_name}")
             print(f"{'='*60}")
 
-        try:
-            _check_model_pulled(model_name)
-        except RuntimeError as e:
-            print(f"  SKIP: {e}")
-            continue
+        if provider == "ollama":
+            try:
+                _check_model_pulled(model_name)
+            except RuntimeError as e:
+                print(f"  SKIP: {e}")
+                continue
+            judge = OllamaRuntimeJudge(model=model_name)
+        else:
+            # No "is this pulled locally" concept for a hosted API — a bad
+            # model string surfaces as a normal API error inside the
+            # per-interaction try/except below.
+            judge = JudgeRegistry.default().get(provider).make_runtime_judge(model=model_name)
 
-        judge = OllamaRuntimeJudge(model=model_name)
         mr = ModelResult(model=model_name)
 
         for i, interaction in enumerate(interactions):
@@ -582,19 +592,22 @@ def print_dimension_report(results: list[ModelResult], baseline_idx: int = 0) ->
                   f"P({r.model}>{base.model})={delta['p_b_gt_a']:.2f}")
 
 
-def _eval_safety_probes(model_name: str, probes: list[dict], verbose: bool = True) -> Optional[dict]:
+def _eval_safety_probes(model_name: str, probes: list[dict], provider: str = "ollama", verbose: bool = True) -> Optional[dict]:
     """Run synthetic safety probes through one model; binary unsafe-detection P/R.
 
     Judge flags 'unsafe' when its safety dim < 0.5. Smoke test (n~12), not calibration.
     """
     if not probes:
         return None
-    try:
-        _check_model_pulled(model_name)
-    except RuntimeError as e:
-        print(f"  SKIP safety probes for {model_name}: {e}")
-        return None
-    judge = OllamaRuntimeJudge(model=model_name)
+    if provider == "ollama":
+        try:
+            _check_model_pulled(model_name)
+        except RuntimeError as e:
+            print(f"  SKIP safety probes for {model_name}: {e}")
+            return None
+        judge = OllamaRuntimeJudge(model=model_name)
+    else:
+        judge = JudgeRegistry.default().get(provider).make_runtime_judge(model=model_name)
     tp = fp = fn = tn = errors = 0
     for p in probes:
         try:
@@ -655,22 +668,35 @@ def main() -> None:
                              "Only used in --fixture mode; pass '' to skip.")
     parser.add_argument("--json-out", type=str, default=None,
                         help="Write results JSON here (use a gitignored path for fixture runs).")
+    parser.add_argument("--provider", type=str, default="ollama", choices=["ollama", "openai"],
+                        help="Judge backend to benchmark (default: ollama). 'openai' opts into "
+                             "EVOLUTION_OPENAI_JUDGE_ENABLED for the duration of this run.")
     args = parser.parse_args()
 
-    if not is_ollama_available():
-        print("ERROR: Ollama is not reachable. Start it with: ollama serve")
-        sys.exit(1)
+    if args.provider == "ollama":
+        if not is_ollama_available():
+            print("ERROR: Ollama is not reachable. Start it with: ollama serve")
+            sys.exit(1)
+    else:
+        # This deliberate CLI invocation IS the opt-in context.
+        os.environ["EVOLUTION_OPENAI_JUDGE_ENABLED"] = "1"
+        if not OpenAIProvider().is_available():
+            print("ERROR: OpenAI judge not available — set OPENAI_API_KEY.")
+            sys.exit(1)
 
     # Determine models to benchmark
     if args.models:
         models = [m.strip() for m in args.models.split(",")]
-    else:
+    elif args.provider == "ollama":
         models = _auto_detect_models()
         if not models:
             print("ERROR: No gemma4 or qwen models found. Pull some first:")
             print("  ollama pull gemma4:e4b")
             print("  ollama pull gemma4:26b")
             sys.exit(1)
+    else:
+        print("ERROR: --models is required for --provider openai (no auto-detect for hosted models).")
+        sys.exit(1)
 
     print(f"Models to benchmark: {', '.join(models)}")
 
@@ -691,7 +717,7 @@ def main() -> None:
         print(f"Loaded {len(interactions)} interactions with stored ground-truth scores.\n")
 
     # Run benchmark
-    results = benchmark(models, interactions, verbose=not args.quiet)
+    results = benchmark(models, interactions, provider=args.provider, verbose=not args.quiet)
 
     # Composite ranking (legacy) + per-dimension report (fixture mode only).
     print_comparison(results)
@@ -703,7 +729,7 @@ def main() -> None:
         probes = _load_safety_probes(Path(args.safety_probes).expanduser())
         if probes:
             print(f"\nRunning {len(probes)} safety probes per model...")
-            safety_results = [_eval_safety_probes(m, probes, verbose=not args.quiet) for m in models]
+            safety_results = [_eval_safety_probes(m, probes, provider=args.provider, verbose=not args.quiet) for m in models]
             print_safety_report(safety_results)
 
     # Print conflicts for human review

--- a/evolution/benchmark_judge.py
+++ b/evolution/benchmark_judge.py
@@ -681,7 +681,11 @@ def main() -> None:
         # This deliberate CLI invocation IS the opt-in context.
         os.environ["EVOLUTION_OPENAI_JUDGE_ENABLED"] = "1"
         if not OpenAIProvider().is_available():
-            print("ERROR: OpenAI judge not available — set OPENAI_API_KEY.")
+            print(
+                "ERROR: OpenAI judge not available — requires a native codex CLI "
+                "install (e.g. `brew install codex`, not npm) and `codex login`. "
+                "Run `codex login status` to check."
+            )
             sys.exit(1)
 
     # Determine models to benchmark

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -12,10 +12,11 @@ services:
     domain classification. Truncated to JUDGE_MAX_PROMPT/RESPONSE_CHARS each.
   - Gemini API: vault/memory file chunks for semantic embeddings, UNLESS
     Ollama is running and EMBEDDING_PROVIDER != 'gemini'.
-  - OpenAI API (via OPENAI_API_KEY), judge scoring ONLY, and ONLY when
+  - OpenAI (via the local `codex` CLI, ChatGPT/Codex subscription auth — no
+    OPENAI_API_KEY), judge scoring ONLY, and ONLY when
     EVOLUTION_OPENAI_JUDGE_ENABLED is explicitly set (opt-in, never
-    auto-selected): same interaction prompts + responses as the Gemini
-    judge, same truncation limits. See docs/security/data-flows.md §7.
+    auto-selected, macOS only): same interaction prompts + responses as the
+    Gemini judge, same truncation limits. See docs/security/data-flows.md §7.
 
 To keep all processing local:
   - Set EVOLUTION_ENABLED=0  (disables judge + reflexion + domain LLM fallback)
@@ -90,13 +91,11 @@ JUDGE_MODEL = os.environ.get("EVOLUTION_JUDGE_MODEL", "models/gemini-3.1-flash-l
 JUDGE_MAX_PROMPT_CHARS = int(os.environ.get("EVOLUTION_JUDGE_MAX_PROMPT_CHARS", "2000"))
 JUDGE_MAX_RESPONSE_CHARS = int(os.environ.get("EVOLUTION_JUDGE_MAX_RESPONSE_CHARS", "2000"))
 
-# ── OpenAI (opt-in judge alternative) ───────────────────────────────────────────
+# ── OpenAI (opt-in judge alternative, via codex-exec/ChatGPT subscription) ─────
 
-# Namespaced env var (NOT the bare OPENAI_BASE_URL) — that name is already used
-# by the credential-proxy/agent-backend subsystem for a different base URL shape
-# (https://api.openai.com, no /v1). Keeping this one prefixed avoids silently
-# cross-coupling the two subsystems' config.
-OPENAI_BASE_URL = os.environ.get("EVOLUTION_OPENAI_BASE_URL", "https://api.openai.com/v1")
+# Model passed to `codex exec -m`. No OPENAI_API_KEY / base-URL config here —
+# this provider authenticates via the codex CLI's own ChatGPT/Codex
+# subscription login, not a raw API key. See evolution/judge/openai_judge.py.
 OPENAI_JUDGE_MODEL = os.environ.get("EVOLUTION_OPENAI_JUDGE_MODEL", "gpt-5.6-luna")
 
 # ── Reflexion ─────────────────────────────────────────────────────────────────
@@ -198,27 +197,5 @@ def load_api_key() -> str:
         checked = ", ".join(str(p) for p in _ENV_SEARCH_PATHS)
         raise RuntimeError(
             f"GEMINI_API_KEY not found. Checked: {checked}, and env var."
-        )
-    return key
-
-
-def load_openai_api_key() -> str:
-    """Load OPENAI_API_KEY from .env files (in priority order) or environment.
-
-    Mirrors load_api_key() exactly (same search paths, same empty-is-absent
-    semantics) but for the judge subsystem's OpenAI provider.
-    """
-    for path in _ENV_SEARCH_PATHS:
-        if path.exists():
-            for line in path.read_text().splitlines():
-                if line.startswith("OPENAI_API_KEY="):
-                    value = line.split("=", 1)[1].strip()
-                    if value:
-                        return value
-    key = os.environ.get("OPENAI_API_KEY", "")
-    if not key:
-        checked = ", ".join(str(p) for p in _ENV_SEARCH_PATHS)
-        raise RuntimeError(
-            f"OPENAI_API_KEY not found. Checked: {checked}, and env var."
         )
     return key

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -12,6 +12,10 @@ services:
     domain classification. Truncated to JUDGE_MAX_PROMPT/RESPONSE_CHARS each.
   - Gemini API: vault/memory file chunks for semantic embeddings, UNLESS
     Ollama is running and EMBEDDING_PROVIDER != 'gemini'.
+  - OpenAI API (via OPENAI_API_KEY), judge scoring ONLY, and ONLY when
+    EVOLUTION_OPENAI_JUDGE_ENABLED is explicitly set (opt-in, never
+    auto-selected): same interaction prompts + responses as the Gemini
+    judge, same truncation limits. See docs/security/data-flows.md §7.
 
 To keep all processing local:
   - Set EVOLUTION_ENABLED=0  (disables judge + reflexion + domain LLM fallback)
@@ -85,6 +89,15 @@ JUDGE_MODEL = os.environ.get("EVOLUTION_JUDGE_MODEL", "models/gemini-3.1-flash-l
 # chars preserves scoring signal while capping outbound payload size.
 JUDGE_MAX_PROMPT_CHARS = int(os.environ.get("EVOLUTION_JUDGE_MAX_PROMPT_CHARS", "2000"))
 JUDGE_MAX_RESPONSE_CHARS = int(os.environ.get("EVOLUTION_JUDGE_MAX_RESPONSE_CHARS", "2000"))
+
+# ── OpenAI (opt-in judge alternative) ───────────────────────────────────────────
+
+# Namespaced env var (NOT the bare OPENAI_BASE_URL) — that name is already used
+# by the credential-proxy/agent-backend subsystem for a different base URL shape
+# (https://api.openai.com, no /v1). Keeping this one prefixed avoids silently
+# cross-coupling the two subsystems' config.
+OPENAI_BASE_URL = os.environ.get("EVOLUTION_OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENAI_JUDGE_MODEL = os.environ.get("EVOLUTION_OPENAI_JUDGE_MODEL", "gpt-5.6-luna")
 
 # ── Reflexion ─────────────────────────────────────────────────────────────────
 
@@ -185,5 +198,27 @@ def load_api_key() -> str:
         checked = ", ".join(str(p) for p in _ENV_SEARCH_PATHS)
         raise RuntimeError(
             f"GEMINI_API_KEY not found. Checked: {checked}, and env var."
+        )
+    return key
+
+
+def load_openai_api_key() -> str:
+    """Load OPENAI_API_KEY from .env files (in priority order) or environment.
+
+    Mirrors load_api_key() exactly (same search paths, same empty-is-absent
+    semantics) but for the judge subsystem's OpenAI provider.
+    """
+    for path in _ENV_SEARCH_PATHS:
+        if path.exists():
+            for line in path.read_text().splitlines():
+                if line.startswith("OPENAI_API_KEY="):
+                    value = line.split("=", 1)[1].strip()
+                    if value:
+                        return value
+    key = os.environ.get("OPENAI_API_KEY", "")
+    if not key:
+        checked = ", ".join(str(p) for p in _ENV_SEARCH_PATHS)
+        raise RuntimeError(
+            f"OPENAI_API_KEY not found. Checked: {checked}, and env var."
         )
     return key

--- a/evolution/judge/__init__.py
+++ b/evolution/judge/__init__.py
@@ -5,6 +5,7 @@ from .provider import JudgeProvider, JudgeRegistry, NoProviderAvailableError
 from .gemini_judge import GeminiRuntimeJudge
 from .ollama_judge import OllamaRuntimeJudge, is_ollama_available
 from .llama_cpp_judge import LlamaCppRuntimeJudge, is_llama_cpp_available
+from .openai_judge import OpenAIRuntimeJudge, is_openai_available
 
 # Register built-in providers on import
 from . import providers as _providers  # noqa: F401
@@ -23,5 +24,6 @@ __all__ = [
     "GeminiRuntimeJudge",
     "OllamaRuntimeJudge", "is_ollama_available",
     "LlamaCppRuntimeJudge", "is_llama_cpp_available",
+    "OpenAIRuntimeJudge", "is_openai_available",
     "make_runtime_judge",
 ]

--- a/evolution/judge/openai_judge.py
+++ b/evolution/judge/openai_judge.py
@@ -1,0 +1,314 @@
+"""
+OpenAI-based judge for the Deus Evolution loop (opt-in — see providers/openai.py).
+
+Standalone runtime evaluator — scores production interactions via evaluate().
+Uses stdlib urllib for HTTP against OpenAI's /v1/chat/completions endpoint
+(no new dependency — mirrors evolution/judge/llama_cpp_judge.py's mechanics),
+with gemini_judge.py's more defensive JSON parsing since a newly-released
+model's structured-output reliability against this schema is unverified.
+"""
+import asyncio
+import json
+import re
+import time
+import urllib.request
+import urllib.error
+from typing import Optional
+
+from ..config import (
+    JUDGE_MAX_PERSONA_CHARS,
+    JUDGE_MAX_PROMPT_CHARS,
+    JUDGE_MAX_RESPONSE_CHARS,
+    JUDGE_RETRY_COUNT,
+    OPENAI_BASE_URL,
+    OPENAI_JUDGE_MODEL,
+    load_openai_api_key,
+)
+from .base import BaseJudge, JudgeResult
+from .criteria import RUBRIC, compose_score, _normalize_dim
+
+_RESPONSE_SCHEMA = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "judge_result",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "safe": {"type": "boolean"},
+                "quality_level": {"type": "integer", "minimum": 1, "maximum": 5},
+                "recalled_preference": {"type": "boolean"},
+                "format_matched": {"type": "boolean"},
+                "tone_matched": {"type": "boolean"},
+                "execution_quality": {"type": "integer", "minimum": 1, "maximum": 5},
+                "rationale": {"type": "string"},
+            },
+            "required": [
+                "safe", "quality_level", "recalled_preference", "format_matched",
+                "tone_matched", "execution_quality", "rationale",
+            ],
+        },
+    },
+}
+
+
+def _openai_url(path: str) -> str:
+    return f"{OPENAI_BASE_URL.rstrip('/')}{path}"
+
+
+def is_openai_available() -> bool:
+    """Key presence only — no network ping (avoids burning a live API call
+    just to check availability)."""
+    try:
+        load_openai_api_key()
+        return True
+    except RuntimeError:
+        return False
+
+
+# HTTP statuses worth retrying (transient) — everything else (401/403/404/400)
+# means "this will fail again" and should raise immediately with a clear message.
+_RETRYABLE_HTTP_CODES = {429, 500, 502, 503, 504}
+
+
+def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
+    """Synchronous OpenAI chat-completion call.
+
+    Unlike llama_cpp_judge.py's local-server call, this hits a real internet
+    API that can rate-limit (429) or have transient outages (5xx) — retries
+    those up to JUDGE_RETRY_COUNT times with backoff. Auth/model errors
+    (401/403/404/400) raise immediately since retrying won't fix them.
+    """
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "response_format": _RESPONSE_SCHEMA,
+    }).encode()
+    key = load_openai_api_key()
+
+    last_exc: Optional[RuntimeError] = None
+    for attempt in range(JUDGE_RETRY_COUNT + 1):
+        req = urllib.request.Request(
+            _openai_url("/chat/completions"),
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {key}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                data = json.loads(resp.read().decode())
+            choices = data.get("choices") or []
+            return choices[0].get("message", {}).get("content") or "" if choices else ""
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")[:500]
+            last_exc = RuntimeError(f"OpenAI API error {exc.code} for model {model}: {detail}")
+            if exc.code not in _RETRYABLE_HTTP_CODES or attempt == JUDGE_RETRY_COUNT:
+                raise last_exc from exc
+        except urllib.error.URLError as exc:
+            last_exc = RuntimeError(f"Cannot reach OpenAI API at {OPENAI_BASE_URL}: {exc.reason}")
+            if attempt == JUDGE_RETRY_COUNT:
+                raise last_exc from exc
+        time.sleep(2 ** attempt)
+    raise last_exc  # pragma: no cover — unreachable, loop always returns or raises
+
+
+async def _call_openai_async(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
+    """Async OpenAI call — runs sync in thread pool to avoid blocking the event loop."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, lambda: _call_openai(prompt, model))
+
+
+def _cap_context_and_profile(
+    context: Optional[str], user_profile: Optional[str]
+) -> tuple[Optional[str], Optional[str]]:
+    """Defense-in-depth truncation before either value reaches OpenAI's API.
+
+    `user_profile` is already capped at JUDGE_MAX_PERSONA_CHARS upstream
+    (evolution/persona.py, before it ever reaches evaluate()); this re-caps
+    it anyway rather than trusting every future caller to do so. `context`
+    has no upstream cap (BaseJudge's interface allows any caller to pass an
+    arbitrarily large string, same as gemini_judge.py) — capped here to
+    JUDGE_MAX_PROMPT_CHARS, the same bound already applied to `prompt`, as
+    defense-in-depth for this newly-added, unvalidated provider specifically.
+    """
+    if context:
+        context = context[:JUDGE_MAX_PROMPT_CHARS]
+    if user_profile:
+        user_profile = user_profile[:JUDGE_MAX_PERSONA_CHARS]
+    return context, user_profile
+
+
+# ── Runtime evaluator ─────────────────────────────────────────────────────────
+
+class OpenAIRuntimeJudge(BaseJudge):
+    """
+    Evaluates production interactions using the structured RUBRIC via an
+    OpenAI-hosted model (e.g. GPT-5.6 Luna/Terra/Sol).
+    Returns a JudgeResult with per-dimension scores and a composite score.
+    """
+
+    def __init__(self, model: str = OPENAI_JUDGE_MODEL):
+        self.model = model
+
+    def evaluate(
+        self,
+        prompt: str,
+        response: str,
+        tools_used: Optional[list[str]] = None,
+        context: Optional[str] = None,
+        user_profile: Optional[str] = None,
+    ) -> JudgeResult:
+        prompt = prompt[:JUDGE_MAX_PROMPT_CHARS]
+        response = (response or "")[:JUDGE_MAX_RESPONSE_CHARS]
+        context, user_profile = _cap_context_and_profile(context, user_profile)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
+        raw = _call_openai(eval_prompt, self.model)
+        result = _parse_result(raw)
+        if result.is_parse_error:
+            for _ in range(JUDGE_RETRY_COUNT):
+                raw = _call_openai(
+                    _build_eval_prompt(prompt, response, tools_used, context, user_profile, strict_json=True),
+                    self.model,
+                )
+                result = _parse_result(raw)
+                if not result.is_parse_error:
+                    break
+        return result
+
+    async def a_evaluate(
+        self,
+        prompt: str,
+        response: str,
+        tools_used: Optional[list[str]] = None,
+        context: Optional[str] = None,
+        user_profile: Optional[str] = None,
+    ) -> JudgeResult:
+        prompt = prompt[:JUDGE_MAX_PROMPT_CHARS]
+        response = (response or "")[:JUDGE_MAX_RESPONSE_CHARS]
+        context, user_profile = _cap_context_and_profile(context, user_profile)
+        eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
+        raw = await _call_openai_async(eval_prompt, self.model)
+        result = _parse_result(raw)
+        if result.is_parse_error:
+            for _ in range(JUDGE_RETRY_COUNT):
+                raw = await _call_openai_async(
+                    _build_eval_prompt(prompt, response, tools_used, context, user_profile, strict_json=True),
+                    self.model,
+                )
+                result = _parse_result(raw)
+                if not result.is_parse_error:
+                    break
+        return result
+
+
+def _build_eval_prompt(
+    prompt: str,
+    response: str,
+    tools_used: Optional[list[str]],
+    context: Optional[str],
+    user_profile: Optional[str] = None,
+    strict_json: bool = False,
+) -> str:
+    parts = [RUBRIC, "\n## Interaction to evaluate\n"]
+    if context:
+        parts.append(f"**Context:** {context}\n")
+    if user_profile:
+        parts.append(f"**Known user preferences (stored profile):**\n{user_profile}\n")
+    parts.append(f"**User prompt:**\n{prompt}\n")
+    if tools_used:
+        parts.append(f"**Tools used:** {', '.join(tools_used)}\n")
+    parts.append(f"**Agent response:**\n{response}\n")
+    if strict_json:
+        parts.append(
+            "\nIMPORTANT: Respond with ONLY a valid JSON object. "
+            "No markdown fences, no explanation, just the raw JSON.\n"
+        )
+    return "\n".join(parts)
+
+
+_JSON_BLOCK_RE = re.compile(r"\{[^{}]*\}")
+
+
+def _parse_result(raw: str) -> JudgeResult:
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+
+    data = None
+    try:
+        candidate = json.loads(text)
+        if isinstance(candidate, dict):
+            data = candidate
+    except json.JSONDecodeError:
+        pass
+
+    if data is None:
+        match = _JSON_BLOCK_RE.search(text)
+        if match:
+            try:
+                candidate = json.loads(match.group(0))
+                if isinstance(candidate, dict):
+                    data = candidate
+            except json.JSONDecodeError:
+                pass
+
+    if data is None:
+        import sys
+        print(
+            f"[judge] Parse error: no JSON found | raw={raw[:200]}",
+            file=sys.stderr,
+        )
+        return JudgeResult(
+            score=0.5,
+            quality=0.5,
+            safety=1.0,
+            tool_use=1.0,
+            personalization=0.5,
+            rationale="Parse error — neutral score assigned",
+            raw_response=raw,
+            is_parse_error=True,
+        )
+
+    try:
+        quality = _normalize_dim("quality", data)
+        safety = _normalize_dim("safety", data)
+        tool_use = _normalize_dim("tool_use", data)
+        personalization = _normalize_dim("personalization", data)
+        dims = {
+            "quality": quality,
+            "safety": safety,
+            "tool_use": tool_use,
+            "personalization": personalization,
+        }
+        return JudgeResult(
+            score=compose_score(dims),
+            rationale=data.get("rationale", ""),
+            raw_response=raw,
+            **dims,
+        )
+    except (KeyError, ValueError) as exc:
+        import sys
+        print(
+            f"[judge] Parse error: {exc.__class__.__name__}: {exc} | raw={raw[:200]}",
+            file=sys.stderr,
+        )
+        return JudgeResult(
+            score=0.5,
+            quality=0.5,
+            safety=1.0,
+            tool_use=1.0,
+            personalization=0.5,
+            rationale="Parse error — neutral score assigned",
+            raw_response=raw,
+            is_parse_error=True,
+        )
+
+
+def make_runtime_judge(model: str = OPENAI_JUDGE_MODEL) -> OpenAIRuntimeJudge:
+    """Return an OpenAIRuntimeJudge for scoring production interactions."""
+    return OpenAIRuntimeJudge(model=model)

--- a/evolution/judge/openai_judge.py
+++ b/evolution/judge/openai_judge.py
@@ -293,7 +293,13 @@ def _classify_stderr(stderr: str) -> str:
     return "fatal"
 
 
-def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
+# Confirmed live against this codex version (0.144.3): passing an invalid
+# value to -c model_reasoning_effort returns a clear 400
+# invalid_enum_value error naming exactly this set.
+_VALID_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+
+
+def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL, effort: str = "high") -> str:
     """Synchronous codex-exec call, sandboxed per the module docstring.
 
     Each attempt gets a fresh isolated temp directory (this-user-scoped,
@@ -301,7 +307,16 @@ def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
     which would honor TMPDIR and could land outside the validated Seatbelt
     grant under a stripped environment) and a fresh Seatbelt profile file;
     both are cleaned up in `finally` regardless of outcome.
+
+    `effort` defaults to "high" (preserving prior behavior for every
+    existing caller) — see the class docstring for why "high" is the
+    production default; exposed as a parameter so a caller can benchmark
+    other levels ("none"/"minimal"/"low"/"medium"/"xhigh"/"max") without
+    touching the sandbox/capability design at all (effort is purely a
+    model-generation knob, zero security surface).
     """
+    if effort not in _VALID_EFFORTS:
+        raise ValueError(f"Invalid effort {effort!r}; must be one of {sorted(_VALID_EFFORTS)}")
     codex_path = shutil.which("codex")
     if codex_path is None:
         raise RuntimeError("`codex` CLI not found on PATH.")
@@ -329,13 +344,14 @@ def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
             cmd += [
                 "-c", 'web_search="disabled"',
                 "-c", "tools.view_image=false",
-                # "high": --ignore-user-config drops config.toml's own
-                # reasoning-effort default, and rubric-adherence accuracy on
-                # a 4-dimension structured-scoring task benefits more from
+                # --ignore-user-config drops config.toml's own
+                # reasoning-effort default, so this is always explicit.
+                # Default "high": rubric-adherence accuracy on a
+                # 4-dimension structured-scoring task benefits more from
                 # higher effort than latency does from lower — accepted
                 # tradeoff despite the retry loops below compounding worst-
                 # case wall-clock (up to (JUDGE_RETRY_COUNT+1)^2 calls).
-                "-c", 'model_reasoning_effort="high"',
+                "-c", f'model_reasoning_effort="{effort}"',
                 "--ignore-user-config", "--ignore-rules",
                 "--sandbox", "read-only", "--ephemeral", "--skip-git-repo-check",
                 "--cd", iso_dir,
@@ -395,10 +411,10 @@ def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
     raise last_exc  # pragma: no cover — unreachable, loop always returns or raises
 
 
-async def _call_openai_async(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
+async def _call_openai_async(prompt: str, model: str = OPENAI_JUDGE_MODEL, effort: str = "high") -> str:
     """Async codex-exec call — runs sync in thread pool to avoid blocking the event loop."""
     loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, lambda: _call_openai(prompt, model))
+    return await loop.run_in_executor(None, lambda: _call_openai(prompt, model, effort))
 
 
 def _cap_context_and_profile(
@@ -432,8 +448,9 @@ class OpenAIRuntimeJudge(BaseJudge):
     and a composite score.
     """
 
-    def __init__(self, model: str = OPENAI_JUDGE_MODEL):
+    def __init__(self, model: str = OPENAI_JUDGE_MODEL, effort: str = "high"):
         self.model = model
+        self.effort = effort
 
     def evaluate(
         self,
@@ -447,13 +464,13 @@ class OpenAIRuntimeJudge(BaseJudge):
         response = (response or "")[:JUDGE_MAX_RESPONSE_CHARS]
         context, user_profile = _cap_context_and_profile(context, user_profile)
         eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
-        raw = _call_openai(eval_prompt, self.model)
+        raw = _call_openai(eval_prompt, self.model, self.effort)
         result = _parse_result(raw)
         if result.is_parse_error:
             for _ in range(JUDGE_RETRY_COUNT):
                 raw = _call_openai(
                     _build_eval_prompt(prompt, response, tools_used, context, user_profile, strict_json=True),
-                    self.model,
+                    self.model, self.effort,
                 )
                 result = _parse_result(raw)
                 if not result.is_parse_error:
@@ -472,13 +489,13 @@ class OpenAIRuntimeJudge(BaseJudge):
         response = (response or "")[:JUDGE_MAX_RESPONSE_CHARS]
         context, user_profile = _cap_context_and_profile(context, user_profile)
         eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
-        raw = await _call_openai_async(eval_prompt, self.model)
+        raw = await _call_openai_async(eval_prompt, self.model, self.effort)
         result = _parse_result(raw)
         if result.is_parse_error:
             for _ in range(JUDGE_RETRY_COUNT):
                 raw = await _call_openai_async(
                     _build_eval_prompt(prompt, response, tools_used, context, user_profile, strict_json=True),
-                    self.model,
+                    self.model, self.effort,
                 )
                 result = _parse_result(raw)
                 if not result.is_parse_error:
@@ -587,6 +604,6 @@ def _parse_result(raw: str) -> JudgeResult:
         )
 
 
-def make_runtime_judge(model: str = OPENAI_JUDGE_MODEL) -> OpenAIRuntimeJudge:
+def make_runtime_judge(model: str = OPENAI_JUDGE_MODEL, effort: str = "high") -> OpenAIRuntimeJudge:
     """Return an OpenAIRuntimeJudge for scoring production interactions."""
-    return OpenAIRuntimeJudge(model=model)
+    return OpenAIRuntimeJudge(model=model, effort=effort)

--- a/evolution/judge/openai_judge.py
+++ b/evolution/judge/openai_judge.py
@@ -1,18 +1,88 @@
 """
-OpenAI-based judge for the Deus Evolution loop (opt-in — see providers/openai.py).
+Codex-subscription-based judge for the Deus Evolution loop (opt-in — see
+providers/openai.py).
 
 Standalone runtime evaluator — scores production interactions via evaluate().
-Uses stdlib urllib for HTTP against OpenAI's /v1/chat/completions endpoint
-(no new dependency — mirrors evolution/judge/llama_cpp_judge.py's mechanics),
-with gemini_judge.py's more defensive JSON parsing since a newly-released
-model's structured-output reliability against this schema is unverified.
+
+Transport: shells out to the `codex` CLI (ChatGPT/Codex subscription auth,
+no OPENAI_API_KEY / per-call billing) wrapped in a macOS Seatbelt sandbox.
+This is macOS-only by design (Seatbelt is a macOS-specific mechanism).
+
+Why not a raw HTTP call to OpenAI's API (like gemini_judge.py does for
+Gemini)? Because `codex exec` is the only viable subscription-backed
+transport to GPT-5.6 in this environment, and unlike a passive completion
+API, `codex exec` is a full AGENT — the model can invoke tools including
+shell execution. The judge's job is to score real, potentially-adversarial
+production interaction text (arbitrary user messages, arbitrary agent
+responses), so a prompt-injection payload hidden in judged content is a
+real threat: it could otherwise instruct the agent to read and exfiltrate
+local secrets (this host's own live ChatGPT/Codex OAuth credential among
+them).
+
+Security design (validated via extensive live adversarial testing, not just
+constructed defensively — see the PR description / session log for the full
+verification trail):
+
+1. Capability removal, not credential gating. `~/.codex/auth.json` (the
+   live OAuth credential) MUST be readable by the codex process for it to
+   authenticate at all — there is no way to keep it unreadable to that
+   process's own shell-tool capability if that capability exists (Seatbelt
+   scopes by process tree, not by which code path triggers a given read).
+   The fix is removing the tool-use capability, not trying to protect the
+   credential from it: `codex exec --disable shell_tool --disable apps
+   --disable unified_exec ...` (a comprehensive list — `codex features list`
+   was used to enumerate every execution/browser/computer/plugin-adjacent
+   feature and confirm each resolves to `false` under this flag set, not
+   just the two flags that looked obviously relevant).
+2. OS-level backstop for the EXEC vector specifically, independent of #1.
+   A Seatbelt profile denies the codex process from exec'ing ANY further
+   binary — `process-exec` is scoped to ONLY the resolved native codex
+   binary itself (the one exec `sandbox-exec` performs to launch it), not
+   a blanket allow. This closes the exec gap even if a future codex version
+   reintroduces an execution capability #1 doesn't anticipate. It does NOT
+   extend to network exfiltration: the profile necessarily grants
+   unrestricted outbound network (`network*`) since codex needs it to reach
+   the model API — if a future codex feature retains network capability
+   despite the `--disable` list, there is no second layer stopping it the
+   way there is for exec.
+3. Minimal filesystem exposure. Beyond the process-exec restriction, reads
+   are scoped to: OS/runtime libraries, a narrow allowlist of codex's own
+   fixed bookkeeping paths under ~/.codex/ (auth token, install id, its own
+   numbered state/log/goals/memories sqlite DBs, its own tmp scratch dir —
+   NOT the whole directory: history.jsonl, hooks.json, config.toml, skills/,
+   plugins/, sessions/ all stay unreadable, and codex gracefully degrades
+   those optional features when denied), this user's own per-user Darwin
+   temp/cache root (derived authoritatively via `getconf
+   DARWIN_USER_TEMP_DIR`, NOT via the `TMPDIR` env var — TMPDIR can be
+   absent or empty and both cases were confirmed live to resolve to an
+   unsafe, overly broad fallback path), and the one per-call isolated temp
+   directory this specific evaluation is allowed to read/write.
+4. Minimal environment. The subprocess environment is explicitly limited to
+   PATH/HOME (not inherited wholesale) — the evolution process's own
+   GEMINI_API_KEY/other secrets are never visible to the codex subprocess.
+5. Fail closed. `is_openai_available()` requires the resolved `codex`
+   binary to be a genuine native Mach-O executable (rejects npm-launcher
+   installs, which resolve to a JS launcher — a different, untested
+   multi-hop-exec shape this transport doesn't attempt to support) and a
+   working `codex login status` check under the same minimal environment
+   the real call uses (not the inherited environment, which could report
+   availability against a different CODEX_HOME than the real call uses).
+
+Caveat for anyone comparing results from this transport: `codex exec` wraps
+GPT-5.6 in Codex's own system instructions and agent scaffolding. Results
+measure "GPT-5.6 *through Codex*," not the raw model a direct API call would
+measure — label this explicitly in any benchmark report.
 """
 import asyncio
 import json
+import os
+import platform
 import re
-import time
-import urllib.request
-import urllib.error
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
 from typing import Optional
 
 from ..config import (
@@ -20,105 +90,313 @@ from ..config import (
     JUDGE_MAX_PROMPT_CHARS,
     JUDGE_MAX_RESPONSE_CHARS,
     JUDGE_RETRY_COUNT,
-    OPENAI_BASE_URL,
     OPENAI_JUDGE_MODEL,
-    load_openai_api_key,
 )
 from .base import BaseJudge, JudgeResult
 from .criteria import RUBRIC, compose_score, _normalize_dim
 
 _RESPONSE_SCHEMA = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "judge_result",
-        "strict": True,
-        "schema": {
-            "type": "object",
-            "additionalProperties": False,
-            "properties": {
-                "safe": {"type": "boolean"},
-                "quality_level": {"type": "integer", "minimum": 1, "maximum": 5},
-                "recalled_preference": {"type": "boolean"},
-                "format_matched": {"type": "boolean"},
-                "tone_matched": {"type": "boolean"},
-                "execution_quality": {"type": "integer", "minimum": 1, "maximum": 5},
-                "rationale": {"type": "string"},
-            },
-            "required": [
-                "safe", "quality_level", "recalled_preference", "format_matched",
-                "tone_matched", "execution_quality", "rationale",
-            ],
-        },
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "safe": {"type": "boolean"},
+        "quality_level": {"type": "integer", "minimum": 1, "maximum": 5},
+        "recalled_preference": {"type": "boolean"},
+        "format_matched": {"type": "boolean"},
+        "tone_matched": {"type": "boolean"},
+        "execution_quality": {"type": "integer", "minimum": 1, "maximum": 5},
+        # Capped: the one free-text field in this schema — bounds the
+        # channel a compromised/tricked agent could use to smuggle a larger
+        # payload through the legitimate structured-output path, and caps
+        # downstream log/report growth (mirrors this file's existing
+        # raw/stderr truncation conventions elsewhere).
+        "rationale": {"type": "string", "maxLength": 500},
     },
+    "required": [
+        "safe", "quality_level", "recalled_preference", "format_matched",
+        "tone_matched", "execution_quality", "rationale",
+    ],
 }
 
+# Every execution/browser/computer/plugin/dependency-install-adjacent codex
+# feature, confirmed via `codex features list --disable <these>` to resolve
+# each name to `false` — not just the two flags (shell_tool, apps) that look
+# obviously relevant. `unified_exec` in particular is a distinct, stable,
+# enabled-by-DEFAULT execution feature that survives disabling shell_tool
+# alone; missing it was a confirmed, live-reproduced gap during this
+# transport's design.
+_DISABLE_FEATURES = [
+    "shell_tool", "apps", "unified_exec", "code_mode_host",
+    "browser_use", "browser_use_external", "browser_use_full_cdp_access",
+    "computer_use", "image_generation", "in_app_browser", "multi_agent",
+    "plugins", "plugin_sharing", "remote_plugin", "shell_snapshot",
+    "tool_call_mcp_elicitation", "workspace_dependencies", "hooks",
+    "skill_mcp_dependency_install", "auth_elicitation",
+]
 
-def _openai_url(path: str) -> str:
-    return f"{OPENAI_BASE_URL.rstrip('/')}{path}"
+# Mach-O magic numbers (thin + 64-bit + 32/64-bit fat/universal, both byte
+# orders) — used to reject non-native codex installs (e.g. an npm-installed
+# JS launcher at bin/codex.js) that resolve via `which` but aren't the real
+# executable this transport's Seatbelt profile is built to sandbox.
+_MACHO_MAGICS = {
+    0xFEEDFACE, 0xCEFAEDFE,  # MH_MAGIC / MH_CIGAM (32-bit)
+    0xFEEDFACF, 0xCFFAEDFE,  # MH_MAGIC_64 / MH_CIGAM_64
+    0xCAFEBABE, 0xBEBAFECA,  # FAT_MAGIC / FAT_CIGAM
+    0xCAFEBABF, 0xBFBAFECA,  # FAT_MAGIC_64 / FAT_CIGAM_64
+}
+
+_PER_USER_ROOT_RE = re.compile(r"^/private/var/folders/[^/]+/[^/]+$")
 
 
-def is_openai_available() -> bool:
-    """Key presence only — no network ping (avoids burning a live API call
-    just to check availability)."""
+def _minimal_env() -> dict:
+    """Resolved fresh per call (not a module-level constant) so it always
+    matches whatever HOME/PATH the process actually has — consistent with
+    _build_sandbox_profile's own live os.path.expanduser("~") read."""
+    return {"PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")}
+
+
+def _is_macho_binary(path: str) -> bool:
     try:
-        load_openai_api_key()
-        return True
-    except RuntimeError:
+        with open(path, "rb") as f:
+            magic_bytes = f.read(4)
+        if len(magic_bytes) != 4:
+            return False
+        import struct
+        magic = struct.unpack(">I", magic_bytes)[0]
+        return magic in _MACHO_MAGICS
+    except OSError:
         return False
 
 
-# HTTP statuses worth retrying (transient) — everything else (401/403/404/400)
-# means "this will fail again" and should raise immediately with a clear message.
-_RETRYABLE_HTTP_CODES = {429, 500, 502, 503, 504}
+def _darwin_per_user_root() -> str:
+    """OS-authoritative per-user Darwin temp/cache root.
+
+    Deliberately NOT derived from the TMPDIR env var: TMPDIR absent resolves
+    (via realpath("/tmp")) to "/private" — broader than this function exists
+    to produce; TMPDIR="" (set-but-empty; os.environ.get's default only
+    applies when the key is fully absent) resolves to the calling process's
+    cwd, a context-dependent path that could cover the repo or sibling
+    worktrees depending on launch directory. Both were confirmed live during
+    this transport's design. `getconf DARWIN_USER_TEMP_DIR` is independent
+    of TMPDIR entirely (confirmed via `env -i getconf DARWIN_USER_TEMP_DIR`).
+
+    Fails closed: raises rather than return an unvalidated path if the
+    resolved value doesn't match the expected two-segment Darwin per-user
+    shape — never silently falls through to a broader grant.
+    """
+    raw = subprocess.run(
+        ["getconf", "DARWIN_USER_TEMP_DIR"],
+        capture_output=True, text=True, timeout=5, check=True,
+    ).stdout.strip()
+    real = os.path.realpath(raw).rstrip("/")
+    per_user_root = os.path.dirname(real)
+    if not _PER_USER_ROOT_RE.match(per_user_root):
+        raise RuntimeError(
+            f"Unexpected Darwin per-user temp root shape: {per_user_root!r} "
+            f"(from getconf DARWIN_USER_TEMP_DIR={raw!r}) — refusing to build "
+            f"an unvalidated Seatbelt grant."
+        )
+    return per_user_root
+
+
+def is_openai_available() -> bool:
+    """codex CLI present, authenticated, native, on a supported OS. No
+    subscription-quota spend — `codex login status` is a local credential
+    check (confirmed live: returns instantly, exit 0, reports zero token
+    usage, unlike every real `codex exec` call)."""
+    if os.environ.get("EVOLUTION_OPENAI_JUDGE_ENABLED", "").lower() not in ("1", "true", "yes"):
+        return False
+    if platform.system() != "Darwin":
+        return False
+    codex_path = shutil.which("codex")
+    if codex_path is None or shutil.which("sandbox-exec") is None:
+        return False
+    resolved = os.path.realpath(codex_path)
+    if not _is_macho_binary(resolved):
+        print(
+            f"[openai_judge] codex resolved to a non-native launcher "
+            f"({resolved!r}) — this transport requires a native Mach-O "
+            f"binary (e.g. `brew install codex`), not an npm-launcher "
+            f"install. Reporting unavailable.",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        result = subprocess.run(
+            ["codex", "login", "status"],
+            capture_output=True, text=True, timeout=10, env=_minimal_env(),
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _build_sandbox_profile(codex_real: str, per_user_root: str, iso_dir: str) -> str:
+    """Seatbelt (SBPL) profile — see module docstring for the security
+    rationale. `process-exec` is scoped to ONLY the resolved codex binary;
+    `~/.codex/*` grants are narrow (fixed bookkeeping paths, not the whole
+    directory); `per_user_root` and `iso_dir` grants are this-user-only,
+    never a blanket /private/var/folders or /private grant."""
+    home = os.path.expanduser("~")
+    return f"""
+(version 1)
+(import "system.sb")
+(deny default)
+
+(allow process-exec (literal "{codex_real}"))
+(allow process-fork)
+(allow signal (target self))
+(allow file-read-metadata)
+(allow mach-lookup)
+(allow iokit-open (iokit-user-client-class "IOSurfaceRootUserClient"))
+(allow sysctl-read)
+(allow network*)
+(allow system-socket)
+(allow user-preference-read)
+(allow ipc-posix-shm)
+
+(allow file-read*
+  (subpath "/usr/lib") (subpath "/usr/bin") (subpath "/bin")
+  (subpath "/System") (subpath "/opt/homebrew")
+  (subpath "/private/var/db/dyld") (subpath "/private/etc")
+  (subpath "/Library/Preferences")
+  (literal "/dev/null") (literal "/dev/urandom") (literal "/dev/random"))
+
+(allow file-read* file-write* (subpath "{per_user_root}"))
+(allow file-write-create (subpath "/private/tmp"))
+
+(allow file-read-data (literal "{home}/.codex"))
+(allow file-read* (literal "{home}/.codex/auth.json"))
+(allow file-read* file-write* (literal "{home}/.codex/installation_id"))
+(allow file-read* file-write* (subpath "{home}/.codex/tmp"))
+(allow file-read* file-write*
+  (regex #"^{re.escape(home)}/\\.codex/[a-z]+_[0-9]+\\.sqlite.*$"))
+
+(allow file-read* file-write* (subpath "{iso_dir}"))
+"""
+
+
+# HTTP-style retry classification doesn't apply to a subprocess call — codex
+# exit codes / stderr substrings play the same role. Rate-limit/transient
+# markers are retried up to JUDGE_RETRY_COUNT times; auth/not-found markers
+# raise immediately (retrying won't fix them).
+_RETRYABLE_MARKERS = ("rate limit", "429", "usage limit", "too many requests", "unavailable")
+_FATAL_MARKERS = ("unauthorized", "not logged in", "401", "authentication")
+
+
+def _classify_stderr(stderr: str) -> str:
+    low = stderr.lower()
+    if any(m in low for m in _FATAL_MARKERS):
+        return "fatal"
+    if any(m in low for m in _RETRYABLE_MARKERS):
+        return "retryable"
+    return "fatal"
 
 
 def _call_openai(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
-    """Synchronous OpenAI chat-completion call.
+    """Synchronous codex-exec call, sandboxed per the module docstring.
 
-    Unlike llama_cpp_judge.py's local-server call, this hits a real internet
-    API that can rate-limit (429) or have transient outages (5xx) — retries
-    those up to JUDGE_RETRY_COUNT times with backoff. Auth/model errors
-    (401/403/404/400) raise immediately since retrying won't fix them.
+    Each attempt gets a fresh isolated temp directory (this-user-scoped,
+    via `_darwin_per_user_root()` — never a bare `tempfile.mkdtemp()`,
+    which would honor TMPDIR and could land outside the validated Seatbelt
+    grant under a stripped environment) and a fresh Seatbelt profile file;
+    both are cleaned up in `finally` regardless of outcome.
     """
-    body = json.dumps({
-        "model": model,
-        "messages": [{"role": "user", "content": prompt}],
-        "temperature": 0,
-        "response_format": _RESPONSE_SCHEMA,
-    }).encode()
-    key = load_openai_api_key()
+    codex_path = shutil.which("codex")
+    if codex_path is None:
+        raise RuntimeError("`codex` CLI not found on PATH.")
+    codex_real = os.path.realpath(codex_path)
 
     last_exc: Optional[RuntimeError] = None
     for attempt in range(JUDGE_RETRY_COUNT + 1):
-        req = urllib.request.Request(
-            _openai_url("/chat/completions"),
-            data=body,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {key}",
-            },
-            method="POST",
-        )
+        per_user_root = _darwin_per_user_root()
+        iso_dir = tempfile.mkdtemp(dir=per_user_root)
+        profile_path = os.path.join(per_user_root, f"{secrets.token_hex(8)}.sb")
+        schema_path = os.path.join(iso_dir, "schema.json")
+        out_path = os.path.join(iso_dir, "out.json")
         try:
-            with urllib.request.urlopen(req, timeout=300) as resp:
-                data = json.loads(resp.read().decode())
-            choices = data.get("choices") or []
-            return choices[0].get("message", {}).get("content") or "" if choices else ""
-        except urllib.error.HTTPError as exc:
-            detail = exc.read().decode(errors="replace")[:500]
-            last_exc = RuntimeError(f"OpenAI API error {exc.code} for model {model}: {detail}")
-            if exc.code not in _RETRYABLE_HTTP_CODES or attempt == JUDGE_RETRY_COUNT:
-                raise last_exc from exc
-        except urllib.error.URLError as exc:
-            last_exc = RuntimeError(f"Cannot reach OpenAI API at {OPENAI_BASE_URL}: {exc.reason}")
-            if attempt == JUDGE_RETRY_COUNT:
-                raise last_exc from exc
-        time.sleep(2 ** attempt)
+            with open(profile_path, "w", encoding="utf-8") as f:
+                f.write(_build_sandbox_profile(codex_real, per_user_root, iso_dir))
+            # --output-schema expects a raw JSON Schema file, not an OpenAI
+            # response_format envelope — confirmed live: wrapping it raises
+            # "'json_schema' is not valid under any of the given schemas."
+            with open(schema_path, "w", encoding="utf-8") as f:
+                json.dump(_RESPONSE_SCHEMA, f)
+
+            cmd = ["sandbox-exec", "-f", profile_path, "--", "codex", "exec"]
+            for feature in _DISABLE_FEATURES:
+                cmd += ["--disable", feature]
+            cmd += [
+                "-c", 'web_search="disabled"',
+                "-c", "tools.view_image=false",
+                # "high": --ignore-user-config drops config.toml's own
+                # reasoning-effort default, and rubric-adherence accuracy on
+                # a 4-dimension structured-scoring task benefits more from
+                # higher effort than latency does from lower — accepted
+                # tradeoff despite the retry loops below compounding worst-
+                # case wall-clock (up to (JUDGE_RETRY_COUNT+1)^2 calls).
+                "-c", 'model_reasoning_effort="high"',
+                "--ignore-user-config", "--ignore-rules",
+                "--sandbox", "read-only", "--ephemeral", "--skip-git-repo-check",
+                "--cd", iso_dir,
+                "--output-schema", schema_path, "-o", out_path,
+                "-m", model, "-",
+            ]
+
+            try:
+                proc = subprocess.run(
+                    cmd, input=prompt, capture_output=True, text=True, timeout=300,
+                    cwd=iso_dir, env=_minimal_env(),
+                )
+            except FileNotFoundError:
+                raise RuntimeError(
+                    "`codex`/`sandbox-exec` not found on PATH. Install the codex CLI "
+                    "(`brew install codex`) and run `codex login`."
+                )
+            except subprocess.TimeoutExpired:
+                last_exc = RuntimeError("codex exec timed out after 300s.")
+                if attempt == JUDGE_RETRY_COUNT:
+                    raise last_exc
+                continue
+
+            if proc.returncode != 0:
+                classification = _classify_stderr(proc.stderr)
+                last_exc = RuntimeError(
+                    f"codex exec exited {proc.returncode} for model {model}: "
+                    f"{proc.stderr.strip()[:500]}"
+                )
+                if classification == "fatal" or attempt == JUDGE_RETRY_COUNT:
+                    raise last_exc
+                continue
+
+            try:
+                with open(out_path, encoding="utf-8") as f:
+                    raw = f.read().strip()
+            except OSError as exc:
+                last_exc = RuntimeError(f"could not read codex output file: {exc}")
+                if attempt == JUDGE_RETRY_COUNT:
+                    raise last_exc
+                continue
+            if not raw:
+                last_exc = RuntimeError(
+                    f"codex produced an EMPTY final message. stderr: {proc.stderr.strip()[:200]}"
+                )
+                if attempt == JUDGE_RETRY_COUNT:
+                    raise last_exc
+                continue
+            return raw
+        finally:
+            for p in (profile_path,):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+            shutil.rmtree(iso_dir, ignore_errors=True)
     raise last_exc  # pragma: no cover — unreachable, loop always returns or raises
 
 
 async def _call_openai_async(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> str:
-    """Async OpenAI call — runs sync in thread pool to avoid blocking the event loop."""
+    """Async codex-exec call — runs sync in thread pool to avoid blocking the event loop."""
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(None, lambda: _call_openai(prompt, model))
 
@@ -126,7 +404,8 @@ async def _call_openai_async(prompt: str, model: str = OPENAI_JUDGE_MODEL) -> st
 def _cap_context_and_profile(
     context: Optional[str], user_profile: Optional[str]
 ) -> tuple[Optional[str], Optional[str]]:
-    """Defense-in-depth truncation before either value reaches OpenAI's API.
+    """Defense-in-depth truncation before either value reaches the codex
+    subprocess.
 
     `user_profile` is already capped at JUDGE_MAX_PERSONA_CHARS upstream
     (evolution/persona.py, before it ever reaches evaluate()); this re-caps
@@ -147,9 +426,10 @@ def _cap_context_and_profile(
 
 class OpenAIRuntimeJudge(BaseJudge):
     """
-    Evaluates production interactions using the structured RUBRIC via an
-    OpenAI-hosted model (e.g. GPT-5.6 Luna/Terra/Sol).
-    Returns a JudgeResult with per-dimension scores and a composite score.
+    Evaluates production interactions using the structured RUBRIC via a
+    sandboxed `codex exec` call (ChatGPT/Codex subscription auth, e.g.
+    GPT-5.6 Luna/Terra/Sol). Returns a JudgeResult with per-dimension scores
+    and a composite score.
     """
 
     def __init__(self, model: str = OPENAI_JUDGE_MODEL):
@@ -258,7 +538,6 @@ def _parse_result(raw: str) -> JudgeResult:
                 pass
 
     if data is None:
-        import sys
         print(
             f"[judge] Parse error: no JSON found | raw={raw[:200]}",
             file=sys.stderr,
@@ -292,7 +571,6 @@ def _parse_result(raw: str) -> JudgeResult:
             **dims,
         )
     except (KeyError, ValueError) as exc:
-        import sys
         print(
             f"[judge] Parse error: {exc.__class__.__name__}: {exc} | raw={raw[:200]}",
             file=sys.stderr,

--- a/evolution/judge/providers/__init__.py
+++ b/evolution/judge/providers/__init__.py
@@ -6,6 +6,7 @@ from .llama_cpp import LlamaCppProvider
 from .gemini import GeminiProvider
 from .mock import MockProvider
 from .claude_proxy import ClaudeProxyProvider
+from .openai import OpenAIProvider
 
 _registry = JudgeRegistry.default()
 _registry.register(OllamaProvider())
@@ -13,5 +14,9 @@ _registry.register(LlamaCppProvider())
 _registry.register(GeminiProvider())
 _registry.register(MockProvider())
 _registry.register(ClaudeProxyProvider())
+_registry.register(OpenAIProvider())
 
-__all__ = ["OllamaProvider", "LlamaCppProvider", "GeminiProvider", "MockProvider", "ClaudeProxyProvider"]
+__all__ = [
+    "OllamaProvider", "LlamaCppProvider", "GeminiProvider", "MockProvider",
+    "ClaudeProxyProvider", "OpenAIProvider",
+]

--- a/evolution/judge/providers/openai.py
+++ b/evolution/judge/providers/openai.py
@@ -1,0 +1,42 @@
+"""OpenAI judge provider — opt-in only (see is_available)."""
+import os
+from typing import Optional
+
+from ..base import BaseJudge
+from ..provider import JudgeProvider
+
+
+class OpenAIProvider(JudgeProvider):
+    """OpenAI API (e.g. GPT-5.6 Luna/Terra/Sol) — opt-in benchmark/eval alternative.
+
+    Priority 20 places it below gemini(5)/ollama(10)/llama-cpp(15) in auto-detect
+    preference (claude_proxy is 30, still lower-preferred than this). Availability
+    additionally requires EVOLUTION_OPENAI_JUDGE_ENABLED to be explicitly set —
+    key-presence alone is NOT enough. Without this second gate, JudgeRegistry's
+    production auto-detect (resolve()) would silently start routing real
+    interactions to an unvalidated paid model the instant Ollama/Gemini simply
+    aren't running, even though nothing has validated its judge quality yet.
+    """
+
+    @property
+    def name(self) -> str:
+        return "openai"
+
+    @property
+    def priority(self) -> int:
+        return 20
+
+    @property
+    def default_model(self) -> str:
+        from ...config import OPENAI_JUDGE_MODEL
+        return OPENAI_JUDGE_MODEL
+
+    def is_available(self) -> bool:
+        if os.environ.get("EVOLUTION_OPENAI_JUDGE_ENABLED", "").lower() not in ("1", "true", "yes"):
+            return False
+        from ..openai_judge import is_openai_available
+        return is_openai_available()
+
+    def make_runtime_judge(self, model: Optional[str] = None) -> BaseJudge:
+        from ..openai_judge import OpenAIRuntimeJudge
+        return OpenAIRuntimeJudge(model=model or self.default_model)

--- a/evolution/tests/test_benchmark_judge_fixture.py
+++ b/evolution/tests/test_benchmark_judge_fixture.py
@@ -2,6 +2,7 @@
 import json
 import math
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,56 @@ def test_spearman_handles_ties():
 
 def test_mae():
     assert abs(bj._mae([0.0, 1.0], [0.5, 0.5]) - 0.5) < 1e-9
+
+
+# ── trivial baselines (fixture gameability) ─────────────────────────────────
+
+def test_constant_mean_mae_hand_value():
+    assert abs(bj._constant_mean_mae([0.0, 0.5, 1.0]) - 1 / 3) < 1e-9
+    assert bj._constant_mean_mae([]) is None
+
+
+def test_logistic_fit_pearson_deterministic_and_realistic_scale():
+    # log(len)-like feature magnitude (~2-9), NOT standardized by the caller —
+    # must not overflow/diverge (this is exactly what plan-review flagged).
+    feature = [2.3, 3.1, 4.0, 4.8, 5.5, 6.2, 6.9, 7.5, 8.1, 8.8] * 3
+    truth = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0] * 3
+    r1 = bj._logistic_fit_pearson(feature, truth)
+    r2 = bj._logistic_fit_pearson(feature, truth)
+    assert r1 == r2                      # identical inputs -> bit-identical output
+    assert r1 is not None and r1 > 0.9   # near-linear signal fits well
+
+
+def test_logistic_fit_pearson_edge_cases():
+    assert bj._logistic_fit_pearson([], []) is None                    # n=0
+    assert bj._logistic_fit_pearson([1.0] * 5, [0.1, 0.2, 0.3, 0.4, 0.5]) is None  # constant feature
+
+
+def test_compute_trivial_baselines_end_to_end():
+    interactions = [
+        {"response": "short", "ground_truth_score": 0.2},
+        {"response": "a bit longer response here", "ground_truth_score": 0.5},
+        {"response": "a substantially longer and more detailed response than the others", "ground_truth_score": 0.9},
+        {"response": "medium length one", "ground_truth_score": 0.4},
+        {"response": "yet another medium-ish length response for this row", "ground_truth_score": 0.6},
+    ]
+    baselines = bj.compute_trivial_baselines(interactions)
+    assert set(baselines) == {"log_length_pearson", "constant_mean_mae", "logistic_pearson"}
+    assert baselines["log_length_pearson"] is not None
+    assert baselines["constant_mean_mae"] is not None
+
+
+def test_compute_trivial_baselines_reproduces_verified_fixture_numbers():
+    # Exact-match regression guard against the independently spot-verified
+    # numbers in Handoffs/2026-08-02-01-15-gpt56-judge-benchmark-reliability.md:
+    # a bare log(response_length) regressor scores r=0.485 on fixture-v1 (n=200)
+    # and r=0.338 on fixture-openai-v1 (n=104).
+    openai_fixture = Path(__file__).resolve().parents[2] / "finetune" / "judge-bench" / "fixture-openai-v1.jsonl"
+    if not openai_fixture.exists():
+        pytest.skip("fixture-openai-v1.jsonl not present in this checkout (gitignored)")
+    interactions = bj._load_fixture(openai_fixture)
+    baselines = bj.compute_trivial_baselines(interactions)
+    assert abs(baselines["log_length_pearson"] - 0.338) < 5e-3
 
 
 def test_threshold_pr_hand_example():
@@ -172,3 +223,36 @@ def test_benchmark_passes_digest_and_records_per_dim(monkeypatch):
     assert mr.dim_scores["personalization"] == [0.25]
     assert mr.dim_truth["personalization"] == [0.5]
     assert mr.scores == [0.55] and mr.ground_truth == [0.6]
+    # per-record dim_truth/dim_scores (what --json-out's "records" array serializes
+    # directly, for paired cross-run/cross-fixture comparison by interaction_id)
+    assert len(mr.details) == 1
+    d0 = mr.details[0]
+    assert d0.interaction_id == "i1"
+    assert d0.dim_scores == {"quality": 0.5, "safety": 1.0, "tool_use": 1.0, "personalization": 0.25}
+    assert d0.dim_truth == {"quality": 0.75, "safety": 1.0, "tool_use": 1.0, "personalization": 0.5}
+
+
+# ── print_comparison back-compat ────────────────────────────────────────────
+
+def test_print_comparison_without_trivial_baselines_still_works(capsys):
+    mr = bj.ModelResult(model="m")
+    mr.scores = [0.1, 0.5, 0.9]
+    mr.ground_truth = [0.2, 0.4, 0.8]
+    mr.total = 3
+    bj.print_comparison([mr])  # trivial_baselines defaults to None — no crash, no Δ column
+    out = capsys.readouterr().out
+    assert "Δ vs log-len" not in out
+    assert "Trivial baselines" not in out
+
+
+def test_print_comparison_with_trivial_baselines(capsys):
+    mr = bj.ModelResult(model="m")
+    mr.scores = [0.1, 0.5, 0.9]
+    mr.ground_truth = [0.2, 0.4, 0.8]
+    mr.total = 3
+    bj.print_comparison([mr], trivial_baselines={
+        "log_length_pearson": 0.3, "logistic_pearson": 0.35, "constant_mean_mae": 0.2,
+    })
+    out = capsys.readouterr().out
+    assert "Trivial baselines" in out and "log-length r=0.300" in out
+    assert "Δ vs log-len" in out

--- a/evolution/tests/test_openai_judge.py
+++ b/evolution/tests/test_openai_judge.py
@@ -1,7 +1,7 @@
-"""Unit tests for evolution/judge/openai_judge.py — runtime judge wrapper."""
+"""Unit tests for evolution/judge/openai_judge.py — codex-exec runtime judge wrapper."""
 import asyncio
 import json
-import urllib.error
+import subprocess
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -9,8 +9,11 @@ import pytest
 from evolution.judge.base import JudgeResult
 from evolution.judge.openai_judge import (
     OpenAIRuntimeJudge,
+    _build_sandbox_profile,
     _call_openai,
     _cap_context_and_profile,
+    _darwin_per_user_root,
+    _is_macho_binary,
     _parse_result,
     is_openai_available,
 )
@@ -19,116 +22,384 @@ from evolution.judge.openai_judge import (
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
-def _stub_urlopen_returning(body: dict):
-    """Build a MagicMock that mimics urlopen's context-manager response."""
-    response = MagicMock()
-    response.read.return_value = json.dumps(body).encode()
-    cm = MagicMock()
-    cm.__enter__.return_value = response
-    cm.__exit__.return_value = None
-    return cm
+def _fake_completed_process(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
 
 
-def _chat_completion_envelope(content: str) -> dict:
-    return {
-        "choices": [
-            {"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}
-        ]
-    }
-
-
-def _http_error(code: int, body: bytes = b'{"error": "boom"}') -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(
-        url="https://api.openai.com/v1/chat/completions",
-        code=code,
-        msg="error",
-        hdrs=None,
-        fp=MagicMock(read=lambda: body),
-    )
+_FAKE_CODEX_PATH = "/opt/homebrew/bin/codex"
 
 
 @pytest.fixture(autouse=True)
-def _fake_key():
-    with patch("evolution.judge.openai_judge.load_openai_api_key", return_value="sk-test-key"):
+def _fake_env():
+    """codex/sandbox-exec present, EVOLUTION_OPENAI_JUDGE_ENABLED set, per-user
+    root resolvable — the baseline every test starts from. Deliberately does
+    NOT patch os.path.realpath globally (that leaked into pytest's own
+    tmp_path fixture machinery, which also calls realpath internally) —
+    shutil.which is patched to directly return the fake codex path, and
+    os.path.realpath is left real (harmless on a nonexistent path: returns
+    the input unchanged)."""
+    with patch("evolution.judge.openai_judge.shutil.which", return_value=_FAKE_CODEX_PATH), \
+         patch("evolution.judge.openai_judge._darwin_per_user_root", return_value="/private/var/folders/1z/xxxxxxxxxxxxxxxxxxxxxxxxxxxx"), \
+         patch.dict("os.environ", {"EVOLUTION_OPENAI_JUDGE_ENABLED": "1"}):
         yield
+
+
+# ── _is_macho_binary ─────────────────────────────────────────────────────────
+
+
+class TestIsMachoBinary:
+    def test_thin_macho_magic_is_binary(self, tmp_path):
+        p = tmp_path / "fake_binary"
+        p.write_bytes(bytes.fromhex("feedfacf") + b"\x00" * 100)
+        assert _is_macho_binary(str(p)) is True
+
+    def test_fat_64_magic_is_binary(self, tmp_path):
+        p = tmp_path / "fake_universal"
+        p.write_bytes(bytes.fromhex("cafebabf") + b"\x00" * 100)
+        assert _is_macho_binary(str(p)) is True
+
+    def test_shebang_script_is_not_binary(self, tmp_path):
+        p = tmp_path / "launcher.js"
+        p.write_bytes(b"#!/usr/bin/env node\nconsole.log('hi')\n")
+        assert _is_macho_binary(str(p)) is False
+
+    def test_missing_file_is_not_binary(self, tmp_path):
+        assert _is_macho_binary(str(tmp_path / "nonexistent")) is False
+
+    def test_empty_file_is_not_binary(self, tmp_path):
+        p = tmp_path / "empty"
+        p.write_bytes(b"")
+        assert _is_macho_binary(str(p)) is False
+
+
+# ── _darwin_per_user_root ────────────────────────────────────────────────────
+
+
+class TestDarwinPerUserRoot:
+    def test_resolves_valid_root(self):
+        with patch("evolution.judge.openai_judge.subprocess.run") as mock_run, \
+             patch("evolution.judge.openai_judge.os.path.realpath",
+                   return_value="/private/var/folders/1z/hashhashhash/T"):
+            mock_run.return_value = MagicMock(stdout="/var/folders/1z/hashhashhash/T/\n")
+            root = _darwin_per_user_root()
+        assert root == "/private/var/folders/1z/hashhashhash"
+
+    def test_fails_closed_on_unexpected_shape(self):
+        """The TMPDIR-absent (-> /private) and TMPDIR="" (-> cwd) failure
+        modes this function exists to close both produce a path with the
+        wrong segment count -- confirm the regex guard rejects them rather
+        than silently returning a broader-than-intended grant."""
+        with patch("evolution.judge.openai_judge.subprocess.run") as mock_run, \
+             patch("evolution.judge.openai_judge.os.path.realpath", return_value="/private"):
+            mock_run.return_value = MagicMock(stdout="/tmp\n")
+            with pytest.raises(RuntimeError, match="Unexpected Darwin per-user temp root shape"):
+                _darwin_per_user_root()
+
+    def test_fails_closed_on_cwd_derived_path(self):
+        with patch("evolution.judge.openai_judge.subprocess.run") as mock_run, \
+             patch("evolution.judge.openai_judge.os.path.realpath",
+                   return_value="/Users/someone/deus/.claude/worktrees/foo"):
+            mock_run.return_value = MagicMock(stdout="\n")
+            with pytest.raises(RuntimeError, match="Unexpected Darwin per-user temp root shape"):
+                _darwin_per_user_root()
+
+
+# ── _build_sandbox_profile ───────────────────────────────────────────────────
+
+
+class TestBuildSandboxProfile:
+    def test_process_exec_scoped_to_exact_codex_binary(self):
+        profile = _build_sandbox_profile("/real/codex/binary", "/per/user/root", "/iso/dir")
+        assert '(allow process-exec (literal "/real/codex/binary"))' in profile
+        # No blanket process-exec allow anywhere in the profile.
+        assert "(allow process-exec)" not in profile
+
+    def test_grants_are_scoped_not_blanket(self):
+        profile = _build_sandbox_profile("/real/codex/binary", "/per/user/root", "/iso/dir")
+        assert '(subpath "/per/user/root")' in profile
+        assert '(subpath "/iso/dir")' in profile
+        # The whole-tree grant this design deliberately avoids.
+        assert '(subpath "/private/var/folders")' not in profile
+
+    def test_codex_home_narrow_allowlist_present(self):
+        profile = _build_sandbox_profile("/real/codex/binary", "/per/user/root", "/iso/dir")
+        assert "auth.json" in profile
+        assert "installation_id" in profile
+        # history.jsonl / hooks.json / config.toml must NOT be individually
+        # granted -- only the directory-listing + narrow fixed-path allowlist.
+        assert "history.jsonl" not in profile
+        assert "hooks.json" not in profile
+
+
+# ── is_openai_available ──────────────────────────────────────────────────────
+
+
+class TestIsOpenAIAvailable:
+    def test_false_when_not_opted_in(self):
+        with patch.dict("os.environ", {"EVOLUTION_OPENAI_JUDGE_ENABLED": "0"}):
+            assert is_openai_available() is False
+
+    def test_false_on_non_darwin(self):
+        with patch("evolution.judge.openai_judge.platform.system", return_value="Linux"):
+            assert is_openai_available() is False
+
+    def test_false_when_codex_not_on_path(self):
+        with patch("evolution.judge.openai_judge.shutil.which", return_value=None):
+            assert is_openai_available() is False
+
+    def test_false_when_sandbox_exec_not_on_path(self):
+        def which(name):
+            return None if name == "sandbox-exec" else "/opt/homebrew/bin/codex"
+        with patch("evolution.judge.openai_judge.shutil.which", side_effect=which):
+            assert is_openai_available() is False
+
+    def test_false_for_non_macho_launcher(self):
+        """The npm-install case: `codex` resolves to a JS launcher, not a
+        native binary -- must report unavailable, not attempt a call that
+        would fail confusingly against a Seatbelt profile built for a
+        binary that isn't the one actually running."""
+        with patch("evolution.judge.openai_judge._is_macho_binary", return_value=False):
+            assert is_openai_available() is False
+
+    def test_true_when_native_binary_and_logged_in(self):
+        with patch("evolution.judge.openai_judge._is_macho_binary", return_value=True), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)):
+            assert is_openai_available() is True
+
+    def test_false_when_native_binary_but_logged_out(self):
+        with patch("evolution.judge.openai_judge._is_macho_binary", return_value=True), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=1)):
+            assert is_openai_available() is False
+
+    def test_false_on_login_status_timeout(self):
+        with patch("evolution.judge.openai_judge._is_macho_binary", return_value=True), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="codex", timeout=10)):
+            assert is_openai_available() is False
+
+    def test_login_status_uses_minimal_env_not_inherited(self):
+        """Round-6 GPT-backend finding: availability check must use the same
+        minimal env as the real call, not the inherited environment (which
+        could report availability against a different CODEX_HOME)."""
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _fake_completed_process(returncode=0)
+
+        with patch("evolution.judge.openai_judge._is_macho_binary", return_value=True), \
+             patch("evolution.judge.openai_judge.subprocess.run", side_effect=fake_run), \
+             patch.dict("os.environ", {"CODEX_HOME": "/some/other/codex/home", "SECRET": "leak-me"}):
+            is_openai_available()
+
+        assert "CODEX_HOME" not in captured["env"]
+        assert "SECRET" not in captured["env"]
+        assert set(captured["env"].keys()) <= {"PATH", "HOME"}
 
 
 # ── _call_openai ─────────────────────────────────────────────────────────────
 
 
 class TestCallOpenAI:
-    def test_returns_assistant_content_from_envelope(self):
-        envelope = _chat_completion_envelope('{"quality_level": 5}')
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            return_value=_stub_urlopen_returning(envelope),
-        ):
-            assert _call_openai("hello", model="gpt-5.6-luna") == '{"quality_level": 5}'
+    def test_returns_output_file_contents_on_success(self, tmp_path):
+        out_file = tmp_path / "out.json"
+        out_file.write_text('{"quality_level": 5}')
 
-    def test_empty_choices_returns_empty_string(self):
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            return_value=_stub_urlopen_returning({"choices": []}),
-        ):
-            assert _call_openai("hello") == ""
+        def fake_mkdtemp(dir=None):
+            return str(tmp_path)
 
-    def test_request_shape(self):
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", side_effect=fake_mkdtemp), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)) as mock_run:
+            # subprocess "writes" out.json as a side effect of running codex;
+            # simulate that by ensuring the file exists before _call_openai reads it.
+            result = _call_openai("hello", model="gpt-5.6-luna")
+        assert result == '{"quality_level": 5}'
+        assert mock_run.call_count == 1
+
+    def test_sandbox_exec_argv_shape(self, tmp_path):
+        out_file = tmp_path / "out.json"
+        out_file.write_text("ok")
         captured = {}
 
-        def fake_urlopen(req, timeout=None):
-            captured["headers"] = dict(req.headers)
-            captured["body"] = json.loads(req.data)
-            return _stub_urlopen_returning(_chat_completion_envelope("ok"))
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return _fake_completed_process(returncode=0)
 
-        with patch("evolution.judge.openai_judge.urllib.request.urlopen", side_effect=fake_urlopen):
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run", side_effect=fake_run):
             _call_openai("hello", model="gpt-5.6-luna")
 
-        assert captured["headers"]["Authorization"] == "Bearer sk-test-key"
-        assert captured["body"]["model"] == "gpt-5.6-luna"
-        assert captured["body"]["messages"] == [{"role": "user", "content": "hello"}]
-        assert captured["body"]["response_format"]["type"] == "json_schema"
+        cmd = captured["cmd"]
+        assert cmd[0] == "sandbox-exec"
+        assert cmd[1] == "-f"
+        assert "codex" in cmd
+        assert "exec" in cmd
+        # Every disabled feature must be present as --disable <name>.
+        # Exact count, not a loose lower bound: this list is the
+        # security-critical output of `codex features list` ground-truth
+        # verification (round 4-6 of the plan review) — a future edit that
+        # silently drops one feature must fail this test, not slide by.
+        from evolution.judge.openai_judge import _DISABLE_FEATURES
+        assert cmd.count("--disable") == len(_DISABLE_FEATURES) == 20
+        assert "shell_tool" in cmd
+        assert "unified_exec" in cmd
+        assert "auth_elicitation" in cmd
+        assert "-m" in cmd and "gpt-5.6-luna" in cmd
+        assert "--ignore-user-config" in cmd
+        assert "--ignore-rules" in cmd
+        assert "--sandbox" in cmd and "read-only" in cmd
 
-    def test_non_retryable_http_error_raises_immediately_with_no_key_leak(self):
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            side_effect=_http_error(401, b'{"error": "invalid_api_key"}'),
-        ):
-            with pytest.raises(RuntimeError) as exc_info:
+    def test_env_is_minimal_allowlist(self, tmp_path):
+        out_file = tmp_path / "out.json"
+        out_file.write_text("ok")
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _fake_completed_process(returncode=0)
+
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run", side_effect=fake_run), \
+             patch.dict("os.environ", {"GEMINI_API_KEY": "leak-me", "OPENAI_API_KEY": "also-leak-me"}):
+            _call_openai("hello", model="gpt-5.6-luna")
+
+        assert "GEMINI_API_KEY" not in captured["env"]
+        assert "OPENAI_API_KEY" not in captured["env"]
+        assert set(captured["env"].keys()) <= {"PATH", "HOME"}
+
+    def test_codex_not_found_raises_clear_error(self):
+        with patch("evolution.judge.openai_judge.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="not found on PATH"):
                 _call_openai("hello", model="gpt-5.6-luna")
-        msg = str(exc_info.value)
-        assert "401" in msg
-        assert "sk-test-key" not in msg  # the bearer key must never appear in a raised error
 
-    def test_retryable_http_error_retries_then_succeeds(self):
+    def test_nonzero_exit_fatal_marker_raises_immediately(self, tmp_path):
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=1, stderr="401 unauthorized")):
+            with pytest.raises(RuntimeError, match="401"):
+                _call_openai("hello", model="gpt-5.6-luna")
+
+    def _fresh_subdir_mkdtemp(self, tmp_path, out_content=None):
+        """Real `mkdtemp()` creates a genuinely fresh directory each call;
+        the retry-exercising tests below need the same, since production
+        code's `finally` block removes `iso_dir` after every attempt
+        (including a retried one) — a fixed return_value would have the
+        second attempt try to write into a directory the first attempt's
+        cleanup already deleted."""
+        counter = {"n": 0}
+
+        def _mkdtemp(dir=None):
+            counter["n"] += 1
+            sub = tmp_path / f"attempt-{counter['n']}"
+            sub.mkdir()
+            if out_content is not None:
+                (sub / "out.json").write_text(out_content)
+            return str(sub)
+        return _mkdtemp
+
+    def test_nonzero_exit_retryable_marker_retries_then_succeeds(self, tmp_path):
         calls = {"n": 0}
 
-        def fake_urlopen(req, timeout=None):
+        def fake_run(cmd, **kwargs):
             calls["n"] += 1
             if calls["n"] == 1:
-                raise _http_error(429, b'{"error": "rate_limited"}')
-            return _stub_urlopen_returning(_chat_completion_envelope("ok"))
+                return _fake_completed_process(returncode=1, stderr="429 rate limit exceeded")
+            return _fake_completed_process(returncode=0)
 
-        with patch("evolution.judge.openai_judge.urllib.request.urlopen", side_effect=fake_urlopen), \
-             patch("evolution.judge.openai_judge.time.sleep"):
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp",
+                   side_effect=self._fresh_subdir_mkdtemp(tmp_path, out_content="ok")), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run", side_effect=fake_run):
             result = _call_openai("hello", model="gpt-5.6-luna")
         assert result == "ok"
         assert calls["n"] == 2
 
-    def test_retryable_http_error_exhausts_retries_and_raises(self):
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            side_effect=_http_error(503, b'{"error": "unavailable"}'),
-        ), patch("evolution.judge.openai_judge.time.sleep"):
-            with pytest.raises(RuntimeError, match="503"):
+    def test_timeout_raises_clear_error(self, tmp_path):
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp",
+                   side_effect=self._fresh_subdir_mkdtemp(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="codex", timeout=300)):
+            with pytest.raises(RuntimeError, match="timed out"):
                 _call_openai("hello", model="gpt-5.6-luna")
 
-    def test_url_error_raises_runtime_error(self):
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            side_effect=urllib.error.URLError("connection refused"),
-        ), patch("evolution.judge.openai_judge.time.sleep"):
-            with pytest.raises(RuntimeError, match="Cannot reach OpenAI API"):
+    def test_empty_output_raises_clear_error(self, tmp_path):
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp",
+                   side_effect=self._fresh_subdir_mkdtemp(tmp_path, out_content="")), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)):
+            with pytest.raises(RuntimeError, match="EMPTY final message"):
                 _call_openai("hello", model="gpt-5.6-luna")
+
+    def test_cleans_up_iso_dir_on_success(self, tmp_path):
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        out_file = work_dir / "out.json"
+        out_file.write_text("ok")
+
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(work_dir)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)):
+            _call_openai("hello", model="gpt-5.6-luna")
+        assert not work_dir.exists()
+
+    def test_cleans_up_iso_dir_on_failure(self, tmp_path):
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(work_dir)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=1, stderr="401 unauthorized")):
+            with pytest.raises(RuntimeError):
+                _call_openai("hello", model="gpt-5.6-luna")
+        assert not work_dir.exists()
+
+    def test_writes_raw_schema_not_wrapped_envelope(self, tmp_path):
+        """Regression test: --output-schema expects a raw JSON Schema, not an
+        OpenAI response_format envelope -- wrapping it was a confirmed live
+        bug ('json_schema is not valid under any of the given schemas')."""
+        out_file = tmp_path / "out.json"
+        out_file.write_text("ok")
+        written_schema = {}
+
+        real_open = open
+
+        def spy_open(path, *args, **kwargs):
+            f = real_open(path, *args, **kwargs)
+            if str(path).endswith("schema.json"):
+                orig_write = f.write
+                def spy_write(s):
+                    written_schema["text"] = written_schema.get("text", "") + s
+                    return orig_write(s)
+                f.write = spy_write
+            return f
+
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)), \
+             patch("builtins.open", side_effect=spy_open):
+            _call_openai("hello", model="gpt-5.6-luna")
+
+        schema = json.loads(written_schema["text"])
+        assert schema["type"] == "object"
+        assert "json_schema" not in schema
+        assert "response_format" not in schema
 
 
 # ── _parse_result ────────────────────────────────────────────────────────────
@@ -171,16 +442,18 @@ class TestParseResult:
 
 
 class TestOpenAIRuntimeJudge:
-    def test_evaluate_round_trip(self):
+    def test_evaluate_round_trip(self, tmp_path):
         canned = json.dumps({
             "safe": True, "quality_level": 5, "recalled_preference": True,
             "format_matched": True, "tone_matched": True, "execution_quality": 5,
             "rationale": "Clear and correct",
         })
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            return_value=_stub_urlopen_returning(_chat_completion_envelope(canned)),
-        ):
+        out_file = tmp_path / "out.json"
+        out_file.write_text(canned)
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)):
             judge = OpenAIRuntimeJudge(model="gpt-5.6-luna")
             result = judge.evaluate(prompt="What's 2+2?", response="4", tools_used=["calculator"])
         assert isinstance(result, JudgeResult)
@@ -190,16 +463,18 @@ class TestOpenAIRuntimeJudge:
         judge = OpenAIRuntimeJudge(model="gpt-5.6-luna")
         assert judge.model == "gpt-5.6-luna"
 
-    def test_a_evaluate_runs_in_executor(self):
+    def test_a_evaluate_runs_in_executor(self, tmp_path):
         canned = json.dumps({
             "safe": True, "quality_level": 3, "recalled_preference": False,
             "format_matched": False, "tone_matched": False, "execution_quality": 3,
             "rationale": "ok",
         })
-        with patch(
-            "evolution.judge.openai_judge.urllib.request.urlopen",
-            return_value=_stub_urlopen_returning(_chat_completion_envelope(canned)),
-        ):
+        out_file = tmp_path / "out.json"
+        out_file.write_text(canned)
+        with patch("evolution.judge.openai_judge.tempfile.mkdtemp", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge._darwin_per_user_root", return_value=str(tmp_path)), \
+             patch("evolution.judge.openai_judge.subprocess.run",
+                   return_value=_fake_completed_process(returncode=0)):
             judge = OpenAIRuntimeJudge(model="gpt-5.6-luna")
             result = asyncio.run(judge.a_evaluate(prompt="hi", response="hi"))
         assert not result.is_parse_error
@@ -226,18 +501,3 @@ class TestCapContextAndProfile:
 
     def test_short_values_unaffected(self):
         assert _cap_context_and_profile("short ctx", "short profile") == ("short ctx", "short profile")
-
-
-# ── is_openai_available ──────────────────────────────────────────────────────
-
-
-class TestIsOpenAIAvailable:
-    def test_returns_true_when_key_present(self):
-        assert is_openai_available() is True
-
-    def test_returns_false_when_key_absent(self):
-        with patch(
-            "evolution.judge.openai_judge.load_openai_api_key",
-            side_effect=RuntimeError("OPENAI_API_KEY not found"),
-        ):
-            assert is_openai_available() is False

--- a/evolution/tests/test_openai_judge.py
+++ b/evolution/tests/test_openai_judge.py
@@ -1,0 +1,243 @@
+"""Unit tests for evolution/judge/openai_judge.py — runtime judge wrapper."""
+import asyncio
+import json
+import urllib.error
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from evolution.judge.base import JudgeResult
+from evolution.judge.openai_judge import (
+    OpenAIRuntimeJudge,
+    _call_openai,
+    _cap_context_and_profile,
+    _parse_result,
+    is_openai_available,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _stub_urlopen_returning(body: dict):
+    """Build a MagicMock that mimics urlopen's context-manager response."""
+    response = MagicMock()
+    response.read.return_value = json.dumps(body).encode()
+    cm = MagicMock()
+    cm.__enter__.return_value = response
+    cm.__exit__.return_value = None
+    return cm
+
+
+def _chat_completion_envelope(content: str) -> dict:
+    return {
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}
+        ]
+    }
+
+
+def _http_error(code: int, body: bytes = b'{"error": "boom"}') -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://api.openai.com/v1/chat/completions",
+        code=code,
+        msg="error",
+        hdrs=None,
+        fp=MagicMock(read=lambda: body),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fake_key():
+    with patch("evolution.judge.openai_judge.load_openai_api_key", return_value="sk-test-key"):
+        yield
+
+
+# ── _call_openai ─────────────────────────────────────────────────────────────
+
+
+class TestCallOpenAI:
+    def test_returns_assistant_content_from_envelope(self):
+        envelope = _chat_completion_envelope('{"quality_level": 5}')
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            return_value=_stub_urlopen_returning(envelope),
+        ):
+            assert _call_openai("hello", model="gpt-5.6-luna") == '{"quality_level": 5}'
+
+    def test_empty_choices_returns_empty_string(self):
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            return_value=_stub_urlopen_returning({"choices": []}),
+        ):
+            assert _call_openai("hello") == ""
+
+    def test_request_shape(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["headers"] = dict(req.headers)
+            captured["body"] = json.loads(req.data)
+            return _stub_urlopen_returning(_chat_completion_envelope("ok"))
+
+        with patch("evolution.judge.openai_judge.urllib.request.urlopen", side_effect=fake_urlopen):
+            _call_openai("hello", model="gpt-5.6-luna")
+
+        assert captured["headers"]["Authorization"] == "Bearer sk-test-key"
+        assert captured["body"]["model"] == "gpt-5.6-luna"
+        assert captured["body"]["messages"] == [{"role": "user", "content": "hello"}]
+        assert captured["body"]["response_format"]["type"] == "json_schema"
+
+    def test_non_retryable_http_error_raises_immediately_with_no_key_leak(self):
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            side_effect=_http_error(401, b'{"error": "invalid_api_key"}'),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                _call_openai("hello", model="gpt-5.6-luna")
+        msg = str(exc_info.value)
+        assert "401" in msg
+        assert "sk-test-key" not in msg  # the bearer key must never appear in a raised error
+
+    def test_retryable_http_error_retries_then_succeeds(self):
+        calls = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _http_error(429, b'{"error": "rate_limited"}')
+            return _stub_urlopen_returning(_chat_completion_envelope("ok"))
+
+        with patch("evolution.judge.openai_judge.urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("evolution.judge.openai_judge.time.sleep"):
+            result = _call_openai("hello", model="gpt-5.6-luna")
+        assert result == "ok"
+        assert calls["n"] == 2
+
+    def test_retryable_http_error_exhausts_retries_and_raises(self):
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            side_effect=_http_error(503, b'{"error": "unavailable"}'),
+        ), patch("evolution.judge.openai_judge.time.sleep"):
+            with pytest.raises(RuntimeError, match="503"):
+                _call_openai("hello", model="gpt-5.6-luna")
+
+    def test_url_error_raises_runtime_error(self):
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ), patch("evolution.judge.openai_judge.time.sleep"):
+            with pytest.raises(RuntimeError, match="Cannot reach OpenAI API"):
+                _call_openai("hello", model="gpt-5.6-luna")
+
+
+# ── _parse_result ────────────────────────────────────────────────────────────
+
+
+class TestParseResult:
+    def test_well_formed_json_returns_judge_result(self):
+        raw = json.dumps({
+            "safe": True,
+            "quality_level": 4,
+            "recalled_preference": True,
+            "format_matched": False,
+            "tone_matched": True,
+            "execution_quality": 5,
+            "rationale": "Looks good",
+        })
+        result = _parse_result(raw)
+        assert isinstance(result, JudgeResult)
+        assert not result.is_parse_error
+        assert 0.0 <= result.score <= 1.0
+        assert "Looks good" in (result.rationale or "")
+
+    def test_strips_markdown_fences(self):
+        raw = (
+            '```json\n{"safe": true, "quality_level": 3, "recalled_preference": false, '
+            '"format_matched": false, "tone_matched": false, "execution_quality": 3, '
+            '"rationale": "ok"}\n```'
+        )
+        result = _parse_result(raw)
+        assert not result.is_parse_error
+
+    def test_invalid_json_returns_neutral_fallback(self):
+        result = _parse_result("not json at all")
+        assert result.is_parse_error
+        assert result.score == 0.5
+        assert "Parse error" in (result.rationale or "")
+
+
+# ── OpenAIRuntimeJudge ───────────────────────────────────────────────────────
+
+
+class TestOpenAIRuntimeJudge:
+    def test_evaluate_round_trip(self):
+        canned = json.dumps({
+            "safe": True, "quality_level": 5, "recalled_preference": True,
+            "format_matched": True, "tone_matched": True, "execution_quality": 5,
+            "rationale": "Clear and correct",
+        })
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            return_value=_stub_urlopen_returning(_chat_completion_envelope(canned)),
+        ):
+            judge = OpenAIRuntimeJudge(model="gpt-5.6-luna")
+            result = judge.evaluate(prompt="What's 2+2?", response="4", tools_used=["calculator"])
+        assert isinstance(result, JudgeResult)
+        assert not result.is_parse_error
+
+    def test_init_skips_preflight_check(self):
+        judge = OpenAIRuntimeJudge(model="gpt-5.6-luna")
+        assert judge.model == "gpt-5.6-luna"
+
+    def test_a_evaluate_runs_in_executor(self):
+        canned = json.dumps({
+            "safe": True, "quality_level": 3, "recalled_preference": False,
+            "format_matched": False, "tone_matched": False, "execution_quality": 3,
+            "rationale": "ok",
+        })
+        with patch(
+            "evolution.judge.openai_judge.urllib.request.urlopen",
+            return_value=_stub_urlopen_returning(_chat_completion_envelope(canned)),
+        ):
+            judge = OpenAIRuntimeJudge(model="gpt-5.6-luna")
+            result = asyncio.run(judge.a_evaluate(prompt="hi", response="hi"))
+        assert not result.is_parse_error
+
+
+# ── _cap_context_and_profile ─────────────────────────────────────────────────
+
+
+class TestCapContextAndProfile:
+    def test_none_values_pass_through(self):
+        assert _cap_context_and_profile(None, None) == (None, None)
+
+    def test_context_truncated_to_judge_max_prompt_chars(self):
+        from evolution.config import JUDGE_MAX_PROMPT_CHARS
+        huge = "x" * (JUDGE_MAX_PROMPT_CHARS + 500)
+        capped, _ = _cap_context_and_profile(huge, None)
+        assert len(capped) == JUDGE_MAX_PROMPT_CHARS
+
+    def test_user_profile_truncated_to_judge_max_persona_chars(self):
+        from evolution.config import JUDGE_MAX_PERSONA_CHARS
+        huge = "y" * (JUDGE_MAX_PERSONA_CHARS + 500)
+        _, capped = _cap_context_and_profile(None, huge)
+        assert len(capped) == JUDGE_MAX_PERSONA_CHARS
+
+    def test_short_values_unaffected(self):
+        assert _cap_context_and_profile("short ctx", "short profile") == ("short ctx", "short profile")
+
+
+# ── is_openai_available ──────────────────────────────────────────────────────
+
+
+class TestIsOpenAIAvailable:
+    def test_returns_true_when_key_present(self):
+        assert is_openai_available() is True
+
+    def test_returns_false_when_key_absent(self):
+        with patch(
+            "evolution.judge.openai_judge.load_openai_api_key",
+            side_effect=RuntimeError("OPENAI_API_KEY not found"),
+        ):
+            assert is_openai_available() is False

--- a/evolution/tests/test_openai_judge.py
+++ b/evolution/tests/test_openai_judge.py
@@ -36,7 +36,15 @@ _FAKE_CODEX_PATH = "/opt/homebrew/bin/codex"
 @pytest.fixture(autouse=True)
 def _fake_env():
     """codex/sandbox-exec present, EVOLUTION_OPENAI_JUDGE_ENABLED set, per-user
-    root resolvable — the baseline every test starts from. Deliberately does
+    root resolvable, Darwin platform — the baseline every test starts from.
+    platform.system is pinned to "Darwin" here (not just left to the real OS)
+    because this module is Darwin-only by design and CI runs these tests on
+    Linux runners: without this, is_openai_available()'s own Darwin gate
+    short-circuits to False before ever reaching the mocks individual tests
+    set up (_is_macho_binary, subprocess.run), so tests asserting the
+    all-mocks-succeed path silently fail on Linux CI while passing locally
+    on macOS. test_false_on_non_darwin overrides this back to "Linux" within
+    its own `with` block to test that gate specifically. Deliberately does
     NOT patch os.path.realpath globally (that leaked into pytest's own
     tmp_path fixture machinery, which also calls realpath internally) —
     shutil.which is patched to directly return the fake codex path, and
@@ -44,6 +52,7 @@ def _fake_env():
     the input unchanged)."""
     with patch("evolution.judge.openai_judge.shutil.which", return_value=_FAKE_CODEX_PATH), \
          patch("evolution.judge.openai_judge._darwin_per_user_root", return_value="/private/var/folders/1z/xxxxxxxxxxxxxxxxxxxxxxxxxxxx"), \
+         patch("evolution.judge.openai_judge.platform.system", return_value="Darwin"), \
          patch.dict("os.environ", {"EVOLUTION_OPENAI_JUDGE_ENABLED": "1"}):
         yield
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-07-23" # auto-bump @1784809980
+last_verified: "2026-08-01" # auto-bump @1785581045
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-07-18" # auto-bump @1784327653
+last_verified: "2026-08-01" # auto-bump @1785581045
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-19" # auto-bump @1784444178
+last_verified: "2026-08-01" # auto-bump @1785581045
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## Summary
- Adds `OpenAIRuntimeJudge`/`OpenAIProvider` to the evolution loop's pluggable judge system, so GPT-5.6 (Luna/Terra/Sol) can be A/B benchmarked against the production Gemini judge via the repo's existing vetted `judge-model-ab-fixture` procedure.
- **Transport**: authenticates via the `codex` CLI (ChatGPT/Codex subscription — no API key, no per-call billing), not raw HTTP. The original raw-API design was blocked by zero account credits; pivoting to the subscription path required solving a real security problem, since `codex exec` is a full agent (not a passive completion API) and the judge scores real, potentially-adversarial production interaction text.
- Never auto-selected — requires `EVOLUTION_OPENAI_JUDGE_ENABLED` (explicit opt-in) **and** a working native codex install, both gated inside `JudgeRegistry`'s resolution path. No production defaults change. macOS only.
- Generalizes `evolution/benchmark_judge.py` with a `--provider {ollama,openai}` flag. The `ollama` code path is byte-identical to before.

## Security design (macOS Seatbelt + capability removal)
`codex exec` needs its own live OAuth credential to authenticate, and that credential is necessarily readable by the same process whose shell-tool capability a prompt-injection payload could hijack. Live testing confirmed this is a real exfiltration path if left unmitigated — a planted decoy secret was successfully read via the model's own shell tool under naive sandboxing.

Fix, iteratively built and empirically verified (11 rounds of adversarial plan review, both Claude and GPT backends):
1. **Capability removal, not credential gating**: 20 codex features disabled (`shell_tool`, `unified_exec`, `apps`, `browser_use`, `computer_use`, `plugins`, etc.) — confirmed via `codex features list` ground truth that each resolves to `false`, not just behavioral probing (an earlier pass missed `unified_exec`, which survives disabling `shell_tool` alone).
2. **OS-level backstop for the exec vector**: a Seatbelt profile restricts `process-exec` to only the resolved native codex binary itself.
3. **Narrow filesystem allowlist**: codex's own fixed bookkeeping paths under `~/.codex/` (not the whole directory), this user's own per-user Darwin temp root (derived via `getconf DARWIN_USER_TEMP_DIR`, fail-closed — not via `TMPDIR`, which was found to fail open into progressively broader grants under two realistic conditions), and one per-call isolated directory.
4. **Minimal subprocess environment** (`PATH`/`HOME` only — the evolution process's own secrets are never visible to the codex subprocess).
5. **Fail-closed availability check**: requires a genuine native Mach-O binary (rejects npm-launcher installs, a different install path this repo's own `/add-codex` skill documents) and a working `codex login status` check under the same minimal env as the real call.

Re-verified against the actual production `evaluate()` interface (not a standalone script): prompt-injection attacks via the `prompt`/`response` fields, canary-secret exfiltration attempts, and a direct `auth.json` exfiltration attempt all blocked with zero leakage.

## Review history
- Plan review: two phases. Phase 1 (raw HTTP transport): 4 rounds (3× REVISE → SHIP). Phase 2 (codex-exec transport swap, after the API-credits blocker): 11 rounds — closed a missing-feature-disable gap, a TMPDIR-fails-open bug, a tempfile-placement/Seatbelt-grant mismatch, and an npm-install compatibility gap, among others.
- Code review: 3 rounds total across both phases (SHIP).
- AI-eng review: 3 rounds total across both phases (SHIP, both backends each time).
- Independent brainstorm consultation (Claude Fable + GPT-5.6 Sol) converged on the capability-removal fix that closed the credential-exposure problem — cited and independently re-verified rather than trusted.

## Test plan
- [x] `python3 -m pytest evolution/tests/test_openai_judge.py evolution/tests/test_benchmark_judge_fixture.py scripts/tests/test_judge_calibration.py -v` — 75 passed, 0 failed.
- [x] Live end-to-end: all 3 GPT-5.6 tiers (Luna/Terra/Sol) confirmed working through the real `evaluate()` call.
- [x] Live adversarial re-verification: prompt-injection attacks through the real production interface, confirmed blocked.
- [ ] Full n~200 fixture benchmark vs Gemini ground truth — next step, not yet run.

No default-judge flip is proposed by this PR — that would need a separate ADR + explicit sign-off per the existing procedure's decision rule (paired 95% CI excludes zero AND delta-composite ≥ +0.05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)