### PR TITLE
feat(wardens): hermes plan-review gate (LIA-523)

### DIFF
--- a/docs/decisions/opa-warden-attestations-v1.md
+++ b/docs/decisions/opa-warden-attestations-v1.md
@@ -692,6 +692,131 @@ previous draft (missing parameterization sites, an unsafe concurrency mechanism,
 deletion/uniqueness/cleanup semantics), not to speculative hardening. No implementation, cutover,
 or Rego change has been added — those remain explicitly out of scope, unchanged since round 4.
 
+### Phase 3 — Hermes plan-review gate (LIA-523, implemented)
+
+Extends this substrate to a SECOND Hermes gate type: a `pre_tool_call` adapter for `write_file`/
+`patch` (file-write-shaped tool calls), the pre-implementation half of "safely doing real
+day-to-day development from Hermes" that Phase 0/1/2 (code-review only) never covered. Went
+through 15 plan-review rounds (Claude) + 2 GPT co-gate rounds before implementation — recorded
+here because several of the roadmap's own working assumptions turned out wrong on inspection,
+and the corrections are load-bearing for anyone extending this gate further.
+
+**Corrected assumption**: the roadmap that scoped this ticket assumed it would need LIA-521's
+fork/monkeypatch pattern (`GatewayRunner._create_adapter` `__class__`-swap), reasoning by analogy
+to LIA-521's `pre_outbound_send` spike. Wrong: Hermes already has a native, production
+`pre_tool_call` hook (this is what `hermes_warden_gate.py` already uses for `terminal`). This
+phase needed zero Hermes source changes — one new `~/.hermes/config.yaml` hook entry
+(`matcher: "write_file|patch"`, separate from the existing `matcher: "terminal"` entry) plus new
+code entirely in this repo (`scripts/hermes_plan_review_gate.py`, plus additive changes to
+`attestation_store.py`, `guardrails.rego`, `attestation-v1.schema.json`, `warden_attest.py`).
+
+**Session-bound subject, not git-tree-bound.** Nothing is staged pre-write, so code-review's
+`git write-tree` binding doesn't apply. Follows Claude Code's own plan-review gate instead
+(`codex_warden_hooks.py::run_plan_review_gate`'s `.plan-reviewed` marker): a plan-reviewer SHIP
+approves a session's reviewed intent, not a diff snapshot (LIA-516 established this same
+principle for Claude Code — diff-hash staleness deliberately disabled for this role).
+`AttestationStore.issue()` gained a `kind` parameter (`"git-tree"` default, byte-identical to
+every existing call site; `"session"` stores the raw `session_id` — an opaque token, nothing to
+digest). `attestation-v1.schema.json`'s `subject` became an `if`/`then`/`else` conditional on
+`kind` rather than a flat `const` shape.
+
+**Enrollment: additive, not a restructure — deliberately reconciled with Phase 2's already-merged
+design.** An early draft restructured `enforced_repos[repo_id]` into a nested `{"gates": {...}}`
+shape; review found this would (a) have no real migration path since OPA evaluates raw JSON
+directly, not through a Python abstraction, (b) require editing `guardrails.rego`'s three
+existing `git.commit` decision bodies to call `enrolled("code-review")` instead of the bare
+`enrolled` fact, and (c) directly conflict with this same ADR's Phase 2 section above, whose
+oracle (`test_cc_write_path_oracle.py`) locks `enroll()`'s flat output shape as a forward-
+compatibility baseline. Final design: a single new field, `enforced_repos[repo_id].plan_review_enabled`
+(boolean, absent = off), via a new `AttestationStore.set_plan_review_enabled(repo_id, enabled)`
+method — `enroll()`'s existing shape, the bare `enrolled` Rego fact, and all three `git.commit`
+decision bodies stay byte-unchanged. A real, necessary fix surfaced during this work: `enroll()`'s
+`_apply` was a wholesale dict-replace, which would have silently erased `plan_review_enabled` if
+`enroll()` ran after `set_plan_review_enabled()` — changed to a merge (`setdefault` + per-key
+assignment), verified to produce byte-identical output to the old code for the case Phase 2's
+oracle actually exercises (a fresh `enroll()` call, nothing pre-existing to preserve).
+
+**Repo-identity resolution — the hardest part, four discarded designs before landing on v1's
+actual shape.** In order, and why each was rejected: (1) calling Hermes's own
+`tools.file_tools._resolve_path_for_task` — its top two resolution tiers read in-memory,
+per-process state (`terminal_tool.py`'s `_session_cwd`/`_task_env_overrides`) that doesn't survive
+into the freshly-spawned gate subprocess; (2) reading `$TERMINAL_CWD` from the subprocess
+environment alone — it is Hermes's own documented "global mutable timeshared between sessions,"
+so a concurrent/child session could read a stale value belonging to a different session,
+risking a false ALLOW; (3) a SessionDB (`hermes_state.py`'s `sessions` table) lookup — its
+safety argument rested on a claim (plain CLI `-w` sessions never populate it) that was
+subsequently found false (`run_agent.py::_ensure_db_session` does populate it for local
+sessions) once someone actually re-checked the grep that produced the claim.
+
+**Final v1 design — branch on path shape first, absolute paths only:**
+- **Absolute** `write_file`/`patch` targets resolve their OWN precise `repo_id` (parent-directory
+  walk to the nearest existing ancestor, then `git -C <dir> rev-parse ...` — identical mechanism
+  to `git_subject.py::resolve_repo_id`) and are checked against THAT repo's own enrollment and
+  attestation state. `payload["cwd"]` is never consulted in this branch, so there is nothing for
+  it to diverge from.
+- **Relative** targets (v1 cannot precisely resolve these — the reason this gate scope-cuts them
+  at all) get only a coarse, best-effort gate-applicability pre-check via `payload["cwd"]` (the
+  same mechanism `hermes_warden_gate.py` already uses for `terminal`) — used ONLY to decide "is
+  this call even in scope," never to grant an attestation-based allow. If the guess looks
+  enrolled, the call fails closed with an explicit message; if not, it falls back to today's
+  pre-existing, already-shipped, ungated behavior (a named, accepted residual gap, not a
+  regression). Tilde-prefixed paths are classified as relative and never expanded (Hermes's own
+  tilde-expansion depends on a process-dependent `HOME` that can differ between gateway and
+  interactive-CLI contexts — the same environment-dependent-resolution risk class as `$TERMINAL_CWD`).
+- **Every target in a `patch` call is checked independently before any call-level decision** — a
+  real false-ALLOW found by the GPT co-gate: an earlier draft let any relative target in a
+  mixed-target patch downgrade the WHOLE call to the weak cwd-based check, letting an absolute
+  target inside an enrolled-but-unattested repo be smuggled through via an irrelevant relative
+  sibling. Fixed so the call blocks if either the absolute-targets' precise check OR the
+  relative-targets' coarse check would block it. Cross-repo ambiguity (more than one distinct
+  ENROLLED repo_id among a patch's absolute targets) fails closed; unenrolled repo_ids never
+  count toward that check.
+
+**Named v1 limitation**: relative-path (including tilde) `write_file`/`patch` calls are
+unconditionally blocked once the repo looks plan-review-enrolled — a real usability cost given
+how commonly coding agents emit relative paths, accepted because no repo-identity mechanism this
+review could verify safe across Hermes's CLI/TUI/Desktop/ACP/gateway/subagent session types
+existed after genuine, repeated attempts. Mitigated by the gate being opt-in per-repo
+(`enable-plan-review`/`disable-plan-review`), not a global default. A `terminal` command can still
+write files directly (`echo > file`) — LIA-522's territory (the git-level backstop), not this
+gate's job.
+
+**Session-attestation TTL**: `~/.hermes/config.yaml`'s `session_reset.mode: none` and
+`agent.max_turns: 500` mean a session-bound attestation with no expiry could authorize writes for
+an entire, potentially very long session. `guardrails.rego`'s new `valid_plan_review_ship` rule
+requires `issued_at` within `plan_review_ttl_seconds` (default 7200, overridable via
+`data.warden_attestations.config.plan_review_ttl_seconds`) — an expired attestation blocks
+exactly like no attestation, never falls through to allow. Named residual gap: Hermes has no
+native "start a new plan mid-session" event (unlike Claude Code's `/plan` or a fresh Plan-subagent
+dispatch), so a session-scoped attestation stays valid for every write in that session (bounded by
+the TTL) even if the actual plan changes mid-session.
+
+**Independent oracle**: `scripts/warden_policy/tests/test_hermes_plan_review_gate_oracle.py`,
+authored via `oracle-author` from the spec before `hermes_plan_review_gate.py` existed (confirmed
+red for the right reason — `ModuleNotFoundError` — before any implementation was written), same
+pattern as Phase 2's oracle above. 22 test cases, tagged `@oracle LIA-523:`, discriminating
+specifically against the false-ALLOW/enrollment-ordering/tilde-expansion/ambiguity-scoping bug
+classes named above. One fixture bug was found and fixed during implementation (the oracle's own
+V4A MOVE-operation test helper used an invented two-line syntax that Hermes's real
+`tools.patch_parser` doesn't recognize as a MOVE at all — corrected to the real single-line
+`*** Move File: <src> -> <dst>` syntax after running the oracle against a real implementation and
+discovering it silently never exercised the MOVE-dual-path property it claimed to).
+
+**Hook activation is NOT just the config entry.** `agent/shell_hooks.py::register_from_config`
+keys registration on the exact `(event, command)` pair against
+`~/.hermes/shell-hooks-allowlist.json`; a non-interactive/gateway caller runs with
+`accept_hooks=False` by default. The new command string (`hermes_plan_review_gate.py`, distinct
+from the already-approved `hermes_warden_gate.py`) needs its own approval — either one interactive
+CLI session to trigger and accept the TTY consent prompt once (persists to the shared allowlist,
+covers every future session type), or `hooks_auto_accept: true` in `~/.hermes/config.yaml` for
+unattended activation. Without this, the hook silently never registers — logged warning only, no
+error — for gateway/non-TTY sessions specifically.
+
+**Not yet done**: live end-to-end verification against a real Hermes session and a real OPA daemon
+(allow/block/fail-closed/TTL-expiry/recovery, mirroring this ADR's own Verification section below)
+— tracked as the final step before this phase is considered fully proven, same posture as every
+other phase's live-verification requirement.
+
 ## Consequences
 
 - OPA (`brew install opa`, v1.19.0+, Rego v1 `if`-keyword syntax) is now a dependency for anyone
@@ -716,10 +841,15 @@ or Rego change has been added — those remain explicitly out of scope, unchange
 
 ## Rollback
 
-- Full: `launchctl bootout gui/$(id -u)/com.deus.warden-opa`, remove the `hooks:` entry from
-  `~/.hermes/config.yaml`, remove the corresponding entry from
+- Full: `launchctl bootout gui/$(id -u)/com.deus.warden-opa`, remove the `hooks:` entries from
+  `~/.hermes/config.yaml` (both `matcher: "terminal"` and, if Phase 3 is enabled,
+  `matcher: "write_file|patch"`), remove the corresponding entries from
   `~/.hermes/shell-hooks-allowlist.json`.
-- Per-repo (daemon stays running): `python3 scripts/warden_attest.py unenroll --repo <path>`.
+- Per-repo, code-review gate (daemon stays running): `python3 scripts/warden_attest.py unenroll --repo <path>`.
+- Per-repo, Phase 3 plan-review gate only: `python3 scripts/warden_attest.py disable-plan-review
+  --repo <path>`, or remove just the `matcher: "write_file|patch"` hook entry to disable Phase 3
+  everywhere at once without touching code-review enforcement — every Phase 3 change is additive,
+  so this alone fully and immediately disables it.
 
 ## Verification
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-08" # auto-bump @1786141938
+last_verified: "2026-08-08" # auto-bump @1786179713
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/hermes_plan_review_gate.py
+++ b/scripts/hermes_plan_review_gate.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Fail-closed Hermes `pre_tool_call` adapter for the plan-review gate (LIA-523).
+
+Sibling to `hermes_warden_gate.py` (the code-review/`terminal` gate) -- same fail-closed
+philosophy, same JSON stdin/stdout protocol, same total-exception-containment in `main()` --
+but NOT a modification of that file. Wired via a SEPARATE `~/.hermes/config.yaml` hook entry
+(`matcher: "write_file|patch"`), independent of the existing `matcher: "terminal"` entry.
+
+Design, in one paragraph (see docs/decisions/opa-warden-attestations-v1.md and
+LIA-523's plan for the full 15-round review history that arrived here): branch on path shape
+FIRST. Every ABSOLUTE target resolves its own precise repo_id (parent-directory walk + `git -C`)
+and is checked against THAT repo's own enrollment/attestation state -- `payload["cwd"]` is never
+consulted for this branch, so there is nothing for it to diverge from. Only when a RELATIVE
+target is present (v1 cannot precisely resolve those) does `payload["cwd"]` get used, purely as
+a coarse "is this call even in scope for gating" pre-check -- never to grant an allow. A patch
+mixing absolute and relative targets gets BOTH checks independently; the call blocks if either
+would block it, so an absolute target's own enrollment status is never bypassed by an unrelated
+relative sibling (the exact false-ALLOW the GPT co-gate found and this design closes).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from warden_policy.attestation_store import AttestationStore, AttestationStoreError
+from warden_policy.git_subject import GitSubjectError, resolve_repo_id
+from warden_policy.opa_client import query_decision
+
+LEDGER_PATH = Path.home() / ".config" / "deus" / "guardrails" / "attestations-v1.json"
+LOG_PATH = Path.home() / ".config" / "deus" / "guardrails" / "logs" / "plan-review-decisions.jsonl"
+OPA_URL = "http://127.0.0.1:8181"
+OPA_TIMEOUT_SECONDS = 0.75
+SHIM_SELF_DEADLINE_SECONDS = 2.5  # stays comfortably under Hermes's configured hook timeout (3s)
+
+_HERMES_HOME = Path.home() / ".hermes" / "hermes-agent"
+
+
+def _block(message: str) -> dict:
+    return {"action": "block", "message": message}
+
+
+def _log(entry: dict) -> None:
+    # Best-effort, never raises -- logging must never itself cause a block/crash. Deliberately
+    # never logs raw paths or session ids beyond what's already needed to debug a decision --
+    # matches hermes_warden_gate.py's redaction discipline.
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+
+def _nearest_existing_dir(path: Path) -> Path:
+    """Walk up to the nearest EXISTING ancestor directory of *path*.
+
+    `git -C <dir>` requires an existing directory; a brand-new file's own path (or a deeply
+    nested new subdirectory) may not exist yet. Filesystem root always exists, so this
+    terminates.
+    """
+    p = path if path.is_dir() else path.parent
+    while not p.exists():
+        parent = p.parent
+        if parent == p:
+            break
+        p = parent
+    return p
+
+
+def _resolve_repo_id_for_path(path_str: str) -> str | None:
+    """Precise repo_id resolution from a real filesystem path. None if no git repo is found
+    anywhere up the tree -- the caller must treat that as fail-closed, never as "unenrolled".
+
+    Resolves symlinks FIRST (`Path.resolve()`, non-strict -- follows every symlink that
+    exists, leaves a nonexistent tail component literal) before walking to the nearest
+    existing ancestor. Found missing by the GPT co-gate: without this, a path inside an
+    unenrolled/attested repo that is itself a symlink (or has a symlinked ancestor
+    directory) into a DIFFERENT, enrolled-and-unattested repo would resolve repo_id from
+    the symlink's own location, not its real target -- a write that follows the symlink
+    lands in the protected repo while the gate checked the wrong one.
+    """
+    try:
+        resolved = Path(path_str).resolve()
+    except OSError:
+        return None
+    try:
+        return resolve_repo_id(_nearest_existing_dir(resolved))
+    except GitSubjectError:
+        return None
+
+
+def _v4a_target_paths(patch_text: str) -> list[str] | None:
+    """Extract every target path (file_path, plus new_path for MOVE ops) from a V4A patch.
+
+    Reuses Hermes's OWN parser (`tools.patch_parser.parse_v4a_patch`) rather than
+    re-implementing V4A parsing independently -- re-implementing risks silent divergence from
+    what Hermes's real `patch` tool actually does. `patch_parser.py` is intentionally
+    lightweight (stdlib-only imports, no file I/O in `parse_v4a_patch` itself -- confirmed by
+    reading the module before relying on it) so this import carries none of the heavy
+    transitive-dependency-chain cost `tools.file_tools` would have. Appended (not inserted at
+    position 0) so it can never shadow this script's own `scripts/`-local modules.
+
+    Returns None if the module can't be imported or the patch fails to parse at all -- the
+    caller must treat that as fail-closed (cannot determine targets -> cannot verify safety),
+    never as "no targets, allow".
+    """
+    if str(_HERMES_HOME) not in sys.path:
+        sys.path.append(str(_HERMES_HOME))
+    try:
+        from tools.patch_parser import parse_v4a_patch
+    except ImportError:
+        return None
+    try:
+        operations, error = parse_v4a_patch(patch_text)
+    except Exception:
+        return None
+    if error is not None and not operations:
+        return None
+    paths: list[str] = []
+    for op in operations:
+        if op.file_path:
+            paths.append(op.file_path)
+        if op.new_path:
+            paths.append(op.new_path)
+    return paths
+
+
+def _target_paths(tool_name: str, tool_input: dict) -> tuple[list[str] | None, dict | None]:
+    """Return (target_paths, early_result). early_result is non-None when this call is either
+    out of scope for this gate (allow) or malformed in a way that must fail closed (block) --
+    in either case the caller returns early without doing any repo/enrollment resolution."""
+    if tool_name == "write_file":
+        path = tool_input.get("path")
+        if not path:
+            return None, {}
+        return [path], None
+
+    if tool_name == "patch":
+        mode = tool_input.get("mode", "replace")
+        if mode == "replace":
+            path = tool_input.get("path")
+            if not path:
+                return None, {}
+            return [path], None
+        if mode == "patch":
+            patch_text = tool_input.get("patch")
+            if not patch_text:
+                return None, _block("patch mode='patch' call has no 'patch' text -- cannot determine targets, failing closed")
+            paths = _v4a_target_paths(patch_text)
+            if paths is None:
+                return None, _block("failed to parse V4A patch content -- cannot determine targets, failing closed")
+            if not paths:
+                return None, {}
+            return paths, None
+        # unrecognized mode -- out of scope for this gate, not this gate's job to guess.
+        return None, {}
+
+    # not a write-shaped tool call at all.
+    return None, {}
+
+
+def decide(payload: dict) -> dict:
+    start = time.monotonic()
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input") or {}
+    session_id = payload.get("session_id", "")
+    cwd = payload.get("cwd") or "."
+
+    log_entry = {"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool_name": tool_name}
+
+    target_paths, early_result = _target_paths(tool_name, tool_input)
+    if early_result is not None:
+        return early_result
+
+    absolute_targets = [p for p in target_paths if os.path.isabs(p)]
+    # Tilde-prefixed paths (~/...) are NOT absolute per os.path.isabs() and are deliberately
+    # never expanded here -- Hermes's own tilde-expansion uses a process-dependent HOME that
+    # can differ between gateway and interactive-CLI contexts (the same environment-dependent-
+    # resolution risk class this design avoids for cwd). They fall through to the relative
+    # branch below, same as any other relative path.
+    relative_targets = [p for p in target_paths if not os.path.isabs(p)]
+
+    store = AttestationStore(LEDGER_PATH, opa_base_url=OPA_URL)
+
+    try:
+        block_message = None
+
+        # Resolve + enrollment-check every absolute target first (cheap, no OPA). The OPA
+        # decision only depends on repo_id/session_id, never on the individual path -- querying
+        # once per FILE in a multi-file V4A patch touching one repo would multiply OPA
+        # round-trips against a shared, bounded self-deadline for no discriminating benefit
+        # (found by code review: enough files in one repo could exhaust the deadline and time
+        # out, which Hermes treats as fail-OPEN -- undermining the fail-closed guarantee for
+        # exactly the multi-file workload this design exists to handle). Dedup to one query per
+        # distinct enrolled repo_id instead.
+        #
+        # The resolution loop itself (a `git` subprocess + a ledger-lock acquisition per
+        # target) is not free either -- found by the GPT co-gate: a sufficiently large patch
+        # could exhaust SHIM_SELF_DEADLINE_SECONDS just walking targets, before ever reaching
+        # the (already-deduped) OPA query, and an internal timeout here still lets Hermes's own
+        # hook-level timeout be the thing that intervenes -- which fails OPEN, not closed. Cache
+        # repeated paths (MOVE's file_path/new_path can coincide with another target) and check
+        # the deadline before each resolution -- if exhausted, fail closed explicitly ourselves
+        # rather than let an external timeout decide.
+        _RESOLUTION_SAFETY_MARGIN_SECONDS = 0.3  # leaves enough budget to emit a block response
+        repo_id_cache: dict[str, str | None] = {}
+        enrolled_repo_ids: set[str] = set()
+        for path in absolute_targets:
+            if time.monotonic() - start > SHIM_SELF_DEADLINE_SECONDS - _RESOLUTION_SAFETY_MARGIN_SECONDS:
+                block_message = "too many targets to resolve within the gate's self-deadline -- failing closed"
+                break
+            if path not in repo_id_cache:
+                repo_id_cache[path] = _resolve_repo_id_for_path(path)
+            repo_id = repo_id_cache[path]
+            if repo_id is None:
+                block_message = block_message or "could not resolve a git repository for an absolute write target -- failing closed"
+                continue
+            with store.locked_read() as doc:
+                enrolled = bool(
+                    doc["warden_attestations"].get("config", {}).get("enforced_repos", {}).get(repo_id, {}).get("plan_review_enabled", False)
+                )
+            if enrolled:
+                enrolled_repo_ids.add(repo_id)
+
+        if len(enrolled_repo_ids) > 1:
+            block_message = block_message or f"ambiguous target repo -- write spans {len(enrolled_repo_ids)} distinct plan-review-enrolled repos in one call, failing closed"
+        elif not block_message and len(enrolled_repo_ids) == 1:
+            # Skip the OPA round-trip entirely if a block is already determined (e.g. the
+            # resolution deadline above was already exhausted) -- the outcome is already a
+            # block, and spending more of the shrinking time budget on a network call whose
+            # answer can no longer change that outcome only makes the timeout risk worse.
+            (repo_id,) = enrolled_repo_ids
+            with store.locked_read() as doc:
+                inner = doc["warden_attestations"]
+                remaining = SHIM_SELF_DEADLINE_SECONDS - (time.monotonic() - start)
+                timeout = min(OPA_TIMEOUT_SECONDS, max(0.05, remaining))
+                opa_input = {
+                    "contract_version": 1,
+                    "enforcement_point": "hermes.pre_tool_call",
+                    "operation": "file.write",
+                    "repo_id": repo_id,
+                    "session_id": session_id,
+                    "expected_generation": inner["generation"],
+                    "gate": "plan-review",
+                }
+                opa_decision = query_decision(OPA_URL, opa_input, timeout_seconds=timeout)
+            if not opa_decision.ok:
+                block_message = (
+                    f"guardrails policy engine (OPA) unreachable or returned an invalid "
+                    f"response ({opa_decision.error}) -- failing closed"
+                )
+            elif not opa_decision.allow:
+                block_message = opa_decision.reason or "no valid plan-review SHIP for this session"
+
+        if relative_targets:
+            guess_repo_id = _resolve_repo_id_for_path(cwd)
+            if guess_repo_id is not None:
+                with store.locked_read() as doc:
+                    inner = doc["warden_attestations"]
+                    guess_enrolled = bool(
+                        inner.get("config", {}).get("enforced_repos", {}).get(guess_repo_id, {}).get("plan_review_enabled", False)
+                    )
+                if guess_enrolled:
+                    block_message = block_message or (
+                        "relative-path write/patch targets are not supported by the plan-review "
+                        "gate in v1 -- retry with an absolute path"
+                    )
+            # guess_repo_id is None (cwd not in a git repo) or not enrolled: this half imposes
+            # no block -- matches the pre-existing, already-shipped ungated behavior for that
+            # specific call (named v1 residual gap), not a regression.
+    except AttestationStoreError as exc:
+        block_message = f"guardrails ledger unreadable ({exc}) -- failing closed"
+
+    if block_message:
+        log_entry.update(decision="block", reason=block_message)
+        _log(log_entry)
+        return _block(block_message)
+
+    log_entry.update(decision="allow", latency_ms=round((time.monotonic() - start) * 1000, 1))
+    _log(log_entry)
+    return {}
+
+
+def main() -> int:
+    # Total exception containment: ANY failure anywhere above results in a block, never an
+    # uncaught exception (which Hermes would treat as an allow, per its fail-open design).
+    try:
+        payload = json.load(sys.stdin)
+        result = decide(payload)
+    except Exception as exc:  # noqa: BLE001 -- intentionally broad: this is the fail-closed floor
+        result = _block(f"plan-review gate adapter internal error ({exc}) -- failing closed")
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/warden_attest.py
+++ b/scripts/warden_attest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Manual attestation CLI for scripts/warden_policy.
 
-Subcommands: enroll, unenroll, issue, inspect, check, sync.
+Subcommands: enroll, unenroll, issue, inspect, check, sync, plan-review, enable-plan-review,
+disable-plan-review.
 Typed exit codes: 0 OK, 1 usage error, 2 git/subject resolution error,
 3 not-activated (persisted but OPA PUT failed -- run `sync`), 6 CONFLICT
 (index changed mid-issuance).
@@ -119,6 +120,16 @@ def cmd_issue(args) -> int:
     return EXIT_OK if result.activated else EXIT_NOT_ACTIVATED
 
 
+def _subject_display(subject: dict) -> str:
+    """Render either subject shape for the human-readable `inspect` output (LIA-523 fix:
+    the old code unconditionally read subject['key'], which a session-kind subject
+    (opaque session_id, nothing to digest) doesn't have -- crashed with KeyError the
+    moment a ledger contained even one plan-review attestation)."""
+    if subject.get("kind") == "session":
+        return f"session:{subject.get('session_id', '?')}"
+    return subject.get("key", "?")
+
+
 def cmd_inspect(args) -> int:
     store = _store(args)
     try:
@@ -132,8 +143,59 @@ def cmd_inspect(args) -> int:
     else:
         print(f"repo_id: {repo_id}")
         for r in sorted(records, key=lambda r: r["issued_at"]):
-            print(f"  [{r['issued_at']}] {r['verdict']:7s} {r['subject']['key']}  ({r['reason']})")
+            print(f"  [{r['issued_at']}] {r['verdict']:7s} {_subject_display(r['subject'])}  ({r['reason']})")
     return EXIT_OK
+
+
+def cmd_plan_review(args) -> int:
+    """Issue a session-bound plan-review attestation (LIA-523) -- the Hermes-side analog
+    of Claude Code's `mark plan-reviewed SHIP`. Does NOT reuse cmd_issue's post-issuance
+    "index changed" race check: that check is meaningless without a staged tree, since a
+    plan-review attestation authorizes a session, not a git-tree snapshot."""
+    store = _store(args)
+    try:
+        repo_id = resolve_repo_id(Path(args.repo))
+    except GitSubjectError as exc:
+        _emit(args, {"ok": False, "error": str(exc)})
+        return EXIT_GIT_ERROR
+    result = store.issue(
+        repo_id=repo_id, gate="plan-review", subject_key=args.session_id, verdict=args.verdict,
+        issuer_kind=args.issuer_kind, reviewer_id=args.reviewer_id, reason=args.reason,
+        kind="session",
+    )
+    _emit(args, {"ok": result.ok, "activated": result.activated, "repo_id": repo_id,
+                  "session_id": args.session_id, "generation": result.generation, "error": result.error})
+    return EXIT_OK if result.activated else EXIT_NOT_ACTIVATED
+
+
+def cmd_enable_plan_review(args) -> int:
+    store = _store(args)
+    try:
+        repo_id = resolve_repo_id(Path(args.repo))
+    except GitSubjectError as exc:
+        _emit(args, {"ok": False, "error": str(exc)})
+        return EXIT_GIT_ERROR
+    result = store.set_plan_review_enabled(repo_id, True)
+    _emit(args, {"ok": result.ok, "activated": result.activated, "repo_id": repo_id,
+                  "generation": result.generation, "error": result.error})
+    return EXIT_OK if result.activated else EXIT_NOT_ACTIVATED
+
+
+def cmd_disable_plan_review(args) -> int:
+    store = _store(args)
+    try:
+        repo_id = resolve_repo_id(Path(args.repo))
+    except GitSubjectError as exc:
+        _emit(args, {"ok": False, "error": str(exc)})
+        return EXIT_GIT_ERROR
+    try:
+        result = store.set_plan_review_enabled(repo_id, False)
+    except AttestationStoreError as exc:
+        _emit(args, {"ok": False, "error": str(exc)})
+        return EXIT_USAGE
+    _emit(args, {"ok": result.ok, "activated": result.activated, "repo_id": repo_id,
+                  "generation": result.generation, "error": result.error})
+    return EXIT_OK if result.activated else EXIT_NOT_ACTIVATED
 
 
 def cmd_check(args) -> int:
@@ -202,6 +264,23 @@ def main(argv=None) -> int:
     p_inspect = sub.add_parser("inspect")
     p_inspect.add_argument("--repo", required=True)
     p_inspect.set_defaults(func=cmd_inspect)
+
+    p_plan_review = sub.add_parser("plan-review")
+    p_plan_review.add_argument("--repo", required=True)
+    p_plan_review.add_argument("--session-id", required=True)
+    p_plan_review.add_argument("--verdict", required=True, choices=["SHIP", "REVISE", "BLOCK"])
+    p_plan_review.add_argument("--issuer-kind", default="manual", choices=["manual", "script"])
+    p_plan_review.add_argument("--reviewer-id", required=True)
+    p_plan_review.add_argument("--reason", required=True)
+    p_plan_review.set_defaults(func=cmd_plan_review)
+
+    p_enable_pr = sub.add_parser("enable-plan-review")
+    p_enable_pr.add_argument("--repo", required=True)
+    p_enable_pr.set_defaults(func=cmd_enable_plan_review)
+
+    p_disable_pr = sub.add_parser("disable-plan-review")
+    p_disable_pr.add_argument("--repo", required=True)
+    p_disable_pr.set_defaults(func=cmd_disable_plan_review)
 
     p_check = sub.add_parser("check")
     p_check.add_argument("--repo", required=True)

--- a/scripts/warden_policy/attestation_store.py
+++ b/scripts/warden_policy/attestation_store.py
@@ -201,10 +201,14 @@ class AttestationStore:
 
     def enroll(self, repo_id: str) -> WriteResult:
         def _apply(inner):
-            inner["config"]["enforced_repos"][repo_id] = {
-                "enabled": True,
-                "enrolled_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            }
+            # MERGE into any existing entry, never replace wholesale (LIA-523 fix): an
+            # earlier version did `enforced_repos[repo_id] = {...}`, silently erasing any
+            # sibling field (e.g. plan_review_enabled) a repo already had set. setdefault({})
+            # produces byte-identical output to the old code on a fresh repo_id, since there
+            # is nothing pre-existing to preserve in that case.
+            entry = inner["config"]["enforced_repos"].setdefault(repo_id, {})
+            entry["enabled"] = True
+            entry["enrolled_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         return self._mutate(_apply)
 
     def unenroll(self, repo_id: str) -> WriteResult:
@@ -215,9 +219,38 @@ class AttestationStore:
             entry["enabled"] = False
         return self._mutate(_apply)
 
+    def set_plan_review_enabled(self, repo_id: str, enabled: bool) -> WriteResult:
+        """Independent, additive on/off switch for the plan-review gate (LIA-523).
+
+        Deliberately does NOT require prior `enroll()` for `enabled=True`: plan-review
+        gating is a genuinely independent surface from code-review gating -- a repo may
+        want plan-review-only enforcement without running the (separately, more heavily
+        adversarially-tested) code-review gate. Auto-vivifies a fresh entry with
+        `enabled: False` (code-review stays off unless separately `enroll()`-ed) when none
+        exists yet. `enabled=False` mirrors `unenroll()`'s raise-if-absent convention --
+        you cannot disable something that was never created, for UX symmetry with the
+        established sibling pattern rather than a second, different behavior shape for
+        what is otherwise the same kind of toggle.
+        """
+        def _apply(inner):
+            entry = inner["config"]["enforced_repos"].get(repo_id)
+            if enabled:
+                if entry is None:
+                    entry = inner["config"]["enforced_repos"][repo_id] = {
+                        "enabled": False,
+                        "enrolled_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    }
+                entry["plan_review_enabled"] = True
+            else:
+                if entry is None:
+                    raise AttestationStoreError(f"repo {repo_id} was never enrolled")
+                entry["plan_review_enabled"] = False
+        return self._mutate(_apply)
+
     def issue(
         self, *, repo_id: str, gate: str, subject_key: str, verdict: str,
         issuer_kind: str, reviewer_id: str, reason: str, backend: str | None = None,
+        kind: str = "git-tree",
     ) -> WriteResult:
         # COULD_NOT_RUN is a real, first-class verdict the legacy verdict store already
         # persists today (e.g. `codex_warden_hooks.py record-verdict ... COULD_NOT_RUN` for
@@ -225,22 +258,33 @@ class AttestationStore:
         # speculative new scope.
         if verdict not in ("SHIP", "REVISE", "BLOCK", "COULD_NOT_RUN"):
             raise AttestationStoreError(f"invalid verdict {verdict!r}")
+        if kind not in ("git-tree", "session"):
+            raise AttestationStoreError(f"invalid subject kind {kind!r}")
 
         def _apply(inner):
             record_id = f"att-{uuid.uuid4()}"
-            record = {
-                "id": record_id,
-                "schema_version": SCHEMA_VERSION,
-                "repo_id": repo_id,
-                "gate": gate,
-                "subject": {
+            if kind == "git-tree":
+                # Every existing call site: byte-for-byte the same shape as before `kind`
+                # existed.
+                subject = {
                     "kind": "git-tree",
                     "key": subject_key,
                     "digest": {
                         "algorithm": subject_key.split(":")[1],
                         "value": subject_key.split(":")[2],
                     },
-                },
+                }
+            else:
+                # session subject: subject_key carries the raw, opaque session_id -- nothing
+                # to hash/digest (unlike a repo-relative git path, a session id has no
+                # sensitive structure to redact).
+                subject = {"kind": "session", "session_id": subject_key}
+            record = {
+                "id": record_id,
+                "schema_version": SCHEMA_VERSION,
+                "repo_id": repo_id,
+                "gate": gate,
+                "subject": subject,
                 "verdict": verdict,
                 "issuer": {"kind": issuer_kind, "reviewer_id": reviewer_id},
                 "issued_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/scripts/warden_policy/policy/attestation-v1.schema.json
+++ b/scripts/warden_policy/policy/attestation-v1.schema.json
@@ -23,15 +23,21 @@
           "required": ["enforced_repos"],
           "additionalProperties": false,
           "properties": {
+            "plan_review_ttl_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Session-bound plan-review attestations older than this are treated as expired by guardrails.rego (LIA-523). Optional -- Rego's own `default plan_review_ttl_seconds := 7200` applies when absent."
+            },
             "enforced_repos": {
               "type": "object",
-              "description": "Keyed by repo_id. Absent or enabled=false means the repo is outside enforcement scope (commits allow, unconditionally, before any commit-form check).",
+              "description": "Keyed by repo_id. Absent or enabled=false means the repo is outside code-review enforcement scope (commits allow, unconditionally, before any commit-form check). plan_review_enabled is a second, independent, additive on/off switch for the plan-review gate -- absent means plan-review enforcement is off for this repo, regardless of the code-review `enabled` value. Deliberately NOT additionalProperties:false so new sibling switches can be added without a migration (LIA-523).",
               "additionalProperties": {
                 "type": "object",
                 "required": ["enabled", "enrolled_at"],
                 "properties": {
                   "enabled": { "type": "boolean" },
-                  "enrolled_at": { "type": "string", "format": "date-time" }
+                  "enrolled_at": { "type": "string", "format": "date-time" },
+                  "plan_review_enabled": { "type": "boolean" }
                 }
               }
             }
@@ -79,22 +85,37 @@
         "id": { "type": "string", "pattern": "^att-" },
         "schema_version": { "const": 1 },
         "repo_id": { "type": "string", "pattern": "^git-common-dir-sha256:[0-9a-f]{64}$" },
-        "gate": { "type": "string", "enum": ["code-review", "code-reviewer", "ai-eng-warden"] },
+        "gate": { "type": "string", "enum": ["code-review", "code-reviewer", "ai-eng-warden", "plan-review"] },
         "subject": {
           "type": "object",
-          "required": ["kind", "key", "digest"],
-          "additionalProperties": false,
+          "required": ["kind"],
           "properties": {
-            "kind": { "const": "git-tree" },
-            "key": { "type": "string", "pattern": "^git-tree:(sha1|sha256):[0-9a-f]+$" },
-            "digest": {
-              "type": "object",
-              "required": ["algorithm", "value"],
-              "additionalProperties": false,
-              "properties": {
-                "algorithm": { "type": "string", "enum": ["sha1", "sha256"] },
-                "value": { "type": "string" }
+            "kind": { "type": "string", "enum": ["git-tree", "session"] }
+          },
+          "if": { "properties": { "kind": { "const": "git-tree" } } },
+          "then": {
+            "required": ["kind", "key", "digest"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": { "const": "git-tree" },
+              "key": { "type": "string", "pattern": "^git-tree:(sha1|sha256):[0-9a-f]+$" },
+              "digest": {
+                "type": "object",
+                "required": ["algorithm", "value"],
+                "additionalProperties": false,
+                "properties": {
+                  "algorithm": { "type": "string", "enum": ["sha1", "sha256"] },
+                  "value": { "type": "string" }
+                }
               }
+            }
+          },
+          "else": {
+            "required": ["kind", "session_id"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": { "const": "session" },
+              "session_id": { "type": "string", "minLength": 1, "description": "Opaque Hermes session identifier -- stored raw, not hashed/digested (nothing sensitive to redact, unlike a repo-relative git path)." }
             }
           }
         },

--- a/scripts/warden_policy/policy/guardrails.rego
+++ b/scripts/warden_policy/policy/guardrails.rego
@@ -89,3 +89,60 @@ backend_verdict(backend) := att.verdict if {
 backend_verdict_map[backend] := backend_verdict(backend) if {
 	some backend in input.required_backends
 }
+
+# --- Plan-review gate (LIA-523) -- purely additive. `enrolled`, `valid_ship`, and the three
+# "git.commit" decision bodies above are byte-unchanged; this section never reads or writes
+# `enforced_repos[repo_id].enabled`. Session-bound (not git-tree-bound): a plan-reviewer SHIP
+# approves a session's reviewed intent, not a specific diff snapshot -- the same reasoning
+# Claude Code's own plan-review gate uses (LIA-516 deliberately disabled diff-hash staleness for
+# this role). `plan_review_enabled` is a second, independent enrollment switch alongside
+# `enabled` -- neither implies the other.
+
+plan_review_enrolled if data.warden_attestations.config.enforced_repos[input.repo_id].plan_review_enabled
+
+default plan_review_ttl_seconds := 7200
+
+plan_review_ttl_seconds := t if {
+	t := data.warden_attestations.config.plan_review_ttl_seconds
+}
+
+# Session-scoped attestations have no diff to bind to, so freshness is time-based instead:
+# expired (issued_at older than the TTL) is treated the same as "no attestation" -- blocks with
+# a re-attestation message, never falls through to an implicit allow.
+valid_plan_review_ship if {
+	id := data.warden_attestations.latest[input.repo_id]["plan-review"][input.session_id]
+	att := data.warden_attestations.records[id]
+	att.schema_version == 1
+	att.repo_id == input.repo_id
+	att.gate == "plan-review"
+	att.subject.kind == "session"
+	att.subject.session_id == input.session_id
+	att.verdict == "SHIP"
+	issued_ns := time.parse_rfc3339_ns(att.issued_at)
+	time.now_ns() - issued_ns < (plan_review_ttl_seconds * 1000000000)
+}
+
+decision := {"allow": true, "reason": "repo not plan-review-enrolled"} if {
+	supported
+	input.operation == "file.write"
+	not plan_review_enrolled
+}
+
+decision := {"allow": true, "reason": "matching plan-review SHIP"} if {
+	supported
+	input.operation == "file.write"
+	input.gate == "plan-review"
+	plan_review_enrolled
+	valid_plan_review_ship
+}
+
+decision := {
+	"allow": false,
+	"reason": sprintf("no valid (non-expired) plan-review SHIP for session %s", [input.session_id]),
+} if {
+	supported
+	input.operation == "file.write"
+	input.gate == "plan-review"
+	plan_review_enrolled
+	not valid_plan_review_ship
+}

--- a/scripts/warden_policy/policy/guardrails_test.rego
+++ b/scripts/warden_policy/policy/guardrails_test.rego
@@ -235,3 +235,117 @@ test_decision_never_fires_for_migrated_gate_when_enrolled if {
 	not decision.allow with input as inp with data.warden_attestations as attestations_with_backend
 	decision.reason == "guardrails policy produced no valid decision" with input as inp with data.warden_attestations as attestations_with_backend
 }
+
+# --- Plan-review gate (LIA-523) ------------------------------------------------------
+
+session_reviewed := "sess-reviewed-abc"
+session_expired := "sess-expired-def"
+session_unknown := "sess-never-attested"
+
+now_fixed_ns := time.parse_rfc3339_ns("2026-08-08T12:00:00Z")
+
+plan_review_input(session_id) := {
+	"contract_version": 1,
+	"enforcement_point": "hermes.pre_tool_call",
+	"operation": "file.write",
+	"repo_id": repo_a,
+	"session_id": session_id,
+	"expected_generation": 5,
+	"gate": "plan-review",
+}
+
+# repo_a with code-review UNTOUCHED (still enabled: true from base_attestations) plus the new,
+# additive plan_review_enabled switch and two session-bound records -- proves the two
+# enrollment surfaces coexist without disturbing each other.
+attestations_with_plan_review := object.union(base_attestations, {
+	"config": {"enforced_repos": {repo_a: object.union(base_attestations.config.enforced_repos[repo_a], {"plan_review_enabled": true})}},
+	"records": object.union(base_attestations.records, {
+		"att-plan-review-fresh": {
+			"id": "att-plan-review-fresh", "schema_version": 1, "repo_id": repo_a, "gate": "plan-review",
+			"subject": {"kind": "session", "session_id": session_reviewed},
+			"verdict": "SHIP", "issuer": {"kind": "manual", "reviewer_id": "plan-reviewer@claude-sonnet-5"},
+			"issued_at": "2026-08-08T11:00:00Z", "reason": "12 rounds, all real findings resolved",
+		},
+		"att-plan-review-expired": {
+			"id": "att-plan-review-expired", "schema_version": 1, "repo_id": repo_a, "gate": "plan-review",
+			"subject": {"kind": "session", "session_id": session_expired},
+			"verdict": "SHIP", "issuer": {"kind": "manual", "reviewer_id": "plan-reviewer@claude-sonnet-5"},
+			"issued_at": "2026-08-08T09:00:00Z", "reason": "issued 3 hours before now_fixed_ns -- past the default 2h TTL",
+		},
+	}),
+	"latest": object.union(base_attestations.latest, {
+		repo_a: object.union(base_attestations.latest[repo_a], {
+			"plan-review": {
+				session_reviewed: "att-plan-review-fresh",
+				session_expired: "att-plan-review-expired",
+			},
+		}),
+	}),
+})
+
+test_plan_review_allow_fresh_ship if {
+	inp := plan_review_input(session_reviewed)
+	decision.allow with input as inp with data.warden_attestations as attestations_with_plan_review with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_deny_expired_ttl if {
+	# Past the default 7200s TTL -- must NOT silently fall through to allow.
+	inp := plan_review_input(session_expired)
+	not decision.allow with input as inp with data.warden_attestations as attestations_with_plan_review with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_deny_no_attestation_for_session if {
+	inp := plan_review_input(session_unknown)
+	not decision.allow with input as inp with data.warden_attestations as attestations_with_plan_review with time.now_ns as now_fixed_ns
+	decision.reason == sprintf("no valid (non-expired) plan-review SHIP for session %s", [session_unknown]) with input as inp with data.warden_attestations as attestations_with_plan_review with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_allow_unenrolled_repo_regardless_of_session if {
+	# repo_a's code-review `enabled: true` must NOT imply plan-review enrollment -- the two
+	# switches are independent. Use base_attestations (no plan_review_enabled at all).
+	inp := plan_review_input(session_unknown)
+	decision.allow with input as inp with data.warden_attestations as base_attestations with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_custom_ttl_from_config if {
+	# A configured plan_review_ttl_seconds of 1 hour makes the (3-hours-old) "expired" fixture
+	# ALSO exceed a custom, SHORTER-than-default TTL -- proves the config path is actually
+	# read, not just the hardcoded default.
+	short_ttl := object.union(attestations_with_plan_review, {
+		"config": object.union(attestations_with_plan_review.config, {"plan_review_ttl_seconds": 3600}),
+	})
+	inp := plan_review_input(session_expired)
+	not decision.allow with input as inp with data.warden_attestations as short_ttl with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_custom_ttl_extends_validity if {
+	# A configured plan_review_ttl_seconds LONGER than the default makes the same 3-hour-old
+	# fixture VALID -- proves the custom TTL genuinely overrides the default in both
+	# directions, not just narrowing it.
+	long_ttl := object.union(attestations_with_plan_review, {
+		"config": object.union(attestations_with_plan_review.config, {"plan_review_ttl_seconds": 14400}),
+	})
+	inp := plan_review_input(session_expired)
+	decision.allow with input as inp with data.warden_attestations as long_ttl with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_defense_in_depth_gate_mismatch if {
+	# A record indexed under "plan-review" in `latest` whose OWN gate field says something
+	# else must still deny -- the same defense-in-depth principle valid_ship already enforces.
+	tampered := object.union(attestations_with_plan_review, {
+		"records": object.union(attestations_with_plan_review.records, {
+			"att-plan-review-fresh": object.union(attestations_with_plan_review.records["att-plan-review-fresh"], {"gate": "code-review"}),
+		}),
+	})
+	inp := plan_review_input(session_reviewed)
+	not decision.allow with input as inp with data.warden_attestations as tampered with time.now_ns as now_fixed_ns
+}
+
+test_plan_review_git_commit_decision_bodies_never_fire_for_file_write if {
+	# Mental-exclusivity check mirroring test_decision_never_fires_for_migrated_gate_when_enrolled:
+	# a "file.write" operation must never satisfy any of the "git.commit" decision bodies.
+	inp := plan_review_input(session_reviewed)
+	d := decision with input as inp with data.warden_attestations as attestations_with_plan_review with time.now_ns as now_fixed_ns
+	d.reason != "matching code-review SHIP"
+	d.reason != "repo not enrolled"
+}

--- a/scripts/warden_policy/tests/test_attestation_store.py
+++ b/scripts/warden_policy/tests/test_attestation_store.py
@@ -49,6 +49,35 @@ class TestEnrollment(unittest.TestCase):
         r2 = self.store.unenroll("repo-a")
         self.assertEqual(r2.generation, r1.generation + 1)
 
+    def test_set_plan_review_enabled_creates_fresh_entry_with_code_review_off(self):
+        r = self.store.set_plan_review_enabled("repo-a", True)
+        self.assertTrue(r.ok)
+        entry = self.store._read_disk()["warden_attestations"]["config"]["enforced_repos"]["repo-a"]
+        self.assertFalse(entry["enabled"])  # code-review stays off, not auto-enrolled
+        self.assertIn("enrolled_at", entry)
+        self.assertTrue(entry["plan_review_enabled"])
+
+    def test_disable_plan_review_never_enrolled_raises(self):
+        with self.assertRaises(AttestationStoreError):
+            self.store.set_plan_review_enabled("never-enrolled", False)
+
+    def test_enroll_after_enable_plan_review_preserves_plan_review_enabled(self):
+        # This is the case that would have caught the old replace-not-merge bug in enroll():
+        # enable-plan-review first, then enroll() for code-review, in that order.
+        self.store.set_plan_review_enabled("repo-a", True)
+        self.store.enroll("repo-a")
+        entry = self.store._read_disk()["warden_attestations"]["config"]["enforced_repos"]["repo-a"]
+        self.assertTrue(entry["enabled"])
+        self.assertTrue(entry["plan_review_enabled"])
+
+    def test_enable_plan_review_after_enroll_preserves_enabled(self):
+        # Mirror order: enroll() first, then enable-plan-review.
+        self.store.enroll("repo-a")
+        self.store.set_plan_review_enabled("repo-a", True)
+        entry = self.store._read_disk()["warden_attestations"]["config"]["enforced_repos"]["repo-a"]
+        self.assertTrue(entry["enabled"])
+        self.assertTrue(entry["plan_review_enabled"])
+
 
 class TestIssueAppendOnly(unittest.TestCase):
     def setUp(self):
@@ -86,6 +115,40 @@ class TestIssueAppendOnly(unittest.TestCase):
                 repo_id="repo-a", gate="code-review", subject_key="git-tree:sha1:aaa",
                 verdict="MAYBE", issuer_kind="manual", reviewer_id="x@y", reason="",
             )
+
+    def test_invalid_subject_kind_rejected(self):
+        with self.assertRaises(AttestationStoreError):
+            self.store.issue(
+                repo_id="repo-a", gate="plan-review", subject_key="sess-1",
+                verdict="SHIP", issuer_kind="manual", reviewer_id="x@y", reason="",
+                kind="not-a-real-kind",
+            )
+
+    def test_session_subject_stores_raw_session_id_not_a_digest(self):
+        self.store.set_plan_review_enabled("repo-a", True)
+        result = self.store.issue(
+            repo_id="repo-a", gate="plan-review", subject_key="sess-abc123",
+            verdict="SHIP", issuer_kind="manual", reviewer_id="plan-reviewer@claude",
+            reason="reviewed", kind="session",
+        )
+        self.assertTrue(result.ok)
+        doc = self.store._read_disk()
+        inner = doc["warden_attestations"]
+        latest_id = inner["latest"]["repo-a"]["plan-review"]["sess-abc123"]
+        record = inner["records"][latest_id]
+        self.assertEqual(record["subject"], {"kind": "session", "session_id": "sess-abc123"})
+        # a git-tree subject on the SAME ledger, issued after, must be unaffected --
+        # proves the two subject shapes don't corrupt each other.
+        self.store.enroll("repo-a")
+        self.store.issue(
+            repo_id="repo-a", gate="code-review", subject_key="git-tree:sha1:bbb",
+            verdict="SHIP", issuer_kind="manual", reviewer_id="x@y", reason="ok",
+        )
+        doc2 = self.store._read_disk()
+        tree_latest_id = doc2["warden_attestations"]["latest"]["repo-a"]["code-review"]["git-tree:sha1:bbb"]
+        tree_record = doc2["warden_attestations"]["records"][tree_latest_id]
+        self.assertEqual(tree_record["subject"]["kind"], "git-tree")
+        self.assertEqual(tree_record["subject"]["digest"], {"algorithm": "sha1", "value": "bbb"})
 
     def test_could_not_run_verdict_accepted(self):
         # Real precedent: the legacy verdict store already persists COULD_NOT_RUN as a

--- a/scripts/warden_policy/tests/test_hermes_plan_review_gate_oracle.py
+++ b/scripts/warden_policy/tests/test_hermes_plan_review_gate_oracle.py
@@ -1,0 +1,584 @@
+"""Independent oracle for scripts/hermes_plan_review_gate.py (LIA-523).
+
+Authored FROM THE SPEC, blind to the implementation -- the file under test
+(``scripts/hermes_plan_review_gate.py``) does not exist yet at authoring time.
+See the LIA-523 ticket / plan for the full spec; the interface assumptions
+this file relies on are recorded below so a reviewer can check them against
+whatever actually gets built, per this repo's independent-oracle pattern
+(same precedent as ``test_cc_write_path_oracle.py`` for LIA-527).
+
+Interface assumed (all justified by the spec's explicit "structurally
+modeled on scripts/hermes_warden_gate.py" instruction, and by reading that
+already-shipped sibling + its test file, ``test_hermes_warden_gate.py``):
+
+  - ``scripts/hermes_plan_review_gate.py`` is importable as top-level module
+    ``hermes_plan_review_gate`` once ``scripts/`` is on ``sys.path`` (exactly
+    how the sibling gate is imported and tested).
+  - It exposes ``decide(payload: dict) -> dict`` taking the full
+    ``pre_tool_call`` payload (``tool_name``, ``tool_input``, ``session_id``,
+    ``cwd``, ``extra``) and returning ``{}`` (allow) or
+    ``{"action": "block", "message": str}`` (block) -- the spec's own
+    "Input"/"Output" sections, verbatim.
+  - It exposes ``main() -> int`` reading JSON from stdin, printing JSON to
+    stdout, always returning 0 -- again the spec's own "Output" section.
+  - It imports ``query_decision`` from ``warden_policy.opa_client`` into its
+    own module namespace (as the sibling does), so the real OPA policy
+    decision for "is this session's plan-review attestation valid" can be
+    mocked at ``gate.query_decision`` without touching a real OPA process.
+  - It has a module-level ``LEDGER_PATH`` (and, matching the sibling,
+    ``LOG_PATH``) constant used to construct its ``AttestationStore`` --
+    needed for test isolation from the real, on-disk production ledger,
+    exactly as the sibling's own test suite already relies on.
+
+Everything else -- internal function names like the spec's own
+``resolve_and_decide``/``parse_v4a_patch_targets``/``resolve_repo_id_precisely``
+pseudocode helpers -- is deliberately NOT depended on here. This suite drives
+the module only through the black-box ``decide()``/``main()`` contract, using
+real temp git repos + a real (temp, isolated) ``AttestationStore`` ledger for
+enrollment/attestation state, and hand-written V4A patch text for the
+multi-file `patch` case -- so it discriminates a wrong *behavior* rather than
+a wrong *internal decomposition*, and keeps passing across any correct
+re-implementation that keeps the same observable contract.
+
+Every discriminating assertion is tagged ``# @oracle LIA-523: ...``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import hermes_plan_review_gate as gate  # noqa: E402 -- see sys.path.insert above
+from warden_policy.attestation_store import AttestationStore  # noqa: E402
+from warden_policy.git_subject import resolve_repo_id  # noqa: E402
+from warden_policy.opa_client import DecisionResult  # noqa: E402
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", cwd=path)
+    _git("config", "user.email", "test@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    (path / "f.txt").write_text("hello\n")
+    _git("add", "f.txt", cwd=path)
+    _git("commit", "-q", "-m", "init", cwd=path)
+
+
+def _always_ok_put(self, inner_doc):
+    return True, inner_doc["generation"], None
+
+
+def _v4a_single(path: str) -> str:
+    return (
+        "*** Begin Patch\n"
+        f"*** Update File: {path}\n"
+        "@@\n"
+        "-old\n"
+        "+new\n"
+        "*** End Patch\n"
+    )
+
+
+def _v4a_two(path_a: str, path_b: str) -> str:
+    return (
+        "*** Begin Patch\n"
+        f"*** Update File: {path_a}\n"
+        "@@\n"
+        "-old-a\n"
+        "+new-a\n"
+        f"*** Update File: {path_b}\n"
+        "@@\n"
+        "-old-b\n"
+        "+new-b\n"
+        "*** End Patch\n"
+    )
+
+
+def _v4a_move(old_path: str, new_path: str) -> str:
+    # Real Hermes V4A syntax (confirmed against tools/patch_parser.py's actual regex,
+    # `re.match(r'\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)', line)`): a MOVE is a SINGLE
+    # "*** Move File: <src> -> <dst>" line, not a separate "Move to:" line after "Update
+    # File:" -- the original two-line form here was a fixture bug (never exercised a real
+    # MOVE operation at all; Hermes's parser silently fell back to a plain UPDATE with the
+    # "Move to:" text ignored as an unrecognized line), found and fixed by running this
+    # oracle against a real implementation and discovering it never actually tested the
+    # MOVE-dual-path property it claimed to.
+    return (
+        "*** Begin Patch\n"
+        f"*** Move File: {old_path} -> {new_path}\n"
+        "*** End Patch\n"
+    )
+
+
+ALLOW = {}
+SESSION_ID = "sess-oracle-0001"
+
+
+class TestHermesPlanReviewGateOracle(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+        # Three distinct real repos so "which repo does this target resolve to"
+        # is answered by real `git rev-parse`, never a stub.
+        self.repo_enrolled_unattested = self.root / "repo-a"  # enrolled, no valid SHIP
+        self.repo_enrolled_attested = self.root / "repo-b"  # enrolled, valid SHIP
+        self.repo_unenrolled = self.root / "repo-c"  # never enrolled for plan-review
+        self.repo_enrolled_attested_2 = self.root / "repo-d"  # enrolled + attested, distinct from repo-b
+        for repo in (
+            self.repo_enrolled_unattested,
+            self.repo_enrolled_attested,
+            self.repo_unenrolled,
+            self.repo_enrolled_attested_2,
+        ):
+            _init_repo(repo)
+
+        self.ledger = self.root / "ledger.json"
+        self.log_path = self.root / "decisions.jsonl"
+
+        self.patchers = [
+            mock.patch.object(gate, "LEDGER_PATH", self.ledger),
+            mock.patch.object(gate, "LOG_PATH", self.log_path),
+        ]
+        for p in self.patchers:
+            p.start()
+
+        # Never let a real AttestationStore mutation try to PUT to a real OPA
+        # process during ledger setup (mirrors test_hermes_warden_gate.py).
+        self.put_patcher = mock.patch.object(AttestationStore, "_put_and_readback", _always_ok_put)
+        self.put_patcher.start()
+
+        self.store = AttestationStore(self.ledger)
+        self.repo_id_a = resolve_repo_id(self.repo_enrolled_unattested)
+        self.repo_id_b = resolve_repo_id(self.repo_enrolled_attested)
+        self.repo_id_c = resolve_repo_id(self.repo_unenrolled)
+        self.repo_id_d = resolve_repo_id(self.repo_enrolled_attested_2)
+
+        self.store.set_plan_review_enabled(self.repo_id_a, True)
+        self.store.set_plan_review_enabled(self.repo_id_b, True)
+        self.store.set_plan_review_enabled(self.repo_id_d, True)
+        # repo_id_c deliberately left with no plan_review_enabled entry at all.
+
+        # Seed real SHIP records for the "attested" repos, for realism -- the
+        # actual pass/fail in these tests is controlled by mocking
+        # `gate.query_decision` (the OPA call), matching how
+        # test_hermes_warden_gate.py tests its own OPA-backed decisions.
+        for repo_id in (self.repo_id_b, self.repo_id_d):
+            self.store.issue(
+                repo_id=repo_id, gate="plan-review", subject_key=SESSION_ID,
+                verdict="SHIP", issuer_kind="warden", reviewer_id="plan-reviewer@claude",
+                reason="oracle fixture", kind="session",
+            )
+
+    def tearDown(self):
+        self.put_patcher.stop()
+        for p in self.patchers:
+            p.stop()
+        self.tmp.cleanup()
+
+    def _payload(self, tool_name, tool_input, cwd, session_id=SESSION_ID):
+        return {
+            "tool_name": tool_name, "tool_input": tool_input,
+            "session_id": session_id, "cwd": str(cwd), "extra": {},
+        }
+
+    def _allow_everything_opa(self):
+        return mock.patch.object(
+            gate, "query_decision",
+            return_value=DecisionResult(ok=True, allow=True, reason="matching plan-review SHIP"),
+        )
+
+    def _deny_everything_opa(self, reason="no valid plan-review SHIP for this session"):
+        return mock.patch.object(
+            gate, "query_decision",
+            return_value=DecisionResult(ok=True, allow=False, reason=reason),
+        )
+
+    # -- interface sanity -------------------------------------------------
+
+    def test_module_exposes_expected_entry_points(self):
+        self.assertTrue(callable(gate.decide))  # @oracle LIA-523: module exposes a callable decide(payload)
+        self.assertTrue(callable(gate.main))  # @oracle LIA-523: module exposes a callable main()
+
+    # -- scope: which calls this gate even looks at ------------------------
+
+    def test_non_write_shaped_tool_allows(self):
+        result = gate.decide(self._payload("read_file", {"path": "x"}, self.repo_unenrolled))
+        self.assertEqual(result, ALLOW)  # @oracle LIA-523: a non write/patch tool_name is out of scope -- always allow
+
+    def test_patch_unknown_mode_allows(self):
+        result = gate.decide(
+            self._payload("patch", {"mode": "rename", "path": "x"}, self.repo_unenrolled)
+        )
+        self.assertEqual(result, ALLOW)  # @oracle LIA-523: an unrecognized patch mode is out of scope -- allow, not a crash/block
+
+    # -- enrollment-before-form-validation, unenrolled repos behave normally --
+
+    def test_relative_write_in_unenrolled_repo_allows(self):
+        result = gate.decide(
+            self._payload("write_file", {"path": "new_file.txt"}, self.repo_unenrolled)
+        )
+        # @oracle LIA-523: falsifies an over-broad "block every relative-path write"
+        # implementation that forgot enrollment-before-form-validation ordering.
+        self.assertEqual(result, ALLOW)
+
+    def test_relative_write_in_plan_review_enrolled_repo_blocks(self):
+        # A purely-relative-path call whose cwd resolves to an ENROLLED repo -- the actual
+        # named v1 limitation the spec calls out (relative paths always block once the
+        # cwd-guessed repo looks enrolled). No prior test exercised this branch in isolation
+        # (existing relative-path tests use an unenrolled cwd, or pair the relative target
+        # with an absolute one whose own block masks this code path) -- found missing by
+        # code review.
+        with mock.patch.object(
+            gate, "query_decision",
+            side_effect=AssertionError("OPA must not be queried for the relative-path coarse pre-check"),
+        ):
+            result = gate.decide(
+                self._payload("write_file", {"path": "new_file.txt"}, self.repo_enrolled_unattested)
+            )
+        # @oracle LIA-523: falsifies an implementation that never actually wires up the
+        # relative-path cwd-based pre-check at all (e.g. one that always allows relative
+        # paths regardless of cwd enrollment) -- and, via the query_decision spy above,
+        # falsifies an implementation that answers this branch by querying OPA instead of
+        # deciding purely from local enrollment state (the design's whole point: the
+        # coarse pre-check must never grant/deny via an attestation match on a guessed repo).
+        self.assertEqual(result.get("action"), "block")
+        self.assertIn("absolute path", result.get("message", ""))
+
+    def test_absolute_write_in_unenrolled_repo_allows(self):
+        target = str(self.repo_unenrolled / "new_file.txt")
+        result = gate.decide(self._payload("write_file", {"path": target}, self.repo_unenrolled))
+        self.assertEqual(result, ALLOW)  # @oracle LIA-523: an unenrolled repo's absolute-path write is not gated at all
+
+    # -- core positive-block cases ------------------------------------------
+
+    def test_absolute_write_in_enrolled_unattested_repo_blocks(self):
+        target = str(self.repo_enrolled_unattested / "new_file.txt")
+        with self._deny_everything_opa():
+            result = gate.decide(
+                self._payload("write_file", {"path": target}, self.repo_unenrolled)
+            )
+        self.assertEqual(result.get("action"), "block")  # @oracle LIA-523: enrolled + no valid attestation must block a write_file
+        self.assertIsInstance(result.get("message"), str)  # @oracle LIA-523: a block always carries a human-readable message
+        self.assertTrue(result["message"])  # @oracle LIA-523: the block message is non-empty
+
+    def test_patch_replace_mode_absolute_enrolled_unattested_blocks(self):
+        target = str(self.repo_enrolled_unattested / "new_file.txt")
+        with self._deny_everything_opa():
+            result = gate.decide(
+                self._payload("patch", {"mode": "replace", "path": target}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: falsifies an implementation that only branches on
+        # tool_name == "write_file" and forgets patch+mode=="replace" carries
+        # the same single-path shape (which would fall through to the "else: allow"
+        # branch and silently un-gate every replace-mode patch call).
+        self.assertEqual(result.get("action"), "block")
+
+    # -- item 1: per-target independence inside one patch call --------------
+
+    def test_absolute_target_blocks_even_with_relative_sibling_in_same_patch(self):
+        abs_target = str(self.repo_enrolled_unattested / "abs_target.txt")
+        patch_text = _v4a_two("relative_sibling.txt", abs_target)
+        with self._deny_everything_opa():
+            result = gate.decide(
+                self._payload("patch", {"mode": "patch", "patch": patch_text}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: falsifies "any relative target present -> whole call
+        # downgrades to the weak cwd-based check" -- the enrolled+unattested
+        # absolute target must independently force a block regardless of the
+        # relative sibling, and regardless of cwd (repo_unenrolled) being unenrolled.
+        self.assertEqual(result.get("action"), "block")
+
+    # -- item 2: absolute-path enrollment must use the path's OWN repo, never cwd --
+
+    def test_absolute_target_enrollment_uses_own_repo_not_cwd(self):
+        # cwd resolves to an UNENROLLED repo; the sole absolute target resolves to
+        # a DIFFERENT, enrolled-but-unattested repo.
+        abs_target = str(self.repo_enrolled_unattested / "abs_target.txt")
+        with self._deny_everything_opa():
+            result = gate.decide(
+                self._payload("write_file", {"path": abs_target}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: falsifies an implementation that checks
+        # is_plan_review_enrolled(cwd's repo) before/instead of branching on path
+        # shape -- cwd's repo (repo_unenrolled) is NOT enrolled, so that bug would
+        # wrongly allow; the correct check resolves enrollment from the absolute
+        # target's own repo (repo_enrolled_unattested) and must block.
+        self.assertEqual(result.get("action"), "block")
+
+    # -- item 3: tilde is relative, never expanded ---------------------------
+
+    def test_tilde_path_never_expanded_treated_as_relative(self):
+        fake_home = self.root / "fake-home"
+        fake_home.mkdir()
+        enrolled_under_home = fake_home / "enrolled-repo"
+        _init_repo(enrolled_under_home)
+        repo_id_home = resolve_repo_id(enrolled_under_home)
+        self.store.set_plan_review_enabled(repo_id_home, True)  # enrolled, unattested
+
+        tilde_path = "~/enrolled-repo/new_file.txt"
+        with mock.patch.dict("os.environ", {"HOME": str(fake_home)}):
+            with self._deny_everything_opa():
+                result = gate.decide(
+                    self._payload("write_file", {"path": tilde_path}, self.repo_unenrolled)
+                )
+        # @oracle LIA-523: falsifies an implementation that calls
+        # os.path.expanduser()/Path.expanduser() on the tilde path. If expanded,
+        # it resolves inside the enrolled-but-unattested `enrolled-repo` and must
+        # (incorrectly, per this bug) block. Treated correctly as relative, it
+        # only gets the weak cwd-based check -- cwd (repo_unenrolled) is not
+        # enrolled, so the correct result is ALLOW.
+        self.assertEqual(result, ALLOW)
+
+    # -- MOVE ops: both file_path and new_path count as targets --------------
+
+    def test_move_new_path_is_also_checked_as_target(self):
+        abs_new_path = str(self.repo_enrolled_unattested / "moved_target.txt")
+        patch_text = _v4a_move("old_relative_name.txt", abs_new_path)
+        with self._deny_everything_opa():
+            result = gate.decide(
+                self._payload("patch", {"mode": "patch", "patch": patch_text}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: falsifies an implementation that only extracts the
+        # "Update File:" file_path and ignores the "Move to:" new_path -- such a
+        # bug would see only the relative old name, apply the weak cwd check
+        # (repo_unenrolled, unenrolled) and wrongly allow.
+        self.assertEqual(result.get("action"), "block")
+
+    # -- item 5 / ambiguity: only ENROLLED repo_ids count -------------------
+
+    def test_enrolled_and_unenrolled_absolute_targets_not_treated_as_ambiguous_allows(self):
+        abs_enrolled_attested = str(self.repo_enrolled_attested / "a.txt")
+        abs_unenrolled = str(self.repo_unenrolled / "b.txt")
+        patch_text = _v4a_two(abs_enrolled_attested, abs_unenrolled)
+        with self._allow_everything_opa():
+            result = gate.decide(
+                self._payload("patch", {"mode": "patch", "patch": patch_text}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: falsifies an implementation that counts every distinct
+        # absolute-path repo_id (enrolled or not) toward the ambiguity check --
+        # only repo_enrolled_attested is plan-review-enrolled here, so there is
+        # exactly one enrolled repo_id in play, it is attested, and the result
+        # must be ALLOW, not a fail-closed ambiguity block.
+        self.assertEqual(result, ALLOW)
+
+    def test_two_distinct_enrolled_repos_in_one_patch_is_ambiguous_and_blocks(self):
+        abs_a = str(self.repo_enrolled_attested / "a.txt")
+        abs_d = str(self.repo_enrolled_attested_2 / "d.txt")
+        patch_text = _v4a_two(abs_a, abs_d)
+        with self._allow_everything_opa():
+            result = gate.decide(
+                self._payload("patch", {"mode": "patch", "patch": patch_text}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: both targets are individually enrolled AND attested
+        # (OPA mocked to allow=True unconditionally), so the ONLY possible cause
+        # for a block here is the cross-repo ambiguity rule itself -- this
+        # falsifies an implementation that has no ambiguity check at all (which
+        # would wrongly allow a write spanning two distinct enrolled repos in
+        # one call, exactly the "do not guess" case the spec calls out).
+        self.assertEqual(result.get("action"), "block")
+
+    def test_resolution_deadline_exhaustion_blocks_without_querying_opa(self):
+        # A large multi-file patch could exceed the self-deadline just resolving targets
+        # (a `git` subprocess + a ledger-lock acquisition per absolute target), before ever
+        # reaching the OPA query -- an internal timeout here must fail closed itself, never
+        # let Hermes's own hook-level timeout (which fails OPEN) be the thing that decides.
+        # Simulated deterministically by making time.monotonic() report elapsed time past
+        # the deadline on the SECOND call (the first call is decide()'s own `start`).
+        abs_target = str(self.repo_enrolled_unattested / "a.txt")
+        real_start = gate.time.monotonic()
+        call_count = {"n": 0}
+
+        def _fake_monotonic():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return real_start
+            return real_start + gate.SHIM_SELF_DEADLINE_SECONDS + 1.0
+
+        with mock.patch.object(gate.time, "monotonic", side_effect=_fake_monotonic):
+            with mock.patch.object(
+                gate, "query_decision",
+                side_effect=AssertionError("OPA must not be queried once the resolution deadline is exhausted"),
+            ):
+                result = gate.decide(
+                    self._payload("write_file", {"path": abs_target}, self.repo_unenrolled)
+                )
+        # @oracle LIA-523: falsifies an implementation with no internal deadline check at
+        # all (which would either proceed to query OPA past budget, or -- worse -- run long
+        # enough that Hermes's own hook timeout intervenes and fails OPEN instead of closed).
+        self.assertEqual(result.get("action"), "block")
+
+    # -- happy path + OPA input shape ----------------------------------------
+
+    def test_attested_absolute_write_allows(self):
+        target = str(self.repo_enrolled_attested / "new_file.txt")
+        with self._allow_everything_opa():
+            result = gate.decide(
+                self._payload("write_file", {"path": target}, self.repo_unenrolled)
+            )
+        self.assertEqual(result, ALLOW)  # @oracle LIA-523: enrolled + valid SHIP attestation must allow
+
+    def test_opa_input_uses_plan_review_gate_and_correct_session_id(self):
+        target = str(self.repo_enrolled_attested / "new_file.txt")
+        captured = {}
+
+        def _capture(opa_url, opa_input, timeout_seconds):
+            captured.update(opa_input)
+            return DecisionResult(ok=True, allow=True, reason="matching plan-review SHIP")
+
+        with mock.patch.object(gate, "query_decision", side_effect=_capture):
+            gate.decide(self._payload("write_file", {"path": target}, self.repo_unenrolled))
+        # @oracle LIA-523: falsifies a copy-paste from hermes_warden_gate.py that
+        # forgot to change the OPA gate name from "code-review" to "plan-review"
+        # (guardrails.rego's plan-review rules are gate-scoped, so a wrong gate
+        # value silently falls through to a default deny/allow that has nothing
+        # to do with plan-review attestations).
+        self.assertEqual(captured.get("gate"), "plan-review")
+        self.assertEqual(captured.get("session_id"), SESSION_ID)  # @oracle LIA-523: the OPA query must carry THIS call's session_id, not a stale/cached one
+
+    def test_opa_deny_blocks_despite_a_local_ledger_record_existing(self):
+        # A real SHIP record for repo_id_b/SESSION_ID already exists on disk
+        # (seeded in setUp) -- this simulates the "expired" scenario: the local
+        # ledger has *a* record, but OPA (the sole source of truth for
+        # attestation freshness/validity, per spec) says it is not currently
+        # valid. The Python gate must defer to OPA's answer, never a local
+        # existence-only shortcut.
+        target = str(self.repo_enrolled_attested / "new_file.txt")
+        with mock.patch.object(
+            gate, "query_decision",
+            return_value=DecisionResult(
+                ok=True, allow=False, reason="plan-review SHIP for this session has expired",
+            ),
+        ) as spy:
+            result = gate.decide(
+                self._payload("write_file", {"path": target}, self.repo_unenrolled)
+            )
+            self.assertTrue(spy.called)  # @oracle LIA-523: the decision is routed through OPA, not answered from local ledger existence alone
+        # @oracle LIA-523: falsifies "no local logic re-implements/short-circuits
+        # freshness" -- an expired (OPA-denied) attestation must block exactly
+        # like no attestation at all, never fall through to allow because *a*
+        # record happens to exist on disk.
+        self.assertEqual(result.get("action"), "block")
+
+    # -- fail-closed: OPA unreachable ----------------------------------------
+
+    def test_opa_unreachable_blocks_enrolled_repo(self):
+        target = str(self.repo_enrolled_attested / "new_file.txt")
+        with mock.patch.object(
+            gate, "query_decision",
+            return_value=DecisionResult(ok=False, allow=False, reason="", error="connection refused"),
+        ):
+            result = gate.decide(
+                self._payload("write_file", {"path": target}, self.repo_unenrolled)
+            )
+        self.assertEqual(result.get("action"), "block")  # @oracle LIA-523: OPA unreachable for an enrolled repo must fail closed, never allow
+
+    def test_opa_unreachable_still_allows_unenrolled_repo(self):
+        target = str(self.repo_unenrolled / "new_file.txt")
+        with mock.patch.object(
+            gate, "query_decision",
+            side_effect=AssertionError("OPA must not be queried for an unenrolled repo"),
+        ):
+            result = gate.decide(
+                self._payload("write_file", {"path": target}, self.repo_unenrolled)
+            )
+        self.assertEqual(result, ALLOW)  # @oracle LIA-523: an outage never blocks a repo this gate was never asked to enforce
+
+    # -- fail-closed: repo resolution -----------------------------------------
+
+    def test_absolute_target_with_no_git_repo_anywhere_blocks(self):
+        non_repo_target = str(self.root / "not-a-repo-at-all" / "new_file.txt")
+        result = gate.decide(
+            self._payload("write_file", {"path": non_repo_target}, self.repo_unenrolled)
+        )
+        # @oracle LIA-523: falsifies "no repo found -> treat as unenrolled -> allow".
+        # The spec requires failing closed when the walk to filesystem root never
+        # finds a git repo at all.
+        self.assertEqual(result.get("action"), "block")
+
+    def test_symlink_into_enrolled_unattested_repo_blocks(self):
+        # A real symlink living INSIDE the unenrolled repo, pointing at a file inside the
+        # enrolled-but-unattested repo. A write that "targets" the symlink's own path
+        # actually lands on the real file it points to -- repo identity must be resolved
+        # from the REAL destination, not the symlink's own containing directory. Found by
+        # the GPT co-gate: resolving from the symlink's own location instead of its target
+        # lets an unenrolled-or-attested repo's symlink smuggle a write into a different,
+        # protected repo.
+        symlink_path = self.repo_unenrolled / "link_into_repo_a.txt"
+        real_target = self.repo_enrolled_unattested / "real_file.txt"
+        real_target.write_text("hello\n")
+        symlink_path.symlink_to(real_target)
+        with self._deny_everything_opa():
+            result = gate.decide(
+                self._payload("write_file", {"path": str(symlink_path)}, self.repo_unenrolled)
+            )
+        # @oracle LIA-523: falsifies an implementation that resolves repo_id from the
+        # symlink's own parent directory (repo_unenrolled, which this call's cwd is also
+        # set to -- so a symlink-blind bug would see BOTH cwd and "target" as unenrolled
+        # and wrongly allow) instead of the real file it points to.
+        self.assertEqual(result.get("action"), "block")
+
+    # -- item 6: total exception containment ----------------------------------
+
+    def test_corrupt_ledger_blocks(self):
+        self.ledger.parent.mkdir(parents=True, exist_ok=True)
+        self.ledger.write_text("{not valid json")
+        target = str(self.repo_enrolled_attested / "new_file.txt")
+        result = gate.decide(
+            self._payload("write_file", {"path": target}, self.repo_unenrolled)
+        )
+        self.assertEqual(result.get("action"), "block")  # @oracle LIA-523: an unreadable ledger must block, never crash or silently allow
+
+    def test_main_never_raises_on_malformed_stdin(self):
+        import io
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO("not json at all")
+        try:
+            exit_code = gate.main()
+        finally:
+            sys.stdin = old_stdin
+        self.assertEqual(exit_code, 0)  # @oracle LIA-523: malformed stdin must still exit 0 (Hermes treats non-zero/crash as allow)
+
+    def test_main_never_raises_on_malformed_patch_payload(self):
+        # mode == "patch" but the required "patch" key is missing entirely --
+        # a plausible internal KeyError deep inside patch parsing.
+        malformed = json.dumps({
+            "tool_name": "patch",
+            "tool_input": {"mode": "patch"},
+            "session_id": SESSION_ID,
+            "cwd": str(self.repo_enrolled_unattested),
+            "extra": {},
+        })
+        import io
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO(malformed)
+        try:
+            captured_stdout = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured_stdout
+            try:
+                exit_code = gate.main()
+            finally:
+                sys.stdout = old_stdout
+        finally:
+            sys.stdin = old_stdin
+        self.assertEqual(exit_code, 0)  # @oracle LIA-523: an internal parsing error must still exit 0
+        printed = json.loads(captured_stdout.getvalue())
+        # @oracle LIA-523: an internal error must produce an EXPLICIT block, not an
+        # accidental `{}` allow -- the fail-closed floor for any unexpected exception.
+        self.assertEqual(printed.get("action"), "block")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fresh PR replacing #1132, which is closed — that PR's `pull_request`-event CI checks never triggered across 3 pushes and a close/reopen (confirmed via direct GitHub API query: zero `event=pull_request` workflow runs for that branch, while other PRs' CI worked normally during the same window). This branch is rebased onto the current `origin/main` tip and contains the identical, already-reviewed content (confirmed via `git diff` against the old branch's HEAD: empty for every LIA-523 source file).

Extends the OPA/Rego attestation-ledger substrate (Phase 0-2, `docs/decisions/opa-warden-attestations-v1.md`) with a second Hermes gate type: a `pre_tool_call` adapter for `write_file`/`patch`, covering the pre-implementation half of safe day-to-day Hermes development that the existing code-review gate (`terminal`/git commits only) never did.

- **Corrects the roadmap's own assumption** that this needed LIA-521's fork/monkeypatch pattern — Hermes already has a native, production `pre_tool_call` hook (already used by `hermes_warden_gate.py`), so this needed **zero Hermes source changes**.
- `scripts/hermes_plan_review_gate.py` (new): branches on path shape first — absolute targets resolve their own precise `repo_id` (via `Path.resolve()`, closing a symlink-based bypass found by the GPT co-gate) and are checked against that repo's own enrollment/attestation state, never consulting `payload["cwd"]`; relative targets (v1 cannot precisely resolve these) get only a coarse, non-authoritative cwd-based gate-applicability pre-check. Every target in a multi-file patch is checked independently before any call-level decision, closing a false-ALLOW the GPT co-gate found in an earlier draft. Resolution is deadline-checked and deduped by `repo_id` so a large multi-file patch can't exhaust the self-deadline before reaching OPA.
- `attestation_store.py`: `issue()` gained a `kind` param for session-bound subjects; `enroll()` changed from a wholesale dict-replace to a merge (a real, necessary data-integrity fix); new `set_plan_review_enabled()` adds a second, independent, purely additive enrollment surface that doesn't touch `enroll()`'s existing shape or LIA-527 Phase 2's already-merged oracle.
- `guardrails.rego`: new, additive `plan_review_enrolled`/`valid_plan_review_ship` facts + 3 decision bodies for a `"file.write"` operation, including a configurable session-attestation TTL. The existing bare `enrolled` fact and all three `"git.commit"` decision bodies are byte-unchanged.
- `attestation-v1.schema.json`: `subject.kind` widened via `if`/`then`/`else`; `gate` enum widened; `enforced_repos` gained the optional `plan_review_enabled` field.
- `warden_attest.py`: new `plan-review`/`enable-plan-review`/`disable-plan-review` subcommands; fixed a real pre-existing `KeyError` in `inspect` on session-kind subjects.
- Independent oracle (`test_hermes_plan_review_gate_oracle.py`, 25 cases) authored via `oracle-author` from the spec before this file existed — confirmed red for the right reason, then green.

Went through 12 substantive plan-review rounds (Claude) + 2 GPT co-gate rounds before implementation, and 3 code-review rounds (Claude) + 2 GPT co-gate rounds before commit — each round found something real, including the repo-identity resolution design being discarded and rebuilt four times before landing on the absolute-paths-only v1 scope, and two more real security bugs (symlink bypass, deadline exhaustion) found by GPT on a diff that had already SHIP'd from Claude.

**Named v1 limitation**: relative-path `write_file`/`patch` calls block unconditionally once the target repo looks plan-review-enrolled — mitigated by the gate being opt-in per repo (`enable-plan-review`), not a global default.

**Not yet done, tracked explicitly in the ADR**: live end-to-end verification against a real Hermes session + OPA daemon, and wiring the new `hooks.pre_tool_call` entry into `~/.hermes/config.yaml` (this diff activates nothing by itself — no repo has `plan_review_enabled` set, and the hook isn't registered anywhere).

Linear: LIA-523.

## Test plan

- [x] `pytest scripts/warden_policy/tests/` (excl. pre-existing-red `test_cc_write_path_oracle.py`, LIA-527's own unimplemented Phase 2 oracle) — 181 passed
- [x] `opa test scripts/warden_policy/policy/` — 25/25
- [x] Independent oracle (`test_hermes_plan_review_gate_oracle.py`) authored blind before implementation, confirmed red (`ModuleNotFoundError`) then green — 25/25
- [x] plan-reviewer SHIP (Claude, 12 rounds) + SHIP (GPT co-gate)
- [x] code-reviewer SHIP (Claude, 3 rounds) + SHIP (GPT co-gate); GLM co-gate `COULD_NOT_RUN` (HTTP 429 insufficient balance — fails open per established precedent, e.g. LIA-527)
- [ ] Live e2e verification against a real Hermes session + OPA daemon (tracked as explicit follow-up in the ADR, not silently dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)