### PR TITLE
feat(evolution): make auto-optimize failures loud and detectable (LIA-551)

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -4,6 +4,7 @@ Deus Evolution CLI.
 
 Usage:
     python evolution/cli.py status [--group <folder>]
+    python evolution/cli.py health [--json]
     python evolution/cli.py get_reflections <query_json>
     python evolution/cli.py log_interaction <json>
     python evolution/cli.py reflect <interaction_id>
@@ -23,6 +24,13 @@ from typing import Optional
 
 log = logging.getLogger(__name__)
 
+# Health component namespace (LIA-551). Every optimizer component lives under
+# this prefix; the `evolution.optimizer` rollup is derived live from the rows
+# beneath it and is never itself persisted.
+_OPTIMIZER_HEALTH_PREFIX = "evolution.optimizer."
+_REGISTRY_COMPONENT = _OPTIMIZER_HEALTH_PREFIX + "registry"
+_STORAGE_COMPONENT = _OPTIMIZER_HEALTH_PREFIX + "storage"
+
 # Allow running as a script (python evolution/cli.py) or module (-m evolution.cli)
 if __name__ == "__main__" and __package__ is None:
     _project_root = str(Path(__file__).parent.parent)
@@ -32,6 +40,7 @@ if __name__ == "__main__" and __package__ is None:
 
 
 def cmd_status(group_folder: Optional[str] = None, domain: Optional[str] = None, compare: bool = False, show_tokens: bool = False) -> None:
+    from . import health
     from .ilog.interaction_log import get_recent, score_trend
     from .optimizer.artifacts import list_artifacts
     from .storage import get_storage
@@ -86,7 +95,27 @@ def cmd_status(group_folder: Optional[str] = None, domain: Optional[str] = None,
                 f"n={a['sample_count']}"
             )
     else:
-        print("  No active artifacts. Run `optimize` to generate one.")
+        # This used to say "Run `optimize` to generate one." — which described
+        # an optimizer nobody had tried yet. In reality it had been auto-firing
+        # and crashing on every cycle since ~2026-03 (LIA-551). An empty
+        # artifact list is only good news if the optimizer is actually healthy,
+        # so say which case this is.
+        opt = health.rollup(_OPTIMIZER_HEALTH_PREFIX)
+        if opt["status"] == health.STATUS_FAILED:
+            print("  No active artifacts — the optimizer is FAILING, not idle:")
+            for row in opt["rows"]:
+                if row["last_status"] != health.STATUS_FAILED:
+                    continue
+                since = (row["first_failed_at"] or "?")[:19]
+                print(
+                    f"    [{row['component']}] FAILED "
+                    f"{row['consecutive_failures']}x since {since} — {row['last_reason']}"
+                )
+            print("  Details: python evolution/cli.py health")
+        elif opt["status"] is None:
+            print("  No active artifacts, and no optimizer run has been recorded yet.")
+        else:
+            print("  No active artifacts. Optimizer healthy; nothing cleared the ship margin.")
 
     # Token trend (optional)
     if show_tokens:
@@ -158,30 +187,109 @@ def _maybe_auto_extract_principles(domain_presets: Optional[list] = None) -> Non
 
 
 def _maybe_auto_optimize(domain_presets: Optional[list] = None) -> None:
-    """Auto-trigger DSPy optimization if enough new scored interactions exist."""
+    """Auto-trigger DSPy optimization if enough new scored interactions exist.
+
+    Every outcome past the `AUTO_OPTIMIZE_THRESHOLD <= 0` opt-out below lands
+    in `subsystem_health` (LIA-551) — module enumeration, the storage queries,
+    and each optimize call. This used to be one try/except ending at
+    log.warning, which made "crashed on every cycle for five months" look
+    exactly like "nothing to do" — and a log line here is not an escalation
+    surface anyway (see evolution/health.py for the two measured reasons).
+    Exceptions are never re-raised from any of those paths: this runs on the
+    batch-judge hot path and the live judge/reflexion loop must keep working.
+    """
+    from . import health
     from .config import AUTO_OPTIMIZE_THRESHOLD
+
     if AUTO_OPTIMIZE_THRESHOLD <= 0:
+        # Deliberate operator opt-out, so no row is written. Consequence:
+        # "disabled by config" and "the trigger stopped firing" look identical
+        # in subsystem_health. LIA-552's staleness probe must tell them apart.
         return
 
-    from .storage import get_storage
+    # Hoisted above the below-threshold return so a skip can be recorded for
+    # every module. Safe without dspy: optimizer.modules guards its dspy import
+    # and falls back to plain object subclasses.
+    try:
+        from .optimizer.modules import MODULE_REGISTRY
+        module_names = list(MODULE_REGISTRY)
+    except Exception as exc:
+        # Cannot even enumerate the work. That is an infrastructure failure,
+        # not a skip, and it gets its own component so the derived rollup has
+        # something real to report.
+        detail = f"{type(exc).__name__}: {exc}"
+        health.record_attempt(_REGISTRY_COMPONENT, health.STATUS_FAILED, detail)
+        log.error('evolution: cannot enumerate optimizer modules — %s', detail)
+        return
+    health.record_attempt(_REGISTRY_COMPONENT, health.STATUS_OK)
 
