### PR TITLE
feat(deus-connect): live model-picker visibility for cliproxy-oauth

### DIFF
--- a/.claude/skills/add-connector/SKILL.md
+++ b/.claude/skills/add-connector/SKILL.md
@@ -31,10 +31,32 @@ inherited from another user), still walk through Phase 2 (select) and
 Phase 3 (risk acknowledgment) — Phase 3 is required every time, regardless
 of configuration state, per its own rule; skipping it here would let an
 already-configured install proceed straight to a real connector launch
-without ever showing the five risks. Only Phases 4-9 (install/authenticate/
+without ever showing the risks. Only Phases 4-9 (install/authenticate/
 write-config) are skippable on an already-configured connector — jump from
 Phase 3 straight to Phase 10 (Verify) unless the user explicitly wants to
 reconfigure.
+
+**`cliproxy-oauth`-specific one-time check, added for the model-picker-
+visibility follow-up — this is a deliberate, documented exception to this
+skill's normal connector-generic design, not a pattern to copy for a
+future connector.** An already-configured `cliproxy-oauth` install
+predating this feature has no `claude-gpt-*` discovery aliases in its real
+config, and the normal skip straight to Phase 10 would never surface the
+migration step needed to add them. Before jumping to Phase 10 on an
+already-configured `cliproxy-oauth`, run:
+```bash
+if [ -f ~/.config/deus/connectors/cliproxy/config.local.yaml ]; then
+  grep -c 'claude-gpt-' ~/.config/deus/connectors/cliproxy/config.local.yaml
+else
+  echo 0
+fi
+```
+If the count is below 3 (a fresh install has 0; a partially-applied manual
+edit could have 1 or 2 — `-c` counts matches rather than a bare presence
+check specifically so a partial edit isn't mistaken for a complete one),
+walk through Phase 7's "Already configured? Add discovery aliases
+manually" subsection before continuing to Phase 10 — every other Phase
+4-9 step still stays skipped.
 
 ## Phase 2: Which connector
 
@@ -83,8 +105,18 @@ five of these before proceeding, every time, for every future user:
 >    `Read`/`Grep`/`Glob`/`Bash`/`WebSearch`/`WebFetch` (not the session's
 >    full tool set), but the top-level connector session itself is not
 >    additionally restricted beyond your normal Deus bypass setting.
+> 6. **`/model` surfaces GPT model names directly in Claude Code's native
+>    picker**, labeled "From gateway", rather than only being reachable by
+>    typing an exact alias. Applies to every fresh setup (the tracked
+>    template always includes the picker-discovery aliases now — not an
+>    opt-in); an already-configured install only gains this once its
+>    real config is migrated per Phase 7's "Already configured" step. Not
+>    a new exposure either way — the same models were already reachable
+>    via `ANTHROPIC_MODEL`/typed `/model` — this just makes it easier to
+>    notice at a glance which model is actually selected, which is a
+>    mitigation of confusion, not a new risk in its own right.
 
-AskUserQuestion: Confirm you understand and accept all five risks above
+AskUserQuestion: Confirm you understand and accept all six risks above
 before continuing?
 - Yes, continue
 - No, cancel setup
@@ -125,11 +157,27 @@ Ask the user (do not invent values):
   names (`gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna`) — **not** confirmed
   real IDs for the user's account/plan. These get hand-edited into
   `oauth-model-alias.codex[].name` in the written config (Phase 7) — the
-  `alias` values (`sol`/`terra`/`luna-max`) stay fixed; only the `name`
-  values (real upstream ids) vary per account.
+  `alias` values (`sol`/`terra`/`luna-max`, and their `claude-gpt-*` picker-
+  discovery twins) stay fixed; only the `name` values (real upstream ids)
+  vary per account. **Each `claude-gpt-*` entry's `name` must be set to the
+  exact same value as its plain-alias twin** (e.g. `claude-gpt-sol`'s
+  `name` = `sol`'s `name`) — a mismatch wouldn't error, CLIProxyAPI would
+  just silently treat them as two different upstream models.
 - **Default model** for the session itself when no `/model` switch has been
   made — recommend `luna-max` (max reasoning effort) unless the user
-  prefers otherwise.
+  prefers otherwise. This is separate from picker visibility: the plain
+  aliases (not the `claude-gpt-*` twins) are what `ANTHROPIC_MODEL` uses.
+- **Picker visibility for the 3 GPT models** — included automatically,
+  not a choice to make here. The tracked template (Phase 7) already bakes
+  in a `claude-`-prefixed alias + `display-name` per GPT model, and
+  `write-config` always writes the full template verbatim — there's no
+  partial-write mechanism to selectively drop these three entries, so
+  don't present skipping them as an option. This is low-risk by design
+  (see Phase 3 risk 6): purely additive, no real alias sacrificed, no new
+  credential exposure. If a user genuinely wants `/model` to show nothing
+  extra, they can remove the 3 `claude-gpt-*` entries from their real
+  `config.local.yaml` by hand after setup — but that's a post-setup
+  edit, not a Phase 5 choice.
 
 ## Phase 6: Authenticate
 
@@ -193,6 +241,40 @@ launchctl load ~/Library/LaunchAgents/com.deus.connectors.cliproxy-oauth.plist
 launchctl kickstart -k gui/$(id -u)/com.deus.connectors.cliproxy-oauth
 ```
 
+### Already configured? Add discovery aliases manually
+
+**For an existing `config.local.yaml` predating the model-picker-
+visibility feature** (reached via Phase 1's check on an already-configured
+`cliproxy-oauth`) — do NOT re-run `write-config` above: it always rebuilds
+the file from the tracked template, which would discard the real upstream
+`name` values you already hand-edited in. Instead, hand-edit
+`~/.config/deus/connectors/cliproxy/config.local.yaml` directly, adding 3
+new entries under `oauth-model-alias.codex[]` — reuse the SAME real
+upstream `name` value already present for each existing plain alias
+(`sol`/`terra`/`luna-max`); only `alias` (add a `claude-` prefix) and
+`display-name` are new:
+
+```yaml
+oauth-model-alias:
+  codex:
+    # ... existing sol/terra/luna-max entries -- do not remove or modify ...
+    - name: "<same real name as the existing sol entry, verbatim>"
+      alias: "claude-gpt-sol"
+      display-name: "GPT Sol"
+    - name: "<same real name as the existing terra entry, verbatim>"
+      alias: "claude-gpt-terra"
+      display-name: "GPT Terra"
+    - name: "<same real name as the existing luna entry, verbatim>"
+      alias: "claude-gpt-luna"
+      display-name: "GPT Luna (max)"
+```
+
+No daemon restart needed — CLIProxyAPI watches its config file for
+changes and reloads automatically on write (confirmed:
+`internal/watcher/events.go`'s fsnotify-based watcher), and Claude Code's
+own gateway discovery re-queries `/v1/models` on each new session start,
+so the very next `deus connect cliproxy-oauth` launch picks this up.
+
 ## Phase 8: `~/.claude.json` pre-approval
 
 Read-merge the connector's inbound key into
@@ -223,6 +305,11 @@ deus connect cliproxy-oauth
 ```
 
 - Model resolution: check `/model` shows the redirected model.
+- **Picker visibility** (new, model-picker-visibility follow-up): if
+  `claude-gpt-*` aliases are configured, run `/model` and confirm all 3
+  GPT entries appear labeled "From gateway" with clean names ("GPT Sol"/
+  "GPT Terra"/"GPT Luna (max)"), not raw ids — and that switching between
+  them takes effect on the next turn without relaunching the session.
 - Inline subagents resolve: dispatch the `Agent` tool with
   `deus-gpt-sol`/`deus-gpt-terra`/`deus-gpt-luna`.
 - Normal Deus context is present: ask it to recall a recent checkpoint —

--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -58,6 +58,28 @@ oauth-model-alias:
       alias: "terra"
     - name: "gpt-5.6-luna" # placeholder — confirm real upstream name
       alias: "luna-max"
+    # Picker-discovery twins of the three aliases above -- same upstream
+    # `name` values (must stay identical to their plain twin above, or
+    # CLIProxyAPI treats them as two different upstream models), only the
+    # `alias`/`display-name` differ. The `claude-` prefix satisfies Claude
+    # Code's gateway-discovery filter (an id must contain "claude" or
+    # "anthropic" to appear in /model when CLAUDE_CODE_ENABLE_GATEWAY_
+    # MODEL_DISCOVERY is set); `display-name` controls what the picker
+    # actually shows instead of the raw id. Confirmed CLIProxyAPI supports
+    # multiple aliases per upstream name (internal/config/config_
+    # normalization.go's SanitizeOAuthModelAlias: "allows multiple aliases
+    # per upstream name"). The plain aliases above stay untouched -- they
+    # remain the discovery-independent ANTHROPIC_MODEL launch default and
+    # subagent routing target.
+    - name: "gpt-5.6-sol" # must match the "sol" entry's name above exactly
+      alias: "claude-gpt-sol"
+      display-name: "GPT Sol"
+    - name: "gpt-5.6-terra" # must match the "terra" entry's name above exactly
+      alias: "claude-gpt-terra"
+      display-name: "GPT Terra"
+    - name: "gpt-5.6-luna" # must match the "luna-max" entry's name above exactly
+      alias: "claude-gpt-luna"
+      display-name: "GPT Luna (max)"
 
 # Deus-specific: maps the three fixed `deus connect` subagent names
 # (connectors/providers/cliproxy_oauth's STABLE_SUBAGENT_NAMES) to the

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -151,6 +151,15 @@ class CliproxyOauthConnector(Connector):
             "ANTHROPIC_BASE_URL": f"http://localhost:{port}",
             "ANTHROPIC_API_KEY": keys[0] if keys else "",
             "ANTHROPIC_MODEL": default_alias,
+            # Lets Claude Code's /model picker discover the claude-gpt-*
+            # aliases (connectors/cliproxy/config.yaml's picker-discovery
+            # twins) via CLIProxyAPI's own /v1/models -- live, in-session
+            # model switching instead of launch-time-only ANTHROPIC_MODEL.
+            # Harmless when no claude-* aliases are configured yet:
+            # discovery just finds nothing extra, same as before this key
+            # existed. Not in launch_connect()'s ambient-var clear list, so
+            # it passes through eval "$env_output" unaffected.
+            "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
         }
 
     def agents_for_launch(self) -> dict[str, Any]:

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -2,6 +2,7 @@
 from typing import Any
 
 import pytest
+import yaml
 
 from connectors.base import Connector, ConnectorSetupHandler
 from connectors.registry import (
@@ -211,6 +212,79 @@ class TestCliproxyOauthIsConfigured:
     def test_missing_config_is_not_configured(self):
         c = self.mod.CliproxyOauthConnector()
         assert c.is_configured() is False
+
+
+class TestCliproxyOauthEnvForLaunch:
+    """Coverage for env_for_launch()'s CLAUDE_CODE_ENABLE_GATEWAY_MODEL_
+    DISCOVERY key (model-picker-visibility follow-up) -- lets Claude Code's
+    /model picker discover the claude-gpt-* aliases via CLIProxyAPI's own
+    /v1/models, for live in-session model switching instead of
+    launch-time-only ANTHROPIC_MODEL.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _redirect_local_config(self, tmp_path, monkeypatch):
+        import connectors.providers.cliproxy_oauth as mod
+
+        monkeypatch.setattr(mod, "LOCAL_CONFIG", tmp_path / "config.local.yaml")
+        self.mod = mod
+
+    def test_gateway_discovery_key_present_alongside_existing_three(self):
+        self.mod.LOCAL_CONFIG.write_text(
+            "port: 8317\n"
+            "api-keys:\n  - real-key\n"
+            "deus-model-map:\n  deus-gpt-sol: sol\n"
+            "default-model-alias: sol\n"
+        )
+        c = self.mod.CliproxyOauthConnector()
+        env = c.env_for_launch()
+        assert env == {
+            "ANTHROPIC_BASE_URL": "http://localhost:8317",
+            "ANTHROPIC_API_KEY": "real-key",
+            "ANTHROPIC_MODEL": "sol",
+            "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+        }
+
+    def test_gateway_discovery_key_present_even_when_unconfigured(self):
+        # env_for_launch() itself doesn't gate on is_configured() -- that's
+        # the caller's job (connectors_cli.py's cmd_env checks is_configured()
+        # first). Confirms the new key isn't accidentally conditional on
+        # having claude-gpt-* aliases set up.
+        c = self.mod.CliproxyOauthConnector()
+        env = c.env_for_launch()
+        assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+
+
+class TestTrackedConfigPickerDiscoveryAliases:
+    """Regression coverage for a documentation-only invariant that has no
+    other enforcement: each claude-gpt-* picker-discovery alias's `name`
+    must exactly match its plain-alias twin's `name`, or CLIProxyAPI
+    silently treats them as two different upstream models. Nothing in
+    code enforces this today (it's a tracked-YAML-file convention,
+    documented three times in connectors/cliproxy/config.yaml's comments
+    and .claude/skills/add-connector/SKILL.md) -- this test at least
+    catches an accidental drift in the tracked template itself.
+    """
+
+    def test_discovery_alias_names_match_plain_twins(self):
+        import connectors.providers.cliproxy_oauth as mod
+
+        cfg = yaml.safe_load(mod.TRACKED_CONFIG.read_text())
+        entries = cfg["oauth-model-alias"]["codex"]
+        by_alias = {e["alias"]: e["name"] for e in entries}
+
+        twins = {
+            "claude-gpt-sol": "sol",
+            "claude-gpt-terra": "terra",
+            "claude-gpt-luna": "luna-max",
+        }
+        for discovery_alias, plain_alias in twins.items():
+            assert discovery_alias in by_alias, f"missing {discovery_alias} entry"
+            assert plain_alias in by_alias, f"missing {plain_alias} entry"
+            assert by_alias[discovery_alias] == by_alias[plain_alias], (
+                f"{discovery_alias}'s name ({by_alias[discovery_alias]!r}) must "
+                f"match {plain_alias}'s name ({by_alias[plain_alias]!r})"
+            )
 
 
 class TestWriteLaunchdPlist:

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-12" # auto-bump @1786520978
+last_verified: "2026-08-12" # auto-bump @1786540903
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Gives `deus connect cliproxy-oauth` sessions a live, in-session `/model` picker showing all 3 GPT models (`sol`/`terra`/`luna-max`) by clean name, switchable without relaunching — replacing launch-time-only `ANTHROPIC_MODEL` as the only way to select a model.
- Adds `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` to `env_for_launch()` and three `claude-`-prefixed picker-discovery alias twins (same upstream model, new `alias` + `display-name`) to the tracked config template, so Claude Code's own gateway model discovery can surface them cleanly.
- No CLIProxyAPI fork or Deus-side shim needed — verified this session that the capability already existed in config `cliproxy-oauth` already writes (confirmed directly against CLIProxyAPI's real Go source: multiple aliases per upstream name is an explicitly supported configuration, not a workaround).
- `.claude/skills/add-connector/SKILL.md` updated: Phase 1 gains a migration check for already-configured installs, Phase 5/7/10 document the new aliases and a manual migration path, Phase 3 gains a 6th risk-disclosure item.

## Review history
Went through 3 rounds of plan-review (Claude + GPT backends) and 2 rounds of code-review (Claude + GPT backends). Plan-review caught two real gaps: the original draft only updated the tracked config template, never an already-configured user's real local config (this machine's own running `cliproxy-oauth` instance, confirmed live); then that a migration step placed in Phase 7 was unreachable, since Phase 1's own skip-logic sends an already-configured connector straight past it. Code-review caught a real doc/implementation mismatch: picker visibility was described as an optional Phase-5 choice when `write_config()` has no mechanism to selectively omit it. GLM backend was unreachable both attempts (confirmed standing account-balance exhaustion, not transient) and fails open per this repo's own co-gate policy — Claude + GPT both SHIP.

## Test plan
- [x] `python3 -m pytest connectors/tests/ -v` — 22/22 pass, including 3 new tests (the new `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` key, and a regression test asserting each `claude-gpt-*` alias's `name` matches its plain-alias twin)
- [x] Live-verified the new YAML config parses correctly with matching `name` values
- [x] Live-verified against this machine's real, already-configured production `cliproxy-oauth` setup (`is_configured() == True`, `env_for_launch()` includes the new discovery key)
- [x] Live-verified the Phase 1 migration-check bash command against all 3 cases (missing file, 0 matches, N matches) — confirmed the `[ -f ... ]` fix resolves an earlier double-print bug caught mid-implementation
- [ ] End-to-end `/model` picker check in a real live session (needs the migration step run against the real config — not yet done in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)