### PR TITLE
docs(hermes): wire + document LIA-523's plan-review gate hook

### DIFF
--- a/docs/HERMES_WARDEN_OPA.md
+++ b/docs/HERMES_WARDEN_OPA.md
@@ -45,10 +45,11 @@ operational how-to.
    ```bash
    python3 scripts/install_warden_opa_sync_launchd.py
    ```
-4. Add the Hermes hooks (personal `~/.hermes/config.yaml`, never repo-committed). Three
-   independent gates, each its own hook entry under the same `matcher: "terminal"` (a distinct
-   `command` string is a distinct, independently-invoked registration — none of the three
-   scripts calls or depends on another):
+4. Add the Hermes hooks (personal `~/.hermes/config.yaml`, never repo-committed). Four
+   independent gates, each its own hook entry (three under `matcher: "terminal"`; the new
+   plan-review gate under its own `matcher: "write_file|patch"` since it fires on file writes,
+   not shell commands) — a distinct `command` string is a distinct, independently-invoked
+   registration — none of the four scripts calls or depends on another:
    ```yaml
    hooks:
      pre_tool_call:
@@ -61,22 +62,63 @@ operational how-to.
        - matcher: "terminal"
          command: "python3 <PROJECT_ROOT>/scripts/hermes_verification_gate.py"
          timeout: 3
+       - matcher: "write_file|patch"
+         command: "python3 <PROJECT_ROOT>/scripts/hermes_plan_review_gate.py"
+         timeout: 3
    ```
-   Do **not** set `hooks_auto_accept: true` globally — approve each command explicitly so
-   Hermes records it in `~/.hermes/shell-hooks-allowlist.json`. Verify with `hermes hooks list`
-   and `hermes hooks doctor`. Worst-case cumulative latency for one `git commit` is
-   sequential-additive across however many of the three hooks are enrolled, each up to its own
-   `timeout:` (3s default) — up to ~9s worst case with all three enrolled and slow; inherent to
-   Hermes's own sequential hook-dispatch loop.
-5. Enroll a repo. Code-review, ai-eng-warden, and verification-gate are three independent,
-   additive on/off switches — enabling one does not enable the others:
+   This is the full target set once every gate below is enabled — a given
+   `~/.hermes/config.yaml` only needs entries for the gates actually enabled for at least one
+   repo, so a real config may legitimately carry fewer than four (e.g. just the `terminal`
+   entry plus the `write_file|patch` one, with the ai-eng-warden/verification-gate `terminal`
+   entries added later only once those gates are actually used).
+
+   Adding the entry above is necessary but **not sufficient** to activate a hook — Hermes
+   still won't dispatch it until its exact `(event, command)` pair is separately approved into
+   the allowlist (next paragraph). Do **not** set `hooks_auto_accept: true` globally — approve
+   each command explicitly so Hermes records it in `~/.hermes/shell-hooks-allowlist.json`. The
+   allowlist keys on the `(event, command)` **pair**, not the command string alone, so
+   approving one script's hook does not implicitly approve another's — start a new `hermes`
+   session: every configured hook that is not yet allowlisted prompts once at startup,
+   regardless of its `matcher`.
+   **A non-interactive/gateway caller runs with `accept_hooks=False` by default and never sees
+   that TTY prompt at all — the hook then silently never registers (a logged warning only, no
+   error raised) and every matching call proceeds completely ungated, with nothing at
+   write-time to indicate it.** For unattended activation, pass `--accept-hooks` on the
+   invoking `hermes` command, or set `hooks_auto_accept: true` and accept its blanket-approval
+   tradeoff. Either way, always confirm real registration afterward with `hermes hooks list`
+   (prints `✓ allowed` / `✗ not allowlisted`) and `hermes hooks doctor` (prints
+   `✓ allowlisted (approved ...)`) — a `doctor` line without `✓ allowlisted` did not activate no
+   matter how confidently the config file reads, and `doctor` also flags a stale approval if the
+   script's mtime moved since it was approved.
+   Worst-case cumulative latency for one `git commit` is sequential-additive across however many
+   of the three `terminal`-matcher hooks are enrolled, each up to its own `timeout:` (3s default)
+   — up to ~9s worst case with all three enrolled and slow; inherent to Hermes's own sequential
+   hook-dispatch loop. The `write_file|patch`-matcher plan-review gate matches a different tool,
+   not `terminal` — it's the same `pre_tool_call` event, so it does not add to that `terminal`-call
+   latency chain, and instead adds its own separate up-to-3s `timeout:` on each qualifying
+   write/patch call.
+5. Enroll a repo. Code-review, ai-eng-warden, verification-gate, and plan-review are four
+   independent, additive on/off switches — enabling one does not enable the others:
    ```bash
    python3 scripts/warden_attest.py enroll --repo /path/to/repo
    python3 scripts/warden_attest.py enable-ai-eng-warden --repo /path/to/repo
    python3 scripts/warden_attest.py enable-verification-gate --repo /path/to/repo
+   python3 scripts/warden_attest.py enable-plan-review --repo /path/to/repo
    ```
    A repo with none of these enabled is completely unaffected by any guardrail — every commit
