### PR TITLE
feat(wardens): wire cc_attestations.enqueue_verdict into gate call sites (LIA-534)

### DIFF
--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -1648,6 +1648,7 @@ def run_verification_gate(event: dict[str, Any], repo_root: Path) -> int:
         return 0
     if _read_verdict("verified", repo_root) == "SHIP":
         _cc_shadow_observe("verification-gate", config, repo_root, [])
+        _cc_mirror_verdicts("verification-gate", config, repo_root)
         return 0
 
     mark_cmd = (
@@ -1683,6 +1684,7 @@ def run_verification_gate(event: dict[str, Any], repo_root: Path) -> int:
         "verification-gate", config, repo_root,
         [(BACKEND_CLAUDE, _last_verdict(repo_root, "verification-gate"))],
     )
+    _cc_mirror_verdicts("verification-gate", config, repo_root)
     return 0
 
 
@@ -2944,6 +2946,49 @@ def _cc_shadow_observe(
         pass
 
 
+def _cc_mirror_verdicts(role: str, config: dict[str, Any], repo_root: Path) -> None:
+    """LIA-534: mirror every configured backend's verdict for ``role`` into the isolated CC
+    ledger via ``cc_attestations.enqueue_verdict`` -- full backend-verdict history (SHIP
+    included), not just the blocking subset ``_evaluate_backends``/``_cc_shadow_observe`` track.
+    ``issuer_kind`` is always ``"script"`` -- every call here mirrors an already-decided verdict
+    programmatically, never a human typing a review at write time (see ``warden_attest.py``'s
+    manual-vs-script split). Subject resolved via ``_resolve_verdict_worktree(repo_root)``,
+    matching ``_cc_shadow_observe`` exactly -- not a separately-threaded cwd, avoiding a second
+    parallel cwd-resolution path in a codebase with a documented history of cwd/worktree
+    bucket-mismatch bugs (LIA-446/467/376).
+
+    Call AFTER the legacy gate decision is already finalized/returned (same ordering discipline
+    ``_cc_shadow_observe`` already established) -- this call's outcome must never be consulted
+    by, or able to affect, the gate that just ran. The whole body is contained:
+    ``enqueue_verdict`` itself already swallows every exception and returns ``None``
+    unconditionally (fully detached, no join/wait), so this ``try/except`` exists only to
+    contain ``resolve_repo_id``/``resolve_subject_key`` (``GitSubjectError`` on an edge-case git
+    state), matching ``_cc_shadow_observe``'s containment floor."""
+    try:
+        from warden_policy import cc_attestations
+        from warden_policy.git_subject import resolve_repo_id, resolve_subject_key
+
+        worktree = _resolve_verdict_worktree(repo_root)
+        repo_id = resolve_repo_id(worktree)
+        subject_key = resolve_subject_key(worktree)
+        for backend in _role_backends(config, role):
+            if backend == BACKEND_CLAUDE:
+                verdict = _last_verdict(repo_root, role)
+            elif backend in KNOWN_MODEL_BACKENDS:
+                verdict = _read_verdict(store_key(role, backend), repo_root)
+            else:
+                continue
+            if verdict is None or verdict == "TRIVIAL":
+                continue
+            cc_attestations.enqueue_verdict(
+                repo_id=repo_id, gate=role, subject_key=subject_key, verdict=verdict,
+                issuer_kind="script", reviewer_id=store_key(role, backend),
+                reason=f"mirrored from legacy {role} verdict store", backend=backend,
+            )
+    except Exception:  # noqa: BLE001 -- containment floor, matches _cc_shadow_observe
+        pass
+
+
 def run_warden_backends_gate(role: str, event: dict[str, Any], repo_root: Path) -> int:
     """Generic commit gate for a warden ROLE across all its configured backends.
 
@@ -2967,9 +3012,11 @@ def run_warden_backends_gate(role: str, event: dict[str, Any], repo_root: Path) 
     blocking = _evaluate_backends(role, config, repo_root)
     if not blocking:
         _cc_shadow_observe(role, config, repo_root, blocking)
+        _cc_mirror_verdicts(role, config, repo_root)
         return 0
     _block_pre_tool(_warden_backends_block_message(role, blocking, repo_root))
     _cc_shadow_observe(role, config, repo_root, blocking)
+    _cc_mirror_verdicts(role, config, repo_root)
     return 0
 
 

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -1757,6 +1757,158 @@ def test_verification_gate_shows_revise_escalation(tmp_path, capsys):
     assert "Trivial-commit bypass" not in out
 
 
+# ── CC verdict mirroring (LIA-534: wire cc_attestations.enqueue_verdict into the two
+# commit-gate call sites -- run_warden_backends_gate and run_verification_gate) ──────
+
+
+def test_cc_mirror_verdicts_called_on_warden_backends_gate_pass(tmp_path, capsys, monkeypatch):
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "code-reviewer", "SHIP", "looks good", "agent")
+
+    calls = []
+    monkeypatch.setattr(
+        "warden_policy.cc_attestations.enqueue_verdict",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    rc = hooks.run_warden_backends_gate(
+        "code-reviewer", bash_event(repo, "git commit -m test"), repo,
+    )
+
+    assert rc == 0
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["gate"] == "code-reviewer"
+    assert call["verdict"] == "SHIP"
+    assert call["issuer_kind"] == "script"
+    assert call["reviewer_id"] == "code-reviewer@claude"
+    assert call["backend"] == "claude"
+    assert call["repo_id"].startswith("git-common-dir-sha256:")
+    assert call["subject_key"].startswith("git-tree:")
+    assert call["reason"]
+
+
+def test_cc_mirror_verdicts_called_on_warden_backends_gate_block(tmp_path, capsys, monkeypatch):
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "code-reviewer", "REVISE", "needs work", "agent")
+
+    calls = []
+    monkeypatch.setattr(
+        "warden_policy.cc_attestations.enqueue_verdict",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    hooks.run_warden_backends_gate("code-reviewer", bash_event(repo, "git commit -m test"), repo)
+
+    assert len(calls) == 1
+    assert calls[0]["verdict"] == "REVISE"
+    assert calls[0]["issuer_kind"] == "script"
+    assert calls[0]["gate"] == "code-reviewer"
+
+
+def test_cc_mirror_verdicts_skips_trivial(tmp_path, capsys, monkeypatch):
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "code-reviewer", "TRIVIAL", "typo fix", "mark")
+
+    calls = []
+    monkeypatch.setattr(
+        "warden_policy.cc_attestations.enqueue_verdict",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    hooks.run_warden_backends_gate("code-reviewer", bash_event(repo, "git commit -m test"), repo)
+
+    assert calls == []
+
+
+def test_cc_mirror_verdicts_skips_never_run_backend(tmp_path, capsys, monkeypatch):
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    # no verdict written at all -- _last_verdict returns None for this role
+
+    calls = []
+    monkeypatch.setattr(
+        "warden_policy.cc_attestations.enqueue_verdict",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    hooks.run_warden_backends_gate("code-reviewer", bash_event(repo, "git commit -m test"), repo)
+
+    assert calls == []
+
+
+def test_cc_mirror_verdicts_called_on_verification_gate_pass(tmp_path, capsys, monkeypatch):
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "verification-gate", "SHIP", "all good", "mark")
+    (repo / ".claude" / ".verified").touch()
+
+    calls = []
+    monkeypatch.setattr(
+        "warden_policy.cc_attestations.enqueue_verdict",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    assert len(calls) == 1
+    assert calls[0]["gate"] == "verification-gate"
+    assert calls[0]["verdict"] == "SHIP"
+    assert calls[0]["issuer_kind"] == "script"
+    assert calls[0]["reviewer_id"] == "verification-gate@claude"
+
+
+def test_cc_mirror_verdicts_called_on_verification_gate_block(tmp_path, capsys, monkeypatch):
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    (repo / ".claude" / "wardens").mkdir(parents=True)
+    hooks._write_verdict(repo, "verification-gate", "REVISE", "incomplete", "agent")
+
+    calls = []
+    monkeypatch.setattr(
+        "warden_policy.cc_attestations.enqueue_verdict",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert len(calls) == 1
+    assert calls[0]["verdict"] == "REVISE"
+    assert calls[0]["gate"] == "verification-gate"
+
+
+def test_cc_mirror_verdicts_never_raises_into_gate_on_resolution_failure(
+    tmp_path, capsys, monkeypatch,
+):
+    """A GitSubjectError (or any exception) from resolve_repo_id/resolve_subject_key must not
+    surface as a gate failure -- matches _cc_shadow_observe's containment floor."""
+    sys.path.insert(0, str(SCRIPT.parent))
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "code-reviewer", "SHIP", "looks good", "agent")
+
+    def _boom(worktree):
+        raise RuntimeError("simulated git failure")
+
+    monkeypatch.setattr("warden_policy.git_subject.resolve_repo_id", _boom)
+
+    # Must not raise, and the gate's own return value/stdout must be unaffected.
+    rc = hooks.run_warden_backends_gate(
+        "code-reviewer", bash_event(repo, "git commit -m test"), repo,
+    )
+    assert rc == 0
+
+
 # ── GIT_COMMIT_RE (LIA-518: broadened commit-gate trigger) ──────────────────
 #
 # First direct coverage for this regex — previously exercised only indirectly


