### PR TITLE
fix(hermes): close shell command/process-substitution injection in commit classifier

### DIFF
--- a/docs/decisions/opa-warden-attestations-v1.md
+++ b/docs/decisions/opa-warden-attestations-v1.md
@@ -90,6 +90,45 @@ alternate invocation form (paths, aliases, shell functions, wrapper scripts) is 
 problem with the same shape as the shell-compound evasion gap already scoped to the git-level
 backstop. Treat it the same way — a coaching-layer limitation, not a v1 defect to chase.
 
+**Fixed gap, found and closed during deep testing (2026-08-03, same day as initial ship)**: the
+classifier validated commit-form *shape* (which flags are present) but never inspected flag
+*values* for shell command-substitution syntax. Since Hermes's `terminal` tool runs commands
+through a real persistent shell, a "supported" commit whose message/author/`-C`/`-c` value
+contained a backtick or `$(` would execute arbitrary code as a side effect, independent of git
+or the tree-attestation logic entirely — verified live: a real Hermes agent ran
+`-m "safe $(touch /tmp/x)"`, classified as supported, and the target file was created (confirmed
+via `ls`, not the agent's self-report). Five adversarial review rounds (GPT-5.6-sol) progressively
+found the fix's scope too narrow (missed `-C`/`-c` values), the check placed too early (would
+have misclassified unrelated non-git commands merely mentioning "commit"), and two distinct
+shell line-continuation splice bypasses (`` `\`` + newline `` inside a quoted value, and the same
+marker with the backslash already consumed by `shlex`'s own escape handling for an unquoted
+value) — both verified live before and after the fix, not just unit-tested. The final fix
+normalizes the *raw command string* for line continuations before tokenization (not individual
+tokens afterward), then checks every token for the two markers once the command is already
+confirmed to be a genuine, otherwise-fully-supported git-commit invocation. **Live re-proof**:
+the fix was re-verified end-to-end against a real Hermes agent (gpt-5.6-sol via OpenAI Codex) —
+the exact original exploit (`-m "safe $(touch /tmp/x)"`, which had succeeded and created the
+target file against the pre-fix code) is now blocked, target file confirmed absent via `ls`; the
+unquoted line-continuation bypass was re-run the same way and also confirmed blocked, target
+file confirmed absent. Both re-proofs used a temporary hook redirect to the fix worktree, fully
+reverted afterward (`~/.hermes/config.yaml` restored byte-identical, confirmed via `diff`). Also
+verified at the unit level: 14 new regression tests (one per exploit variant found across all
+six review rounds, including process substitution -- see below), full `scripts/warden_policy/`
+suite (83 tests) passes with no regressions.
+
+A closely related construct, process substitution (`<(`, `>(`), was found missing from the
+marker set by code review after the above rounds -- the same vulnerability class (bash forks and
+runs the enclosed command to set up the substitution as a side effect of word-splitting alone,
+whether or not the resulting path is ever read), verified live the same way. Both markers are
+now included.
+
+**Named residual gap, not fixed in this round**: any `-c <key>=<value>` other than
+`core.hooksPath` is accepted with no restriction on `key` -- e.g. `-c core.fsmonitor=<path>` is
+a known git-config code-execution vector independent of shell substitution (git itself would
+execute `<path>` as a filesystem-monitor hook). Not live-verified against `git commit`
+specifically, so not asserted as a confirmed bypass here -- flagged as a conscious, named gap
+for a future round to verify and close, not a silent omission.
+
 ### Cross-reference: not the same system as `hook-dispatch-system.md`
 
 `docs/decisions/hook-dispatch-system.md` / `hook-dispatch-facade-correction.md` describe a

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-03" # auto-bump @1785756982
+last_verified: "2026-08-03" # auto-bump @1785760449
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/warden_policy/command_parser.py
+++ b/scripts/warden_policy/command_parser.py
@@ -18,10 +18,49 @@ message between this classifier's authorization and the actual commit
 (found in this repo's own `.husky/pre-commit` -> `npx lint-staged`, and by
 name for `prepare-commit-msg` in adversarial plan review -- `--no-verify`
 alone does not suppress that one).
