### PR TITLE
fix(wardens): self-heal OPA/disk ledger desync via periodic reconciliation (LIA-533)

### DIFF
--- a/docs/HERMES_WARDEN_OPA.md
+++ b/docs/HERMES_WARDEN_OPA.md
@@ -36,7 +36,16 @@ operational how-to.
    launchctl kickstart -k gui/$(id -u)/com.deus.warden-opa
    curl -fsS 'http://127.0.0.1:8181/health?plugins'
    ```
-3. Add the Hermes hook (personal `~/.hermes/config.yaml`, never repo-committed):
+3. Install the periodic self-heal job (LIA-533) -- re-syncs the disk ledger to OPA every 5
+   minutes if they've drifted (e.g. a transient PUT failure inside a write, or OPA restarting
+   with a stale on-disk snapshot). Without this, a divergence is permanent until someone
+   manually runs `sync` (see Troubleshooting). Run this from your main checkout, not a worktree
+   -- the plist bakes in the invoking directory as `PROJECT_ROOT` (same convention as
+   `install_hermes_procedure_recheck_launchd.py`), so a removed worktree silently breaks it:
+   ```bash
+   python3 scripts/install_warden_opa_sync_launchd.py
+   ```
+4. Add the Hermes hook (personal `~/.hermes/config.yaml`, never repo-committed):
    ```yaml
    hooks:
      pre_tool_call:
@@ -47,7 +56,7 @@ operational how-to.
    Do **not** set `hooks_auto_accept: true` globally — approve this one command explicitly so
    Hermes records it in `~/.hermes/shell-hooks-allowlist.json`. Verify with `hermes hooks list`
    and `hermes hooks doctor`.
-4. Enroll a repo:
+5. Enroll a repo:
    ```bash
    python3 scripts/warden_attest.py enroll --repo /path/to/repo
    ```
@@ -78,6 +87,10 @@ python3 scripts/warden_attest.py inspect --repo <path>
   `~/.hermes/shell-hooks-allowlist.json`.
 - **Turn off for one repo only** (daemon and other repos unaffected):
   `python3 scripts/warden_attest.py unenroll --repo <path>`.
+- **Turn off the periodic self-heal job only** (daemon and gate unaffected — you lose automatic
+  drift recovery, manual `sync` still works): `python3
+  scripts/install_warden_opa_sync_launchd.py --uninstall`, or directly `launchctl bootout
+  gui/$(id -u)/com.deus.warden-opa-sync`.
 
 ## Troubleshooting
 
@@ -85,8 +98,11 @@ python3 scripts/warden_attest.py inspect --repo <path>
   `launchctl kickstart -k gui/$(id -u)/com.deus.warden-opa`, then check
   `~/.config/deus/guardrails/logs/warden-opa.error.log`.
 - **Commit blocked with "persisted but not activated" after `issue`**: the disk write succeeded
