### PR TITLE
fix(wardens): exempt plan-reviewer model-backend verdicts from diff-hash staleness (LIA-516)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -1446,16 +1446,23 @@ def run_plan_review_gate(event: dict[str, Any], repo_root: Path) -> int:
     # from the store; the invalidators clear plan-reviewer@<backend> so a fresh plan needs fresh
     # model review (no stale-SHIP bypass — oracle O1/O2). With no model backend configured for
     # plan-reviewer (the default), this stays a pure JSON read: no added subprocess cost, since
-    # _evaluate_backends' per-backend loop `continue`s before ever reaching _read_verdict. LIA-382:
-    # when a model backend IS configured, this now costs ~3 git subprocess calls per SHIP/TRIVIAL
-    # entry read (_fresh_entry's staleness fingerprint) on EVERY Edit/Write/MultiEdit/apply_patch
-    # while the marker is present — not just at commit time, since this fast path fires on every
-    # edit in an active session. Left as-is deliberately (not special-cased to skip staleness
-    # checking here): correctness at every gate the fix was designed to cover outweighs the
-    # measured ~27ms/read cost, which is small next to LLM-inference-dominated agentic loop
-    # latency. Revisit this call site specifically if it's ever measured to matter in practice.
+    # _evaluate_backends' per-backend loop `continue`s before ever reaching _read_verdict.
+    #
+    # check_fingerprint=False (LIA-516): the LIA-382 diff-hash staleness check in _fresh_entry is
+    # deliberately DISABLED for this read. A plan-reviewer SHIP approves the plan TEXT (intent),
+    # not a diff snapshot — unlike code-reviewer/verification-gate, which review an actual diff and
+    # correctly go stale when it changes. Fingerprinting this read meant the very first
+    # implementation edit after a genuine SHIP (any tracked-file change, since diff_hash covers the
+    # whole worktree) invalidated it, blocking the second edit of any multi-file implementation.
+    # Correct invalidation for this role already happens elsewhere: run_session_init and
+    # run_plan_mode_invalidator explicitly clear plan-reviewer@<backend> on every SessionStart and
+    # on every new plan (/plan, ExitPlanMode, or a fresh Plan-subagent dispatch) — see those
+    # functions. The fingerprint check was a third, redundant invalidation path for this role, and
+    # the wrong one: it fired on implementation edits, not on new plans.
     if _marker(repo_root, ".plan-reviewed").exists():
-        model_blocking = _evaluate_backends("plan-reviewer", config, repo_root, skip_claude=True)
+        model_blocking = _evaluate_backends(
+            "plan-reviewer", config, repo_root, skip_claude=True, check_fingerprint=False,
+        )
         if not model_blocking:
             return 0
         _block_pre_tool(_warden_backends_block_message("plan-reviewer", model_blocking, repo_root))