-    store = get_storage()
-    last_ts = store.get_latest_artifact_timestamp() or "1970-01-01"
-    scored_since = store.count_scored_since(last_ts)
+    # Guarded for the same reason as everything else here: if any of these
+    # three raise, the old code wrote no health row AND let the exception
+    # escape to an outer log.warning — this ticket's exact bug, one frame up.
+    try:
+        from .storage import get_storage
+
+        store = get_storage()
+        last_ts = store.get_latest_artifact_timestamp() or "1970-01-01"
+        scored_since = store.count_scored_since(last_ts)
+    except Exception as exc:
+        detail = f"{type(exc).__name__}: {exc}"
+        health.record_attempt(_STORAGE_COMPONENT, health.STATUS_FAILED, detail)
+        log.error('evolution: cannot read optimizer scheduling state — %s', detail)
+        return
+    health.record_attempt(_STORAGE_COMPONENT, health.STATUS_OK,
+                          "completed without error")
 
     if scored_since < AUTO_OPTIMIZE_THRESHOLD:
+        # Records only that a cycle ran and idled. A skip must not carry a
+        # reason: last_reason belongs to attempts, and letting a skip write it
+        # destroyed a real failure's diagnostic cause (caught in review).
+        for module_name in module_names:
+            health.record_skip(_OPTIMIZER_HEALTH_PREFIX + module_name)
         return
 
     try:
         from .optimizer.dspy_optimizer import optimize
-        from .optimizer.modules import MODULE_REGISTRY
-        for module_name in MODULE_REGISTRY:
-            optimize(module=module_name)
-            # Domain-specific optimization if enough domain data
-            for domain in (domain_presets or []):
-                optimize(module=module_name, domain=domain)
     except Exception as exc:
-        log.warning('evolution: auto-optimize failed — %s: %s', type(exc).__name__, exc)
+        detail = f"import optimize: {type(exc).__name__}: {exc}"
+        for module_name in module_names:
+            health.record_attempt(
+                _OPTIMIZER_HEALTH_PREFIX + module_name, health.STATUS_FAILED, detail
+            )
+        log.error('evolution: optimizer unavailable — %s', detail)
+        return
+
+    for module_name in module_names:
+        # Exactly one health write per module, aggregating its cross-domain call
+        # and every domain variant. Writing after each call instead would let a
+        # later domain success overwrite an earlier cross-domain failure and
+        # clear the streak — this ticket's own failure mode, one level down.
+        scopes = [("cross-domain", None)] + [(d, d) for d in (domain_presets or [])]
+        failures = []
+        for scope, domain in scopes:
+            try:
+                if domain is None:
+                    optimize(module=module_name)
+                else:
+                    optimize(module=module_name, domain=domain)
+            except Exception as exc:
+                failures.append(f"{scope}: {type(exc).__name__}: {exc}")
+
+        component = _OPTIMIZER_HEALTH_PREFIX + module_name
+        if failures:
+            detail = "; ".join(failures)
+            health.record_attempt(component, health.STATUS_FAILED, detail)
+            log.error('evolution: auto-optimize failed for %s — %s', module_name, detail)
+        else:
+            # OK means every call for this module returned without raising —
+            # not necessarily that anything was optimized. tool_selection is
+            # permanently excluded (LIA-151: no usable ground truth), so its
+            # optimize() returns early and lands here too. Deliberately not a
+            # separate status: this state machine has already produced two
+            # masking bugs by growing extra states, and the reason string
+            # carries the nuance without adding one.
+            health.record_attempt(component, health.STATUS_OK,
+                                  "completed without error")
 
 
 def _maybe_batch_judge(domain_presets: Optional[list] = None) -> None:
@@ -645,6 +753,48 @@ def cmd_serve() -> None:
     _run_mcp_server()
 
 
+def cmd_health(as_json: bool = False) -> None:
+    """Report subsystem health; exit 1 if anything is FAILED.
+
+    This exit code is the escalation surface for LIA-551 — a log line is not
+    one, for the reasons in evolution/health.py. LIA-552's daily cockpit check
+    and the hourly healthcheck gate on it, so it must stay meaningful.
+    """
+    from . import health
+
+    rows = health.list_all()
+    opt = health.rollup(_OPTIMIZER_HEALTH_PREFIX)
+
+    if as_json:
+        summary = {k: v for k, v in opt.items() if k != "rows"}
+        print(json.dumps(
+            {"rollups": {opt["component"]: summary}, "components": rows},
+            indent=2, default=str,
+        ))
+    else:
+        print("\n=== Subsystem Health ===")
+        if not rows:
+            print("  No health records yet.")
+        for row in rows:
+            # NEVER-ATTEMPTED is deliberately distinct from OK: a component
+            # that has never run is not a healthy one.
+            status = row["last_status"] or "NEVER-ATTEMPTED"
+            print(f"  [{status}] {row['component']}")
+            if row["last_status"] == health.STATUS_FAILED:
+                since = (row["first_failed_at"] or "?")[:19]
+                print(f"      failing {row['consecutive_failures']}x since {since}")
+            if row["last_reason"]:
+                print(f"      reason: {row['last_reason']}")
+            if row["last_attempt_at"]:
+                print(f"      last attempt: {row['last_attempt_at'][:19]}")
+            if row["last_skipped_at"]:
+                print(f"      last skipped: {row['last_skipped_at'][:19]}")
+        print(f"\n  rollup {opt['component']}: {opt['status'] or 'NEVER-ATTEMPTED'}")
+
+    if health.has_failure():
+        sys.exit(1)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(prog="evolution")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -738,6 +888,12 @@ def main() -> None:
     p_consolidate.add_argument("--min-score", type=float, default=0.7, help="Min reflection score (default: 0.7)")
     p_consolidate.add_argument("--force", action="store_true", help="Override minimum count check")
 