-  but OPA's PUT failed (daemon was briefly down, e.g.). Run `python3 scripts/warden_attest.py
-  sync` once the daemon is back up — no need to reissue the attestation.
+  but OPA's PUT failed (daemon was briefly down, e.g.). If the periodic self-heal job (LIA-533,
+  install step 3 above) is running, this self-corrects within 5 minutes automatically. For
+  immediate recovery, run `python3 scripts/warden_attest.py sync` once the daemon is back up —
+  no need to reissue the attestation. Check `launchctl list | grep warden-opa-sync` and
+  `<PROJECT_ROOT>/logs/warden-opa-sync.log` to confirm the self-heal job is actually running.
 - **Every decision logged to** `~/.config/deus/guardrails/logs/decisions.jsonl` (one JSON line
   per commit-shaped call) — redacted (hashed command, no raw repo paths or commit messages), but
   enough to answer "is this gate ever actually firing."
@@ -98,6 +114,8 @@ opa fmt --fail scripts/warden_policy/policy
 opa check --strict scripts/warden_policy/policy
 opa test -v scripts/warden_policy/policy
 python3 -m pytest scripts/warden_policy/tests -v
+python3 -m pytest scripts/tests/test_warden_attest_reconcile.py -v
 shellcheck scripts/start_warden_opa.sh
 plutil -lint launchd/com.deus.warden-opa.plist
+python3 -m py_compile scripts/install_warden_opa_sync_launchd.py
 ```

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-08" # auto-bump @1786182880
+last_verified: "2026-08-08" # auto-bump @1786192944
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/install_warden_opa_sync_launchd.py
+++ b/scripts/install_warden_opa_sync_launchd.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Installs the periodic launchd job that self-heals OPA/disk ledger drift (LIA-533).
+
+Root cause this exists to fix: `AttestationStore.sync()`/`reconcile_if_drifted()` are the only
+reconciliation mechanisms between the on-disk attestation ledger and OPA's live in-memory copy,
+and nothing ever calls them automatically -- once OPA's copy diverges from disk (a transient PUT
+failure inside a real write, or an out-of-band PUT from elsewhere), the divergence is permanent
+until a human manually runs `warden_attest.py sync`. See docs/decisions/opa-warden-attestations-v1.md
+and docs/HERMES_WARDEN_OPA.md for the full design; this script mirrors the pattern established by
+scripts/install_hermes_procedure_recheck_launchd.py (LIA-511) -- a standalone, macOS-only
+installer rather than folding into setup/service.ts, since com.deus.warden-opa.plist itself (the
+daemon this job repairs) is not installed via /setup either -- it's manual, documented Hermes/dev
+infra, and this job belongs at the same install layer.
+
+Usage:
+    python3 scripts/install_warden_opa_sync_launchd.py
+    python3 scripts/install_warden_opa_sync_launchd.py --uninstall
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+LABEL = "com.deus.warden-opa-sync"
+
+
+def _python_executable() -> str:
+    for candidate in ("python3", "python"):
+        found = shutil.which(candidate)
+        if found:
+            return found
+    return "python3"
+
+
+def _plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def _plist_contents() -> str:
+    python_path = _python_executable()
+    home = str(Path.home())
+    logs_dir = PROJECT_ROOT / "logs"
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python_path}</string>
+        <string>{PROJECT_ROOT}/scripts/warden_attest.py</string>
+        <string>--json</string>
+        <string>reconcile</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{PROJECT_ROOT}</string>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{home}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{logs_dir}/warden-opa-sync.log</string>
+    <key>StandardErrorPath</key>
+    <string>{logs_dir}/warden-opa-sync.log</string>
+</dict>
+</plist>"""
+
+
+def install() -> None:
+    if sys.platform != "darwin":
+        print("warden-opa-sync launchd install: macOS only, skipping.")
+        return
+
+    plist_path = _plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    (PROJECT_ROOT / "logs").mkdir(exist_ok=True)
+    plist_path.write_text(_plist_contents())
+
+    try:
+        subprocess.run(["launchctl", "load", str(plist_path)], check=True,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        print(f"warden-opa-sync job scheduled (every 5 min, RunAtLoad): {plist_path}")
+    except subprocess.CalledProcessError:
+        print(f"launchctl load failed for {LABEL} (may already be loaded)")
+
+
+def uninstall() -> None:
+    plist_path = _plist_path()
+    if not plist_path.is_file():
+        print(f"{LABEL}: nothing installed.")
+        return
+    subprocess.run(["launchctl", "unload", str(plist_path)],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    plist_path.unlink()
+    print(f"{LABEL}: unloaded and removed {plist_path}")
+
+
+if __name__ == "__main__":
+    if "--uninstall" in sys.argv:
+        uninstall()
+    else:
+        install()

--- a/scripts/tests/test_warden_attest_reconcile.py
+++ b/scripts/tests/test_warden_attest_reconcile.py
@@ -1,0 +1,61 @@
+"""LIA-533: tests for warden_attest.py's `reconcile` subcommand -- the CLI entry point the
+periodic launchd job (scripts/install_warden_opa_sync_launchd.py) invokes. The underlying
+reconciliation logic itself is tested in scripts/warden_policy/tests/test_attestation_store.py
+(TestReconcileIfDrifted, TestLockedNonBlocking); this file only proves the CLI correctly wires
+`reconcile` to `AttestationStore.reconcile_if_drifted()` and emits the documented JSON shape with
+the right exit code, consistent with `sync`'s existing convention."""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import warden_attest
+from warden_policy.attestation_store import WriteResult
+
+
+def test_reconcile_calls_reconcile_if_drifted_not_sync(capsys):
+    fake_store = mock.MagicMock()
+    fake_store.reconcile_if_drifted.return_value = WriteResult(
+        ok=True, generation=5, activated=True, error=None,
+    )
+    with mock.patch.object(warden_attest, "_store", return_value=fake_store):
+        exit_code = warden_attest.main(["--json", "reconcile"])
+    fake_store.reconcile_if_drifted.assert_called_once()
+    fake_store.sync.assert_not_called()
+    assert exit_code == warden_attest.EXIT_OK
+
+
+def test_reconcile_emits_documented_json_shape(capsys):
+    fake_store = mock.MagicMock()
+    fake_store.reconcile_if_drifted.return_value = WriteResult(
+        ok=True, generation=7, activated=True, error=None,
+    )
+    with mock.patch.object(warden_attest, "_store", return_value=fake_store):
+        warden_attest.main(["--json", "reconcile"])
+    out = capsys.readouterr().out
+    assert '"ok": true' in out
+    assert '"activated": true' in out
+    assert '"generation": 7' in out
+
+
+def test_reconcile_not_activated_returns_exit_not_activated(capsys):
+    fake_store = mock.MagicMock()
+    fake_store.reconcile_if_drifted.return_value = WriteResult(
+        ok=False, generation=5, activated=False, error="lock busy (reconciliation skipped, retries next tick)",
+    )
+    with mock.patch.object(warden_attest, "_store", return_value=fake_store):
+        exit_code = warden_attest.main(["--json", "reconcile"])
+    assert exit_code == warden_attest.EXIT_NOT_ACTIVATED
+
+
+def test_sync_still_calls_sync_not_reconcile_if_drifted(capsys):
+    # Regression guard: `sync` (the existing documented manual-recovery command) must remain
+    # byte-identical -- it must never be silently rerouted to the new reconciliation logic.
+    fake_store = mock.MagicMock()
+    fake_store.sync.return_value = WriteResult(ok=True, generation=3, activated=True, error=None)
+    with mock.patch.object(warden_attest, "_store", return_value=fake_store):
+        warden_attest.main(["--json", "sync"])
+    fake_store.sync.assert_called_once()
+    fake_store.reconcile_if_drifted.assert_not_called()

