### PR TITLE
feat(deus-connect): add global default-connector persistence

### DIFF
--- a/.claude/skills/add-connector/SKILL.md
+++ b/.claude/skills/add-connector/SKILL.md
@@ -234,6 +234,29 @@ deus connect cliproxy-oauth
   makes; env-var inheritance by nested processes and session-resume
   visibility are both disclosed tradeoffs, not guarantees — see Phase 3).
 
+## Phase 11: Set as default (optional)
+
+By default, every future session still needs `deus connect <id>` typed
+explicitly — a bare `deus`/`deus home` is never affected. If you want this
+connector to be your default everywhere instead (every bare `deus`/`deus
+home` session, in any project, routes through it automatically), ask:
+
+AskUserQuestion: Set `<id>` as your default connector for every session?
+- Yes — run `deus connect default <id>` interactively and walk through its
+  own confirmation prompt (a materially bigger blast radius than one-off
+  `deus connect <id>` use, so it carries its own disclosure, not just
+  Phase 3's).
+- No — skip; `deus connect <id>` remains available on demand.
+
+If yes, `deus connect default <id>` requires an interactive terminal (fails
+closed, not silently, when piped/non-interactive) and prints its own
+five-point-adjacent disclosure before writing anything — most importantly:
+`deus claude` (typed explicitly) is the only guaranteed way to force plain
+Claude once a default is set; a persistent `deus backend set claude` choice
+or `DEUS_CLI_AGENT`/`DEUS_AGENT_BACKEND` env vars are NOT enough on their
+own to block it. Reversible any time with `deus connect default off`
+(`clear` is an accepted synonym).
+
 ## Troubleshooting
 
 ### `deus connect cliproxy-oauth` says "connector is unknown or not configured"

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,14 @@ ASSISTANT_HAS_OWN_NUMBER=false
 # === AI / API Keys ===
 DEUS_AGENT_BACKEND=claude
 DEUS_CLI_AGENT=
+# `deus connect <id>` — route a Claude Code session to a non-Claude model
+# (GPT via CLIProxyAPI OAuth-subscription reuse) alongside normal Claude
+# access, with Deus identity/vault/memory/preferences intact. Deliberately
+# NOT configured here: its real credentials live entirely outside this repo
+# (~/.config/deus/connectors/), never in .env, so a container agent with
+# read access to the project can never see them. Run `/add-connector` to
+# set up (per-session opt-in by default; `deus connect default <id>`
+# persists it globally). See README.md's "deus connect" bullet.
 DEUS_OPENAI_MODEL=
 DEUS_CODEX_MODEL=
 DEUS_CONTEXT_FILE_MAX_CHARS=20000

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A personal AI that understands you - not just recalls things you've said. It lea
 - [Ollama](https://ollama.ai/download) for local embeddings and scoring (not an agent backend) - `/setup` pulls the right models automatically based on your hardware
 - **Optional:** [llama.cpp](https://github.com/ggerganov/llama.cpp) for a fully local, API-free agent backend — no per-turn cost, works offline. Run `/add-llama-cpp` to install.
 - **Optional:** [free-claude-code](https://github.com/Alishahryar1/free-claude-code) proxy for using Claude Code CLI with alternative models (Ollama, llama-server, Gemini). Launch with `deus fcc` after configuring via `deus provider` and `deus model`.
-- **Optional:** `deus connect` — reuse an OAuth-subscription-multiplexing engine (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) to route a session to non-Claude models (GPT 5.6 Sol/Terra/Luna) alongside normal Claude access, with Deus identity/vault/memory/preferences/skills intact. Run `/add-connector` to set up. **Unsupported by Anthropic** (routing Claude Code to non-Claude models through any gateway is explicitly outside its support scope) and carries a real, disclosed session-resume-visibility tradeoff — read the risk disclosure in `/add-connector` before enabling.
+- **Optional:** `deus connect` — reuse an OAuth-subscription-multiplexing engine (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)) to route a session to non-Claude models (GPT 5.6 Sol/Terra/Luna) alongside normal Claude access, with Deus identity/vault/memory/preferences/skills intact. Run `/add-connector` to set up. **Unsupported by Anthropic** (routing Claude Code to non-Claude models through any gateway is explicitly outside its support scope) and carries a real, disclosed session-resume-visibility tradeoff — read the risk disclosure in `/add-connector` before enabling. Opt-in per session by default (`deus connect <id>`); `deus connect default <id>` persists it globally instead, so every bare `deus`/`deus home` session routes there until `deus connect default off` — `deus claude` always bypasses either mode.
 
 ### Install
 
@@ -120,7 +120,7 @@ See [AGENTS.md](AGENTS.md#commands-and-skills) for all available skills.
 | `deus arch` | Visualize a project's architecture in an interactive 3D explorer |
 | `deus codex` | Use OpenAI/Codex backend for this session |
 | `deus fcc` | Launch with a local proxy model (Ollama, llama-server, Gemini) |
-| `deus connect <id>` | Launch via a registered non-Claude connector (`list`/`setup`/`status <id>`) — see `/add-connector` |
+| `deus connect <id>` | Launch via a registered non-Claude connector (`list`/`setup <id>`/`status <id>`/`default <id>\|off`) — see `/add-connector` |
 | `deus provider <name>` | Switch proxy provider (`ollama`, `llamacpp`, `gemini`) |
 | `deus model <name>` | Switch proxy model (auto-prefixes active provider) |
 | `deus model dashboard` | Open proxy admin UI in browser |

--- a/connectors/base.py
+++ b/connectors/base.py
@@ -68,8 +68,9 @@ class Connector(ABC):
     def id(self) -> str:
         """Stable connector id, e.g. 'cliproxy-oauth'.
 
-        Never one of the reserved words `list`/`setup`/`status` — the
-        registry rejects registration of a connector using any of those.
+        Never one of the reserved words `list`/`setup`/`status`/`default`/
+        `show`/`off`/`clear` — the registry rejects registration of a
+        connector using any of those (see `registry.RESERVED_IDS`).
         """
         ...
 

--- a/connectors/registry.py
+++ b/connectors/registry.py
@@ -13,10 +13,14 @@ from typing import Optional
 
 from .base import Connector
 
-# `deus connect list`/`setup <id>`/`status <id>` are reserved command words —
-# a connector id can never take one of these (see deus-cmd.sh's `connect`
-# prefix-dispatch branch).
-RESERVED_IDS = frozenset({"list", "setup", "status"})
+# `deus connect list`/`setup <id>`/`status <id>`/`default <id>`, plus
+# `default`'s own sub-namespace (`show`/`off`/`clear`), are reserved command
+# words — a connector id can never take one of these (see deus-cmd.sh's
+# `connect` prefix-dispatch branch and the `default)` arm's deferred
+# continuation). Without this, e.g. a connector literally named "default"
+# would be permanently unreachable via `deus connect default` -- that case
+# arm always intercepts it first, before the launch catch-all ever runs.
+RESERVED_IDS = frozenset({"list", "setup", "status", "default", "show", "off", "clear"})
 
 
 class ConnectorRegistrationError(ValueError):

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -96,7 +96,11 @@ class TestConnectorRegistry:
 
     def test_register_rejects_reserved_ids(self):
         reg = ConnectorRegistry.default()
-        for reserved in ("list", "setup", "status"):
+        # "default" plus its own sub-namespace (show/off/clear) -- a
+        # connector using any of these would be permanently unreachable
+        # via `deus connect <id>`, intercepted by the `default)` case arm
+        # before the launch catch-all ever runs (deus connect, #1171-followup).
+        for reserved in ("list", "setup", "status", "default", "show", "off", "clear"):
             with pytest.raises(ConnectorRegistrationError):
                 reg.register(FakeConnector(reserved))
 

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -35,6 +35,12 @@ _file_mtime() {
 # invocation. Plain `deus` still defaults to Claude unless env/config says
 # otherwise.
 if [ "$1" = "codex" ] || [ "$1" = "claude" ] || [ "$1" = "fcc" ]; then
+  # A literally-typed backend prefix is the deterministic escape hatch for
+  # `deus connect default <id>` (deus-cmd.sh, #1171-followup) -- it must
+  # ALWAYS bypass any global default connector, regardless of config state.
+  # Plain, non-exported: this signal only needs to survive within this
+  # script's own process, not leak into anything it launches.
+  _DEUS_EXPLICIT_PREFIX=1
   if [ "$1" = "claude" ]; then
     export DEUS_CLI_AGENT="claude"
     export DEUS_AGENT_BACKEND="claude"
@@ -66,7 +72,12 @@ if [ "$1" = "connect" ]; then
       ;;
     status)
       shift
-      python3 "$SCRIPT_DIR/scripts/connectors_cli.py" status "$1"
+      # `--` stops argparse from treating a leading-dash id (e.g. a
+      # mistyped "--help") as a flag on the `status` subparser itself --
+      # without it, `deus connect status --help` silently prints argparse's
+      # own help and exits 0 instead of erroring on an unknown connector.
+      # (deus connect, #1171-followup)
+      python3 "$SCRIPT_DIR/scripts/connectors_cli.py" status -- "$1"
       exit $?
       ;;
     setup)
@@ -83,6 +94,23 @@ if [ "$1" = "connect" ]; then
       # call happens right after the function's own definition, before the
       # main case "$1" in ... dispatcher begins.
       export DEUS_CONNECT_SETUP_ID="$1"
+      ;;
+    default)
+      shift
+      # Do NOT call _read_config_key/_write_config_key here -- same
+      # ordering constraint as `setup` above: this early prefix-dispatch
+      # block runs before those functions are DEFINED. Signal only; the
+      # real work happens in the deferred continuation right after
+      # _ensure_portable_skills's own definition (deus-cmd.sh, #1171-
+      # followup). Plain, non-exported scalar -- an exported sentinel
+      # would leak into the launched session and anything it subsequently
+      # runs, the same class of bug the DEUS_CONNECT_ID/SETUP_ID sentinels
+      # already guard against elsewhere in this file. "${1:-show}" (not
+      # "${1:-}") so the continuation can tell "arm fired with no arg,
+      # i.e. the bare 'deus connect default' show-current-value form" apart
+      # from "arm never fired at all" -- both would otherwise read as an
+      # empty/unset variable.
+      _DEUS_CONNECT_DEFAULT_ARG="${1:-show}"
       ;;
     *)
       # Do NOT reuse CLI_AGENT/_normalize_cli_agent -- deus fcc's own
@@ -757,6 +785,116 @@ if [ -n "$DEUS_CONNECT_SETUP_ID" ]; then
   cd "$SCRIPT_DIR" && exec claude "/add-connector $_connect_setup_id"
 fi
 
+# `deus connect default <id>/off/<bare>` — signaled by the early connect
+# prefix-dispatch block above via _DEUS_CONNECT_DEFAULT_ARG. Deferred to
+# here for the same ordering reason as the setup continuation above:
+# _read_config_key/_write_config_key/_normalize_cli_agent aren't defined
+# until well after that early block runs. (deus connect, #1171-followup)
+if [ -n "$_DEUS_CONNECT_DEFAULT_ARG" ]; then
+  _dc_default_arg="$_DEUS_CONNECT_DEFAULT_ARG"
+  unset _DEUS_CONNECT_DEFAULT_ARG
+  case "$_dc_default_arg" in
+    show)
+      _dc_current="$(_read_config_key default_connect)"
+      if [ -n "$_dc_current" ]; then
+        echo "Default connector: $_dc_current"
+      else
+        echo "No default connector set."
+      fi
+      exit 0
+      ;;
+    off|clear)
+      _write_config_key default_connect ""
+      echo "Default connector cleared."
+      exit 0
+      ;;
+    *)
+      # `--` stops argparse from treating a leading-dash id as a flag on
+      # the `is-configured` subparser -- without it, e.g. `deus connect
+      # default --help` reaches argparse's own -h/--help handling (exit 0,
+      # no error), sailing straight past this validation gate and letting
+      # "--help" get written into default_connect as if it were a real
+      # connector id. Confirmed via direct reproduction. (#1171-followup)
+      if ! python3 "$SCRIPT_DIR/scripts/connectors_cli.py" is-configured -- "$_dc_default_arg" >/dev/null 2>&1; then
+        echo "Error: connector '$_dc_default_arg' is not configured -- run 'deus connect setup $_dc_default_arg' first." >&2
+        exit 1
+      fi
+      # A standing security-posture change, not a low-stakes indexing
+      # action like `deus arch`'s own prompt -- non-interactive/piped
+      # invocation fails closed rather than silently proceeding.
+      if [ ! -t 0 ]; then
+        echo "Error: setting a default connector requires interactive confirmation -- run this from an interactive terminal." >&2
+        exit 1
+      fi
+      echo "Setting '$_dc_default_arg' as your default connector means every future bare"
+      echo "'deus'/'deus home' session -- in any project, any directory -- will silently"
+      echo "route through it instead of Claude, until you run 'deus connect default off'."
+      echo ""
+      echo "The only guaranteed way to force plain Claude regardless of this default is"
+      echo "'deus claude' (explicit, typed that invocation). Note: a persistent Claude"
+      echo "preference alone -- 'deus backend set claude', or the DEUS_CLI_AGENT/"
+      echo "DEUS_AGENT_BACKEND environment variables -- does NOT block this default. This"
+      echo "tool cannot distinguish an explicit \"I want Claude\" choice from simply never"
+      echo "having configured anything, so all of those are treated the same way once a"
+      echo "default connector is set."
+      echo ""
+      printf "Continue? [y/N] "
+      read -r _dc_confirm
+      case "$_dc_confirm" in
+        [Yy]*) ;;
+        *)
+          echo "Cancelled. No change made."
+          exit 1
+          ;;
+      esac
+      _write_config_key default_connect "$_dc_default_arg"
+      echo "Default connector set to '$_dc_default_arg'."
+      exit 0
+      ;;
+  esac
+fi
+
+# Implicit default-connector injection — activates ONLY on a truly bare
+# launch: no literal claude/codex/fcc prefix typed this invocation
+# (_DEUS_EXPLICIT_PREFIX, the deterministic escape hatch), no explicit
+# `deus connect <id>` already in flight (DEUS_CONNECT_ID), $1 is exactly
+# "home" or empty (never any other subcommand -- init/arch/backend/etc),
+# AND --print-identity is absent from EVERY position, not just $1 -- that
+# query path must stay a pure, side-effect-free read (matching
+# _deus_freshness_check's/_deus_auto_sync's own every-position scan for
+# the identical flag, not just this file's convention by coincidence).
+# _normalize_cli_agent() = "claude" also folds in DEUS_CLI_AGENT/
+# DEUS_AGENT_BACKEND env vars and the persistent `agent_backend` config
+# key -- this means a user who explicitly ran `deus backend set claude` is
+# NOT distinguishable from one who configured nothing; both are eligible
+# for this injection. Disclosed, accepted limitation (see the confirmation
+# text above and the backend-set note below) rather than new persisted
+# state to track the distinction -- `deus claude` already resolves it
+# deterministically for anyone who wants guaranteed non-redirected Claude.
+# (deus connect, #1171-followup)
+_dc_print_identity_present=""
+for _dc_pi_arg in "$@"; do
+  [ "$_dc_pi_arg" = "--print-identity" ] && _dc_print_identity_present=1
+done
+if [ -z "$_DEUS_EXPLICIT_PREFIX" ] && [ -z "$DEUS_CONNECT_ID" ] \
+   && [ -z "$_dc_print_identity_present" ] \
+   && { [ "$1" = "home" ] || [ -z "$1" ]; }; then
+  if [ "$(_normalize_cli_agent)" = "claude" ]; then
+    _default_connect_id="$(_read_config_key default_connect)"
+    if [ -n "$_default_connect_id" ]; then
+      export DEUS_CONNECT_ID="$_default_connect_id"
+      DEUS_CONNECT_ARGS=()
+      # Distinguishes this from an explicit `deus connect <id>` invocation
+      # so launch_connect()'s error message (if the connector has since
+      # become unconfigured) can point at the actually-relevant remedy
+      # ("deus connect default off") instead of "deus connect setup <id>"
+      # -- the user typed nothing connector-related this time and may not
+      # remember a default is even set.
+      _DEUS_CONNECT_ID_IMPLICIT=1
+    fi
+  fi
+fi
+
 case "$1" in
   init|onboard)
     # Onboard a project into Deus code intelligence (codegraph + code_search)
