### PR TITLE
fix(startup-gate): log the startup banner at its own severity, not error

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-15" # auto-bump @1786751042
+last_verified: "2026-08-15" # auto-bump @1786788311
 governs:
   - src/
   - evolution/

--- a/src/startup-gate.test.ts
+++ b/src/startup-gate.test.ts
@@ -379,7 +379,30 @@ describe('printStartupReport', () => {
 
   beforeEach(() => {
     mockLogger.error.mockClear();
+    mockLogger.warn.mockClear();
+    mockLogger.info.mockClear();
   });
+
+  // The banner's level now depends on its worst finding (LIA-553), so the
+  // content assertions below read from whichever level was used. Only the
+  // dedicated severity tests at the end care which one that is.
+  function bannerLines(): string[] {
+    return [
+      ...mockLogger.error.mock.calls,
+      ...mockLogger.warn.mock.calls,
+      ...mockLogger.info.mock.calls,
+    ].flat() as string[];
+  }
+
+  function allOutput(): string {
+    return bannerLines().join('\n');
+  }
+
+  function expectSilent(): void {
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  }
 
   function makeReport(
     overrides: Partial<StartupCheckReport> = {},
@@ -398,7 +421,7 @@ describe('printStartupReport', () => {
       { name: 'API credentials', level: 'fatal', ok: true, hint: '' },
     ];
     printStartupReport(makeReport({ passed }));
-    expect(mockLogger.error).not.toHaveBeenCalled();
+    expectSilent();
   });
 
   it('prints nothing when fatals/warnings/suggestions are all empty even with passed items', () => {
@@ -407,7 +430,7 @@ describe('printStartupReport', () => {
       { name: 'Check B', level: 'warn', ok: true, hint: '' },
     ];
     printStartupReport(makeReport({ passed }));
-    expect(mockLogger.error).not.toHaveBeenCalled();
+    expectSilent();
   });
 
   it('uses "FAILED" in the title when there are fatals', () => {
@@ -420,7 +443,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ fatals }));
-    const allCalls = mockLogger.error.mock.calls.flat().join('\n');
+    const allCalls = allOutput();
     expect(allCalls).toContain('FAILED');
   });
 
@@ -440,7 +463,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ fatals }));
-    const allCalls = mockLogger.error.mock.calls.flat().join('\n');
+    const allCalls = allOutput();
     expect(allCalls).toContain('2 fatal error(s)');
     expect(allCalls).toContain('cannot start');
   });
@@ -455,7 +478,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ warnings }));
-    const allCalls = mockLogger.error.mock.calls.flat().join('\n');
+    const allCalls = allOutput();
     expect(allCalls).toContain('running with limited functionality');
     expect(allCalls).not.toContain('FAILED');
   });
@@ -470,7 +493,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ suggestions }));
-    const allCalls = mockLogger.error.mock.calls.flat().join('\n');
+    const allCalls = allOutput();
     expect(allCalls).toContain('running with limited functionality');
   });
 
@@ -484,7 +507,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ warnings }));
-    const calls = mockLogger.error.mock.calls.flat();
+    const calls = bannerLines();
     expect(calls[0]).toMatch(/^╔/);
     expect(calls[calls.length - 1]).toMatch(/^╚/);
   });
@@ -499,7 +522,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ warnings }));
-    const calls = mockLogger.error.mock.calls.flat();
+    const calls = bannerLines();
     const widths = calls.map((line) => [...(line as string)].length);
     const first = widths[0];
     for (const w of widths) {
@@ -517,7 +540,7 @@ describe('printStartupReport', () => {
       },
     ];
     printStartupReport(makeReport({ fatals }));
-    const allCalls = mockLogger.error.mock.calls.flat().join('\n');
+    const allCalls = allOutput();
     expect(allCalls).toContain('✗');
   });
 
@@ -529,7 +552,7 @@ describe('printStartupReport', () => {
       { name: 'Channels', level: 'suggest', ok: false, hint: 'No channels' },
     ];
     printStartupReport(makeReport({ passed, suggestions }));
-    const allCalls = mockLogger.error.mock.calls.flat().join('\n');
+    const allCalls = allOutput();
     expect(allCalls).toContain('✓');
   });
 
