### PR TITLE
feat(warden-policy): isolated CC attestation write path (LIA-527 Phase 2)

### DIFF
--- a/docs/decisions/opa-warden-attestations-v1.md
+++ b/docs/decisions/opa-warden-attestations-v1.md
@@ -320,13 +320,16 @@ property was **self-authored by the implementer**, not produced independently vi
 (the implementing agent had no dispatch capability). An independently authored oracle should be
 run before any Phase 2 cutover.
 
-### Phase 2 — isolated CC write path (design only; not yet implemented)
+### Phase 2 — isolated CC write path (LIA-527, implemented; gate wiring tracked separately as LIA-534)
 
-This section designs the write path Phase 1 deliberately left undesigned. It does not
-implement it, does not enable any cutover, and does not change what any existing gate
-does. Written now because the design itself is reviewable independently of real shadow data;
-the *cutover decision* (which gates, if any, start consulting OPA) still needs that data and
-is explicitly out of scope here — see "Not yet started" below.
+This section designs, and (as of LIA-527) implements, the write path Phase 1 deliberately left
+undesigned. Implemented: the six-site `AttestationStore` parameterization, `issue_if_newer`,
+`scripts/warden_policy/cc_attestations.py`, and the CC-specific schema file. Not implemented
+here, and tracked separately: wiring `cc_attestations.enqueue_verdict` into any Claude Code
+gate (LIA-534) and any Rego rule consulting `data.warden_cc_attestations` (LIA-530 item 2) — so
+this phase still does not enable any cutover, and does not change what any existing gate does.
+The *cutover decision* (which gates, if any, start consulting OPA) still needs real shadow data
+and is explicitly out of scope here — see "Not yet started" below.
 
 **Chosen shape: an isolated document, not a fixed `_mutate` ordering.** Phase 1's own write-path
 post-mortem (above) identified the root cause precisely: `_mutate` persists disk at
@@ -670,19 +673,25 @@ regardless of the wrapper's own correctness. It is expected **red** until Phase 
 implemented; passing it is a precondition for treating the write path as done, not evidence it
 already is.
 
-**Not yet started, and why:** actual implementation of `AttestationStore`'s parameterization
-(all six sites), the new `cc_attestations` write/worker/sweep call sites, and the CC-specific
-schema file. Two independent reasons to hold here rather than implement in the same pass as this
-design: (1) LIA-527 itself is the lowest-urgency item in the roadmap by explicit prior decision —
-implementation should not compete for attention with higher-priority work; (2) the *cutover*
-decision this write path exists to eventually support needs real shadow-observer data first, and
-as of this design there is essentially none — `~/.config/deus/guardrails/logs/cc-shadow.jsonl`
-holds 9 lines, all from 2026-08-04 pre-toggle dev testing; the toggle (LIA-520) was only switched
-on 2026-08-07, less than two hours before this section was written, and has produced zero new
-observations since (no commit gate has fired in that window). Implementing the write path itself
-is not blocked on that data — only the cutover is — but there is no benefit to landing unused
-write-path code before the data that would justify designing the cutover on top of it exists.
-Tracked as explicit follow-up scope, not silently dropped.
+**Not yet started, and why** *(historical — as of this design's 7th review round, before
+LIA-527 implemented it; kept for the reasoning, superseded by the heading above)*: actual
+implementation of `AttestationStore`'s parameterization (all six sites), the new `cc_attestations`
+write/worker/sweep call sites, and the CC-specific schema file. Two independent reasons to hold
+here rather than implement in the same pass as this design: (1) LIA-527 itself is the
+lowest-urgency item in the roadmap by explicit prior decision — implementation should not compete
+for attention with higher-priority work; (2) the *cutover* decision this write path exists to
+eventually support needs real shadow-observer data first, and as of this design there is
+essentially none — `~/.config/deus/guardrails/logs/cc-shadow.jsonl` holds 9 lines, all from
+2026-08-04 pre-toggle dev testing; the toggle (LIA-520) was only switched on 2026-08-07, less than
+two hours before this section was written, and has produced zero new observations since (no
+commit gate has fired in that window). Implementing the write path itself is not blocked on that
+data — only the cutover is — but there is no benefit to landing unused write-path code before the
+data that would justify designing the cutover on top of it exists. Tracked as explicit follow-up
+scope, not silently dropped.
+
+**Still not yet started, current** — post-LIA-527: `cc_attestations.enqueue_verdict` wiring into
+any Claude Code gate (LIA-534) and the Rego cutover rule (LIA-530 item 2). Both remain out of
+scope for LIA-527 itself.
 
 **Scope check** (round-count-circuit-breaker, per `plan-review-rules.md`): after 7 review rounds,
 re-confirming this is still the smallest design that satisfies LIA-527's ask — "design the write

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-08" # auto-bump @1786179713
+last_verified: "2026-08-08" # auto-bump @1786182880
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -108,6 +108,13 @@ def main():
         "compress_sweep", [compress_sweep], dry_run, timeout=600,
     )
 