--- a/scripts/warden_attest.py
+++ b/scripts/warden_attest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Manual attestation CLI for scripts/warden_policy.
 
-Subcommands: enroll, unenroll, issue, inspect, check, sync, plan-review, enable-plan-review,
-disable-plan-review.
+Subcommands: enroll, unenroll, issue, inspect, check, sync, reconcile, plan-review,
+enable-plan-review, disable-plan-review.
 Typed exit codes: 0 OK, 1 usage error, 2 git/subject resolution error,
 3 not-activated (persisted but OPA PUT failed -- run `sync`), 6 CONFLICT
 (index changed mid-issuance).
@@ -235,6 +235,19 @@ def cmd_sync(args) -> int:
     return EXIT_OK if result.activated else EXIT_NOT_ACTIVATED
 
 
+def cmd_reconcile(args) -> int:
+    """LIA-533: best-effort periodic/background reconciliation -- the intended entry point for
+    a launchd job, distinct from `sync` (which always attempts a blocking, unconditional PUT --
+    the documented manual-recovery command, unchanged). `reconcile` only touches OPA's exclusive
+    lock when a genuine content mismatch is confirmed, and never blocks waiting for it -- see
+    `AttestationStore.reconcile_if_drifted()`."""
+    store = _store(args)
+    result = store.reconcile_if_drifted()
+    _emit(args, {"ok": result.ok, "activated": result.activated,
+                  "generation": result.generation, "error": result.error})
+    return EXIT_OK if result.activated else EXIT_NOT_ACTIVATED
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="warden_attest.py")
     parser.add_argument("--ledger-path", default=None)
@@ -289,6 +302,9 @@ def main(argv=None) -> int:
 
     p_sync = sub.add_parser("sync")
     p_sync.set_defaults(func=cmd_sync)
