### PR TITLE
feat(deus-connect): per-model reasoning-effort control for cliproxy-oauth

### DIFF
--- a/.claude/skills/add-connector/SKILL.md
+++ b/.claude/skills/add-connector/SKILL.md
@@ -74,6 +74,23 @@ walk through Phase 7's "Already configured? Add discovery aliases
 manually" subsection before continuing to Phase 9 — every other Phase
 4-8 step still stays skipped.
 
+**Second `cliproxy-oauth`-specific one-time check, added for the
+per-model reasoning-effort feature — same reasoning as the check above,
+same deliberate exception.** An already-configured install predating this
+feature has no `payload.override` block, and the normal skip straight to
+Phase 9 would never surface the migration step needed to add it:
+```bash
+if [ -f ~/.config/deus/connectors/cliproxy/config.local.yaml ]; then
+  grep -c 'reasoning\.effort' ~/.config/deus/connectors/cliproxy/config.local.yaml
+else
+  echo 0
+fi
+```
+If the count is below 3, walk through Phase 7's "Already configured? Add
+reasoning-effort overrides manually" subsection before continuing to
+Phase 9 (in addition to the discovery-alias check above, if that one also
+applies) — every other Phase 4-8 step still stays skipped.
+
 **Also for any already-configured `cliproxy-oauth` install (regardless of
 the check above)**: if it predates the credential-fallthrough fix, it may
 have gone through the old (now-deleted) Phase 8 flow, which left a
@@ -258,6 +275,13 @@ the user isn't surprised by a failed verify later.
   exact same value as its plain-alias twin** (e.g. `claude-gpt-sol`'s
   `name` = `sol`'s `name`) — a mismatch wouldn't error, CLIProxyAPI would
   just silently treat them as two different upstream models.
+- **Reasoning effort per model** — CLIProxyAPI force-sets the outbound
+  Codex `reasoning.effort` for each of the 3 GPT models via a config-side
+  override (confirmed live: it overrides whatever Claude Code itself
+  sends, regardless). Tracked-template defaults are `sol`=`high`,
+  `terra`=`high`, `luna`=`xhigh` (Codex's ceiling — there's no `max`
+  level on this protocol). Offer the user each default and let them
+  change any of them. Accepted values: `low`/`medium`/`high`/`xhigh`.
 - **Default model** for the session itself when no `/model` switch has been
   made — recommend `luna-max` (max reasoning effort) unless the user
   prefers otherwise. This is separate from picker visibility: the plain
@@ -324,9 +348,15 @@ Where `<json values>` is a JSON object:
   "anthropic_api_key": "<optional, only if the user opted in>",
   "model_map": {"deus-gpt-sol": "sol", "deus-gpt-terra": "terra", "deus-gpt-luna": "luna-max"},
   "default_model_alias": "luna-max",
+  "effort_map": {"deus-gpt-luna": "xhigh"},
   "binary_path": "<absolute path from: command -v cli-proxy-api>"
 }
 ```
+
+`effort_map` is optional — only include the subagents whose effort level
+the user changed from the tracked template's defaults (Phase 5). Omitting
+it, or omitting a specific subagent's key, leaves that subagent at its
+template default (`sol`=`high`, `terra`=`high`, `luna`=`xhigh`).
 
 This writes the real config to
 `~/.config/deus/connectors/cliproxy/config.local.yaml` — **outside any
@@ -350,9 +380,15 @@ overwrite it on their behalf.
 
 **Then hand-edit the real upstream model id strings** collected in Phase 5
 into `~/.config/deus/connectors/cliproxy/config.local.yaml`'s
-`oauth-model-alias.codex[].name` fields (the `write-config` call above does
-not touch these — only `deus-model-map`, `api-keys`, `claude-api-key`, and
-`default-model-alias`).
+`oauth-model-alias.codex[].name` fields **and** the matching
+`payload.override[].models[].name` field for each GPT model (the
+`write-config` call above does not touch either — only `deus-model-map`,
+`api-keys`, `claude-api-key`, `default-model-alias`, and — new for the
+reasoning-effort feature — `payload.override[].params["reasoning.effort"]`
+when `effort_map` was given). Keep each model's `oauth-model-alias.name`
+and `payload.override[].models[].name` identical, same requirement as the
+`claude-gpt-*` picker-discovery twin's name — a mismatch wouldn't error,
+the effort override would just silently stop matching any real request.
 
 Load the daemon:
 
@@ -394,6 +430,44 @@ changes and reloads automatically on write (confirmed:
 `internal/watcher/events.go`'s fsnotify-based watcher), and Claude Code's
 own gateway discovery re-queries `/v1/models` on each new session start,
 so the very next `deus connect cliproxy-oauth` launch picks this up.
+
+### Already configured (cliproxy-oauth)? Add reasoning-effort overrides manually
+
+**For an existing `config.local.yaml` predating the per-model
+reasoning-effort feature** (reached via Phase 1's second check on an
+already-configured `cliproxy-oauth`) — same rule as the discovery-alias
+subsection above: do NOT re-run `write-config`, for the same reason (it
+rebuilds the file from the tracked template, discarding the real upstream
+`name` values already hand-edited in). Instead, hand-edit
+`~/.config/deus/connectors/cliproxy/config.local.yaml` directly, adding a
+top-level `payload.override` block — reuse the SAME real upstream `name`
+value already present for each existing plain alias (`sol`/`terra`/
+`luna-max`), never the tracked template's placeholder names:
+
+```yaml
+payload:
+  override:
+    - models:
+        - name: "<same real name as the existing sol entry, verbatim>"
+          protocol: "codex"
+      params:
+        "reasoning.effort": "high"
+    - models:
+        - name: "<same real name as the existing terra entry, verbatim>"
+          protocol: "codex"
+      params:
+        "reasoning.effort": "high"
+    - models:
+        - name: "<same real name as the existing luna entry, verbatim>"
+          protocol: "codex"
+      params:
+        "reasoning.effort": "xhigh"
+```
+
+Ask the user for each level the same way Phase 5 would for a fresh
+setup (defaults shown above; accepted values `low`/`medium`/`high`/
+`xhigh`). No daemon restart needed — same fsnotify-based config watcher
+as the discovery-alias subsection above, since it's the same config file.
 
 **ollama (no daemon):**
 ```bash