+    # LIA-527 Phase 2: reclaims cc-write-queue job files a crashed/killed detached worker
+    # missed. Single-best-effort-no-retry design -- see cc_write_queue_sweep.py's docstring.
+    cc_write_queue_sweep = str(SCRIPTS_DIR / "maintenance" / "cc_write_queue_sweep.py")
+    results["cc_write_queue_sweep"] = run_task(
+        "cc_write_queue_sweep", [cc_write_queue_sweep], dry_run,
+    )
+
     # ── Weekly tasks (Sunday or --weekly) ────────────────────────────────────
 
     if run_weekly:

--- a/scripts/maintenance/cc_write_queue_sweep.py
+++ b/scripts/maintenance/cc_write_queue_sweep.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Stale-job sweep for the LIA-527 Phase 2 CC write-path queue
+(see ../warden_policy/cc_attestations.py and
+../../docs/decisions/opa-warden-attestations-v1.md's Phase 2 section).
+
+Deletes any `*.json` in `cc_attestations.QUEUE_DIR` older than 24h -- a job the
+detached worker never got to, or got to and crashed before deleting. No
+`.running`/`.failed` state machine or attempts counter is needed here (unlike
+compress_sweep.py's sibling queue): this design already chose
+single-best-effort-no-retry, so a stale file is definitionally one there is
+nothing left to retry, only to reclaim.
+
+Registered in scripts/maintenance.py's Daily section.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+from warden_policy.cc_attestations import QUEUE_DIR  # noqa: E402
+
+STALE_AFTER_SECONDS = 24 * 60 * 60
+
+
+def sweep(dry_run: bool = False) -> int:
+    if not QUEUE_DIR.exists():
+        print("cc_write_queue_sweep: no queue dir, nothing to do")
+        return 0
+
+    now = time.time()
+    deleted = 0
+    # `*.json`: normal queued jobs. `.tmp-cc-job-*`: enqueue_verdict's own mkstemp staging
+    # prefix (cc_attestations.py) -- a SIGKILL between mkstemp and os.replace leaks one of
+    # these with no `.json` suffix, otherwise unreclaimable by this sweep.
+    targets = sorted(QUEUE_DIR.glob("*.json")) + sorted(QUEUE_DIR.glob(".tmp-cc-job-*"))
+    for entry in targets:
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError:
+            continue
+        if age <= STALE_AFTER_SECONDS:
+            continue
+        if dry_run:
+            print(f"cc_write_queue_sweep: would delete stale {entry.name} (age {age:.0f}s)")
+            continue
+        try:
+            entry.unlink()
+        except OSError:
+            continue
+        deleted += 1
+        print(f"cc_write_queue_sweep: deleted stale {entry.name} (age {age:.0f}s)")
+
+    print(f"cc_write_queue_sweep: deleted {deleted} stale job(s)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true", help="Print what would happen; touch nothing.")
+    args = parser.parse_args(argv)
+    return sweep(args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/warden_policy/attestation_store.py
+++ b/scripts/warden_policy/attestation_store.py
@@ -52,13 +52,16 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 OPA_DEFAULT_BASE_URL = "http://127.0.0.1:8181"
-OPA_DATA_PATH = "/v1/data/warden_attestations"
+#: Hermes's own document key -- the default for every existing call site (Hermes's, Phase 0's
+#: `backend=`, `warden_attest.py`'s CLI). A separate, isolated document/store (`cc_attestations.py`)
+#: uses AttestationStore.__init__'s `document_key`/`opa_data_path` params instead of this default.
+_DEFAULT_DOCUMENT_KEY = "warden_attestations"
 _OPA_TIMEOUT_SECONDS = 5
 
 
-def _empty_document() -> dict[str, Any]:
+def _empty_document(document_key: str) -> dict[str, Any]:
     return {
-        "warden_attestations": {
+        document_key: {
             "schema_version": SCHEMA_VERSION,
             "generation": 0,
             "config": {"enforced_repos": {}},
@@ -66,6 +69,28 @@ def _empty_document() -> dict[str, Any]:
             "latest": {},
         }
     }
+
+
+def _build_subject(kind: str, subject_key: str) -> dict[str, Any]:
+    """Pure subject-dict constructor shared by `issue()` and `issue_if_newer()`.
+
+    Callers MUST validate `kind in ("git-tree", "session")` themselves before calling this --
+    it only branches on `kind == "git-tree"` vs. else, so an unvalidated unknown `kind` would
+    silently be treated as `"session"` if a caller dropped its own guard.
+    """
+    if kind == "git-tree":
+        # Every existing call site: byte-for-byte the same shape as before `kind` existed.
+        return {
+            "kind": "git-tree",
+            "key": subject_key,
+            "digest": {
+                "algorithm": subject_key.split(":")[1],
+                "value": subject_key.split(":")[2],
+            },
+        }
+    # session subject: subject_key carries the raw, opaque session_id -- nothing to hash/digest
+    # (unlike a repo-relative git path, a session id has no sensitive structure to redact).
+    return {"kind": "session", "session_id": subject_key}
 
 
 @dataclass(frozen=True)
@@ -81,11 +106,24 @@ class AttestationStoreError(Exception):
 
 
 class AttestationStore:
-    def __init__(self, ledger_path: Path, opa_base_url: str = OPA_DEFAULT_BASE_URL):
+    def __init__(
+        self,
+        ledger_path: Path,
+        opa_base_url: str = OPA_DEFAULT_BASE_URL,
+        *,
+        document_key: str = _DEFAULT_DOCUMENT_KEY,
+        opa_data_path: str | None = None,
+    ):
         self.ledger_path = Path(ledger_path)
         self.lock_path = self.ledger_path.with_suffix(self.ledger_path.suffix + ".lock")
         self.opa_base_url = opa_base_url.rstrip("/")
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # LIA-527 Phase 2: every existing call site passes neither kwarg and gets byte-identical
+        # behavior (document_key defaults to Hermes's own "warden_attestations"). The isolated CC
+        # store (cc_attestations.py) passes document_key="warden_cc_attestations" so its writes
+        # can never land in -- or overwrite -- Hermes's live OPA document.
+        self.document_key = document_key
+        self.opa_data_path = opa_data_path or f"/v1/data/{document_key}"
 
     # -- locking ------------------------------------------------------
 
@@ -104,14 +142,14 @@ class AttestationStore:
 
     def _read_disk(self) -> dict[str, Any]:
         if not self.ledger_path.exists():
-            return _empty_document()
+            return _empty_document(self.document_key)
         try:
             with open(self.ledger_path, encoding="utf-8") as f:
                 doc = json.load(f)
         except (json.JSONDecodeError, OSError) as exc:
             raise AttestationStoreError(f"ledger unreadable/corrupt: {exc}") from exc
-        if "warden_attestations" not in doc:
-            raise AttestationStoreError("ledger missing warden_attestations root key")
+        if self.document_key not in doc:
+            raise AttestationStoreError(f"ledger missing {self.document_key} root key")
         return doc
 
     def _write_disk_atomic(self, doc: dict[str, Any]) -> None:
@@ -137,9 +175,12 @@ class AttestationStore:
     # -- OPA sync ---------------------------------------------------------
 
     def _put_and_readback(self, inner_doc: dict[str, Any]) -> tuple[bool, int | None, str | None]:
+        # Must read self.opa_data_path here, not a module-level constant -- otherwise an
+        # isolated CC store's write would still PUT to Hermes's live OPA document regardless
+        # of what the on-disk ledger's own key is named.
         body = json.dumps(inner_doc).encode("utf-8")
         req = urllib.request.Request(
-            self.opa_base_url + OPA_DATA_PATH, data=body,
+            self.opa_base_url + self.opa_data_path, data=body,
             headers={"Content-Type": "application/json"}, method="PUT",
         )
         try:
@@ -148,7 +189,7 @@ class AttestationStore:
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             return False, None, f"PUT to OPA failed: {exc}"
 
-        gen_req = urllib.request.Request(self.opa_base_url + OPA_DATA_PATH + "/generation")
+        gen_req = urllib.request.Request(self.opa_base_url + self.opa_data_path + "/generation")
         try:
             with urllib.request.urlopen(gen_req, timeout=_OPA_TIMEOUT_SECONDS) as resp:
                 result = json.loads(resp.read()).get("result")
@@ -189,7 +230,7 @@ class AttestationStore:
     def _mutate(self, apply_fn) -> WriteResult:
         with self._locked(exclusive=True):
             doc = self._read_disk()
-            inner = doc["warden_attestations"]
+            inner = doc[self.document_key]
             apply_fn(inner)
             inner["generation"] = inner["generation"] + 1
             self._write_disk_atomic(doc)
@@ -263,22 +304,7 @@ class AttestationStore:
 
         def _apply(inner):
             record_id = f"att-{uuid.uuid4()}"
-            if kind == "git-tree":
-                # Every existing call site: byte-for-byte the same shape as before `kind`
-                # existed.
-                subject = {
-                    "kind": "git-tree",
-                    "key": subject_key,
-                    "digest": {
-                        "algorithm": subject_key.split(":")[1],
-                        "value": subject_key.split(":")[2],
-                    },
-                }
-            else:
-                # session subject: subject_key carries the raw, opaque session_id -- nothing
-                # to hash/digest (unlike a repo-relative git path, a session id has no
-                # sensitive structure to redact).
-                subject = {"kind": "session", "session_id": subject_key}
+            subject = _build_subject(kind, subject_key)
             record = {
                 "id": record_id,
                 "schema_version": SCHEMA_VERSION,
@@ -306,17 +332,82 @@ class AttestationStore:
                 ).setdefault(subject_key, {})[backend] = record_id
         return self._mutate(_apply)
 
+    def issue_if_newer(
+        self, *, repo_id: str, gate: str, subject_key: str, verdict: str,
+        issuer_kind: str, reviewer_id: str, reason: str, queued_at: int,
+        backend: str | None = None, kind: str = "git-tree",
+    ) -> WriteResult:
+        """LIA-527 Phase 2: `issue()`, layered with an ordering guard for detached, concurrently
+        completing writers (see `cc_attestations.py`'s worker pattern).
+
+        `flock` mutual exclusion alone only prevents two writers from writing *concurrently* --
+        it says nothing about which one writes *last*. Detached workers acquire the lock in
+        whatever order the OS schedules them, which is not enqueue order. This method compares
+        `queued_at` (caller-supplied, `time.time_ns()` wall-clock -- reboot-durable, unlike
+        `monotonic_ns()`) against whichever record the relevant `latest`/`latest_by_backend`
+        pointer currently references, and only advances the pointer when this write is strictly
+        newer -- entirely INSIDE `_mutate`'s own exclusive-lock critical section, so there is no
+        separate pre-lock read for a concurrent writer to race against. Ties are broken in favor
+        of the already-established pointer (never flipped by an equal `queued_at`). The
+        append-only `records` map still gains the new record unconditionally either way -- only
+        pointer advancement is guarded, so a "superseded" write is not an error, just a write
+        that correctly loses the ordering comparison.
+        """
+        if verdict not in ("SHIP", "REVISE", "BLOCK", "COULD_NOT_RUN"):
+            raise AttestationStoreError(f"invalid verdict {verdict!r}")
+        if kind not in ("git-tree", "session"):
+            raise AttestationStoreError(f"invalid subject kind {kind!r}")
+
+        def _apply(inner):
+            record_id = f"att-{uuid.uuid4()}"
+            subject = _build_subject(kind, subject_key)
+            record = {
+                "id": record_id,
+                "schema_version": SCHEMA_VERSION,
+                "repo_id": repo_id,
+                "gate": gate,
+                "subject": subject,
+                "verdict": verdict,
+                "issuer": {"kind": issuer_kind, "reviewer_id": reviewer_id},
+                "issued_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "reason": reason,
+                "queued_at": queued_at,
+            }
+            if backend is None:
+                pointer_scope = inner["latest"].setdefault(repo_id, {}).setdefault(gate, {})
+                pointer_key = subject_key
+            else:
+                record["backend"] = backend
+                pointer_scope = inner.setdefault("latest_by_backend", {}).setdefault(
+                    repo_id, {}
+                ).setdefault(gate, {}).setdefault(subject_key, {})
+                pointer_key = backend
+            # Append-only: every attempted write lands in `records`, regardless of whether it
+            # goes on to win or lose the ordering comparison below.
+            inner["records"][record_id] = record
+            existing_id = pointer_scope.get(pointer_key)
+            existing_queued_at = (
+                inner["records"].get(existing_id, {}).get("queued_at") if existing_id else None
+            )
+            # Strict >: a missing existing_queued_at (no prior pointer, or a pre-existing plain
+            # issue()-written record that predates this field) counts as always-older, so the
+            # first write for a key always becomes latest. An equal queued_at never flips an
+            # already-established pointer.
+            if existing_queued_at is None or queued_at > existing_queued_at:
+                pointer_scope[pointer_key] = record_id
+        return self._mutate(_apply)
+
     def sync(self) -> WriteResult:
         """Re-PUT the current disk state to OPA without incrementing generation -- the
         retry path when a prior write's PUT/read-back failed ("persisted but not activated")."""
         with self._locked(exclusive=True):
             doc = self._read_disk()
-            inner = doc["warden_attestations"]
+            inner = doc[self.document_key]
             ok, activated_gen, err = self._put_and_readback(inner)
             return WriteResult(ok=ok, generation=inner["generation"], activated=ok, error=err)
 
     def inspect(self, repo_id: str) -> list[dict[str, Any]]:
         with self._locked(exclusive=False):
             doc = self._read_disk()
-        inner = doc["warden_attestations"]
+        inner = doc[self.document_key]
         return [r for r in inner["records"].values() if r["repo_id"] == repo_id]

--- a/scripts/warden_policy/cc_attestations.py
+++ b/scripts/warden_policy/cc_attestations.py
@@ -1,0 +1,194 @@
+"""Isolated Claude-Code-authored attestation write path (LIA-527 Phase 2).
+
+See ``docs/decisions/opa-warden-attestations-v1.md``'s "### Phase 2 -- isolated CC write path"
+section for the full design, including the ordering-guard rationale behind
+``AttestationStore.issue_if_newer``.
+
+Two public functions:
+
+- ``enqueue_verdict(...)`` -- the hook call site's entry point. Writes one job file atomically
+  and spawns a fully-detached worker subprocess, returning immediately with no wait of any kind.
+  **No production caller yet.** Wiring this into ``codex_warden_hooks.py``'s
+  ``run_warden_backends_gate``/``run_verification_gate`` (the ADR's "Who writes, and when"
+  section) is a deliberately separate, distinct follow-up -- not bundled into the PR that adds
+  this module, since those gate functions run on every commit's critical path across every
+  enrolled repo and deserve their own dedicated review pass. Tracked as LIA-534. Do not wire this
+  module into those gates as a side effect of an unrelated change; that wiring is LIA-534's own
+  scope.
+- ``process_job(job_id, ...)`` -- the detached worker's entry point (what ``--worker <job_id>``
+  invokes). Performs the actual ``cc_store.issue_if_newer()`` call and reports whether the job
+  file should be deleted.
+
+Absolute imports with an explicit ``sys.path`` insert (not the package-relative imports
+``cc_shadow.py`` uses), because unlike ``cc_shadow.py`` this module is also re-invoked directly
+as ``python3 cc_attestations.py --worker <job_id>`` by its own spawned worker subprocess -- under
+that invocation ``__name__ == "__main__"`` and there is no parent package context for a relative
+import to resolve against.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+from warden_policy.attestation_store import AttestationStore  # noqa: E402
+
+#: The isolated OPA data document CC writes target -- distinct from Hermes's own
+#: "warden_attestations", so a failed CC write can never desynchronize Hermes's gate.
+CC_DOCUMENT_KEY = "warden_cc_attestations"
+CC_LEDGER_PATH = Path.home() / ".config" / "deus" / "guardrails" / "attestations-cc-v1.json"
+QUEUE_DIR = Path.home() / ".config" / "deus" / "guardrails" / "cc-write-queue"
+
+#: The legacy gate's human trivial-commit bypass. AttestationStore.issue()/issue_if_newer()
+#: reject this outright as an invalid verdict -- enqueue_verdict must recognize and skip it
+#: BEFORE doing anything else, never invent a synthetic non-TRIVIAL verdict to satisfy the
+#: schema. A TRIVIAL-bypassed commit was never actually reviewed by a backend, so the CC ledger
+#: simply has no record for it -- that's honest, not a gap.
+TRIVIAL_VERDICT = "TRIVIAL"
+
+
+def _cc_store(ledger_path: Path) -> AttestationStore:
+    return AttestationStore(ledger_path, document_key=CC_DOCUMENT_KEY)
+
+
+def enqueue_verdict(
+    *,
+    repo_id: str,
+    gate: str,
+    subject_key: str,
+    verdict: str,
+    issuer_kind: str,
+    reviewer_id: str,
+    reason: str,
+    backend: str,
+    queue_dir: Path = QUEUE_DIR,
+) -> None:
+    """Write one job file + spawn a detached worker. Returns None unconditionally.
+
+    Every failure -- including a bug in this function -- is swallowed by the broad
+    ``try/except`` below, matching ``cc_shadow.observe()``'s containment floor: a mirror-write
+    attempt must never be able to affect the gate that already decided.
+    """
+    try:
+        if verdict == TRIVIAL_VERDICT:
+            return None
+
+        queue_dir = Path(queue_dir)
+        queue_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        job_id = str(uuid.uuid4())
+        job = {
+            "repo_id": repo_id,
+            "gate": gate,
+            "subject_key": subject_key,
+            "verdict": verdict,
+            "issuer_kind": issuer_kind,
+            "reviewer_id": reviewer_id,
+            "reason": reason,
+            "backend": backend,
+            "queued_at": time.time_ns(),
+        }
+
+        fd, tmp_path = tempfile.mkstemp(dir=queue_dir, prefix=".tmp-cc-job-")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(job, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, queue_dir / f"{job_id}.json")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+
+        # Fully detached: no join, no timeout, no wait of any kind -- the hook process that
+        # calls enqueue_verdict is short-lived (main() -> sys.exit(main())) and must return
+        # immediately regardless of how long the actual write takes.
+        #
+        # --queue-dir is always passed, positioned BEFORE --worker <job_id>, so the worker
+        # reads from the SAME directory the job file was written to -- a caller using the
+        # public queue_dir override would otherwise spawn a worker that silently looks in the
+        # module-default QUEUE_DIR instead. Positioning it before --worker also keeps
+        # argv[-1] == job_id.
+        subprocess.Popen(
+            [
+                sys.executable, str(Path(__file__).resolve()),
+                "--queue-dir", str(queue_dir),
+                "--worker", job_id,
+            ],
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:  # noqa: BLE001 -- containment floor, matches cc_shadow.observe()
+        pass
+    return None
+
+
+def process_job(
+    job_id: str, *, queue_dir: Path = QUEUE_DIR, ledger_path: Path = CC_LEDGER_PATH,
+) -> bool:
+    """Detached worker body: read the job file, write it through, report deletion eligibility.
+
+    Returns True iff the write persisted to disk (``WriteResult.ok is True``) -- regardless of
+    OPA activation, and regardless of whether the ordering comparison inside
+    ``issue_if_newer`` was won or lost. A persisted-but-not-activated write (OPA unreachable) is
+    this ledger's normal "failed PUT" state, which ``sync()`` already exists to retry on a later
+    mutation; gating deletion on ``.activated`` instead would leave every job attempted during an
+    OPA outage stuck in the queue with no retry path.
+
+    Does NOT delete the job file itself -- that's the ``--worker`` CLI wrapper's job when this
+    returns True, so ``process_job`` stays a pure "did it land" query, testable without touching
+    the filesystem beyond the job/ledger files it's explicitly given.
+    """
+    job_path = Path(queue_dir) / f"{job_id}.json"
+    store = _cc_store(Path(ledger_path))
+    try:
+        payload = json.loads(job_path.read_text(encoding="utf-8"))
+        kwargs = {
+            key: payload[key]
+            for key in (
+                "repo_id", "gate", "subject_key", "verdict", "issuer_kind", "reviewer_id",
+                "reason", "queued_at",
+            )
+        }
+        if payload.get("backend") is not None:
+            kwargs["backend"] = payload["backend"]
+        result = store.issue_if_newer(**kwargs)
+    except Exception:
+        # A permanently-invalid job (missing/malformed file, or a payload issue_if_newer
+        # rejects -- bad verdict, malformed subject_key, ...) has no retry path that would ever
+        # succeed -- it sits until the 24h stale-job sweep reclaims it, producing one sweep log
+        # line. Single-best-effort-no-retry, per the ADR. Covers both a corrupt/unreadable job
+        # file AND a store-layer rejection under the same containment.
+        return False
+    return result.ok is True
+
+
+def _worker_main(job_id: str, *, queue_dir: Path = QUEUE_DIR) -> None:
+    queue_dir = Path(queue_dir)
+    if process_job(job_id, queue_dir=queue_dir):
+        (queue_dir / f"{job_id}.json").unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    if "--worker" in sys.argv:
+        _job_id = sys.argv[sys.argv.index("--worker") + 1]
+        _queue_dir = QUEUE_DIR
+        if "--queue-dir" in sys.argv:
+            _queue_dir = Path(sys.argv[sys.argv.index("--queue-dir") + 1])
+        try:
+            _worker_main(_job_id, queue_dir=_queue_dir)
+        except Exception as e:
+            sys.stderr.write(f"[cc-attestations worker] {type(e).__name__}: {e}\n")

--- a/scripts/warden_policy/policy/attestation-cc-v1.schema.json
+++ b/scripts/warden_policy/policy/attestation-cc-v1.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://deus.local/schemas/warden-attestations-cc-v1.schema.json",
+  "title": "Claude-Code-authored attestation ledger v1 (LIA-527 Phase 2)",
+  "description": "OPA data document for scripts/warden_policy's isolated CC write path (docs/decisions/opa-warden-attestations-v1.md, Phase 2). Backed by its own on-disk ledger and its own generation counter -- wholly separate from attestation-v1.schema.json's warden_attestations document, so a failed write here can never desynchronize Hermes's own gate. Append-only: a new verdict adds a record and advances latest/latest_by_backend; no record is ever edited or deleted.",
+  "type": "object",
+  "required": ["warden_cc_attestations"],
+  "additionalProperties": false,
+  "properties": {
+    "warden_cc_attestations": {
+      "type": "object",
+      "required": ["schema_version", "generation", "config", "records", "latest"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": { "const": 1 },
+        "generation": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monotonically incremented on every mutating write to this document. Independent of warden_attestations's own generation counter."
+        },
+        "config": {
+          "type": "object",
+          "required": ["enforced_repos"],
+          "additionalProperties": false,
+          "properties": {
+            "enforced_repos": {
+              "type": "object",
+              "description": "Unused by the CC write path today (no enroll()/unenroll() call site writes this document) -- present only for structural parity with warden_attestations. No Rego rule consults data.warden_cc_attestations yet (Phase 2 designs writing only).",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "enabled": { "type": "boolean" },
+                  "enrolled_at": { "type": "string", "format": "date-time" }
+                }
+              }
+            }
+          }
+        },
+        "records": {
+          "type": "object",
+          "description": "Keyed by attestation id (att-<uuid>). Immutable once written.",
+          "additionalProperties": { "$ref": "#/$defs/record" }
+        },
+        "latest": {
+          "type": "object",
+          "description": "repo_id -> gate -> subject_key -> attestation id, advanced only when issue_if_newer's ordering guard determines the write is newer than whatever the pointer currently references.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": { "type": "string", "pattern": "^att-" }
+            }
+          }
+        },
+        "latest_by_backend": {
+          "type": "object",
+          "description": "repo_id -> gate -> subject_key -> backend -> attestation id. This is the pointer shape CC writes actually use (every enqueue_verdict call passes backend=). Additive, optional -- absent entirely on a ledger that has never issued a write.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": { "type": "string", "pattern": "^att-" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "record": {
+      "type": "object",
+      "required": ["id", "schema_version", "repo_id", "gate", "subject", "verdict", "issuer", "issued_at", "reason", "queued_at"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^att-" },
+        "schema_version": { "const": 1 },
+        "repo_id": { "type": "string", "pattern": "^git-common-dir-sha256:[0-9a-f]{64}$" },
+        "gate": { "type": "string", "enum": ["code-review", "code-reviewer", "ai-eng-warden", "plan-review", "verification-gate"] },
+        "subject": {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["git-tree", "session"] }
+          },
+          "if": { "properties": { "kind": { "const": "git-tree" } } },
+          "then": {
+            "required": ["kind", "key", "digest"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": { "const": "git-tree" },
+              "key": { "type": "string", "pattern": "^git-tree:(sha1|sha256):[0-9a-f]+$" },
+              "digest": {
+                "type": "object",
+                "required": ["algorithm", "value"],
+                "additionalProperties": false,
+                "properties": {
+                  "algorithm": { "type": "string", "enum": ["sha1", "sha256"] },
+                  "value": { "type": "string" }
+                }
+              }
+            }
+          },
+          "else": {
+            "required": ["kind", "session_id"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": { "const": "session" },
+              "session_id": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "verdict": { "type": "string", "enum": ["SHIP", "REVISE", "BLOCK", "COULD_NOT_RUN"] },
+        "issuer": {
+          "type": "object",
+          "required": ["kind", "reviewer_id"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "type": "string", "enum": ["manual", "script"] },
+            "reviewer_id": { "type": "string", "description": "<role>@<backend>, e.g. code-reviewer@claude -- mirrors verdict_store.py's record_script_verdict vocabulary." }
+          }
+        },
+        "issued_at": { "type": "string", "format": "date-time" },
+        "reason": { "type": "string" },
+        "backend": { "type": "string", "description": "Present for every CC record -- enqueue_verdict always passes backend=." },
+        "queued_at": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "time.time_ns() wall-clock timestamp at enqueue time. Persisted onto the record (not just the deleted-on-success job file) so a later issue_if_newer call has a durable value to compare its own queued_at against. Reboot-durable (unlike monotonic_ns()), nanosecond resolution."
+        }
+      }
+    }
+  }
+}

--- a/scripts/warden_policy/tests/test_cc_write_path_oracle.py
+++ b/scripts/warden_policy/tests/test_cc_write_path_oracle.py
@@ -319,14 +319,16 @@ class TestCcWriteResultDeletionOracle(unittest.TestCase):
             should_delete = process_job(job_id, queue_dir=queue_dir, ledger_path=ledger_path)
             self.assertTrue(should_delete)  # @oracle LIA-527: a genuinely successful write also deletes its job
 
-        document = json.loads(ledger_path.read_text(encoding="utf-8"))
-        inner = document[CC_DOCUMENT_KEY]
-        record_id = inner["latest_by_backend"]["repo-real"]["code-reviewer"][subject_key][
-            "claude"
-        ]  # @oracle LIA-527: process_job actually calls issue_if_newer, which populates latest_by_backend
-        record = inner["records"][record_id]
-        self.assertEqual(record["verdict"], "SHIP")  # @oracle LIA-527: the persisted record's verdict matches the job's
-        self.assertEqual(record["subject"]["key"], subject_key)  # @oracle LIA-527: the persisted record's subject matches the job's
+            # Read-back must stay INSIDE the `with` block: tempfile.TemporaryDirectory deletes
+            # `tmp` -- and therefore `ledger_path`, which lives under it -- on __exit__.
+            document = json.loads(ledger_path.read_text(encoding="utf-8"))
+            inner = document[CC_DOCUMENT_KEY]
+            record_id = inner["latest_by_backend"]["repo-real"]["code-reviewer"][subject_key][
+                "claude"
+            ]  # @oracle LIA-527: process_job actually calls issue_if_newer, which populates latest_by_backend
+            record = inner["records"][record_id]
+            self.assertEqual(record["verdict"], "SHIP")  # @oracle LIA-527: the persisted record's verdict matches the job's
+            self.assertEqual(record["subject"]["key"], subject_key)  # @oracle LIA-527: the persisted record's subject matches the job's
 
 
 class TestCcTrivialVerdictOracle(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements `docs/decisions/opa-warden-attestations-v1.md`'s "### Phase 2 — isolated CC write path" section: an isolated OPA document (`warden_cc_attestations`) for Claude-Code-authored attestations, so a failed CC write can never desynchronize Hermes's own gate.

- `AttestationStore`: parameterize `document_key`/`opa_data_path` across all six sites that previously hardcoded `"warden_attestations"` (`_put_and_readback`, `_empty_document`, `_read_disk`, `_mutate`, `sync()`, `inspect()`). Every existing call site (Hermes's, Phase 0's `backend=`, `warden_attest.py`'s CLI) stays byte-identical -- no new required argument, no changed default.
- `AttestationStore.issue_if_newer()`: an ordering-guarded write for out-of-order concurrent detached workers. The `queued_at` comparison and conditional pointer-advance run entirely inside `_mutate`'s own exclusive-lock critical section, so there's no separate pre-lock read for a concurrent writer to race against. Ties keep the established pointer.
- New `scripts/warden_policy/cc_attestations.py`: `enqueue_verdict`/`process_job` per the ADR's public-interface spec, using a fully-detached-subprocess worker pattern mirroring `session_end_hook.py`'s `_spawn_worker`/`_run_worker`.
- New `scripts/warden_policy/policy/attestation-cc-v1.schema.json`: CC-specific schema (adds `verification-gate` to the `gate` enum; the Hermes-facing schema is untouched).
- New `scripts/maintenance/cc_write_queue_sweep.py` + registration in `scripts/maintenance.py`: reclaims stale queue jobs a crashed/killed detached worker missed.
- One fix to the pre-existing, independently-authored oracle (`test_cc_write_path_oracle.py`): a read-back assertion was dedented outside its `tempfile.TemporaryDirectory()` block, causing a guaranteed `FileNotFoundError` regardless of implementation correctness (the temp dir is deleted on `__exit__` before the read ran). Re-indented; no assertion semantics changed.

## Scope

Lands **LIA-530 item 1 only**. Explicitly out of scope, tracked separately:
- Wiring `cc_attestations.enqueue_verdict` into `codex_warden_hooks.py`'s commit gates (`run_warden_backends_gate`/`run_verification_gate`) — filed as **LIA-534**, cited in the module's docstring. `enqueue_verdict` has zero production callers in this diff by design.
- The Rego cutover rule consulting `data.warden_cc_attestations` — **LIA-530 item 2**, not yet designed.

No `guardrails.rego` change. `enroll()`/`_apply`/`enforced_repos` untouched (LIA-523's merge-based `_apply`, already on `main`, was independently confirmed to already accommodate this design).

## Review history

- **plan-reviewer** (Opus, 2 rounds): round 1 REVISE (3 warnings: regression-scope too narrow, missing connectivity-wiring citation, dead `OPA_DATA_PATH`) — all fixed. Round 2 SHIP, with 2 conditions (keep `kind` validation in both callers of the extracted `_build_subject` helper; use one constant for `__init__`'s default) — both applied.
- **GPT co-gate on the plan** (2 rounds): round 1 REVISE — caught a real bug (`queue_dir` not propagated to the spawned worker subprocess). Fixed via `--queue-dir <path>` inserted before `--worker <job_id>` in the `Popen` argv. Round 2 SHIP.
- **code-reviewer** (Opus): SHIP with 3 non-blocking warnings, all fixed (`process_job`'s payload-key extraction moved inside its `try` so a malformed job returns `False` instead of raising; dead `OPA_DATA_PATH` constant deleted; review-provenance narrative trimmed from shipped code comments) + 2 recommendations applied (sweep now also reclaims leaked `.tmp-cc-job-*` staging files; stale ADR Phase-2 heading updated).
- **GPT code-reviewer co-gate**: one round REVISE on a false positive (claimed the new sweep script needs an executable bit; verified false — `maintenance.py`'s `run_task` always invokes `[sys.executable, script_path]`, and the sibling `compress_sweep.py` has identical mode 644). Applied `chmod +x` anyway as a harmless, zero-risk resolution rather than disputing the round. Second round SHIP.
- **GLM code-reviewer co-gate**: `COULD_NOT_RUN` — genuine infra failure (HTTP 429, API billing), not a code defect. Fails open per this repo's established convention (`COULD_NOT_RUN` never blocks).
- **verification-gate** (Opus): SHIP, independently re-ran all evidence (full oracle red-green rebuild against HEAD, unmocked end-to-end smoke test of the real detached-worker path).

## Test plan

- [x] `python3 -m pytest scripts/warden_policy/tests/test_cc_write_path_oracle.py -q` — 76 failed/5 passed → **21/21 tests, 72/72 tagged assertions passing**.
- [x] `python3 -m pytest scripts/warden_policy/tests/ -q` — **202 passed, 63 subtests passed** (181/3 pre-existing baseline unchanged).
- [x] Real, unmocked natural-usage smoke test: called `cc_attestations.enqueue_verdict(...)` directly against production config paths (no test mocks), confirmed a real detached subprocess spawned, the record landed on disk under `latest_by_backend` with `queued_at`, and the job file was deleted after success. Cleaned up the resulting files afterward -- no residue left in `~/.config/deus/guardrails/`.
- [ ] CI (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)