+
+    p_reconcile = sub.add_parser("reconcile")
+    p_reconcile.set_defaults(func=cmd_reconcile)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/scripts/warden_policy/attestation_store.py
+++ b/scripts/warden_policy/attestation_store.py
@@ -27,7 +27,9 @@ and vice versa. `read_locked()` is a separate, narrower convenience method
 that releases the lock before returning -- correct only for callers that
 need a point-in-time snapshot with no follow-on query to keep atomic with
 it (e.g. the CLI's `inspect`); it must NOT be used for the Hermes adapter's
-read-then-query sequence.
+read-then-query sequence. `reconcile_if_drifted()` (LIA-533) is a second, deliberate caller of
+`read_locked()` -- its later OPA GET/PUT don't need to stay atomic with this snapshot the way
+the Hermes adapter's live gate decision does, so this is not a repeat of that mistake.
 
 No `--watch`: OPA's own docs note file-watching can silently drop updates
 across `os.replace` -- unacceptable here, since a stale snapshot could still
@@ -57,6 +59,14 @@ OPA_DEFAULT_BASE_URL = "http://127.0.0.1:8181"
 #: uses AttestationStore.__init__'s `document_key`/`opa_data_path` params instead of this default.
 _DEFAULT_DOCUMENT_KEY = "warden_attestations"
 _OPA_TIMEOUT_SECONDS = 5
+
+#: Sentinel distinct from a legitimate `None` document (LIA-533): `_get_opa_document()` returns
+#: this only when the request itself never got a valid answer (network/timeout/malformed JSON).
+#: A reachable OPA reporting no document for the path (HTTP 200, `result` key absent/null -- its
+#: documented shape for an undefined path) returns plain `None`, which is real, confirmed drift,
+#: not an unknown state -- conflating the two would silently skip repairing a deleted/null
+#: document forever.
+_OPA_REQUEST_FAILED = object()
 
 
 def _empty_document(document_key: str) -> dict[str, Any]:
@@ -128,11 +138,20 @@ class AttestationStore:
     # -- locking ------------------------------------------------------
 
     @contextlib.contextmanager
-    def _locked(self, exclusive: bool):
+    def _locked(self, exclusive: bool, non_blocking: bool = False):
+        """`non_blocking=True` (LIA-533): raises `BlockingIOError` immediately instead of
+        waiting if the lock is currently held by anyone else -- used only by
+        `reconcile_if_drifted()`'s repair path, so a periodic/background caller can never make a
+        concurrent reader (the Hermes gate's `locked_read()`) or another writer (`_mutate`) queue
+        behind it. Every existing caller omits this parameter and gets today's exact blocking
+        behavior, unchanged."""
         self.lock_path.touch(exist_ok=True)
         fd = os.open(self.lock_path, os.O_RDWR)
+        flags = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        if non_blocking:
+            flags |= fcntl.LOCK_NB
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+            fcntl.flock(fd, flags)
             yield
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
@@ -174,24 +193,33 @@ class AttestationStore:
 
     # -- OPA sync ---------------------------------------------------------
 
-    def _put_and_readback(self, inner_doc: dict[str, Any]) -> tuple[bool, int | None, str | None]:
+    def _put_and_readback(
+        self, inner_doc: dict[str, Any], *, timeout_seconds: float | None = None,
+    ) -> tuple[bool, int | None, str | None]:
         # Must read self.opa_data_path here, not a module-level constant -- otherwise an
         # isolated CC store's write would still PUT to Hermes's live OPA document regardless
         # of what the on-disk ledger's own key is named.
+        #
+        # timeout_seconds (LIA-533): overrides _OPA_TIMEOUT_SECONDS for both calls below when
+        # given. `None` (every existing caller: _mutate, sync()) preserves today's 5s default
+        # exactly. reconcile_if_drifted()'s repair path passes a short override (0.5s) to bound
+        # its own worst-case exclusive-lock hold, since it (unlike _mutate) may be contending
+        # with the Hermes gate's own tight external timeout budget.
+        timeout = timeout_seconds if timeout_seconds is not None else _OPA_TIMEOUT_SECONDS
         body = json.dumps(inner_doc).encode("utf-8")
         req = urllib.request.Request(
             self.opa_base_url + self.opa_data_path, data=body,
             headers={"Content-Type": "application/json"}, method="PUT",
         )
         try:
-            with urllib.request.urlopen(req, timeout=_OPA_TIMEOUT_SECONDS):
+            with urllib.request.urlopen(req, timeout=timeout):
                 pass
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             return False, None, f"PUT to OPA failed: {exc}"
 
         gen_req = urllib.request.Request(self.opa_base_url + self.opa_data_path + "/generation")
         try:
-            with urllib.request.urlopen(gen_req, timeout=_OPA_TIMEOUT_SECONDS) as resp:
+            with urllib.request.urlopen(gen_req, timeout=timeout) as resp:
                 result = json.loads(resp.read()).get("result")
         except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError) as exc:
             return False, None, f"generation read-back failed: {exc}"
