### PR TITLE
feat(wardens): attestation-verify workflow + query script (LIA-536)

### DIFF
--- a/.github/workflows/attestation-verify.yml
+++ b/.github/workflows/attestation-verify.yml
@@ -1,0 +1,166 @@
+name: Attestation Verify (git-level hard backstop)
+
+# LIA-536, implementing docs/decisions/git-level-hard-backstop-design.md. This is the
+# `attestation-verify` check the `main-attestation-backstop` ruleset will require once activated
+# -- as of this file landing, that ruleset does NOT exist yet (created disabled as a later,
+# separate step of LIA-536, after this workflow merges and its one live test-PR run confirms it
+# actually posts a Check Run correctly). Re-queries
+# `deus.wardens.decision`'s Phase-4 `attestation.verify` block (LIA-530,
+# scripts/warden_policy/policy/guardrails.rego ~150-228) server-side, on the self-hosted runner
+# registered for this repo, against the local ledgers + loopback OPA daemon -- the same
+# infrastructure scripts/hermes_warden_gate.py already relies on locally.
+#
+# Trust model (design doc §3.3): `pull_request_target` runs THIS file's definition and
+# scripts/warden_policy/attestation_verify_check.py from the BASE branch, never from the PR --
+# closing the "a PR edits the verifier to always report success" vector. The actor guard below is
+# the FIRST step in the job, before any checkout, so a non-owner PR is rejected before any
+# PR-derived data is touched at all. The PR's head commit is only ever `git fetch`ed (shallow,
+# blobless) into the trusted checkout to resolve its tree sha -- never checked out, never executed.
+#
+# Residual, disclosed, NOT-closed-by-this-file gap (design doc §3.4, this ticket's plan §9): a
+# same-repo PR that adds/edits a DIFFERENT workflow (triggered on plain `pull_request`, so it runs
+# the PR's own content) could forge a same-named Check Run directly via the Checks API, bypassing
+# this file entirely. Closing that requires LIA-531 (credential separation) -- tracked separately,
+# not attempted here. The `main-attestation-backstop` ruleset (once created) will stay
+# `enforcement: "disabled"` until LIA-531 lands.
+#
+# TEMPORARY `paths:` filter: no self-hosted runner is registered for this repo as of this file
+# landing (that registration is a deliberately separate, later, EPHEMERAL step -- see LIA-536's
+# plan design decision #8 -- bounded to one live test-PR run, then torn down). Without a runner,
+# `pull_request_target` with no path filter would queue an unpickable job on EVERY future PR to
+# this repo indefinitely (fail-closed, not a security gap -- nothing requires this check yet since
+# the ruleset doesn't exist -- but real Actions-UI clutter across every concurrent PR in this
+# repo). Scoped narrowly for now. Removal is tracked as its own activation precondition in
+# docs/decisions/git-level-hard-backstop-design.md's "### 5. Not yet started" section, alongside
+# LIA-531/LIA-534/ruleset-creation -- MUST be removed before `main-attestation-backstop` is ever
+# activated, since the whole point of the backstop is universal PR coverage, not just PRs touching
+# these paths. The one live test-PR run this ticket still needs (design doc §5, the
+# required-status-check-registration verification item) MUST itself touch one of these two paths,
+# or the workflow will not trigger at all for it.
+on:
+  pull_request_target:
+    paths:
+      - '.github/workflows/attestation-verify.yml'
+      - 'scripts/warden_policy/**'
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  verify:
+    name: attestation-verify-job
+    runs-on: [self-hosted, lia536-verify]
+    timeout-minutes: 5
+    steps:
+      - name: Actor guard (must run first, before any checkout)
+        id: actor_guard
+        # Unconditional step -- never gated by `if:`, since GitHub's required-check evaluation
+        # treats a `skipped` conclusion as PASSING, silently defeating this ruleset's
+        # `bypass_actors: []`. For a non-owner actor this step posts an explicit `failure`
+        # Check Run directly via the Checks API BEFORE calling exit 1 -- a bare exit here would
+        # skip every later step (including whatever posts a Check Run), leaving the check
+        # permanently pending rather than failed, which is the same "looks blocked, isn't"
+        # trap this whole mechanism exists to close, reached a different way.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_ACTOR: ${{ github.event.pull_request.user.login }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ "$PR_ACTOR" != "$REPO_OWNER" ]; then
+            gh api "repos/${GH_REPO}/check-runs" \
+              -f name="attestation-verify" \
+              -f head_sha="$HEAD_SHA" \
+              -f status="completed" \
+              -f conclusion="failure" \
+              -f output[title]="non-owner actor" \
+              -f output[summary]="attestation-verify only evaluates PRs from the repository owner." \
+              > /dev/null
+            echo "::error::non-owner actor ($PR_ACTOR) -- posted failure Check Run, exiting"
+            exit 1
+          fi
+          echo "actor guard passed: $PR_ACTOR"
+
+      - name: Checkout base branch (trusted -- never the PR head)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # No `ref:` override -- pull_request_target's default checkout ref is the base branch,
+          # so the verifier script that actually runs is always the trusted base-branch version.
+
+      - name: Fetch PR head commit (object only -- never checked out, never executed)
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 --filter=blob:none origin "$HEAD_SHA"
+
+      - name: Query attestation-verify decision
+        id: verify
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/warden_policy/attestation_verify_check.py \
+            --repo-path "$GITHUB_WORKSPACE" --head-sha "$HEAD_SHA" --json > result.json
+          cat result.json
+          python3 -c 'import json,sys; sys.exit(0 if json.load(open("result.json"))["conclusion"]=="success" else 1)'
+
+      - name: Report Check Run
+        # Runs whenever the actor guard actually passed -- regardless of what happened after
+        # (checkout/fetch infra failure, a verify-step crash, a malformed result.json). Gated on
+        # actor_guard specifically, NOT on steps.verify.outcome: a checkout/fetch failure skips
+        # "Query attestation-verify decision" entirely by GitHub's default cascade, and gating on
+        # that step's own outcome would then ALSO skip this reporting step -- leaving the check
+        # permanently pending rather than failed, the same class of trap the actor guard's own
+        # inline-report-before-exit-1 mechanism exists to close. A non-owner actor is the one case
+        # that correctly skips this step, since the actor guard already reported failure itself.
+        if: always() && steps.actor_guard.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Never trust result.json's mere existence -- `> result.json` in the query step creates
+          # a 0-byte file even when the piped command crashed before writing anything, so `[ -f ]`
+          # alone would take the "parse it" branch on an empty file and abort under `set -e`
+          # before ever reaching `gh api`. This script reads defensively (missing file, empty
+          # file, invalid JSON, or an unexpected conclusion value) and ALWAYS writes a valid
+          # payload, never raising.
+          python3 - <<'PYEOF'
+          import json
+
+          conclusion, title, summary = (
+              "failure", "verifier did not complete",
+              "no valid result.json (crash, timeout, or an earlier step failed) -- treated as failure",
+          )
+          try:
+              with open("result.json") as f:
+                  data = json.load(f)
+              c = data.get("conclusion")
+              if c in ("success", "failure"):
+                  conclusion = c
+                  title = data.get("title", title)
+                  summary = data.get("summary", summary)
+              else:
+                  title, summary = "malformed result.json", f"conclusion field was {c!r}, not success/failure"
+          except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+              pass
+          with open("check_run_payload.json", "w") as f:
+              json.dump({"conclusion": conclusion, "title": title, "summary": summary}, f)
+          PYEOF
+          CONCLUSION=$(python3 -c 'import json;print(json.load(open("check_run_payload.json"))["conclusion"])')
+          TITLE=$(python3 -c 'import json;print(json.load(open("check_run_payload.json"))["title"])')
+          SUMMARY=$(python3 -c 'import json;print(json.load(open("check_run_payload.json"))["summary"])')
+          gh api "repos/${GH_REPO}/check-runs" \
+            -f name="attestation-verify" \
+            -f head_sha="$HEAD_SHA" \
+            -f status="completed" \
+            -f conclusion="$CONCLUSION" \
+            -f output[title]="$TITLE" \
+            -f output[summary]="$SUMMARY" \
+            > /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,8 @@ src/private/
 
 # Architecture Explorer — generated graph data (re-run build.py to regenerate)
 tools/architecture-explorer/graph-data.js
+
+# attestation-verify workflow (LIA-536) — CI job working files, also produced by a local
+# standalone run of the workflow's own Report Check Run step (for verifying it directly)
+result.json
+check_run_payload.json

--- a/docs/decisions/git-level-hard-backstop-design.md
+++ b/docs/decisions/git-level-hard-backstop-design.md
@@ -1,5 +1,5 @@
 ---
-name: Git-level hard backstop for `main` (LIA-522) — design only, not yet implemented
+name: Git-level hard backstop for `main` (LIA-522) — design; workflow + check script implemented (LIA-536), ruleset not yet activated
 description: >
   Unifies LIA-467/517's dead-end text-parsing redesign with the OPA ADR's own
   deferred "later, separate phase" for a git-level enforcement point. Reuses
@@ -13,7 +13,9 @@ date: 2026-08-07
 # Git-level hard backstop for `main` — design
 
 **Date:** 2026-08-07
-**Status:** Design only. No implementation in this pass — see "Not yet started" below.
+**Status:** Design complete; the `attestation-verify` workflow and check script are implemented
+(LIA-536). The `main-attestation-backstop` ruleset is not yet created or activated — see "Not yet
+started" below for what remains.
 **Scope:** GitHub repository configuration (`sliamh11/Deus`), a new `.github/workflows/` check, a
 new small query script reusing `scripts/warden_policy/opa_client.py`. No change to
 `scripts/codex_warden_hooks.py`, `scripts/warden_policy/command_parser.py`, or