@@ -1024,6 +1162,20 @@ sys.exit(1)
         _write_env_key "DEUS_AGENT_BACKEND" "$NEW_BACKEND"
         echo "Default backend set to: $INPUT"
         echo "Takes effect on next 'deus' launch. Background service uses .env."
+        # $INPUT is only "claude" for one of the 4 canonical literals above --
+        # a default connector can only ever intercept bare `deus` when
+        # _normalize_cli_agent() resolves to exactly "claude" (deus connect,
+        # #1171-followup), so this note would be actively misleading if
+        # printed for codex/ollama/llama-cpp, where default_connect can't
+        # apply regardless of whether it's set.
+        if [ "$INPUT" = "claude" ]; then
+          _dc_default_check="$(_read_config_key default_connect)"
+          if [ -n "$_dc_default_check" ]; then
+            echo "Note: a default connector ($_dc_default_check) is also configured -- bare"
+            echo "'deus' still routes there unless you use 'deus claude' explicitly. Run"
+            echo "'deus connect default off' to fully disable."
+          fi
+        fi
         ;;
       model)
         if [ -z "$2" ]; then
@@ -1175,6 +1327,12 @@ sys.exit(1)
     done
     # Print mode must never exec an interactive UI — the query flag wins.
     if [ "$AGENTS_MODE" = "true" ] && [ "$PRINT_IDENTITY" != "true" ]; then