@@ -405,6 +433,61 @@ class AttestationStore:
             inner = doc[self.document_key]
             ok, activated_gen, err = self._put_and_readback(inner)
             return WriteResult(ok=ok, generation=inner["generation"], activated=ok, error=err)
+
+    def _get_opa_document(self) -> dict[str, Any] | None | object:
+        """Plain GET of the full live document, no lock held (LIA-533). Returns:
+        - a dict: OPA answered and has this document.
+        - `None`: OPA answered but reports no document for this path (its documented shape for
+          an undefined/deleted/null document) -- a real, confirmed state, not "unknown."
+        - `_OPA_REQUEST_FAILED`: the request itself never got a valid answer (network error,
+          timeout, malformed response) -- genuinely unknown state, distinct from the above.
+        """
+        req = urllib.request.Request(self.opa_base_url + self.opa_data_path)
+        try:
+            with urllib.request.urlopen(req, timeout=_OPA_TIMEOUT_SECONDS) as resp:
+                return json.loads(resp.read()).get("result")
+        except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError):
+            return _OPA_REQUEST_FAILED
+
+    def reconcile_if_drifted(self) -> WriteResult:
+        """Best-effort periodic/background reconciliation (LIA-533) for a caller -- e.g. a
+        launchd job -- that must never contend with the hot commit-gate's `locked_read()`, and
+        must never race a real `_mutate()` write's own PUT-and-readback.
+
+        Three-way outcome, each handled differently:
+        1. OPA already matches disk (full content comparison, not just `generation` -- a foreign
+           document could coincidentally carry a matching generation with different content):
+           done, no lock touched at all.
+        2. The GET itself failed (`_OPA_REQUEST_FAILED`): genuinely unknown state -- OPA may be
+           fully down, in which case attempting a repair PUT is doomed to also fail. Skip
+           entirely without ever touching the exclusive lock, so a sustained outage never creates
+           a recurring lock-hold window; the next tick (or the next real write's own embedded
+           PUT) retries once OPA is reachable again.
+        3. Confirmed drift (OPA answered -- possibly with no document at all, itself a real,
+           repairable state -- and it differs from disk): repair under the SAME lock `_mutate`
+           already uses for its own PUT-and-readback, acquired non-blocking so this call can
+           never make a concurrent reader or writer wait on ITS acquisition, and with a short,
+           measured timeout bounding its own worst-case hold to ~1s if acquired. If the lock is
+           contended (a real write in flight), back off immediately -- that write's own PUT
+           already handles activation, so nothing is lost by skipping this tick.
+        """
+        doc = self.read_locked()
+        inner = doc[self.document_key]
+        opa_doc = self._get_opa_document()
+        if opa_doc is _OPA_REQUEST_FAILED:
+            return WriteResult(ok=False, generation=inner["generation"], activated=False,
+                                error="OPA unreachable -- skipped, not a confirmed content mismatch")
+        if opa_doc == inner:
+            return WriteResult(ok=True, generation=inner["generation"], activated=True, error=None)
+        try:
+            with self._locked(exclusive=True, non_blocking=True):
+                doc = self._read_disk()
+                inner = doc[self.document_key]
+                ok, activated_gen, err = self._put_and_readback(inner, timeout_seconds=0.5)
+                return WriteResult(ok=ok, generation=inner["generation"], activated=ok, error=err)
+        except BlockingIOError:
+            return WriteResult(ok=False, generation=inner["generation"], activated=False,
+                                error="lock busy (reconciliation skipped, retries next tick)")
 
     def inspect(self, repo_id: str) -> list[dict[str, Any]]:
         with self._locked(exclusive=False):