@@ -540,11 +563,64 @@ describe('printStartupReport', () => {
       { name: 'Memory vault', level: 'warn', ok: false, hint: longHint },
     ];
     printStartupReport(makeReport({ warnings }));
-    const calls = mockLogger.error.mock.calls.flat();
+    const calls = bannerLines();
     const widths = calls.map((line) => [...(line as string)].length);
     const expectedWidth = widths[0]; // take from border line
     for (const w of widths) {
       expect(w).toBe(expectedWidth);
     }
+  });
+
+  // ── severity mapping (LIA-553) ──────────────────────────────────────────
+  //
+  // The banner used to go out entirely at error level, which made 46% of all
+  // ERROR records in deus.log non-errors — measured over 161 startup events,
+  // every one of them a suggestion-level "No groups registered yet". These
+  // three tests pin the level to the report's worst finding so that noise
+  // cannot come back, and so a genuinely fatal banner is never demoted.
+
+  it('logs at error level when there are fatals', () => {
+    const fatals: CheckResult[] = [
+      { name: 'API credentials', level: 'fatal', ok: false, hint: 'Set a key' },
+    ];
+    printStartupReport(makeReport({ fatals }));
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it('logs at warn level when there are warnings but no fatals', () => {
+    const warnings: CheckResult[] = [
+      { name: 'Memory vault', level: 'warn', ok: false, hint: 'Not found' },
+    ];
+    const suggestions: CheckResult[] = [
+      { name: 'Channels', level: 'suggest', ok: false, hint: 'No channels' },
+    ];
+    printStartupReport(makeReport({ warnings, suggestions }));
+    expect(mockLogger.warn).toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it('logs at info level when there are only suggestions', () => {
+    // The production case: 160 of 161 real startups took this path and were
+    // logged as errors.
+    const suggestions: CheckResult[] = [
+      {
+        name: 'Registered groups',
+        level: 'suggest',
+        ok: false,
+        hint: 'No groups registered yet. Use /setup to add your first',
+      },
+    ];
+    const passed: CheckResult[] = [
+      { name: 'API credentials', level: 'fatal', ok: true, hint: '' },
+    ];
+    printStartupReport(makeReport({ suggestions, passed }));
+    expect(mockLogger.info).toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    // and the whole banner went to that one level, not just part of it
+    expect(mockLogger.info.mock.calls.length).toBe(bannerLines().length);
   });
 });

--- a/src/startup-gate.ts
+++ b/src/startup-gate.ts
@@ -299,7 +299,26 @@ export function printStartupReport(report: StartupCheckReport): void {
 
   lines.push(BORDER_BOT);
 
+  // The banner's severity has to match its worst finding, per the three levels
+  // this gate is built around. Emitting the whole box at error level — "✓ API
+  // credentials OK" included — made 46% of every ERROR record in deus.log a
+  // non-error, which poisons any alerting built on severity (LIA-553).
+  //
+  // A fatal banner stays at error: it is the last thing written before
+  // index.ts exits 1, so demoting it would hide a real unrecoverable failure.
+  //
+  // Tradeoff: a suggest-only banner now sits at info, so LOG_LEVEL=warn would
+  // filter it out along with its "Run /setup" hint. Nothing sets LOG_LEVEL
+  // today (it defaults to info), and a deployment that raises it is asking for
+  // exactly that filtering — but it is the one thing this change makes less
+  // visible.
+  const level = hasFatals
+    ? 'error'
+    : report.warnings.length > 0
+      ? 'warn'
+      : 'info';
+
   for (const line of lines) {
-    logger.error(line);
+    logger[level](line);
   }
 }


### PR DESCRIPTION
## What

`printStartupReport` looped `logger.error` over every line of the box-drawn startup banner — "✓ API credentials OK" included. The level now follows the report's worst finding:

| report contains | level |
| -- | -- |
| any fatal | `error` |
| warnings, no fatals | `warn` |
| suggestions only | `info` |

First slice of LIA-553, deliberately independent of every log-routing decision in that ticket.

## Why this first

Measured against the live log (`~/deus/logs/deus.log`): **2,879 of 6,188 ERROR-level records are banner lines — 46.5%**, from 161 startup events. Any alerting built on severity was reading noise. The rest of LIA-553 is about making error-level records reach the alerting pipeline; that is not worth doing while half of them are `✓ ... OK`.

This also restores a distinction the design already had. `docs/decisions/startup-gate.md` defines three severities ("**warn** — allows startup, prints warning"); the implementation had flattened all three onto `error`.

## Why fatal stays at error

`src/index.ts:107-109` calls `process.exit(1)` immediately after printing when fatals exist, so the fatal banner is the last thing written before an unrecoverable exit. Demoting it would trade one silent failure for another inside a ticket about removing silent failures.

Production has never taken that path: all 161 recorded banners are titled `Deus startup check`, never `FAILED` — which is exactly what that `exit(1)` implies. 160 of them were triggered by a single `suggest`-level "No groups registered yet".

## Tradeoff, stated

A suggest-only banner now sits at `info`, so a deployment setting `LOG_LEVEL=warn` would filter it out along with its "Run /setup" hint. `LOG_LEVEL` is currently set nowhere — absent from `~/.config/deus/.env`, `~/deus/.env`, and the launchd plist — and `docs/ENVIRONMENT.md:192` documents the default as `info`. Recorded in a comment at the call site rather than only here.

## Verification

- `vitest src/startup-gate.test.ts` — **42 passed** (39 before; 3 new tests pin the mapping)
- Red-green: reverting **only** `startup-gate.ts` fails 2 of the 3 new tests, so they discriminate
- Full suite — **115 files, 2084 tests passed**
- `tsc --noEmit`, `prettier --check`, `eslint` — clean

Existing content assertions were made severity-agnostic via a `bannerLines()` helper; only the three new tests assert which level was used.

## Note on the second commit

`chore(patterns): auto-bump drifted patterns` is the repo's own pre-push `drift-check` hook bumping a `last_verified` timestamp in `patterns/general-code.md`. It refuses the push until the bump is committed. Not part of this change.

Refs LIA-553

🤖 Generated with [Claude Code](https://claude.com/claude-code)