+      # If a default connector injected DEUS_CONNECT_ID earlier in this
+      # invocation (deus connect, #1171-followup), it must not leak into
+      # `claude agents` -- that process doesn't read the var today, but
+      # this matches the file's own leak discipline elsewhere (see
+      # launch_connect's own `unset DEUS_CONNECT_ID` for the same reason).
+      unset DEUS_CONNECT_ID
       exec claude agents
     fi
     # Keep captured stdout pure in print mode: progress noise ("Reading
@@ -1286,12 +1444,29 @@ sys.exit(1)
                               # subsequently runs, e.g. a nested
                               # "deus connect <other-id>" call from inside a
                               # tool call).
-      local env_output py_exit agents_json agents_py_exit
-      env_output="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" env "$id")"
+      local env_output py_exit agents_json agents_py_exit was_implicit
+      was_implicit="$_DEUS_CONNECT_ID_IMPLICIT"
+      unset _DEUS_CONNECT_ID_IMPLICIT
+      # `--` guards against a leading-dash id reaching argparse as a flag --
+      # $id can now come from a PERSISTED default_connect value (this
+      # feature's whole point), not just a one-shot typo, so a poisoned
+      # value here would silently misbehave on every future bare launch,
+      # not just the one invocation that introduced it. (#1171-followup)
+      env_output="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" env -- "$id")"
       py_exit=$?
       if [ "$py_exit" -ne 0 ] || [ -z "$env_output" ]; then
         echo "Error: connector '$id' is unknown or not configured."