--- a/scripts/warden_policy/tests/test_attestation_store.py
+++ b/scripts/warden_policy/tests/test_attestation_store.py
@@ -1,3 +1,4 @@
+import contextlib
 import sys
 import tempfile
 import threading
@@ -8,14 +9,19 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from warden_policy.attestation_store import AttestationStore, AttestationStoreError
+from warden_policy.attestation_store import AttestationStore, AttestationStoreError, _OPA_REQUEST_FAILED
+
+# Captured once, before any test patches AttestationStore._locked -- LIA-533's lock-contention
+# tests need to delegate to the real locking behavior for the non-contended branch while
+# overriding only the contended one.
+_real_locked = AttestationStore._locked
 
 
-def _always_ok(self, inner_doc):
+def _always_ok(self, inner_doc, **kwargs):
     return True, inner_doc["generation"], None
 
 
-def _always_fails(self, inner_doc):
+def _always_fails(self, inner_doc, **kwargs):
     return False, inner_doc["generation"] - 1, "simulated PUT failure"
 
 
@@ -344,6 +350,171 @@ class TestReadLocked(unittest.TestCase):
         self.assertEqual(len(reader_saw_generation_at), 1)
         # the reader's view was only obtained AFTER the writer released its exclusive lock
         self.assertGreaterEqual(reader_saw_generation_at[0], writer_released_at[0])
