### PR TITLE
feat(deus-connect): add deus connect multi-model connector system

### DIFF
--- a/.claude/skills/add-connector/SKILL.md
+++ b/.claude/skills/add-connector/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: add-connector
+description: Onboard a `deus connect` connector — a way to route Claude Code sessions to non-Claude models (e.g. GPT via CLIProxyAPI) alongside normal Claude access. Generic orchestrator over whichever connector is selected.
+disable-model-invocation: true
+---
+
+# Add a `deus connect` Connector
+
+`deus connect` launches the real, unmodified `claude` binary with which
+upstream model answers its requests redirected via `ANTHROPIC_BASE_URL` —
+identity, vault/memory context, preferences, and portable skills stay
+intact, exactly like a normal `deus`/`deus home` session. This is separate
+from Deus's own container-agent backend adapters (`deus codex`,
+`DEUS_AGENT_BACKEND`) — see
+`docs/decisions/backend-neutral-agent-runtime.md`'s note near the Parity
+Matrix.
+
+This skill is generic over any registered connector (currently ships with
+`cliproxy-oauth` only) — adding a second connector in the future changes
+`connectors/providers/`, not this skill.
+
+## Phase 1: Pre-flight
+
+```bash
+python3 scripts/connectors_cli.py list
+```
+
+Shows every registered connector and whether it's already configured. If
+the target connector shows `configured` (e.g. a repeat run, or a machine
+inherited from another user), still walk through Phase 2 (select) and
+Phase 3 (risk acknowledgment) — Phase 3 is required every time, regardless
+of configuration state, per its own rule; skipping it here would let an
+already-configured install proceed straight to a real connector launch
+without ever showing the five risks. Only Phases 4-9 (install/authenticate/
+write-config) are skippable on an already-configured connector — jump from
+Phase 3 straight to Phase 10 (Verify) unless the user explicitly wants to
+reconfigure.
+
+## Phase 2: Which connector
+
+AskUserQuestion: Which connector do you want to set up? (ships with
+`cliproxy-oauth` only today — CLIProxyAPI, OAuth-login, reuses your
+ChatGPT/Codex subscription for GPT models alongside Claude).
+
+## Phase 3: Required risk acknowledgment
+
+**Not a footnote — block progression on explicit confirmation.** Show all
+five of these before proceeding, every time, for every future user:
+
+> **`deus connect` risk disclosure:**
+>
+> 1. **OAuth-subscription reuse is a real, non-zero, documented account-ban
+>    risk class.** This connector extracts an OAuth token from your
+>    ChatGPT/Codex subscription and reuses it for a separate HTTP client —
+>    see `examples/multi-model-cliproxyapi/README.md`'s "Known open risks"
+>    for the full account, including real dated ban reports in CLIProxyAPI's
+>    own issue tracker for other providers. Unlike a config mistake, there
+>    is no rollback if this fires.
+> 2. **Anthropic explicitly disclaims support** for routing Claude Code to
+>    non-Claude models through any gateway
+>    (https://code.claude.com/docs/en/llm-gateway) — a support-scope
+>    statement independent of whether this is configured correctly.
+> 3. **Connector sessions are discoverable via a bare `claude`'s resume
+>    picker.** `--name` tags the session (`connect:<id> (non-Claude)`) so
+>    it's identifiable, not invisible or inaccessible — native Claude Code
+>    session-resume is not isolated between a connector session and a bare
+>    one.
+> 4. **A nested `claude`/`deus claude` launched from inside a connector
+>    session inherits that session's model redirection.** Once
+>    `ANTHROPIC_*` env vars are set for the launched session, any subprocess
+>    it spawns (e.g. a `Bash` tool call running `claude` again) inherits
+>    them — a plain Unix process-inheritance property, no mechanism exists
+>    to prevent it. Narrow in practice (requires deliberately launching
+>    another interactive session mid-connector-session).
+> 5. **A connector session gets the same no-prompt tool execution as a
+>    trusted Claude session, driven by a model outside Anthropic's support
+>    scope.** `deus connect` launches through the same `launch_claude`
+>    every other session uses; if `bypass_permissions` is `true` in your
+>    Deus preferences (the default), a connector session runs with
+>    `--dangerously-skip-permissions` like any other Deus session — full,
+>    unprompted tool execution, just with a non-Claude, unsupported model
+>    driving it instead of Claude. The three inline subagents are scoped to
+>    `Read`/`Grep`/`Glob`/`Bash`/`WebSearch`/`WebFetch` (not the session's
+>    full tool set), but the top-level connector session itself is not
+>    additionally restricted beyond your normal Deus bypass setting.
+
+AskUserQuestion: Confirm you understand and accept all five risks above
+before continuing?
+- Yes, continue
+- No, cancel setup
+
+Stop here if the user declines.
+
+## Phase 4: Install the engine
+
+```bash
+python3 scripts/connectors_cli.py install-check cliproxy-oauth
+```
+
+If `not installed`, tell the user:
+
+> The `cli-proxy-api` binary isn't on your PATH. Build or download it from
+> https://github.com/router-for-me/CLIProxyAPI (see the upstream repo's
+> releases/instructions).
+>
+> After installation, verify: `cli-proxy-api --version`
+
+**Require explicit confirmation before proceeding once installed — never
+silently auto-fetch a binary that's about to hold real OAuth tokens.**
+
+Re-run the install-check after the user confirms installation is done.
+
+## Phase 5: Collect config values
+
+Ask the user (do not invent values):
+
+- **Inbound key** — generate one rather than asking the user to invent it:
+  `python3 -c "import secrets; print(secrets.token_urlsafe(24))"`. This is
+  what Claude Code authenticates to the local proxy with.
+- **Route Opus/Claude through the same proxy too?** Optional. If yes,
+  collect a real, official Anthropic API key (not OAuth) for the
+  `claude-api-key` leg.
+- **Confirm the real upstream Codex/GPT model id strings.** The tracked
+  placeholder (`connectors/cliproxy/config.yaml`) ships with illustrative
+  names (`gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna`) — **not** confirmed
+  real IDs for the user's account/plan. These get hand-edited into
+  `oauth-model-alias.codex[].name` in the written config (Phase 7) — the
+  `alias` values (`sol`/`terra`/`luna-max`) stay fixed; only the `name`
+  values (real upstream ids) vary per account.
+- **Default model** for the session itself when no `/model` switch has been
+  made — recommend `luna-max` (max reasoning effort) unless the user
+  prefers otherwise.
+
+## Phase 6: Authenticate
+
+```bash
+python3 scripts/connectors_cli.py authenticate cliproxy-oauth
+```
+
+Runs `cli-proxy-api --codex-login --config <local config>` — opens a
+browser for OAuth. Running headless/remote instead of a local desktop? The
+underlying engine supports `--no-browser` with a printed URL; if that's
+needed, tell the user to run the login step manually with that flag instead
+of through this script, then continue to Phase 7.
+
+## Phase 7: Write config + launchd daemon
+
+```bash
+echo '<json values>' | python3 scripts/connectors_cli.py write-config cliproxy-oauth
+```
+
+Where `<json values>` is a JSON object:
+```json
+{
+  "inbound_key": "<generated key from Phase 5>",
+  "anthropic_api_key": "<optional, only if the user opted in>",
+  "model_map": {"deus-gpt-sol": "sol", "deus-gpt-terra": "terra", "deus-gpt-luna": "luna-max"},
+  "default_model_alias": "luna-max",
+  "binary_path": "<absolute path from: command -v cli-proxy-api>"
+}
+```
+
+This writes the real config to
+`~/.config/deus/connectors/cliproxy/config.local.yaml` — **outside any
+project root a container agent could ever have mounted** (confirmed
+against `src/project-registry.ts:155-174` +
+`src/container-mounter.ts:76-102`: the tracked placeholder at
+`connectors/cliproxy/config.yaml` stays in-repo and safe to commit; the
+real values never do) — and the launchd plist
+(`~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist`,
+`RunAtLoad`+`KeepAlive`, macOS-only for now) with a fully home-expanded
+absolute `--config` path (launchd execs directly with literal argv
+strings, never shell-expanding `~`).
+
+**If `write-config` errors with "A launchd job already exists at ... with
+different settings"**: something else — possibly the user's own,
+unrelated launchd job — already occupies that exact path. This is a
+refusal-to-overwrite safety check (`_write_launchd_plist`), not a bug.
+Show the user the error's own `ProgramArguments` detail and ask them to
+move or remove that file themselves before retrying — never delete or
+overwrite it on their behalf.
+
+**Then hand-edit the real upstream model id strings** collected in Phase 5
+into `~/.config/deus/connectors/cliproxy/config.local.yaml`'s
+`oauth-model-alias.codex[].name` fields (the `write-config` call above does
+not touch these — only `deus-model-map`, `api-keys`, `claude-api-key`, and
+`default-model-alias`).
+
+Load the daemon:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist
+launchctl kickstart -k gui/$(id -u)/com.deus.connectors.cliproxy-oauth
+```
+
+## Phase 8: `~/.claude.json` pre-approval
+
+Read-merge the connector's inbound key into
+`~/.claude.json`'s `customApiKeyResponses.approved` array — back up the
+file first (`cp ~/.claude.json ~/.claude.json.bak-<date>`), then merge
+(never overwrite the whole array — other entries may already exist).
+
+## Phase 9: Validate subagent definitions
+
+```bash
+python3 scripts/connectors_cli.py agents-json cliproxy-oauth
+```
+
+Confirm it prints valid, non-empty JSON — no file templates to install,
+`deus connect`'s launch mechanism passes these inline via `claude --agents`.
+
+## Phase 10: Verify
+
+```bash
+python3 scripts/connectors_cli.py verify-setup cliproxy-oauth
+```
+
+Engine health + a real functional probe. Then run one real launch and
+confirm, end to end:
+
+```bash
+deus connect cliproxy-oauth
+```
+
+- Model resolution: check `/model` shows the redirected model.
+- Inline subagents resolve: dispatch the `Agent` tool with
+  `deus-gpt-sol`/`deus-gpt-terra`/`deus-gpt-luna`.
+- Normal Deus context is present: ask it to recall a recent checkpoint —
+  the round 11/12 fix's whole point was that a connector session gets the
+  same identity/vault/memory/preferences pipeline as a bare `deus` launch,
+  not a redirected-but-otherwise-bare Claude Code process.
+- A bare `claude` in a separate terminal never sees `deus-gpt-*` — confirms
+  subagent isolation (the one fully structural guarantee this feature
+  makes; env-var inheritance by nested processes and session-resume
+  visibility are both disclosed tradeoffs, not guarantees — see Phase 3).
+
+## Troubleshooting
+
+### `deus connect cliproxy-oauth` says "connector is unknown or not configured"
+
+Config didn't write correctly, or the daemon isn't running:
+
+```bash
+python3 scripts/connectors_cli.py status cliproxy-oauth
+launchctl list | grep com.deus.connectors.cliproxy-oauth
+```
+
+### Model doesn't resolve / 401s from the proxy
+
+```bash
+curl -s http://localhost:8317/healthz
+cat ~/.config/deus/connectors/cliproxy/config.local.yaml   # confirm api-keys, oauth-model-alias
+```
+
+### Subagents don't appear via the `Agent` tool
+
+Confirm you launched through `deus connect cliproxy-oauth`, not a bare
+`claude` — subagent definitions are injected inline on that exact launch
+command and never written to disk.
+
+## Removal
+
+1. Unload and remove the launchd daemon:
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist
+   rm ~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist
+   ```
+2. Remove the real local config:
+   ```bash
+   rm ~/.config/deus/connectors/cliproxy/config.local.yaml
+   ```
+3. Revert the `~/.claude.json` `customApiKeyResponses.approved` entry added
+   in Phase 8 (remove that one key, keep the rest of the array intact).
+4. Confirm: `python3 scripts/connectors_cli.py status cliproxy-oauth` now
+   reports "not configured".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,12 @@ jobs:
         # only sparse skipif guards and memory_indexer does a bare `import
         # sqlite_vec`, so they are NOT safe to run before it is present. Installing
         # it up front lets every python test step run in the same environment.