-   form works normally, including any of the repo's own git hooks.
+   form works normally, including any of the repo's own git hooks. `enable-plan-review` is the
+   *last* of three things that must all be true before writes are actually gated for a repo,
+   not the only one: (1) the `write_file|patch` config entry from step 4 must be present, (2)
+   that hook's `(event, command)` pair must be genuinely **allowlisted** (step 4's TTY
+   approval, or `--accept-hooks`/`hooks_auto_accept` — confirm with `hermes hooks doctor`,
+   since a non-interactive/gateway session silently never registers it otherwise, no error,
+   just a logged warning), and only then does (3) `enable-plan-review` make the
+   already-registered hook start gating writes for this repo. Skip any one of the three and
+   writes proceed completely ungated with no visible warning at write time — see Daily use
+   below for the command that authorizes writes once all three are true, and the two named
+   limitations (relative-path calls, session-attestation TTL) before relying on it in a real
+   session. To turn plan-review back off for one repo without touching the other three
+   switches: `python3 scripts/warden_attest.py disable-plan-review --repo /path/to/repo`.
 
 ## Daily use
 
@@ -93,7 +135,42 @@ python3 scripts/warden_attest.py issue --repo <path> --gate ai-eng-warden --back
 # verification-gate: latest-indexed, single-verdict -- no --backend flag:
 python3 scripts/warden_attest.py issue --repo <path> --gate verification-gate \
     --verdict SHIP --reviewer-id 'verification-gate@hermes' --reason '...'
+```
 
+```bash
+# plan-review: session-bound, not tree-bound -- authorizes WRITES for a Hermes session
+# (--session-id), not a git commit. Required once a repo has enable-plan-review on, or every
+# write_file/patch call is blocked. Re-issue after plan_review_ttl_seconds (default 7200s)
+# elapses, or the attestation expires mid-session and writes silently re-block.
+#
+# <hermes-session-id>: `hermes -q ...` (one-shot automation) prints it to stderr as
+# `session_id: <id>` when the run ends (e.g. 20260101_120000_abc123); inside an interactive
+# `hermes chat` session, the default (non-compact) startup welcome banner already shows
+# `Session: <id>`, or get it via `/title` (prints `Session ID: <id>`) or the exit summary --
+# `--compact` mode / a narrow (<80 col) terminal omits the startup banner's session line, so
+# those two are the fallbacks there. To find a recent session's id afterward, run
+# `hermes sessions list` (its `ID` column uses the same value):
+python3 scripts/warden_attest.py plan-review --repo <path> --session-id <hermes-session-id> \
+    --verdict SHIP --reviewer-id 'plan-reviewer@hermes' --reason '...'
+```
+
+Two named v1 limitations (`docs/decisions/opa-warden-attestations-v1.md`, "Phase 3 — Hermes
+plan-review gate" section, the bold-labeled "Named v1 limitation" and "Session-attestation TTL"
+passages) worth knowing before relying on plan-review in a real session:
+- **Relative-path (including `~`) `write_file`/`patch` calls are always blocked (no override)** once
+  the gate resolves the call's `cwd` to a repo that is itself plan-review-enrolled
+  (`scripts/hermes_plan_review_gate.py:261-275`) — a real usability cost given how commonly
+  coding agents emit relative paths. Use absolute paths for writes in an enrolled repo. Named
+  v1 residual gap: when `cwd` isn't inside an enrolled repo at all (e.g. not a git repo, or a
+  repo that hasn't run `enable-plan-review`), this half of the gate imposes no block on the
+  relative-path call — matching the pre-existing, already-shipped ungated behavior for that
+  case, not a regression.
+- **Session attestations expire** after `plan_review_ttl_seconds` (default 7200s / 2h,
+  overridable via `data.warden_attestations.config.plan_review_ttl_seconds`). A long session can
+  silently re-block mid-flight once the TTL lapses — re-run the `plan-review` command above to
+  refresh it.
+
+```bash
 # supported commit form (BOTH flags required, -c must precede `commit`):
 git -c core.hooksPath=<any-empty-dir> commit --no-verify -m 'message'
 