+    # health
+    p_health = sub.add_parser(
+        "health", help="Report subsystem health; exit 1 if any component FAILED")
+    p_health.add_argument("--json", dest="as_json", action="store_true",
+                          help="Emit machine-readable JSON")
+
     # serve
     sub.add_parser("serve", help="Start MCP stdio server")
 
@@ -776,6 +932,8 @@ def main() -> None:
 
     if args.cmd == "status":
         cmd_status(group_folder=args.group, domain=args.domain, compare=args.compare, show_tokens=args.tokens)
+    elif args.cmd == "health":
+        cmd_health(as_json=args.as_json)
     elif args.cmd == "get_reflections":
         cmd_get_reflections(args.query_json)
     elif args.cmd == "get_active_prompt":

--- a/evolution/health.py
+++ b/evolution/health.py
@@ -1,0 +1,281 @@
+"""Durable health records for evolution subsystems (LIA-551).
+
+Why this exists: `_maybe_auto_optimize` wrapped its whole body in
+`except Exception: log.warning(...)`, so an optimizer that could not run at all
+was indistinguishable from one with nothing to do. It stayed broken from
+~2026-03 to 2026-08 while the surrounding judge/reflexion loop kept working —
+1,766 judged interactions, 0 prompt artifacts, no signal anywhere.
+
+Escalation deliberately does NOT go through the logger. Two independent reasons,
+both measured:
+  1. `src/evolution-client.ts` flattens all Python child stderr to a hardcoded
+     `logger.warn(...)`, so severity does not survive the process boundary.
+  2. The auto-issue job reads `logs/deus.error.log`, which held 20 warn/error
+     lines while `logs/deus.log` held 8,255 (LIA-553).
+Raising a log level here would therefore change nothing. The durable row below
+and the `health` CLI subcommand's exit code are the escalation surface.
+
+Two design choices worth keeping:
+
+* This does not go through `StorageProvider`. Adding abstract methods would
+  break `FakeStorageProvider` in the tests, and more importantly a mechanism
+  that reports whether the storage-consuming subsystem works should not depend
+  on the abstraction it monitors. It also skips `sqlite_vec` for the same
+  reason — fewer things that can break underneath it.
+* SKIPPED is not a status. `last_status` only ever holds OK, FAILED, or NULL.
+  An earlier design made SKIPPED a third status that preserved the failure
+  counters but still overwrote `last_status`; since the rollup and the exit
+  code both read `last_status`, one below-threshold cycle after a real failure
+  flipped the system back to "healthy" with the failure unresolved. A skip now
+  cannot write a status at all, so it cannot mask a failure — the sharp edge is
+  removed rather than guarded.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from . import config as _config
+
+log = logging.getLogger(__name__)
+
+STATUS_OK = "OK"
+STATUS_FAILED = "FAILED"
+
+# Rank for worst-of aggregation: FAILED > never-attempted > OK.
+#
+# Never-attempted ranks ABOVE OK deliberately. An earlier ordering put it at
+# the bottom, which meant one healthy sibling outranked it and the rollup
+# reported OK while other components had never run at all — a newly added
+# MODULE_REGISTRY entry would have been invisible behind its neighbours. The
+# invariant is that never-attempted is not healthy, so it must survive
+# aggregation. It still does not trigger the failure exit code; only FAILED
+# does, so honesty here costs no false alarms.
+# The absence of a third key is intentional: never-attempted is represented by
+# `last_status` being NULL, and callers reach _RANK_NEVER through the `.get()`
+# default. Do not add `None: 1` here — the lookup is by status value, and a
+# literal None key would shadow nothing while implying the default is unused.
+_STATUS_RANK = {STATUS_FAILED: 2, STATUS_OK: 0}
+_RANK_NEVER = 1
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS subsystem_health (
+    component            TEXT PRIMARY KEY,
+    last_status          TEXT,
+    last_reason          TEXT,
+    last_attempt_at      TEXT,
+    last_skipped_at      TEXT,
+    last_ok_at           TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    first_failed_at      TEXT
+)
+"""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _db_path():
+    """Resolved per call so test monkeypatching of config works, matching the
+    storage provider's lazy-read convention."""
+    return _config.EVOLUTION_DB_PATH
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # timeout=30 + WAL mirror the storage provider: this writes the same file
+    # from a second connection on the batch-judge hot path, immediately after
+    # the provider's own writes.
+    db = sqlite3.connect(path, timeout=30)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute(_SCHEMA)
+    return db
+
+
+def record_attempt(component: str, status: str, reason: Optional[str] = None) -> None:
+    """Record a real optimization attempt. `status` must be OK or FAILED.
+
+    OK is the only thing that clears a failure streak. FAILED increments it and
+    pins `first_failed_at` to the start of the streak.
+    """
+    if status not in (STATUS_OK, STATUS_FAILED):
+        raise ValueError(f"status must be {STATUS_OK} or {STATUS_FAILED}, got {status!r}")
+
+    now = _now()
+    try:
+        db = _connect()
+        try:
+            if status == STATUS_OK:
+                db.execute(
+                    """
+                    INSERT INTO subsystem_health
+                        (component, last_status, last_reason, last_attempt_at,
+                         last_ok_at, consecutive_failures, first_failed_at)
+                    VALUES (?, 'OK', ?, ?, ?, 0, NULL)
+                    ON CONFLICT(component) DO UPDATE SET
+                        last_status          = 'OK',
+                        last_reason          = excluded.last_reason,
+                        last_attempt_at      = excluded.last_attempt_at,
+                        last_ok_at           = excluded.last_ok_at,
+                        consecutive_failures = 0,
+                        first_failed_at      = NULL
+                    """,
+                    (component, reason, now, now),
+                )
+            else:
+                db.execute(
+                    """
+                    INSERT INTO subsystem_health
+                        (component, last_status, last_reason, last_attempt_at,
+                         consecutive_failures, first_failed_at)
+                    VALUES (?, 'FAILED', ?, ?, 1, ?)
+                    ON CONFLICT(component) DO UPDATE SET
+                        last_status          = 'FAILED',
+                        last_reason          = excluded.last_reason,
+                        last_attempt_at      = excluded.last_attempt_at,
+                        consecutive_failures = subsystem_health.consecutive_failures + 1,
+                        first_failed_at      = COALESCE(subsystem_health.first_failed_at,
+                                                        excluded.first_failed_at)
+                    """,
+                    (component, reason, now, now),
+                )
+            db.commit()
+        finally:
+            db.close()
+    except Exception:
+        # Never break the caller: this runs on the batch-judge hot path and the
+        # live judge/reflexion loop must keep working. Logged at ERROR with a
+        # traceback rather than swallowed — the very pattern this module exists
+        # to eliminate. (Reaching a human still depends on LIA-553.)
+        log.error("health: failed to record attempt for %s", component, exc_info=True)
+
+
+def record_skip(component: str) -> None:
+    """Record that a cycle ran but deliberately did no work.
+
+    Touches `last_skipped_at` and nothing else — not `last_status`, not
+    `last_reason`, not the failure counters, not `last_ok_at`. That is what
+    makes a skip structurally incapable of damaging an unresolved failure's
+    record: it can neither flip the status nor overwrite the diagnostic cause.
+    Both were real bugs before this shape.
+
+    Deliberately takes no `reason` argument. There is exactly one skip path
+    (the below-threshold early return in cli.py), so the explanation is
+    constant and derivable from the threshold config. Storing it in a column
+    was tried and produced three further defects — `rollup()` reads
+    `last_reason` only and would have reported None for a skip-only component;
+    the column needed an ALTER TABLE that every reader would execute, adding
+    DDL lock exposure on a concurrently-written file; and it deviated from
+    patterns/eval-change.md. The field is simply not written.
+
+    On the INSERT branch `last_status` is left as SQL NULL, so a
+    never-attempted component is never confused with a healthy one.
+    """
+    now = _now()
+    try:
+        db = _connect()
+        try:
+            db.execute(
+                """
+                INSERT INTO subsystem_health (component, last_skipped_at)
+                VALUES (?, ?)
+                ON CONFLICT(component) DO UPDATE SET
+                    last_skipped_at = excluded.last_skipped_at
+                """,
+                (component, now),
+            )
+            db.commit()
+        finally:
+            db.close()
+    except Exception:
+        log.error("health: failed to record skip for %s", component, exc_info=True)
+
+
+def get(component: str) -> Optional[Dict[str, Any]]:
+    """Return one component's row, or None if it has no row at all."""
+    try:
+        db = _connect()
+        try:
+            row = db.execute(
+                "SELECT * FROM subsystem_health WHERE component = ?", (component,)
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            db.close()
+    except Exception:
+        log.error("health: failed to read %s", component, exc_info=True)
+        return None
+
+
+def list_all(prefix: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Return all rows, optionally restricted to a component prefix."""
+    try:
+        db = _connect()
+        try:
+            if prefix:
+                rows = db.execute(
+                    "SELECT * FROM subsystem_health WHERE component LIKE ? ORDER BY component",
+                    (f"{prefix}%",),
+                ).fetchall()
+            else:
+                rows = db.execute(
+                    "SELECT * FROM subsystem_health ORDER BY component"
+                ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            db.close()
+    except Exception:
+        log.error("health: failed to list rows", exc_info=True)
+        return []
+
+
+def rollup(prefix: str) -> Dict[str, Any]:
+    """Derive a worst-of verdict across every row under `prefix`.
+
+    Computed live and never persisted, so there is no second copy of the truth
+    to drift. Precedence is FAILED > never-attempted > OK, per `_STATUS_RANK`
+    — never-attempted deliberately outranks OK so a component that has never
+    run cannot hide behind a healthy sibling. Do not "correct" this to put OK
+    last without reading the rationale at `_STATUS_RANK`; that ordering was
+    tried and it reintroduced the masking bug.
+    """
+    rows = list_all(prefix)
+    if not rows:
+        return {
+            "component": prefix.rstrip("."),
+            "status": None,
+            "reason": "no health records",
+            "worst_component": None,
+            "consecutive_failures": 0,
+            "rows": [],
+        }
+
+    worst = max(rows, key=lambda r: _STATUS_RANK.get(r["last_status"], _RANK_NEVER))
+    return {
+        "component": prefix.rstrip("."),
+        "status": worst["last_status"],
+        "reason": worst["last_reason"],
+        "worst_component": worst["component"],
+        "consecutive_failures": max(r["consecutive_failures"] or 0 for r in rows),
+        "rows": rows,
+    }
+
+
+def has_failure(prefix: Optional[str] = None) -> bool:
+    """True if any component under `prefix` is currently FAILED; with no
+    prefix, across every component. This is what the `health` subcommand's
+    exit code keys off — see `cmd_health`, which calls it rather than
+    reimplementing the check.
+
+    Known, accepted gap: `list_all()` returns `[]` if the health store itself
+    is unreadable (corrupt DB, disk full), so this reports False — healthy —
+    in that case. It is the read-side mirror of the write-side bug this module
+    fixes. Accepted rather than overlooked: a broken `evolution.db` surfaces
+    loudly through `StorageProvider` on the same hot path, so this is not the
+    only signal. Revisit if that stops being true."""
+    return any(r["last_status"] == STATUS_FAILED for r in list_all(prefix))

--- a/evolution/tests/test_cli_log_interaction.py
+++ b/evolution/tests/test_cli_log_interaction.py
@@ -924,8 +924,12 @@ def test_main_unknown_subcommand_exits_nonzero():
 # ── _maybe_auto_optimize tests ──────────────────────────────────────────────
 
 
-def test_auto_optimize_calls_all_modules(monkeypatch):
-    """_maybe_auto_optimize should call optimize() for every module in MODULE_REGISTRY."""
+def test_auto_optimize_calls_all_modules(test_db, monkeypatch):
+    """_maybe_auto_optimize should call optimize() for every module in MODULE_REGISTRY.
+
+    `test_db` is required since LIA-551: this path now writes subsystem_health
+    rows, and without the fixture they would land in the real ~/.deus/evolution.db.
+    """
     import evolution.config as cfg
     monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
 
@@ -953,7 +957,7 @@ def test_auto_optimize_calls_all_modules(monkeypatch):
     assert "summarization" in called_modules
 
 
-def test_auto_optimize_includes_domain_presets(monkeypatch):
+def test_auto_optimize_includes_domain_presets(test_db, monkeypatch):
     """_maybe_auto_optimize should call optimize() with each domain for every module."""
     import evolution.config as cfg
     monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
@@ -987,7 +991,7 @@ def test_auto_optimize_includes_domain_presets(monkeypatch):
         assert "engineering" in domains, f"{mod} missing engineering domain call"
 
 
-def test_auto_optimize_disabled_when_threshold_zero(monkeypatch):
+def test_auto_optimize_disabled_when_threshold_zero(test_db, monkeypatch):
     """EVOLUTION_AUTO_OPTIMIZE_THRESHOLD=0 should disable auto-optimization."""
     import evolution.config as cfg
     monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 0)
@@ -1001,7 +1005,7 @@ def test_auto_optimize_disabled_when_threshold_zero(monkeypatch):
     assert len(optimize_calls) == 0, "optimize should not be called when threshold is 0"
 
 
-def test_auto_optimize_skips_below_threshold(monkeypatch):
+def test_auto_optimize_skips_below_threshold(test_db, monkeypatch):
     """_maybe_auto_optimize should skip when scored count is below threshold."""
     import evolution.config as cfg
     monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)

--- a/evolution/tests/test_optimizer_health.py
+++ b/evolution/tests/test_optimizer_health.py
@@ -1,0 +1,378 @@
+"""Tests for the optimizer health records (LIA-551).
+
+These exist because the optimizer was dead for ~5 months and nothing noticed.
+Several cases below are direct regressions for defects found during plan
+review — each is labelled with what it protects, because the whole point of
+this module is that a silent failure must never be able to look healthy again.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+import evolution.config as cfg
+from evolution import health
+
+
+OPT = "evolution.optimizer."
+QA = OPT + "qa"
+REGISTRY = OPT + "registry"
+STORAGE = OPT + "storage"
+
+
+@pytest.fixture
+def store_above_threshold(monkeypatch):
+    """Storage reporting enough scored interactions to trigger optimization."""
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+    fake = MagicMock()
+    fake.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake.count_scored_since.return_value = 20
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake)
+    return fake
+
+
+@pytest.fixture
+def store_below_threshold(monkeypatch):
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+    fake = MagicMock()
+    fake.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake.count_scored_since.return_value = 3
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake)
+    return fake
+
+
+def _patch_optimize(monkeypatch, fn):
+    monkeypatch.setattr("evolution.optimizer.dspy_optimizer.optimize", fn)
+
+
+def _run(domain_presets=None):
+    from evolution.cli import _maybe_auto_optimize
+    _maybe_auto_optimize(domain_presets=domain_presets)
+
+
+# ── the core failure path ────────────────────────────────────────────────────
+
+
+def test_failure_is_recorded_and_not_propagated(test_db, store_above_threshold, monkeypatch):
+    """A crashing optimizer must leave a durable FAILED record and must not
+    break the caller — the batch-judge hot path has to keep working."""
+    def boom(module="qa", **kw):
+        raise RuntimeError("dspy exploded")
+    _patch_optimize(monkeypatch, boom)
+
+    _run()  # must not raise
+
+    row = health.get(QA)
+    assert row is not None
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "RuntimeError" in row["last_reason"]
+    assert row["consecutive_failures"] == 1
+    assert row["first_failed_at"] is not None
+
+
+def test_consecutive_failures_accumulate(test_db, store_above_threshold, monkeypatch):
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    _run()
+    _run()
+    _run()
+    row = health.get(QA)
+    assert row["consecutive_failures"] == 3
+    # first_failed_at pins the START of the streak, not the latest failure.
+    first = row["first_failed_at"]
+    _run()
+    assert health.get(QA)["first_failed_at"] == first
+
+
+def test_success_clears_the_streak(test_db, store_above_threshold, monkeypatch):
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    _run()
+    assert health.get(QA)["consecutive_failures"] == 1
+
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+
+    row = health.get(QA)
+    assert row["last_status"] == health.STATUS_OK
+    assert row["consecutive_failures"] == 0
+    assert row["first_failed_at"] is None
+    assert row["last_ok_at"] is not None
+
+
+def test_one_failing_module_does_not_block_the_others(test_db, store_above_threshold, monkeypatch):
+    """Regression: the original code wrapped the whole MODULE_REGISTRY loop in
+    a single try, so one module's exception aborted every remaining module."""
+    def selective(module="qa", **kw):
+        if module == "qa":
+            raise RuntimeError("only qa fails")
+    _patch_optimize(monkeypatch, selective)
+
+    _run()
+
+    assert health.get(QA)["last_status"] == health.STATUS_FAILED
+    assert health.get(OPT + "tool_selection")["last_status"] == health.STATUS_OK
+    assert health.get(OPT + "summarization")["last_status"] == health.STATUS_OK
+
+
+# ── skip semantics: a skip must never mask a failure ─────────────────────────
+
+
+def test_skip_touches_only_the_skip_column(test_db, store_below_threshold, monkeypatch):
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+
+    row = health.get(QA)
+    assert row is not None
+    assert row["last_skipped_at"] is not None
+    # A skip is not an attempt, so it must leave every attempt field alone.
+    # last_reason is in this set deliberately: letting a skip write it is what
+    # destroyed a real failure's diagnostic cause before this shape.
+    assert row["last_status"] is None
+    assert row["last_reason"] is None
+    assert row["last_attempt_at"] is None
+    assert row["last_ok_at"] is None
+    assert row["consecutive_failures"] == 0
+
+
+def test_first_ever_write_being_a_skip_leaves_status_sql_null(test_db, store_below_threshold, monkeypatch):
+    """Round-5 review item: the UPSERT's INSERT branch must leave last_status
+    as real SQL NULL, not '' or 0 — a never-attempted component must never be
+    confusable with a healthy one."""
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+
+    assert health.get(QA)["last_status"] is None
+    assert health.rollup(OPT)["status"] is None
+    # ...and NEVER-ATTEMPTED must not count as a failure for the exit code.
+    assert health.has_failure(OPT) is False
+
+
+def test_skip_after_failure_keeps_reporting_failed(test_db, monkeypatch):
+    """THE regression the GPT co-gate caught (round 4).
+
+    The earlier design made SKIPPED a third status that preserved the counters
+    but still overwrote last_status. Since the rollup and the health exit code
+    both read last_status, one quiet cycle after a real failure flipped the
+    system back to healthy with the failure unresolved.
+    """
+    # 1. a genuine failure
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+    fake = MagicMock()
+    fake.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake.count_scored_since.return_value = 20
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake)
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    _run()
+    assert health.rollup(OPT)["status"] == health.STATUS_FAILED
+
+    # 2. a quiet cycle: volume drops below the threshold
+    fake.count_scored_since.return_value = 1
+    _run()
+
+    # 3. the failure must survive it, at BOTH surfaces that decide "healthy"
+    assert health.get(QA)["last_status"] == health.STATUS_FAILED
+    assert health.get(QA)["consecutive_failures"] == 1
+    assert health.rollup(OPT)["status"] == health.STATUS_FAILED
+    assert health.has_failure(OPT) is True
+
+    # 4. and the DIAGNOSTIC CAUSE must survive too, not just the status.
+    #    The code-review co-gate caught this: an earlier record_skip wrote
+    #    last_reason, so a quiet cycle rewrote "RuntimeError: x" to
+    #    "below threshold" — an unresolved failure reported with the wrong
+    #    cause and the evidence gone. The original assertions above all passed
+    #    while that was broken, which is exactly why this one exists.
+    assert "RuntimeError" in health.get(QA)["last_reason"]
+    assert "below threshold" not in (health.get(QA)["last_reason"] or "")
+
+
+def test_raising_the_threshold_cannot_silence_a_failure(test_db, monkeypatch):
+    """The operator-silences-noise path, end to end: bumping the threshold
+    above the available count after a failure must not clear or hide it."""
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+    fake = MagicMock()
+    fake.get_latest_artifact_timestamp.return_value = "1970-01-01"
+    fake.count_scored_since.return_value = 20
+    monkeypatch.setattr("evolution.storage.get_storage", lambda: fake)
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    _run()
+
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10_000)
+    _run()
+    _run()
+
+    assert health.has_failure(OPT) is True
+    assert health.get(QA)["consecutive_failures"] == 1
+
+
+# ── domain-variant aggregation ───────────────────────────────────────────────
+
+
+def test_domain_success_cannot_erase_a_cross_domain_failure(test_db, store_above_threshold, monkeypatch):
+    """Round-3 blocking issue: cross-domain runs first, then each domain, all
+    writing the same row. Writing per call let a later domain success clear a
+    genuine cross-domain failure — every batch, whenever presets are set."""
+    def cross_domain_only_fails(module="qa", **kw):
+        if kw.get("domain") is None:
+            raise RuntimeError("cross-domain broke")
+    _patch_optimize(monkeypatch, cross_domain_only_fails)
+
+    _run(domain_presets=["marketing", "engineering"])
+
+    row = health.get(QA)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "cross-domain" in row["last_reason"]
+    assert row["consecutive_failures"] == 1
+
+
+def test_exactly_one_health_write_per_module_per_invocation(test_db, store_above_threshold, monkeypatch):
+    """Aggregate-then-write, regardless of how many domain presets exist."""
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+
+    calls = []
+    real = health.record_attempt
+    def counting(component, status, reason=None):
+        calls.append(component)
+        return real(component, status, reason)
+    monkeypatch.setattr("evolution.health.record_attempt", counting)
+
+    _run(domain_presets=["a", "b", "c"])
+
+    # 3 modules + the registry and storage components, and nothing more.
+    assert sorted(calls) == sorted(
+        [REGISTRY, STORAGE, QA, OPT + "tool_selection", OPT + "summarization"]
+    )
+
+
+# ── enumeration health ───────────────────────────────────────────────────────
+
+
+def test_registry_import_failure_is_failed_not_silent(test_db, store_above_threshold, monkeypatch):
+    """If we cannot even enumerate the work, that is an infrastructure failure
+    and must surface — not look like an idle cycle."""
+    class Exploding:
+        def __iter__(self):
+            raise ImportError("no dspy for you")
+    monkeypatch.setattr("evolution.optimizer.modules.MODULE_REGISTRY", Exploding())
+
+    _run()
+
+    row = health.get(REGISTRY)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "ImportError" in row["last_reason"]
+    # and it reaches the derived rollup, so it has a real consumer
+    assert health.rollup(OPT)["status"] == health.STATUS_FAILED
+    assert health.has_failure(OPT) is True
+
+
+def test_registry_self_heals_on_the_next_good_run(test_db, store_above_threshold, monkeypatch):
+    class Exploding:
+        def __iter__(self):
+            raise ImportError("boom")
+
+    # Scoped context, NOT monkeypatch.undo(). undo() reverses EVERY patch
+    # registered on this monkeypatch instance — including the test_db
+    # fixture's redirect of EVOLUTION_DB_PATH — so the _run() after it wrote
+    # OK rows straight into the real ~/.deus/evolution.db. Not merely untidy:
+    # an OK write zeroes consecutive_failures and clears first_failed_at, so
+    # running the suite could erase a genuine production failure streak —
+    # exactly the state this module exists to protect. Caught by the
+    # code-review co-gate; it also explains four stray OK rows that appeared
+    # in the live DB while this ticket was being developed.
+    with monkeypatch.context() as scoped:
+        scoped.setattr("evolution.optimizer.modules.MODULE_REGISTRY", Exploding())
+        _run()
+        assert health.get(REGISTRY)["last_status"] == health.STATUS_FAILED
+
+    # Outside the context MODULE_REGISTRY is real again, while test_db's
+    # redirect — and every other fixture patch — remains in force.
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+
+    assert health.get(REGISTRY)["last_status"] == health.STATUS_OK
+
+
+def test_storage_query_failure_is_recorded_not_swallowed(test_db, monkeypatch):
+    """Round-3 code review: the storage queries that decide whether to run at
+    all were unguarded. If they raised, no health row was written AND the
+    exception escaped to an outer log.warning — this ticket's own bug, one
+    frame up, on a path the docstring claimed was covered."""
+    monkeypatch.setattr(cfg, "AUTO_OPTIMIZE_THRESHOLD", 10)
+
+    def exploding_storage():
+        raise RuntimeError("evolution.db is locked")
+    monkeypatch.setattr("evolution.storage.get_storage", exploding_storage)
+
+    _run()  # must not raise
+
+    row = health.get(STORAGE)
+    assert row is not None, "a storage failure left no health record"
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "RuntimeError" in row["last_reason"]
+    assert health.rollup(OPT)["status"] == health.STATUS_FAILED
+    assert health.has_failure() is True
+
+
+def test_storage_component_self_heals(test_db, store_above_threshold, monkeypatch):
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+    assert health.get(STORAGE)["last_status"] == health.STATUS_OK
+
+
+# ── the escalation surface ───────────────────────────────────────────────────
+
+
+def test_health_command_exits_nonzero_on_failure(test_db, store_above_threshold, monkeypatch):
+    from evolution.cli import cmd_health
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    _run()
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_health()
+    assert exc.value.code == 1
+
+
+def test_health_command_exits_zero_when_clean(test_db, store_above_threshold, monkeypatch):
+    from evolution.cli import cmd_health
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+
+    cmd_health()  # must not raise SystemExit
+
+
+def test_health_json_is_machine_readable(test_db, store_above_threshold, monkeypatch, capsys):
+    import json
+    from evolution.cli import cmd_health
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: None)
+    _run()
+
+    cmd_health(as_json=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert "components" in payload and "rollups" in payload
+
+
+def test_status_names_the_failure_instead_of_suggesting_optimize(
+    test_db, store_above_threshold, monkeypatch, capsys
+):
+    """The old message read 'Run `optimize` to generate one.' while the
+    optimizer was crashing on every cycle. An empty artifact list is only good
+    news if the optimizer is healthy."""
+    from evolution.cli import cmd_status
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    _run()
+
+    cmd_status()
+    out = capsys.readouterr().out
+    assert "FAILING, not idle" in out
+    assert "Run `optimize` to generate one." not in out
+
+
+# ── anti-regression ──────────────────────────────────────────────────────────
+
+
+def test_a_failure_always_leaves_a_record(test_db, store_above_threshold, monkeypatch):
+    """Guard against anyone reinstating a bare log-and-continue. If the except
+    path stops recording, this fails."""
+    _patch_optimize(monkeypatch, lambda module="qa", **kw: (_ for _ in ()).throw(ValueError("nope")))
+
+    _run()
+
+    rows = health.list_all(OPT)
+    assert rows, "a failing optimizer left no health record at all"
+    assert any(r["last_status"] == health.STATUS_FAILED for r in rows)

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-02" # auto-bump @1785674769
+last_verified: "2026-08-15" # auto-bump @1786751042
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-02" # auto-bump @1785674769
+last_verified: "2026-08-15" # auto-bump @1786751042
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
Closes LIA-551.

## The problem

The DSPy/GEPA optimizer arm has been non-functional since ~2026-03 and nothing surfaced it. Measured against the live DB on 2026-08-15:

| Signal | Value |
|---|---|
| `interactions` | 1,770 |
| with `judge_score` | 1,766 |
| `reflections` | 1,994 |
| `prompt_artifacts` | **0** |

The ingest → judge → reflexion half runs on real traffic. The optimize → artifact → activate half has produced nothing, for five months, with no signal anywhere.

**Root cause of the silence** (not of the breakage): `_maybe_auto_optimize` wrapped its entire body in `except Exception: log.warning(...)`. It auto-fires every 5 interactions and is enabled by default (`AUTO_OPTIMIZE_THRESHOLD=15`), so "cannot run at all" looked exactly like "nothing to do".

Worse, the one place you'd naturally look actively reassured you: `cmd_status` printed *"No active artifacts. Run `optimize` to generate one."* — describing an optimizer nobody had tried, while it was in fact crashing on every cycle.

## Why logging is not the fix

Two independently measured reasons, both verified in this branch's investigation:

1. `src/evolution-client.ts` flattens **all** Python child stderr to a hardcoded `logger.warn` regardless of the Python-side level, so severity does not survive the process boundary.
2. The auto-issue job reads `logs/deus.error.log`, which holds **20** warn/error lines, while `logs/deus.log` holds **8,255** (tracked separately as LIA-553).

Raising a log level here would change nothing. The durable health row and the `health` subcommand's exit code are the escalation surface.

## Changes

- **New `evolution/health.py`** — a `subsystem_health` table recording per-component status, failure streak, and first-failure timestamp. Deliberately outside `StorageProvider` and `sqlite_vec`: a fail-loud mechanism should not depend on the abstraction it monitors. `timeout=30` + WAL match the storage provider, since this writes the same file from a second connection on the batch-judge hot path.
- **`_maybe_auto_optimize` restructured** — each `optimize()` call gets its own try/except, so one module's failure no longer aborts the rest. Exactly one worst-of health write per module, so a later domain success cannot erase an earlier cross-domain failure. Storage queries and module enumeration are guarded too, each with its own component.
- **`cmd_status` tells the truth** — when the optimizer is failing it names the failure, the count, and since when.
- **New `evolution/cli.py health [--json]`** — per-component status, exit 1 on any FAILED, so LIA-552's daily check and the hourly healthcheck can gate on it.

## Design decisions worth keeping

**SKIPPED is not a status.** A skip writes only its timestamp, so a quiet cycle can neither flip a FAILED status nor overwrite its diagnostic cause. Both were real bugs found in review — the first preserved the failure counters but overwrote the status; the second preserved the status but destroyed the cause. Removing the shared field beat guarding it.

**Never-attempted outranks OK in the rollup**, so a newly added module cannot hide behind healthy siblings. It does not trigger the failure exit code, so honesty costs no false alarms.

## Scope: detection only

Deliberately **not** fixing the missing `dspy`, the missing `reflection_lm`, or the `EVOLUTION_OPTIMIZED_PROMPTS` flag. The optimizer's holdout is a rolling chronological slice of the same production window (`dspy_optimizer.py:283-287`, train = newest 80% / dev = oldest 20%, re-derived each run). Re-enabling before a frozen holdout risks repeating the 2026-03-30 artifact — `baseline 0.77 → optimized 1.0` produced under a `len(pred) > 20` metric.

## A production data-integrity bug fixed along the way

`test_registry_self_heals_on_the_next_good_run` used `monkeypatch.undo()`, which reverses **every** patch on that fixture — including the `test_db` redirect of `EVOLUTION_DB_PATH`. Every full suite run therefore wrote health records into the real `~/.deus/evolution.db`.

Not merely stray data: an `OK` write zeroes `consecutive_failures` and clears `first_failed_at`, so running the test suite could erase a genuine production failure streak — via the module built to preserve it. It also explains five stray `OK` rows that appeared in the live DB during development with no known cause.

Fixed with a scoped `monkeypatch.context()`. **Proven, not assumed:** snapshotted the live `subsystem_health` table, ran all 835 tests, re-snapshotted — byte-identical including timestamps. Before the fix the same check showed all five rows rewritten on every run.

## Verification

- **Tests:** 835 passed, 2 skipped, 0 failed.
- **Natural end-to-end with the REAL optimizer** (failure not mocked): `qa` and `summarization` recorded FAILED carrying the genuine `ImportError: dspy is required for prompt optimization`; `registry`, `storage`, `tool_selection` OK; rollup FAILED; `evolution/cli.py health` exited 1.
- **Live-DB isolation:** proven identical before/after a full suite run; independently reconfirmed by review via unchanged file sha256.

Note: `test_judge_registry.py::test_default_model_reads_from_config` fails locally when `EVOLUTION_OLLAMA_JUDGE_MODEL` is set in the shell, overriding the `config.py:44` default the test asserts. Confirmed pre-existing on `origin/main` and unrelated; CI sets no such variable.

## Review

Plan review: 5 rounds + 3 delta rounds, co-gate PASS across claude and gpt.
Code review: 5 rounds, co-gate PASS across claude and gpt.
GLM backend returned `COULD_NOT_RUN` (HTTP 429, "Insufficient balance or no resource package") — fails open by design; two independent backends reviewed and SHIPped.

Ten defects were caught across those cycles, three of them by the second backend after the first had said SHIP.

## Deferred to follow-ups, deliberately

- A systemic autouse conftest guard failing any test whose `EVOLUTION_DB_PATH` points at the real `~/.deus` path — would prevent that whole class, but touches shared fixtures for every evolution test.
- `_maybe_auto_extract_principles` has the identical swallow-and-log-warning pattern, untouched by this ticket.
- `rollup()`'s `status is None` is ambiguous between "zero rows" and "all never-attempted"; cosmetic, cannot mask a FAILED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
