### PR TITLE
fix(deus-connect): widen Codex effort levels to include "max"

### DIFF
--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -101,8 +101,13 @@ default-model-alias: "luna-max"
 # the response change (5 vs 26 output tokens on an identical prompt) when
 # only this override changed. That makes Claude Code's own `--agents`
 # `effort` frontmatter field moot for these three subagents; this is the
-# real, authoritative control. Codex protocol levels: low/medium/high/xhigh
-# (no "max" -- xhigh is the ceiling). The `name` values here MUST match
+# real, authoritative control. Codex's real levels (confirmed via `codex
+# debug models` against the live account catalog): low/medium/high/xhigh/
+# max/ultra on sol and terra, but no "ultra" on luna. This connector only
+# ever writes low/medium/high/xhigh/max -- "ultra" is deliberately left
+# out (not universal across all three models, and its "automatic task
+# delegation" behavior is unverified through this proxy mechanism). The
+# `name` values here MUST match
 # their oauth-model-alias.codex[] plain-alias twin above exactly, same
 # name-sync requirement as the claude-gpt-* picker-discovery twins --
 # `deus connect setup cliproxy-oauth`'s write-config keeps them in sync

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -116,10 +116,20 @@ GPT_MODELS: tuple[GptModelDef, ...] = (
     ),
 )
 
-# CLIProxyAPI's Codex protocol reasoning-effort levels (confirmed against
-# Claude Code's own effort-level table -- Codex has no "max"; "xhigh" is
-# its ceiling). Used to validate effort_map values in write_config().
-_CODEX_EFFORT_LEVELS = ("low", "medium", "high", "xhigh")
+# Codex's real reasoning-effort levels (confirmed via `codex debug
+# models` against the account's own live model catalog -- NOT Claude
+# Code's effort-level table, which was the wrong source for a prior
+# version of this constant and undercounted these levels). The full
+# catalog shows 6 levels on gpt-5.6-sol/terra (low/medium/high/xhigh/
+# max/ultra) but only 5 on gpt-5.6-luna (no "ultra"). "ultra" is
+# deliberately excluded from this shared tuple: it isn't available on
+# all three models, and its catalog description ("automatic task
+# delegation") suggests client-side orchestration behavior that this
+# connector's payload.override raw-JSON-injection mechanism may not be
+# able to replicate through the proxy -- unverified, needs a live probe
+# before trusting it. Used to validate effort_map values in
+# write_config().
+_CODEX_EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
 
 # Must match connectors/cliproxy/config.yaml's literal placeholder exactly.
 # authenticate() bootstraps LOCAL_CONFIG by copying that tracked template

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -410,6 +410,17 @@ class TestCliproxyOauthWriteConfig:
             "gpt-5.6-luna": "low",
         }
 
+    def test_max_effort_level_is_accepted(self):
+        # Regression guard: "max" is a real Codex level (confirmed via
+        # `codex debug models` against the live account catalog, on all
+        # three of sol/terra/luna) that a prior version of this constant
+        # wrongly rejected -- pin it so a future accidental narrowing
+        # back to the 4-level set is caught here, not live.
+        self.handler.write_config(
+            self._base_values(effort_map={"deus-gpt-luna": "max"})
+        )
+        assert self._written_overrides()["gpt-5.6-luna"] == "max"
+
     def test_invalid_effort_level_raises(self):
         with pytest.raises(ValueError, match="invalid effort level"):
             self.handler.write_config(


### PR DESCRIPTION
## Summary
Follow-up to #1181. `_CODEX_EFFORT_LEVELS = ("low", "medium", "high", "xhigh")` was sourced from an illustrative example in Claude Code's own docs, not real Codex capability data -- confirmed wrong via `codex debug models` against the real account model catalog: gpt-5.6-sol/terra/luna actually support up to `max` (all three) and `ultra` (sol/terra only, not luna). The 4-level set shipped actually matched a different, deprecated model (gpt-5.4).

- Widens `_CODEX_EFFORT_LEVELS` to add `"max"` (5 levels, shared across all three subagents since it's universal).
- Deliberately excludes `"ultra"` -- not available on luna, and unverified whether `payload.override`'s raw JSON injection can replicate its "automatic task delegation" behavior through the proxy.
- No default effort level changed (Luna stays `xhigh`) -- this only widens what's accepted.
- Corrects the now-inaccurate "Codex has no max" comments in both `__init__.py` and `config.yaml`.

## Review
- 2 rounds of `plan-reviewer` (Claude + GPT co-gate) -- round 1 caught that the plan's prose overstated luna as having all 6 levels including `ultra` (it only has 5, no `ultra`); fixed and re-verified in round 2. Both SHIP.
- `code-reviewer` (Claude + GPT co-gate; GLM hit its known billing-exhaustion `COULD_NOT_RUN`, fails open by design) -- SHIP, no findings.

## Test plan
- [x] `pytest connectors/tests/` -- 49/49 pass (1 new case: `test_max_effort_level_is_accepted`, confirmed discriminating against the pre-fix 4-level tuple)
- [x] Underlying claim independently verified against the real account's Codex model catalog (`codex debug models`), not assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)