### PR DESCRIPTION
## Summary

- LIA-527 Phase 2 added `scripts/warden_policy/cc_attestations.py` with `enqueue_verdict()`/`process_job()` but deliberately left them with zero production callers — wiring into the commit-gate hot path (`run_warden_backends_gate`, `run_verification_gate` in `codex_warden_hooks.py`) was scoped as this separate follow-up, since those functions run on every commit across every enrolled repo and deserve their own dedicated review pass.
- Adds `_cc_mirror_verdicts(role, config, repo_root)`, mirroring every configured backend's verdict — SHIP included, not just the blocking subset `_evaluate_backends`/`_cc_shadow_observe` already track — into the isolated CC ledger (`data.warden_cc_attestations`). Mirrors `_cc_shadow_observe`'s exact ordering discipline (call only after the legacy gate decision is already finalized/returned; its own outcome can never affect the gate that just ran) and worktree resolution (`_resolve_verdict_worktree(repo_root)`, not a separately-threaded cwd).
- `issuer_kind` is always `"script"` — confirmed against the Phase 2 oracle test's own fixture (`test_cc_write_path_oracle.py`), not `"manual"` for the claude backend as an earlier draft had it.

## Process

2 rounds of dual-backend (Claude + GPT) plan review — round 1 caught `issuer_kind` being wrong for the claude backend and a cwd-vs-worktree resolution inconsistency (both fixed to reuse `_resolve_verdict_worktree` exactly like `_cc_shadow_observe`); round 2 both backends SHIP. Implementation reviewed by code-reviewer (Claude+GPT SHIP; GLM `COULD_NOT_RUN` — insufficient z.ai API balance, fails open per this repo's documented safety contract), verification-gate (SHIP — independently re-derived the exception-containment claim with its own 28-combination fault-injection probe across both gate functions × both pass/block paths, since the author's own test only covered one narrow case), and ai-eng-warden (SHIP — confirmed in code, not just docstring, that the fail-open/fail-closed property is unaffected and traced the injection surface on `repo_id`/`subject_key`/`verdict` two hops deep, found nothing).