@@ -145,19 +147,31 @@ Rego rule (`scripts/warden_policy/policy/guardrails.rego`, queried via
 substrate this whole roadmap chose OPA specifically to provide. **Corrected (was: "Zero new Rego,
 zero new attestation store, zero new schema" — stale, contradicted by LIA-530's implementation):**
 the decision now includes a dedicated attestation-verify block within that same Rego file
-(`opa-warden-attestations-v1.md`'s "### Phase 4" section), with its own `operation` value. A small
-new script (not yet written — see "Not yet started") builds the `opa_input` shape that block
+(`opa-warden-attestations-v1.md`'s "### Phase 4" section), with its own `operation` value.
+**Corrected (was: "not yet written"; done since LIA-536, see §5):** a small script
+(`scripts/warden_policy/attestation_verify_check.py`) builds the `opa_input` shape that block
 expects: `operation: "attestation.verify"` (a distinct operation from the `git.commit` shape
-Hermes's own adapter builds), `gate: "code-review"`, `repo_id`, `subject_key: git-tree:<merge
-commit's tree sha>`, `expected_generation`, plus `expected_cc_generation` (new, checked against the
-isolated `data.warden_cc_attestations` document's own `generation` counter) — and exits non-zero
-unless `result.allow is True`. **Both `expected_generation` and `expected_cc_generation` must be
-read from their respective on-disk ledgers under a shared lock, the same way
-`hermes_warden_gate.py`'s existing adapter reads `expected_generation` today (never from OPA's own
-served snapshot) — sourcing either from the snapshot being queried would make its corresponding
-`supported`/`cc_supported` freshness guard tautologically true and silently void it, exactly the
-"machine-local-input precondition" the design history behind this rule already named (Fix 7,
-carried unchanged through every design revision).** See `opa-warden-attestations-v1.md`'s Phase 4
+Hermes's own adapter builds), `gate: "code-review"`, `repo_id`, `subject_key: git-tree:<the PR's
+HEAD commit's tree sha>` (**corrected here too — was wrongly "merge commit's" in an earlier
+draft**; the CI check resolves the tree of the PR's head commit specifically, fetched but never
+checked out into the base-branch checkout, per §3.3/LIA-536's own design decisions — the merge
+commit doesn't exist yet at the point this check needs to evaluate), `expected_generation`, plus
+`expected_cc_generation` (new, checked against the isolated `data.warden_cc_attestations`
+document's own `generation` counter) — and exits non-zero unless `result.allow is True`. **Both
+`expected_generation` and `expected_cc_generation` must be read from their respective on-disk
+ledgers, never from OPA's own served snapshot** — sourcing either from the snapshot being queried
+would make its corresponding `supported`/`cc_supported` freshness guard tautologically true and
+silently void it, exactly the "machine-local-input precondition" the design history behind this
+rule already named (Fix 7, carried unchanged through every design revision). **Mechanism corrected
+here (LIA-536 implementation deliberately diverges from a shared-lock-across-query pattern for
+this specific CI script)**: `hermes_warden_gate.py`'s synchronous adapter holds one shared lock
+across the whole read-then-query sequence, safe only because its own OPA call is tightly bounded;
+`attestation_verify_check.py` instead reads both generations under brief, separately-released
+locks, queries OPA with no lock held (this script's own timeout budget is deliberately more
+generous, a CI step rather than a hook), then re-acquires both locks to confirm neither generation
+moved, retrying once (bounded) before failing closed — an optimistic-concurrency approach chosen
+specifically because holding two ledger locks across a longer CI-scale OPA call would stall every
+concurrent local session's own commit-gate writes. See `opa-warden-attestations-v1.md`'s Phase 4
 section for the full query contract and decision logic rather than duplicating it here.
 
 ### 3.3 Where the check runs, and why: self-hosted runner reads the local ledger directly
@@ -321,30 +335,38 @@ nowhere in that file. **Superseded below**: `valid_ship` itself is still byte-un
 LIA-530, implemented) that DOES consult `data.warden_cc_attestations` for the `attestation.verify`
 operation specifically — see the corrected precondition list immediately below.
 
-The real, complete precondition is **three** pieces of work, two now done:
+The real, complete precondition was **three** pieces of work; **all three now done, verified
+directly against source, not assumed from a PR title**:
 (a) LIA-527 Phase 2's write path (isolating CC-authored mirrors so they can't fail-close Hermes) —
 **done, PR #1138**; (b) a **cutover Rego rule** that makes the decision Claude Code's own gate
 would use actually consult `data.warden_cc_attestations` — **done, LIA-530, reviewed and
 implemented; see `opa-warden-attestations-v1.md`'s "### Phase 4" section for the mechanism**; and
 (c) **`cc_attestations.enqueue_verdict` wired into the real commit gates**
 (`codex_warden_hooks.py`'s `run_warden_backends_gate`/`run_verification_gate` call sites) so the CC
-ledger the Phase-4 Rego rule reads is genuinely populated on real commits, not empty — **tracked
-separately as LIA-534** (filed during Phase 2's implementation, confirmed still open, Backlog
-state), **explicitly NOT done yet**. (b) was out of scope for LIA-527 Phase 2 itself (its own doc:
-*"the cutover decision... is explicitly out of scope here"*) and was new, undesigned follow-up work
-when this section was first written; it has since been designed, reviewed, and implemented as
-LIA-530. (c) remains the one genuinely open item.
+ledger the Phase-4 Rego rule reads is genuinely populated on real commits, not empty — **done, PR
+#1144/`dd90400d` (LIA-534), merged 2026-08-08, confirmed via direct `git show --stat` read during
+LIA-536's own session, not merely a Linear-state check**: adds `_cc_mirror_verdicts(role, config,
+repo_root)` mirroring every configured backend's verdict into the isolated CC ledger, reviewed
+through 2 rounds of dual-backend plan review, code-reviewer, verification-gate (a 28-combination
+fault-injection probe), and ai-eng-warden, all SHIP. (b) was out of scope for LIA-527 Phase 2
+itself (its own doc: *"the cutover decision... is explicitly out of scope here"*) and was new,
+undesigned follow-up work when this section was first written; it has since been designed,
+reviewed, and implemented as LIA-530. (c) was the one genuinely open item as of LIA-536's session
+start; **it landed on `origin/main` mid-session, discovered via this session's own routine
+`git fetch`+diff freshness check, not sought out — see `.claude/rules/orchestration-rules.md`'s
+"Session-Start State Freshness" discipline this reflects.**
 
-Consequence, stated plainly: **landing (a) and (b) alone does NOT clear activation while (c)
-remains open** — without LIA-534's gate-wiring, the CC ledger `attestation-verify`'s CC-mirror path
-reads stays empty in production even though the Rego rule that would read it now exists, so
-`attestation-verify` can in practice only pass via Hermes's own native gate (or manual enrollment
-via `warden_attest.py`), not via a commit whose only review was Claude Code's native gates. **This
-ruleset must not be activated (`enforcement: "active"`) until ALL THREE of (a), (b), and (c)
-clear** — the ruleset JSON above can be created now with `enforcement: "disabled"` (a real,
-inspectable artifact with zero live effect) as preparatory work, but must stay disabled until all
-three clear. This three-part dependency — and specifically that (a)+(b) together are still
-insufficient without (c) — is corrected here per this session's own "log each forced deviation...
+Consequence, stated plainly, **corrected from this section's prior framing** ("landing (a) and (b)
+alone does NOT clear activation while (c) remains open"): (a), (b), and (c) have **all** now landed
+— the CC-mirror path `attestation-verify` reads is genuinely populated in production today, not
+empty. This is **necessary, not sufficient**, for activation: `main-attestation-backstop` must
+still not be activated (`enforcement: "active"`) until **LIA-531** (credential separation, §3.4)
+also lands — still open as of this writing, confirmed via live coordination with the session
+working it (round 9 of threat-model review, unshipped) — and the workflow's own temporary `paths:`
+trigger filter (see the dedicated bullet in §5) is removed. The ruleset JSON above can be created
+now with `enforcement: "disabled"` (a real, inspectable artifact with zero live effect) as
+preparatory work, but must stay disabled until LIA-531 clears too. This is corrected here per this
+session's own "log each forced deviation...
 as a `Deviation:` note... at discovery" discipline, and per this document's own established
 practice (§3.1, §3.3) of correcting a wrong claim in place rather than letting it stand once found.
 
@@ -371,8 +393,14 @@ practice (§3.1, §3.3) of correcting a wrong claim in place rather than letting
 ## 5. Not yet started, and why
 
 - The `attestation-verify` GitHub Actions workflow file itself, and the small query script it
-  runs (reusing `opa_client.query_decision`, resolving `repo_id`/`subject_key` for the PR's merge
-  commit the same way `git_subject.py` already does for Hermes's path).
+  runs (reusing `opa_client.query_decision`; `repo_id`/`subject_key` resolution deliberately
+  diverges from how `git_subject.py` resolves them for Hermes's path — see §3.2's corrected text
+  for why). **Done: implemented as LIA-536** (`.github/workflows/attestation-verify.yml` +
+  `scripts/warden_policy/attestation_verify_check.py`) — covered end-to-end (unit tests plus an
+  independently-authored oracle test against a real OPA instance), but not yet exercised by a
+  live GitHub Actions run; the self-hosted runner it depends on (next bullet) remains open, and
+  the workflow's own `paths:` trigger filter is itself a new, separate precondition (see the
+  dedicated bullet below, alongside LIA-531/LIA-534/ruleset-creation).
 - Registering and hardening the self-hosted runner (a real, consequential change to the user's
   GitHub account/repo security posture — explicitly not something to do autonomously without the
   user's direct awareness, distinct from a normal code change) — blocked on confirming the
@@ -398,22 +426,25 @@ practice (§3.1, §3.3) of correcting a wrong claim in place rather than letting
   fixes above exist to close, recurring one layer up at the required-check-registration boundary
   instead of the workflow's own logic.
 - Creating the `main-attestation-backstop` ruleset via `gh api` (safe to create in `disabled`
-  state now; must stay disabled per §3.6 until ALL THREE parts of that section's dependency clear).
+  state now; must stay disabled until LIA-531 clears — §3.6's three-part CC-attestation dependency
+  has fully cleared, see below, but LIA-531 is now the sole remaining activation blocker).
 - LIA-527 Phase 2's actual implementation — **done, PR #1138** — the FIRST of §3.6's three
-  activation preconditions.
+  CC-attestation preconditions.
 - **The cutover Rego rule** making `attestation-verify`'s decision actually consult
   `data.warden_cc_attestations` (§3.6) — the SECOND precondition. **Done: designed, reviewed, and
   implemented as LIA-530** (`opa-warden-attestations-v1.md`'s "### Phase 4" section). Was
   undesigned when this section was first written; is not undesigned any longer.
 - **`cc_attestations.enqueue_verdict` wired into the real commit gates**
   (`codex_warden_hooks.py`'s `run_warden_backends_gate`/`run_verification_gate` call sites) — the
-  THIRD precondition, still open, tracked as **LIA-534** (filed during LIA-527 Phase 2's
-  implementation, confirmed Backlog state). Without this, the CC ledger the Phase-4 Rego rule reads
-  stays empty on real commits even though the rule itself is implemented — see §3.6 for the full
-  consequence. This is the one item still needing its own implementation pass before
-  `main-attestation-backstop` can safely go `active`.
-- Credential separation per §3.4 (routine agent `gh` access vs. ruleset-administration access) —
-  must cover both stripping repository-Administration permission (closes the ruleset-disable
+  THIRD precondition. **Done: PR #1144/`dd90400d` (LIA-534), merged 2026-08-08** — was still open
+  as of this section first being written; landed mid-LIA-536-session, discovered via that session's
+  own routine freshness `git fetch`, confirmed directly via `git show --stat` rather than trusted
+  from a title. **All three of §3.6's CC-attestation preconditions are now done** — the remaining
+  activation blocker is LIA-531 (credential separation, next bullet) alone, plus this workflow's
+  own temporary `paths:` filter (bullet above).
+- Credential separation per §3.4 (routine agent `gh` access vs. ruleset-administration access),
+  tracked as **LIA-531** — must cover both stripping repository-Administration permission (closes
+  the ruleset-disable
   vector) AND the `workflow` scope specifically (closes the workflow-file-edit vector named in
   §3.1 — found by this round of review to be a real gap in §3.4's original remediation, which only
   named Administration permission; a credential retaining `workflow` scope could still edit
@@ -421,12 +452,26 @@ practice (§3.1, §3.3) of correcting a wrong claim in place rather than letting
   own real app identity, defeating the `integration_id: 15368` binding from the inside rather than
   around it). Without both, the backstop's non-bypassability claim is bounded, not absolute, as
   stated there.
+- **Remove `attestation-verify.yml`'s temporary `paths:` trigger filter** (added during LIA-536's
+  implementation, found necessary by verification-gate: with zero self-hosted runners registered as
+  of the workflow's initial landing, an unfiltered `pull_request_target` trigger would queue an
+  unpickable job on every PR to the repo indefinitely — non-blocking, since nothing requires this
+  check while the ruleset doesn't exist yet, but real Actions-UI clutter). Scoped narrowly
+  (`.github/workflows/attestation-verify.yml`, `scripts/warden_policy/**`) while inactive. **Must be
+  removed before `main-attestation-backstop` is ever activated** — the whole point of the backstop
+  is universal PR coverage, and a path-scoped trigger would silently exempt every PR that doesn't
+  touch those paths from ever getting an `attestation-verify` check at all, defeating
+  `bypass_actors: []` for those PRs by omission rather than by any bypass mechanism. Added as its
+  own precondition here (not folded into the credential-separation bullet above) because it's an
+  independent, purely mechanical follow-up with no security-design content of its own.
 
-None of the above was implemented in this pass. This is a design document only, matching the
-scope LIA-522 itself asks for ("Design... + implement + get an independently-authored oracle test
-before treating it as the hard backstop") narrowed the same way LIA-527 was: the design is real
-and reviewed; implementation is real, consequential follow-up work, not compressed into the same
-pass as first-cut design.
+None of the above was implemented in **LIA-522's own original design pass** — this document was a
+design document only at that time, matching the scope LIA-522 itself asked for ("Design...
++ implement + get an independently-authored oracle test before treating it as the hard backstop")
+narrowed the same way LIA-527 was: the design was real and reviewed; implementation was real,
+consequential follow-up work, deliberately not compressed into the same pass as first-cut design.
+**Several items have since been implemented** in their own dedicated follow-up passes, corrected
+in place above rather than left stale — see the "Done" markers throughout §3.2, §3.6, and §5.
 
 ## Alternatives considered
 

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-08" # auto-bump @1786201220
+last_verified: "2026-08-08" # auto-bump @1786211091
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/scripts/warden_policy/attestation_store.py
+++ b/scripts/warden_policy/attestation_store.py
@@ -30,6 +30,17 @@ it (e.g. the CLI's `inspect`); it must NOT be used for the Hermes adapter's
 read-then-query sequence. `reconcile_if_drifted()` (LIA-533) is a second, deliberate caller of
 `read_locked()` -- its later OPA GET/PUT don't need to stay atomic with this snapshot the way
 the Hermes adapter's live gate decision does, so this is not a repeat of that mistake.
+`attestation_verify_check.py` (LIA-536) is a THIRD deliberate caller of `read_locked()`, for both
+the Hermes and CC ledgers -- it deliberately does NOT hold a lock across its OPA query either
+(that CI script's timeout budget is more generous than the Hermes adapter's, and holding two
+`flock`s across a longer network call would stall every local Hermes/CC gate's own `LOCK_EX` the
+moment they need to write). Unlike a bare "read then trust," it re-acquires both locks after the
+query and compares `generation` against the pre-query read, discarding the result (one bounded
+retry, then fail-closed) if either ledger moved in between -- an optimistic-concurrency check that
+achieves the same atomicity-from-the-reader's-perspective guarantee `locked_read()` provides via
+holding, without ever holding a lock across the network call. This is not a repeat of the
+"released the lock too early and blindly trusted the snapshot" mistake this docstring warns
+against -- the snapshot is explicitly re-verified, never blindly trusted.
 
 No `--watch`: OPA's own docs note file-watching can silently drop updates
 across `os.replace` -- unacceptable here, since a stale snapshot could still

--- a/scripts/warden_policy/attestation_verify_check.py
+++ b/scripts/warden_policy/attestation_verify_check.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""CI-side re-query of ``deus.wardens.decision`` for the ``attestation-verify`` git-level backstop
+(LIA-536, implementing ``docs/decisions/git-level-hard-backstop-design.md``).
+
+Runs on the self-hosted Actions runner registered for this repo, calling the same OPA endpoint
+(``scripts/warden_policy/opa_client.py``'s ``query_decision``) Hermes's own commit gate already
+uses, via the Phase-4 ``attestation.verify`` Rego block (LIA-530,
+``scripts/warden_policy/policy/guardrails.rego`` lines ~150-228). This is the "actual git object
+observation point" the design doc's §1 names as the missing piece every earlier enforcement point
+lacked -- unlike a PreToolUse hook, it runs server-side against the real merge candidate, not the
+driving agent's own command text.
+
+Two identifiers this script resolves DIFFERENTLY from every other caller in this package, and why
+(``docs/decisions/git-level-hard-backstop-design.md`` and this ticket's own plan cover the full
+rationale -- summarized here for anyone reading only this file):
+
+- ``repo_id``: resolved from the canonical repo path named by the ``DEUS_CANONICAL_REPO``
+  environment variable (set at self-hosted-runner registration time, operator-controlled, never
+  PR- or workflow-file-influenceable), NOT from ``GITHUB_WORKSPACE`` (the Actions runner's own
+  ephemeral checkout under ``_work/``, which has a different git-common-dir on every run and would
+  make ``resolve_repo_id()`` compute a different hash every time -- a silent-forever-deny bug, not
+  a security issue, but one indistinguishable from "OPA is down"). ``DEUS_CANONICAL_REPO`` must
+  point at the SAME canonical repo every local Hermes/Claude-Code session already writes
+  attestations against, or ``attestation-verify`` will never find a matching record.
+- ``subject_key``: resolved from the PR's head commit tree, but the head commit is only ever
+  ``git fetch``ed into the trusted base-branch checkout (never checked out as the working tree,
+  never executed) -- see ``resolve_subject_key_for_commit`` below.
+
+Fail-closed (LIA-515's Fog item, decided here): every non-``ok`` ``DecisionResult``
+(``opa_client.DecisionResult(ok=False, ...)``) AND every ``ok=True, allow=False`` result both map
+to conclusion ``"failure"``. There is no code path in this script that can return ``"success"``
+without a verified ``ok=True, allow=True`` decision. ``evaluate()``'s outer catch-all makes this
+hold even for an exception a future edit forgets to convert explicitly.
+
+**Disclosed, NOT closed by this file**: this script's own OPA query is only as trustworthy as the
+Check Run the calling workflow posts against it -- any OTHER same-repo workflow granted
+``checks: write`` could forge a same-named, same-app-id ``attestation-verify`` Check Run directly
+via the Checks API, bypassing this script and the actor guard entirely. See
+``.github/workflows/attestation-verify.yml``'s own header comment and design decision #9 in
+LIA-536's plan for the full mechanism and why it's deferred to LIA-531 (credential separation)
+rather than attempted here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from warden_policy.attestation_store import AttestationStore  # noqa: E402
+from warden_policy.cc_attestations import CC_DOCUMENT_KEY, CC_LEDGER_PATH  # noqa: E402
+from warden_policy.opa_client import DecisionResult, query_decision  # noqa: E402
+
+LEDGER_PATH = Path.home() / ".config" / "deus" / "guardrails" / "attestations-v1.json"
+OPA_URL = os.environ.get("DEUS_OPA_URL", "http://127.0.0.1:8181")
+#: More generous than hermes_warden_gate.py's tight 0.75s/2.5s hook-latency budget -- this is a
+#: CI job step, not a synchronous pre-tool-call hook, and per design decision #3 this script never
+#: holds a ledger lock across this call, so a longer timeout here cannot stall a local session's
+#: own commit gate the way it would if the lock-hold-across-query shape had been copied.
+OPA_TIMEOUT_SECONDS = 10.0
+#: One bounded retry on a detected generation race, never an unbounded loop.
+MAX_GENERATION_RACE_RETRIES = 1
+
+GATE = "code-review"
+OPERATION = "attestation.verify"
+CONTRACT_VERSION = 1
+
+
+class RepoIdentityError(Exception):
+    """Raised when repo_id or subject_key cannot be resolved -- always fail-closed."""
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    conclusion: str  # "success" or "failure" -- never anything else
+    title: str
+    summary: str
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def resolve_repo_id_from_env() -> str:
+    """Resolve repo_id from ``DEUS_CANONICAL_REPO``, never from the Actions runner's own checkout.
+
+    Deliberately does NOT call ``git_subject.resolve_repo_id`` against ``GITHUB_WORKSPACE`` --
+    see this module's docstring. Fails closed via ``RepoIdentityError`` (never a bare exception
+    escaping to a stack trace with no diagnosis) if the env var is unset or doesn't resolve to a
+    real git repo, logging the missing/invalid var name -- not just the resulting hash -- so this
+    failure mode is diagnosable rather than reading as "OPA is down."
+    """
+    canonical = os.environ.get("DEUS_CANONICAL_REPO")
+    if not canonical:
+        raise RepoIdentityError(
+            "DEUS_CANONICAL_REPO is not set -- cannot resolve repo_id. This must be set at "
+            "self-hosted-runner registration time to the canonical repo path every local "
+            "Hermes/Claude-Code session writes attestations against."
+        )
+    canonical_path = Path(canonical)
+    if not canonical_path.is_dir():
+        raise RepoIdentityError(
+            f"DEUS_CANONICAL_REPO={canonical!r} does not exist or is not a directory."
+        )
+    from warden_policy.git_subject import GitSubjectError, resolve_repo_id
+
+    try:
+        return resolve_repo_id(canonical_path)
+    except GitSubjectError as exc:
+        raise RepoIdentityError(
+            f"DEUS_CANONICAL_REPO={canonical!r} did not resolve to a valid git repo: {exc}"
+        ) from exc
+
+
+def resolve_subject_key_for_commit(repo_path: Path, head_sha: str) -> str:
+    """Resolve subject_key for an already-fetched (never checked out) commit.
+
+    Distinct from ``git_subject.resolve_subject_key``, which computes ``write-tree`` of the
+    *current index* (correct for Hermes's pre-commit-hook context, where no commit exists yet).
+    In CI the commit already exists -- fetched into ``repo_path``'s object database by the
+    workflow's own ``git fetch`` step (never checked out as the working tree; see this module's
+    docstring and design decision #2 in the LIA-536 plan) -- so this resolves the tree of that
+    already-existing commit directly. Content-addressed and clone-independent: byte-identical to
+    what ``resolve_subject_key`` would have produced locally at commit/SHIP time for the same tree.
+    """
+    try:
+        object_format = _run_git("rev-parse", "--show-object-format", cwd=repo_path) or "sha1"
+        tree_oid = _run_git("rev-parse", f"{head_sha}^{{tree}}", cwd=repo_path)
+    except subprocess.CalledProcessError as exc:
+        # An unresolvable/unfetched head_sha raises CalledProcessError, which is NOT a
+        # RepoIdentityError -- converted explicitly so it can't escape evaluate()'s narrow
+        # except clause, contradicting design decision #4's "script exception -> failure,
+        # never neutral/skipped/pass" contract.
+        raise RepoIdentityError(
+            f"git rev-parse failed while resolving subject_key for {head_sha!r}: {exc.stderr!r}"
+        ) from exc
+    if not tree_oid:
+        raise RepoIdentityError(f"could not resolve tree for fetched commit {head_sha!r}")
+    return f"git-tree:{object_format}:{tree_oid}"
+
+
+def _read_generations() -> tuple[int, int]:
+    """Read (expected_generation, expected_cc_generation), each under its own brief shared lock,
+    released immediately -- never both held at once. See design decision #3 / this script's
+    entry in attestation_store.py's own module docstring for the full read-verify-recheck
+    rationale."""
+    hermes_store = AttestationStore(LEDGER_PATH)
+    cc_store = AttestationStore(CC_LEDGER_PATH, document_key=CC_DOCUMENT_KEY)
+    hermes_doc = hermes_store.read_locked()
+    expected_generation = hermes_doc[hermes_store.document_key]["generation"]
+    cc_doc = cc_store.read_locked()
+    expected_cc_generation = cc_doc[cc_store.document_key]["generation"]
+    return expected_generation, expected_cc_generation
+
+
+def query_decision_with_race_check(
+    repo_id: str, subject_key: str, opa_url: str = OPA_URL, timeout_seconds: float = OPA_TIMEOUT_SECONDS,
+) -> DecisionResult:
+    """Read-verify-recheck: read both ledger generations (locks released immediately), query OPA
+    with NO lock held, then re-read both generations and confirm neither moved. One bounded retry
+    on a detected race; a second consecutive race fails closed.
+
+    This achieves the same never-trust-a-stale-snapshot guarantee ``hermes_warden_gate.py``'s
+    hold-across-query pattern provides, without ever holding a ledger lock across the (here,
+    deliberately more generous) OPA network call -- see design decision #3 in the LIA-536 plan for
+    the full rationale (holding two locks across a longer CI-scale timeout would stall every local
+    session's own commit-gate writes, which need the same locks in exclusive mode).
+    """
+    for attempt in range(MAX_GENERATION_RACE_RETRIES + 1):
+        expected_generation, expected_cc_generation = _read_generations()
+        opa_input = {
+            "contract_version": CONTRACT_VERSION,
+            "operation": OPERATION,
+            "gate": GATE,
+            "repo_id": repo_id,
+            "subject_key": subject_key,
+            "expected_generation": expected_generation,
+            "expected_cc_generation": expected_cc_generation,
+        }
+        decision = query_decision(opa_url, opa_input, timeout_seconds=timeout_seconds)
+
+        recheck_generation, recheck_cc_generation = _read_generations()
+        if (
+            recheck_generation == expected_generation
+            and recheck_cc_generation == expected_cc_generation
+        ):
+            return decision
+
+        if attempt < MAX_GENERATION_RACE_RETRIES:
+            continue
+
+        return DecisionResult(
+            ok=False, allow=False, reason="",
+            error=(
+                "ledger generation changed during OPA query (stale-race retry exhausted) -- "
+                "failing closed rather than trusting a possibly-stale snapshot"
+            ),
+        )
+
+    raise AssertionError("unreachable: loop always returns")
+
+
+def evaluate(repo_path: Path, head_sha: str) -> VerifyResult:
+    """Top-level fail-closed evaluation. NEVER raises -- every expected failure mode
+    (RepoIdentityError, a non-allow/non-ok DecisionResult) maps to an explicit failure
+    VerifyResult, and an outer catch-all (below) converts any OTHER exception the same way, so a
+    forgotten conversion anywhere in this call chain can never escape as a bare traceback. Only a
+    fully-validated ok=True, allow=True result is "success"."""
+    try:
+        return _evaluate_inner(repo_path, head_sha)
+    except Exception as exc:  # noqa: BLE001 -- deliberate last-resort backstop, see docstring
+        # Without this, an exception any inner helper forgot to convert to RepoIdentityError would
+        # propagate out of evaluate() as a bare traceback -- exactly the "script exception" case
+        # design decision #4 explicitly promises maps to conclusion="failure", never a crash.
+        return VerifyResult(
+            conclusion="failure", title="unexpected script exception",
+            summary=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _evaluate_inner(repo_path: Path, head_sha: str) -> VerifyResult:
+    try:
+        repo_id = resolve_repo_id_from_env()
+    except RepoIdentityError as exc:
+        return VerifyResult(conclusion="failure", title="repo identity unresolved", summary=str(exc))
+
+    try:
+        subject_key = resolve_subject_key_for_commit(repo_path, head_sha)
+    except RepoIdentityError as exc:
+        return VerifyResult(conclusion="failure", title="subject tree unresolved", summary=str(exc))
+
+    decision = query_decision_with_race_check(repo_id, subject_key)
+
+    if not decision.ok:
+        return VerifyResult(
+            conclusion="failure", title="guardrails policy engine unreachable or invalid",
+            summary=f"OPA query failed: {decision.error} -- failing closed",
+        )
+
+    if not decision.allow:
+        return VerifyResult(
+            conclusion="failure", title="no valid attestation found",
+            summary=decision.reason or "guardrails policy denied",
+        )
+
+    return VerifyResult(conclusion="success", title="attestation verified", summary=decision.reason)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-path", required=True,
+        help="path to the checked-out repo (trusted base-branch checkout) whose object "
+             "database has the PR head commit fetched into it",
+    )
+    parser.add_argument(
+        "--head-sha", required=True,
+        help="the PR's head commit sha (already fetched, never checked out, into --repo-path)",
+    )
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON result")
+    args = parser.parse_args()
+
+    start = time.monotonic()
+    result = evaluate(Path(args.repo_path), args.head_sha)
+    elapsed = time.monotonic() - start
+
+    if args.json:
+        print(json.dumps({
+            "conclusion": result.conclusion, "title": result.title,
+            "summary": result.summary, "elapsed_seconds": round(elapsed, 3),
+        }))
+    else:
+        print(f"[{result.conclusion}] {result.title}: {result.summary}", file=sys.stderr)
+
+    return 0 if result.conclusion == "success" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/warden_policy/attestation_verify_check.py
+++ b/scripts/warden_policy/attestation_verify_check.py
@@ -102,7 +102,7 @@ def resolve_repo_id_from_env() -> str:
     real git repo, logging the missing/invalid var name -- not just the resulting hash -- so this
     failure mode is diagnosable rather than reading as "OPA is down."
     """
-    canonical = os.environ.get("DEUS_CANONICAL_REPO")
+    canonical = os.environ.get("DEUS_CANONICAL_REPO")  # LIA-536
     if not canonical:
         raise RepoIdentityError(
             "DEUS_CANONICAL_REPO is not set -- cannot resolve repo_id. This must be set at "

--- a/scripts/warden_policy/tests/test_attestation_verify_check.py
+++ b/scripts/warden_policy/tests/test_attestation_verify_check.py
@@ -1,0 +1,325 @@
+"""Tests for attestation_verify_check.py (LIA-536).
+
+Coverage notes: the actor-guard mechanism (design decision #5 -- must run first, must post its
+own failure Check Run before `exit 1`) lives entirely in `.github/workflows/attestation-verify.yml`
+shell steps, not in this Python module, so it has no direct unit-test surface here. It is verified
+by direct review of the workflow YAML and by the one live end-to-end test PR run against the
+ephemeral self-hosted runner (design decision #8) -- not reproduced as a pytest case, since there
+is no Python function to call.
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import warden_policy.attestation_verify_check as avc
+from warden_policy.attestation_store import AttestationStore
+from warden_policy.cc_attestations import CC_DOCUMENT_KEY
+from warden_policy.git_subject import resolve_subject_key
+from warden_policy.opa_client import DecisionResult
+
+
+def _git(*args, cwd):
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True,
+    ).stdout
+
+
+def _init_repo(path):
+    _git("init", "-q", cwd=path)
+    _git("config", "user.email", "test@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+
+
+def _commit_file(path, name, content):
+    (Path(path) / name).write_text(content)
+    _git("add", name, cwd=path)
+    _git("commit", "-q", "-m", f"add {name}", cwd=path)
+    return _git("rev-parse", "HEAD", cwd=path).strip()
+
+
+class TestResolveRepoId(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        _init_repo(self.repo)
+        _commit_file(self.repo, "f.txt", "hello\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_resolves_from_deus_canonical_repo_env_var(self):
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(self.repo)}, clear=False):
+            repo_id = avc.resolve_repo_id_from_env()
+        self.assertTrue(repo_id.startswith("git-common-dir-sha256:"))
+
+    def test_differs_from_a_naive_github_workspace_derived_id(self):
+        # A different (ephemeral-checkout-shaped) path must resolve to a DIFFERENT repo_id --
+        # proves this script is not accidentally coupled to GITHUB_WORKSPACE. Two independent
+        # repos never collide (git_subject.resolve_repo_id hashes an absolute canonical path).
+        other = Path(self.tmp.name) / "ephemeral-actions-checkout"
+        other.mkdir()
+        _init_repo(other)
+        _commit_file(other, "f.txt", "hello\n")
+
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(self.repo)}, clear=False):
+            canonical_id = avc.resolve_repo_id_from_env()
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(other)}, clear=False):
+            workspace_shaped_id = avc.resolve_repo_id_from_env()
+
+        self.assertNotEqual(canonical_id, workspace_shaped_id)
+
+    def test_unset_env_var_fails_closed_with_var_name_in_message(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(avc.RepoIdentityError) as ctx:
+                avc.resolve_repo_id_from_env()
+        self.assertIn("DEUS_CANONICAL_REPO", str(ctx.exception))
+
+    def test_invalid_path_fails_closed_with_path_in_message(self):
+        bogus = str(Path(self.tmp.name) / "does-not-exist")
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": bogus}, clear=False):
+            with self.assertRaises(avc.RepoIdentityError) as ctx:
+                avc.resolve_repo_id_from_env()
+        self.assertIn(bogus, str(ctx.exception))
+
+    def test_non_repo_directory_fails_closed(self):
+        not_a_repo = Path(self.tmp.name) / "just-a-dir"
+        not_a_repo.mkdir()
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(not_a_repo)}, clear=False):
+            with self.assertRaises(avc.RepoIdentityError):
+                avc.resolve_repo_id_from_env()
+
+
+class TestSubjectKeyEquivalence(unittest.TestCase):
+    """The single load-bearing correctness claim of design decision #2: the CI-style resolver
+    (git rev-parse ^{tree} against an existing commit) must be byte-identical to what
+    git_subject.resolve_subject_key() computes pre-commit via write-tree for the same tree."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        _init_repo(self.repo)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_ci_resolver_matches_pre_commit_write_tree_resolver(self):
+        (self.repo / "f.txt").write_text("content\n")
+        _git("add", "f.txt", cwd=self.repo)
+
+        pre_commit_key = resolve_subject_key(self.repo)
+
+        _git("commit", "-q", "-m", "commit it", cwd=self.repo)
+        head_sha = _git("rev-parse", "HEAD", cwd=self.repo).strip()
+
+        ci_key = avc.resolve_subject_key_for_commit(self.repo, head_sha)
+
+        self.assertEqual(pre_commit_key, ci_key)
+
+    def test_ci_resolver_on_a_fetched_but_not_checked_out_commit(self):
+        # Simulates the real workflow shape: a second bare-ish repo fetches the first repo's
+        # commit without ever checking it out, then resolves subject_key against the fetched ref.
+        head_sha = _commit_file(self.repo, "f.txt", "content\n")
+        fetcher = Path(self.tmp.name) / "fetcher"
+        fetcher.mkdir()
+        _init_repo(fetcher)
+        # An initial commit so the fetcher repo has a HEAD of its own (mirrors the workflow's
+        # base-branch checkout, which always has content before fetching the PR head).
+        _commit_file(fetcher, "base.txt", "base\n")
+
+        _git("fetch", str(self.repo), head_sha, cwd=fetcher)
+        # Confirm nothing was checked out -- the fetched file must not appear in the working tree.
+        self.assertFalse((fetcher / "f.txt").exists())
+
+        ci_key = avc.resolve_subject_key_for_commit(fetcher, head_sha)
+        expected_key = resolve_subject_key(self.repo)  # computed pre-commit-equivalent, in repo
+        # resolve_subject_key(self.repo) reflects self.repo's CURRENT index (post-commit, clean --
+        # write-tree of a clean tree matches HEAD^{tree}), so this is a valid cross-clone check.
+        self.assertEqual(ci_key, expected_key)
+
+
+class TestReadVerifyRecheck(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.hermes_ledger = Path(self.tmp.name) / "hermes.json"
+        self.cc_ledger = Path(self.tmp.name) / "cc.json"
+        self.hermes_patcher = mock.patch.object(avc, "LEDGER_PATH", self.hermes_ledger)
+        self.cc_patcher = mock.patch("warden_policy.attestation_verify_check.CC_LEDGER_PATH", self.cc_ledger)
+        self.hermes_patcher.start()
+        self.cc_patcher.start()
+        # Touch both ledgers into existence at generation 0 via a throwaway store instance.
+        AttestationStore(self.hermes_ledger).read_locked()
+        AttestationStore(self.cc_ledger, document_key=CC_DOCUMENT_KEY).read_locked()
+
+    def tearDown(self):
+        self.hermes_patcher.stop()
+        self.cc_patcher.stop()
+        self.tmp.cleanup()
+
+    def test_happy_path_no_lock_held_during_query(self):
+        lock_held_during_query = {"held": None}
+
+        def _fake_query_decision(opa_url, opa_input, timeout_seconds):
+            # Attempt a non-blocking exclusive lock on both ledgers -- if this script were still
+            # holding a shared lock during the query, acquiring EXCLUSIVE here would raise
+            # BlockingIOError, proving the held-lock shape. Success here proves NO lock is held.
+            import fcntl
+            for ledger in (self.hermes_ledger, self.cc_ledger):
+                lock_path = ledger.with_suffix(ledger.suffix + ".lock")
+                fd = __import__("os").open(lock_path, __import__("os").O_RDWR)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                finally:
+                    __import__("os").close(fd)
+            lock_held_during_query["held"] = False
+            return DecisionResult(ok=True, allow=True, reason="ok")
+
+        with mock.patch.object(avc, "query_decision", side_effect=_fake_query_decision):
+            result = avc.query_decision_with_race_check("repo-id", "subject-key")
+
+        self.assertFalse(lock_held_during_query["held"])
+        self.assertTrue(result.ok)
+        self.assertTrue(result.allow)
+
+    def test_generation_mismatch_triggers_exactly_one_bounded_retry(self):
+        call_count = {"n": 0}
+
+        def _fake_query_decision(opa_url, opa_input, timeout_seconds):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Simulate a concurrent write landing between the pre-read and the recheck.
+                store = AttestationStore(self.hermes_ledger)
+                store.enroll("some-repo-id")
+            return DecisionResult(ok=True, allow=True, reason="ok")
+
+        with mock.patch.object(avc, "query_decision", side_effect=_fake_query_decision):
+            result = avc.query_decision_with_race_check("repo-id", "subject-key")
+
+        self.assertEqual(call_count["n"], 2)  # exactly one retry, not zero, not unbounded
+        self.assertTrue(result.ok)
+
+    def test_second_consecutive_mismatch_fails_closed(self):
+        def _fake_query_decision(opa_url, opa_input, timeout_seconds):
+            # Every call perturbs the ledger -- every recheck will see a mismatch.
+            store = AttestationStore(self.hermes_ledger)
+            store.enroll(f"repo-id-{id(opa_input)}")
+            return DecisionResult(ok=True, allow=True, reason="ok")
+
+        with mock.patch.object(avc, "query_decision", side_effect=_fake_query_decision):
+            result = avc.query_decision_with_race_check("repo-id", "subject-key")
+
+        self.assertFalse(result.ok)
+        self.assertIn("stale-race", result.error)
+
+    def test_recheck_locks_are_sequential_never_simultaneous(self):
+        # _read_generations() itself must never hold both locks at once -- verified by acquiring
+        # an exclusive, non-blocking lock on ONE ledger from inside a mocked read of the OTHER.
+        import fcntl
+        import os as _os
+
+        def _read_generations_probe():
+            # Reimplements _read_generations but asserts, after the hermes read releases, that
+            # the hermes lock is immediately acquirable exclusively (i.e., not still held while
+            # the CC read proceeds).
+            hermes_store = AttestationStore(self.hermes_ledger)
+            hermes_doc = hermes_store.read_locked()
+            hermes_lock = self.hermes_ledger.with_suffix(self.hermes_ledger.suffix + ".lock")
+            fd = _os.open(hermes_lock, _os.O_RDWR)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # must not raise
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                _os.close(fd)
+            cc_store = AttestationStore(self.cc_ledger, document_key=CC_DOCUMENT_KEY)
+            cc_doc = cc_store.read_locked()
+            return (
+                hermes_doc[hermes_store.document_key]["generation"],
+                cc_doc[cc_store.document_key]["generation"],
+            )
+
+        with mock.patch.object(avc, "_read_generations", side_effect=_read_generations_probe):
+            with mock.patch.object(
+                avc, "query_decision",
+                return_value=DecisionResult(ok=True, allow=True, reason="ok"),
+            ):
+                result = avc.query_decision_with_race_check("repo-id", "subject-key")
+        self.assertTrue(result.ok)
+
+
+class TestFailClosed(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        _init_repo(self.repo)
+        self.head_sha = _commit_file(self.repo, "f.txt", "hello\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _evaluate_with_decision(self, decision):
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(self.repo)}, clear=False):
+            with mock.patch.object(avc, "query_decision_with_race_check", return_value=decision):
+                return avc.evaluate(self.repo, self.head_sha)
+
+    def test_opa_unreachable_is_failure(self):
+        decision = DecisionResult(ok=False, allow=False, reason="", error="request failed")
+        result = self._evaluate_with_decision(decision)
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_malformed_response_is_failure(self):
+        decision = DecisionResult(ok=False, allow=False, reason="", error="malformed JSON")
+        result = self._evaluate_with_decision(decision)
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_legitimate_deny_ok_true_allow_false_is_failure(self):
+        # A correctly-computed deny (e.g. guardrails.rego's explicit deny body) must map to
+        # "failure" exactly the same as an infra error -- both are "the check does not pass."
+        decision = DecisionResult(ok=True, allow=False, reason="no code-review SHIP for staged tree")
+        result = self._evaluate_with_decision(decision)
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_verified_allow_is_success(self):
+        decision = DecisionResult(ok=True, allow=True, reason="matching code-review SHIP")
+        result = self._evaluate_with_decision(decision)
+        self.assertEqual(result.conclusion, "success")
+
+    def test_repo_identity_failure_is_failure_before_any_opa_call(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with mock.patch.object(avc, "query_decision_with_race_check") as mock_query:
+                result = avc.evaluate(self.repo, self.head_sha)
+        mock_query.assert_not_called()
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_unresolvable_head_sha_is_failure_not_a_crash(self):
+        # Found by code-reviewer + ai-eng-warden (independently, same root cause): an
+        # unfetched/bogus head_sha makes `git rev-parse <sha>^{tree}` fail with
+        # CalledProcessError, which used to escape resolve_subject_key_for_commit uncaught.
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(self.repo)}, clear=False):
+            result = avc.evaluate(self.repo, "0" * 40)  # a well-formed but nonexistent sha
+        self.assertEqual(result.conclusion, "failure")
+        self.assertIn("subject tree unresolved", result.title)
+
+    def test_unexpected_exception_anywhere_in_evaluate_is_failure_not_a_crash(self):
+        # The outer catch-all backstop: even an exception NO inner helper converts must still
+        # surface as conclusion="failure", never a bare traceback escaping evaluate().
+        with mock.patch.dict("os.environ", {"DEUS_CANONICAL_REPO": str(self.repo)}, clear=False):
+            with mock.patch.object(
+                avc, "query_decision_with_race_check", side_effect=RuntimeError("boom"),
+            ):
+                result = avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(result.conclusion, "failure")
+        self.assertIn("unexpected script exception", result.title)
+        self.assertIn("boom", result.summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/warden_policy/tests/test_attestation_verify_oracle.py
+++ b/scripts/warden_policy/tests/test_attestation_verify_oracle.py
@@ -1,0 +1,557 @@
+"""Independent oracle for LIA-536's `attestation-verify` git-level backstop.
+
+Authored by the `oracle-author` role, from the spec, BLIND to
+`scripts/warden_policy/attestation_verify_check.py` (which does not exist yet -- this ticket is
+pre-implementation) and to the implementer's own `test_attestation_verify_check.py`. Sources used:
+`docs/decisions/git-level-hard-backstop-design.md`, `docs/decisions/opa-warden-attestations-v1.md`'s
+"### Phase 4" section, the real `scripts/warden_policy/policy/guardrails.rego` (ground truth for the
+Rego contract, read lines ~150-228 plus the shared helpers it depends on), and this repo's own
+existing, already-tested `scripts/warden_policy/opa_client.py` / `attestation_store.py` /
+`cc_attestations.py` / `git_subject.py` modules (public, pre-existing infrastructure this new check
+is documented to reuse, not the new implementation itself).
+
+Two independent tracks, of deliberately different strength:
+
+TRACK A -- `RegoAttestationVerifyOracle`: spins up a REAL local `opa run --server` process loading
+the ACTUAL `guardrails.rego` policy file, writes fixtures through the real, already-tested
+`AttestationStore` write path (both the Hermes-shaped default document and the isolated
+`warden_cc_attestations` document `cc_attestations.py` uses), and queries
+`deus.wardens.decision` for `operation: "attestation.verify"` through the real, already-tested
+`query_decision` client. This is strong, direct evidence: it validates the real policy file
+end-to-end, completely independent of whether `attestation_verify_check.py` (which does not exist
+yet) ever gets the wrapping right. Skipped (loudly, not silently) if `opa` is not on PATH.
+
+TRACK B -- `AttestationVerifyCheckContractOracle`: black-box tests against the documented public
+contract of `attestation_verify_check.evaluate(repo_path, head_sha) -> VerifyResult`. Since that
+module does not exist yet, every test here is expected to fail today with
+`ModuleNotFoundError`/`ImportError` -- a stronger, more specific red than a stand-in function's
+tautological pass, matching this repo's own established convention for pre-implementation oracles
+(see `opa-warden-attestations-v1.md`'s Phase 2/Phase 3 "Independent oracle" sections). Once the
+module exists, these tests exercise the Python wrapper's fail-closed CONCLUSION MAPPING by mocking
+`query_decision`'s return value -- this does NOT re-validate the Rego policy (Track A already does
+that against a real OPA process); it validates that `evaluate()` correctly maps a KNOWN-GOOD or
+KNOWN-BAD OPA answer into `conclusion == "success"` / `"failure"`, per this ticket's own documented
+fail-closed contract. This is the weaker of the two tracks, and is reported as such.
+
+DISCLOSED LIMITATION on independence: while reading `attestation_store.py` (pre-existing, already-
+tested infrastructure, needed to build ledger fixtures for Track A) this author incidentally saw a
+docstring passage naming `attestation_verify_check.py` as a third caller of `read_locked()` and
+describing, in prose, an internal locking/retry strategy it is said to use (reading both ledgers,
+querying OPA without holding a lock across the network call, then re-acquiring and comparing
+generations, one bounded retry, fail-closed on drift). That passage describes internal MECHANISM,
+not observable CONTRACT, and no assertion in this file targets it -- every assertion here targets
+only the documented public contract (`evaluate(repo_path, head_sha) -> VerifyResult`, the Rego
+decision shape, and the ledger paths/constants explicitly named in this ticket's own brief).
+Disclosed here rather than silently used, per this role's standing honesty requirement.
+
+NOT COVERED by this oracle (see "Falsifies" notes on individual tests for what each one DOES
+catch):
+  - The GitHub Actions actor-guard (non-owner PRs) -- enforced entirely in
+    `.github/workflows/attestation-verify.yml`, not in Python. See
+    `AttestationVerifyCheckContractOracle.test_actor_guard_out_of_scope_for_python_oracle`.
+  - `integration_id`/ruleset/`bypass_actors` GitHub configuration -- not a Python-testable surface.
+  - The internal locking/retry mechanism named in the disclosed limitation above -- deliberately,
+    per that disclosure.
+  - Live concurrency/race behavior of the two-ledger read -- out of scope for a pre-implementation
+    oracle; would need the real implementation to exist first.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from warden_policy.attestation_store import AttestationStore  # noqa: E402
+from warden_policy.cc_attestations import CC_DOCUMENT_KEY  # noqa: E402
+from warden_policy.git_subject import resolve_repo_id  # noqa: E402
+from warden_policy.opa_client import DecisionResult, query_decision  # noqa: E402
+
+POLICY_PATH = Path(__file__).resolve().parents[1] / "policy" / "guardrails.rego"
+OPA_AVAILABLE = __import__("shutil").which("opa") is not None
+
+
+# --------------------------------------------------------------------------------------------
+# Shared git/OPA-process test helpers -- none of this is the new implementation; it is plumbing
+# to build realistic fixtures against the real, pre-existing git_subject.py / AttestationStore /
+# guardrails.rego contract.
+# --------------------------------------------------------------------------------------------
+
+def _git(*args: str, cwd) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True,
+    )
+    return result.stdout
+
+
+def _init_repo(path) -> str:
+    """Create a real, throwaway git repo with one commit. Returns the commit sha."""
+    _git("init", "-q", cwd=path)
+    _git("config", "user.email", "oracle@test.example", cwd=path)
+    _git("config", "user.name", "Oracle", cwd=path)
+    (Path(path) / "f.txt").write_text("hello\n")
+    _git("add", "f.txt", cwd=path)
+    _git("commit", "-q", "-m", "init", cwd=path)
+    return _git("rev-parse", "HEAD", cwd=path).strip()
+
+
+def _subject_key_for_commit(repo, commit_sha: str) -> str:
+    """`git-tree:<object-format>:<oid>` for *commit_sha*'s own tree.
+
+    Mirrors the format `git_subject.py::resolve_subject_key` uses for the staged index
+    (`git-tree:<algo>:<oid>`), applied instead to a real commit's tree -- the shape
+    `git-level-hard-backstop-design.md` §3.2 documents for the merge-commit case
+    ("subject_key: git-tree:<merge commit's tree sha>"). Deliberately independent of any
+    resolution helper `attestation_verify_check.py` itself might define internally.
+    """
+    object_format = _git("rev-parse", "--show-object-format", cwd=repo).strip() or "sha1"
+    tree_sha = _git("rev-parse", f"{commit_sha}^{{tree}}", cwd=repo).strip()
+    return f"git-tree:{object_format}:{tree_sha}"
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _OpaServer:
+    """Manages one real `opa run --server` subprocess loading the real guardrails.rego."""
+
+    def __init__(self, policy_path: Path):
+        self.policy_path = policy_path
+        self.port = _find_free_port()
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self.proc: subprocess.Popen | None = None
+
+    def start(self, timeout: float = 20.0) -> None:
+        self.proc = subprocess.Popen(
+            ["opa", "run", "--server", "--addr", f"127.0.0.1:{self.port}", str(self.policy_path)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError("opa server process exited before becoming healthy")
+            try:
+                with urllib.request.urlopen(f"{self.base_url}/health", timeout=1) as resp:
+                    if resp.status == 200:
+                        return
+            except (urllib.error.URLError, OSError, TimeoutError):
+                pass
+            time.sleep(0.2)
+        self.stop()
+        raise RuntimeError("opa server did not become healthy in time")
+
+    def stop(self) -> None:
+        if self.proc is not None and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=5)
+        self.proc = None
+
+
+@contextlib.contextmanager
+def _canonical_repo_env(value: str | None):
+    """Set (or explicitly unset) DEUS_CANONICAL_REPO for the duration of the block."""
+    had_original = "DEUS_CANONICAL_REPO" in os.environ
+    original = os.environ.get("DEUS_CANONICAL_REPO")
+    if value is None:
+        os.environ.pop("DEUS_CANONICAL_REPO", None)
+    else:
+        os.environ["DEUS_CANONICAL_REPO"] = value
+    try:
+        yield
+    finally:
+        if had_original:
+            os.environ["DEUS_CANONICAL_REPO"] = original
+        else:
+            os.environ.pop("DEUS_CANONICAL_REPO", None)
+
+
+# --------------------------------------------------------------------------------------------
+# TRACK A -- real OPA, real guardrails.rego. Strong, direct evidence.
+# --------------------------------------------------------------------------------------------
+
+@unittest.skipUnless(OPA_AVAILABLE, "opa not found on PATH -- Track A requires a real OPA binary")
+class RegoAttestationVerifyOracle(unittest.TestCase):
+    """Exercises the REAL `deus.wardens.decision` Rego rule for `operation: attestation.verify`,
+    via a real local `opa run --server` process loading the real
+    `scripts/warden_policy/policy/guardrails.rego` file -- independent of whether
+    `attestation_verify_check.py` exists or wraps this correctly. This is the ground-truth policy
+    contract per `opa-warden-attestations-v1.md`'s Phase 4 section and `guardrails.rego:150-228`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.opa = _OpaServer(POLICY_PATH)
+        cls.opa.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opa.stop()
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self.head_sha = _init_repo(self.repo)
+        self.repo_id = resolve_repo_id(self.repo)
+        self.subject_key = _subject_key_for_commit(self.repo, self.head_sha)
+        self.hermes_store = AttestationStore(
+            Path(self.tmp.name) / "hermes.json", opa_base_url=self.opa.base_url,
+        )
+        self.cc_store = AttestationStore(
+            Path(self.tmp.name) / "cc.json", opa_base_url=self.opa.base_url,
+            document_key=CC_DOCUMENT_KEY,
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # -- fixture helpers --------------------------------------------------------------------
+
+    def _issue_hermes(self, subject_key: str, verdict: str) -> int:
+        result = self.hermes_store.issue(
+            repo_id=self.repo_id, gate="code-review", subject_key=subject_key,
+            verdict=verdict, issuer_kind="manual", reviewer_id="oracle@test", reason="fixture",
+        )
+        self.assertTrue(result.ok and result.activated, f"Hermes fixture write failed: {result}")
+        return result.generation
+
+    def _enroll_hermes_only(self) -> int:
+        """Bring the Hermes document into existence (so `supported` can hold) without issuing
+        any record for `self.subject_key` -- used by scenarios needing 'Hermes has no opinion'.
+        """
+        result = self.hermes_store.enroll(self.repo_id)
+        self.assertTrue(result.ok and result.activated, f"Hermes enroll fixture failed: {result}")
+        return result.generation
+
+    def _issue_cc(self, subject_key: str, verdict: str, backend: str) -> int:
+        result = self.cc_store.issue_if_newer(
+            repo_id=self.repo_id, gate="code-reviewer", subject_key=subject_key,
+            verdict=verdict, issuer_kind="manual", reviewer_id="oracle-cc@test",
+            reason="fixture", queued_at=time.time_ns(), backend=backend,
+        )
+        self.assertTrue(result.ok and result.activated, f"CC fixture write failed: {result}")
+        return result.generation
+
+    def _query(self, subject_key: str, hermes_gen: int, cc_gen: int) -> DecisionResult:
+        opa_input = {
+            "contract_version": 1,
+            "operation": "attestation.verify",
+            "gate": "code-review",
+            "repo_id": self.repo_id,
+            "subject_key": subject_key,
+            "expected_generation": hermes_gen,
+            "expected_cc_generation": cc_gen,
+        }
+        return query_decision(self.opa.base_url, opa_input, timeout_seconds=5.0)
+
+    # -- scenario 1 -----------------------------------------------------------------------
+
+    def test_hermes_native_ship_allows(self):
+        # @oracle LIA-536: guardrails.rego:183-186,202-206 hermes_path_ok -- a fresh Hermes-
+        # native code-review SHIP for the exact subject tree must allow, attributed to the
+        # Hermes-native path. Falsifies: a Rego regression that stops recognizing a genuine
+        # Hermes SHIP, or attributes the allow to the wrong path.
+        gen = self._issue_hermes(self.subject_key, "SHIP")
+        result = self._query(self.subject_key, gen, 0)
+        self.assertTrue(result.ok, result.error)
+        self.assertTrue(result.allow, result.reason)
+        self.assertIn("Hermes-native", result.reason)
+
+    # -- scenario 2 -----------------------------------------------------------------------
+
+    def test_cc_mirrored_ship_allows_when_no_hermes_record(self):
+        # @oracle LIA-536: guardrails.rego:167-181,196-200,208-218 cc_path_ok / valid_cc_
+        # mirrored_ship -- a CC-mirrored claude-backend SHIP is sufficient evidence when Hermes
+        # genuinely has no record at all for this tree. Falsifies: a Rego regression that
+        # requires a Hermes SHIP even when Hermes never reviewed the tree, defeating the whole
+        # point of LIA-530's CC-mirror fallback path.
+        hermes_gen = self._enroll_hermes_only()
+        cc_gen = self._issue_cc(self.subject_key, "SHIP", backend="claude")
+        result = self._query(self.subject_key, hermes_gen, cc_gen)
+        self.assertTrue(result.ok, result.error)
+        self.assertTrue(result.allow, result.reason)
+        self.assertIn("Claude Code native", result.reason)
+
+    # -- scenario 3 -- the REVISE-override protection --------------------------------------
+
+    def test_hermes_non_ship_verdict_overrides_cc_mirrored_ship(self):
+        # @oracle LIA-536: guardrails.rego:188-200 hermes_record_exists -- the exact
+        # REVISE-override bug named in opa-warden-attestations-v1.md's Phase 4 section, found
+        # and fixed during LIA-530's own review: an explicit fresh Hermes REVISE or BLOCK for a
+        # tree must NEVER be silently overridden by a CC-mirrored claude SHIP for that same
+        # tree. Falsifies: a regression back to gating the CC path on `not valid_ship` (a
+        # SHIP-specific check) instead of `not hermes_record_exists` (an existence check) --
+        # exactly the exploit two independent reviewers found against an earlier draft.
+        for non_ship_verdict in ("REVISE", "BLOCK"):
+            with self.subTest(hermes_verdict=non_ship_verdict):
+                hermes_store = AttestationStore(
+                    Path(self.tmp.name) / f"hermes-{non_ship_verdict}.json",
+                    opa_base_url=self.opa.base_url,
+                )
+                cc_store = AttestationStore(
+                    Path(self.tmp.name) / f"cc-{non_ship_verdict}.json",
+                    opa_base_url=self.opa.base_url, document_key=CC_DOCUMENT_KEY,
+                )
+                hermes_result = hermes_store.issue(
+                    repo_id=self.repo_id, gate="code-review", subject_key=self.subject_key,
+                    verdict=non_ship_verdict, issuer_kind="manual", reviewer_id="oracle@test",
+                    reason="fixture-non-ship",
+                )
+                self.assertTrue(hermes_result.ok and hermes_result.activated)
+                cc_result = cc_store.issue_if_newer(
+                    repo_id=self.repo_id, gate="code-reviewer", subject_key=self.subject_key,
+                    verdict="SHIP", issuer_kind="manual", reviewer_id="oracle-cc@test",
+                    reason="fixture-cc-ship", queued_at=time.time_ns(), backend="claude",
+                )
+                self.assertTrue(cc_result.ok and cc_result.activated)
+                opa_input = {
+                    "contract_version": 1,
+                    "operation": "attestation.verify",
+                    "gate": "code-review",
+                    "repo_id": self.repo_id,
+                    "subject_key": self.subject_key,
+                    "expected_generation": hermes_result.generation,
+                    "expected_cc_generation": cc_result.generation,
+                }
+                result = query_decision(self.opa.base_url, opa_input, timeout_seconds=5.0)
+                self.assertTrue(result.ok, result.error)
+                self.assertFalse(
+                    result.allow,
+                    f"a CC-mirrored SHIP must not override an explicit Hermes {non_ship_verdict}",
+                )
+
+    # -- scenario 4 -----------------------------------------------------------------------
+
+    def test_no_evidence_anywhere_denies(self):
+        # @oracle LIA-536: guardrails.rego:220-228 catch-all deny -- no Hermes record and no CC
+        # record for the tree at all must deny. Falsifies: a default-allow regression (the
+        # single most dangerous failure mode for a hard backstop).
+        hermes_gen = self._enroll_hermes_only()
+        result = self._query(self.subject_key, hermes_gen, 0)
+        self.assertTrue(result.ok, result.error)
+        self.assertFalse(result.allow)
+        self.assertIn("no SHIP found", result.reason)
+
+    # -- scenario 6 -- staleness guards ------------------------------------------------------
+
+    def test_stale_hermes_generation_denies_despite_valid_ship(self):
+        # @oracle LIA-536: guardrails.rego:18-22 `supported` -- gates BOTH the Hermes-native and
+        # CC-mirror paths (per the file's own header comment). A stale expected_generation must
+        # deny even though a genuinely valid Hermes SHIP exists for the tree. Falsifies: a
+        # regression that lets a stale OPA snapshot (e.g. after a failed/ambiguous PUT) still
+        # serve an allow.
+        gen = self._issue_hermes(self.subject_key, "SHIP")
+        result = self._query(self.subject_key, gen + 1, 0)
+        self.assertTrue(result.ok, result.error)
+        self.assertFalse(result.allow)
+
+    def test_stale_cc_generation_denies_cc_only_path(self):
+        # @oracle LIA-536: guardrails.rego:161-165 cc_supported -- the CC-mirror path's OWN,
+        # separate staleness guard on data.warden_cc_attestations.generation. A stale
+        # expected_cc_generation must deny the CC path even though a genuinely valid CC SHIP
+        # exists and Hermes has no opinion. Falsifies: a regression that drops this guard,
+        # letting a stale CC snapshot serve an allow.
+        hermes_gen = self._enroll_hermes_only()
+        cc_gen = self._issue_cc(self.subject_key, "SHIP", backend="claude")
+        result = self._query(self.subject_key, hermes_gen, cc_gen + 1)
+        self.assertTrue(result.ok, result.error)
+        self.assertFalse(result.allow)
+
+    # -- scenario 7 -- backend-key hardcoding ------------------------------------------------
+
+    def test_cc_mirrored_ship_under_non_claude_backend_denies(self):
+        # @oracle LIA-536: guardrails.rego:167-168 valid_cc_mirrored_ship -- the backend index
+        # is hardcoded to the literal "claude" key. A SHIP mirrored under any other backend
+        # (e.g. "gpt") must NOT satisfy the CC path when no claude-backend record exists for the
+        # same tree. Falsifies: a future accidental change to that hardcoded key (e.g. reading
+        # an arbitrary/first backend) going undetected -- the exact risk the Rego file's own
+        # comment at this line names explicitly.
+        hermes_gen = self._enroll_hermes_only()
+        cc_gen = self._issue_cc(self.subject_key, "SHIP", backend="gpt")
+        result = self._query(self.subject_key, hermes_gen, cc_gen)
+        self.assertTrue(result.ok, result.error)
+        self.assertFalse(result.allow)
+
+
+# --------------------------------------------------------------------------------------------
+# TRACK B -- black-box contract test against attestation_verify_check.evaluate(). Weaker
+# evidence (mocks query_decision rather than exercising a real OPA), and expected to fail with
+# ModuleNotFoundError today since the module does not exist yet -- see module docstring.
+# --------------------------------------------------------------------------------------------
+
+class AttestationVerifyCheckContractOracle(unittest.TestCase):
+    """Black-box tests against the documented public contract:
+
+        evaluate(repo_path: Path, head_sha: str) -> VerifyResult
+        VerifyResult.conclusion in {"success", "failure"}, plus .title, .summary
+
+    ASSUMPTION, stated explicitly since this module cannot be read to confirm it: these tests
+    patch `attestation_verify_check.query_decision`, following the exact import/patch pattern
+    `scripts/hermes_warden_gate.py` and its own test (`test_hermes_warden_gate.py`) already
+    establish in this codebase for the identical `opa_client.query_decision` boundary (the spec
+    says this module "queries OPA's deus.wardens.decision endpoint (via
+    scripts/warden_policy/opa_client.py's query_decision)"). If the real implementation calls
+    query_decision through some other indirection, `mock.patch.object` will raise AttributeError
+    -- that would itself be a legitimate implementation-review finding (an unexpected import
+    shape for a boundary this repo has an established pattern for), not a flaw in the contract
+    this oracle checks.
+    """
+
+    def setUp(self):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        from warden_policy import attestation_verify_check as avc  # noqa: PLC0415
+        self.avc = avc
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self.head_sha = _init_repo(self.repo)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # -- fail-closed conclusion mapping ------------------------------------------------------
+
+    def test_success_only_on_ok_true_allow_true(self):
+        # @oracle LIA-536: spec's documented fail-closed contract -- "Only a verified ok=True,
+        # allow=True maps to success." Falsifies: a wrapper that treats any non-error OPA
+        # response as success regardless of `allow`.
+        with _canonical_repo_env(str(self.repo)), mock.patch.object(
+            self.avc, "query_decision",
+            return_value=DecisionResult(
+                ok=True, allow=True, reason="matching code-review SHIP (Hermes-native)",
+            ),
+        ):
+            result = self.avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(result.conclusion, "success")
+
+    def test_failure_on_legitimate_deny(self):
+        # @oracle LIA-536: spec's fail-closed contract -- "any legitimate ok=True, allow=False
+        # deny... map[s] to conclusion=failure." Falsifies: a wrapper that only fails closed on
+        # errors but treats a real, well-formed OPA deny as some other non-failure outcome.
+        with _canonical_repo_env(str(self.repo)), mock.patch.object(
+            self.avc, "query_decision",
+            return_value=DecisionResult(
+                ok=True, allow=False, reason="no SHIP found for git-tree:sha1:x",
+            ),
+        ):
+            result = self.avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_failure_on_opa_unreachable(self):
+        # @oracle LIA-536: scenario 5 / spec's fail-closed contract -- "ANY OPA-unreachable...
+        # condition... map[s] to conclusion=failure," and design doc §3.5: never skipped or
+        # defaulted to pass. Falsifies: an unreachable-OPA condition that raises uncaught (CI
+        # would likely then report a different, less clear failure mode) or that defaults to
+        # success.
+        with _canonical_repo_env(str(self.repo)), mock.patch.object(
+            self.avc, "query_decision",
+            return_value=DecisionResult(
+                ok=False, allow=False, reason="", error="request failed: connection refused",
+            ),
+        ):
+            result = self.avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_failure_on_malformed_opa_response(self):
+        # @oracle LIA-536: scenario 5, malformed-response variant -- same fail-closed contract,
+        # distinct trigger (a reachable-but-garbage OPA response) from plain unreachability.
+        with _canonical_repo_env(str(self.repo)), mock.patch.object(
+            self.avc, "query_decision",
+            return_value=DecisionResult(
+                ok=False, allow=False, reason="", error="malformed JSON: ...",
+            ),
+        ):
+            result = self.avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(result.conclusion, "failure")
+
+    def test_missing_canonical_repo_fails_closed_without_querying_opa(self):
+        # @oracle LIA-536: spec -- "DEUS_CANONICAL_REPO... must be set to a real git repo path
+        # or evaluate() fails closed." Falsifies: a wrapper that falls back to some other repo
+        # resolution silently, or crashes uncaught, when the env var is absent/invalid; also
+        # falsifies a wrapper that queries OPA anyway with a garbage repo_id instead of failing
+        # closed before ever reaching the network.
+        with _canonical_repo_env(None), mock.patch.object(
+            self.avc, "query_decision",
+            side_effect=AssertionError(
+                "must not query OPA when DEUS_CANONICAL_REPO cannot be resolved"
+            ),
+        ):
+            result = self.avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(result.conclusion, "failure")
+
+    # -- shape / documented-field checks -----------------------------------------------------
+
+    def test_verify_result_has_documented_fields(self):
+        # @oracle LIA-536: spec -- "VerifyResult has fields conclusion, title, summary." Does
+        # NOT assert exact wording (unspecified by the ticket) -- only that the documented shape
+        # is honored with non-empty, human-readable content.
+        with _canonical_repo_env(str(self.repo)), mock.patch.object(
+            self.avc, "query_decision",
+            return_value=DecisionResult(
+                ok=True, allow=True, reason="matching code-review SHIP (Hermes-native)",
+            ),
+        ):
+            result = self.avc.evaluate(self.repo, self.head_sha)
+        self.assertIn(result.conclusion, ("success", "failure"))
+        self.assertIsInstance(result.title, str)
+        self.assertTrue(result.title.strip())
+        self.assertIsInstance(result.summary, str)
+        self.assertTrue(result.summary.strip())
+
+    def test_opa_input_carries_documented_operation_and_gate(self):
+        # @oracle LIA-536: spec -- queries OPA "with operation: 'attestation.verify', gate:
+        # 'code-review'." Falsifies: a wrapper that sends the wrong operation/gate string,
+        # which per guardrails.rego's own guards would silently fall through to the file's
+        # default deny for every real invocation.
+        captured: dict = {}
+
+        def _capture(opa_base_url, opa_input, timeout_seconds):
+            captured.update(opa_input)
+            return DecisionResult(
+                ok=True, allow=True, reason="matching code-review SHIP (Hermes-native)",
+            )
+
+        with _canonical_repo_env(str(self.repo)), mock.patch.object(
+            self.avc, "query_decision", side_effect=_capture,
+        ):
+            self.avc.evaluate(self.repo, self.head_sha)
+        self.assertEqual(captured.get("operation"), "attestation.verify")
+        self.assertEqual(captured.get("gate"), "code-review")
+
+    # -- explicit, documented scope exclusion ------------------------------------------------
+
+    def test_actor_guard_out_of_scope_for_python_oracle(self):
+        # @oracle LIA-536: scenario 8 -- the non-owner-actor guard is enforced entirely inside
+        # .github/workflows/attestation-verify.yml's own unconditional early step (never a
+        # job/step-level `if:`, per git-level-hard-backstop-design.md §3.3, so its conclusion is
+        # always success/failure, never `skipped` -- GitHub's required-status-check evaluation
+        # treats `skipped` as satisfying the requirement). No OPA query happens on that path at
+        # all, so there is nothing in evaluate() for a Python-side oracle to assert. Recorded as
+        # an explicit, visible scope exclusion rather than silently omitted.
+        self.skipTest(
+            "actor-guard enforcement lives entirely in the GitHub Actions workflow YAML "
+            "(.github/workflows/attestation-verify.yml), not in Python -- see "
+            "git-level-hard-backstop-design.md Sec 3.3. Out of scope for this Python oracle."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/warden_policy/tests/test_attestation_verify_oracle.py
+++ b/scripts/warden_policy/tests/test_attestation_verify_oracle.py
@@ -167,18 +167,18 @@ class _OpaServer:
 
 @contextlib.contextmanager
 def _canonical_repo_env(value: str | None):
-    """Set (or explicitly unset) DEUS_CANONICAL_REPO for the duration of the block."""
-    had_original = "DEUS_CANONICAL_REPO" in os.environ
-    original = os.environ.get("DEUS_CANONICAL_REPO")
+    """Set (or explicitly unset) DEUS_CANONICAL_REPO (LIA-536) for the duration of the block."""
+    had_original = "DEUS_CANONICAL_REPO" in os.environ  # LIA-536
+    original = os.environ.get("DEUS_CANONICAL_REPO")  # LIA-536
     if value is None:
         os.environ.pop("DEUS_CANONICAL_REPO", None)
     else:
-        os.environ["DEUS_CANONICAL_REPO"] = value
+        os.environ["DEUS_CANONICAL_REPO"] = value  # LIA-536
     try:
         yield
     finally:
         if had_original:
-            os.environ["DEUS_CANONICAL_REPO"] = original
+            os.environ["DEUS_CANONICAL_REPO"] = original  # LIA-536
         else:
             os.environ.pop("DEUS_CANONICAL_REPO", None)
 


### PR DESCRIPTION
## Summary

Implements the `attestation-verify` GitHub Actions workflow and CI-side query script for the git-level hard backstop designed in `docs/decisions/git-level-hard-backstop-design.md` (PR #1129). Re-queries the same `deus.wardens.decision` OPA endpoint (Phase-4 `attestation.verify` block, LIA-530) Hermes's own commit gate uses, server-side against the actual PR being merged rather than inferring intent from command text.

**This PR does NOT create the `main-attestation-backstop` ruleset and does NOT register any self-hosted runner.** Both are separate, explicitly-confirmed steps per LIA-536, gated on LIA-531 (credential separation, still open) before any activation.

## Key design decisions (all threat-modeled — 3 rounds — and plan-reviewed — 5 rounds, co-gate PASS)

- `repo_id` resolved from a `DEUS_CANONICAL_REPO` env var (operator-set at runner registration), never from the Actions runner's own ephemeral checkout — avoids a silent-forever-deny bug and a "runner must run as the interactive user" coupling.
- `subject_key` resolved by fetching (never checking out) the PR's head commit into the trusted base-branch checkout, so the verifier script that actually executes is always the base-branch version, never PR-controlled.
- Ledger generation reads use an optimistic read-verify-recheck pattern instead of holding locks across the OPA query, so a CI-scale timeout can't stall local sessions' own commit-gate writes.
- The workflow's actor guard runs first, unconditionally, and posts its own failure Check Run via the Checks API before `exit 1` — avoiding the skipped-satisfies-required-check trap GitHub's evaluation has.
- Fail-closed throughout (LIA-515's Fog item, decided here): every OPA-unreachable/malformed-response/exception path, and every legitimate `ok=true,allow=false` deny, maps to `conclusion=failure`. `evaluate()` has an outer catch-all so no exception can ever escape as a bare traceback.
- A temporary `paths:` trigger filter, since no self-hosted runner is registered yet — tracked as an explicit activation precondition in the design doc, must be removed before the ruleset is ever activated.

## Review process

- plan-reviewer: 5 rounds to co-gate PASS (claude+gpt SHIP), catching a missing `contents: read` permission, a PR-head-checkout code-execution vector, and an actor-guard ordering gap.
- threat-modeler: 3 rounds to SHIP. Round 1 BLOCKed a persistent self-hosted runner design (zero enforcement value while open, real RCE surface) — redesigned to an ephemeral, labeled, torn-down-after-one-use runner registration (deferred to a later confirmed step, not part of this PR).
- Independently-authored oracle test (oracle-author agent, blind to this implementation): validates 7 scenarios against a **real local OPA instance loading the actual `guardrails.rego`** — not mocked — including a mutation test proving it actually catches a reintroduced REVISE-override bug.
- code-reviewer + ai-eng-warden: 2 rounds each, both independently found the same real bug (uncaught `CalledProcessError` + a workflow crash-fallback that never fired) — fixed and re-verified.
- verification-gate: 7 rounds, catching a stale-daemon issue, several doc-accuracy regressions, and (significantly) confirming mid-session that LIA-534 merged upstream (PR #1144), updating this PR's own design-doc precondition tracking accordingly.

## Test plan

- [x] `python3 -m pytest scripts/warden_policy/tests/ -v` — 242 passed, 1 skipped (actor-guard enforcement lives in the workflow YAML, no Python surface), 65 subtests, zero regressions
- [x] Independent oracle test against a real OPA instance, mutation-tested
- [x] Workflow YAML validated (`yaml.safe_load`) and its "Report Check Run" step manually executed standalone against 0-byte/absent/valid `result.json` cases
- [ ] Live end-to-end test PR against a real self-hosted runner — deliberately deferred to a separate, confirmed step (design decision #8), not part of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>