-        echo "Run: deus connect setup $id"
+        if [ -n "$was_implicit" ]; then
+          # This id came from the implicit default-connector injection
+          # (deus connect default <id>), not a literal `deus connect <id>`
+          # this invocation -- the user typed nothing connector-related and
+          # may not remember a default is even set, so the explicit-
+          # invocation-only "run setup" remedy below is the wrong fix here.
+          echo "A default connector is configured -- run 'deus connect default off' to"
+          echo "disable it, or 'deus connect setup $id' to reconfigure it."
+        else
+          echo "Run: deus connect setup $id"
+        fi
         return 1
       fi
       eval "$env_output"
@@ -1309,7 +1484,7 @@ sys.exit(1)
       # this connector session is unaffected.
       unset ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY
 
-      agents_json="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" agents-json "$id")"
+      agents_json="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" agents-json -- "$id")"
       agents_py_exit=$?
       if [ "$agents_py_exit" -ne 0 ] || [ -z "$agents_json" ]; then
         echo "Error: connector '$id' produced invalid subagent definitions."
@@ -2173,6 +2348,9 @@ $STARTUP_INSTRUCTION"
     echo "  deus codex      Launch with Codex (OpenAI) for this session"
     echo "  deus fcc        Launch with proxy model (see: deus provider, deus model)"
     echo "  deus connect    Launch via a registered non-Claude connector (list|setup|status <id> | <id>)"
