### PR TITLE
feat(deus-connect): add native ollama connector

### DIFF
--- a/.claude/skills/add-connector/SKILL.md
+++ b/.claude/skills/add-connector/SKILL.md
@@ -15,9 +15,25 @@ from Deus's own container-agent backend adapters (`deus codex`,
 `docs/decisions/backend-neutral-agent-runtime.md`'s note near the Parity
 Matrix.
 
-This skill is generic over any registered connector (currently ships with
-`cliproxy-oauth` only) — adding a second connector in the future changes
-`connectors/providers/`, not this skill.
+This skill is generic over any registered connector (ships with
+`cliproxy-oauth` and `ollama`) — adding another connector in the future
+changes `connectors/providers/`, not this skill.
+
+**Four distinct "ollama" surfaces exist in this repo — do not conflate
+them when guiding a user:**
+1. **`deus connect ollama`** (this skill, this section) — routes a Claude
+   Code session directly to a local Ollama instance via its native
+   Anthropic-API mode. No proxy, no daemon management.
+2. **`deus provider ollama` / `deus fcc`** (`deus-cmd.sh`'s `fcc` proxy
+   system) — a *different* mechanism: routes through `fcc-server`'s
+   OpenAI-compat translation proxy. Also reaches a local Ollama install,
+   but via proxy translation, not a direct native-mode redirect.
+3. **`deus backend set ollama`** — a persisted `DEUS_AGENT_BACKEND` value.
+   Not yet wired to a working CLI agent; its stub error message points
+   here (`deus connect ollama`) and to `deus provider ollama`/`fcc`.
+4. **`.claude/skills/add-ollama-tool`** — an unrelated feature: adds an
+   Ollama MCP server so a *container agent* (not a `deus connect` session)
+   can offload tasks to a local model.
 
 ## Phase 1: Pre-flight
 
@@ -38,24 +54,31 @@ reconfigure.
 
 ## Phase 2: Which connector
 
-AskUserQuestion: Which connector do you want to set up? (ships with
-`cliproxy-oauth` only today — CLIProxyAPI, OAuth-login, reuses your
-ChatGPT/Codex subscription for GPT models alongside Claude).
+AskUserQuestion: Which connector do you want to set up?
+- `cliproxy-oauth` — CLIProxyAPI, OAuth-login, reuses your ChatGPT/Codex
+  subscription for GPT models alongside Claude.
+- `ollama` — routes to a locally-pulled Ollama model via its native
+  Anthropic-API mode. No OAuth, no proxy daemon (Ollama runs its own
+  service already).
 
 ## Phase 3: Required risk acknowledgment
 
-**Not a footnote — block progression on explicit confirmation.** Show all
-five of these before proceeding, every time, for every future user:
+**Not a footnote — block progression on explicit confirmation, every time,
+for every future user.** Risks 2-5 below are structural to `deus connect`
+itself and apply to every connector; risk 1 is `cliproxy-oauth`-specific
+(OAuth-subscription reuse — Ollama has no OAuth token extraction, this risk
+class does not apply to it) and risk 6 is `ollama`-specific. Show the set
+that matches the connector selected in Phase 2:
 
 > **`deus connect` risk disclosure:**
 >
