### PR TITLE
docs(orchestration-rules): note Agent(general-purpose) denial gotcha

### DIFF
--- a/.claude/rules/orchestration-rules.md
+++ b/.claude/rules/orchestration-rules.md
@@ -28,6 +28,7 @@
 - Dispatched agents must work against the current issue state. If the issue was modified after dispatch, the agent's output is suspect — re-evaluate before accepting.
 - Agent output that doesn't match the issue's acceptance criteria should not auto-merge, even if CI passes. The output-quality-gate exists for this.
 - Failed dispatches (auth errors, container failures, timeouts) must be surfaced with clear error state — not silently swallowed.
+- **`subagent_type: "general-purpose"` is denied in this repo** (2026-08-09, confirmed via `.claude/settings.json:4`: `"deny": ["Agent(Explore)", "Agent(general-purpose)", "Agent(Plan)"]`). Use `"general"` instead — it's the equivalent catch-all agent type actually permitted here. A denied dispatch fails immediately with a permission-rule error, not silently, but it still wastes a round trip; default to `"general"` for open-ended delegated research/tasks in this repo.
 
 ## Tool Hygiene
 - When creating or updating issues via MCP tools, verify the rendered output matches intent. Double-escaped markdown, broken formatting, and missing fields are bugs, not cosmetic issues — they degrade agent scoping and human review.


### PR DESCRIPTION
## Summary
- Documents a gotcha found during the diri security-audit session: this repo's `.claude/settings.json` denies `Agent(general-purpose)` (and `Agent(Explore)`/`Agent(Plan)`), so `subagent_type: "general"` should be used instead for open-ended delegated work here.

## Test plan
- [x] plan-reviewer SHIP (claude + gpt backends)
- [x] code-reviewer SHIP (claude + gpt backends; glm backend unavailable — billing/quota error, gate fails open)
- [x] verification-gate SHIP — staged diff verified line-exact against `.claude/settings.json:4`, denial behavior empirically reproduced live

## Follow-up (not in scope here)
verification-gate flagged that `.claude/skills/deep-research/SKILL.md:98,131` and `.claude/wardens/README.md:247` still instruct `Agent(subagent_type="general-purpose")` and will fail at dispatch time. Pre-existing, separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)