## Real-invocation smoke test

Per this repo's `hook-pr-smoke-test` rule (any PR touching a `PreToolUse` hook script needs real-invocation evidence, not unit tests alone): ran the actual `python3 scripts/codex_warden_hooks.py run <hook-name> --repo-root ...` command directly against this branch's own script (the bash shim `warden-shim.sh` intentionally anchors execution to the *main-repo's* stable copy by design, so testing through it before merge exercises the *old*, pre-LIA-534 script — confirmed this is the shim's deliberate safety property, not a bug, by tracing why it initially appeared to no-op).

- `run_verification_gate` happy path (SHIP marked) → real production CC ledger gained a new `verification-gate`/`SHIP` record.
- `run_verification_gate` block path (REVISE marked) → real block JSON emitted, real production CC ledger gained a new `verification-gate`/`REVISE` record.
- `run_warden_backends_gate` via `code-review-gate` (co-gate not fully satisfied — gpt/glm not marked) → real block JSON emitted correctly, and the claude backend's own SHIP was still individually mirrored (matching the "full backend-verdict history, not just blocking" design intent).

## Test plan

- [x] `python3 -m pytest scripts/tests/test_codex_warden_hooks.py scripts/warden_policy/tests/ -v` — 565 passed (348 pre-existing + 7 new + 210 warden_policy), 63 subtests
- [x] `python3 -m py_compile scripts/codex_warden_hooks.py`
- [x] Real-invocation smoke test (see above) — both gate functions, both pass/block paths, confirmed against the actual live production CC ledger
- [x] 7 new tests cover: pass/block for both gate functions, TRIVIAL-skip, never-run-skip, exception containment on `resolve_repo_id` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)