### PR TITLE
fix(deus-connect): route cliproxy-oauth credential via ANTHROPIC_AUTH_TOKEN

### DIFF
--- a/.claude/skills/add-connector/SKILL.md
+++ b/.claude/skills/add-connector/SKILL.md
@@ -47,9 +47,9 @@ inherited from another user), still walk through Phase 2 (select) and
 Phase 3 (risk acknowledgment) — Phase 3 is required every time, regardless
 of configuration state, per its own rule; skipping it here would let an
 already-configured install proceed straight to a real connector launch
-without ever showing the risks. Only Phases 4-9 (install/authenticate/
+without ever showing the risks. Only Phases 4-8 (install/authenticate/
 write-config) are skippable on an already-configured connector — jump from
-Phase 3 straight to Phase 10 (Verify) unless the user explicitly wants to
+Phase 3 straight to Phase 9 (Verify) unless the user explicitly wants to
 reconfigure.
 
 **`cliproxy-oauth`-specific one-time check, added for the model-picker-
@@ -57,8 +57,8 @@ visibility follow-up — this is a deliberate, documented exception to this
 skill's normal connector-generic design, not a pattern to copy for a
 future connector.** An already-configured `cliproxy-oauth` install
 predating this feature has no `claude-gpt-*` discovery aliases in its real
-config, and the normal skip straight to Phase 10 would never surface the
-migration step needed to add them. Before jumping to Phase 10 on an
+config, and the normal skip straight to Phase 9 would never surface the
+migration step needed to add them. Before jumping to Phase 9 on an
 already-configured `cliproxy-oauth`, run:
 ```bash
 if [ -f ~/.config/deus/connectors/cliproxy/config.local.yaml ]; then
@@ -71,8 +71,19 @@ If the count is below 3 (a fresh install has 0; a partially-applied manual
 edit could have 1 or 2 — `-c` counts matches rather than a bare presence
 check specifically so a partial edit isn't mistaken for a complete one),
 walk through Phase 7's "Already configured? Add discovery aliases
-manually" subsection before continuing to Phase 10 — every other Phase
-4-9 step still stays skipped.
+manually" subsection before continuing to Phase 9 — every other Phase
+4-8 step still stays skipped.
+
+**Also for any already-configured `cliproxy-oauth` install (regardless of
+the check above)**: if it predates the credential-fallthrough fix, it may
+have gone through the old (now-deleted) Phase 8 flow, which left a
+plaintext copy of the connector's inbound key sitting in
+`~/.claude.json`'s `customApiKeyResponses.approved` array — orphaned and
+functionally dead once this connector authenticates via
+`ANTHROPIC_AUTH_TOKEN`, but still real credential material at rest.
+Cleanup for this is tracked as a separate follow-up (not yet built) —
+flag it to the user rather than hand-editing their `~/.claude.json`
+yourself.
 
 ## Phase 2: Which connector
 
@@ -101,7 +112,12 @@ selected in Phase 2:
 >    separate HTTP client — see `examples/multi-model-cliproxyapi/README.md`'s
 >    "Known open risks" for the full account, including real dated ban
 >    reports in CLIProxyAPI's own issue tracker for other providers. Unlike
->    a config mistake, there is no rollback if this fires.
+>    a config mistake, there is no rollback if this fires. This leg was
+>    dormant for every install predating the credential-fallthrough fix
+>    (a `~/.claude.json` approval-check mismatch meant the connector's key
+>    was silently never used, so this OAuth leg was never actually
+>    exercised) — it becomes genuinely live for the first time once that
+>    fix lands, not something that "was already happening."
 > 2. **Anthropic explicitly disclaims support** for routing Claude Code to
 >    non-Claude models through any gateway
 >    (https://code.claude.com/docs/en/llm-gateway) — a support-scope
@@ -139,7 +155,10 @@ selected in Phase 2:
 >    were already reachable via `ANTHROPIC_MODEL`/typed `/model` — this
 >    just makes it easier to notice at a glance which model is actually
 >    selected, which is a mitigation of confusion, not a new risk in its
->    own right.
+>    own right. Discovery itself never fired at all before the
+>    credential-fallthrough fix (see risk 1) — this goes from a picker
+>    showing nothing extra to one showing exactly these 3 curated models,
+>    not from an unfiltered catalog down to 3.
 > 7. **(ollama only) A small/weak local model can silently produce
 >    lower-quality or subtly wrong tool-use sequences** — misread
 >    instructions, bad tool-call arguments, incomplete reasoning — while
@@ -149,10 +168,18 @@ selected in Phase 2:
 >    silently degrading task correctness, not about where the model comes
 >    from, and it carries no distinct warning signal beyond noticing the
 >    output itself looks off.
+> 8. **(cliproxy-oauth only) A background/`--bg` session launched from
+>    inside a connector session loses the model redirect.** Claude Code
+>    strips `ANTHROPIC_AUTH_TOKEN` (this connector's credential mechanism)
+>    when starting a background session against a custom
+>    `ANTHROPIC_BASE_URL` — a background session spawned this way silently
+>    falls back to your normal Claude access instead of the connector's
+>    model, rather than erroring or redirecting. Disclosed as a known
+>    consequence, not something this connector tries to prevent.
 
-AskUserQuestion: Confirm you understand and accept the risks above (risk 6
-applies only to `cliproxy-oauth`; risk 7 applies only to `ollama`) before
-continuing?
+AskUserQuestion: Confirm you understand and accept the risks above (risks
+6 and 8 apply only to `cliproxy-oauth`; risk 7 applies only to `ollama`)
+before continuing?
 - Yes, continue
 - No, cancel setup
 
@@ -189,10 +216,10 @@ point Phase 5 hasn't collected the user's real host yet and a live check
 here could only ever reach the default `localhost:11434` (silently wrong
 for a non-default-host setup, with no way to recover except repeating the
 same failing check). Service liveness — against the real configured host —
-is checked in Phase 10's `verify-setup`, after Phase 7 writes it. If
+is checked in Phase 9's `verify-setup`, after Phase 7 writes it. If
 `not installed`, tell the user to install Ollama
 (https://ollama.com/download); if it's installed but the service isn't
-running (menu-bar app on macOS / systemd unit on Linux), Phase 10 will
+running (menu-bar app on macOS / systemd unit on Linux), Phase 9 will
 catch that instead, with the real host. This connector never manages the
 Ollama service itself — no daemon to start on the user's behalf, unlike
 `cliproxy-oauth`'s launchd plist.
@@ -206,7 +233,7 @@ least 64000 before continuing:
 - **CLI/systemd-managed install**: `export OLLAMA_CONTEXT_LENGTH=65536`
   in the service's environment, then restart the service.
 
-Phase 10's `verify-setup` checks this automatically (via `/api/ps`'s
+Phase 9's `verify-setup` checks this automatically (via `/api/ps`'s
 `context_length`) and fails if it's still too small — but flag it now so
 the user isn't surprised by a failed verify later.
 
@@ -386,26 +413,7 @@ Writes only `~/.config/deus/connectors/ollama/config.local.yaml` — no
 launchd plist, no daemon to load or kickstart. Ollama's own service is
 already running (confirmed in Phase 4) and this connector never manages it.
 
-## Phase 8: `~/.claude.json` pre-approval
-
-**cliproxy-oauth only.** Read-merge the connector's inbound key into
-`~/.claude.json`'s `customApiKeyResponses.approved` array — back up the
-file first (`cp ~/.claude.json ~/.claude.json.bak-<date>`), then merge
-(never overwrite the whole array — other entries may already exist).
-
-**ollama: not applicable, based on docs — not yet confirmed by a live run.**
-`env_for_launch()` sets `ANTHROPIC_API_KEY=""` (empty) and authenticates via
-`ANTHROPIC_AUTH_TOKEN=ollama` instead, which Claude Code's own auth
-precedence resolves before `ANTHROPIC_API_KEY` — the custom-API-key
-approval prompt this phase exists to pre-answer is keyed off
-`ANTHROPIC_API_KEY` being set, so it's expected not to trigger. This is
-reasoned from `code.claude.com/docs/en/authentication`'s precedence order,
-not yet observed in a real run (no live Ollama setup existed at
-implementation time to test against). Treat Phase 10's live check as the
-first real confirmation of this — if a prompt does appear there, that's a
-genuine finding to fix, not an expected step to route around.
-
-## Phase 9: Validate subagent definitions
+## Phase 8: Validate subagent definitions
 
 ```bash
 python3 scripts/connectors_cli.py agents-json <id>
@@ -415,7 +423,7 @@ python3 scripts/connectors_cli.py agents-json <id>
 prints valid, non-empty JSON — no file templates to install, `deus
 connect`'s launch mechanism passes these inline via `claude --agents`.
 
-## Phase 10: Verify
+## Phase 9: Verify
 
 ```bash
 python3 scripts/connectors_cli.py verify-setup <id>
@@ -449,7 +457,7 @@ deus connect <id>
   and session-resume visibility are both disclosed tradeoffs, not
   guarantees — see Phase 3).
 
-## Phase 11: Set as default (optional)
+## Phase 10: Set as default (optional)
 
 By default, every future session still needs `deus connect <id>` typed
 explicitly — a bare `deus`/`deus home` is never affected. If you want this
@@ -529,10 +537,12 @@ never written to disk.
    ```bash
    rm ~/.config/deus/connectors/cliproxy/config.local.yaml
    ```
-3. Revert the `~/.claude.json` `customApiKeyResponses.approved` entry added
-   in Phase 8 (remove that one key, keep the rest of the array intact).
-4. Confirm: `python3 scripts/connectors_cli.py status cliproxy-oauth` now
+3. Confirm: `python3 scripts/connectors_cli.py status cliproxy-oauth` now
    reports "not configured".
+4. If this install predates the credential-fallthrough fix, it may still
+   have the orphaned `~/.claude.json` residue described in Phase 1's
+   migration-check subsection — removing the connector's own config here
+   doesn't touch that file.
 
 **ollama:**
 1. Remove the real local config (no launchd daemon to unload — this

--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -94,3 +94,12 @@ deus-model-map:
 # Default model for the session itself (ANTHROPIC_MODEL) when no /model
 # switch has been made yet.
 default-model-alias: "luna-max"
+
+# Makes /v1/models return raw, uncloaked upstream ids instead of
+# obfuscated claude-branded ones. Claude Code's own gateway-discovery
+# filter (an id must contain "claude" or "anthropic") then keeps exactly
+# the 3 claude-gpt-* picker-discovery aliases above and drops every other
+# catalog entry (image-generation models, internal tooling, etc.) instead
+# of surfacing all of them under meaningless obfuscated names.
+claude-code:
+  disable-cloaking-model-list: true

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -149,7 +149,21 @@ class CliproxyOauthConnector(Connector):
         )
         return {
             "ANTHROPIC_BASE_URL": f"http://localhost:{port}",
-            "ANTHROPIC_API_KEY": keys[0] if keys else "",
+            # Real credential goes on ANTHROPIC_AUTH_TOKEN, not
+            # ANTHROPIC_API_KEY -- matches the ollama connector's exact
+            # pattern. Claude Code's ANTHROPIC_API_KEY approval check
+            # compares only the last 20 characters of the key against a
+            # ~/.claude.json allowlist, so this connector's full-length key
+            # could never match and silently fell through to the user's
+            # personal OAuth subscription instead. ANTHROPIC_AUTH_TOKEN
+            # sidesteps that check and outranks ANTHROPIC_API_KEY in
+            # Claude Code's own auth precedence.
+            "ANTHROPIC_AUTH_TOKEN": keys[0] if keys else "",
+            # Explicitly emptied, not omitted: masks any ambient
+            # ANTHROPIC_API_KEY the launching shell might have set, so it
+            # can never be picked up instead of this connector's own
+            # credential.
+            "ANTHROPIC_API_KEY": "",
             "ANTHROPIC_MODEL": default_alias,
             # Lets Claude Code's /model picker discover the claude-gpt-*
             # aliases (connectors/cliproxy/config.yaml's picker-discovery

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -240,7 +240,8 @@ class TestCliproxyOauthEnvForLaunch:
         env = c.env_for_launch()
         assert env == {
             "ANTHROPIC_BASE_URL": "http://localhost:8317",
-            "ANTHROPIC_API_KEY": "real-key",
+            "ANTHROPIC_AUTH_TOKEN": "real-key",
+            "ANTHROPIC_API_KEY": "",
             "ANTHROPIC_MODEL": "sol",
             "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
         }

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-12" # auto-bump @1786540903
+last_verified: "2026-08-12" # auto-bump @1786566487
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- The `cliproxy-oauth` connector's inbound key was placed on `ANTHROPIC_API_KEY`, but Claude Code's custom-API-key approval check compares only the **last 20 characters** of the key against a `~/.claude.json` allowlist — a full-length (32-char) key can never match, so sessions silently fell through to the user's personal claude.ai OAuth subscription instead of the connector's credential, and Claude Code's gateway model discovery never fired at all (confirmed via live network capture: zero `GET /v1/models` requests across a full session).
- Fix: switch to `ANTHROPIC_AUTH_TOKEN` (real key) + `ANTHROPIC_API_KEY: ""` (explicit empty, masks any ambient value), matching the already-merged `ollama` connector's exact pattern. `ANTHROPIC_AUTH_TOKEN` sidesteps the broken approval check entirely and outranks `ANTHROPIC_API_KEY` in Claude Code's own auth precedence.
- Adds `claude-code: {disable-cloaking-model-list: true}` to the tracked CLIProxyAPI config so `/model` shows exactly the 3 curated GPT aliases (`sol`/`terra`/`luna-max`) instead of the full ~14-entry raw catalog.
- `.claude/skills/add-connector/SKILL.md`: deletes the now-obsolete "Phase 8: `~/.claude.json` pre-approval" step (the actual root cause), renumbers phases 9–11→8–10 with all cross-references fixed (re-grepped after editing, zero stale references), and updates risk-disclosure language to reflect that OAuth-reuse and gateway discovery were dormant before this fix, not previously live.

## Deferred (not in this PR)
An orphaned plaintext copy of the connector's key already sits in `~/.claude.json`'s `customApiKeyResponses.approved` array on affected machines (confirmed live, backed up 3× via Claude Code's own `.bak` files). A cleanup script for this was drafted and hardened over 5 rounds of `threat-modeler` review (atomic write, concurrency fingerprint guard, no credential ever printed, no process listing). It's deferred to a follow-up PR: the GPT backend of `code-reviewer` correctly and repeatedly identified a structurally irreducible concurrent-write window between the fingerprint recheck and the file replace (no code-level fix closes it fully, since Claude Code — the other writer — takes no lock of its own; `threat-modeler` independently reached the same "accepted, irreducible" conclusion). Rather than ship an unresolved REVISE, the core fix ships alone here.

## Review history
- `plan-reviewer`: SHIP (Claude + GPT backends)
- `threat-modeler`: SHIP after 5 rounds (credential-handling change, explicitly requested per this repo's discipline)
- `code-reviewer`: SHIP (Claude + GPT backends) on the final trimmed scope; GLM backend `COULD_NOT_RUN` (HTTP 429, standing account-balance exhaustion — fails open per this repo's co-gate policy)
- `verification-gate`: SHIP (38/38 tests, index/worktree agreement confirmed, end-to-end shell-propagation of the new env var independently traced through `connectors_cli.py` → `deus-cmd.sh`'s ambient-var clear logic)

## Test plan
- [x] `python3 -m pytest connectors/tests/test_registry.py connectors/tests/test_ollama_connector.py -v` — 38/38 pass, including the rewritten `test_gateway_discovery_key_present_alongside_existing_three` asserting the new `ANTHROPIC_AUTH_TOKEN`/empty-`ANTHROPIC_API_KEY` shape
- [x] Re-grepped `.claude/skills/add-connector/SKILL.md` for `Phase [0-9]`/`Phases [0-9]` after renumbering — zero stale references
- [x] Traced `env_for_launch()`'s new key end-to-end through `scripts/connectors_cli.py`'s shell-export emission and `deus-cmd.sh`'s ambient-var clear loop (verification-gate)
- [ ] Live end-to-end verification (fresh `deus connect cliproxy-oauth` session, confirm `/model` shows the 3 curated GPT models labeled "From gateway") — needs a fresh session; discovery fetch is one-shot at startup so an already-open session won't pick this up

🤖 Generated with [Claude Code](https://claude.com/claude-code)