### PR TITLE
docs(admin-merge-gate): record LIA-513 cross-repo CI-check investigation

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -1845,6 +1845,10 @@ def _evaluate_standing_grant(
 
 
 def run_admin_merge_gate(event: dict[str, Any], repo_root: Path) -> int:
+    # LIA-513: `cwd` below is used only for worktree resolution, never for
+    # scoping the internal `gh` calls below (`repo=` comes from the command
+    # text) — see ci_status.py's module docstring for why threading `cwd=`
+    # into those subprocess calls doesn't fix cross-repo CI-check mismatches.
     cwd = Path(str(event.get("cwd") or os.getcwd())).resolve(strict=False)
     wt = _worktree_for_cwd(cwd, repo_root)
     if wt is None:

--- a/scripts/warden_hooks/ci_status.py
+++ b/scripts/warden_hooks/ci_status.py
@@ -13,6 +13,37 @@ IS monkeypatched by tests, but its callers (``approve_admin_merge`` /
 name, so ``monkeypatch.setattr(hooks, "_check_ci_status", ...)`` rebinds exactly
 what those callers see. Tests also read ``hooks._CI_STATUS_*``; the entry
 re-exports every constant, so those reads resolve.
+
+LIA-513 (2026-08-01 cross-repo incident, investigated — no code change needed
+beyond the existing ``repo`` param above): two follow-up fixes were considered
+and deliberately NOT implemented, to save a future reader from re-deriving why.
+(a) Explicitly deriving ``--repo`` from a URL-shaped ``pr_ref`` — unnecessary:
+``gh pr checks``/``gh pr view`` already resolve a fully-qualified PR URL
+natively, independent of ``--repo``/cwd, which is exactly why the documented
+full-URL workaround fixed the live incident with zero code changes. (b)
+Passing an explicit ``cwd=`` to the internal ``subprocess.run`` calls here —
+also doesn't help: the admin-merge gate only fires when the event's cwd is
+already inside the *launch* repo's own worktree tree (see
+``_worktree_for_cwd`` in ``codex_warden_hooks.py``), so for a genuinely
+cross-repo target, no cwd value the gate could ever see resolves to the
+correct repo. A bare PR number/branch with no explicit ``--repo`` flag,
+targeting a different repo than the session's own worktree, is undecidable
+from any information available to the gate; the documented
+fully-qualified-URL workaround is the correct permanent mitigation for it,
+not a bug to fix here.
+
+One residual gap the URL workaround does NOT close:
+``_branch_protection_plan_limited``'s ``gh api repos/{owner}/{repo}/...``
+probe takes no ``pr_ref`` at all (``gh api`` has no ``--repo`` flag — repo
+scoping goes directly in the endpoint path, see that function's own
+docstring), so a URL-shaped ``pr_ref`` never reaches it. With ``repo=None``
+it falls back to ``gh``'s ``{owner}/{repo}`` placeholder, resolved from the
+process cwd's git remote — i.e. the launch repo, not the actual target.
+Accepted as-is rather than fixed: the only consequence is that a plan-limited
+*launch* repo can steer a cross-repo check onto the relaxed plan-limited
+fallback path (which still fail-closes on any non-green check) instead of
+the stricter no-required-checks path — never a silent pass-through of a red
+target-repo check, since that fallback still demands the check set be green.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Investigated LIA-513 (admin-merge-gate CI-status check resolving against the wrong repo in cross-repo/cwd contexts). The ticket's suggested code fixes (URL-derived `--repo`, threaded `cwd=`) both turned out to close no real gap — `gh` already resolves full PR URLs natively (confirmed via `gh --help` and by the fact the documented workaround fixed the live incident with zero code changes), and `_worktree_for_cwd` means the gate never fires outside the launch repo's own tree, so no cwd value could ever resolve a genuinely foreign repo.
- Two plan-review rounds (claude + gpt backends) converged on a documentation-only deliverable instead of speculative code.
- A verification-gate pass caught a real accuracy gap in my first draft — `_branch_protection_plan_limited`'s `gh api` probe takes no `pr_ref` and has no `--repo` flag, so it's a genuine residual cross-repo gap the URL workaround doesn't cover. Fixed by documenting it explicitly, including why it's accepted as-is (fail-closed fallback, never a silent pass of a red check).
- Net result: zero behavior change, two doc/comment additions recording the investigation so a future reader doesn't re-derive or re-attempt the same dead ends.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_codex_warden_hooks.py -q` — 303 passed, unchanged
- [x] plan-reviewer SHIP (claude + gpt backends, 2 rounds)
- [x] code-reviewer SHIP (claude + gpt backends, 2 rounds; glm backend unavailable — API billing error, fails open)
- [x] verification-gate SHIP (2 rounds — first caught a real doc-accuracy gap, second confirmed the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)