@@ -2824,7 +2831,8 @@ def _warden_backends_block_message(
 
 
 def _evaluate_backends(
-    role: str, config: dict[str, Any], repo_root: Path, *, skip_claude: bool = False
+    role: str, config: dict[str, Any], repo_root: Path, *, skip_claude: bool = False,
+    check_fingerprint: bool = True,
 ) -> list[tuple[str, str | None]]:
     """Strict-AND verdict evaluation for a role's configured backends.
 
@@ -2835,7 +2843,12 @@ def _evaluate_backends(
     Trigger-agnostic by design: it reads only the verdict store, so commit-triggered gates
     (code-reviewer/ai-eng-warden) and edit-triggered gates (plan-reviewer) can share it.
     ``skip_claude=True`` evaluates only the model backends — used by plan-reviewer, whose
-    Claude signal is the ``.plan-reviewed`` marker (not the verdict store)."""
+    Claude signal is the ``.plan-reviewed`` marker (not the verdict store).
+
+    ``check_fingerprint=False`` (LIA-516) disables the LIA-382 diff-hash staleness
+    check on the model-backend reads — see ``run_plan_review_gate``'s call site and
+    ``_fresh_entry``'s docstring for why this is correct for plan-reviewer specifically
+    and wrong for every other role, which keeps the default."""
     blocking: list[tuple[str, str | None]] = []
     for backend in _role_backends(config, role):
         if backend == BACKEND_CLAUDE:
@@ -2852,7 +2865,9 @@ def _evaluate_backends(
             if verdict == "TRIVIAL":
                 continue
         elif backend in KNOWN_MODEL_BACKENDS:
-            verdict = _read_verdict(store_key(role, backend), repo_root)
+            verdict = _read_verdict(
+                store_key(role, backend), repo_root, check_fingerprint=check_fingerprint,
+            )
         else:
             sys.stderr.write(
                 f"[warden-backends-gate] WARNING: unknown backend '{backend}' in "

--- a/scripts/tests/test_phase3_cogate_oracle.py
+++ b/scripts/tests/test_phase3_cogate_oracle.py
@@ -403,3 +403,93 @@ def test_o3_code_reviewer_gpt_could_not_run_fails_open(repo, blocks):
     assert blocks == [], (
         "COULD_NOT_RUN must fail open — infra failures must not block commits"
     )
+
+
+# ── LIA-516: check_fingerprint=False keeps a genuine plan-reviewer@gpt SHIP ──
+# ── alive across implementation edits, without weakening code-reviewer's gate ─
+#
+# Uses a REAL git repo (unlike the `repo` fixture above, which is a bare
+# tmp_path with no git init — under that fixture, _compute_state_fingerprint
+# always fails, so every verdict is written legacy-shaped and _fresh_entry's
+# staleness check never actually engages regardless of check_fingerprint. A
+# real repo is required so the fingerprint mechanism is genuinely exercised.
+
+def _init_git_repo_lia516(path: Path) -> None:
+    import subprocess
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.email", "oracle-lia516@example.invalid"],
+                    cwd=path, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.name", "Oracle LIA-516"],
+                    cwd=path, check=True, stdout=subprocess.DEVNULL)
+    (path / "src").mkdir()
+    (path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=path, check=True,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    (path / ".claude" / "wardens").mkdir(parents=True)
+
+
+@pytest.fixture
+def real_git_repo(tmp_path, monkeypatch):
+    repo_path = tmp_path / "real_repo"
+    _init_git_repo_lia516(repo_path)
+    monkeypatch.setattr(h, "_claude_marker_dir", lambda root: root / ".claude")
+    monkeypatch.setattr(h, "_worktree_for_cwd", lambda cwd, root: root)
+    return repo_path
+
+
+def test_lia516_plan_review_gate_survives_implementation_edit(real_git_repo, blocks):
+    # @oracle LIA-516: after a genuine plan-reviewer@gpt SHIP, the FIRST
+    # implementation edit (a real tracked-file change, not a new plan) must NOT
+    # re-block the gate — the SHIP approved the plan text, and correct
+    # invalidation for this role is SessionStart/new-plan (Contracts B/C above),
+    # not a diff-hash fingerprint.
+    repo = real_git_repo
+    _config(repo, {_PLAN_ROLE: {"backends": ["claude", "gpt"]}})
+
+    marker_path = h._marker(repo, ".plan-reviewed")
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.touch()
+    _set(repo, _GPT_KEY, "SHIP")  # genuine SHIP, fingerprinted against current real HEAD/diff
+
+    # The first implementation edit after plan approval: a real tracked-file
+    # change, made via plain write_text (as any Bash-based or hook-invisible
+    # edit would be) — this is exactly the diff_hash-changing edit LIA-516
+    # reports as wrongly blocking the SECOND edit.
+    (repo / "src" / "main.py").write_text("print('hello world')\n", encoding="utf-8")
+
+    h.run_plan_review_gate(_plan_edit_event(repo), repo)
+
+    assert not blocks, (
+        f"run_plan_review_gate blocked after a real implementation edit "
+        f"following a genuine plan-reviewer@gpt SHIP: {blocks!r} — the LIA-382 "
+        "diff-hash fingerprint must not stale a plan-reviewer verdict on an "
+        "implementation edit (LIA-516); only SessionStart/new-plan should "
+        "invalidate it (see Contracts B/C above)."
+    )
+
+
+def test_lia516_code_reviewer_gate_still_blocks_on_stale_ship(real_git_repo, blocks):
+    # @oracle LIA-516 (contrast/control): the SAME kind of implementation edit
+    # must STILL stale a code-reviewer@gpt SHIP and block the commit gate — the
+    # LIA-516 exemption is plan-reviewer-scoped, not a global weakening of
+    # LIA-382 staleness protection for diff-reviewing wardens.
+    repo = real_git_repo
+    _config(repo, {_CODE_ROLE: {"backends": ["claude", "gpt"]}})
+
+    _set(repo, _CODE_GPT_KEY, "SHIP")  # genuine SHIP, fingerprinted against current HEAD/diff
+
+    # Same kind of edit as the plan-reviewer test above.
+    (repo / "src" / "main.py").write_text("print('hello world')\n", encoding="utf-8")
+
+    h.run_warden_backends_gate(_CODE_ROLE, _commit_event(repo), repo)
+
+    assert blocks, (
+        "run_warden_backends_gate for code-reviewer did NOT block after a "
+        "tracked-file edit staled its GPT SHIP — the LIA-516 fix must not "
+        "regress diff-based staleness protection for code-reviewer/"
+        "verification-gate/ai-eng-warden; only plan-reviewer's model-backend "
+        "reads are exempted from the fingerprint check."
+    )

--- a/scripts/tests/test_verdict_store_staleness.py
+++ b/scripts/tests/test_verdict_store_staleness.py
@@ -592,3 +592,64 @@ def test_cogate_gpt_verdict_read_respects_staleness(store_root, monkeypatch):
         "live PASS — cogate.py's GPT-verdict read site must respect the same "
         "staleness filtering as every other read site (spec point 6)."
     )
+
+
+# ---------------------------------------------------------------------------
+# 9) LIA-516 — check_fingerprint=False exempts plan-reviewer model-backend
+#    reads from the LIA-382 diff-hash staleness check
+# ---------------------------------------------------------------------------
+
+
+def test_check_fingerprint_false_exempts_entry_from_staleness(store_root):
+    # @oracle LIA-516: plan-reviewer's SHIP approves plan TEXT (intent), not a
+    # diff snapshot — a tracked-file edit (the first implementation edit after
+    # a genuine plan SHIP) must NOT stale it when check_fingerprint=False, even
+    # though the identical write+edit DOES stale the entry under the default
+    # check_fingerprint=True (the control, proving this test is discriminating).
+    repo = store_root
+    from warden_review.constants import BACKEND_GPT, store_key
+
+    gpt_key = store_key("plan-reviewer", BACKEND_GPT)
+    _vs._write_verdict(repo, gpt_key, "SHIP", "plan approved")
+
+    _bash_edit_tracked_file(repo, "first implementation edit after plan SHIP\n")
+
+    # Control: the default (check_fingerprint=True) still stales this entry —
+    # proves the edit above is the same kind of change every other test in this
+    # file uses to demonstrate staleness, so the real assertion below is real.
+    assert _vs._read_verdict(gpt_key, repo) is None, (
+        "setup precondition failed: a normal fingerprinted SHIP did not go "
+        "stale after a tracked-file edit under the default check_fingerprint=True "
+        "— this test cannot meaningfully demonstrate the check_fingerprint=False "
+        "exemption without this control holding."
+    )
+
+    # Real assertion: the SAME entry, read with check_fingerprint=False, survives.
+    assert _vs._read_verdict(gpt_key, repo, check_fingerprint=False) == "SHIP", (
+        "a plan-reviewer@gpt SHIP was invalidated by a tracked-file edit even "
+        "with check_fingerprint=False — the LIA-516 exemption must skip the "
+        "fingerprint comparison entirely for this read, not just widen the "
+        "match tolerance."
+    )
+
+
+def test_check_fingerprint_false_does_not_resurrect_revise(store_root, monkeypatch):
+    # @oracle LIA-516: check_fingerprint=False must NOT change REVISE/BLOCK
+    # handling — those are already unconditionally unfiltered (spec point 4 of
+    # LIA-382), and this new parameter must not accidentally widen or narrow
+    # that invariant.
+    repo = store_root
+    from warden_review.constants import BACKEND_GPT, store_key
+
+    gpt_key = store_key("plan-reviewer", BACKEND_GPT)
+    _vs._write_verdict(repo, gpt_key, "REVISE", "found issues in the plan")
+    _bash_edit_tracked_file(repo, "edit after REVISE was recorded\n")
+
+    assert _vs._read_verdict(gpt_key, repo, check_fingerprint=False) == "REVISE", (
+        "check_fingerprint=False hid a REVISE verdict — REVISE/BLOCK must stay "
+        "visible regardless of this parameter, exactly as with the default."
+    )
+    assert _vs._read_verdict(gpt_key, repo, check_fingerprint=True) == "REVISE", (
+        "sanity: REVISE is unfiltered under the default too (already covered by "
+        "the LIA-382 oracle, re-asserted here for contrast)."
+    )

--- a/scripts/warden_hooks/verdict_store.py
+++ b/scripts/warden_hooks/verdict_store.py
@@ -214,6 +214,7 @@ def _compute_state_fingerprint(worktree: Path) -> tuple[str | None, str | None]:
 
 def _fresh_entry(
     data: dict[str, Any], warden: str, worktree: Path, fail_open: bool = True,
+    check_fingerprint: bool = True,
 ) -> dict[str, Any] | None:
     """Return ``data[warden]`` if it should be trusted right now, else ``None``.
 
@@ -224,6 +225,17 @@ def _fresh_entry(
       must stay visible and blocking, or ``mark_warden``'s post-REVISE
       TRIVIAL-bypass guard (which reads ``_last_verdict``) would be silently
       defeated by the very edit someone makes to FIX the REVISE.
+    - ``check_fingerprint=False`` (LIA-516): a SHIP/TRIVIAL entry is returned
+      UNCHANGED without ever comparing fingerprints — same outcome as the
+      legacy-entry branch below, but explicit and role-driven. Exists for
+      ``plan-reviewer``'s model-backend reads (``run_plan_review_gate``'s
+      ``_evaluate_backends(..., skip_claude=True)``): that SHIP approves the
+      *plan text* (intent), not a diff snapshot, so a ``diff_hash`` change on
+      the first implementation edit must NOT stale it — correct invalidation
+      for that role already happens via ``run_session_init`` and
+      ``run_plan_mode_invalidator`` explicitly clearing
+      ``plan-reviewer@<backend>`` on session start / a new plan, not via this
+      fingerprint.
     - SHIP/TRIVIAL entry with no ``head_sha``/``diff_hash`` recorded (a legacy,
       pre-LIA-382 entry): returned UNCHANGED — the staleness check is skipped,
       not treated as automatically stale, so this fix doesn't retroactively
@@ -245,6 +257,8 @@ def _fresh_entry(
         return None
     if entry.get("verdict") not in _STALENESS_ELIGIBLE_VERDICTS:
         return entry
+    if not check_fingerprint:
+        return entry
     stored_head = entry.get("head_sha")
     stored_diff = entry.get("diff_hash")
     if stored_head is None or stored_diff is None:
@@ -257,7 +271,9 @@ def _fresh_entry(
     return None  # stale
 
 
-def _read_verdict(marker_name: str, repo_root: Path) -> str | None:
+def _read_verdict(
+    marker_name: str, repo_root: Path, *, check_fingerprint: bool = True,
+) -> str | None:
     """Return the verdict string for *marker_name* from .warden-verdicts.json.
 
     Maps the marker name (e.g. ``"code-reviewed"``) to the warden key used in
@@ -265,13 +281,18 @@ def _read_verdict(marker_name: str, repo_root: Path) -> str | None:
     if the file is absent, malformed, the entry is missing, or (LIA-382) a
     SHIP/TRIVIAL entry's fingerprint no longer matches the worktree's current
     state — see ``_fresh_entry``.
+
+    ``check_fingerprint=False`` (LIA-516) skips that fingerprint comparison
+    entirely — see ``_fresh_entry``'s docstring for when this is appropriate
+    (plan-reviewer's model-backend reads only; every other caller keeps the
+    default).
     """
     warden = _entry.MARKER_NAMES.get(marker_name)
     if not warden:
         return None
     data = _read_verdicts(repo_root)
     worktree = _entry._resolve_verdict_worktree(repo_root)
-    entry = _fresh_entry(data, warden, worktree)
+    entry = _fresh_entry(data, warden, worktree, check_fingerprint=check_fingerprint)
     if not isinstance(entry, dict):
         return None
     v = entry.get("verdict")


### PR DESCRIPTION
## Summary
- Fixes LIA-516: `run_plan_review_gate`'s marker-present fast path staled a genuine `plan-reviewer@gpt` SHIP on the *first* implementation edit after plan approval (any diff_hash change), blocking every subsequent edit of a multi-file implementation — because the LIA-382 diff-hash fingerprint check assumes a SHIP is bound to a specific diff, which is true for code-reviewer/verification-gate but not for plan-reviewer (its SHIP approves plan *text*, not a diff snapshot).
- Adds `check_fingerprint: bool = True` threaded through `_fresh_entry` → `_read_verdict` → `_evaluate_backends`, defaulting `True` everywhere (byte-identical behavior for every other caller — code-reviewer/ai-eng-warden's commit gate, verification-gate, the admin-merge standing grant, `cogate.py`). Only `run_plan_review_gate`'s marker-present read passes `check_fingerprint=False`, since correct invalidation for `plan-reviewer@<backend>` already exists via `run_session_init` (SessionStart) and `run_plan_mode_invalidator` (`/plan`, `ExitPlanMode`, new Plan-subagent dispatch) — both already covered by existing Contract B/C tests.
- Reverses a prior LIA-382 decision to fingerprint-check uniformly ("correctness at every gate ... outweighs the cost") and removes an asymmetry it introduced: the Claude-side `.plan-reviewed` marker was never fingerprint-tied, so the GPT-side verdict was held to a stricter, diff-bound standard for reviewing the same plan.

## Test plan
- [x] `pytest scripts/tests/test_verdict_store_staleness.py scripts/tests/test_phase3_cogate_oracle.py scripts/tests/test_codex_warden_hooks.py -v` — 334 passed (330 existing + 4 new), no regressions
- [x] `pytest scripts/tests/test_codex_warden.py scripts/tests/test_review_runner.py scripts/tests/test_verdict_store_lock.py scripts/tests/test_verdict_store_race.py scripts/tests/test_warden_review.py -q` — 134 passed, no regressions
- [x] New: `test_check_fingerprint_false_exempts_entry_from_staleness` / `test_check_fingerprint_false_does_not_resurrect_revise` (direct, with internal controls)
- [x] New: `test_lia516_plan_review_gate_survives_implementation_edit` / `test_lia516_code_reviewer_gate_still_blocks_on_stale_ship` (end-to-end, real git repo, with a code-reviewer contrast/control proving the exemption is plan-reviewer-scoped)
- [x] Review trail: `plan-reviewer` SHIP (1 REVISE round, stale test-count baseline, corrected); `code-reviewer` SHIP, no blocking issues

Closes LIA-516. Unblocks the next handoff item (resuming `codegraph-gate-retire`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)