-        run: python3 -m pip install pytest 'httpx>=0.27,<1.0' sqlite-vec==0.1.6
+        #
+        # pyyaml is installed here for the connectors tests below: connectors/
+        # providers/cliproxy_oauth does a bare `import yaml` at module load
+        # (CLIProxyAPI's own config format is YAML), so it must be present before
+        # that step runs too.
+        run: python3 -m pip install pytest 'httpx>=0.27,<1.0' sqlite-vec==0.1.6 pyyaml
 
       - name: Pattern drift check
         run: python3 scripts/drift_check.py --all --base origin/${{ github.base_ref }}
@@ -162,6 +167,9 @@ jobs:
 
       - name: Evolution tests
         run: python3 -m pytest evolution/tests/ -v
+
+      - name: Connectors tests
+        run: python3 -m pytest connectors/tests/ scripts/tests/test_connectors_cli.py -v
 
       - name: Validate commits
         uses: wagoid/commitlint-github-action@v6

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A personal AI that understands you - not just recalls things you've said. It lea
 - [Ollama](https://ollama.ai/download) for local embeddings and scoring (not an agent backend) - `/setup` pulls the right models automatically based on your hardware
 - **Optional:** [llama.cpp](https://github.com/ggerganov/llama.cpp) for a fully local, API-free agent backend — no per-turn cost, works offline. Run `/add-llama-cpp` to install.
 - **Optional:** [free-claude-code](https://github.com/Alishahryar1/free-claude-code) proxy for using Claude Code CLI with alternative models (Ollama, llama-server, Gemini). Launch with `deus fcc` after configuring via `deus provider` and `deus model`.
+- **Optional:** `deus connect` — reuse an OAuth-subscription-multiplexing engine (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) to route a session to non-Claude models (GPT 5.6 Sol/Terra/Luna) alongside normal Claude access, with Deus identity/vault/memory/preferences/skills intact. Run `/add-connector` to set up. **Unsupported by Anthropic** (routing Claude Code to non-Claude models through any gateway is explicitly outside its support scope) and carries a real, disclosed session-resume-visibility tradeoff — read the risk disclosure in `/add-connector` before enabling.
 
 ### Install
 
@@ -119,6 +120,7 @@ See [AGENTS.md](AGENTS.md#commands-and-skills) for all available skills.
 | `deus arch` | Visualize a project's architecture in an interactive 3D explorer |
 | `deus codex` | Use OpenAI/Codex backend for this session |
 | `deus fcc` | Launch with a local proxy model (Ollama, llama-server, Gemini) |
+| `deus connect <id>` | Launch via a registered non-Claude connector (`list`/`setup`/`status <id>`) — see `/add-connector` |
 | `deus provider <name>` | Switch proxy provider (`ollama`, `llamacpp`, `gemini`) |
 | `deus model <name>` | Switch proxy model (auto-prefixes active provider) |
 | `deus model dashboard` | Open proxy admin UI in browser |

--- a/connectors/__init__.py
+++ b/connectors/__init__.py
@@ -1,0 +1,8 @@
+"""Deus connect: registry of non-Claude model connectors for `deus connect`.
+
+Importing this package registers all built-in connectors (see providers/).
+"""
+from . import registry
+from . import providers  # noqa: F401 -- import side effect: registers built-ins
+
+__all__ = ["registry"]

--- a/connectors/base.py
+++ b/connectors/base.py
@@ -1,0 +1,127 @@
+"""
+Connector ABC for Deus's `deus connect` multi-model CLI feature.
+
+A Connector routes a `deus connect <id>` session to a non-Claude model via
+an OAuth-subscription-multiplexing engine (e.g. CLIProxyAPI), while keeping
+the session structurally Deus — identity, vault/memory context, preferences,
+and portable skills intact, not a bare Claude Code process that merely
+happens to be redirected. See docs/decisions/backend-neutral-agent-runtime.md
+for how this differs from Deus's container-agent backend adapters.
+
+Mirrors evolution/judge/provider.py's ABC+Registry shape.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ConnectorSetupHandler(ABC):
+    """Engine-specific onboarding logic for one Connector.
+
+    The "1 file + 1 registry line" extensibility claim holds for the
+    Connector ABC's runtime behavior (env vars, model aliases, inline agent
+    definitions) but not for onboarding — a differently-shaped engine needs
+    its own install/login/config-write logic. The generic `add-connector`
+    skill orchestrates whichever handler the selected connector supplies.
+    """
+
+    @abstractmethod
+    def install(self) -> bool:
+        """Confirm the engine binary is present (or guide installing it).
+
+        Returns True once the engine is ready to configure. Never silently
+        auto-fetches a binary that will go on to hold real OAuth tokens —
+        require explicit user confirmation before any install step.
+        """
+        ...
+
+    @abstractmethod
+    def authenticate(self) -> bool:
+        """Run the engine's own OAuth login interactively. Returns True on success."""
+        ...
+
+    @abstractmethod
+    def write_config(self, values: dict[str, Any]) -> None:
+        """Write the real, local-only config for this connector.
+
+        Must never write real secrets into a path a container agent could
+        read — see connectors/providers/cliproxy_oauth for the concrete
+        container-credential-boundary handling this guards against.
+        """
+        ...
+
+    @abstractmethod
+    def verify(self) -> bool:
+        """Engine health plus a real functional probe — not just a bare
+        `/health` hit. Returns True only if the connector is genuinely
+        usable end to end.
+        """
+        ...
+
+
+class Connector(ABC):
+    """A single registered `deus connect` destination."""
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Stable connector id, e.g. 'cliproxy-oauth'.
+
+        Never one of the reserved words `list`/`setup`/`status` — the
+        registry rejects registration of a connector using any of those.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """One-line human-readable summary, shown by `deus connect list`."""
+        ...
+
+    @property
+    @abstractmethod
+    def engine(self) -> str:
+        """Underlying engine name, e.g. 'cliproxy'."""
+        ...
+
+    @property
+    @abstractmethod
+    def risk_level(self) -> str:
+        """Short risk label surfaced during onboarding, e.g. 'oauth-reuse'."""
+        ...
+
+    @property
+    @abstractmethod
+    def setup_handler(self) -> ConnectorSetupHandler:
+        """The engine-specific onboarding handler for this connector."""
+        ...
+
+    @abstractmethod
+    def model_aliases(self) -> dict[str, str]:
+        """Fixed stable subagent name -> the routing alias configured for
+        it in this connector's local config (read fresh on every call, not
+        cached — the local config is user-editable at any time)."""
+        ...
+
+    @abstractmethod
+    def is_configured(self) -> bool:
+        """True once real local config + at least one model alias exist."""
+        ...
+
+    @abstractmethod
+    def env_for_launch(self) -> dict[str, str]:
+        """Env vars for the launching shell only. Never written to
+        `~/.claude/settings.json`'s global `env` block — that would leak
+        this redirection into every Claude Code session on the machine."""
+        ...
+
+    @abstractmethod
+    def agents_for_launch(self) -> dict[str, Any]:
+        """Inline subagent definitions for `claude --agents <json>`.
+
+        Must always be valid JSON-serializable data on success — an empty
+        dict for a connector with no subagents, matching env_for_launch()'s
+        convention of never failing silently.
+        """
+        ...

--- a/connectors/cliproxy/.gitignore
+++ b/connectors/cliproxy/.gitignore
@@ -1,0 +1,1 @@
+config.local.yaml

--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -1,0 +1,74 @@
+# Tracked, placeholder-only config for the `cliproxy-oauth` connector
+# (deus connect setup cliproxy-oauth writes the real version to
+# ~/.config/deus/connectors/cliproxy/config.local.yaml — OUTSIDE this repo
+# entirely, never here). Relocated/generalized from the already-merged
+# examples/multi-model-cliproxyapi/config.yaml.
+#
+# SECURITY: CLIProxyAPI's config format takes literal values only (no
+# env-var indirection). NEVER fill in real keys/tokens directly in this
+# tracked file — `deus connect setup cliproxy-oauth` (the `add-connector`
+# skill) writes real values to config.local.yaml for you.
+#
+# Mechanism this relies on: once Claude Code's ANTHROPIC_BASE_URL points at
+# a non-Anthropic endpoint, it skips its own model-name validation and
+# passes whatever string it's given (via /model, ANTHROPIC_MODEL, or a
+# subagent's `model:` frontmatter) straight through to that endpoint. The
+# `alias` values below are exactly those strings.
+#
+# See examples/multi-model-cliproxyapi/README.md's "Known open risks"
+# section before using this for real — in particular, the OAuth-login leg
+# (Codex) carries a real, documented account-ban risk with no rollback.
+
+port: 8317
+# CLIProxyAPI's own default for an unset `host` is empty (""), which binds
+# ALL interfaces (IPv4 + IPv6) -- not localhost-only, despite this connector
+# being designed and launched as a local-only daemon. Confirmed directly
+# against CLIProxyAPI's source (internal/config/config.go's own doc comment
+# on the Host field: 'Default is empty ("") to bind all interfaces... Use
+# "127.0.0.1" or "localhost" for local-only access.') and its listener
+# construction (internal/api/server.go: `Addr: fmt.Sprintf("%s:%d",
+# cfg.Host, cfg.Port)`). Pinned here explicitly so every generated config
+# inherits the intended network boundary.
+host: "127.0.0.1"
+auth-dir: "~/.cli-proxy-api"
+
+# Inbound auth: what Claude Code authenticates to THIS proxy with.
+# Replaced with a real value in config.local.yaml — never a real secret here.
+api-keys:
+  - "REPLACE_WITH_YOUR_OWN_INBOUND_KEY"
+
+# Optional safe leg: a real, official Anthropic API key (not OAuth) can be
+# routed through the same proxy for a Claude-family alias if desired.
+claude-api-key:
+  - api-key: "REPLACE_WITH_YOUR_REAL_ANTHROPIC_API_KEY"
+    models:
+      - name: "claude-opus-5"
+        alias: "opus-planner"
+
+# Accepted-risk leg: Codex OAuth-login (run `deus connect setup
+# cliproxy-oauth`, which drives `--codex-login` once to authenticate).
+# Reuses a ChatGPT/Codex subscription rather than a real API key — see
+# examples/multi-model-cliproxyapi/README.md's "Known open risks" before
+# relying on this.
+oauth-model-alias:
+  codex:
+    - name: "gpt-5.6-sol" # placeholder — confirm real upstream name
+      alias: "sol"
+    - name: "gpt-5.6-terra" # placeholder — confirm real upstream name
+      alias: "terra"
+    - name: "gpt-5.6-luna" # placeholder — confirm real upstream name
+      alias: "luna-max"
+
+# Deus-specific: maps the three fixed `deus connect` subagent names
+# (connectors/providers/cliproxy_oauth's STABLE_SUBAGENT_NAMES) to the
+# CLIProxyAPI alias configured above. Only the alias values should change
+# per real model; the deus-gpt-* keys are fixed and referenced directly by
+# connectors/providers/cliproxy_oauth's agents_for_launch().
+deus-model-map:
+  deus-gpt-sol: "sol"
+  deus-gpt-terra: "terra"
+  deus-gpt-luna: "luna-max"
+
+# Default model for the session itself (ANTHROPIC_MODEL) when no /model
+# switch has been made yet.
+default-model-alias: "luna-max"

--- a/connectors/providers/__init__.py
+++ b/connectors/providers/__init__.py
@@ -1,0 +1,9 @@
+"""Built-in connectors. Importing this package registers them all."""
+from ..registry import ConnectorRegistry
+
+from .cliproxy_oauth import CliproxyOauthConnector
+
+_registry = ConnectorRegistry.default()
+_registry.register(CliproxyOauthConnector())
+
+__all__ = ["CliproxyOauthConnector"]

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -1,0 +1,337 @@
+"""
+CLIProxyAPI OAuth connector — the proof-of-concept `deus connect` provider.
+
+Reuses CLIProxyAPI (https://github.com/router-for-me/CLIProxyAPI) as the
+engine rather than building a Deus-native gateway — same relationship Deus
+already has with free-claude-code/Ollama/llama.cpp/Docker: orchestrate an
+installed third-party binary, never fork or reimplement OAuth-multiplexing
+logic ourselves.
+
+Config split, relocated/generalized from the already-merged
+examples/multi-model-cliproxyapi/ (commit b43f8c1d):
+  - connectors/cliproxy/config.yaml — tracked, placeholder-only, safe to commit.
+  - ~/.config/deus/connectors/cliproxy/config.local.yaml — the real config,
+    OUTSIDE any project root a container agent could ever have mounted.
+    Confirmed directly against src/project-registry.ts:155-174's
+    SENSITIVE_FILE_PATTERNS/SENSITIVE_DIR_PATTERNS (checked only at the
+    project-root top level) and src/container-mounter.ts:76-102's
+    pushProjectShadows() (only shadows those exact top-level patterns): a
+    nested connectors/cliproxy/config.local.yaml inside the repo would NOT
+    have matched any shadowed pattern and would have been fully readable —
+    including the real Anthropic key and the CLIProxyAPI inbound secret —
+    by any container agent with read-only project access.
+"""
+from __future__ import annotations
+
+import json
+import plistlib
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import xml.parsers.expat
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ...base import Connector, ConnectorSetupHandler
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACKED_CONFIG = _REPO_ROOT / "connectors" / "cliproxy" / "config.yaml"
+LOCAL_CONFIG = Path(
+    "~/.config/deus/connectors/cliproxy/config.local.yaml"
+).expanduser()
+# Namespaced under this specific connector, not the generic "cliproxyapi" --
+# that generic name is exactly the kind of label anyone standing up their
+# own personal CLIProxyAPI daemon would also pick (confirmed: it collided
+# with a real, pre-existing personal install on this machine during
+# testing). Namespacing reduces the odds of a future collision but is not
+# itself the safety guarantee -- _write_launchd_plist's own existence/
+# collision check below is.
+PLIST_LABEL = "com.deus.connectors.cliproxy-oauth"
+PLIST_PATH = Path(f"~/Library/LaunchAgents/{PLIST_LABEL}.plist").expanduser()
+
+# Fixed, connector-defined stable subagent names — portable across users
+# (real upstream model ids are per-account, not portable). Only the
+# gitignored local config's alias-to-real-id mapping varies per user.
+STABLE_SUBAGENT_NAMES = ("deus-gpt-sol", "deus-gpt-terra", "deus-gpt-luna")
+
+# Must match connectors/cliproxy/config.yaml's literal placeholder exactly.
+# authenticate() bootstraps LOCAL_CONFIG by copying that tracked template
+# before OAuth login runs (so `--codex-login --config <path>` has a file to
+# target) -- if login is then cancelled or fails, LOCAL_CONFIG is left
+# holding this sentinel as api-keys[0]. is_configured() must reject it
+# explicitly: a bare truthiness check on api-keys passes for this
+# placeholder just as readily as for a real key, which would let a failed
+# first authentication look "configured" to both a later setup run (which
+# would then skip straight to verification) and a real deus connect launch
+# (which would then use this literal string as ANTHROPIC_API_KEY).
+_PLACEHOLDER_INBOUND_KEY = "REPLACE_WITH_YOUR_OWN_INBOUND_KEY"
+
+_SUBAGENT_DESCRIPTIONS = {
+    "deus-gpt-sol": (
+        "General-purpose subagent pinned to GPT 5.6 Sol via the local "
+        "multi-model gateway. Use for research, analysis, or a second "
+        "opinion where a genuinely independent (non-Claude) model is "
+        "valuable."
+    ),
+    "deus-gpt-terra": (
+        "General-purpose subagent pinned to GPT 5.6 Terra via the local "
+        "multi-model gateway. Use for research, analysis, or a second "
+        "opinion where a genuinely independent (non-Claude) model is "
+        "valuable."
+    ),
+    "deus-gpt-luna": (
+        "General-purpose subagent pinned to GPT 5.6 Luna (max reasoning "
+        "effort) via the local multi-model gateway. Use for harder "
+        "research/analysis tasks warranting deeper reasoning."
+    ),
+}
+
+
+def _load_local_config() -> dict[str, Any]:
+    if not LOCAL_CONFIG.is_file():
+        return {}
+    return yaml.safe_load(LOCAL_CONFIG.read_text()) or {}
+
+
+def _find_binary() -> str | None:
+    return shutil.which("cli-proxy-api")
+
+
+class CliproxyOauthConnector(Connector):
+    @property
+    def id(self) -> str:
+        return "cliproxy-oauth"
+
+    @property
+    def description(self) -> str:
+        return (
+            "CLIProxyAPI, OAuth-login (reuses your ChatGPT/Codex "
+            "subscription) — GPT 5.6 Sol/Terra/Luna subagents alongside "
+            "normal Claude access."
+        )
+
+    @property
+    def engine(self) -> str:
+        return "cliproxy"
+
+    @property
+    def risk_level(self) -> str:
+        return "oauth-reuse"
+
+    @property
+    def setup_handler(self) -> ConnectorSetupHandler:
+        return CliproxyOauthSetupHandler(self)
+
+    def model_aliases(self) -> dict[str, str]:
+        mapping = _load_local_config().get("deus-model-map") or {}
+        return {
+            name: mapping[name] for name in STABLE_SUBAGENT_NAMES if name in mapping
+        }
+
+    def is_configured(self) -> bool:
+        cfg = _load_local_config()
+        keys = cfg.get("api-keys") or []
+        if not keys or keys[0] == _PLACEHOLDER_INBOUND_KEY:
+            return False
+        return bool(self.model_aliases())
+
+    def env_for_launch(self) -> dict[str, str]:
+        cfg = _load_local_config()
+        port = cfg.get("port", 8317)
+        keys = cfg.get("api-keys") or []
+        aliases = self.model_aliases()
+        default_alias = cfg.get("default-model-alias") or next(
+            iter(aliases.values()), ""
+        )
+        return {
+            "ANTHROPIC_BASE_URL": f"http://localhost:{port}",
+            "ANTHROPIC_API_KEY": keys[0] if keys else "",
+            "ANTHROPIC_MODEL": default_alias,
+        }
+
+    def agents_for_launch(self) -> dict[str, Any]:
+        aliases = self.model_aliases()
+        agents: dict[str, Any] = {}
+        for name in STABLE_SUBAGENT_NAMES:
+            alias = aliases.get(name)
+            if not alias:
+                continue
+            agents[name] = {
+                "description": _SUBAGENT_DESCRIPTIONS[name],
+                "prompt": (
+                    f"You are {name}, dispatched as a subagent, reachable "
+                    "only through this deus connect session. Do the task "
+                    "described in the prompt directly and report your "
+                    "findings/output -- you are not a reviewer unless "
+                    "explicitly asked to review something."
+                ),
+                "model": alias,
+                # Matches the least-privilege scope of the personal
+                # prototype agents this connector formalizes
+                # (~/.claude/agents/gpt-sol.md et al.) -- not the launching
+                # session's full tool set.
+                "tools": ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"],
+            }
+        return agents
+
+
+class CliproxyOauthSetupHandler(ConnectorSetupHandler):
+    def __init__(self, connector: "CliproxyOauthConnector"):
+        self._connector = connector
+
+    def install(self) -> bool:
+        """Confirm the cli-proxy-api binary is present on PATH.
+
+        Never silently auto-fetches — this binary will hold real OAuth
+        tokens, so a missing binary must surface upstream repo + build
+        instructions and require explicit confirmation, not a silent fetch.
+        """
+        return _find_binary() is not None
+
+    def authenticate(self) -> bool:
+        binary = _find_binary()
+        if not binary:
+            return False
+        LOCAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        if not LOCAL_CONFIG.is_file():
+            LOCAL_CONFIG.write_text(TRACKED_CONFIG.read_text())
+            LOCAL_CONFIG.chmod(0o600)
+        result = subprocess.run(
+            [binary, "--codex-login", "--config", str(LOCAL_CONFIG)]
+        )
+        return result.returncode == 0
+
+    def write_config(self, values: dict[str, Any]) -> None:
+        placeholder = yaml.safe_load(TRACKED_CONFIG.read_text())
+        placeholder["api-keys"] = [values["inbound_key"]]
+        if values.get("anthropic_api_key"):
+            claude_keys = placeholder.get("claude-api-key") or [{}]
+            claude_keys[0]["api-key"] = values["anthropic_api_key"]
+            placeholder["claude-api-key"] = claude_keys
+        else:
+            # The optional Anthropic leg was declined -- strip the
+            # placeholder claude-api-key block entirely rather than
+            # carrying REPLACE_WITH_YOUR_REAL_ANTHROPIC_API_KEY through into
+            # the real config. CLIProxyAPI would register that sentinel as
+            # a live provider leg, and a later `/model opus-planner` (or
+            # whatever alias it maps to) would 401 for a reason nothing
+            # surfaces.
+            placeholder.pop("claude-api-key", None)
+        model_map = values["model_map"]
+        placeholder["deus-model-map"] = model_map
+        placeholder["default-model-alias"] = values.get(
+            "default_model_alias", next(iter(model_map.values()), "")
+        )
+        LOCAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        LOCAL_CONFIG.write_text(yaml.safe_dump(placeholder, sort_keys=False))
+        LOCAL_CONFIG.chmod(0o600)
+        if sys.platform == "darwin":
+            self._write_launchd_plist(values["binary_path"])
+        else:
+            print(
+                "deus connect: launchd daemon setup is macOS-only for now "
+                "(Linux systemd-unit parity is a stated follow-up) -- "
+                "config was written, but you must start "
+                f"'{values['binary_path']} --config {LOCAL_CONFIG}' "
+                "yourself, e.g. via a systemd user unit."
+            )
+
+    def _write_launchd_plist(self, binary_path: str) -> None:
+        """macOS-only -- callers must guard with sys.platform == "darwin"
+        before calling this (see write_config()). ProgramArguments must use
+        the fully home-expanded absolute path -- launchd execs the binary
+        directly with literal argv strings and never shell-expands `~`.
+        Confirmed against this repo's own launchd precedent,
+        com.deus.warden-opa.plist, whose ProgramArguments already use
+        fully-expanded absolute paths throughout — the established
+        convention, not a new pattern.
+        """
+        plist = {
+            "Label": PLIST_LABEL,
+            "ProgramArguments": [binary_path, "--config", str(LOCAL_CONFIG)],
+            "RunAtLoad": True,
+            "KeepAlive": True,
+        }
+        # Never lose, overwrite, or downgrade user data (core-behavioral-
+        # rules.md § Data & Security) -- a bare plistlib.dump here would
+        # silently destroy a pre-existing file at this exact path with no
+        # backup, and the setup skill's own `launchctl kickstart` step one
+        # phase later would then kill and relaunch whatever daemon that
+        # file used to describe under THIS config instead -- turning a
+        # latent file collision into an active hijack of a running
+        # process. Reproduced for real on this machine during this
+        # session's own testing (a personal, pre-existing CLIProxyAPI
+        # install happened to use this same conventional path). Abort
+        # loudly instead of overwriting if something else is already there.
+        if PLIST_PATH.exists():
+            try:
+                existing = plistlib.loads(PLIST_PATH.read_bytes())
+                existing_args = existing.get("ProgramArguments")
+            except (
+                plistlib.InvalidFileException,
+                xml.parsers.expat.ExpatError,
+                ValueError,
+                OSError,
+            ):
+                existing_args = None
+            if existing_args != plist["ProgramArguments"]:
+                raise RuntimeError(
+                    f"A launchd job already exists at {PLIST_PATH} with "
+                    f"different settings (ProgramArguments: {existing_args!r}). "
+                    "Refusing to overwrite it -- this may be an unrelated "
+                    "daemon. Move or remove that file yourself first if you "
+                    "intend to replace it, then re-run setup."
+                )
+        PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(PLIST_PATH, "wb") as f:
+            plistlib.dump(plist, f)
+
+    def verify(self) -> bool:
+        cfg = _load_local_config()
+        port = cfg.get("port", 8317)
+        try:
+            with urllib.request.urlopen(
+                f"http://localhost:{port}/healthz", timeout=3
+            ) as resp:
+                if resp.status != 200:
+                    return False
+        except (urllib.error.URLError, OSError):
+            return False
+        aliases = self._connector.model_aliases()
+        keys = cfg.get("api-keys") or []
+        if not aliases or not keys:
+            return False
+        # /healthz only proves the process is up -- it says nothing about
+        # whether the OAuth credential behind it still works or the
+        # configured model alias actually resolves. Perform one real,
+        # minimal, authenticated inference request through the exact
+        # Anthropic Messages API path a `deus connect` launch would use, so
+        # an expired token or a broken upstream alias genuinely fails
+        # verification instead of reporting "healthy".
+        alias = cfg.get("default-model-alias") or next(iter(aliases.values()))
+        payload = json.dumps(
+            {
+                "model": alias,
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "ping"}],
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"http://localhost:{port}/v1/messages",
+            data=payload,
+            method="POST",
+            headers={
+                "content-type": "application/json",
+                "x-api-key": keys[0],
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return resp.status == 200
+        except (urllib.error.URLError, OSError):
+            return False

--- a/connectors/registry.py
+++ b/connectors/registry.py
@@ -1,0 +1,82 @@
+"""
+ConnectorRegistry — central registry of `deus connect` Connector instances.
+
+Mirrors evolution/judge/provider.py:18-51,54-139's JudgeRegistry shape.
+
+Usage:
+    registry = ConnectorRegistry.default()
+    connector = registry.resolve("cliproxy-oauth")
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import Connector
+
+# `deus connect list`/`setup <id>`/`status <id>` are reserved command words —
+# a connector id can never take one of these (see deus-cmd.sh's `connect`
+# prefix-dispatch branch).
+RESERVED_IDS = frozenset({"list", "setup", "status"})
+
+
+class ConnectorRegistrationError(ValueError):
+    """Raised when registering a connector with a reserved or duplicate id."""
+
+
+class UnknownConnectorError(LookupError):
+    """Raised when resolving an id that isn't registered.
+
+    Deliberately NOT a KeyError subclass: KeyError.__str__ is overridden to
+    return repr(args[0]) instead of str(args[0]), which wraps every
+    user-facing message from this exception in stray quotes (e.g.
+    "Unknown connector 'bogus'. Registered: [...]" prints as a quoted repr,
+    not plain text). LookupError -- KeyError's own parent -- has no such
+    override.
+    """
+
+
+class ConnectorRegistry:
+    """Singleton registry of registered connectors."""
+
+    _instance: Optional["ConnectorRegistry"] = None
+
+    def __init__(self):
+        self._connectors: dict[str, Connector] = {}
+
+    @classmethod
+    def default(cls) -> "ConnectorRegistry":
+        """Return the singleton registry, creating it on first call."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset singleton — for testing only."""
+        cls._instance = None
+
+    def register(self, connector: Connector) -> None:
+        """Register a connector. Rejects reserved ids; last-write-wins otherwise."""
+        if connector.id in RESERVED_IDS:
+            raise ConnectorRegistrationError(
+                f"Connector id '{connector.id}' is reserved "
+                f"(reserved: {sorted(RESERVED_IDS)})"
+            )
+        self._connectors[connector.id] = connector
+
+    def resolve(self, connector_id: str) -> Connector:
+        """Resolve a connector by exact id. Raises UnknownConnectorError if not found."""
+        try:
+            return self._connectors[connector_id]
+        except KeyError:
+            raise UnknownConnectorError(
+                f"Unknown connector '{connector_id}'. Registered: {self.list_ids()}"
+            ) from None
+
+    def list_ids(self) -> list[str]:
+        """Return registered connector ids, sorted."""
+        return sorted(self._connectors)
+
+    def list_connectors(self) -> list[Connector]:
+        """Return registered connectors, sorted by id."""
+        return [self._connectors[cid] for cid in self.list_ids()]

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -1,0 +1,261 @@
+"""Tests for the Connector / ConnectorRegistry pattern."""
+from typing import Any
+
+import pytest
+
+from connectors.base import Connector, ConnectorSetupHandler
+from connectors.registry import (
+    ConnectorRegistrationError,
+    ConnectorRegistry,
+    UnknownConnectorError,
+)
+
+
+# ── Test helpers ──────────────────────────────────────────────────────────────
+
+
+class FakeSetupHandler(ConnectorSetupHandler):
+    def install(self) -> bool:
+        return True
+
+    def authenticate(self) -> bool:
+        return True
+
+    def write_config(self, values: dict[str, Any]) -> None:
+        pass
+
+    def verify(self) -> bool:
+        return True
+
+
+class FakeConnector(Connector):
+    """Configurable connector for testing."""
+
+    def __init__(self, connector_id: str, configured: bool = True):
+        self._id = connector_id
+        self._configured = configured
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return f"fake connector {self._id}"
+
+    @property
+    def engine(self) -> str:
+        return "fake-engine"
+
+    @property
+    def risk_level(self) -> str:
+        return "none"
+
+    @property
+    def setup_handler(self) -> ConnectorSetupHandler:
+        return FakeSetupHandler()
+
+    def model_aliases(self) -> dict[str, str]:
+        return {"fake-agent": "fake-alias"} if self._configured else {}
+
+    def is_configured(self) -> bool:
+        return self._configured
+
+    def env_for_launch(self) -> dict[str, str]:
+        return {"ANTHROPIC_BASE_URL": "http://localhost:9999"} if self._configured else {}
+
+    def agents_for_launch(self) -> dict[str, Any]:
+        return {"fake-agent": {"description": "d", "prompt": "p", "model": "fake-alias"}}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Ensure each test gets a fresh registry."""
+    ConnectorRegistry.reset()
+    yield
+    ConnectorRegistry.reset()
+
+
+# ── Registry unit tests ─────────────────────────────────────────────────────
+
+
+class TestConnectorRegistry:
+    def test_register_and_resolve(self):
+        reg = ConnectorRegistry.default()
+        c = FakeConnector("test")
+        reg.register(c)
+        assert reg.resolve("test") is c
+
+    def test_resolve_unknown_raises(self):
+        reg = ConnectorRegistry.default()
+        with pytest.raises(UnknownConnectorError):
+            reg.resolve("nonexistent")
+
+    def test_register_rejects_reserved_ids(self):
+        reg = ConnectorRegistry.default()
+        for reserved in ("list", "setup", "status"):
+            with pytest.raises(ConnectorRegistrationError):
+                reg.register(FakeConnector(reserved))
+
+    def test_list_ids_sorted(self):
+        reg = ConnectorRegistry.default()
+        reg.register(FakeConnector("zeta"))
+        reg.register(FakeConnector("alpha"))
+        reg.register(FakeConnector("mid"))
+        assert reg.list_ids() == ["alpha", "mid", "zeta"]
+
+    def test_list_connectors_matches_list_ids_order(self):
+        reg = ConnectorRegistry.default()
+        reg.register(FakeConnector("b"))
+        reg.register(FakeConnector("a"))
+        assert [c.id for c in reg.list_connectors()] == ["a", "b"]
+
+    def test_register_last_write_wins(self):
+        reg = ConnectorRegistry.default()
+        first = FakeConnector("dup")
+        second = FakeConnector("dup")
+        reg.register(first)
+        reg.register(second)
+        assert reg.resolve("dup") is second
+
+    def test_singleton(self):
+        a = ConnectorRegistry.default()
+        b = ConnectorRegistry.default()
+        assert a is b
+
+    def test_reset_creates_fresh_instance(self):
+        a = ConnectorRegistry.default()
+        a.register(FakeConnector("x"))
+        ConnectorRegistry.reset()
+        b = ConnectorRegistry.default()
+        assert a is not b
+        assert b.list_ids() == []
+
+
+class TestConnectorContract:
+    def test_is_configured_reflects_state(self):
+        configured = FakeConnector("a", configured=True)
+        unconfigured = FakeConnector("b", configured=False)
+        assert configured.is_configured() is True
+        assert unconfigured.is_configured() is False
+
+    def test_env_for_launch_empty_when_unconfigured(self):
+        c = FakeConnector("a", configured=False)
+        assert c.env_for_launch() == {}
+
+    def test_setup_handler_returns_handler_instance(self):
+        c = FakeConnector("a")
+        assert isinstance(c.setup_handler, ConnectorSetupHandler)
+
+
+class TestBuiltInProviders:
+    """Smoke tests that the real connector can be instantiated directly.
+
+    Deliberately does NOT resolve through ConnectorRegistry.default() here:
+    connectors/providers/__init__.py registers into the singleton once, at
+    first import (module-cached, like any Python import) -- this test
+    file's own `clean_registry` fixture resets that singleton before/after
+    every test, so a registry-based lookup here would depend on import
+    order versus fixture order rather than testing the connector itself.
+    Mirrors evolution/tests/test_judge_registry.py's TestBuiltInProviders,
+    which instantiates providers directly for the same reason.
+    """
+
+    def test_cliproxy_oauth_has_correct_id_and_engine(self):
+        from connectors.providers.cliproxy_oauth import CliproxyOauthConnector
+
+        c = CliproxyOauthConnector()
+        assert c.id == "cliproxy-oauth"
+        assert c.engine == "cliproxy"
+        assert isinstance(c.setup_handler, ConnectorSetupHandler)
+
+
+class TestCliproxyOauthIsConfigured:
+    """Regression coverage for a real defect a GPT co-gate review caught:
+    authenticate() bootstraps LOCAL_CONFIG by copying the tracked
+    placeholder template before OAuth login runs, so a cancelled/failed
+    login left is_configured() reporting True on nothing but sentinel
+    values (a bare truthiness check on api-keys passes for the literal
+    placeholder string just as readily as for a real key).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _redirect_local_config(self, tmp_path, monkeypatch):
+        import connectors.providers.cliproxy_oauth as mod
+
+        monkeypatch.setattr(mod, "LOCAL_CONFIG", tmp_path / "config.local.yaml")
+        self.mod = mod
+
+    def test_bootstrapped_placeholder_is_not_configured(self):
+        # Exactly what authenticate() does before OAuth login: copy the
+        # tracked template verbatim, no real values yet.
+        self.mod.LOCAL_CONFIG.write_text(self.mod.TRACKED_CONFIG.read_text())
+        c = self.mod.CliproxyOauthConnector()
+        assert c.is_configured() is False
+
+    def test_real_inbound_key_is_configured(self):
+        self.mod.LOCAL_CONFIG.write_text(
+            "api-keys:\n  - real-key\n"
+            "deus-model-map:\n  deus-gpt-sol: sol\n"
+        )
+        c = self.mod.CliproxyOauthConnector()
+        assert c.is_configured() is True
+
+    def test_missing_config_is_not_configured(self):
+        c = self.mod.CliproxyOauthConnector()
+        assert c.is_configured() is False
+
+
+class TestWriteLaunchdPlist:
+    """Regression coverage for a real defect a verification-gate pass
+    caught: _write_launchd_plist did a bare plistlib.dump with no existence
+    check, silently destroying anything already at that path -- reproduced
+    for real when this connector's original generic label
+    (com.deus.cliproxyapi) collided with a pre-existing personal
+    CLIProxyAPI install on the developer's own machine during testing.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _redirect_plist_path(self, tmp_path, monkeypatch):
+        import connectors.providers.cliproxy_oauth as mod
+
+        monkeypatch.setattr(mod, "PLIST_PATH", tmp_path / "test.plist")
+        self.mod = mod
+        self.handler = mod.CliproxyOauthSetupHandler(mod.CliproxyOauthConnector())
+
+    def test_writes_cleanly_when_nothing_exists(self):
+        self.handler._write_launchd_plist("/usr/local/bin/cli-proxy-api")
+        assert self.mod.PLIST_PATH.exists()
+
+    def test_identical_rewrite_is_idempotent(self):
+        self.handler._write_launchd_plist("/usr/local/bin/cli-proxy-api")
+        self.handler._write_launchd_plist("/usr/local/bin/cli-proxy-api")  # no raise
+
+    def test_refuses_to_overwrite_unrelated_existing_plist(self):
+        import plistlib
+
+        self.mod.PLIST_PATH.write_bytes(
+            plistlib.dumps(
+                {
+                    "Label": "com.someone.else",
+                    "ProgramArguments": ["/totally/different/binary", "--flag"],
+                }
+            )
+        )
+        before = self.mod.PLIST_PATH.read_bytes()
+        with pytest.raises(RuntimeError, match="already exists"):
+            self.handler._write_launchd_plist("/usr/local/bin/cli-proxy-api")
+        assert self.mod.PLIST_PATH.read_bytes() == before  # untouched
+
+    def test_refuses_to_overwrite_malformed_existing_file(self):
+        # A file that fails to parse at all must fail closed (refuse) --
+        # not be silently treated as absent, and not raise an unhandled
+        # ExpatError past the guard's own except tuple.
+        self.mod.PLIST_PATH.write_bytes(b"not a plist at all <<<")
+        before = self.mod.PLIST_PATH.read_bytes()
+        with pytest.raises(RuntimeError, match="already exists"):
+            self.handler._write_launchd_plist("/usr/local/bin/cli-proxy-api")
+        assert self.mod.PLIST_PATH.read_bytes() == before  # untouched

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -48,6 +48,74 @@ if [ "$1" = "codex" ] || [ "$1" = "claude" ] || [ "$1" = "fcc" ]; then
   shift
 fi
 
+# deus connect <id> [claude-args...] — route to a non-Claude model via a
+# registered connector, staying on the same identity/vault/preferences
+# pipeline the block above uses instead of a self-contained branch (that
+# would bypass identity/vault/memory-level/preferences/portable-skills
+# entirely — the exact defect this design avoids). list/setup/status are
+# immediate, self-contained utility commands with no `claude` launch; the
+# default arm signals via DEUS_CONNECT_ID and clears positional params so
+# the shared dispatcher below still matches `home|""|--print-identity`
+# regardless of what followed the connector id.
+if [ "$1" = "connect" ]; then
+  shift
+  case "${1:-}" in
+    ""|list)
+      python3 "$SCRIPT_DIR/scripts/connectors_cli.py" list
+      exit $?
+      ;;
+    status)
+      shift
+      python3 "$SCRIPT_DIR/scripts/connectors_cli.py" status "$1"
+      exit $?
+      ;;
+    setup)
+      shift
+      if [ -z "${1:-}" ]; then
+        echo "Usage: deus connect setup <id>" >&2
+        python3 "$SCRIPT_DIR/scripts/connectors_cli.py" list >&2
+        exit 1
+      fi
+      # Do NOT call _ensure_portable_skills here -- this early prefix-
+      # dispatch block runs before that function is DEFINED; shell scripts
+      # execute top-to-bottom, so calling it this early would hit "command
+      # not found" on every invocation. Just signal and shift; the actual
+      # call happens right after the function's own definition, before the
+      # main case "$1" in ... dispatcher begins.
+      export DEUS_CONNECT_SETUP_ID="$1"
+      ;;
+    *)
+      # Do NOT reuse CLI_AGENT/_normalize_cli_agent -- deus fcc's own
+      # runtime dispatch on that chain is confirmed dead code today, not a
+      # safe pattern to extend for a new launch path.
+      export DEUS_CONNECT_ID="$1"
+      shift
+      DEUS_CONNECT_ARGS=("$@")   # preserve trailing claude args separately
+      # --agents/--name/-n are injected by launch_connect() itself (below) --
+      # a user-supplied one here would silently override the required
+      # inline agents or the resume-identification tag, since passthrough
+      # args are appended AFTER the injected ones (--agents is also a
+      # documented top-level `deus` flag, so this is a plausible collision,
+      # not just theoretical). Claude's CLI also accepts the equals form
+      # (--agents=<json>, --name=<name>), which a token-only match would
+      # miss entirely -- must reject both forms.
+      for _dc_arg in "${DEUS_CONNECT_ARGS[@]}"; do
+        case "$_dc_arg" in
+          --agents|--agents=*|--name|--name=*|-n)
+            echo "Error: deus connect already injects $_dc_arg -- pass a different flag." >&2
+            exit 1
+            ;;
+        esac
+      done
+      set --                     # force the shared dispatcher below into
+                                  # home|""|--print-identity, so the
+                                  # connector launch (not setup -- see
+                                  # above) gets the full identity/vault/
+                                  # preferences/portable-skills pipeline
+      ;;
+  esac
+fi
+
 _read_config_key() {
   python3 -c "
 import json; from pathlib import Path
@@ -633,6 +701,7 @@ PORTABLE_SKILLS=(
   wardens
   add-editor
   add-understand-anything
+  add-connector
 )
 
 _ensure_portable_skills() {
@@ -660,6 +729,32 @@ _ensure_portable_skills() {
 _deus_freshness_check "$@"
 # Passive background auto-sync (mutating — see the auto-sync sentinel block above).
 _deus_auto_sync "$@"
+
+# `deus connect setup <id>` continuation — signaled by the early prefix-
+# dispatch block above. Deferred to here (the earliest point the function
+# genuinely exists) rather than called from that block directly. Runs
+# outside the home/external-project pipeline below on purpose: routing
+# `setup` through that pipeline would run project onboarding for whatever
+# directory the user happens to be in, an unintended mutation.
+if [ -n "$DEUS_CONNECT_SETUP_ID" ]; then
+  _connect_setup_id="$DEUS_CONNECT_SETUP_ID"
+  unset DEUS_CONNECT_SETUP_ID   # exported vars leak into every child process --
+                                # the claude session this launches (and anything
+                                # IT launches, e.g. add-connector's own
+                                # verification step running "deus connect <id>")
+                                # must not inherit a stale setup sentinel that
+                                # would hijack that nested launch back into
+                                # /add-connector.
+  _ensure_portable_skills
+  # `deus connect setup` must work from any directory (that's the whole
+  # point of the PORTABLE_SKILLS fix above) -- but the launched session gets
+  # none of the normal Deus context pipeline (no --append-system-prompt),
+  # and the skill's own commands (e.g. "python3 scripts/connectors_cli.py
+  # list") use repo-relative paths, matching every other portable skill's
+  # convention. Without cd'ing first, those commands would fail the moment
+  # this is invoked from outside $SCRIPT_DIR.
+  cd "$SCRIPT_DIR" && exec claude "/add-connector $_connect_setup_id"
+fi
 
 case "$1" in
   init|onboard)
@@ -1181,7 +1276,68 @@ sys.exit(1)
       fi
     }
 
+    launch_connect() {
+      local id="$DEUS_CONNECT_ID"
+      unset DEUS_CONNECT_ID   # exported vars leak into every child process --
+                              # this must not leak into the claude process
+                              # about to be launched (or anything it
+                              # subsequently runs, e.g. a nested
+                              # "deus connect <other-id>" call from inside a
+                              # tool call).
+      local env_output py_exit agents_json agents_py_exit
+      env_output="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" env "$id")"
+      py_exit=$?
+      if [ "$py_exit" -ne 0 ] || [ -z "$env_output" ]; then
+        echo "Error: connector '$id' is unknown or not configured."
+        echo "Run: deus connect setup $id"
+        return 1
+      fi
+      eval "$env_output"
+
+      # Claude Code's own authentication precedence (confirmed against
+      # code.claude.com/docs/en/authentication's "Authentication precedence"
+      # section) ranks cloud-provider selection (CLAUDE_CODE_USE_BEDROCK/
+      # VERTEX/FOUNDRY) above ANTHROPIC_AUTH_TOKEN, which itself outranks
+      # ANTHROPIC_API_KEY -- the one var this connector actually sets above.
+      # A user with any of these already set ambiently (e.g. an existing
+      # corporate gateway/cloud-provider config) would have the connector
+      # launch silently authenticate against THAT instead of routing through
+      # CLIProxyAPI at all -- not an error, just silently wrong. Clear them
+      # for this launch specifically; a bare `claude`/`deus claude` outside
+      # this connector session is unaffected.
+      unset ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY
+
+      agents_json="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" agents-json "$id")"
+      agents_py_exit=$?
+      if [ "$agents_py_exit" -ne 0 ] || [ -z "$agents_json" ]; then
+        echo "Error: connector '$id' produced invalid subagent definitions."
+        return 1
+      fi
+
+      # That var silently collapses every subagent's model to one if ever
+      # set -- unset on every connect launch, not just during onboarding.
+      unset CLAUDE_CODE_SUBAGENT_MODEL
+
+      echo "warning: Connected via $id -- non-Claude model, do not resume bare."
+
+      # "$@" here is launch_connect's own positional params, forwarded from
+      # launch_agent's "$@" below -- this is the pipeline's assembled
+      # context (e.g. --append-system-prompt "$FULL_PROMPT"). --agents is
+      # injected only here, at the final launch_claude call, never earlier
+      # in any positional-parameter list the AGENTS_MODE scan above sees --
+      # that scan string-matches a literal "--agents" token appearing
+      # anywhere in "$@" and execs `claude agents` (Claude's own
+      # agent-management TUI) instead of a normal launch if it appears
+      # before this point.
+      launch_claude "$@" --agents "$agents_json" --name "connect:$id (non-Claude)" "${DEUS_CONNECT_ARGS[@]}"
+      return $?
+    }
+
     launch_agent() {
+      if [ -n "$DEUS_CONNECT_ID" ]; then
+        launch_connect "$@"
+        return $?
+      fi
       if [ "$CLI_AGENT" = "fcc" ]; then
         launch_fcc "$@"
         return $?
@@ -1519,7 +1675,14 @@ $STARTUP_INSTRUCTION"
         printf '%s' "$FULL_PROMPT" >&3
         exit 0
       fi
-      if [ "$TUI_DEFAULT" = "true" ]; then
+      # deus connect always forces the plain-claude path below, ignoring
+      # tui_default entirely: env-var redirection would propagate into the
+      # TUI's own claude subprocess for free (Rust's Command inherits the
+      # full parent environment), but --agents/--name are CLI flags the
+      # TUI's own Rust code constructs per-turn with no propagation path
+      # without modifying that binary -- a partial-parity variant risks
+      # confusing, undocumented behavior more than it's worth.
+      if [ "$TUI_DEFAULT" = "true" ] && [ -z "$DEUS_CONNECT_ID" ]; then
         cd "$CURRENT_DIR" && _launch_tui_with_context "$FULL_PROMPT" "" "external"
       fi
       launch_agent --append-system-prompt "$FULL_PROMPT"
@@ -1572,7 +1735,9 @@ $STARTUP_INSTRUCTION"
       printf '%s' "$FULL_PROMPT" >&3
       exit 0
     fi
-    if [ "$TUI_DEFAULT" = "true" ]; then
+    # deus connect always forces the plain-claude path (see the matching
+    # comment in external-project mode above for why).
+    if [ "$TUI_DEFAULT" = "true" ] && [ -z "$DEUS_CONNECT_ID" ]; then
       cd "$HOME/deus" && _launch_tui_with_context "$FULL_PROMPT" "$INITIAL_MSG" "home"
     fi
 
@@ -2003,6 +2168,7 @@ $STARTUP_INSTRUCTION"
     echo "  deus            Launch in current directory (external project mode if not ~/deus)"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
     echo "  deus fcc        Launch with proxy model (see: deus provider, deus model)"
+    echo "  deus connect    Launch via a registered non-Claude connector (list|setup|status <id> | <id>)"
     echo "  deus home       Launch in home mode (~/deus) regardless of current directory"
     echo "  deus init       Onboard the current project: index it for code intelligence"
     echo "                    (codegraph + code_search) and register it (alias: onboard)"

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -98,7 +98,7 @@ if [ "$1" = "connect" ]; then
       # documented top-level `deus` flag, so this is a plausible collision,
       # not just theoretical). Claude's CLI also accepts the equals form
       # (--agents=<json>, --name=<name>), which a token-only match would
-      # miss entirely -- must reject both forms.
+      # miss entirely -- must reject both forms. (deus connect, #1171)
       for _dc_arg in "${DEUS_CONNECT_ARGS[@]}"; do
         case "$_dc_arg" in
           --agents|--agents=*|--name|--name=*|-n)
@@ -735,7 +735,8 @@ _deus_auto_sync "$@"
 # genuinely exists) rather than called from that block directly. Runs
 # outside the home/external-project pipeline below on purpose: routing
 # `setup` through that pipeline would run project onboarding for whatever
-# directory the user happens to be in, an unintended mutation.
+# directory the user happens to be in, an unintended mutation. (deus
+# connect, #1171)
 if [ -n "$DEUS_CONNECT_SETUP_ID" ]; then
   _connect_setup_id="$DEUS_CONNECT_SETUP_ID"
   unset DEUS_CONNECT_SETUP_ID   # exported vars leak into every child process --
@@ -1277,6 +1278,7 @@ sys.exit(1)
     }
 
     launch_connect() {
+      # deus connect (#1171)
       local id="$DEUS_CONNECT_ID"
       unset DEUS_CONNECT_ID   # exported vars leak into every child process --
                               # this must not leak into the claude process
@@ -1328,12 +1330,13 @@ sys.exit(1)
       # that scan string-matches a literal "--agents" token appearing
       # anywhere in "$@" and execs `claude agents` (Claude's own
       # agent-management TUI) instead of a normal launch if it appears
-      # before this point.
+      # before this point. (deus connect, #1171)
       launch_claude "$@" --agents "$agents_json" --name "connect:$id (non-Claude)" "${DEUS_CONNECT_ARGS[@]}"
       return $?
     }
 
     launch_agent() {
+      # deus connect (#1171)
       if [ -n "$DEUS_CONNECT_ID" ]; then
         launch_connect "$@"
         return $?
@@ -1681,7 +1684,8 @@ $STARTUP_INSTRUCTION"
       # full parent environment), but --agents/--name are CLI flags the
       # TUI's own Rust code constructs per-turn with no propagation path
       # without modifying that binary -- a partial-parity variant risks
-      # confusing, undocumented behavior more than it's worth.
+      # confusing, undocumented behavior more than it's worth. (deus
+      # connect, #1171)
       if [ "$TUI_DEFAULT" = "true" ] && [ -z "$DEUS_CONNECT_ID" ]; then
         cd "$CURRENT_DIR" && _launch_tui_with_context "$FULL_PROMPT" "" "external"
       fi
@@ -1736,7 +1740,7 @@ $STARTUP_INSTRUCTION"
       exit 0
     fi
     # deus connect always forces the plain-claude path (see the matching
-    # comment in external-project mode above for why).
+    # comment in external-project mode above for why). (#1171)
     if [ "$TUI_DEFAULT" = "true" ] && [ -z "$DEUS_CONNECT_ID" ]; then
       cd "$HOME/deus" && _launch_tui_with_context "$FULL_PROMPT" "$INITIAL_MSG" "home"
     fi

--- a/docs/decisions/backend-neutral-agent-runtime.md
+++ b/docs/decisions/backend-neutral-agent-runtime.md
@@ -53,6 +53,12 @@ Every backend adapter change should include or update a parity matrix covering:
 
 At minimum, run TypeScript checks plus targeted backend/session/auth/container tests before merging. Full live verification requires a rebuilt agent container and provider credentials.
 
+Note: `deus connect` (see the `add-connector` skill) is a CLI-level model
+redirect — it launches the real, unmodified `claude` binary with only the
+upstream model swapped via `ANTHROPIC_BASE_URL` — and is explicitly outside
+the backend-adapter concept this ADR governs; it does not participate in the
+Parity Matrix below.
+
 ## Parity Matrix
 
 | Surface | Claude Default | OpenAI/Codex Opt-In | Llama.cpp Local Opt-In |

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-09" # auto-bump @1786264137
+last_verified: "2026-08-11" # auto-bump @1786466779
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-08" # auto-bump @1786144564
+last_verified: "2026-08-11" # auto-bump @1786466779
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/connectors_cli.py
+++ b/scripts/connectors_cli.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""connectors_cli.py — bash/Python bridge for `deus connect` (deus-cmd.sh).
+
+Subcommands:
+  list                  enumerate registered connectors + configured status
+  status <id>            engine health + functional probe for one connector
+  env <id>                print 'export KEY=<shlex-quoted value>' lines for
+                           deus-cmd.sh to `eval`; exits non-zero with no
+                           stdout on an unknown/unconfigured id
+  agents-json <id>        print agents_for_launch()'s dict as one-line JSON
+
+  Setup orchestration, used by the add-connector skill (not deus-cmd.sh):
+  install-check <id>      prints "installed"/"not installed" per setup_handler.install()
+  authenticate <id>        runs setup_handler.authenticate() interactively
+  write-config <id>        reads a JSON values object from stdin, calls
+                            setup_handler.write_config(values)
+  verify-setup <id>        runs setup_handler.verify() (distinct from `status`,
+                            which also requires is_configured() first)
+
+Invoked by deus-cmd.sh via an absolute path from whatever directory the
+caller happens to be in (`deus connect` must work from anywhere) — so
+sys.path is fixed up before importing the sibling `connectors` package,
+mirroring scripts/code_search.py:35-40's existing convention.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    # connectors.providers.cliproxy_oauth does `import yaml` at module load
+    # (CLIProxyAPI's own config format is YAML) -- PyYAML is not a repo-wide
+    # dependency (this repo has no root requirements.txt; host-side Python
+    # deps are installed on demand per feature, matching e.g. the setup
+    # skill's `pip install mcp sqlite_vec` pattern for code-search), so a
+    # fresh install without it must fail with an actionable message here,
+    # not a raw traceback the first time any `deus connect` subcommand runs.
+    import yaml  # noqa: F401
+except ModuleNotFoundError:
+    print(
+        "Error: deus connect requires PyYAML (used for the CLIProxyAPI "
+        "engine's config file format). Install it: pip3 install pyyaml",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# Importing `connectors` (below) already runs connectors/__init__.py, which
+# imports `providers` as a side effect to register the built-ins -- no
+# separate explicit import needed here.
+from connectors.registry import ConnectorRegistry, UnknownConnectorError  # noqa: E402
+
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _registry() -> ConnectorRegistry:
+    return ConnectorRegistry.default()
+
+
+def cmd_list(_args: argparse.Namespace) -> int:
+    for connector in _registry().list_connectors():
+        status = "configured" if connector.is_configured() else "not configured"
+        print(
+            f"{connector.id}\t{connector.engine}\t{connector.risk_level}\t"
+            f"{status}\t{connector.description}"
+        )
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if not connector.is_configured():
+        print("not configured")
+        return 1
+    healthy = connector.setup_handler.verify()
+    print("healthy" if healthy else "unhealthy")
+    return 0 if healthy else 1
+
+
+def cmd_env(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError:
+        return 1
+    if not connector.is_configured():
+        return 1
+    env = connector.env_for_launch()
+    if not env:
+        return 1
+    # env_for_launch() is an abstract contract any future connector
+    # implements -- deus-cmd.sh `eval`s this output, so an unvalidated key
+    # (unlike `value`, which is shlex-quoted) would be arbitrary shell
+    # injection the moment a connector's dict contains one.
+    for key, value in env.items():
+        if not _ENV_KEY_RE.match(key):
+            print(f"Error: connector produced an invalid env var name: {key!r}", file=sys.stderr)
+            return 1
+    for key, value in env.items():
+        print(f"export {key}={shlex.quote(value)}")
+    return 0
+
+
+def cmd_agents_json(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError:
+        return 1
+    if not connector.is_configured():
+        return 1
+    print(json.dumps(connector.agents_for_launch()))
+    return 0
+
+
+def cmd_install_check(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    installed = connector.setup_handler.install()
+    print("installed" if installed else "not installed")
+    return 0 if installed else 1
+
+
+def cmd_authenticate(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0 if connector.setup_handler.authenticate() else 1
+
+
+def cmd_write_config(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    try:
+        values = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"Error: invalid JSON on stdin: {exc}", file=sys.stderr)
+        return 1
+    connector.setup_handler.write_config(values)
+    return 0
+
+
+def cmd_verify_setup(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    healthy = connector.setup_handler.verify()
+    print("healthy" if healthy else "unhealthy")
+    return 0 if healthy else 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="connectors_cli.py")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list").set_defaults(func=cmd_list)
+
+    p_status = sub.add_parser("status")
+    p_status.add_argument("id")
+    p_status.set_defaults(func=cmd_status)
+
+    p_env = sub.add_parser("env")
+    p_env.add_argument("id")
+    p_env.set_defaults(func=cmd_env)
+
+    p_agents = sub.add_parser("agents-json")
+    p_agents.add_argument("id")
+    p_agents.set_defaults(func=cmd_agents_json)
+
+    p_install = sub.add_parser("install-check")
+    p_install.add_argument("id")
+    p_install.set_defaults(func=cmd_install_check)
+
+    p_auth = sub.add_parser("authenticate")
+    p_auth.add_argument("id")
+    p_auth.set_defaults(func=cmd_authenticate)
+
+    p_write = sub.add_parser("write-config")
+    p_write.add_argument("id")
+    p_write.set_defaults(func=cmd_write_config)
+
+    p_verify = sub.add_parser("verify-setup")
+    p_verify.add_argument("id")
+    p_verify.set_defaults(func=cmd_verify_setup)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/test_connectors_cli.py
+++ b/scripts/tests/test_connectors_cli.py
@@ -1,0 +1,121 @@
+"""
+Tests for scripts/connectors_cli.py's `env` subcommand's key-validation
+guard -- the highest-risk line in the `deus connect` diff: deus-cmd.sh
+`eval`s this command's stdout, so an unvalidated env var *key* (unlike
+`value`, which is shlex-quoted) from a future/buggy connector's
+env_for_launch() dict would be arbitrary shell injection the moment it ran.
+"""
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Ensure scripts/ is importable so `import connectors_cli` resolves.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import connectors_cli  # noqa: E402
+from connectors.base import Connector, ConnectorSetupHandler  # noqa: E402
+from connectors.registry import ConnectorRegistry  # noqa: E402
+
+
+class _NoopSetupHandler(ConnectorSetupHandler):
+    def install(self) -> bool:
+        return True
+
+    def authenticate(self) -> bool:
+        return True
+
+    def write_config(self, values: dict[str, Any]) -> None:
+        pass
+
+    def verify(self) -> bool:
+        return True
+
+
+class _EnvFakeConnector(Connector):
+    """A connector whose env_for_launch() is controlled per-test."""
+
+    def __init__(self, connector_id: str, env: dict[str, str]):
+        self._id = connector_id
+        self._env = env
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return "fake"
+
+    @property
+    def engine(self) -> str:
+        return "fake"
+
+    @property
+    def risk_level(self) -> str:
+        return "none"
+
+    @property
+    def setup_handler(self) -> ConnectorSetupHandler:
+        return _NoopSetupHandler()
+
+    def model_aliases(self) -> dict[str, str]:
+        return {"fake-agent": "fake-alias"}
+
+    def is_configured(self) -> bool:
+        return True
+
+    def env_for_launch(self) -> dict[str, str]:
+        return self._env
+
+    def agents_for_launch(self) -> dict[str, Any]:
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    ConnectorRegistry.reset()
+    yield
+    ConnectorRegistry.reset()
+
+
+def test_env_rejects_malicious_key(capsys):
+    reg = ConnectorRegistry.default()
+    reg.register(_EnvFakeConnector("evil", {"FOO; rm -rf /": "value"}))
+    rc = connectors_cli.cmd_env(argparse.Namespace(id="evil"))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.out == ""  # no export lines leaked before the abort
+
+
+def test_env_rejects_if_any_key_in_batch_is_invalid(capsys):
+    reg = ConnectorRegistry.default()
+    reg.register(
+        _EnvFakeConnector(
+            "evil", {"ANTHROPIC_API_KEY": "ok-value", "$(whoami)": "value"}
+        )
+    )
+    rc = connectors_cli.cmd_env(argparse.Namespace(id="evil"))
+    captured = capsys.readouterr()
+    assert rc == 1
+    # Full-batch abort, not a partial drop of just the bad key.
+    assert captured.out == ""
+
+
+def test_env_accepts_valid_keys(capsys):
+    reg = ConnectorRegistry.default()
+    reg.register(
+        _EnvFakeConnector(
+            "good",
+            {"ANTHROPIC_BASE_URL": "http://localhost:8317", "ANTHROPIC_API_KEY": "k"},
+        )
+    )
+    rc = connectors_cli.cmd_env(argparse.Namespace(id="good"))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "export ANTHROPIC_BASE_URL=" in captured.out
+    assert "export ANTHROPIC_API_KEY=" in captured.out


### PR DESCRIPTION
## Summary
- Adds `deus connect <id>` — routes a Claude Code session to a non-Claude model (GPT 5.6 Sol/Terra/Luna via CLIProxyAPI OAuth-subscription reuse) while preserving Deus's normal identity/vault/memory/preferences/portable-skills pipeline, on an extensible `Connector` ABC + registry (mirrors `evolution/judge/provider.py`).
- Onboarding via the new `/add-connector` skill: risk disclosure, install, OAuth login, config write (outside any container-mountable project root), launchd daemon setup, verification.
- One-sentence ADR amendment clarifying this is outside `backend-neutral-agent-runtime.md`'s backend-adapter concept, plus a new optional-setup README bullet.

## Review process
- Plan: 22 rounds of `plan-reviewer`, unanimous SHIP from both Claude and GPT backends.
- Implementation diff: 12 rounds of full-diff `code-reviewer` co-gate review + 3 independent `verification-gate` passes, fixing 12 real defects, including:
  - Claude Code auth-precedence bypass (ambient `ANTHROPIC_AUTH_TOKEN`/cloud-provider vars silently outrank the connector's own key — verified against Anthropic's official docs)
  - Wrong CLIProxyAPI health-check endpoint + a network exposure from an unset `host` binding all interfaces instead of localhost (both verified against upstream CLIProxyAPI source)
  - Missing production PyYAML dependency
  - A launchd-plist collision that would have silently destroyed (and, via `launchctl kickstart`, actively hijacked) a real pre-existing daemon at the same conventional path — reproduced for real during testing, fixed with a connector-specific label plus a mutation-tested existence/collision guard
  - Several smaller correctness/security gaps (directory handling, CLI-flag collision, risk-disclosure skip path, placeholder-credential detection)

## Test plan
- [x] `python3 -m pytest connectors/tests/ scripts/tests/test_connectors_cli.py -v` — 22/22 pass
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all checks pass
- [x] Manual end-to-end shell dispatch testing via a stub `claude` binary (context payload, `--agents` JSON, `--name`, trailing args, auth-precedence var clearing all confirmed reaching the final launch correctly)
- [x] `deus connect list/status/setup` all tested against the real dispatch path
- [ ] Real OAuth login + live connector launch (requires the user's own ChatGPT/Codex subscription — left for the user via `/add-connector`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)