@@ -112,14 +189,28 @@ python3 scripts/warden_attest.py inspect --repo <path>
 ## Rollback
 
 - **Turn off entirely**: `launchctl bootout gui/$(id -u)/com.deus.warden-opa`, remove the
-  `hooks:` block from `~/.hermes/config.yaml`, remove the corresponding entry from
-  `~/.hermes/shell-hooks-allowlist.json`.
-- **Turn off for one repo only** (daemon and other repos unaffected):
+  `hooks:` entries from `~/.hermes/config.yaml` (all `matcher: "terminal"` entries and, if
+  the plan-review gate is enabled, the `matcher: "write_file|patch"` entry), remove the
+  corresponding entries from `~/.hermes/shell-hooks-allowlist.json`. Takes effect on the
+  next `hermes` start, not immediately — hooks are registered once at process startup with
+  no unregister/reload path, so an already-running session keeps every hook it started with
+  registered for its lifetime regardless of this edit.
+- **Turn off for one repo only, code-review gate** (daemon and other repos unaffected):
   `python3 scripts/warden_attest.py unenroll --repo <path>`.
 - **Turn off ai-eng-warden or verification-gate for one repo only** (independent of
   code-review's own `enabled` switch and of each other):
   `python3 scripts/warden_attest.py disable-ai-eng-warden --repo <path>` /
   `python3 scripts/warden_attest.py disable-verification-gate --repo <path>`.
+- **Turn off the plan-review gate for one repo only** (independent of the other three
+  switches; code-review/ai-eng-warden/verification-gate enforcement for that repo stays
+  active): `python3 scripts/warden_attest.py disable-plan-review --repo <path>`.
+- **Turn off the plan-review gate everywhere at once** (code-review/ai-eng-warden/
+  verification-gate enforcement unaffected — the plan-review gate is purely additive over the
+  other three): remove just the `matcher: "write_file|patch"` entry from
+  `~/.hermes/config.yaml`. Same startup-only-registration caveat as above: takes effect on
+  the next `hermes` start, not immediately — an already-running session keeps the hook
+  registered for its lifetime. The corresponding `~/.hermes/shell-hooks-allowlist.json`
+  entry can stay — it is inert without the matching config entry.
 - **Turn off the periodic self-heal job only** (daemon and gate unaffected — you lose automatic
   drift recovery, manual `sync` still works): `python3
   scripts/install_warden_opa_sync_launchd.py --uninstall`, or directly `launchctl bootout

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-08" # auto-bump @1786219501
+last_verified: "2026-08-09" # auto-bump @1786242972
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary
- LIA-523/PR #1137 shipped `scripts/hermes_plan_review_gate.py`, but it was never wired into a Hermes config nor documented — the gate existed as dead code.
- Documents the `write_file|patch` hook entry and the full activation/rollback flow in `docs/HERMES_WARDEN_OPA.md`: Install steps 4-5 now cover all four gates (code-review, ai-eng-warden, verification-gate, plan-review); Daily use gains the `plan-review` command example plus the two named v1 limitations; Rollback gains per-repo/global plan-review-off paths with an explicit restart caveat (hooks register once at Hermes startup, no unregister path).
- Docs-only change — the actual `~/.hermes/config.yaml` hook entry is a personal, never-repo-committed file; the doc now walks through that manual step.

## Review
- plan-reviewer: SHIP (round 3, fresh Opus dispatch)
- code-reviewer: SHIP (round 6, fresh Opus dispatch — every factual claim in the doc independently re-derived from live Hermes source, not taken on faith) + GPT co-gate SHIP. GLM co-gate: `COULD_NOT_RUN` (z.ai balance exhausted, HTTP 429 — fails open per this repo's established policy, 2/3 backends genuinely SHIP)
- verification-gate: SHIP (cross-checked diff against 303 passing Python tests + 65 passing Rego tests)

## Follow-up filed separately (not fixed here)
LIA-541 — found during round-6 review: `PluginManager.discover_and_load(force=True)` silently clears all registered Hermes shell hooks mid-session (`hermes_cli/plugins.py:1313`), killing every warden gate (plan-review, code-review, ai-eng-warden, verification-gate) with no error. Hermes-side reliability gap, out of scope for this doc change.

## Test plan
- [x] `pytest scripts/warden_policy/tests/` — 303 passed, 1 skipped
- [x] `opa test scripts/warden_policy/policy/guardrails.rego scripts/warden_policy/policy/guardrails_test.rego` — 65/65 pass
- [x] Verified diff is docs-only; live `~/.hermes/config.yaml` untouched by this change
- [x] All markdown code-fences balanced; every cited file:line re-verified against Hermes source

🤖 Generated with [Claude Code](https://claude.com/claude-code)