### PR TITLE
fix(wardens): resolve opa fmt formatting drift in guardrails.rego (LIA-542)

### DIFF
--- a/scripts/warden_policy/policy/guardrails.rego
+++ b/scripts/warden_policy/policy/guardrails.rego
@@ -225,7 +225,7 @@ valid_plan_review_ship if {
 	att.subject.session_id == input.session_id
 	att.verdict == "SHIP"
 	issued_ns := time.parse_rfc3339_ns(att.issued_at)
-	time.now_ns() - issued_ns < (plan_review_ttl_seconds * 1000000000)
+	time.now_ns() - issued_ns < plan_review_ttl_seconds * 1000000000
 }
 
 decision := {"allow": true, "reason": "repo not plan-review-enrolled"} if {
@@ -274,7 +274,7 @@ cc_supported if {
 }
 
 valid_cc_mirrored_ship if {
-	id := data.warden_cc_attestations.latest_by_backend[input.repo_id]["code-reviewer"][input.subject_key]["claude"]
+	id := data.warden_cc_attestations.latest_by_backend[input.repo_id]["code-reviewer"][input.subject_key].claude
 	att := data.warden_cc_attestations.records[id]
 	att.schema_version == 1
 	att.repo_id == input.repo_id
@@ -282,10 +282,11 @@ valid_cc_mirrored_ship if {
 	att.subject.key == input.subject_key
 	att.backend == "claude"
 	att.verdict == "SHIP"
-	att.queued_at   # CC-only field (issue_if_newer sets it; Hermes's issue() never does) --
-	                # the real mis-targeted-document discriminator. Existence check: Rego's `if`
-	                # fails on undefined; the schema types this an integer >= 0, so no
-	                # legitimate value (including 0) is falsy here.
+	att.queued_at # CC-only field (issue_if_newer sets it; Hermes's issue() never does) --
+
+	# the real mis-targeted-document discriminator. Existence check: Rego's `if`
+	# fails on undefined; the schema types this an integer >= 0, so no
+	# legitimate value (including 0) is falsy here.
 	cc_supported
 }
 
@@ -317,12 +318,13 @@ decision := {"allow": true, "reason": "matching code-review SHIP (Hermes-native)
 decision := {"allow": true, "reason": "matching code-reviewer SHIP (Claude Code native, claude backend only -- gpt/glm not verified, permanent limitation)"} if {
 	input.operation == "attestation.verify"
 	input.gate == "code-review"
-	not hermes_path_ok   # deliberate defense-in-depth, provably redundant with cc_path_ok's own
-	                      # `not hermes_record_exists` given valid_ship and hermes_record_exists
-	                      # resolve the identical index lookup -- kept for clarity at zero cost,
-	                      # never remove `not hermes_record_exists` from cc_path_ok on the mistaken
-	                      # belief that THIS line alone still protects against Hermes-record
-	                      # override (mutation-verified, opa-warden-attestations-v1.md Phase 4).
+	not hermes_path_ok # deliberate defense-in-depth, provably redundant with cc_path_ok's own
+
+	# `not hermes_record_exists` given valid_ship and hermes_record_exists
+	# resolve the identical index lookup -- kept for clarity at zero cost,
+	# never remove `not hermes_record_exists` from cc_path_ok on the mistaken
+	# belief that THIS line alone still protects against Hermes-record
+	# override (mutation-verified, opa-warden-attestations-v1.md Phase 4).
 	cc_path_ok
 }
 


### PR DESCRIPTION
## Summary
- `opa fmt --fail scripts/warden_policy/policy` (the first command in `docs/HERMES_WARDEN_OPA.md`'s Verification section) was exiting 2 ("unexpected diff"), isolated to `guardrails.rego`, due to OPA version drift between whatever `opa` version last formatted the file and the currently-installed `opa 1.19.0`.
- Ran `opa fmt --write` on `guardrails.rego` only. **Formatting-only change, no Rego logic/decision rules/test behavior touched.**
- Fixes [LIA-542](https://linear.app/liams-private-workspace/issue/LIA-542/opa-fmt-fail-scriptswarden-policypolicy-fails-guardrailsrego).

## What changed (4 hunks, 1 file)
1. Drops redundant parens around a multiplication that already binds tighter than the surrounding comparison.
2. Rego v1 bracket-index-to-dot-notation for a static string key (`["claude"]` → `.claude`).
3 & 4. Reflows two multi-line WHY-comments (trailing `att.queued_at` and `not hermes_path_ok`) — `opa fmt` inserts a blank line before the continuation paragraph and normalizes indentation. **Comment text is byte-identical pre/post** — not reworded, not truncated, still directly attached to the same code line with nothing else it could document.

The blank-line insertion in the comment reflow is `opa 1.19`'s own canonical/idempotent formatting rule for "code line followed by a multi-line own-line comment block" — confirmed unavoidable while keeping the file `opa fmt`-clean. I tested two alternatives (manually stripping the blank line; restructuring as a fully-leading comment block) and both re-trigger `opa fmt --list` dirtiness, so this is accepted as-is rather than hand-fought.

This touches `scripts/warden_policy/policy/guardrails.rego` — the sole place gate/allow decisions are made for this repo's Warden policy system (a disabled-but-real git-level hard backstop, `main-attestation-backstop`, will eventually run this exact policy) — so it went through the full plan-review → implement → code-review → verification-gate discipline despite being mechanical.

## Verification evidence (before == after, zero regressions)
| Check | Result |
|---|---|
| `opa fmt --list guardrails.rego` | clean (no output) |
| `opa fmt --fail scripts/warden_policy/policy` | exit 0 |
| `opa check --strict scripts/warden_policy/policy` | exit 0 |
| `opa test -v --ignore="*.schema.json"` | PASS 68/68 (identical to pre-fix baseline) |
| `python3 -m pytest scripts/warden_policy/tests -q` | 303 passed, 1 skipped, 65 subtests passed (identical to pre-fix baseline) |
| AST identity check | `opa parse --format json` on pre/post with `location` keys stripped: **identical** — proves zero behavioral change at the evaluation level, not just matching test counts |

verification-gate additionally rebuilt the pre-fix baseline independently from `git show HEAD:...` and reproduced the original `exit 2` failure, confirming the bug was real before confirming the fix resolves it.

## Review discipline
All 4 required warden gates SHIP in this worktree's bucket before commit:
- `plan-reviewer` (Claude): SHIP
- `plan-reviewer@gpt`: SHIP
- `code-reviewer` (Claude): SHIP
- `code-reviewer@gpt`: SHIP
- `code-reviewer@glm`: COULD_NOT_RUN (quota exhaustion, HTTP 429 — expected, fails open, does not block)
- `verification-gate`: SHIP

## Reversibility
Single-file, whitespace-only diff — one `git revert` fully undoes it.

## Follow-up (out of scope for this PR, flagged by reviewers)
No CI workflow currently runs `opa fmt --fail`/`opa check`/`opa test` (confirmed via `.github/workflows/*.yml` — zero hits), so this exact drift can silently recur on a future `opa` upgrade. Worth a follow-up ticket to add it to CI.

## Test plan
- [x] `opa fmt --list` clean
- [x] `opa fmt --fail` exit 0
- [x] `opa check --strict` exit 0
- [x] `opa test` pass count unchanged (68/68)
- [x] `pytest scripts/warden_policy/tests` unchanged (303 passed, 1 skipped, 65 subtests)
- [x] AST-identity diff confirms zero behavioral change
- [x] Full diff reviewed line-by-line; comment text confirmed byte-identical pre/post

🤖 Generated with [Claude Code](https://claude.com/claude-code)