+    echo "                    deus connect default <id>|off  Persist a connector as the global default"
+    echo "                    for every bare 'deus'/'deus home' launch ('clear' is an accepted synonym"
+    echo "                    for 'off'; escape hatch: 'deus claude')"
     echo "  deus home       Launch in home mode (~/deus) regardless of current directory"
     echo "  deus init       Onboard the current project: index it for code intelligence"
     echo "                    (codegraph + code_search) and register it (alias: onboard)"

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-11" # auto-bump @1786466779
+last_verified: "2026-08-12" # auto-bump @1786520978
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/scripts/connectors_cli.py
+++ b/scripts/connectors_cli.py
@@ -4,6 +4,9 @@
 Subcommands:
   list                  enumerate registered connectors + configured status
   status <id>            engine health + functional probe for one connector
+  is-configured <id>      is_configured() only, no health probe -- for a
+                           setup-time gate (e.g. `deus connect default <id>`)
+                           that shouldn't require the daemon to be up right now
   env <id>                print 'export KEY=<shlex-quoted value>' lines for
                            deus-cmd.sh to `eval`; exits non-zero with no
                            stdout on an unknown/unconfigured id
@@ -87,6 +90,17 @@ def cmd_status(args: argparse.Namespace) -> int:
     healthy = connector.setup_handler.verify()
     print("healthy" if healthy else "unhealthy")
     return 0 if healthy else 1
