### PR TITLE
fix(wardens): opa test merge error on schema JSON files (LIA-538)

### DIFF
--- a/docs/HERMES_WARDEN_OPA.md
+++ b/docs/HERMES_WARDEN_OPA.md
@@ -236,7 +236,10 @@ python3 scripts/warden_attest.py inspect --repo <path>
 ```bash
 opa fmt --fail scripts/warden_policy/policy
 opa check --strict scripts/warden_policy/policy
-opa test -v scripts/warden_policy/policy
+# --ignore excludes the loose JSON Schema docs: opa test merges same-directory JSON files into one
+# data tree, and the two schema files' conflicting top-level keys (e.g. $id) trigger a merge error
+# otherwise (LIA-538). Neither schema file is consumed by the Rego policy itself.
+opa test -v --ignore="*.schema.json" scripts/warden_policy/policy
 python3 -m pytest scripts/warden_policy/tests -v
 python3 -m pytest scripts/tests/test_warden_attest_reconcile.py -v
 shellcheck scripts/start_warden_opa.sh

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-09" # auto-bump @1786245180
+last_verified: "2026-08-09" # auto-bump @1786264137
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"


### PR DESCRIPTION
## Summary
- `opa test -v scripts/warden_policy/policy` has failed with a merge error since `attestation-cc-v1.schema.json` was added (LIA-527/530) — OPA's directory loader merges sibling JSON files into one data tree, and the two schema docs' conflicting top-level keys (`$id`, `title`, etc.) collide.
- Fix: add `--ignore="*.schema.json"` to the documented command in `docs/HERMES_WARDEN_OPA.md`, plus a 3-line comment explaining why.
- Docs-only. Neither schema file is read by the Rego policy, and the live `com.deus.warden-opa` daemon loads `guardrails.rego` directly (not the directory), so this never affected production — only the documented verification command.

## Test plan
- [x] `opa test -v --ignore="*.schema.json" scripts/warden_policy/policy` → 65/65 pass
- [x] Without the flag → reproduces the original merge error (confirms real bug + real fix)
- [x] `opa check --strict scripts/warden_policy/policy` → exit 0 either way, unaffected
- [x] `python3 -m pytest scripts/warden_policy/tests` → 303 passed, 1 skipped, 65 subtests
- [x] No CI workflow invokes `opa test` (grepped `.github/workflows/`) — this doc is the only place the command lives
- [x] plan-reviewer SHIP (Claude + GPT co-gate)
- [x] code-reviewer SHIP (Claude + GPT co-gate; GLM COULD_NOT_RUN on quota exhaustion, fails open per established precedent)
- [x] verification-gate SHIP (independently re-ran all commands above)

Note: `opa fmt --fail scripts/warden_policy/policy` currently fails on a pre-existing, unrelated formatting drift in `guardrails.rego` (confirmed identical on `origin/main`, not touched by this diff). Filed separately as LIA-542 rather than folded into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)