--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -95,6 +95,38 @@ deus-model-map:
 # switch has been made yet.
 default-model-alias: "luna-max"
 
+# Per-model reasoning-effort overrides. CLIProxyAPI force-sets the outbound
+# Codex `reasoning.effort` regardless of what Claude Code itself sends --
+# confirmed live: a client requesting effort "low" on every call still saw
+# the response change (5 vs 26 output tokens on an identical prompt) when
+# only this override changed. That makes Claude Code's own `--agents`
+# `effort` frontmatter field moot for these three subagents; this is the
+# real, authoritative control. Codex protocol levels: low/medium/high/xhigh
+# (no "max" -- xhigh is the ceiling). The `name` values here MUST match
+# their oauth-model-alias.codex[] plain-alias twin above exactly, same
+# name-sync requirement as the claude-gpt-* picker-discovery twins --
+# `deus connect setup cliproxy-oauth`'s write-config keeps them in sync
+# automatically; hand-editing this file for an already-configured install
+# (add-connector/SKILL.md's migration subsection) must keep them in sync
+# by hand.
+payload:
+  override:
+    - models:
+        - name: "gpt-5.6-sol" # must match the "sol" entry's name above exactly
+          protocol: "codex"
+      params:
+        "reasoning.effort": "high"
+    - models:
+        - name: "gpt-5.6-terra" # must match the "terra" entry's name above exactly
+          protocol: "codex"
+      params:
+        "reasoning.effort": "high"
+    - models:
+        - name: "gpt-5.6-luna" # must match the "luna-max" entry's name above exactly
+          protocol: "codex"
+      params:
+        "reasoning.effort": "xhigh"
+
 # Makes /v1/models return raw, uncloaked upstream ids instead of
 # obfuscated claude-branded ones. Claude Code's own gateway-discovery
 # filter (an id must contain "claude" or "anthropic") then keeps exactly

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -75,6 +75,13 @@ class GptModelDef:
 
     subagent_name: str
     description: str
+    # The tracked template's placeholder upstream model name
+    # (connectors/cliproxy/config.yaml's oauth-model-alias.codex[].name
+    # AND its payload.override[].models[].name -- these two must stay in
+    # sync, same as the claude-gpt-* picker-discovery twin's name).
+    # write_config() uses this to find the right payload.override entry
+    # to mutate for effort_map, without a second hardcoded lookup table.
+    template_upstream_name: str
 
 
 # Single source of truth for every onboarded GPT model. To add one: add a