+
+
+class TestLockedNonBlocking(unittest.TestCase):
+    """LIA-533: `_locked(non_blocking=True)` must never wait -- this is the primitive
+    `reconcile_if_drifted()`'s repair phase relies on to never queue behind a real `_mutate()`
+    write in progress (GPT round-3's writer-race finding)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = AttestationStore(Path(self.tmp.name) / "attestations-v1.json")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_non_blocking_exclusive_fails_immediately_against_a_held_lock(self):
+        holder_acquired = threading.Event()
+        release_holder = threading.Event()
+
+        def _holder():
+            with self.store._locked(exclusive=True):
+                holder_acquired.set()
+                release_holder.wait(timeout=5)
+
+        t = threading.Thread(target=_holder)
+        t.start()
+        self.assertTrue(holder_acquired.wait(timeout=5))
+        start = time.monotonic()
+        with self.assertRaises(BlockingIOError):
+            with self.store._locked(exclusive=True, non_blocking=True):
+                pass
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 0.5)  # returned immediately, did not wait for the holder
+        release_holder.set()
+        t.join(timeout=5)
+
+    def test_non_blocking_default_is_false_existing_behavior_unchanged(self):
+        # Every existing caller omits non_blocking and gets today's exact blocking behavior.
+        with self.store._locked(exclusive=True):
+            pass  # no exception, no behavior change from the added parameter's default
+
+
+class TestReconcileIfDrifted(unittest.TestCase):
+    """LIA-533: periodic/background reconciliation -- distinguishes "already in sync" (no lock),
+    "confirmed content mismatch" (repair, short-timeout non-blocking lock), and "OPA request
+    failed" (unknown state, skip without ever touching the lock)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = AttestationStore(Path(self.tmp.name) / "attestations-v1.json")
+        self.patcher = mock.patch.object(AttestationStore, "_put_and_readback", _always_ok)
+        self.patcher.start()
+        self.store.enroll("repo-a")
+        self.patcher.stop()  # each test below installs its own spy/mock for _put_and_readback
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _disk_inner(self):
+        return self.store._read_disk()["warden_attestations"]
+
+    def test_matching_content_never_attempts_a_repair_put(self):
+        matching = self._disk_inner()
+        put_spy = mock.MagicMock(side_effect=lambda inner, **kw: _always_ok(self.store, inner))
+        with mock.patch.object(AttestationStore, "_get_opa_document", return_value=matching), \
+             mock.patch.object(AttestationStore, "_put_and_readback", put_spy):
+            result = self.store.reconcile_if_drifted()
+        self.assertTrue(result.ok)
+        self.assertTrue(result.activated)
+        self.assertIsNone(result.error)
+        put_spy.assert_not_called()
+
+    def test_confirmed_content_mismatch_attempts_repair_with_short_timeout(self):
+        # GPT round-2's finding: comparison must be full-content, not generation-only -- this
+        # fixture proves the mismatch is detected via content, and that the repair PUT is
+        # bounded to a short timeout (GPT round-5/6), not the module default.
+        differing = dict(self._disk_inner())
+        differing["generation"] = 999
+        put_spy = mock.MagicMock(side_effect=lambda inner, **kw: _always_ok(self.store, inner))
+        with mock.patch.object(AttestationStore, "_get_opa_document", return_value=differing), \
+             mock.patch.object(AttestationStore, "_put_and_readback", put_spy):
+            result = self.store.reconcile_if_drifted()
+        self.assertTrue(result.activated)
+        put_spy.assert_called_once()
+        _, kwargs = put_spy.call_args
+        self.assertEqual(kwargs.get("timeout_seconds"), 0.5)
+
+    def test_null_opa_document_is_confirmed_drift_not_unreachable(self):
+        # GPT round-5 finding 1: a reachable OPA reporting no document (HTTP 200, no `result`)
+        # is real, confirmed drift -- must not be folded into "request failed, skip."
+        put_spy = mock.MagicMock(side_effect=lambda inner, **kw: _always_ok(self.store, inner))
+        with mock.patch.object(AttestationStore, "_get_opa_document", return_value=None), \
+             mock.patch.object(AttestationStore, "_put_and_readback", put_spy):
+            result = self.store.reconcile_if_drifted()
+        self.assertTrue(result.activated)
+        put_spy.assert_called_once()
+
+    def test_opa_request_failure_skips_without_touching_the_lock(self):
+        # GPT round-4 finding: distinct from a confirmed mismatch -- must never attempt the
+        # locked repair, or a sustained outage recreates a recurring fail-open window.
+        put_spy = mock.MagicMock(side_effect=lambda inner, **kw: _always_ok(self.store, inner))
+        with mock.patch.object(AttestationStore, "_get_opa_document",
+                                return_value=_OPA_REQUEST_FAILED), \
+             mock.patch.object(AttestationStore, "_put_and_readback", put_spy):
+            result = self.store.reconcile_if_drifted()
+        self.assertFalse(result.ok)
+        self.assertFalse(result.activated)
+        self.assertIn("unreachable", result.error)
+        put_spy.assert_not_called()
+
+    def test_repair_lock_contention_reports_busy_without_mutating(self):
+        # The end-to-end regression test for GPT round-3's writer-race finding: when the repair
+        # phase's non-blocking acquisition is contended (a real write in flight), reconcile
+        # backs off immediately and never calls _put_and_readback -- no interleaving possible.
+        differing = dict(self._disk_inner())
+        differing["generation"] = 999
+        put_spy = mock.MagicMock(side_effect=lambda inner, **kw: _always_ok(self.store, inner))
+
+        @contextlib.contextmanager
+        def _contended_locked(self_, exclusive, non_blocking=False):
+            if non_blocking:
+                raise BlockingIOError("simulated contention")
+            with _real_locked(self_, exclusive, non_blocking=non_blocking):
+                yield
+
+        with mock.patch.object(AttestationStore, "_get_opa_document", return_value=differing), \
+             mock.patch.object(AttestationStore, "_put_and_readback", put_spy), \
+             mock.patch.object(AttestationStore, "_locked", _contended_locked):
+            result = self.store.reconcile_if_drifted()
+        self.assertFalse(result.ok)
+        self.assertFalse(result.activated)
+        self.assertIn("lock busy", result.error)
+        put_spy.assert_not_called()
+
+    def test_real_writer_in_flight_does_not_interleave_with_reconcile_repair(self):
+        # True concurrency version of the test above: a real _mutate() write genuinely holding
+        # the exclusive lock in a background thread (same sleep-based pattern already
+        # established by TestReadLocked.test_locked_read_waits_for_a_slow_writer_to_release in
+        # this file), reconcile_if_drifted() called concurrently from the main thread. Proves
+        # the two can never interleave in practice, not just that the mocked exception path is
+        # handled by the deterministic test above.
+        differing = dict(self._disk_inner())
+        differing["generation"] = 999
+        put_spy = mock.MagicMock(side_effect=lambda inner, **kw: _always_ok(self.store, inner))
+
+        def _slow_apply(inner):
+            time.sleep(0.3)
+            inner["config"]["enforced_repos"]["repo-b"] = {
+                "enabled": True, "enrolled_at": "2026-08-03T00:00:00Z",
+            }
+
+        def _writer():
+            self.store._mutate(_slow_apply)
+
+        with mock.patch.object(AttestationStore, "_get_opa_document", return_value=differing), \
+             mock.patch.object(AttestationStore, "_put_and_readback", put_spy):
+            t = threading.Thread(target=_writer)
+            t.start()
+            time.sleep(0.05)  # let the writer acquire the exclusive lock first
+            self.store.reconcile_if_drifted()
+            t.join(timeout=5)
+        # reconcile's own read_locked() (shared) genuinely waits for the writer's exclusive hold
+        # to release first -- correct, pre-existing reader/writer coordination, not new. What
+        # matters: no interleaved/duplicate repair PUT -- the writer's own legitimate PUT, plus
+        # at most one repair attempt from reconcile, never more (never two overlapping PUTs).
+        self.assertLessEqual(put_spy.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- OPA's live `warden_attestations` document was found frozen at generation 1 while the disk ledger was at generation 22 — confirmed live via `curl` + a direct disk read, not just the ticket's snapshot. `AttestationStore.sync()` is the only reconciliation mechanism between disk and OPA, and nothing ever calls it automatically; once OPA's copy diverges from disk (a transient PUT failure inside a real write, or an out-of-band PUT from elsewhere), the divergence is permanent until a human manually runs `sync`.
- Adds `AttestationStore.reconcile_if_drifted()` — a periodic/background-safe reconciliation method, distinct from `sync()` — plus a `reconcile` CLI subcommand and a `launchd` installer (`scripts/install_warden_opa_sync_launchd.py`, mirroring the existing `install_hermes_procedure_recheck_launchd.py` pattern) that runs it every 5 minutes.
- Full document **content** comparison (not just `generation`) detects drift; a genuine mismatch triggers a repair under the **same lock** real writes already use, acquired **non-blocking** with a short, empirically-measured timeout — so it can never queue behind, or be queued behind by, the Hermes commit gate's own lock read. An OPA request failure is distinguished from a confirmed-empty/differing document via a dedicated sentinel, so a sustained outage never re-triggers a lock attempt every tick.
- Every new parameter on existing `AttestationStore` methods (`_locked(non_blocking=)`, `_put_and_readback(timeout_seconds=)`) defaults to today's exact behavior — no existing call site (`_mutate`, `enroll`, `unenroll`, `issue`, `issue_if_newer`, `sync()`'s own call) changes.