+
+
+def cmd_is_configured(args: argparse.Namespace) -> int:
+    try:
+        connector = _registry().resolve(args.id)
+    except UnknownConnectorError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    configured = connector.is_configured()
+    print("configured" if configured else "not configured")
+    return 0 if configured else 1
 
 
 def cmd_env(args: argparse.Namespace) -> int:
@@ -178,6 +192,10 @@ def main(argv: list[str]) -> int:
     p_status = sub.add_parser("status")
     p_status.add_argument("id")
     p_status.set_defaults(func=cmd_status)
+
+    p_is_configured = sub.add_parser("is-configured")
+    p_is_configured.add_argument("id")
+    p_is_configured.set_defaults(func=cmd_is_configured)
 
     p_env = sub.add_parser("env")
     p_env.add_argument("id")

--- a/scripts/tests/test_connectors_cli.py
+++ b/scripts/tests/test_connectors_cli.py
@@ -76,6 +76,46 @@ class _EnvFakeConnector(Connector):
         return {}
 
 
+class _ConfigurableFakeConnector(Connector):
+    """A connector whose is_configured() is controlled per-test."""
+
+    def __init__(self, connector_id: str, configured: bool):
+        self._id = connector_id
+        self._configured = configured
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return "fake"
+
+    @property
+    def engine(self) -> str:
+        return "fake"
+
+    @property
+    def risk_level(self) -> str:
+        return "none"
+
+    @property
+    def setup_handler(self) -> ConnectorSetupHandler:
+        return _NoopSetupHandler()
+
+    def model_aliases(self) -> dict[str, str]:
+        return {}
+
+    def is_configured(self) -> bool:
+        return self._configured
+
+    def env_for_launch(self) -> dict[str, str]:
+        return {}
+
+    def agents_for_launch(self) -> dict[str, Any]:
+        return {}
+
+
 @pytest.fixture(autouse=True)
 def clean_registry():
     ConnectorRegistry.reset()
@@ -119,3 +159,68 @@ def test_env_accepts_valid_keys(capsys):
     assert rc == 0
     assert "export ANTHROPIC_BASE_URL=" in captured.out
     assert "export ANTHROPIC_API_KEY=" in captured.out