@@ -90,6 +97,7 @@ GPT_MODELS: tuple[GptModelDef, ...] = (
         "multi-model gateway. Use for research, analysis, or a second "
         "opinion where a genuinely independent (non-Claude) model is "
         "valuable.",
+        "gpt-5.6-sol",
     ),
     GptModelDef(
         "deus-gpt-terra",
@@ -97,14 +105,21 @@ GPT_MODELS: tuple[GptModelDef, ...] = (
         "multi-model gateway. Use for research, analysis, or a second "
         "opinion where a genuinely independent (non-Claude) model is "
         "valuable.",
+        "gpt-5.6-terra",
     ),
     GptModelDef(
         "deus-gpt-luna",
         "General-purpose subagent pinned to GPT 5.6 Luna (max reasoning "
         "effort) via the local multi-model gateway. Use for harder "
         "research/analysis tasks warranting deeper reasoning.",
+        "gpt-5.6-luna",
     ),
 )
+
+# CLIProxyAPI's Codex protocol reasoning-effort levels (confirmed against
+# Claude Code's own effort-level table -- Codex has no "max"; "xhigh" is
+# its ceiling). Used to validate effort_map values in write_config().
+_CODEX_EFFORT_LEVELS = ("low", "medium", "high", "xhigh")
 
 # Must match connectors/cliproxy/config.yaml's literal placeholder exactly.
 # authenticate() bootstraps LOCAL_CONFIG by copying that tracked template
@@ -280,6 +295,51 @@ class CliproxyOauthSetupHandler(ConnectorSetupHandler):
         placeholder["default-model-alias"] = values.get(
             "default_model_alias", next(iter(model_map.values()), "")
         )
+        # Only touches entries the caller actually specifies -- a subagent
+        # omitted from effort_map keeps the template's baked-in default
+        # (see connectors/cliproxy/config.yaml's payload.override block).
+        # An unknown key (typo, stale/removed model) is rejected loudly
+        # rather than silently never applied, matching this file's
+        # fail-loud posture elsewhere (e.g. the claude-api-key placeholder
+        # rejection above).
+        effort_map = values.get("effort_map") or {}
+        known_subagents = {m.subagent_name for m in GPT_MODELS}
+        unknown = set(effort_map) - known_subagents
+        if unknown:
+            raise ValueError(
+                f"effort_map has unknown subagent name(s) {sorted(unknown)} "
+                f"-- must be one of {sorted(known_subagents)}"
+            )
+        overrides = placeholder.get("payload", {}).get("override", [])
+        for model in GPT_MODELS:
+            level = effort_map.get(model.subagent_name)
+            if level is None:
+                continue
+            if level not in _CODEX_EFFORT_LEVELS:
+                raise ValueError(
+                    f"invalid effort level {level!r} for {model.subagent_name} "
+                    f"-- must be one of {_CODEX_EFFORT_LEVELS}"
+                )
+            matched = False
+            for rule in overrides:
+                names = [m.get("name") for m in rule.get("models", [])]
+                if model.template_upstream_name in names:
+                    rule["params"]["reasoning.effort"] = level
+                    matched = True
+                    break
+            if not matched:
+                # Same fail-loud posture as the unknown-key/invalid-level
+                # checks above -- a template with a dropped/renamed
+                # payload.override entry (drift the TestTrackedConfig
+                # PickerDiscoveryAliases test guards against, but that's an
+                # external guard, not a runtime check) must not silently
+                # write a config where the requested effort was never
+                # actually applied.
+                raise ValueError(
+                    f"no payload.override entry found for "
+                    f"{model.subagent_name}'s upstream name "
+                    f"{model.template_upstream_name!r} -- template drift?"
+                )
         LOCAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
         LOCAL_CONFIG.write_text(yaml.safe_dump(placeholder, sort_keys=False))
         LOCAL_CONFIG.chmod(0o600)

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -324,6 +324,145 @@ class TestCliproxyOauthAgentsForLaunch:
         assert len(descriptions) == 3
 
 