+
+Defense-in-depth: `classify()` also rejects any command whose tokens contain a
+shell command- or process-substitution marker (backtick, `$(`, `<(`, `>(`),
+checked ONLY after the command is already confirmed to be a genuine,
+otherwise-fully-supported git-commit invocation (never before -- an early
+check would misclassify an unrelated command that merely mentions "commit"
+as a substring, e.g. `rg -F '$(' docs/commit-notes.md`). Found live: Hermes's
+`terminal` tool runs commands through a real persistent shell, so a
+"supported" commit message like `-m "safe $(touch /tmp/x)"` would execute
+arbitrary code as a side effect, independent of git or the tree-attestation
+logic entirely -- verified by actually running it through a live Hermes
+agent and confirming the target file was created. Process substitution
+(`<(`/`>(`) is the same vulnerability class: bash forks and runs the enclosed
+command to set up the substitution as a side effect of word-splitting alone,
+whether or not the resulting path is ever read -- verified live the same way
+(a brief delay is needed before checking, since the fork runs in the
+background and can race ahead of a naive immediate check).
+
+Before the marker check runs, the RAW command string is normalized to strip
+shell line-continuations (a backslash immediately followed by a newline,
+stripped by a real shell before word-splitting/quote-removal even runs,
+regardless of quoting style) -- normalizing the raw string, not patching
+individual tokens after tokenization, because a per-token fix was tried and
+found insufficient: for a quoted value `shlex.split()` preserves the literal
+backslash-newline sequence intact, but for an unquoted value `shlex`'s own
+escape handling already consumes the backslash while leaving the bare
+newline behind, so no backslash remains for a post-tokenization check to
+match. Verified live in both forms. Accepted, named tradeoff: stripping the
+raw string unconditionally also strips inside what would be a single-quoted
+section (where a real shell does NOT remove line continuations at all) --
+an over-blocking direction only, never under-blocking.
+
+This is NOT a claim of exhaustive shell quote-removal or metacharacter
+sanitization (that would be reinventing a shell parser and remains this
+classifier's non-goal, same as the deliberately unaddressed shell-compound
+and alternate-invocation gaps below) -- it closes the specific, tractable,
+well-known constructs verified live across several adversarial review
+rounds.
 """
 
 from __future__ import annotations
 
+import re
 import shlex
 from dataclasses import dataclass
 
@@ -39,6 +78,20 @@ _FLAG_TAKES_VALUE = {"-m", "--message", "--author"}
 
 # Global options recognized BEFORE the `commit` subcommand.
 _GLOBAL_FLAG_TAKES_VALUE = {"-C"}  # value is a path; -c is handled specially (must be hooksPath)
+
+# Shell command-/process-substitution markers -- see the module docstring's "Defense-in-depth"
+# paragraph for the full rationale (why these four, why checked last, why line continuations
+# are normalized on the raw string rather than per-token).
+_COMMAND_SUBSTITUTION_MARKERS = ("`", "$(", "<(", ">(")
+_LINE_CONTINUATION_RE = re.compile(r"\\\r?\n")
+
+
+def _strip_line_continuations(command: str) -> str:
+    return _LINE_CONTINUATION_RE.sub("", command)
+
+
+def _contains_command_substitution(tokens: list[str]) -> bool:
+    return any(marker in tok for tok in tokens for marker in _COMMAND_SUBSTITUTION_MARKERS)
 
 
 @dataclass(frozen=True)
@@ -64,6 +117,9 @@ def _blocked(reason: str) -> Classification:
 
 
 def classify(command: str) -> Classification:
+    # Normalize line continuations before any other processing -- see the module docstring.
+    command = _strip_line_continuations(command)
+
     if "commit" not in command:
         return _not_commit_shaped()
 
@@ -130,5 +186,12 @@ def classify(command: str) -> Classification:
 
     if not saw_no_verify:
         return _blocked("missing required `--no-verify`.")
+
+    # Defense-in-depth, checked LAST -- see the module docstring.
+    if _contains_command_substitution(tokens):
+        return _blocked(
+            "commit contains a shell command- or process-substitution marker "
+            "(backtick, $(, <(, or >() in a value"
+        )
 
     return Classification(is_commit_shaped=True, supported=True, reason="supported commit form")

--- a/scripts/warden_policy/tests/test_command_parser.py
+++ b/scripts/warden_policy/tests/test_command_parser.py
@@ -146,5 +146,90 @@ class TestBlockedForms(unittest.TestCase):
         self.assertFalse(c.supported)
 
 
+class TestCommandSubstitutionInjection(unittest.TestCase):
+    """Regression tests for a real, live-verified vulnerability found during deep testing of
+    the shipped v1: a "supported" commit whose message/author/global-option values contain a
+    shell command-substitution marker executes arbitrary code as a side effect when Hermes's
+    terminal tool runs it through a real persistent shell -- independent of git or the
+    tree-attestation logic entirely. See the module docstring's "Defense-in-depth" paragraph.
+    """
+
+    def test_backtick_in_message_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m "safe `whoami`"')
+        self.assertTrue(c.is_commit_shaped)
+        self.assertFalse(c.supported)
+
+    def test_dollar_paren_in_message_space_form_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m "safe $(touch /tmp/x)"')
+        self.assertFalse(c.supported)
+
+    def test_dollar_paren_in_author_space_form_blocked(self):
+        c = classify(
+            'git -c core.hooksPath=/tmp/e commit --no-verify --author "$(touch /tmp/x) <a@b.c>" -m x'
+        )
+        self.assertFalse(c.supported)
+
+    def test_dollar_paren_in_message_equals_form_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify --message=$(touch /tmp/x)')
+        self.assertFalse(c.supported)
+
+    def test_dollar_paren_in_author_equals_form_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify --author=$(touch /tmp/x) -m x')
+        self.assertFalse(c.supported)
+
+    def test_dollar_paren_in_dash_capital_c_value_blocked(self):
+        # GPT-5.6-sol's specific finding: -C's value is consumed with zero content validation.
+        c = classify('git -C "$(touch /tmp/x)" -c core.hooksPath=/tmp/e commit --no-verify -m safe')
+        self.assertFalse(c.supported)
+
+    def test_process_substitution_input_form_blocked(self):
+        # Code-review's finding: <(...) is the same vulnerability class as $(...) -- bash forks
+        # and runs the enclosed command to set up the substitution as a side effect of
+        # word-splitting alone, regardless of whether the resulting path is ever read.
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m <(touch /tmp/x)')
+        self.assertFalse(c.supported)
+
+    def test_process_substitution_output_form_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m >(touch /tmp/x)')
+        self.assertFalse(c.supported)
+
+    def test_dollar_paren_in_non_hookspath_dash_c_value_blocked(self):
+        c = classify(
+            'git -c core.hooksPath=/tmp/e -c user.name="$(touch /tmp/x)" commit --no-verify -m safe'
+        )
+        self.assertFalse(c.supported)
+
+    def test_line_continuation_split_marker_quoted_form_blocked(self):
+        # Round 4: shlex.split() preserves a literal backslash-newline inside a quoted value
+        # intact -- a per-token check could catch this form alone, but the actual fix
+        # normalizes the raw string, which also covers it.
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m "safe $\\\n(touch /tmp/x)"')
+        self.assertFalse(c.supported)
+
+    def test_line_continuation_split_marker_unquoted_form_blocked(self):
+        # Round 5: the case that broke the per-token normalization approach -- shlex's own
+        # escape handling consumes the backslash for an UNQUOTED value, leaving only a bare
+        # newline by the time a token exists, which a post-tokenization regex can't recover.
+        # The fix normalizes the raw command string before shlex.split() ever runs, so this
+        # form is caught the same way as the quoted one.
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m $\\\n(touch>/tmp/x)')
+        self.assertFalse(c.supported)
+
+    def test_literal_dollar_sign_alone_not_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m "fix: cost is \\$5"')
+        self.assertTrue(c.supported)
+
+    def test_literal_braces_not_blocked(self):
+        c = classify('git -c core.hooksPath=/tmp/e commit --no-verify -m "fix: use {x} syntax"')
+        self.assertTrue(c.supported)
+
+    def test_unrelated_non_git_command_with_marker_and_commit_substring_not_commit_shaped(self):
+        # Round 3's finding: the check must never fire before commit-shape is confirmed, or an
+        # entirely unrelated command gets misclassified just for mentioning "commit" and a
+        # marker in unrelated positions (e.g. a filename).
+        c = classify("rg -F '$(' docs/commit-notes.md")
+        self.assertFalse(c.is_commit_shaped)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Found during deep-testing of the just-shipped OPA guardrails v1 (PR #1105): `command_parser.py` validated commit-form *shape* (which flags are present) but never inspected flag *values* for shell command-substitution syntax. Since Hermes's `terminal` tool runs commands through a real persistent shell, a "supported" commit message like `-m "safe $(touch /tmp/x)"` executed arbitrary code as a side effect, independent of git or the tree-attestation logic entirely — **verified live**: a real Hermes agent ran the exact exploit, the target file was created, confirmed via `ls`, not the agent's self-report.

Six rounds of adversarial review (5 plan-review, 1 code-review) each found a real, empirically-verified gap:
- Initial scope (message/author only) missed `-C`/`-c` values.
- The widened check was placed too early — would have misclassified unrelated non-git commands merely containing the substring "commit".
- Two distinct shell line-continuation splice bypasses (quoted and unquoted forms) required normalizing the *raw command string* before tokenization, not patching individual tokens afterward — `shlex`'s own escape handling behaves differently for quoted vs. unquoted values in a way that broke a naive per-token fix.
- Process substitution (`<(`, `>(`) is the same vulnerability class as `$(`/backtick — bash forks and runs the enclosed command as a side effect of word-splitting alone, regardless of whether the result is ever read.

## Test plan

- [x] 83 tests pass (14 new), no regressions on the 69 existing tests.
- [x] `opa test -v scripts/warden_policy/policy` — 10/10 pass (policy untouched by this fix, still green).
- [x] **Live re-proof against a real Hermes agent**, after implementation: the original exploit and the unquoted line-continuation bypass are both now blocked — confirmed via `ls` (target files absent) and `git log`/commit count (unchanged), not the agent's self-report. Used a temporary hook redirect to the fix worktree, fully reverted afterward.
- [x] `npm run drift-check` — all checks pass

## Explicitly named, not fixed here

Unrestricted `-c <key>=<value>` for keys other than `core.hooksPath` (e.g. `core.fsmonitor`, a known git-config code-execution vector independent of shell substitution) — not live-verified against `git commit` specifically, flagged as a conscious residual gap for a future round rather than left silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)