+
+
+class TestArgparseDashArgument:
+    """Regression coverage for a real bug a verification-gate pass caught
+    and live-reproduced: `deus connect default <id>` (deus-cmd.sh) passes a
+    user-typed, unvalidated string straight through to connectors_cli.py's
+    argv. Without a `--` separator before it, a leading-dash id like
+    "--help" is consumed by argparse's own built-in -h/--help handling
+    (prints help, exits 0) INSTEAD of reaching the subcommand's actual
+    logic -- silently bypassing the is-configured validation gate the
+    `deus connect default <id>` flow relies on to refuse bad input, and
+    letting "--help" get persisted into default_connect as if it were a
+    real connector id. deus-cmd.sh's fix is to always pass `--` before the
+    id; this test confirms main()'s real argv-parsing path (not the
+    Namespace-construction shortcut the other tests in this file use)
+    actually respects that separator the way the shell-side fix assumes.
+    """
+
+    def test_dashed_id_without_separator_is_swallowed_by_argparse_help(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            connectors_cli.main(["is-configured", "--help"])
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 0  # argparse's own help exit, not our code
+        assert "usage:" in captured.out.lower()
+
+    def test_dashed_id_with_separator_reaches_real_logic(self, capsys):
+        rc = connectors_cli.main(["is-configured", "--", "--help"])
+        captured = capsys.readouterr()
+        assert rc == 1  # correctly treated as an unknown connector id
+        assert "Unknown connector" in captured.err
+        assert "--help" in captured.err
+
+
+class TestIsConfigured:
+    """`is-configured` is the gate `deus connect default <id>` uses at
+    set-time -- distinct from `status`, whose exit code conflates
+    "not configured" with "configured but unhealthy" (both print
+    different text but return the same exit 1), which would make a
+    setup-time default-connector check wrongly refuse a connector that's
+    merely transiently unhealthy (e.g. its daemon isn't running right
+    now) rather than genuinely unconfigured.
+    """
+
+    def test_configured_connector_exits_zero(self, capsys):
+        reg = ConnectorRegistry.default()
+        reg.register(_ConfigurableFakeConnector("good", configured=True))
+        rc = connectors_cli.cmd_is_configured(argparse.Namespace(id="good"))
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "configured"
+
+    def test_unconfigured_connector_exits_one(self, capsys):
+        reg = ConnectorRegistry.default()
+        reg.register(_ConfigurableFakeConnector("bad", configured=False))
+        rc = connectors_cli.cmd_is_configured(argparse.Namespace(id="bad"))
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert captured.out.strip() == "not configured"
+
+    def test_unknown_connector_exits_one(self, capsys):
+        ConnectorRegistry.default()  # empty registry
+        rc = connectors_cli.cmd_is_configured(argparse.Namespace(id="nonexistent"))
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "Unknown connector" in captured.err


### PR DESCRIPTION
## Summary
- Adds `deus connect default <id>` — mark a connector as the global default so every bare `deus`/`deus home` launch (any directory, any project, no per-project setup) routes through it automatically, without typing `connect <id>` each time.
- `deus connect default off` (or `clear`) reverts. `deus claude`/`deus codex`/`deus fcc` (typed explicitly, this invocation) always bypass any default — the deterministic escape hatch.
- New `connectors_cli.py is-configured <id>` subcommand — a setup-time-only gate (no health probe) so setting a default doesn't require the connector's daemon to be actively running.

## Review process
- Plan: 4 rounds of Claude-backend `plan-reviewer` + 2 rounds of independent Fable-backend `plan-reviewer`. Round 1 of the Fable pass returned REVISE, catching a real stale-default error-message gap (the existing "run setup" remedy misdirects a user who never typed anything connector-related) plus 3 zsh-dialect implementation details (this repo's `deus-cmd.sh` is zsh, not bash). Round 2: SHIP.
- Implementation: 2 rounds of `code-reviewer` co-gate + 2 rounds of `verification-gate`, fixing:
  - A registry reserved-word gap — a connector literally named `default`/`show`/`off`/`clear` would have been permanently unreachable via `deus connect <id>`, since the new case arms intercept those tokens first.
  - **Live-reproduced via a real A/B test**: an argparse flag-injection bug where `deus connect default --help` bypassed the connector-validation gate entirely (consumed by argparse's own `-h`/`--help` handling before reaching the actual check) and was one keystroke from persisting `"--help"` into the global default config. Fixed with a `--` separator at every `connectors_cli.py` call site that passes a user-controlled id.

## Test plan
- [x] `python3 -m pytest connectors/tests/ scripts/tests/test_connectors_cli.py -v` — 27/27 pass
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all checks pass
- [x] `zsh -n deus-cmd.sh` — clean
- [x] All 10 scenarios in the plan's own verification list confirmed end-to-end against the real script (stub `claude` binary on PATH + a real pty harness for the interactive confirmation prompt), including using the maintainer's own real configured connector to prove the implicit redirect genuinely fires
- [x] The argparse-bypass bug reproduced pre-fix and confirmed closed post-fix via a real A/B pty test

🤖 Generated with [Claude Code](https://claude.com/claude-code)