### PR TITLE
feat(skills): add show-me skill from humanlayer/skills

### DIFF
--- a/.claude/skills/ATTRIBUTION-humanlayer-skills.md
+++ b/.claude/skills/ATTRIBUTION-humanlayer-skills.md
@@ -1,0 +1,48 @@
+# Attribution — humanlayer/skills
+
+The `show-me` skill was imported from the open-source repo
+**[humanlayer/skills](https://github.com/humanlayer/skills)** (MIT-licensed).
+
+| Skill | Upstream path |
+|-------|----------------|
+| `show-me` | `plugins/show-me/skills/show-me/SKILL.md` |
+
+**Source:** `github.com/humanlayer/skills` @ commit
+`4d8d644ca747517973f58d7953f58d7cd07520cd`.
+
+## Adaptations from upstream
+
+Byte-identical copy — no changes. Upstream's frontmatter carries only `name` and
+`description` (no `disable-model-invocation` flag), so `show-me` is both model- and
+user-invocable, same class as this repo's own `research` skill.
+
+This is a single-skill import, not a bulk sync (contrast
+`ATTRIBUTION-mattpocock-skills.md`, which imported 14 skills at once).
+
+## License
+
+Distributed under the MIT License, retained from upstream:
+
+```
+MIT License
+
+Copyright (c) 2026 HumanLayer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/.claude/skills/show-me/SKILL.md
+++ b/.claude/skills/show-me/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: show-me
+description: Help the user understand the current topic visually with concise diagrams, code-shape sketches, and focused HTML artifacts.
+---
+
+Help the user understand the current topic of conversation visually. Skip the preamble and keep prose brief. Pick the smallest view that makes the key point clear.
+
+- Show logic or an algorithm as pseudocode:
+
+```text
+on(save)
+  if content is unchanged
+    return cached result
+  write new content
+  return fresh result
+```
+
+- Show runtime control flow as a call tree:
+
+```text
+submitForm
+  createSession
+    persistPrompt
+    launchAgent
+  navigateToSession
+```
+
+- Show UI structure as a component tree, including state and module boundaries that matter:
+
+```tsx
+<SessionPage> (apps/example/src/routes/session.tsx)
+  useSessionEvents()
+  <SessionToolbar>
+    <RunSkillButton> (packages/ui)
+```
+
+- Show file responsibility or a broad refactor as a shallow file tree:
+
+```text
+src/
+├── commands/       # parses user actions
+├── sessions/       # owns session state
+└── transport/      # sends API requests
+```
+
+- Show component interaction, control flow, or data flow with Mermaid:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UI
+    participant Daemon
+    User->>UI: choose command
+    UI->>Daemon: send expanded prompt
+    Daemon-->>UI: stream result
+```
+
+- Use `diff` when the point is what changes and the surrounding shape already exists. Match the diff shape to the topic.
+
+For a component change:
+
+```diff
+ <SessionPage>
+   useSessionEvents()
+   <SessionToolbar>
++    <RunSkillButton />
+   <SessionTimeline>
++    <SkillResultCard />
+```
+
+For a file-layout change:
+
+```diff
+ src/
+ ├── commands/
++│   └── show-me.ts       # expands the slash command
+ ├── sessions/
+-└── transport.ts
++└── transport/
++    ├── client.ts
++    └── stream.ts
+```
+
+For a call-tree or call-stack change:
+
+```diff
+ submitForm
+   createSession
+     persistPrompt
++    expandSkillMention
+     launchAgent
+-  navigateToSession
++  navigateToSession
++    subscribeToEvents
+```
+
+For a state or control-flow change:
+
+```diff
+ on(save)
+-  write content
++  if content is unchanged
++    return cached result
++  write new content
++  invalidate cache
+```
+
+- Show the whole block when most of it is new, when omitted context would hide ownership or order, or when the user needs a copyable target shape:
+
+```ts
+function expandSkill(command: string): string {
+  const skillName = command.slice(1)
+  return `use the ${skillName} skill`
+}
+```
+
+- For a visual UI, layout, state comparison, or concept too dense for Mermaid, write one focused HTML file — a diagram, an infographic, or a short slide deck, whichever fits the point. Match the product's colors, type, spacing, and components; use real labels and data; support desktop and mobile. Then open it for the user:
+
+```
+Bash(open path/to/show-me-{description}.html)
+```
+
+- Place each visual next to the short text it supports. Keep only the calls, files, props, states, and boundaries needed to answer the user's current question.
+
+You may use one of these, you may use several, it is unlikely you will use all of them. Use your judgement and don't overwhelm the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ renaming a repo-owned skill, update this table in the same change.
 | `/resume` | Load recent work and memory context |
 | `/review-logs` | Review Deus system health logs |
 | `/setup` | Run first-time installation and configuration |
+| `/show-me` | Explain the current topic visually — diagrams, code-shape sketches, focused HTML artifacts |
 | `/tdd` | Test-driven development loop — red-green-refactor, behavior-first |
 | `/teach` | Teach a skill or concept over multiple sessions (stateful teaching workspace) |
 | `/update-skills` | Update installed skill branches from upstream |

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-12" # auto-bump @1786566487
+last_verified: "2026-08-13" # auto-bump @1786603249
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- Hand-ports the `show-me` skill from `humanlayer/skills` (MIT, commit `4d8d644`) — byte-identical, verified via direct diff against the live upstream file.
- Matches the existing skill-import precedent (`ATTRIBUTION-mattpocock-skills.md` / `ATTRIBUTION-no-numb.md`): attribution file + `AGENTS.md` skill-table row, no upstream CLI/plugin install.
- `/show-me` explains the current topic visually — pseudocode, call trees, component trees, file trees, Mermaid diagrams, targeted diffs, or a focused HTML artifact when Mermaid is too sparse.

## Review trail
- plan-reviewer: SHIP (Claude, round 4) + SHIP (GPT)
- code-reviewer: SHIP (Claude) + SHIP (GPT); GLM returned `COULD_NOT_RUN` (billing exhaustion, documented fail-open case)
- verification-gate: SHIP — byte-identical copy, license text, and AGENTS.md placement all independently re-verified against live upstream

## Test plan
- [x] `diff` of committed `SKILL.md` against live-fetched upstream — byte-identical
- [x] `git status --porcelain` — exactly the 3 intended paths changed
- [x] `AGENTS.md` alphabetical placement (`/setup` → `/show-me` → `/tdd`) confirmed
- [x] No `src/`/`agent.ts`/`host.ts`/`scripts/` touched (patterns/skill-add.md CI rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)