### PR TITLE
feat(cliproxy-oauth): auto-compact GPT-5.6 sessions at their real 272K context window

### DIFF
--- a/connectors/base.py
+++ b/connectors/base.py
@@ -114,7 +114,18 @@ class Connector(ABC):
     def env_for_launch(self) -> dict[str, str]:
         """Env vars for the launching shell only. Never written to
         `~/.claude/settings.json`'s global `env` block — that would leak
-        this redirection into every Claude Code session on the machine."""
+        this redirection into every Claude Code session on the machine.
+
+        One reserved key: `DEUS_CONNECT_SETTINGS_JSON`. If present,
+        `deus-cmd.sh`'s `launch_connect()` forwards its value as
+        `claude --settings <value>` for this one launch only, then unsets
+        it so it can't leak into a nested `deus connect <other-id>` call.
+        Use this for session-scoped Claude Code settings overrides (e.g.
+        forcing `autoCompactEnabled` on for a connector whose routed model
+        has a real, smaller context window) without touching the user's
+        global `~/.claude/settings.json`. Optional — a connector that omits
+        it is unaffected (no `--settings` flag gets appended at all).
+        """
         ...
 
     @abstractmethod

--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -80,6 +80,19 @@ oauth-model-alias:
     - name: "gpt-5.6-luna" # must match the "luna-max" entry's name above exactly
       alias: "claude-gpt-luna"
       display-name: "GPT Luna (max)"
+    # KNOWN GAP: the `claude-` prefix that makes these three discoverable in
+    # /model also means Claude Code's CLAUDE_CODE_MAX_CONTEXT_TOKENS=272000
+    # override (connectors/providers/cliproxy_oauth's env_for_launch(),
+    # correcting for GPT-5.6's real 272K Codex-OAuth context window) does
+    # NOT apply to them -- Claude Code only applies that override to an ID
+    # it can't resolve as a Claude model; a `claude-`-prefixed ID needs
+    # DISABLE_COMPACT too, which disables compaction entirely instead of
+    # correcting its threshold. A user who reaches a GPT model via these
+    # picker-discovery aliases (rather than the primary deus-gpt-sol/
+    # terra/luna subagent dispatch, which correctly gets the override via
+    # its own plain "sol"/"terra"/"luna-max" model field) is NOT protected
+    # by that override. See the full case-by-case citation in cliproxy_
+    # oauth's env_for_launch().
 
 # Deus-specific: maps the three fixed `deus connect` subagent names
 # (connectors/providers/cliproxy_oauth's GPT_MODELS) to the

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -219,6 +219,73 @@ class CliproxyOauthConnector(Connector):
             # existed. Not in launch_connect()'s ambient-var clear list, so
             # it passes through eval "$env_output" unaffected.
             "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+            # GPT-5.6 Sol/Terra/Luna have a real, server-enforced 272,000-
+            # token context window when reached through Codex OAuth (this
+            # connector's mechanism) -- confirmed directly against this
+            # account's live model catalog and independently corroborated
+            # by an OpenAI Codex maintainer statement (github.com/openai/
+            # codex#19464: "this is not something you can work around by
+            # making client-side adjustments... needs to be implemented
+            # server-side") and a CLIProxyAPI maintainer statement on this
+            # exact model family (github.com/router-for-me/CLIProxyAPI
+            # #4195). No config/proxy override changes this -- it is not a
+            # display artifact.
+            #
+            # Claude Code determines auto-compact's threshold by pattern-
+            # matching the model ID against three cases (verified verbatim
+            # against code.claude.com/docs/en/model-config "Correct the
+            # window for a gateway or custom model ID"): (1) an ID with no
+            # `claude-` prefix, no `[1m]` suffix, and unresolvable to a
+            # Claude model -> this override applies directly; (2) same but
+            # with `[1m]` -> needs CLAUDE_CODE_DISABLE_1M_CONTEXT too
+            # (not our case); (3) an ID that starts with `claude-` or
+            # resolves to a Claude model -> this override is IGNORED unless
+            # DISABLE_COMPACT is also set (which disables compaction
+            # entirely, not what we want).
+            #
+            # Each dispatched subagent (deus-gpt-sol/terra/luna, via
+            # agents_for_launch() below) runs in its own context window
+            # keyed to ITS OWN "model" field -- the plain aliases
+            # ("sol"/"terra"/"luna-max"), which hit case (1) and get this
+            # override correctly. That is the primary, intended path this
+            # override exists for.
+            #
+            # Known, NOT-fully-covered gap: connectors/cliproxy/config.yaml
+            # also configures `claude-gpt-sol`/`terra`/`luna` picker-
+            # discovery aliases (deliberately `claude-`-prefixed so
+            # CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY surfaces them in
+            # the /model picker) and a separate real-Claude-model leg
+            # (`claude-api-key` -> "opus-planner", for `opus-planner`).
+            # `opus-planner` itself is NOT `claude-`-prefixed and Claude
+            # Code cannot resolve that opaque proxy alias to a real Claude
+            # model -- so it hits case (1) too, meaning if a user ever
+            # `/model`-switches to `opus-planner` mid-session, it
+            # INCORRECTLY inherits this 272K cap (a real Claude model
+            # artificially throttled). Conversely, the `claude-gpt-*`
+            # picker-discovery aliases hit case (3) -- this override does
+            # NOT apply to them at all, so a user reaching a GPT model via
+            # the /model picker (rather than subagent dispatch) gets NO
+            # correction and is exposed to the original silent-wrong-
+            # threshold problem this override exists to fix. Both gaps are
+            # scoped to manual /model-switching only, not the primary
+            # dispatched-subagent path, and are not fixed by this override
+            # -- Claude Code has no mechanism to resolve an opaque proxy
+            # alias to its real upstream model or context window.
+            "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "272000",
+            # Forces auto-compact on for this connector's launched session,
+            # overriding the user's global ~/.claude/settings.json
+            # (autoCompactEnabled: false is a deliberate host-wide choice
+            # for normal Claude usage, left untouched). Consumed by
+            # deus-cmd.sh's launch_connect() via the DEUS_CONNECT_SETTINGS_
+            # JSON reserved key (connectors/base.py's env_for_launch()
+            # docstring) -- forwarded as `claude --settings <value>` for
+            # this one launch only. Session-wide, with no per-subagent
+            # override (Claude Code has no such mechanism) -- so any
+            # portion of the session using a real Claude model (e.g.
+            # `opus-planner`) also auto-compacts more eagerly than the
+            # user's global default would, independent of the context-
+            # window gaps documented above.
+            "DEUS_CONNECT_SETTINGS_JSON": '{"autoCompactEnabled": true}',
         }
 
     def agents_for_launch(self) -> dict[str, Any]:

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -244,6 +244,8 @@ class TestCliproxyOauthEnvForLaunch:
             "ANTHROPIC_API_KEY": "",
             "ANTHROPIC_MODEL": "sol",
             "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+            "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "272000",
+            "DEUS_CONNECT_SETTINGS_JSON": '{"autoCompactEnabled": true}',
         }
 
     def test_gateway_discovery_key_present_even_when_unconfigured(self):
@@ -254,6 +256,19 @@ class TestCliproxyOauthEnvForLaunch:
         c = self.mod.CliproxyOauthConnector()
         env = c.env_for_launch()
         assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+
+    def test_context_window_and_autocompact_keys_present(self):
+        # GPT-5.6 Sol/Terra/Luna have a real, server-enforced 272,000-token
+        # context window via Codex OAuth (confirmed against this account's
+        # live model catalog + independent OpenAI/CLIProxyAPI maintainer
+        # statements). These two keys correct Claude Code's auto-compact
+        # threshold for the unrecognized model aliases and force
+        # auto-compact on for this connector's session only, without
+        # touching the user's global ~/.claude/settings.json.
+        c = self.mod.CliproxyOauthConnector()
+        env = c.env_for_launch()
+        assert env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "272000"
+        assert env["DEUS_CONNECT_SETTINGS_JSON"] == '{"autoCompactEnabled": true}'
 
 
 class TestCliproxyOauthAgentsForLaunch:

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -129,7 +129,7 @@ if [ "$1" = "connect" ]; then
       # miss entirely -- must reject both forms. (deus connect, #1171)
       for _dc_arg in "${DEUS_CONNECT_ARGS[@]}"; do
         case "$_dc_arg" in
-          --agents|--agents=*|--name|--name=*|-n)
+          --agents|--agents=*|--name|--name=*|-n|--settings|--settings=*)
             echo "Error: deus connect already injects $_dc_arg -- pass a different flag." >&2
             exit 1
             ;;
@@ -1445,7 +1445,7 @@ sys.exit(1)
                               # "deus connect <other-id>" call from inside a
                               # tool call).
       local env_output py_exit agents_json agents_py_exit was_implicit
-      local _dc_clear_var
+      local _dc_clear_var settings_args
       was_implicit="$_DEUS_CONNECT_ID_IMPLICIT"
       unset _DEUS_CONNECT_ID_IMPLICIT
       # `--` guards against a leading-dash id reaching argparse as a flag --
@@ -1472,6 +1472,23 @@ sys.exit(1)
       fi
       eval "$env_output"
 
+      # Reserved env-var convention (connectors/base.py's env_for_launch()
+      # docstring): a connector may set DEUS_CONNECT_SETTINGS_JSON to have
+      # its value forwarded as `claude --settings <json>` for this one
+      # launch only -- e.g. cliproxy-oauth uses it to force
+      # autoCompactEnabled on for its GPT-5.6 sessions (272K real context
+      # window) without touching the user's global ~/.claude/settings.json.
+      # Conditional append (mirrors launch_codex()'s codex_args pattern
+      # above) so a connector that never sets it (e.g. ollama) never gets a
+      # bare `--settings ""` appended. Unset immediately after reading, same
+      # leak-prevention rationale as the DEUS_CONNECT_ID unset above -- must
+      # not survive into a nested "deus connect <other-id>" call.
+      settings_args=()
+      if [ -n "$DEUS_CONNECT_SETTINGS_JSON" ]; then
+        settings_args=(--settings "$DEUS_CONNECT_SETTINGS_JSON")
+      fi
+      unset DEUS_CONNECT_SETTINGS_JSON
+
       # Claude Code's own authentication precedence (confirmed against
       # code.claude.com/docs/en/authentication's "Authentication precedence"
       # section, plus code.claude.com/docs/en/amazon-bedrock for Mantle)
@@ -1497,7 +1514,17 @@ sys.exit(1)
       # substring match could false-positive on a connector value that
       # happens to contain the literal text `export ANTHROPIC_AUTH_TOKEN=`
       # elsewhere in the string.
-      for _dc_clear_var in ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY CLAUDE_CODE_USE_MANTLE; do
+      # CLAUDE_CODE_MAX_CONTEXT_TOKENS (added below) isn't an auth-
+      # precedence var like the other five in this list -- it's a
+      # connector-scoped context-window override (see connectors/
+      # providers/cliproxy_oauth's env_for_launch(), 272000 for GPT-5.6's
+      # real Codex-OAuth window) that needs the identical connector-aware
+      # leak-prevention treatment: without it, a NESTED `deus connect
+      # <other-id>` call from inside this launched session would inherit
+      # the outer connector's exported value and apply the wrong threshold
+      # to an unrelated connector's model. Caught by code-reviewer's GPT
+      # backend on this diff.
+      for _dc_clear_var in ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY CLAUDE_CODE_USE_MANTLE CLAUDE_CODE_MAX_CONTEXT_TOKENS; do
         case $'\n'"$env_output" in
           *$'\n'"export ${_dc_clear_var}="*) ;;  # connector set it itself -- leave it
           *) unset "$_dc_clear_var" ;;
@@ -1526,7 +1553,7 @@ sys.exit(1)
       # anywhere in "$@" and execs `claude agents` (Claude's own
       # agent-management TUI) instead of a normal launch if it appears
       # before this point. (deus connect, #1171)
-      launch_claude "$@" --agents "$agents_json" --name "connect:$id (non-Claude)" "${DEUS_CONNECT_ARGS[@]}"
+      launch_claude "$@" --agents "$agents_json" --name "connect:$id (non-Claude)" "${settings_args[@]}" "${DEUS_CONNECT_ARGS[@]}"
       return $?
     }
 

--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1483,6 +1483,7 @@ sys.exit(1)
       # bare `--settings ""` appended. Unset immediately after reading, same
       # leak-prevention rationale as the DEUS_CONNECT_ID unset above -- must
       # not survive into a nested "deus connect <other-id>" call.
+      # Tracked: #1185
       settings_args=()
       if [ -n "$DEUS_CONNECT_SETTINGS_JSON" ]; then
         settings_args=(--settings "$DEUS_CONNECT_SETTINGS_JSON")

--- a/scripts/tests/test_deus_cmd_connect_settings_forward.py
+++ b/scripts/tests/test_deus_cmd_connect_settings_forward.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_deus_connect_rejects_user_supplied_settings_flag():
+    """A user-supplied --settings in deus connect's trailing args would
+    silently override the connector's own DEUS_CONNECT_SETTINGS_JSON
+    injection (passthrough args are appended AFTER the injected ones) --
+    must be rejected the same way --agents/--name/-n already are.
+
+    Static-source assertion (the file is sourced into a running zsh, so this
+    suite verifies the wiring is present, not the runtime branching — that is
+    covered by the manual smoke test documented in the PR)."""
+    script = (ROOT / "deus-cmd.sh").read_text()
+
+    assert "--agents|--agents=*|--name|--name=*|-n|--settings|--settings=*)" in script
+
+
+def test_launch_connect_forwards_settings_json_and_unsets_it():
+    script = (ROOT / "deus-cmd.sh").read_text()
+
+    # Conditional append -- mirrors launch_codex()'s codex_args pattern, so
+    # a connector that never sets DEUS_CONNECT_SETTINGS_JSON (e.g. ollama)
+    # never gets a bare `--settings ""` appended.
+    assert "settings_args=()" in script
+    assert 'if [ -n "$DEUS_CONNECT_SETTINGS_JSON" ]; then' in script
+    assert 'settings_args=(--settings "$DEUS_CONNECT_SETTINGS_JSON")' in script
+    # Unset immediately after reading -- must not leak into a nested
+    # "deus connect <other-id>" call, same rationale as DEUS_CONNECT_ID.
+    assert "unset DEUS_CONNECT_SETTINGS_JSON" in script
+    # The final launch_claude call actually forwards the built array.
+    assert (
+        'launch_claude "$@" --agents "$agents_json" '
+        '--name "connect:$id (non-Claude)" "${settings_args[@]}" '
+        '"${DEUS_CONNECT_ARGS[@]}"' in script
+    )
+
+
+def test_nested_connect_clears_max_context_tokens():
+    # CLAUDE_CODE_MAX_CONTEXT_TOKENS is a connector-scoped override (e.g.
+    # cliproxy-oauth's 272000 for GPT-5.6's real Codex-OAuth context
+    # window), exported into the launcher shell via `eval "$env_output"`.
+    # Without clearing it, a nested `deus connect <other-id>` call from
+    # inside a launched session would inherit the outer connector's value
+    # and apply the wrong threshold to an unrelated connector's model.
+    script = (ROOT / "deus-cmd.sh").read_text()
+
+    assert (
+        "for _dc_clear_var in ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK "
+        "CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY CLAUDE_CODE_USE_MANTLE "
+        "CLAUDE_CODE_MAX_CONTEXT_TOKENS; do" in script
+    )


### PR DESCRIPTION
## Summary
- GPT-5.6 Sol/Terra/Luna have a real, server-enforced 272,000-token context window via Codex OAuth (much smaller than the models' raw 1.05M API spec) — confirmed via direct account instrumentation plus independent OpenAI/CLIProxyAPI maintainer statements.
- Sets `CLAUDE_CODE_MAX_CONTEXT_TOKENS=272000` and forces `autoCompactEnabled` on for the `cliproxy-oauth` connector's launched session only, via a new opt-in `DEUS_CONNECT_SETTINGS_JSON` reserved env-var convention forwarded by `deus-cmd.sh`'s `launch_connect()` as `claude --settings <value>` — the user's global `~/.claude/settings.json` (`autoCompactEnabled: false`) is untouched.
- Fixes a nested-`deus connect`-call env-var leak found by code-reviewer's GPT backend mid-review: `CLAUDE_CODE_MAX_CONTEXT_TOKENS` is now cleared in `launch_connect()`'s existing connector-aware var-clearing loop.
- Documents a known, unfixed gap: the `claude-gpt-*` picker-discovery aliases (surfaced in `/model` for manual switching) don't get this correction, since Claude Code only applies the override to IDs it can't resolve as Claude models — only the primary `deus-gpt-sol/terra/luna` subagent-dispatch path is covered.

## Test plan
- [x] `pytest connectors/tests/ scripts/tests/test_deus_cmd_backend_prefix.py scripts/tests/test_deus_cmd_connect_settings_forward.py -q` — 55 passed
- [x] `pytest connectors/ -q` (full suite, regression check) — 49 passed
- [x] `zsh -n deus-cmd.sh` — syntax clean
- [x] Manual smoke test: `env_for_launch()` against a fixture config confirms both new keys with correct values via the real code path
- [x] plan-reviewer SHIP (claude+gpt co-gate, 2 rounds — original plan + addendum)
- [x] code-reviewer SHIP (claude+gpt co-gate, 2 rounds — caught and fixed a factual comment error + the nested-connect leak; glm backend COULD_NOT_RUN due to real billing exhaustion, fails open per this repo's documented policy)
- [x] verification-gate SHIP (independently re-ran all tests and re-read the diff against all 4 stated requirements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)