### PR TITLE
refactor(deus-connect): consolidate cliproxy-oauth's GPT model list into one registry

### DIFF
--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -82,7 +82,7 @@ oauth-model-alias:
       display-name: "GPT Luna (max)"
 
 # Deus-specific: maps the three fixed `deus connect` subagent names
-# (connectors/providers/cliproxy_oauth's STABLE_SUBAGENT_NAMES) to the
+# (connectors/providers/cliproxy_oauth's GPT_MODELS) to the
 # CLIProxyAPI alias configured above. Only the alias values should change
 # per real model; the deus-gpt-* keys are fixed and referenced directly by
 # connectors/providers/cliproxy_oauth's agents_for_launch().

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -31,6 +31,7 @@ import sys
 import urllib.error
 import urllib.request
 import xml.parsers.expat
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -53,10 +54,57 @@ LOCAL_CONFIG = Path(
 PLIST_LABEL = "com.deus.connectors.cliproxy-oauth"
 PLIST_PATH = Path(f"~/Library/LaunchAgents/{PLIST_LABEL}.plist").expanduser()
 
-# Fixed, connector-defined stable subagent names — portable across users
-# (real upstream model ids are per-account, not portable). Only the
-# gitignored local config's alias-to-real-id mapping varies per user.
-STABLE_SUBAGENT_NAMES = ("deus-gpt-sol", "deus-gpt-terra", "deus-gpt-luna")
+
+@dataclass(frozen=True)
+class GptModelDef:
+    """One onboarded GPT model's portable (account-agnostic) metadata --
+    the per-account upstream routing (which real model "sol" points to)
+    lives only in the user's local config's deus-model-map, never here.
+
+    Value Object (frozen, structural equality, no identity) -- the single
+    source of truth model_aliases()/agents_for_launch() derive from,
+    replacing what used to be two separately hand-maintained structures
+    (a name tuple + a description dict) that had to be kept in sync by
+    hand when onboarding a new model. Deliberately a plain tuple below,
+    not its own Registry class: every consumer only ever needs full
+    iteration, never id-keyed lookup, so O(n) iteration is exactly what's
+    needed -- the same "declarative single source of truth" idea
+    Connector/ConnectorRegistry already apply one level up (per-engine),
+    applied one level down (per-model, within this one connector).
+    """
+
+    subagent_name: str
+    description: str
+
+
+# Single source of truth for every onboarded GPT model. To add one: add a
+# GptModelDef entry here, plus the matching oauth-model-alias.codex[]
+# (plain + picker-discovery) and deus-model-map entries to
+# connectors/cliproxy/config.yaml (the real upstream model id is
+# account-specific and can only be confirmed during setup -- see
+# add-connector/SKILL.md Phase 5).
+GPT_MODELS: tuple[GptModelDef, ...] = (
+    GptModelDef(
+        "deus-gpt-sol",
+        "General-purpose subagent pinned to GPT 5.6 Sol via the local "
+        "multi-model gateway. Use for research, analysis, or a second "
+        "opinion where a genuinely independent (non-Claude) model is "
+        "valuable.",
+    ),
+    GptModelDef(
+        "deus-gpt-terra",
+        "General-purpose subagent pinned to GPT 5.6 Terra via the local "
+        "multi-model gateway. Use for research, analysis, or a second "
+        "opinion where a genuinely independent (non-Claude) model is "
+        "valuable.",
+    ),
+    GptModelDef(
+        "deus-gpt-luna",
+        "General-purpose subagent pinned to GPT 5.6 Luna (max reasoning "
+        "effort) via the local multi-model gateway. Use for harder "
+        "research/analysis tasks warranting deeper reasoning.",
+    ),
+)
 
 # Must match connectors/cliproxy/config.yaml's literal placeholder exactly.
 # authenticate() bootstraps LOCAL_CONFIG by copying that tracked template
@@ -69,26 +117,6 @@ STABLE_SUBAGENT_NAMES = ("deus-gpt-sol", "deus-gpt-terra", "deus-gpt-luna")
 # would then skip straight to verification) and a real deus connect launch
 # (which would then use this literal string as ANTHROPIC_API_KEY).
 _PLACEHOLDER_INBOUND_KEY = "REPLACE_WITH_YOUR_OWN_INBOUND_KEY"
-
-_SUBAGENT_DESCRIPTIONS = {
-    "deus-gpt-sol": (
-        "General-purpose subagent pinned to GPT 5.6 Sol via the local "
-        "multi-model gateway. Use for research, analysis, or a second "
-        "opinion where a genuinely independent (non-Claude) model is "
-        "valuable."
-    ),
-    "deus-gpt-terra": (
-        "General-purpose subagent pinned to GPT 5.6 Terra via the local "
-        "multi-model gateway. Use for research, analysis, or a second "
-        "opinion where a genuinely independent (non-Claude) model is "
-        "valuable."
-    ),
-    "deus-gpt-luna": (
-        "General-purpose subagent pinned to GPT 5.6 Luna (max reasoning "
-        "effort) via the local multi-model gateway. Use for harder "
-        "research/analysis tasks warranting deeper reasoning."
-    ),
-}
 
 
 def _load_local_config() -> dict[str, Any]:
@@ -129,7 +157,9 @@ class CliproxyOauthConnector(Connector):
     def model_aliases(self) -> dict[str, str]:
         mapping = _load_local_config().get("deus-model-map") or {}
         return {
-            name: mapping[name] for name in STABLE_SUBAGENT_NAMES if name in mapping
+            m.subagent_name: mapping[m.subagent_name]
+            for m in GPT_MODELS
+            if m.subagent_name in mapping
         }
 
     def is_configured(self) -> bool:
@@ -179,18 +209,19 @@ class CliproxyOauthConnector(Connector):
     def agents_for_launch(self) -> dict[str, Any]:
         aliases = self.model_aliases()
         agents: dict[str, Any] = {}
-        for name in STABLE_SUBAGENT_NAMES:
-            alias = aliases.get(name)
+        for model in GPT_MODELS:
+            alias = aliases.get(model.subagent_name)
             if not alias:
                 continue
-            agents[name] = {
-                "description": _SUBAGENT_DESCRIPTIONS[name],
+            agents[model.subagent_name] = {
+                "description": model.description,
                 "prompt": (
-                    f"You are {name}, dispatched as a subagent, reachable "
-                    "only through this deus connect session. Do the task "
-                    "described in the prompt directly and report your "
-                    "findings/output -- you are not a reviewer unless "
-                    "explicitly asked to review something."
+                    f"You are {model.subagent_name}, dispatched as a "
+                    "subagent, reachable only through this deus connect "
+                    "session. Do the task described in the prompt "
+                    "directly and report your findings/output -- you are "
+                    "not a reviewer unless explicitly asked to review "
+                    "something."
                 ),
                 "model": alias,
                 # Matches the least-privilege scope of the personal

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -256,6 +256,74 @@ class TestCliproxyOauthEnvForLaunch:
         assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
 
 
+class TestCliproxyOauthAgentsForLaunch:
+    """agents_for_launch() had zero direct test coverage before this class
+    -- added as a real before/after regression check for the GPT model-
+    registry consolidation (STABLE_SUBAGENT_NAMES + _SUBAGENT_DESCRIPTIONS
+    -> a single GptModelDef/GPT_MODELS table).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _redirect_local_config(self, tmp_path, monkeypatch):
+        import connectors.providers.cliproxy_oauth as mod
+
+        monkeypatch.setattr(mod, "LOCAL_CONFIG", tmp_path / "config.local.yaml")
+        self.mod = mod
+
+    def test_empty_when_unconfigured(self):
+        c = self.mod.CliproxyOauthConnector()
+        assert c.agents_for_launch() == {}
+
+    def test_only_configured_subagents_are_included(self):
+        self.mod.LOCAL_CONFIG.write_text("deus-model-map:\n  deus-gpt-sol: sol\n")
+        c = self.mod.CliproxyOauthConnector()
+        agents = c.agents_for_launch()
+        assert set(agents.keys()) == {"deus-gpt-sol"}
+
+    def test_agent_shape_and_content(self):
+        self.mod.LOCAL_CONFIG.write_text(
+            "deus-model-map:\n"
+            "  deus-gpt-sol: sol\n"
+            "  deus-gpt-terra: terra\n"
+            "  deus-gpt-luna: luna-max\n"
+        )
+        c = self.mod.CliproxyOauthConnector()
+        agents = c.agents_for_launch()
+
+        assert set(agents.keys()) == {
+            "deus-gpt-sol",
+            "deus-gpt-terra",
+            "deus-gpt-luna",
+        }
+        sol = agents["deus-gpt-sol"]
+        assert sol["model"] == "sol"
+        assert "deus-gpt-sol" in sol["prompt"]
+        assert sol["description"]
+        assert sol["tools"] == [
+            "Read",
+            "Grep",
+            "Glob",
+            "Bash",
+            "WebSearch",
+            "WebFetch",
+        ]
+
+        luna = agents["deus-gpt-luna"]
+        assert luna["model"] == "luna-max"
+
+    def test_descriptions_are_distinct_per_subagent(self):
+        self.mod.LOCAL_CONFIG.write_text(
+            "deus-model-map:\n"
+            "  deus-gpt-sol: sol\n"
+            "  deus-gpt-terra: terra\n"
+            "  deus-gpt-luna: luna-max\n"
+        )
+        c = self.mod.CliproxyOauthConnector()
+        agents = c.agents_for_launch()
+        descriptions = {a["description"] for a in agents.values()}
+        assert len(descriptions) == 3
+
+
 class TestTrackedConfigPickerDiscoveryAliases:
     """Regression coverage for a documentation-only invariant that has no
     other enforcement: each claude-gpt-* picker-discovery alias's `name`


### PR DESCRIPTION
## Summary
- Adding a GPT model to the `cliproxy-oauth` connector required hand-editing two separately-maintained Python structures (`STABLE_SUBAGENT_NAMES` tuple + `_SUBAGENT_DESCRIPTIONS` dict) that had to be kept in sync manually. Replaces both with a single `GptModelDef` frozen dataclass + `GPT_MODELS` tuple — the same "declarative single source of truth" idea `Connector`/`ConnectorRegistry` already apply one level up (per-engine), applied one level down (per-model, within this one connector).
- `model_aliases()` and `agents_for_launch()` now iterate `GPT_MODELS` directly. Pure internal refactor — no change to `env_for_launch()`, `is_configured()`, or any `ConnectorSetupHandler` method; no user-visible behavior change.
- `agents_for_launch()` had zero direct test coverage before this change (caught by plan-reviewer round 2) — adds `TestCliproxyOauthAgentsForLaunch` (4 tests), verified to pass against the pre-refactor code too, so it's a genuine before/after regression check rather than retrofitted to the new implementation.
- One comment fix in `connectors/cliproxy/config.yaml` (stale reference to the now-deleted `STABLE_SUBAGENT_NAMES`).

## Design note
`GptModelDef` deliberately carries only 2 fields (`subagent_name`, `description`) — the ones actually read by `model_aliases()`/`agents_for_launch()`. Plan-reviewer round 2 caught that an earlier draft's `plain_alias`/`picker_alias`/`display_name` fields were dead code never read by either function (that per-account routing data correctly lives only in the user's local config's `deus-model-map`); carrying them would have added a 5th hand-synced place without reducing any duplication.

## Review history
- `plan-reviewer`: SHIP (Claude + GPT), 3 rounds — round 1 REVISE (no named design pattern given the explicit ask for OOP/design-pattern rigor here), round 2 REVISE (dead-field warning + missing `agents_for_launch()` test coverage), round 3 SHIP.
- `code-reviewer`: SHIP (Claude + GPT). GLM `COULD_NOT_RUN` (standing account-balance exhaustion, fails open per this repo's co-gate policy).
- `verification-gate`: SHIP — 42/42 tests, full `connectors/` suite (53) + `connectors_cli` suite (8) + `drift_check --all` all green, dead-field claim independently re-verified, new tests independently re-run against pre-refactor code in an isolated copy.
- No `threat-modeler` needed — not a credential-handling change.

## Test plan
- [x] `python3 -m pytest connectors/tests/test_registry.py connectors/tests/test_ollama_connector.py -v` — 42/42 pass
- [x] `python3 -m pytest connectors/tests/` (full suite) — 53/53 pass
- [x] `python3 -m pytest scripts/tests/test_connectors_cli.py` — 8/8 pass
- [x] `python3 scripts/drift_check.py --all --base origin/main` — all checks passed
- [x] New `TestCliproxyOauthAgentsForLaunch` tests independently confirmed to pass against the pre-refactor implementation (genuine before/after check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)