-> 1. **OAuth-subscription reuse is a real, non-zero, documented account-ban
->    risk class.** This connector extracts an OAuth token from your
->    ChatGPT/Codex subscription and reuses it for a separate HTTP client —
->    see `examples/multi-model-cliproxyapi/README.md`'s "Known open risks"
->    for the full account, including real dated ban reports in CLIProxyAPI's
->    own issue tracker for other providers. Unlike a config mistake, there
->    is no rollback if this fires.
+> 1. **(cliproxy-oauth only) OAuth-subscription reuse is a real, non-zero,
+>    documented account-ban risk class.** This connector extracts an OAuth
+>    token from your ChatGPT/Codex subscription and reuses it for a
+>    separate HTTP client — see `examples/multi-model-cliproxyapi/README.md`'s
+>    "Known open risks" for the full account, including real dated ban
+>    reports in CLIProxyAPI's own issue tracker for other providers. Unlike
+>    a config mistake, there is no rollback if this fires.
 > 2. **Anthropic explicitly disclaims support** for routing Claude Code to
 >    non-Claude models through any gateway
 >    (https://code.claude.com/docs/en/llm-gateway) — a support-scope
@@ -79,13 +102,22 @@ five of these before proceeding, every time, for every future user:
 >    Deus preferences (the default), a connector session runs with
 >    `--dangerously-skip-permissions` like any other Deus session — full,
 >    unprompted tool execution, just with a non-Claude, unsupported model
->    driving it instead of Claude. The three inline subagents are scoped to
->    `Read`/`Grep`/`Glob`/`Bash`/`WebSearch`/`WebFetch` (not the session's
->    full tool set), but the top-level connector session itself is not
->    additionally restricted beyond your normal Deus bypass setting.
+>    driving it instead of Claude. Each connector's inline subagents are
+>    scoped to `Read`/`Grep`/`Glob`/`Bash`/`WebSearch`/`WebFetch` (not the
+>    session's full tool set), but the top-level connector session itself
+>    is not additionally restricted beyond your normal Deus bypass setting.
+> 6. **(ollama only) A small/weak local model can silently produce
+>    lower-quality or subtly wrong tool-use sequences** — misread
+>    instructions, bad tool-call arguments, incomplete reasoning — while
+>    running under the exact same full bypass-permission trust as Claude
+>    (risk 5). This is a different risk profile than `cliproxy-oauth`'s,
+>    not a lesser version of it: it's about the model's own capability
+>    silently degrading task correctness, not about where the model comes
+>    from, and it carries no distinct warning signal beyond noticing the
+>    output itself looks off.
 
-AskUserQuestion: Confirm you understand and accept all five risks above
-before continuing?
+AskUserQuestion: Confirm you understand and accept the risks above before
+continuing?
 - Yes, continue
 - No, cancel setup
 
@@ -93,6 +125,7 @@ Stop here if the user declines.
 
 ## Phase 4: Install the engine
 
+**cliproxy-oauth:**
 ```bash
 python3 scripts/connectors_cli.py install-check cliproxy-oauth
 ```
@@ -110,9 +143,41 @@ silently auto-fetch a binary that's about to hold real OAuth tokens.**
 
 Re-run the install-check after the user confirms installation is done.
 
+**ollama:**
+```bash
+python3 scripts/connectors_cli.py install-check ollama
+```
+
+Checks only that the `ollama` binary is on PATH — deliberately does NOT
+probe whether the background service is actually running, since at this
+point Phase 5 hasn't collected the user's real host yet and a live check
+here could only ever reach the default `localhost:11434` (silently wrong
+for a non-default-host setup, with no way to recover except repeating the
+same failing check). Service liveness — against the real configured host —
+is checked in Phase 10's `verify-setup`, after Phase 7 writes it. If
+`not installed`, tell the user to install Ollama
+(https://ollama.com/download); if it's installed but the service isn't
+running (menu-bar app on macOS / systemd unit on Linux), Phase 10 will
+catch that instead, with the real host. This connector never manages the
+Ollama service itself — no daemon to start on the user's behalf, unlike
+`cliproxy-oauth`'s launchd plist.
+
+**ollama-only: context window prerequisite.** Ollama defaults its context
+window by available VRAM — under 24 GiB VRAM defaults to 4k, well below
+what a real Deus session needs (Ollama's own Claude Code guidance
+recommends 64k+). Tell the user to raise `OLLAMA_CONTEXT_LENGTH` to at
+least 64000 before continuing:
+- **macOS menu-bar app**: Settings → context-length slider.
+- **CLI/systemd-managed install**: `export OLLAMA_CONTEXT_LENGTH=65536`
+  in the service's environment, then restart the service.
+
+Phase 10's `verify-setup` checks this automatically (via `/api/ps`'s
+`context_length`) and fails if it's still too small — but flag it now so
+the user isn't surprised by a failed verify later.
+
 ## Phase 5: Collect config values
 
-Ask the user (do not invent values):
+**cliproxy-oauth:**
 
 - **Inbound key** — generate one rather than asking the user to invent it:
   `python3 -c "import secrets; print(secrets.token_urlsafe(24))"`. This is
@@ -131,8 +196,23 @@ Ask the user (do not invent values):
   made — recommend `luna-max` (max reasoning effort) unless the user
   prefers otherwise.
 
+**ollama:**
+
+- **Which locally-pulled model backs `deus-ollama-local`?** Run
+  `ollama list` and show the user the real, currently-pulled models —
+  never invent a plausible-looking tag the way `cliproxy-oauth`'s
+  placeholder does for GPT ids (that's necessary there because a remote
+  account's real upstream id can't be locally enumerated; here it can, so
+  there's no reason to guess). If nothing is pulled yet, help the user
+  `ollama pull <model>` first.
+- **Host** — default `http://localhost:11434`, only ask if the user runs
+  Ollama on a non-default host/port.
+- No inbound key, no OAuth leg, no launchd config — this connector doesn't
+  need them.
+
 ## Phase 6: Authenticate
 
+**cliproxy-oauth:**
 ```bash
 python3 scripts/connectors_cli.py authenticate cliproxy-oauth
 ```
@@ -143,8 +223,18 @@ underlying engine supports `--no-browser` with a printed URL; if that's
 needed, tell the user to run the login step manually with that flag instead
 of through this script, then continue to Phase 7.
 
-## Phase 7: Write config + launchd daemon
+**ollama:**
+```bash
+python3 scripts/connectors_cli.py authenticate ollama
+```
 
+No-op — always returns success. No OAuth/login concept for locally-pulled
+models. (Ollama's optional hosted "cloud" model aliases require `ollama
+signin`, out of scope for this connector's current scope.)
+
+## Phase 7: Write config
+
+**cliproxy-oauth (+ launchd daemon):**
 ```bash
 echo '<json values>' | python3 scripts/connectors_cli.py write-config cliproxy-oauth
 ```
@@ -193,46 +283,81 @@ launchctl load ~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist
 launchctl kickstart -k gui/$(id -u)/com.deus.connectors.cliproxy-oauth
 ```
 
+**ollama (no daemon):**
+```bash
+echo '<json values>' | python3 scripts/connectors_cli.py write-config ollama
+```
+
+Where `<json values>` is a JSON object:
+```json
+{
+  "host": "http://localhost:11434",
+  "model_map": {"deus-ollama-local": "<real pulled model tag from Phase 5>"},
+  "default_model_alias": "<same real pulled model tag>"
+}
+```
+
+Writes only `~/.config/deus/connectors/ollama/config.local.yaml` — no
+launchd plist, no daemon to load or kickstart. Ollama's own service is
+already running (confirmed in Phase 4) and this connector never manages it.
+
 ## Phase 8: `~/.claude.json` pre-approval
 
-Read-merge the connector's inbound key into
+**cliproxy-oauth only.** Read-merge the connector's inbound key into
 `~/.claude.json`'s `customApiKeyResponses.approved` array — back up the
 file first (`cp ~/.claude.json ~/.claude.json.bak-<date>`), then merge
 (never overwrite the whole array — other entries may already exist).
 
+**ollama: not applicable, based on docs — not yet confirmed by a live run.**
+`env_for_launch()` sets `ANTHROPIC_API_KEY=""` (empty) and authenticates via
+`ANTHROPIC_AUTH_TOKEN=ollama` instead, which Claude Code's own auth
+precedence resolves before `ANTHROPIC_API_KEY` — the custom-API-key
+approval prompt this phase exists to pre-answer is keyed off
+`ANTHROPIC_API_KEY` being set, so it's expected not to trigger. This is
+reasoned from `code.claude.com/docs/en/authentication`'s precedence order,
+not yet observed in a real run (no live Ollama setup existed at
+implementation time to test against). Treat Phase 10's live check as the
+first real confirmation of this — if a prompt does appear there, that's a
+genuine finding to fix, not an expected step to route around.
+
 ## Phase 9: Validate subagent definitions
 
 ```bash
-python3 scripts/connectors_cli.py agents-json cliproxy-oauth
+python3 scripts/connectors_cli.py agents-json <id>
 ```
 
-Confirm it prints valid, non-empty JSON — no file templates to install,
-`deus connect`'s launch mechanism passes these inline via `claude --agents`.
+(`<id>` = `cliproxy-oauth` or `ollama`, whichever was set up.) Confirm it
+prints valid, non-empty JSON — no file templates to install, `deus
+connect`'s launch mechanism passes these inline via `claude --agents`.
 
 ## Phase 10: Verify
 
 ```bash
-python3 scripts/connectors_cli.py verify-setup cliproxy-oauth
+python3 scripts/connectors_cli.py verify-setup <id>
 ```
 
-Engine health + a real functional probe. Then run one real launch and
-confirm, end to end:
+Engine health + a real functional probe (for `ollama`: liveness, a
+tool-schema-bearing `/v1/messages` probe, and the context-length check from
+Phase 4 — all three must pass). Then run one real launch and confirm, end
+to end:
 
 ```bash
-deus connect cliproxy-oauth
+deus connect <id>
 ```
 
 - Model resolution: check `/model` shows the redirected model.
 - Inline subagents resolve: dispatch the `Agent` tool with
-  `deus-gpt-sol`/`deus-gpt-terra`/`deus-gpt-luna`.
+  `deus-gpt-sol`/`deus-gpt-terra`/`deus-gpt-luna` (`cliproxy-oauth`) or
+  `deus-ollama-local` (`ollama`).
 - Normal Deus context is present: ask it to recall a recent checkpoint —
   the round 11/12 fix's whole point was that a connector session gets the
   same identity/vault/memory/preferences pipeline as a bare `deus` launch,
   not a redirected-but-otherwise-bare Claude Code process.
-- A bare `claude` in a separate terminal never sees `deus-gpt-*` — confirms
-  subagent isolation (the one fully structural guarantee this feature
-  makes; env-var inheritance by nested processes and session-resume
-  visibility are both disclosed tradeoffs, not guarantees — see Phase 3).
+- A bare `claude` in a separate terminal never sees the connector's
+  subagents — confirms subagent isolation (the one fully structural
+  guarantee this feature makes; env-var inheritance by nested processes
+  and session-resume visibility are both disclosed tradeoffs, not
+  guarantees — see Phase 3).
 
 ## Phase 11: Set as default (optional)
 
@@ -268,21 +393,43 @@ python3 scripts/connectors_cli.py status cliproxy-oauth
 launchctl list | grep com.deus.connectors.cliproxy-oauth
 ```
 
-### Model doesn't resolve / 401s from the proxy
+### `deus connect ollama` says "connector is unknown or not configured"
+
+Config didn't write correctly, or the Ollama service isn't running (this
+connector never starts/manages it):
+
+```bash
+python3 scripts/connectors_cli.py status ollama
+curl -s http://localhost:11434/api/version
+```
+
+### Model doesn't resolve / 401s from the proxy (cliproxy-oauth)
 
 ```bash
 curl -s http://localhost:8317/healthz
 cat ~/.config/deus/connectors/cliproxy/config.local.yaml   # confirm api-keys, oauth-model-alias
 ```
 
+### `deus connect ollama` fails verify / real session fails on tool use or truncates
+
+```bash
+curl -s http://localhost:11434/api/ps   # check context_length for the loaded model
+cat ~/.config/deus/connectors/ollama/config.local.yaml   # confirm host, deus-model-map
+```
+
+If `context_length` is below 64000, raise `OLLAMA_CONTEXT_LENGTH` per Phase
+4 and restart the Ollama service. If the model itself doesn't support
+tool-calling, pick a different pulled model in Phase 5/7.
+
 ### Subagents don't appear via the `Agent` tool
 
-Confirm you launched through `deus connect cliproxy-oauth`, not a bare
-`claude` — subagent definitions are injected inline on that exact launch
-command and never written to disk.
+Confirm you launched through `deus connect <id>`, not a bare `claude` —
+subagent definitions are injected inline on that exact launch command and
+never written to disk.
 
 ## Removal
 
+**cliproxy-oauth:**
 1. Unload and remove the launchd daemon:
    ```bash
    launchctl unload ~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist
@@ -296,3 +443,13 @@ command and never written to disk.
    in Phase 8 (remove that one key, keep the rest of the array intact).
 4. Confirm: `python3 scripts/connectors_cli.py status cliproxy-oauth` now
    reports "not configured".
+
+**ollama:**
+1. Remove the real local config (no launchd daemon to unload — this
+   connector never created one):
+   ```bash
+   rm ~/.config/deus/connectors/ollama/config.local.yaml
+   ```
+2. Confirm: `python3 scripts/connectors_cli.py status ollama` now reports
+   "not configured". Ollama's own service is untouched — it wasn't started
+   or managed by this connector, so there's nothing else to stop.

--- a/connectors/ollama/config.yaml
+++ b/connectors/ollama/config.yaml
@@ -1,0 +1,23 @@
+# Tracked, placeholder-only config for the `ollama` connector
+# (deus connect setup ollama writes the real version to
+# ~/.config/deus/connectors/ollama/config.local.yaml — OUTSIDE this repo
+# entirely, never here).
+#
+# Unlike cliproxy_oauth, there is no OAuth token and no inbound API key to
+# protect here -- Ollama's native Anthropic-API mode authenticates with the
+# fixed literal ANTHROPIC_AUTH_TOKEN=ollama (not a real secret). This file
+# only ever holds the local Ollama host and which locally-pulled model
+# backs the deus-ollama-local subagent -- nothing sensitive.
+
+host: "http://localhost:11434"
+
+# Which locally-pulled Ollama model tag backs the deus-ollama-local
+# subagent. `deus connect setup ollama` confirms this against a real
+# `ollama list` -- never invent a plausible-looking tag, unlike a
+# remote-account GPT id that can't be locally enumerated.
+deus-model-map:
+  deus-ollama-local: "REPLACE_WITH_A_REAL_PULLED_MODEL_TAG"
+
+# Default model for the session itself (ANTHROPIC_MODEL) when no /model
+# switch has been made yet.
+default-model-alias: "REPLACE_WITH_A_REAL_PULLED_MODEL_TAG"

--- a/connectors/providers/__init__.py
+++ b/connectors/providers/__init__.py
@@ -2,8 +2,10 @@
 from ..registry import ConnectorRegistry
 
 from .cliproxy_oauth import CliproxyOauthConnector
+from .ollama import OllamaConnector
 
 _registry = ConnectorRegistry.default()
 _registry.register(CliproxyOauthConnector())
+_registry.register(OllamaConnector())
 
-__all__ = ["CliproxyOauthConnector"]
+__all__ = ["CliproxyOauthConnector", "OllamaConnector"]

--- a/connectors/providers/ollama/__init__.py
+++ b/connectors/providers/ollama/__init__.py
@@ -1,0 +1,303 @@
+"""Ollama connector -- native Anthropic-API-mode `deus connect` provider.
+
+Ollama v0.14.0+ natively speaks the Anthropic Messages API (confirmed
+against docs.ollama.com/integrations/claude-code and ollama.com/blog/claude)
+-- no proxy/translation layer, no OAuth flow, no launchd daemon, since
+Ollama already runs its own persistent service (menu-bar app on macOS /
+systemd on Linux). This connector is a much simpler counterpart to
+cliproxy_oauth: env_for_launch() is 3 static env vars plus one credential
+value, write_config() has no daemon plist to manage.
+
+Config split, mirroring cliproxy_oauth's pattern:
+  - connectors/ollama/config.yaml -- tracked, placeholder-only, safe to commit.
+  - ~/.config/deus/connectors/ollama/config.local.yaml -- the real config,
+    OUTSIDE any project root a container agent could ever have mounted.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ...base import Connector, ConnectorSetupHandler
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACKED_CONFIG = _REPO_ROOT / "connectors" / "ollama" / "config.yaml"
+LOCAL_CONFIG = Path(
+    "~/.config/deus/connectors/ollama/config.local.yaml"
+).expanduser()
+
+# ONE generic subagent, not cliproxy_oauth's three GPT-tier names
+# (deus-gpt-sol/terra/luna) -- real local-model diversity per user doesn't
+# map to a fixed 3-tier split, and most users have 1-2 pulled models
+# actually worth dispatching as a subagent, not three meaningfully distinct
+# reasoning tiers of the same family.
+STABLE_SUBAGENT_NAMES = ("deus-ollama-local",)
+
+# Ollama's own Claude Code guidance (docs.ollama.com/integrations/claude-code)
+# recommends 64k+ context; below 24 GiB VRAM Ollama defaults to 4k
+# (docs.ollama.com/context-length), which is smaller than Deus's own system
+# prompt -- a too-small allocation reports "healthy" on a bare ping and then
+# fails or silently truncates real sessions.
+_MIN_CONTEXT_LENGTH = 64000
+
+# Ollama v0.14.0+ is required for native Anthropic Messages API support
+# (docs.ollama.com/integrations/claude-code, docs.ollama.com/blog/claude) --
+# below this, /v1/messages simply doesn't exist, an opaque failure that
+# doesn't point back to "your Ollama is too old". Checked in verify(), not
+# install() -- see OllamaSetupHandler.install()'s docstring for why a live
+# version probe can't happen before the real host is known.
+_MIN_OLLAMA_VERSION = (0, 14, 0)
+
+_SUBAGENT_DESCRIPTIONS = {
+    "deus-ollama-local": (
+        "General-purpose subagent pinned to a local Ollama model via the "
+        "native `deus connect ollama` route. Use for offline/no-cost tasks "
+        "where a smaller local model is acceptable -- not a substitute for "
+        "Claude on tasks needing strong reasoning or reliable tool use."
+    ),
+}
+
+
+def _load_local_config() -> dict[str, Any]:
+    if not LOCAL_CONFIG.is_file():
+        return {}
+    return yaml.safe_load(LOCAL_CONFIG.read_text()) or {}
+
+
+def _find_binary() -> str | None:
+    return shutil.which("ollama")
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse a dotted version string ("0.31.1") into a comparable int
+    tuple. Non-numeric trailing content (e.g. a "-rc1" suffix) is dropped
+    from that component rather than raising -- an unparseable/empty string
+    parses to (0,), which always compares below _MIN_OLLAMA_VERSION and
+    fails verify() closed rather than raising.
+    """
+    parts: list[int] = []
+    for part in version.split("."):
+        digits = ""
+        for ch in part:
+            if not ch.isdigit():
+                break
+            digits += ch
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts) or (0,)
+
+
+def _probe_context_length(host: str, alias: str) -> bool:
+    """GET /api/ps and confirm the running model's allocated context meets
+    _MIN_CONTEXT_LENGTH. Must be called after a request that loads the
+    model (e.g. the /v1/messages ping in verify()) -- /api/ps only reports
+    currently-loaded models.
+    """
+    try:
+        with urllib.request.urlopen(f"{host}/api/ps", timeout=5) as resp:
+            if resp.status != 200:
+                return False
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return False
+    for model in data.get("models", []):
+        name = model.get("name") or model.get("model")
+        if name == alias:
+            return model.get("context_length", 0) >= _MIN_CONTEXT_LENGTH
+    return False
+
+
+class OllamaConnector(Connector):
+    @property
+    def id(self) -> str:
+        return "ollama"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Ollama, native Anthropic-API mode -- routes to a "
+            "locally-pulled model, no OAuth, no proxy daemon."
+        )
+
+    @property
+    def engine(self) -> str:
+        return "ollama"
+
+    @property
+    def risk_level(self) -> str:
+        return "local-only"
+
+    @property
+    def setup_handler(self) -> ConnectorSetupHandler:
+        return OllamaSetupHandler(self)
+
+    def model_aliases(self) -> dict[str, str]:
+        mapping = _load_local_config().get("deus-model-map") or {}
+        return {
+            name: mapping[name] for name in STABLE_SUBAGENT_NAMES if name in mapping
+        }
+
+    def is_configured(self) -> bool:
+        return bool(self.model_aliases())
+
+    def env_for_launch(self) -> dict[str, str]:
+        cfg = _load_local_config()
+        host = cfg.get("host", "http://localhost:11434")
+        aliases = self.model_aliases()
+        default_alias = cfg.get("default-model-alias") or next(
+            iter(aliases.values()), ""
+        )
+        return {
+            "ANTHROPIC_BASE_URL": host,
+            "ANTHROPIC_AUTH_TOKEN": "ollama",
+            "ANTHROPIC_API_KEY": "",
+            "ANTHROPIC_MODEL": default_alias,
+        }
+
+    def agents_for_launch(self) -> dict[str, Any]:
+        aliases = self.model_aliases()
+        alias = aliases.get("deus-ollama-local")
+        if not alias:
+            return {}
+        return {
+            "deus-ollama-local": {
+                "description": _SUBAGENT_DESCRIPTIONS["deus-ollama-local"],
+                "prompt": (
+                    "You are deus-ollama-local, dispatched as a subagent, "
+                    "reachable only through this deus connect session. Do "
+                    "the task described in the prompt directly and report "
+                    "your findings/output -- you are not a reviewer unless "
+                    "explicitly asked to review something."
+                ),
+                "model": alias,
+                # Same least-privilege scope as cliproxy_oauth's subagents,
+                # for consistency across connectors.
+                "tools": ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"],
+            }
+        }
+
+
+class OllamaSetupHandler(ConnectorSetupHandler):
+    def __init__(self, connector: "OllamaConnector"):
+        self._connector = connector
+
+    def install(self) -> bool:
+        """Confirm the ollama binary is on PATH -- matches cliproxy_oauth's
+        own install() (binary-presence-only, no live probe). Deliberately
+        does NOT probe any host: at install-check time (Phase 4, before
+        Phase 5 collects the real host), a non-default-host user's local
+        config doesn't exist yet, so a live probe here could only ever
+        check the default localhost:11434 -- reporting "not installed" for
+        a legitimately-running non-default-host Ollama with no way to
+        recover short of re-running the same failing check. Service
+        liveness (and version compatibility) is checked in verify(), which
+        runs after Phase 7 has written the real configured host.
+        """
+        return _find_binary() is not None
+
+    def authenticate(self) -> bool:
+        """No-op -- no OAuth/login concept for locally-pulled models.
+
+        Ollama's optional hosted "cloud" model aliases require `ollama
+        signin`, which is out of scope for this connector's v1 (documented
+        future extension, same pattern as cliproxy_oauth's optional
+        claude-api-key leg).
+        """
+        return True
+
+    def write_config(self, values: dict[str, Any]) -> None:
+        """No launchd plist at all -- Ollama manages its own persistent
+        service already. Writes only the local YAML config: host + the
+        deus-ollama-local model tag (confirmed against a real `ollama list`
+        by the caller -- never invented, unlike a remote-account GPT id).
+        """
+        placeholder = yaml.safe_load(TRACKED_CONFIG.read_text())
+        placeholder["host"] = values.get("host", "http://localhost:11434")
+        model_map = values["model_map"]
+        placeholder["deus-model-map"] = model_map
+        placeholder["default-model-alias"] = values.get(
+            "default_model_alias", next(iter(model_map.values()), "")
+        )
+        LOCAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        LOCAL_CONFIG.write_text(yaml.safe_dump(placeholder, sort_keys=False))
+        LOCAL_CONFIG.chmod(0o600)
+
+    def verify(self) -> bool:
+        cfg = _load_local_config()
+        host = cfg.get("host", "http://localhost:11434")
+        try:
+            with urllib.request.urlopen(f"{host}/api/version", timeout=3) as resp:
+                if resp.status != 200:
+                    return False
+                version_data = json.loads(resp.read())
+            # A response that is valid JSON but the wrong shape (e.g.
+            # {"version": null}, a bare list, a non-string version) must
+            # still fail closed like every other branch here -- .get()'s
+            # default only covers a missing key, not a present-but-wrong
+            # value, so this is guarded explicitly rather than left to
+            # _parse_version to raise on a non-str .split() call.
+            raw_version = version_data.get("version", "") if isinstance(version_data, dict) else ""
+            if not isinstance(raw_version, str):
+                return False
+        except (urllib.error.URLError, OSError, json.JSONDecodeError):
+            return False
+        if _parse_version(raw_version) < _MIN_OLLAMA_VERSION:
+            # Below this, Ollama has no native Anthropic Messages API at
+            # all -- the /v1/messages probe below would 404, an opaque
+            # failure that doesn't point back to "your Ollama is too old".
+            return False
+        aliases = self._connector.model_aliases()
+        if not aliases:
+            return False
+        alias = cfg.get("default-model-alias") or next(iter(aliases.values()))
+        # Real, minimal, authenticated inference request through the exact
+        # Anthropic Messages API path a `deus connect` launch would use --
+        # includes a harmless tool definition (not a bare text ping) so a
+        # completion-only model without tool-calling support fails here,
+        # not on the first real Claude Code turn (which always sends tools).
+        payload = json.dumps(
+            {
+                "model": alias,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "What time is it?"}],
+                "tools": [
+                    {
+                        "name": "get_current_time",
+                        "description": "Get the current time.",
+                        "input_schema": {"type": "object", "properties": {}},
+                    }
+                ],
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"{host}/v1/messages",
+            data=payload,
+            method="POST",
+            headers={
+                "content-type": "application/json",
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        try:
+            # 120s, not 15s: this is a one-time setup-verification probe,
+            # not a runtime request-latency budget -- a cold-starting
+            # 32B-class local model (exactly what this connector expects
+            # users to configure) commonly takes well over 15s just to
+            # load into memory on first request, before any inference
+            # even begins. A short timeout here would report a correctly
+            # configured connector as unhealthy.
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                if resp.status != 200:
+                    return False
+        except (urllib.error.URLError, OSError):
+            return False
+        # The ping above loads the model, populating /api/ps's entry for
+        # it -- confirm the allocated context is large enough for a real
+        # Deus session (Ollama's own default can be as low as 4k on
+        # consumer VRAM, well under what Deus's system prompt needs).
+        return _probe_context_length(host, alias)

--- a/connectors/tests/test_ollama_connector.py
+++ b/connectors/tests/test_ollama_connector.py
@@ -1,0 +1,262 @@
+"""Tests for the OllamaConnector's pure/mockable surface.
+
+verify()'s live HTTP calls are integration-only (matches cliproxy_oauth's
+own verify(), also untested at the unit level) -- not unit-testable
+without a running Ollama instance, EXCEPT the version-gate at the top,
+which is cheap to exercise with a mocked /api/version response and worth
+it since that gate is exactly what round-2 code-review's MINOR finding was
+about.
+"""
+import json
+from unittest.mock import patch
+
+import yaml
+
+from connectors.providers.ollama import OllamaConnector
+
+
+class _FakeResponse:
+    """Minimal stand-in for the context-manager urlopen() returns."""
+
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def _write_config(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data))
+
+
+def test_model_aliases_empty_when_no_config_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "connectors.providers.ollama.LOCAL_CONFIG", tmp_path / "config.local.yaml"
+    )
+    connector = OllamaConnector()
+    assert connector.model_aliases() == {}
+    assert connector.is_configured() is False
+
+
+def test_model_aliases_empty_when_deus_model_map_missing(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(config_path, {"host": "http://localhost:11434"})
+    connector = OllamaConnector()
+    assert connector.model_aliases() == {}
+    assert connector.is_configured() is False
+
+
+def test_model_aliases_populated(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(
+        config_path,
+        {
+            "host": "http://localhost:11434",
+            "deus-model-map": {"deus-ollama-local": "qwen3:32b"},
+            "default-model-alias": "qwen3:32b",
+        },
+    )
+    connector = OllamaConnector()
+    assert connector.model_aliases() == {"deus-ollama-local": "qwen3:32b"}
+    assert connector.is_configured() is True
+
+
+def test_env_for_launch_shape(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(
+        config_path,
+        {
+            "host": "http://localhost:11434",
+            "deus-model-map": {"deus-ollama-local": "qwen3:32b"},
+            "default-model-alias": "qwen3:32b",
+        },
+    )
+    connector = OllamaConnector()
+    assert connector.env_for_launch() == {
+        "ANTHROPIC_BASE_URL": "http://localhost:11434",
+        "ANTHROPIC_AUTH_TOKEN": "ollama",
+        "ANTHROPIC_API_KEY": "",
+        "ANTHROPIC_MODEL": "qwen3:32b",
+    }
+
+
+def test_env_for_launch_defaults_host_when_unset(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(
+        config_path,
+        {
+            "deus-model-map": {"deus-ollama-local": "qwen3:32b"},
+        },
+    )
+    connector = OllamaConnector()
+    env = connector.env_for_launch()
+    assert env["ANTHROPIC_BASE_URL"] == "http://localhost:11434"
+    assert env["ANTHROPIC_MODEL"] == "qwen3:32b"
+
+
+def test_agents_for_launch_empty_when_unconfigured(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "connectors.providers.ollama.LOCAL_CONFIG", tmp_path / "config.local.yaml"
+    )
+    connector = OllamaConnector()
+    assert connector.agents_for_launch() == {}
+
+
+def test_agents_for_launch_single_entry_when_configured(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(
+        config_path,
+        {
+            "deus-model-map": {"deus-ollama-local": "qwen3:32b"},
+            "default-model-alias": "qwen3:32b",
+        },
+    )
+    connector = OllamaConnector()
+    agents = connector.agents_for_launch()
+    assert set(agents.keys()) == {"deus-ollama-local"}
+    entry = agents["deus-ollama-local"]
+    assert entry["model"] == "qwen3:32b"
+    assert entry["tools"] == ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
+    assert "description" in entry and "prompt" in entry
+
+
+def test_install_false_when_binary_missing():
+    with patch("connectors.providers.ollama.shutil.which", return_value=None):
+        connector = OllamaConnector()
+        assert connector.setup_handler.install() is False
+
+
+def test_install_true_when_binary_present(monkeypatch):
+    # install() is binary-presence-only (matches cliproxy_oauth's own
+    # install()) -- deliberately does NOT probe any host, since at
+    # install-check time (Phase 4) a non-default-host user's real host
+    # isn't known yet (Phase 5 collects it). Service liveness + version
+    # compatibility are checked in verify() instead, once the real
+    # configured host exists.
+    monkeypatch.setattr(
+        "connectors.providers.ollama.shutil.which", lambda _name: "/usr/local/bin/ollama"
+    )
+    connector = OllamaConnector()
+    assert connector.setup_handler.install() is True
+
+
+def test_parse_version_simple():
+    from connectors.providers.ollama import _parse_version
+
+    assert _parse_version("0.31.1") == (0, 31, 1)
+    assert _parse_version("0.14.0") == (0, 14, 0)
+
+
+def test_parse_version_compares_correctly_against_minimum():
+    from connectors.providers.ollama import _MIN_OLLAMA_VERSION, _parse_version
+
+    assert _parse_version("0.31.1") >= _MIN_OLLAMA_VERSION
+    assert _parse_version("0.14.0") >= _MIN_OLLAMA_VERSION
+    assert _parse_version("0.9.0") < _MIN_OLLAMA_VERSION
+    assert _parse_version("0.9.5") < _MIN_OLLAMA_VERSION  # not a string-compare trap
+
+
+def test_parse_version_handles_suffix_and_empty():
+    from connectors.providers.ollama import _parse_version
+
+    assert _parse_version("0.14.0-rc1") == (0, 14, 0)
+    assert _parse_version("") == (0,)
+    assert _parse_version("") < (0, 14, 0)
+
+
+def test_authenticate_is_a_noop():
+    connector = OllamaConnector()
+    assert connector.setup_handler.authenticate() is True
+
+
+def test_write_config_writes_local_config_only(tmp_path, monkeypatch):
+    tracked_config = tmp_path / "tracked-config.yaml"
+    tracked_config.write_text(
+        yaml.safe_dump(
+            {
+                "host": "http://localhost:11434",
+                "deus-model-map": {"deus-ollama-local": "REPLACE_ME"},
+                "default-model-alias": "REPLACE_ME",
+            }
+        )
+    )
+    local_config = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.TRACKED_CONFIG", tracked_config)
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", local_config)
+
+    connector = OllamaConnector()
+    connector.setup_handler.write_config(
+        {
+            "host": "http://localhost:11434",
+            "model_map": {"deus-ollama-local": "qwen3:32b"},
+            "default_model_alias": "qwen3:32b",
+        }
+    )
+
+    written = yaml.safe_load(local_config.read_text())
+    assert written["deus-model-map"] == {"deus-ollama-local": "qwen3:32b"}
+    assert written["default-model-alias"] == "qwen3:32b"
+    assert local_config.stat().st_mode & 0o777 == 0o600
+
+
+def test_verify_false_when_ollama_version_too_low(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(
+        config_path,
+        {
+            "host": "http://localhost:11434",
+            "deus-model-map": {"deus-ollama-local": "qwen3:32b"},
+            "default-model-alias": "qwen3:32b",
+        },
+    )
+    body = json.dumps({"version": "0.9.0"}).encode()
+
+    def _fake_urlopen(*_args, **_kwargs):
+        return _FakeResponse(200, body)
+
+    monkeypatch.setattr(
+        "connectors.providers.ollama.urllib.request.urlopen", _fake_urlopen
+    )
+    connector = OllamaConnector()
+    assert connector.setup_handler.verify() is False
+
+
+def test_verify_false_when_version_field_malformed(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.local.yaml"
+    monkeypatch.setattr("connectors.providers.ollama.LOCAL_CONFIG", config_path)
+    _write_config(
+        config_path,
+        {
+            "host": "http://localhost:11434",
+            "deus-model-map": {"deus-ollama-local": "qwen3:32b"},
+            "default-model-alias": "qwen3:32b",
+        },
+    )
+    # A response that's valid JSON but the wrong shape must fail closed,
+    # not raise -- this is exactly the crash round-2 code-review's warning
+    # caught (a present `null` value passes .get()'s default, and
+    # _parse_version(None) would previously raise AttributeError).
+    body = json.dumps({"version": None}).encode()
+
+    def _fake_urlopen(*_args, **_kwargs):
+        return _FakeResponse(200, body)
+
+    monkeypatch.setattr(
+        "connectors.providers.ollama.urllib.request.urlopen", _fake_urlopen
+    )
+    connector = OllamaConnector()
+    assert connector.setup_handler.verify() is False

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1445,6 +1445,7 @@ sys.exit(1)
                               # "deus connect <other-id>" call from inside a
                               # tool call).
       local env_output py_exit agents_json agents_py_exit was_implicit
+      local _dc_clear_var
       was_implicit="$_DEUS_CONNECT_ID_IMPLICIT"
       unset _DEUS_CONNECT_ID_IMPLICIT
       # `--` guards against a leading-dash id reaching argparse as a flag --
@@ -1473,16 +1474,35 @@ sys.exit(1)
 
       # Claude Code's own authentication precedence (confirmed against
       # code.claude.com/docs/en/authentication's "Authentication precedence"
-      # section) ranks cloud-provider selection (CLAUDE_CODE_USE_BEDROCK/
-      # VERTEX/FOUNDRY) above ANTHROPIC_AUTH_TOKEN, which itself outranks
-      # ANTHROPIC_API_KEY -- the one var this connector actually sets above.
-      # A user with any of these already set ambiently (e.g. an existing
-      # corporate gateway/cloud-provider config) would have the connector
-      # launch silently authenticate against THAT instead of routing through
-      # CLIProxyAPI at all -- not an error, just silently wrong. Clear them
-      # for this launch specifically; a bare `claude`/`deus claude` outside
-      # this connector session is unaffected.
-      unset ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY
+      # section, plus code.claude.com/docs/en/amazon-bedrock for Mantle)
+      # ranks cloud-provider selection (CLAUDE_CODE_USE_BEDROCK/VERTEX/
+      # FOUNDRY/MANTLE) above ANTHROPIC_AUTH_TOKEN, which itself outranks
+      # ANTHROPIC_API_KEY. A user with any of these already set ambiently
+      # (e.g. an existing corporate gateway/cloud-provider config) would
+      # have the connector launch silently authenticate against THAT
+      # instead of routing through the connector's own engine at all --
+      # not an error, just silently wrong. Clear them for this launch
+      # specifically; a bare `claude`/`deus claude` outside this connector
+      # session is unaffected.
+      #
+      # connector-aware: only unset a var the connector's own env_output
+      # did NOT itself set. Needed because the `ollama` connector (unlike
+      # cliproxy_oauth) sets ANTHROPIC_AUTH_TOKEN=ollama as its actual
+      # credential -- an unconditional unset here would erase it
+      # immediately after eval sets it, silently breaking auth. The match
+      # is anchored to a real line start (`$'\n'"$env_output"` / matching
+      # `*$'\n'"export ...="*`), not a bare substring: `env_output` is
+      # newline-delimited `export KEY=value` lines (connectors_cli.py's
+      # cmd_env), and shlex.quote() does not escape `=`, so a bare
+      # substring match could false-positive on a connector value that
+      # happens to contain the literal text `export ANTHROPIC_AUTH_TOKEN=`
+      # elsewhere in the string.
+      for _dc_clear_var in ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY CLAUDE_CODE_USE_MANTLE; do
+        case $'\n'"$env_output" in
+          *$'\n'"export ${_dc_clear_var}="*) ;;  # connector set it itself -- leave it
+          *) unset "$_dc_clear_var" ;;
+        esac
+      done
 
       agents_json="$(python3 "$SCRIPT_DIR/scripts/connectors_cli.py" agents-json -- "$id")"
       agents_py_exit=$?
@@ -1521,8 +1541,11 @@ sys.exit(1)
         return $?
       fi
       if [ "$CLI_AGENT" = "ollama" ]; then
-        echo "Error: Ollama backend is not yet available as a CLI agent."
-        echo "Use 'deus backend set claude' or 'deus backend set openai' instead."
+        echo "Error: 'deus backend set ollama' is not a CLI agent -- use"
+        echo "'deus connect ollama' instead (routes via Ollama's native"
+        echo "Anthropic-API mode; run 'deus connect setup ollama' first if"
+        echo "not yet configured). 'deus backend set claude/openai' remains"
+        echo "for the persisted-backend model, unrelated to deus connect."
         return 1
       fi
       if [ "$CLI_AGENT" = "llama-cpp" ]; then

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-12" # auto-bump @1786520978
+last_verified: "2026-08-12" # auto-bump @1786539613
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Adds a second `deus connect` connector, `ollama`, routing sessions directly to a locally-pulled Ollama model via its native Anthropic Messages API mode (v0.14.0+) — no OAuth, no proxy, no launchd daemon, since Ollama runs its own persistent service.
- Fixes a real shared-code bug in `launch_connect()`: the unconditional ambient-env-var clear would have silently erased this connector's own `ANTHROPIC_AUTH_TOKEN=ollama` credential immediately after setting it. The fix makes the clear connector-aware and anchors the match to a real line start (avoids a substring false-positive `shlex.quote()` doesn't guard against).
- `verify()` runs a real 3-stage functional probe: liveness + Ollama version check (>=0.14.0), a tool-schema-bearing `/v1/messages` request (catches a model without tool-calling support before a real session would), and an `/api/ps` context-length check (Ollama's VRAM-based default context can be as low as 4k, well under the 64k+ Ollama's own docs recommend for Claude Code).
- `.claude/skills/add-connector/SKILL.md` updated to branch per-connector across all phases, plus a new disambiguation note covering all four "ollama"-named surfaces in this repo (this connector, `deus provider ollama`/`fcc`, the `deus backend set ollama` stub, and `add-ollama-tool`).

## Review history
Went through 3 rounds of plan-review (Claude + GPT backends) and 3 rounds of code-review (Claude + GPT backends), catching and fixing 4 real defects along the way: the env-var-clearing collision above, an `install()` that probed a host before the onboarding flow had collected it (would've broken non-default-host setups), a `verify()` crash on a malformed-but-valid `/api/version` response, and a functional-probe timeout too short for cold-loading a larger local model. GLM backend was unreachable both attempts (confirmed account-balance exhaustion, not a transient error) and fails open per this repo's own co-gate policy — Claude + GPT both SHIP.

## Test plan
- [x] `python3 -m pytest connectors/tests/ -v` — 35/35 pass
- [x] `bash -n deus-cmd.sh` — syntax OK
- [x] Live-verified the `launch_connect()` env-clear fix against both connectors' real `env_output` shapes: `cliproxy-oauth` still gets all 5 ambient vars cleared (unchanged behavior), `ollama`'s own `ANTHROPIC_AUTH_TOKEN=ollama` survives while the other 4 cloud-provider vars still clear
- [x] Live-verified `/api/version` and `/v1/messages` response shapes against a real running Ollama instance (0.31.1) on this machine
- [ ] End-to-end `deus connect ollama` live session (needs a real pulled model configured — not yet done in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)