### PR TITLE
docs(wardens): LIA-527 Phase 2 isolated CC write path design + independent oracle

### DIFF
--- a/docs/decisions/opa-warden-attestations-v1.md
+++ b/docs/decisions/opa-warden-attestations-v1.md
@@ -320,6 +320,378 @@ property was **self-authored by the implementer**, not produced independently vi
 (the implementing agent had no dispatch capability). An independently authored oracle should be
 run before any Phase 2 cutover.
 
+### Phase 2 — isolated CC write path (design only; not yet implemented)
+
+This section designs the write path Phase 1 deliberately left undesigned. It does not
+implement it, does not enable any cutover, and does not change what any existing gate
+does. Written now because the design itself is reviewable independently of real shadow data;
+the *cutover decision* (which gates, if any, start consulting OPA) still needs that data and
+is explicitly out of scope here — see "Not yet started" below.
+
+**Chosen shape: an isolated document, not a fixed `_mutate` ordering.** Phase 1's own write-path
+post-mortem (above) identified the root cause precisely: `_mutate` persists disk at
+`generation` N+1 before its OPA PUT is confirmed, and `guardrails.rego`'s `supported` guard
+requires `data.warden_attestations.generation == input.expected_generation` — so a failed PUT on
+*any* write to that document fails closed for *every* enrolled repo's Hermes gate, including ones
+having nothing to do with the write that failed. Reordering `_mutate` to persist only after PUT
+confirmation was considered and rejected for this phase: it would rewrite the write transaction
+that six-plus rounds of adversarial review already hardened for Hermes's real, field-proven path,
+for a benefit (avoiding a redundant OPA document) that isolation achieves more cheaply and with
+zero shared-state blast radius.
+
+Instead: Claude-Code-authored mirrors go to a **second, wholly separate OPA data document**,
+`data.warden_cc_attestations`, backed by its own on-disk ledger
+(`~/.config/deus/guardrails/attestations-cc-v1.json`) and its own `generation` counter. A failed
+PUT on this document can only ever desynchronize `warden_cc_attestations.generation` from its own
+disk value — no Rego rule reads that path today (no rule exists yet; Phase 2 adds none), and
+`warden_attestations.generation` (the value Hermes's `supported` guard actually checks) is never
+touched by this write path at all, PROVIDED every OPA-bound write actually targets the isolated
+document's own data path rather than the module-level default (see the six sites below — this is
+not automatic and one of them is exactly the mechanism that would silently defeat it).
+
+**Mechanism reuse, not reimplementation.** `AttestationStore`'s locking/atomic-write/PUT-readback
+transaction is exactly what this write path needs — parameterize it rather than duplicate it:
+
+```python
+class AttestationStore:
+    def __init__(
+        self,
+        ledger_path: Path,
+        opa_base_url: str = OPA_DEFAULT_BASE_URL,
+        *,
+        document_key: str = "warden_attestations",      # new, defaults to today's behavior
+        opa_data_path: str | None = None,                # new; defaults to f"/v1/data/{document_key}"
+    ):
+        ...
+        self.document_key = document_key
+        self.opa_data_path = opa_data_path or f"/v1/data/{document_key}"
+```
+
+Every site in `attestation_store.py` that hardcodes the literal string `warden_attestations` —
+confirmed exhaustively via `grep -n "warden_attestations" scripts/warden_policy/attestation_store.py`
+(unquoted; a narrower quoted-literal grep undercounts and was the root cause of an earlier
+round's gap) — becomes `self.document_key`/`self.opa_data_path`-scoped together, as one
+atomic change, not a partial subset. All six sites:
+
+1. `OPA_DATA_PATH = "/v1/data/warden_attestations"` (:55) — the module constant `_put_and_readback`
+   uses for both the PUT (`Request` built at :142, sent at :146) and the generation read-back
+   (`Request` built at :151, sent at :153). This is the site that
+   actually determines which OPA document a write lands in, regardless of what the on-disk
+   ledger's own key is named — **the single most load-bearing site for the isolation guarantee**,
+   and the one an earlier round's review caught missing. `_put_and_readback` must read
+   `self.opa_data_path` here, not the module constant.
+2. `_empty_document()`'s `"warden_attestations"` wrapper key (:61).
+3. `_read_disk`'s schema-shape check, `if "warden_attestations" not in doc` (:113-114).
+4. `_mutate` (:192) — `inner = doc["warden_attestations"]`. `enroll`, `unenroll`, and
+   `issue()` all route through `_mutate`; `issue()` is what the whole Phase 2 write path is
+   built on.
+5. `sync()` (:270) — same `doc["warden_attestations"]` pattern, the retry path for a prior
+   failed PUT.
+6. `inspect()` (:277) — same pattern, the read-only listing path.
+
+Missing any of these six would let a CC-authored write silently reach or report on
+`data.warden_attestations` / the on-disk `warden_attestations` key instead of the isolated
+`warden_cc_attestations` counterpart — reproducing the exact failure mode the "Chosen shape"
+section above exists to rule out. Site #1 is the one that would do so most dangerously: even if
+sites 2-6 correctly read/write an isolated on-disk ledger file, an unparameterized
+`_put_and_readback` would still PUT that isolated document's contents to OPA's live
+`/v1/data/warden_attestations` path — overwriting the real document `guardrails.rego`'s
+`supported` guard reads and fail-closing every Hermes-enrolled repo immediately. All six must be
+fixed together; none is optional.
+
+Every existing call site (Hermes's, Phase 0's `backend=` parameter, `warden_attest.py`'s CLI)
+passes no new argument and is byte-identical in behavior — this is additive, confirmed by keeping
+`test_attestation_store.py`'s existing cases unparameterized and adding a new parameterized class
+for the second document, including a regression test that asserts the isolated store's PUT target
+is `/v1/data/warden_cc_attestations`, never `/v1/data/warden_attestations` (the concrete, testable
+form of the guarantee site #1 above states in prose). A `CcAttestationStore` convenience wrapper
+(or a `scripts/warden_policy/cc_attestations.py` module analogous to `cc_shadow.py`) instantiates
+`AttestationStore(CC_LEDGER_PATH, document_key="warden_cc_attestations")` so call sites never
+touch the constructor directly.
+
+**Who writes, and when.** `run_warden_backends_gate` (code-reviewer, ai-eng-warden) and
+`run_verification_gate` enqueue a job for `cc_store.issue_if_newer(backend=<backend>, gate=<role>,
+..., queued_at=...)` (see "Ordering guard" below for why the plain `issue()` method is not what
+the write path actually calls) once per backend verdict, **after** the legacy decision is already
+finalized and returned/written — same
+ordering discipline `cc_shadow.observe()` already established for Phase 1, and for the same
+reason: this call's outcome (success or failure) must never be consulted by the gate that just
+ran. A failed write here means "this SHIP wasn't mirrored to the CC ledger yet," never a block,
+never a retry-on-the-critical-path. `verification-gate` is not yet in any schema's `gate` enum
+(Phase 1 flagged this as a prerequisite for covering it at all) — Phase 2 satisfies that via a
+**new**, CC-specific schema file (`attestation-cc-v1.schema.json`) that includes it from the
+start, rather than widening the Hermes-facing `attestation-v1.schema.json`, so Hermes's own
+schema contract is untouched by this phase.
+
+**Bounding the synchronous call, and TRIVIAL handling** (found missing by the GPT co-gate review
+of this design, round 1 — a real gap, not addressed by the "outcome is discarded" framing alone).
+Two further rounds of Claude-backend review corrected the mechanism below: a first draft proposed
+a daemon-thread-plus-`join(timeout=...)` approach, but `codex_warden_hooks.py`'s hook invocations
+are short-lived, single-shot subprocesses (`main()` → `sys.exit(main())`) — when the join times
+out and the process exits, CPython does not let a daemon thread finish; it is torn down with the
+process almost every time, not "eventually completes independently" as that draft claimed. That
+would make the whole write path silently produce almost no real mirrors, undermining the reason
+Phase 2 exists (a CC ledger a future cutover can actually read).
+
+Discarding the *result* of `cc_store.issue_if_newer()` is not sufficient on its own: it (like
+`issue()`, the primitive it's layered on — see "Fix" below) runs under `_mutate`'s exclusive lock,
+`fcntl.flock(fd, fcntl.LOCK_EX)` (`attestation_store.py:97`)
+— a raw blocking syscall with **no timeout parameter at all** — and can spend up to 10s total
+across the two already-bounded `urlopen(..., timeout=_OPA_TIMEOUT_SECONDS)` calls inside
+`_put_and_readback` (the PUT at `:146`, the generation read-back at `:153`, each capped at 5s). A
+bare `try/except Exception:` cannot bound wall-clock time — it only fires after the call returns —
+and an in-process thread cannot outlive the hook's own short-lived subprocess.
+
+**Concrete mechanism, adopting this codebase's own established pattern for exactly this problem**
+(`session_end_hook.py`'s `_spawn_worker`/`_run_worker`, mirrored in `memory_tree_hook.py` — "work
+that must survive past the hook's own short lifetime" is not new scope here, it is a solved
+problem in this repo): the gate call site never calls the store's write method itself. It:
+
+- (a) writes one small JSON job file — the exact `issue()` kwargs (`repo_id`, `gate`,
+  `subject_key`, `verdict`, `issuer_kind`, `reviewer_id`, `reason`, `backend`) plus a `queued_at`
+  timestamp, keyed by `job_id = str(uuid.uuid4())` (guarantees no collision between
+  near-simultaneous gates for the same commit, or a REVISE round quickly followed by a SHIP
+  re-run) — atomically (write-temp, `os.replace`, `chmod(0o600)`) into a queue directory
+  (`~/.config/deus/guardrails/cc-write-queue/`, created with `mkdir(..., mode=0o700)` — both
+  matching `AttestationStore`'s own ledger-directory and temp-file permissions exactly; the job
+  file's `reason` field carries the same review text `AttestationStore.issue()` already accepts
+  and stores unredacted in `records[...].reason`, so it gets no less protection in the queue than
+  at rest in the ledger it is about to be written into);
+- (b) spawns a **fully detached** subprocess via `subprocess.Popen([sys.executable,
+  str(Path(__file__).resolve()), "--worker", job_id], start_new_session=True, stdin=DEVNULL,
+  stdout=DEVNULL, stderr=DEVNULL)` (module path resolved the same way `session_end_hook.py:110`
+  resolves its own — the worker re-invokes the `cc_attestations` module itself, not a separate
+  script) — the exact `Popen` shape `_spawn_worker` already uses. `start_new_session=True` here
+  protects specifically against a process-*group*-wide signal or a harness reaping the whole
+  subprocess tree as a unit on hook-process exit (a plain parent exit alone never kills an
+  already-forked child on POSIX regardless of session; the risk this flag closes is
+  SIGHUP/session-teardown propagation and being caught up in the parent's own process-group
+  cleanup, not "child dies because parent died") — and returns immediately, unconditionally, with
+  **no `join`, no timeout, no wait of any kind**.
+
+The detached worker process then does the actual `cc_store.issue_if_newer()` call on its own time, with no
+hook-budget constraint at all, since it is no longer part of the hook's critical path. Concurrency
+across independently-spawned workers is already safe by the same mechanism that protects Hermes's
+own concurrent writers today: `_locked()`'s `fcntl.flock` is acquired on a physical lockfile path
+opened independently by each process, which POSIX `flock` serializes correctly across *separate
+processes*, not just threads within one — no new race is introduced by moving the call from an
+in-process thread to a subprocess.
+
+**Ordering guard — completion order is not enqueue order** (found by the required GPT code-review
+co-gate on this design, a real gap `flock` mutual exclusion alone does not close). Mutual exclusion
+prevents two workers from writing *concurrently*, but says nothing about which one writes *last* —
+and `_apply`'s `latest[...] = record_id` (the line `issue()`'s inner apply function uses to update
+the pointer `guardrails.rego` and any future consumer would read) unconditionally overwrites
+whatever was there, with no ordering check. Detached workers acquire the lock in whatever order the
+OS schedules them, which is not enqueue order: for the explicitly-supported "REVISE round quickly
+followed by a SHIP re-run" sequence, if the SHIP worker's OPA round-trip happens to finish first and
+the REVISE worker (queued earlier, still legitimately in flight) wins the lock second, `latest`
+ends up pointing at the REVISE record even though SHIP is the true, newer verdict — a stale-overwrite
+that misrepresents the CC ledger's own append-only, mirror-of-reality purpose. `queued_at` alone
+(as specified above) does not prevent this: it timestamps enqueue, not the write that actually
+lands, and nothing before this fix compared it against anything.
+
+**Fix**: a CC-specific write method, `issue_if_newer(..., queued_at)`, layered on top of `issue()`'s
+existing `_mutate`-based transaction rather than changing `issue()` itself (Hermes's own call sites
+use plain `issue()`, untouched, byte-identical). Inside the same locked apply function — so the
+check and the write are atomic with respect to every other writer, not a separate read-then-write
+race of its own — it looks up the record currently pointed to by `latest[repo_id][gate][subject_key]`
+(or `latest_by_backend[...][backend]` for the CC path's backend-scoped writes), and only advances
+the pointer to the new record if no existing record for that key has a `queued_at` newer than this
+job's own. The append-only `records` map still gains the new record unconditionally either way —
+every attempted write stays part of the permanent audit trail, per this ledger's existing
+never-edit-never-delete contract — only pointer advancement is guarded. A worker that loses this
+comparison is not an error: it correctly recognizes its own job as superseded and exits normally
+after seeing its write did not become `latest`.
+
+Two further requirements this fix depends on, found by the same review round when checking whether
+the fix as first stated could actually work in practice:
+
+- **`queued_at` must be persisted onto the stored record, not just the (deleted-on-success) job
+  file.** The CC-specific record schema (a variant of the `record` shape in
+  `attestation-v1.schema.json`, scoped to the new `attestation-cc-v1.schema.json`) adds a
+  `queued_at` field alongside the existing `issued_at` — otherwise a *later* `issue_if_newer` call
+  has nothing durable to compare its own `queued_at` against once an earlier job's file is gone.
+- **Clock source: `time.time_ns()` (wall-clock, nanosecond resolution) — not `monotonic_ns()`, and
+  not the ledger's existing 1-second `time.strftime(...)` convention either.** An earlier draft of
+  this fix specified `time.monotonic_ns()`, found wrong by the same GPT code-review co-gate that
+  found the original ordering race: `queued_at` is *persisted to disk* and compared against
+  writes from arbitrarily later processes, but `monotonic_ns()`'s epoch is boot-relative and resets
+  on every reboot — a value written before a reboot is not just stale, it is not meaningfully
+  comparable at all to one written after, and a lower post-reboot value could leave `latest`
+  pointing at a genuinely obsolete pre-reboot record indefinitely (until uptime happens to exceed
+  the old value). `time.time_ns()` is wall-clock (UTC epoch), so it survives reboots and stays
+  comparable across the ledger's entire lifetime, while still getting nanosecond resolution — far
+  finer than the existing `time.strftime(...)` convention's 1-second granularity, which alone would
+  let two same-host re-runs enqueued within the same second tie. Ties (still possible, though far
+  less likely at ns resolution than at 1-second resolution) are broken in favor of keeping whichever
+  record is already `latest` unchanged, so a tie can never flip an established pointer. This is not
+  claimed to be perfectly monotonic (wall clocks can rarely step backward under NTP correction,
+  the same caveat every other timestamp already in this ledger — `issued_at`/`enrolled_at` — already
+  carries), only reboot-durable and precise enough that a real correctness bug (the reboot-reset
+  case) is not traded for a merely theoretical one already accepted elsewhere in this design.
+
+The oracle (below) must assert this ordering property directly, including both new requirements
+above, not merely that both writes eventually land.
+
+**Deletion criterion, stated explicitly** (a first draft left this to inference and a wrong reading
+would quietly reintroduce the same low-mirror-rate problem this redesign fixes): the job file is
+deleted when `cc_store.issue_if_newer(...)` returns a `WriteResult` with `.ok is True` — disk persistence,
+which `_mutate`'s own code comment states is "always true past this point" once `_write_disk_atomic`
+returns without raising — **not** gated on `.activated` (OPA PUT+read-back success). A
+persisted-but-not-activated write (OPA unreachable at write time — plausible early on, since the
+shadow toggle went live with essentially zero traffic yet) is the ledger's normal "failed PUT"
+state, which `sync()` already exists to retry on a later mutation; gating deletion on `.activated`
+instead would leave every job attempted during an OPA outage stuck in the queue with no retry path
+at all, a different flavor of the exact failure this redesign exists to avoid. `.ok` reflects disk
+persistence of the append-only `records` entry, independent of whether `issue_if_newer` advanced
+`latest`/`latest_by_backend` — a job that loses the ordering comparison above still persists (its
+verdict is real and belongs in the audit trail) and its job file is still deleted on that same
+`.ok is True`, exactly like a job that wins; "lost the ordering comparison" and "failed to persist"
+are different outcomes and only the second one should ever leave a job file behind for the sweep.
+
+**No worker self-ceiling needed, but a stale-job sweep is** — two related but distinct concerns,
+handled differently. `session_end_hook.py`'s `_run_worker` arms a `threading.Timer`-based wall-clock
+ceiling (LIA-235 pattern, "so a hung child can't leave an orphan") because its own worker's runtime
+is not intrinsically bounded (it invokes `auto_compress.py`, an LLM-driven summarization step with
+open-ended duration). This design's worker has no equivalent unbounded step: its entire body is one
+`cc_store.issue_if_newer()` call, whose worst case is fully bounded by `AttestationStore` itself — up to 10s
+across the two 5s-capped `urlopen` calls inside `_put_and_readback`, plus a `flock` acquisition that
+is fast in practice (single-writer-at-a-time ledger, no long-held cross-process contention by
+design) and, unlike the timer's actual target (a hung *userspace* loop), is released by the kernel
+immediately on process death regardless of how the process ends. A self-imposed timer would be
+redundant here, not missing.
+
+The orphan-file risk `session_end_hook.py`'s belt-and-sweep pair actually guards against — a worker
+killed (OOM, forced termination, an unhandled exception before the delete step) leaving its job file
+on disk forever, since nothing else ever revisits it — is real for this design too and is not
+covered by the "no ceiling needed" argument above; those are separate risks. Phase 2 needs the
+sweep half of that pair, not the belt half: extend `scripts/maintenance.py`'s existing daily
+registration (the same one that runs `compress_sweep.py`) with a lightweight `cc-write-queue` sweep
+that deletes (and logs one line per deletion, surfacing in `logs/maintenance.log` for `/review-logs`,
+matching `compress_sweep.py`'s own `MAX_ATTEMPTS`-exhausted logging convention) any `*.json` in the
+queue dir older than 24h — no `.running`/`.failed` state machine or attempts counter needed, since
+this design already chose single-best-effort-no-retry (below): a stale file is definitionally one
+the worker never got to, or got to and crashed before deleting, and either way there is nothing left
+to retry, only to reclaim.
+
+This mechanism needs no retry queue or attempts counter the way `session_end_hook.py`'s fuller
+worker does — a missed mirror costs one absent row of shadow-adjacent data, the same acceptable-loss
+shape Phase 1 already accepts for its own classification gaps (`generation-unknown`,
+`opa-unreachable`, etc.); a single best-effort attempt per queued job is sufficient scope. The
+parent hook's own containment is now trivial: (a) and (b) above wrapped in a single broad
+`try/except Exception: pass`, matching `cc_shadow.observe()`'s containment floor, purely against
+the enqueue/spawn step itself ever raising — never against anything inside `AttestationStore`,
+which remains untouched.
+
+`TRIVIAL` verdicts need explicit, distinct handling: the legacy gate accepts a human `TRIVIAL`
+bypass as satisfied, but `AttestationStore.issue()` rejects `TRIVIAL` as an invalid `verdict` value
+outright (`verdict not in ("SHIP", "REVISE", "BLOCK", "COULD_NOT_RUN")`), and the proposed
+CC-specific schema does not admit it either — an unhandled TRIVIAL commit would either raise inside
+the mirror call (caught by the containment above, so not a gate-breaking bug, but silently
+producing zero record) or need to be misrepresented as some other verdict. The write-path call site
+must recognize `TRIVIAL` explicitly and skip enqueueing entirely for it — never enqueue a job with
+an invalid verdict, and never invent a synthetic non-TRIVIAL verdict to satisfy the schema. The CC
+ledger simply has no record for a TRIVIAL-bypassed commit, which is honest: it was never actually
+reviewed by a backend, so mirroring "as if reviewed" would misrepresent Phase 1's own shadow-log
+data this design is meant to eventually build on.
+
+**What Phase 2 explicitly does NOT do:**
+- No Rego rule consults `data.warden_cc_attestations`. Writing and reading are separate
+  decisions; this section designs writing only.
+- No Claude Code gate's pass/fail outcome changes. Identical invariant to Phase 1's #1
+  ("no gate outcome can depend on it"), extended to cover write failures specifically.
+- No change to `data.warden_attestations`, its schema, or any code path Hermes depends on —
+  contingent on all six sites above being fixed together, not aspirational.
+
+**Public interface** (named now specifically so the independent oracle below can target the real
+future call site, not a stand-in — found necessary by GPT code-review co-gate: an oracle that
+tests only `AttestationStore` directly, with no reference to the call-site module, can be
+satisfied by a call site that gets the wrapping wrong even when the store primitive itself is
+correct). `scripts/warden_policy/cc_attestations.py`, not yet implemented, exposes exactly two
+functions the rest of this design already specifies the behavior of:
+
+- `enqueue_verdict(*, repo_id, gate, subject_key, verdict, issuer_kind, reviewer_id, reason,
+  backend, queue_dir: Path = QUEUE_DIR) -> None` — the hook call site's entry point (`queue_dir`
+  defaults to the real module-level constant for production use, overridable so tests never touch
+  the real queue directory, same rationale as `process_job`'s overrides below). Recognizes and
+  skips `TRIVIAL` before doing anything else (never writes a job file for it); otherwise performs
+  the atomic job-file write plus detached-`Popen` spawn described above. Wrapped in the broad
+  `try/except Exception: pass` containment already specified; returns `None` unconditionally.
+- `process_job(job_id: str, *, queue_dir: Path = QUEUE_DIR, ledger_path: Path = CC_LEDGER_PATH) ->
+  bool` — the detached worker's entry point (what `--worker <job-id>` invokes, resolving the job
+  file as `queue_dir / f"{job_id}.json"`). Reads the job file, calls `cc_store.issue_if_newer(...)`
+  against a store built from `ledger_path`, and returns whether the job file should be deleted —
+  `True` iff `WriteResult.ok is True`, per the deletion criterion above, regardless of `.activated`
+  or of whether the ordering comparison was won or lost. `queue_dir`/`ledger_path` default to the
+  real module-level constants for production use; both are overridable so tests never touch the
+  real `~/.config/deus/guardrails/` paths. The `--worker` CLI wrapper (not specified further here
+  — trivial glue) deletes the job file when this returns `True`.
+
+**Independent oracle.** Per this ADR's own open item above and `.claude/wardens/plan-review-rules.md`'s
+independent-oracle pattern, the discriminating test for this design is authored by the
+`oracle-author` role (dispatched via `scripts/dispatch-oracle-author.sh`, which runs it on
+GPT-5.6-Sol — genuine model diversity from whichever model eventually implements this, per the
+2026-07-15 user decision recorded in that script) from this spec, blind to any implementation
+(none exists yet) — `scripts/warden_policy/tests/test_cc_write_path_oracle.py`, with each
+assertion tagged `# @oracle LIA-527: <spec point>`, extending (per-assertion rather than the
+precedent's usual per-test-function granularity) this repo's existing convention
+(`test_verdict_store_staleness.py`, `test_codex_warden_hooks.py`, `test_warden_review.py`). The
+oracle brief must explicitly require tests asserting: the isolated store's OPA PUT target is
+`/v1/data/warden_cc_attestations`, distinct from `/v1/data/warden_attestations` (the site-#1
+guarantee above, made executable); `issue_if_newer`'s ordering guarantee on **both** paths CC
+writes actually use — the backend-scoped `latest_by_backend[repo_id][gate][subject_key][backend]`
+pointer (since CC writes always pass `backend=`, per "Who writes, and when," above) and, for
+completeness, the plain `latest[repo_id][gate][subject_key]` pointer `issue_if_newer` also
+supports — given two writes for the same key with different `queued_at` values applied to the
+store in EITHER order, the relevant pointer ends up referencing the newer `queued_at`'s record,
+never the older one, while `records` still contains both — sequential calls alone are not
+sufficient here (found necessary by the same GPT co-gate: an implementation that reads the current
+pointer BEFORE acquiring `_mutate`'s lock, then only conditionally mutates, can pass every
+sequential ordering test while still racing under real concurrent detached workers), so the oracle
+must ALSO exercise this with genuinely concurrent threads released together via a
+`threading.Barrier`, repeated across enough trials to give a non-atomic implementation a real
+chance to interleave (best-effort, not a formal proof — this property has no single deterministic
+pre-implementation assertion); and, **against the `cc_attestations`
+module named above, not a local stand-in** — `process_job` returns `True` for a persisted-but-not-
+activated `WriteResult` and `False` only for a genuinely failed one (the deletion criterion, made
+discriminating against the real call site rather than a proxy that could pass even if a future
+implementation wraps the criterion wrong), and `enqueue_verdict` writes no job file at all for
+`verdict="TRIVIAL"` (checkable by asserting the queue directory stays empty after the call, not
+merely that `AttestationStore.issue()` itself rejects TRIVIAL when called directly). Since
+`cc_attestations.py` does not exist yet, these two assertions are expected to fail with
+`ImportError`/`ModuleNotFoundError` today — a stronger, more specific red than a stand-in
+function's tautological pass, and the correct oracle shape for a module that hasn't been written:
+it can only ever be satisfied by the real interface behaving correctly, never by a look-alike.
+Every other assertion in the oracle (isolation, six-site coverage, ordering, legacy defaults)
+targets `AttestationStore` directly, which is the correct target for those — `cc_attestations.py`
+is a thin wrapper around it, not a reimplementation, so those properties belong at the store layer
+regardless of the wrapper's own correctness. It is expected **red** until Phase 2 is actually
+implemented; passing it is a precondition for treating the write path as done, not evidence it
+already is.
+
+**Not yet started, and why:** actual implementation of `AttestationStore`'s parameterization
+(all six sites), the new `cc_attestations` write/worker/sweep call sites, and the CC-specific
+schema file. Two independent reasons to hold here rather than implement in the same pass as this
+design: (1) LIA-527 itself is the lowest-urgency item in the roadmap by explicit prior decision —
+implementation should not compete for attention with higher-priority work; (2) the *cutover*
+decision this write path exists to eventually support needs real shadow-observer data first, and
+as of this design there is essentially none — `~/.config/deus/guardrails/logs/cc-shadow.jsonl`
+holds 9 lines, all from 2026-08-04 pre-toggle dev testing; the toggle (LIA-520) was only switched
+on 2026-08-07, less than two hours before this section was written, and has produced zero new
+observations since (no commit gate has fired in that window). Implementing the write path itself
+is not blocked on that data — only the cutover is — but there is no benefit to landing unused
+write-path code before the data that would justify designing the cutover on top of it exists.
+Tracked as explicit follow-up scope, not silently dropped.
+
+**Scope check** (round-count-circuit-breaker, per `plan-review-rules.md`): after 7 review rounds,
+re-confirming this is still the smallest design that satisfies LIA-527's ask — "design the write
+path... get the independent oracle authored" — rather than scope creep accumulated round-by-round.
+It is: every addition since round 4 traces directly to a real defect a reviewer found in the
+previous draft (missing parameterization sites, an unsafe concurrency mechanism, unstated
+deletion/uniqueness/cleanup semantics), not to speculative hardening. No implementation, cutover,
+or Rego change has been added — those remain explicitly out of scope, unchanged since round 4.
+
 ## Consequences
 
 - OPA (`brew install opa`, v1.19.0+, Rego v1 `if`-keyword syntax) is now a dependency for anyone

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-04" # auto-bump @1785849140
+last_verified: "2026-08-07" # auto-bump @1786121260
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/warden_policy/tests/test_cc_write_path_oracle.py
+++ b/scripts/warden_policy/tests/test_cc_write_path_oracle.py
@@ -1,0 +1,720 @@
+import json
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from warden_policy.attestation_store import (
+    AttestationStore,
+    AttestationStoreError,
+    WriteResult,
+)
+
+
+CC_DOCUMENT_KEY = "warden_cc_attestations"
+DEFAULT_DOCUMENT_KEY = "warden_attestations"
+CC_OPA_DATA_PATH = "/v1/data/warden_cc_attestations"
+DEFAULT_OPA_DATA_PATH = "/v1/data/warden_attestations"
+
+
+class _StubResponse:
+    def __init__(self, payload: bytes = b""):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _OpaRecorder:
+    """Minimal urlopen replacement that records the real Request target."""
+
+    def __init__(self):
+        self.requests: list[tuple[str, str]] = []
+        self.generation: int | None = None
+
+    def __call__(self, request, timeout):
+        method = request.get_method()
+        self.requests.append((method, request.full_url))
+        if method == "PUT":
+            self.generation = json.loads(request.data)["generation"]
+            return _StubResponse()
+        return _StubResponse(json.dumps({"result": self.generation}).encode("utf-8"))
+
+
+def _persisted_but_not_activated(self, inner_doc):
+    return False, None, "simulated OPA outage"
+
+
+def _job_should_be_deleted(result: WriteResult) -> bool:
+    # Stand-in for the Phase 2 worker branch, which does not exist yet. The worker must
+    # delete a queued job based only on disk persistence (`ok`), never OPA activation.
+    # TODO(LIA-527 implementation): once scripts/warden_policy/cc_attestations.py's worker
+    # exists, replace this stand-in with the real predicate/call site so these tests
+    # exercise production code, not a hand-written proxy for its intended behavior.
+    return result.ok is True
+
+
+class TestCcDocumentIsolationOracle(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ledger_path = Path(self.tmp.name) / "attestations-cc-v1.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _new_store(self, **kwargs) -> AttestationStore:
+        return AttestationStore(
+            self.ledger_path,
+            opa_base_url="http://opa.test",
+            document_key=CC_DOCUMENT_KEY,
+            **kwargs,
+        )
+
+    def _assert_isolated_ledger(self) -> dict:
+        contents = self.ledger_path.read_text(encoding="utf-8")
+        document = json.loads(contents)
+        self.assertEqual(set(document), {CC_DOCUMENT_KEY})  # @oracle LIA-527: disk root is the isolated CC document
+        self.assertNotIn(DEFAULT_DOCUMENT_KEY, document)  # @oracle LIA-527: disk root never aliases Hermes's live document
+        self.assertNotIn(f'"{DEFAULT_DOCUMENT_KEY}"', contents)  # @oracle LIA-527: written JSON never contains the Hermes document key
+        return document
+
+    def test_custom_document_key_derives_isolated_opa_path_and_empty_document(self):
+        store = self._new_store()
+
+        self.assertEqual(store.document_key, CC_DOCUMENT_KEY)  # @oracle LIA-527: constructor retains the requested document key
+        self.assertEqual(store.opa_data_path, CC_OPA_DATA_PATH)  # @oracle LIA-527: OPA path derives from the requested document key
+        empty = store.read_locked()
+        self.assertEqual(set(empty), {CC_DOCUMENT_KEY})  # @oracle LIA-527: empty document creation uses the isolated root key
+        self.assertNotIn(DEFAULT_DOCUMENT_KEY, empty)  # @oracle LIA-527: empty CC documents never expose the Hermes root key
+
+    def test_explicit_opa_data_path_override_is_retained(self):
+        explicit_path = "/v1/data/cc-test-override"
+        store = self._new_store(opa_data_path=explicit_path)
+        recorder = _OpaRecorder()
+
+        with mock.patch(
+            "warden_policy.attestation_store.urllib.request.urlopen",
+            side_effect=recorder,
+        ):
+            store.enroll("repo-a")
+
+        self.assertEqual(store.opa_data_path, explicit_path)  # @oracle LIA-527: explicit OPA data paths override the derived path
+        self.assertEqual(recorder.requests[0], ("PUT", "http://opa.test" + explicit_path))  # @oracle LIA-527: explicit OPA paths control the actual PUT target
+
+    def test_isolated_store_puts_to_cc_document_never_hermes_document(self):
+        store = self._new_store()
+        recorder = _OpaRecorder()
+
+        with mock.patch(
+            "warden_policy.attestation_store.urllib.request.urlopen",
+            side_effect=recorder,
+        ):
+            result = store.enroll("repo-a")
+
+        put_targets = [url for method, url in recorder.requests if method == "PUT"]
+        self.assertTrue(result.activated)  # @oracle LIA-527: the intercepted PUT/read-back transaction completes
+        self.assertEqual(put_targets, ["http://opa.test" + CC_OPA_DATA_PATH])  # @oracle LIA-527: isolated writes target only the CC OPA document
+        self.assertNotIn("http://opa.test" + DEFAULT_OPA_DATA_PATH, put_targets)  # @oracle LIA-527: isolated writes never overwrite Hermes's live OPA document
+        self.assertEqual(recorder.requests[1], ("GET", "http://opa.test" + CC_OPA_DATA_PATH + "/generation"))  # @oracle LIA-527: generation read-back uses the isolated CC OPA document
+
+    def test_all_public_store_paths_keep_cc_ledger_isolated(self):
+        store = self._new_store()
+
+        with mock.patch.object(
+            AttestationStore,
+            "_put_and_readback",
+            lambda self, inner_doc: (True, inner_doc["generation"], None),
+        ):
+            enrolled = store.enroll("repo-a")
+            self.assertTrue(enrolled.ok)  # @oracle LIA-527: enroll succeeds through the isolated mutation path
+            self._assert_isolated_ledger()
+
+            issued = store.issue(
+                repo_id="repo-a",
+                gate="code-reviewer",
+                subject_key="git-tree:sha1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                verdict="SHIP",
+                issuer_kind="script",
+                reviewer_id="code-reviewer@claude",
+                reason="oracle fixture",
+                backend="claude",
+            )
+            self.assertTrue(issued.ok)  # @oracle LIA-527: issue re-reads and mutates the isolated ledger
+            self._assert_isolated_ledger()
+
+            synced = store.sync()
+            self.assertTrue(synced.ok)  # @oracle LIA-527: sync reads the isolated root and activates it
+            self._assert_isolated_ledger()
+
+            records = store.inspect("repo-a")
+            self.assertEqual(len(records), 1)  # @oracle LIA-527: inspect reads records from the isolated root
+            self.assertEqual(records[0]["repo_id"], "repo-a")  # @oracle LIA-527: inspect reports the isolated ledger's record
+            self._assert_isolated_ledger()
+
+            unenrolled = store.unenroll("repo-a")
+            self.assertTrue(unenrolled.ok)  # @oracle LIA-527: unenroll mutates the isolated ledger
+            document = self._assert_isolated_ledger()
+
+        entry = document[CC_DOCUMENT_KEY]["config"]["enforced_repos"]["repo-a"]
+        self.assertFalse(entry["enabled"])  # @oracle LIA-527: unenroll updates the CC document rather than Hermes's document
+
+
+class TestCcWriteResultDeletionOracle(unittest.TestCase):
+    # Note: the real-call-site tests below (test_process_job_*) only ever exercise the
+    # ok=True/persisted path against the actual `process_job`. The ok=False/"genuinely failed"
+    # branch the design's "Public interface" section also names is only exercised against the
+    # `_job_should_be_deleted` stand-in just below, not `process_job` itself -- because
+    # `AttestationStore.issue_if_newer()` (like `issue()`) has no realistic ok=False return today
+    # (attestation_store.py:196-198's own comment: disk persistence success is "always true past
+    # this point"; a disk failure raises instead). That branch is design-only until a real
+    # ok=False path exists to test against, not merely untested by oversight.
+    def test_worker_deletes_on_ok_regardless_of_activation(self):
+        persisted_not_activated = WriteResult(
+            ok=True,
+            generation=7,
+            activated=False,
+            error="OPA unavailable",
+        )
+        synthetic_failed_result = WriteResult(
+            ok=False,
+            generation=None,
+            activated=False,
+            error="disk write failed",
+        )
+
+        self.assertTrue(_job_should_be_deleted(persisted_not_activated))  # @oracle LIA-527: persisted jobs delete even when OPA activation fails
+        self.assertFalse(_job_should_be_deleted(synthetic_failed_result))  # @oracle LIA-527: an unsuccessful write result does not delete its job
+
+    def test_issue_reports_ok_after_persistence_even_when_activation_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = AttestationStore(Path(tmp) / "attestations-v1.json")
+            with mock.patch.object(
+                AttestationStore,
+                "_put_and_readback",
+                _persisted_but_not_activated,
+            ):
+                result = store.issue(
+                    repo_id="repo-a",
+                    gate="code-reviewer",
+                    subject_key="git-tree:sha1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    verdict="SHIP",
+                    issuer_kind="script",
+                    reviewer_id="code-reviewer@claude",
+                    reason="oracle fixture",
+                    backend="claude",
+                )
+
+        self.assertTrue(result.ok)  # @oracle LIA-527: successful disk persistence is the issue success criterion
+        self.assertFalse(result.activated)  # @oracle LIA-527: OPA activation failure remains distinct from issue success
+        self.assertTrue(_job_should_be_deleted(result))  # @oracle LIA-527: the worker deletes this persisted job despite failed activation
+
+    def test_issue_disk_failure_raises_instead_of_returning_ok_false(self):
+        # `issue()` has no realistic WriteResult(ok=False) return today: once its atomic
+        # disk write succeeds it returns ok=True; a disk failure raises before any result.
+        with tempfile.TemporaryDirectory() as tmp:
+            store = AttestationStore(Path(tmp) / "attestations-v1.json")
+            with mock.patch.object(
+                store,
+                "_write_disk_atomic",
+                side_effect=OSError("simulated disk failure"),
+            ):
+                with self.assertRaises(OSError):  # @oracle LIA-527: issue write failure is an exception path, not ok=False
+                    store.issue(
+                        repo_id="repo-a",
+                        gate="code-reviewer",
+                        subject_key="git-tree:sha1:cccccccccccccccccccccccccccccccccccccccc",
+                        verdict="SHIP",
+                        issuer_kind="script",
+                        reviewer_id="code-reviewer@claude",
+                        reason="oracle fixture",
+                        backend="claude",
+                    )
+
+    def test_process_job_deletes_on_ok_regardless_of_activation(self):
+        # Discriminating against the REAL call site (docs/decisions/opa-warden-attestations-v1.md's
+        # "Public interface" section), not the local `_job_should_be_deleted` stand-in above --
+        # `cc_attestations.py` does not exist yet, so this is expected to fail with
+        # ImportError/ModuleNotFoundError today. A future implementation that wraps the deletion
+        # criterion wrong (e.g. gates on `.activated`) must fail THIS test even if it happens to
+        # pass every AttestationStore-level assertion elsewhere in this file.
+        from warden_policy.cc_attestations import process_job  # @oracle LIA-527: process_job must exist as the real worker entry point
+
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            AttestationStore, "_put_and_readback", _persisted_but_not_activated
+        ):
+            ledger_path = Path(tmp) / "attestations-cc-v1.json"
+            queue_dir = Path(tmp) / "cc-write-queue"
+            queue_dir.mkdir()
+            job_id = "job-persisted-not-activated"
+            job_path = queue_dir / f"{job_id}.json"
+            job_path.write_text(
+                json.dumps(
+                    {
+                        "repo_id": "repo-a",
+                        "gate": "code-reviewer",
+                        "subject_key": "git-tree:sha1:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                        "verdict": "SHIP",
+                        "issuer_kind": "script",
+                        "reviewer_id": "code-reviewer@claude",
+                        "reason": "oracle fixture",
+                        "backend": "claude",
+                        "queued_at": time.time_ns(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            should_delete = process_job(
+                job_id, queue_dir=queue_dir, ledger_path=ledger_path
+            )  # @oracle LIA-527: process_job must delete a persisted-but-not-activated job
+
+            self.assertTrue(should_delete)  # @oracle LIA-527: deletion is gated on .ok, not .activated, at the real call site
+
+    def test_process_job_actually_persists_the_record_not_a_no_op(self):
+        # Discriminates against a no-op `process_job` that just returns True for every job
+        # without ever calling issue_if_newer -- found necessary by the GPT code-review co-gate:
+        # the sibling test above only checks the RETURN VALUE, which a stub could satisfy while
+        # silently dropping every real attestation. This test reads the ledger back afterward
+        # and confirms the record genuinely landed, with the pointer genuinely advanced.
+        from warden_policy.cc_attestations import process_job  # @oracle LIA-527: process_job must exist as the real worker entry point
+
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            AttestationStore,
+            "_put_and_readback",
+            lambda self, inner_doc: (True, inner_doc["generation"], None),
+        ):
+            ledger_path = Path(tmp) / "attestations-cc-v1.json"
+            queue_dir = Path(tmp) / "cc-write-queue"
+            queue_dir.mkdir()
+            job_id = "job-real-persistence"
+            subject_key = "git-tree:sha1:9999999999999999999999999999999999999999"
+            (queue_dir / f"{job_id}.json").write_text(
+                json.dumps(
+                    {
+                        "repo_id": "repo-real",
+                        "gate": "code-reviewer",
+                        "subject_key": subject_key,
+                        "verdict": "SHIP",
+                        "issuer_kind": "script",
+                        "reviewer_id": "code-reviewer@claude",
+                        "reason": "oracle fixture -- real persistence",
+                        "backend": "claude",
+                        "queued_at": time.time_ns(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            should_delete = process_job(job_id, queue_dir=queue_dir, ledger_path=ledger_path)
+            self.assertTrue(should_delete)  # @oracle LIA-527: a genuinely successful write also deletes its job
+
+        document = json.loads(ledger_path.read_text(encoding="utf-8"))
+        inner = document[CC_DOCUMENT_KEY]
+        record_id = inner["latest_by_backend"]["repo-real"]["code-reviewer"][subject_key][
+            "claude"
+        ]  # @oracle LIA-527: process_job actually calls issue_if_newer, which populates latest_by_backend
+        record = inner["records"][record_id]
+        self.assertEqual(record["verdict"], "SHIP")  # @oracle LIA-527: the persisted record's verdict matches the job's
+        self.assertEqual(record["subject"]["key"], subject_key)  # @oracle LIA-527: the persisted record's subject matches the job's
+
+
+class TestCcTrivialVerdictOracle(unittest.TestCase):
+    def test_store_layer_rejects_trivial_as_defense_in_depth(self):
+        # Store-layer defense-in-depth only -- NOT the design's actual mandate (see
+        # test_enqueue_verdict_never_writes_a_job_file_for_trivial below for that).
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger_path = Path(tmp) / "attestations-cc-v1.json"
+            store = AttestationStore(ledger_path, document_key=CC_DOCUMENT_KEY)
+
+            with self.assertRaises(AttestationStoreError):  # @oracle LIA-527: TRIVIAL is not a valid attestation verdict
+                store.issue(
+                    repo_id="repo-a",
+                    gate="code-reviewer",
+                    subject_key="git-tree:sha1:dddddddddddddddddddddddddddddddddddddddd",
+                    verdict="TRIVIAL",
+                    issuer_kind="script",
+                    reviewer_id="code-reviewer@claude",
+                    reason="human trivial bypass",
+                    backend="claude",
+                )
+
+    def test_enqueue_verdict_never_writes_a_job_file_for_trivial(self):
+        # Discriminating against the REAL call site (docs/decisions/opa-warden-attestations-v1.md's
+        # "Public interface" section), not the store primitive above -- `cc_attestations.py` does
+        # not exist yet, so this is expected to fail with ImportError/ModuleNotFoundError today.
+        # A future implementation that enqueues TRIVIAL jobs and relies on the worker/store to
+        # reject them later must fail THIS test, since the design mandates the skip happens at
+        # enqueue time, before any job file is ever written.
+        from warden_policy.cc_attestations import enqueue_verdict  # @oracle LIA-527: enqueue_verdict must exist as the real hook call site
+
+        with tempfile.TemporaryDirectory() as tmp:
+            queue_dir = Path(tmp) / "cc-write-queue"
+
+            enqueue_verdict(
+                repo_id="repo-a",
+                gate="code-reviewer",
+                subject_key="git-tree:sha1:ffffffffffffffffffffffffffffffffffffffff",
+                verdict="TRIVIAL",
+                issuer_kind="manual",
+                reviewer_id="human",
+                reason="human trivial bypass",
+                backend="claude",
+                queue_dir=queue_dir,
+            )  # @oracle LIA-527: enqueue_verdict must skip TRIVIAL before writing anything
+
+            job_files = list(queue_dir.glob("*.json")) if queue_dir.exists() else []
+            self.assertEqual(job_files, [])  # @oracle LIA-527: no job file is ever written for a TRIVIAL verdict
+
+    def test_enqueue_verdict_writes_a_real_job_and_spawns_a_worker_for_ship(self):
+        # Discriminates against an unconditional no-op `enqueue_verdict` that would leave the
+        # queue empty for every verdict, not just TRIVIAL -- found necessary by the GPT
+        # code-review co-gate: the sibling test above only exercises the TRIVIAL-skip path, which
+        # a stub that skips everything would also pass. This test exercises the real, common case
+        # (a genuine SHIP verdict) and asserts both the job file's actual content and that a
+        # worker subprocess was actually spawned, matching the exact Popen shape this design
+        # specifies (start_new_session=True, stdin/stdout/stderr=DEVNULL).
+        from warden_policy import cc_attestations  # @oracle LIA-527: cc_attestations module must exist
+        from warden_policy.cc_attestations import enqueue_verdict
+
+        with tempfile.TemporaryDirectory() as tmp:
+            queue_dir = Path(tmp) / "cc-write-queue"
+
+            with mock.patch.object(cc_attestations, "subprocess") as mock_subprocess:
+                enqueue_verdict(
+                    repo_id="repo-real",
+                    gate="ai-eng-warden",
+                    subject_key="git-tree:sha1:8888888888888888888888888888888888888888",
+                    verdict="SHIP",
+                    issuer_kind="script",
+                    reviewer_id="ai-eng-warden@claude",
+                    reason="oracle fixture -- real enqueue",
+                    backend="claude",
+                    queue_dir=queue_dir,
+                )
+
+                self.assertTrue(mock_subprocess.Popen.called)  # @oracle LIA-527: a non-TRIVIAL verdict spawns a detached worker
+
+            job_files = list(queue_dir.glob("*.json")) if queue_dir.exists() else []
+            self.assertEqual(len(job_files), 1)  # @oracle LIA-527: exactly one job file is written for a real verdict
+            job = json.loads(job_files[0].read_text(encoding="utf-8"))
+            self.assertEqual(job["repo_id"], "repo-real")  # @oracle LIA-527: the job file's content matches the call's arguments
+            self.assertEqual(job["gate"], "ai-eng-warden")  # @oracle LIA-527: the job file's content matches the call's arguments
+            self.assertEqual(job["verdict"], "SHIP")  # @oracle LIA-527: the job file's content matches the call's arguments
+            self.assertIn("queued_at", job)  # @oracle LIA-527: the job file records a queued_at ordering token
+
+            popen_call = mock_subprocess.Popen.call_args
+            argv = popen_call.args[0]
+            self.assertEqual(argv[0], sys.executable)  # @oracle LIA-527: the worker is spawned via the same Python interpreter
+            self.assertIn("--worker", argv)  # @oracle LIA-527: the worker subprocess is invoked with --worker
+            self.assertEqual(argv[-1], job_files[0].stem)  # @oracle LIA-527: the spawned worker is told this exact job's id
+            self.assertTrue(popen_call.kwargs.get("start_new_session"))  # @oracle LIA-527: the worker is fully detached from the parent process group
+            self.assertEqual(popen_call.kwargs.get("stdin"), mock_subprocess.DEVNULL)  # @oracle LIA-527: the worker's stdio is fully detached
+            self.assertEqual(popen_call.kwargs.get("stdout"), mock_subprocess.DEVNULL)  # @oracle LIA-527: the worker's stdio is fully detached
+            self.assertEqual(popen_call.kwargs.get("stderr"), mock_subprocess.DEVNULL)  # @oracle LIA-527: the worker's stdio is fully detached
+
+
+class _IssueIfNewerOrderingOracleBase(unittest.TestCase):
+    repo_id = "repo-a"
+    gate = "code-reviewer"
+    subject_key = "git-tree:sha1:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = AttestationStore(Path(self.tmp.name) / "attestations-v1.json")
+        self.opa_patch = mock.patch.object(
+            AttestationStore,
+            "_put_and_readback",
+            lambda self, inner_doc: (True, inner_doc["generation"], None),
+        )
+        self.opa_patch.start()
+
+    def tearDown(self):
+        self.opa_patch.stop()
+        self.tmp.cleanup()
+
+    def _issue_if_newer(
+        self,
+        *,
+        queued_at: int,
+        verdict: str,
+        backend: str | None,
+    ) -> WriteResult:
+        kwargs = {
+            "repo_id": self.repo_id,
+            "gate": self.gate,
+            "subject_key": self.subject_key,
+            "verdict": verdict,
+            "issuer_kind": "script",
+            "reviewer_id": "code-reviewer@claude",
+            "reason": f"oracle fixture queued at {queued_at}",
+            "queued_at": queued_at,
+        }
+        if backend is not None:
+            kwargs["backend"] = backend
+        return self.store.issue_if_newer(**kwargs)
+
+    def _exercise_distinct_timestamps(
+        self,
+        *,
+        backend: str | None,
+        newer_first: bool,
+    ) -> tuple[dict, dict[int, WriteResult], int, int]:
+        older = time.time_ns()
+        newer = older + 1
+        writes = [(newer, "SHIP"), (older, "REVISE")]
+        if not newer_first:
+            writes.reverse()
+
+        results = {
+            queued_at: self._issue_if_newer(
+                queued_at=queued_at,
+                verdict=verdict,
+                backend=backend,
+            )
+            for queued_at, verdict in writes
+        }
+        inner = self.store.read_locked()[DEFAULT_DOCUMENT_KEY]
+        return inner, results, older, newer
+
+    def _assert_newer_pointer_wins(
+        self,
+        *,
+        inner: dict,
+        results: dict[int, WriteResult],
+        older: int,
+        newer: int,
+        backend: str | None,
+    ) -> None:
+        records = inner["records"]
+        self.assertEqual(len(records), 2)  # @oracle LIA-527: issue_if_newer keeps both attempts in the append-only record map
+        self.assertEqual({record["queued_at"] for record in records.values()}, {older, newer})  # @oracle LIA-527: queued_at is persisted for every attempted CC write
+        newer_record_ids = [
+            record_id
+            for record_id, record in records.items()
+            if record["queued_at"] == newer
+        ]
+        self.assertEqual(len(newer_record_ids), 1)  # @oracle LIA-527: the newer enqueue timestamp identifies one durable record
+        if backend is None:
+            pointer = inner["latest"][self.repo_id][self.gate][self.subject_key]
+        else:
+            pointer = inner["latest_by_backend"][self.repo_id][self.gate][
+                self.subject_key
+            ][backend]
+        self.assertEqual(pointer, newer_record_ids[0])  # @oracle LIA-527: the relevant latest pointer always references the newer queued_at record
+        self.assertTrue(results[older].ok)  # @oracle LIA-527: an older or superseded attempt remains a successful persisted write
+        self.assertTrue(results[newer].ok)  # @oracle LIA-527: the newer attempt reports successful persistence
+
+    def _exercise_concurrent_distinct_timestamps(
+        self, *, backend: str | None, trials: int = 30
+    ) -> None:
+        # Discriminates against a TOCTOU-vulnerable implementation the sequential tests above
+        # cannot catch -- found necessary by the GPT code-review co-gate: an implementation that
+        # reads the current pointer BEFORE acquiring _mutate's exclusive lock, then only
+        # conditionally calls the locked mutation, can pass every sequential test (there is never
+        # any overlap to race) while still losing the ordering guarantee under real concurrent
+        # detached workers, since both threads can observe the same stale pointer before either
+        # commits. A `threading.Barrier` forces both calls to actually start together on every
+        # trial, giving a buggy (non-atomic) implementation a real chance to interleave its
+        # pre-lock read with the other thread's write; a correct implementation (the comparison
+        # performed INSIDE _mutate's own exclusive-lock critical section, as this design specifies)
+        # is safe by construction regardless of scheduling, so it must pass every trial, not just
+        # most. `trials=30` is a best-effort repeat count, not a formal proof -- it exists because
+        # this property cannot be verified with a single deterministic assertion pre-implementation.
+        for trial in range(trials):
+            with self.subTest(trial=trial):
+                subject_key = f"{self.subject_key}-concurrent-{trial}"
+                older, newer = time.time_ns(), None
+                while newer is None or newer == older:
+                    newer = time.time_ns()
+                if newer < older:
+                    older, newer = newer, older
+
+                barrier = threading.Barrier(2)
+                results: dict[int, WriteResult] = {}
+                errors: dict[int, BaseException] = {}
+
+                def _run(queued_at: int, verdict: str) -> None:
+                    kwargs = {
+                        "repo_id": self.repo_id,
+                        "gate": self.gate,
+                        "subject_key": subject_key,
+                        "verdict": verdict,
+                        "issuer_kind": "script",
+                        "reviewer_id": "code-reviewer@claude",
+                        "reason": f"oracle concurrency fixture queued at {queued_at}",
+                        "queued_at": queued_at,
+                    }
+                    if backend is not None:
+                        kwargs["backend"] = backend
+                    barrier.wait()  # force both threads to attempt the race window together
+                    try:
+                        results[queued_at] = self.store.issue_if_newer(**kwargs)
+                    except BaseException as exc:  # a bare thread target swallows exceptions
+                        # silently by default -- capture and re-raise on the main thread below
+                        # so a missing/broken issue_if_newer fails LOUDLY, not as a downstream
+                        # KeyError that looks like an assertion failure instead of the real cause.
+                        errors[queued_at] = exc
+
+                threads = [
+                    threading.Thread(target=_run, args=(newer, "SHIP")),
+                    threading.Thread(target=_run, args=(older, "REVISE")),
+                ]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join(timeout=5)
+                    self.assertFalse(t.is_alive())  # @oracle LIA-527: concurrent issue_if_newer calls complete, never deadlock
+                if errors:
+                    raise next(iter(errors.values()))  # @oracle LIA-527: issue_if_newer must not raise under real concurrent access
+
+                inner = self.store.read_locked()[DEFAULT_DOCUMENT_KEY]
+                if backend is None:
+                    pointer = inner["latest"][self.repo_id][self.gate][subject_key]
+                else:
+                    pointer = inner["latest_by_backend"][self.repo_id][self.gate][subject_key][
+                        backend
+                    ]
+                newer_record_ids = [
+                    record_id
+                    for record_id, record in inner["records"].items()
+                    if record["queued_at"] == newer
+                ]
+                self.assertEqual(len(newer_record_ids), 1)  # @oracle LIA-527: the newer concurrent attempt is durably recorded exactly once
+                self.assertEqual(
+                    pointer, newer_record_ids[0]
+                )  # @oracle LIA-527: under real thread concurrency, the pointer still reflects the newer queued_at, never a stale interleaving
+                self.assertTrue(results[older].ok)  # @oracle LIA-527: the losing concurrent attempt still persists successfully
+                self.assertTrue(results[newer].ok)  # @oracle LIA-527: the winning concurrent attempt persists successfully
+
+    def _exercise_equal_timestamp_tie(self, *, backend: str | None) -> tuple[dict, WriteResult]:
+        tied_at = time.time_ns()
+        first_result = self._issue_if_newer(
+            queued_at=tied_at,
+            verdict="SHIP",
+            backend=backend,
+        )
+        second_result = self._issue_if_newer(
+            queued_at=tied_at,
+            verdict="REVISE",
+            backend=backend,
+        )
+        inner = self.store.read_locked()[DEFAULT_DOCUMENT_KEY]
+        records = inner["records"]
+        first_record_ids = [
+            record_id
+            for record_id, record in records.items()
+            if record["verdict"] == "SHIP"
+        ]
+        self.assertTrue(first_result.ok)  # @oracle LIA-527: the first equal-timestamp record is persisted successfully
+        self.assertTrue(second_result.ok)  # @oracle LIA-527: the tied record persists successfully even though it cannot advance the pointer
+        self.assertEqual(len(records), 2)  # @oracle LIA-527: equal-timestamp attempts remain append-only
+        self.assertEqual(len(first_record_ids), 1)  # @oracle LIA-527: the established record can be identified after a timestamp tie
+        return inner, first_record_ids[0]
+
+
+class TestCcIssueIfNewerBackendOrderingOracle(_IssueIfNewerOrderingOracleBase):
+    backend = "claude"
+
+    def test_backend_pointer_newer_then_older_keeps_newer(self):
+        inner, results, older, newer = self._exercise_distinct_timestamps(
+            backend=self.backend,
+            newer_first=True,
+        )
+
+        self._assert_newer_pointer_wins(
+            inner=inner,
+            results=results,
+            older=older,
+            newer=newer,
+            backend=self.backend,
+        )
+
+    def test_backend_pointer_older_then_newer_advances_to_newer(self):
+        inner, results, older, newer = self._exercise_distinct_timestamps(
+            backend=self.backend,
+            newer_first=False,
+        )
+
+        self._assert_newer_pointer_wins(
+            inner=inner,
+            results=results,
+            older=older,
+            newer=newer,
+            backend=self.backend,
+        )
+
+    def test_backend_pointer_tie_keeps_established_record(self):
+        inner, established_record_id = self._exercise_equal_timestamp_tie(
+            backend=self.backend,
+        )
+
+        pointer = inner["latest_by_backend"][self.repo_id][self.gate][self.subject_key][
+            self.backend
+        ]
+        self.assertEqual(pointer, established_record_id)  # @oracle LIA-527: an equal queued_at never flips an established backend pointer
+
+    def test_backend_pointer_survives_real_concurrent_writers(self):
+        self._exercise_concurrent_distinct_timestamps(backend=self.backend)
+
+
+class TestCcIssueIfNewerPlainOrderingOracle(_IssueIfNewerOrderingOracleBase):
+    def test_plain_pointer_newer_then_older_keeps_newer(self):
+        inner, results, older, newer = self._exercise_distinct_timestamps(
+            backend=None,
+            newer_first=True,
+        )
+
+        self._assert_newer_pointer_wins(
+            inner=inner,
+            results=results,
+            older=older,
+            newer=newer,
+            backend=None,
+        )
+
+    def test_plain_pointer_older_then_newer_advances_to_newer(self):
+        inner, results, older, newer = self._exercise_distinct_timestamps(
+            backend=None,
+            newer_first=False,
+        )
+
+        self._assert_newer_pointer_wins(
+            inner=inner,
+            results=results,
+            older=older,
+            newer=newer,
+            backend=None,
+        )
+
+    def test_plain_pointer_tie_keeps_established_record(self):
+        inner, established_record_id = self._exercise_equal_timestamp_tie(backend=None)
+
+        pointer = inner["latest"][self.repo_id][self.gate][self.subject_key]
+        self.assertEqual(pointer, established_record_id)  # @oracle LIA-527: an equal queued_at never flips an established plain pointer
+
+    def test_plain_pointer_survives_real_concurrent_writers(self):
+        self._exercise_concurrent_distinct_timestamps(backend=None)
+
+
+class TestLegacyDefaultsOracle(unittest.TestCase):
+    def test_old_constructor_shape_preserves_hermes_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = AttestationStore(Path(tmp) / "attestations-v1.json")
+
+        self.assertEqual(store.document_key, DEFAULT_DOCUMENT_KEY)  # @oracle LIA-527: legacy construction keeps the Hermes document key
+        self.assertEqual(store.opa_data_path, DEFAULT_OPA_DATA_PATH)  # @oracle LIA-527: legacy construction keeps the Hermes OPA path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Designs (docs-only) the write path Phase 1 deliberately left unbuilt: an isolated OPA data document (`data.warden_cc_attestations`) for Claude-Code-authored verdict mirrors, structurally separate from Hermes's own `data.warden_attestations` so a failed/slow CC write can never fail-close a Hermes-enrolled repo's gate.
- Adds an independent oracle test (`scripts/warden_policy/tests/test_cc_write_path_oracle.py`, 79 tagged `@oracle LIA-527` assertions) authored blind to any implementation via `scripts/dispatch-oracle-author.sh` (GPT-5.6-Sol) — correctly red today (76 failed / 5 passed) since no production code implements the design yet.
- No production code changes. Implementation and the actual cutover decision are explicit follow-up work — real shadow-observer data barely exists yet (`cc-shadow.jsonl`: 9 lines, all pre-toggle dev testing) and LIA-527 is the roadmap's lowest-urgency item by prior decision.

## Review history (unusually deep for a docs-only PR — recorded because it's the interesting part)
- Plan-reviewed: Claude SHIP (round 8, after 7 REVISE/BLOCK rounds) + GPT co-gate SHIP.
- Code-reviewed: Claude + GPT SHIP after several more rounds, catching real defects each time: an incomplete `AttestationStore` parameterization list (missed the module-level `OPA_DATA_PATH` constant that actually performs the OPA PUT — would have silently overwritten Hermes's live document), an unsafe daemon-thread write mechanism (replaced with a detached-subprocess pattern matching this repo's own `session_end_hook.py` precedent), a completion-order race across independently-spawned workers (fixed via `issue_if_newer(..., queued_at)`), a reboot-unsafe `monotonic_ns()` clock choice (fixed to `time.time_ns()`), a doc/test interface signature mismatch, two oracle tests that only covered negative/degenerate paths (a no-op stub could have passed them — added real positive-path tests that read the ledger back), and a TOCTOU gap the sequential-only ordering tests couldn't catch (closed with a genuine `threading.Barrier`-forced concurrent test).
- GLM backend: `COULD_NOT_RUN` (API billing exhausted) — fails open per this repo's existing co-gate semantics, does not block.
- Verification-gate: SHIP (confirmed scope matches claim — design + oracle only, hash-matched dual-backend SHIP verdicts, oracle genuinely red for the right reason, zero regression to `test_attestation_store.py`).

## Test plan
- [x] `python3 -m pytest -q scripts/warden_policy/tests/test_cc_write_path_oracle.py` → 76 failed / 5 passed, all failures are missing-implementation errors (`document_key`/`opa_data_path`/`issue_if_newer`/`cc_attestations` module), not test bugs.
- [x] `python3 -m pytest -q scripts/warden_policy/tests/test_attestation_store.py` → 14 passed, unaffected (Hermes-facing path untouched).
- [x] CI

Refs: LIA-527

🤖 Generated with [Claude Code](https://claude.com/claude-code)