+class TestCliproxyOauthWriteConfig:
+    """write_config() had zero direct test coverage before this class --
+    added alongside the per-model reasoning-effort feature (effort_map),
+    since a config-writing method with no tests is exactly where a
+    silent-no-op or wrong-mutation regression would go unnoticed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _redirect_paths(self, tmp_path, monkeypatch):
+        import connectors.providers.cliproxy_oauth as mod
+
+        tracked_config = tmp_path / "tracked-config.yaml"
+        tracked_config.write_text(
+            yaml.safe_dump(
+                {
+                    "api-keys": ["REPLACE_WITH_YOUR_OWN_INBOUND_KEY"],
+                    "deus-model-map": {},
+                    "default-model-alias": "",
+                    "payload": {
+                        "override": [
+                            {
+                                "models": [
+                                    {"name": "gpt-5.6-sol", "protocol": "codex"}
+                                ],
+                                "params": {"reasoning.effort": "high"},
+                            },
+                            {
+                                "models": [
+                                    {"name": "gpt-5.6-terra", "protocol": "codex"}
+                                ],
+                                "params": {"reasoning.effort": "high"},
+                            },
+                            {
+                                "models": [
+                                    {"name": "gpt-5.6-luna", "protocol": "codex"}
+                                ],
+                                "params": {"reasoning.effort": "xhigh"},
+                            },
+                        ]
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+        monkeypatch.setattr(mod, "TRACKED_CONFIG", tracked_config)
+        monkeypatch.setattr(mod, "LOCAL_CONFIG", tmp_path / "config.local.yaml")
+        monkeypatch.setattr(mod, "PLIST_PATH", tmp_path / "test.plist")
+        self.mod = mod
+        self.handler = mod.CliproxyOauthSetupHandler(mod.CliproxyOauthConnector())
+
+    def _base_values(self, **overrides):
+        values = {
+            "inbound_key": "real-key",
+            "model_map": {"deus-gpt-sol": "sol"},
+            "default_model_alias": "sol",
+            "binary_path": "/usr/local/bin/cli-proxy-api",
+        }
+        values.update(overrides)
+        return values
+
+    def _written_overrides(self):
+        written = yaml.safe_load(self.mod.LOCAL_CONFIG.read_text())
+        by_name = {}
+        for rule in written["payload"]["override"]:
+            name = rule["models"][0]["name"]
+            by_name[name] = rule["params"]["reasoning.effort"]
+        return by_name
+
+    def test_effort_map_omitted_leaves_template_defaults(self):
+        self.handler.write_config(self._base_values())
+        assert self._written_overrides() == {
+            "gpt-5.6-sol": "high",
+            "gpt-5.6-terra": "high",
+            "gpt-5.6-luna": "xhigh",
+        }
+
+    def test_effort_map_with_one_subagent_only_changes_that_entry(self):
+        self.handler.write_config(
+            self._base_values(effort_map={"deus-gpt-luna": "low"})
+        )
+        assert self._written_overrides() == {
+            "gpt-5.6-sol": "high",
+            "gpt-5.6-terra": "high",
+            "gpt-5.6-luna": "low",
+        }
+
+    def test_invalid_effort_level_raises(self):
+        with pytest.raises(ValueError, match="invalid effort level"):
+            self.handler.write_config(
+                self._base_values(effort_map={"deus-gpt-sol": "bogus"})
+            )
+
+    def test_unknown_subagent_key_raises_not_silently_skipped(self):
+        with pytest.raises(ValueError, match="unknown subagent"):
+            self.handler.write_config(
+                self._base_values(effort_map={"deus-gpt-solo": "high"})
+            )
+
+    def test_missing_override_entry_raises_not_silently_skipped(self, tmp_path, monkeypatch):
+        # A template whose payload.override drifted (e.g. an entry got
+        # dropped or its name renamed) must not let write_config() silently
+        # write a config where the requested effort was never applied.
+        drifted_config = tmp_path / "drifted-tracked-config.yaml"
+        drifted_config.write_text(
+            yaml.safe_dump(
+                {
+                    "api-keys": ["REPLACE_WITH_YOUR_OWN_INBOUND_KEY"],
+                    "deus-model-map": {},
+                    "default-model-alias": "",
+                    "payload": {
+                        "override": [
+                            {
+                                "models": [
+                                    {"name": "gpt-5.6-sol", "protocol": "codex"}
+                                ],
+                                "params": {"reasoning.effort": "high"},
+                            },
+                            # terra's entry is missing entirely -- simulates
+                            # template drift.
+                            {
+                                "models": [
+                                    {"name": "gpt-5.6-luna", "protocol": "codex"}
+                                ],
+                                "params": {"reasoning.effort": "xhigh"},
+                            },
+                        ]
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+        monkeypatch.setattr(self.mod, "TRACKED_CONFIG", drifted_config)
+
+        with pytest.raises(ValueError, match="template drift"):
+            self.handler.write_config(
+                self._base_values(effort_map={"deus-gpt-terra": "low"})
+            )
+
+
 class TestTrackedConfigPickerDiscoveryAliases:
     """Regression coverage for a documentation-only invariant that has no
     other enforcement: each claude-gpt-* picker-discovery alias's `name`