## Process

Went through 6 rounds of dual-backend (Claude + GPT) adversarial plan review before implementation — every round surfaced a real, distinct concurrency/correctness gap in the design (lock-blocking risk on the Hermes commit gate, generation-only comparison insufficiency, a writer-writer race with real `_mutate()` writes, recurring lock-hold during a sustained OPA outage, conflating "request failed" with "request succeeded with no document"), each closed in turn. Implementation reviewed by code-reviewer (Claude+GPT SHIP; GLM `COULD_NOT_RUN` — insufficient z.ai API balance, fails open per this repo's documented safety contract), verification-gate (SHIP, live-tested against production OPA), and ai-eng-warden (out-of-scope/SHIP on both backends — no LLM surface in this diff).

## Test plan

- [x] `python3 -m pytest scripts/warden_policy/tests/ scripts/tests/test_warden_attest_reconcile.py -v` — 214 passed, 63 subtests passed (32 new)
- [x] `python3 -m py_compile` on all three touched/new Python files
- [x] Manual install/uninstall smoke test of the launchd installer — confirmed `plutil -lint` clean, job fires, log shows correct `reconcile` output against the live daemon
- [x] Verified live against production: `python3 scripts/warden_attest.py --json reconcile` returns `{"ok": true, "activated": true, "generation": 22, "error": null}` — already in sync (the desync was manually resolved as a diagnostic side effect during root-cause investigation, before this PR)
- [x] Regression-checked against a clean `origin/main` baseline (verification-gate): 202 → 210 test node IDs, 0 lost, 8 added
- [x] fd-leak stress test (verification-gate): 500/500 contended non-blocking lock attempts, zero fd leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)