### PR TITLE
fix(ci): make safety-recall always post a status on pull requests

### DIFF
--- a/.github/workflows/judge-gate.yml
+++ b/.github/workflows/judge-gate.yml
@@ -8,18 +8,35 @@ name: Judge Regression Gate
 # INCONCLUSIVE run, _classify_gate_outcome in safety_redteam.py), and a missing
 # GEMINI_API_KEY skips the bench step (preflight below). So a Gemini hiccup
 # cannot hard-block evolution/** PRs -- only a real recall drop does.
+#
+# `safety-recall` is a REQUIRED branch-protection check. This workflow used to
+# trigger only via `on.pull_request.paths: evolution/**` -- but when a required
+# check's own workflow never triggers (any PR outside evolution/**), GitHub
+# Actions posts NO status for the job name at all (not a pass, not a skip), and
+# a required-but-absent check leaves the PR permanently "Expected"/blocked in
+# the merge UI. Confirmed live on PR #1102: branch protection lists
+# `safety-recall` as required, but it never appeared in `gh pr checks` for a PR
+# touching zero evolution/ files. Fix: trigger on EVERY pull_request (paths:
+# removed below) so the job always posts a status; gate the real bench work via
+# an in-job `dorny/paths-filter` check instead -- the SAME pattern `ci.yml`'s
+# `test-packages`/`test-agent-runner` (also required checks) already use for
+# this exact problem. One divergence from their shape: this workflow keeps its
+# pre-existing `workflow_dispatch` trigger able to force-run the real bench
+# regardless of changed paths (ci.yml's jobs have no such trigger, so they can
+# gate the WHOLE job on `github.event_name == 'pull_request'`; doing that here
+# would silently turn workflow_dispatch into a permanent no-op).
+#
 # Recovery: if this required check is persistently red due to a JOB-level infra
 # failure (OOM/runner timeout/Docker), drop 'safety-recall' from the branch
 # protection required_status_checks contexts and re-enable after resolution.
 
 on:
   pull_request:
-    paths:
-      - 'evolution/**'
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: read # dorny/paths-filter reads the PR changed-file list via the API on pull_request runs
 
 jobs:
   safety-recall:
@@ -27,7 +44,18 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+
+      - name: Check whether this PR touches evolution/
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            evolution:
+              - 'evolution/**'
+
       - uses: actions/setup-python@v7
+        if: github.event_name != 'pull_request' || steps.filter.outputs.evolution == 'true'
         with:
           python-version: '3.12'
 
@@ -35,6 +63,7 @@ jobs:
         # Only the Gemini judge client is needed for this path (pinned to match
         # eval/requirements.txt). Not the full eval deps -- safety_redteam does
         # not use deepeval/langchain.
+        if: github.event_name != 'pull_request' || steps.filter.outputs.evolution == 'true'
         run: pip install google-genai==1.14.0
 
       - name: Check Gemini secret
@@ -45,6 +74,7 @@ jobs:
         # so it must not block (consistent with the in-bench infra-skip). NOTE:
         # this must gate the bench via `if:` -- a bare `exit 0` here would NOT
         # skip later steps; GitHub runs steps regardless of a prior step's exit.
+        if: github.event_name != 'pull_request' || steps.filter.outputs.evolution == 'true'
         id: preflight
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -57,7 +87,7 @@ jobs:
           fi
 
       - name: Run safety red-team recall bench (Gemini judge)
-        if: steps.preflight.outputs.has_key == 'true'
+        if: (github.event_name != 'pull_request' || steps.filter.outputs.evolution == 'true') && steps.preflight.outputs.has_key == 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           # Pin the judge model to the one the baselines.json floor was measured


### PR DESCRIPTION
## Summary

`safety-recall` (`.github/workflows/judge-gate.yml`) is a required branch-protection status check, but it only triggered on `pull_request` events touching `evolution/**` paths. Any PR outside that path never triggers the workflow at all, and GitHub Actions posts **no status** for the job name — a required-but-absent check blocks merge indefinitely in the UI. Confirmed live on PR #1102: `gh pr checks 1102` lists every other check but `safety-recall` is entirely absent, not pending/failed.

## Fix

Removes the `paths:` filter from `on.pull_request` so the job always triggers, and gates the real bench work via an in-job `dorny/paths-filter@v4` check instead — the same pattern `ci.yml`'s `test-packages`/`test-agent-runner` jobs (also required checks) already use for this exact problem. Adds `pull-requests: read` permission (required for `dorny/paths-filter`'s API-based changed-file read, matching `ci.yml`'s own precedent). Preserves the existing `workflow_dispatch` trigger's ability to force-run the bench regardless of changed paths — a deliberate divergence from the `ci.yml` precedent, which has no such trigger and can gate the whole job on `pull_request` only.

## Review process

Plan reviewed by `plan-reviewer` (Claude + GPT backends), 2 rounds: round 1 REVISE caught a false claim in my first draft that no repo precedent existed (real prior art in `ci.yml` was found and matched, including fixing a stale `@v3` pin to the already-proven `@v4`); round 2 REVISE flagged the verification plan needed to actually exercise a PR touching `evolution/**` (not just a non-evolution PR + `workflow_dispatch`), since a silent filter misconfiguration there would be the worst failure mode — the safety gate reporting green while never actually running. Code reviewed by `code-reviewer`: SHIP, GitHub Actions skipped-step/expression semantics traced by hand, header comment cross-checked against `ci.yml`.

## Follow-up (out of scope here)

GitHub evaluates a `pull_request`-triggered workflow using the workflow file version on the **PR's own branch**, not `main` — merging this does not retroactively unstick PR #1102 or any other currently-open PR. Each needs to separately pick up this fix (merge/rebase `main`, or cherry-pick) for `safety-recall` to post a real status.

## Test plan

- [ ] This PR itself (touches only `judge-gate.yml`, zero `evolution/` files) — confirm `safety-recall` shows a real PASS status, not absent
- [ ] `workflow_dispatch` manual trigger — confirm the real bench steps execute
- [ ] Throwaway branch/PR that also touches a file under `evolution/**` — confirm `steps.filter.outputs.evolution == 'true'` and the bench step actually runs (not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)