@@ -354,6 +493,40 @@ class TestTrackedConfigPickerDiscoveryAliases:
                 f"{discovery_alias}'s name ({by_alias[discovery_alias]!r}) must "
                 f"match {plain_alias}'s name ({by_alias[plain_alias]!r})"
             )
+
+    def test_payload_override_names_match_oauth_alias_twins(self):
+        """Same invariant, same enforcement gap, for the reasoning-effort
+        feature's payload.override block: each entry's models[].name must
+        match GPT_MODELS.template_upstream_name, which must itself equal
+        the real upstream name registered for that subagent's alias under
+        oauth-model-alias.codex[] -- or the override silently stops
+        matching any real request. Catches drift in the tracked template
+        itself, same as the discovery-alias test above.
+        """
+        import connectors.providers.cliproxy_oauth as mod
+
+        cfg = yaml.safe_load(mod.TRACKED_CONFIG.read_text())
+        oauth_names = {
+            e["alias"]: e["name"] for e in cfg["oauth-model-alias"]["codex"]
+        }
+        deus_model_map = cfg["deus-model-map"]
+        by_override_name = {
+            rule["models"][0]["name"]: rule for rule in cfg["payload"]["override"]
+        }
+
+        for model in mod.GPT_MODELS:
+            alias = deus_model_map[model.subagent_name]
+            assert oauth_names[alias] == model.template_upstream_name, (
+                f"{model.subagent_name}'s alias {alias!r} resolves to upstream "
+                f"name {oauth_names[alias]!r}, but GPT_MODELS declares "
+                f"template_upstream_name={model.template_upstream_name!r}"
+            )
+            assert model.template_upstream_name in by_override_name, (
+                f"missing payload.override entry for {model.template_upstream_name!r}"
+            )
+            rule = by_override_name[model.template_upstream_name]
+            assert rule["models"][0]["protocol"] == "codex"
+            assert rule["params"]["reasoning.effort"] in mod._CODEX_EFFORT_LEVELS
 
 
 class TestWriteLaunchdPlist:

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-13" # auto-bump @1786603249
+last_verified: "2026-08-13" # auto-bump @1786611349
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## Summary
- `deus connect cliproxy-oauth` GPT subagents (deus-gpt-sol/terra/luna) now get their Codex `reasoning.effort` set via CLIProxyAPI's `payload.override` config mechanism. Previously `deus-gpt-luna`'s "max reasoning effort" description was aspirational — nothing enforced it.
- Confirmed live against a running `cli-proxy-api` daemon that `payload.override` force-sets the outbound `reasoning.effort` regardless of what Claude Code itself sends, making Claude Code's own `--agents` `effort` field moot on this path.
- Includes a migration path for already-configured installs (mirrors the existing `claude-gpt-*` discovery-alias precedent in the same skill file — `write-config` rebuilds the config from the template and would discard hand-edited upstream model names, so migration is a manual, name-preserving hand-edit instead).
- `write_config()`'s `effort_map` handling is fail-loud: unknown subagent keys, invalid effort levels, and template drift (a `payload.override` entry that doesn't match any known upstream name) all raise `ValueError` instead of silently no-op'ing.

## Review
- 4 rounds of `plan-reviewer` (Claude + GPT co-gate) during planning — round 1 caught a missing migration path for existing installs, round 2 caught the verification plan itself being destructive (would have run `write-config` against a live config) and a statistically fragile single-sample effort probe. Final round: SHIP on both backends.
- 3 rounds of `code-reviewer` (Claude + GPT + GLM co-gate) — round 1 caught a silent-no-op gap in the `effort_map` mutation loop (fixed). GLM hit a known billing-exhaustion `COULD_NOT_RUN` (fails open by design). Final: SHIP.

## Test plan
- [x] `pytest connectors/tests/` — 48/48 pass (4 new `write_config` cases + a template-invariant drift check, extending existing coverage)
- [x] Live verification against the real running daemon: backed up config, exercised the new migration hand-edit procedure on one real GPT model, sampled effort levels (low: 45/44/45 vs xhigh: 42/64/104 output tokens on an identical prompt — directional signal as designed, not a strict-ordering claim), restored the backup, confirmed daemon healthy afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)