### PR TITLE
test(evolution): stop the suite writing to the real ~/.deus databases

### DIFF
--- a/evolution/tests/conftest.py
+++ b/evolution/tests/conftest.py
@@ -1,17 +1,174 @@
 """
 Shared test fixtures for evolution tests.
 
-Patches EVOLUTION_DB_PATH in both evolution.db and evolution.config so that
-the storage provider layer (which reads config.EVOLUTION_DB_PATH lazily)
-and the legacy open_db() shim both use the test database.
+test_db redirects EVOLUTION_DB_PATH for both evolution.db and evolution.config,
+and DB_PATH so the legacy migration cannot reach the real memory.db.
 
-Also patches DB_PATH to prevent the legacy migration from accessing the
-real memory.db during tests.
+Two autouse layers then keep the whole package off the real ~/.deus databases
+(LIA-555): Layer 0 points the DEUS_* env vars at a session tmp dir so a
+subprocess a test spawns inherits safe paths, and Layer 1 wraps sqlite3.connect
+so an in-process open of a real database fails at the moment it happens rather
+than at fixture setup. See the PR for the incident that motivated each.
 """
+import os
+import sqlite3
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
 import pytest
 
 import evolution.config as config_mod
 import evolution.db as db_mod
+
+# ── Guarded real paths ────────────────────────────────────────────────────────
+#
+# Snapshotted at import, which happens before any fixture runs and so before
+# Layer 0 rewrites the environment. That ordering is deliberate: these have to
+# be the paths production would really use, including any DEUS_DB /
+# DEUS_EVOLUTION_DB override already present in the environment.
+
+_REAL_DEUS_DIR = Path("~/.deus").expanduser().resolve()
+_REAL_EVOLUTION_DB = Path(config_mod.EVOLUTION_DB_PATH).expanduser().resolve()
+_REAL_LEGACY_DB = Path(config_mod.DB_PATH).expanduser().resolve()
+_REAL_DBS = frozenset({_REAL_EVOLUTION_DB, _REAL_LEGACY_DB})
+
+
+class RealDatabaseAccess(BaseException):
+    """Raised when a test tries to open a real ~/.deus database.
+
+    BaseException, not Exception: non-test evolution/ code has 66
+    `except Exception` handlers -- health.record_attempt (health.py:150) among
+    them, on the exact path the LIA-551 incident took -- and any of them would
+    catch this and let the test pass green. Same reasoning as KeyboardInterrupt.
+    """
+
+
+def _target_path(target):
+    """Normalise a sqlite3.connect() target to a filesystem path string.
+
+    Returns None when the target is not a filesystem path at all (in-memory,
+    empty).
+
+    os.fsdecode rather than str(): sqlite3.connect accepts a bytes path, and
+    str(b"/x/y.db") is "b'/x/y.db'" -- a string that could never match a
+    guarded path, so a bytes-spelled real path would slip straight through.
+    """
+    if not target:
+        return None
+    raw = os.fsdecode(target)
+    if raw.startswith("file:"):
+        # Drop the query string ("?mode=ro") and decode percent-escapes so a
+        # URI spelling of a real path is checked like any other path. Note
+        # "file::memory:?cache=shared" extracts to the literal ":memory:",
+        # which is why the next check is a membership test rather than an
+        # emptiness test.
+        raw = unquote(urlsplit(raw).path)
+    if raw in ("", ":memory:"):
+        return None
+    return raw
+
+
+def _same_inode(a: Path, b: Path) -> bool:
+    """True when two paths name the same file on disk, whatever they are called.
+
+    Catches aliases string comparison misses: a case-different spelling on a
+    case-insensitive filesystem (macOS resolves ~/.Deus and ~/.deus to one
+    inode; os.path.normcase does not help, it is a no-op on POSIX), and hard
+    links. Both paths must exist, so this supplements the literal check rather
+    than replacing it -- on CI, ~/.deus does not exist at all.
+    """
+    try:
+        sa, sb = a.stat(), b.stat()
+    except OSError:
+        return False
+    return (sa.st_dev, sa.st_ino) == (sb.st_dev, sb.st_ino)
+
+
+def _is_real_db(target) -> bool:
+    """True when a connect target resolves inside the real ~/.deus tree.
+
+    resolve() normalises relative paths, "~", and symlinks; _same_inode covers
+    the aliases it cannot see.
+    """
+    raw = _target_path(target)
+    if raw is None:
+        return False
+    try:
+        resolved = Path(raw).expanduser().resolve()
+    except (OSError, ValueError, RuntimeError):
+        # An unresolvable target is not a real-DB write. Let sqlite3 raise its
+        # own error rather than replacing it with a confusing guard failure.
+        return False
+    if (
+        resolved in _REAL_DBS
+        or resolved == _REAL_DEUS_DIR
+        or _REAL_DEUS_DIR in resolved.parents
+    ):
+        return True
+    if any(_same_inode(resolved, db) for db in _REAL_DBS):
+        return True
+    return any(
+        _same_inode(candidate, _REAL_DEUS_DIR)
+        for candidate in (resolved, *resolved.parents)
+    )
+
+
+# ── Layer 0: keep subprocesses off the real databases ─────────────────────────
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_deus_env(tmp_path_factory):
+    """Point the DEUS_* database env vars at a session tmp dir.
+
+    A spawned `python -m evolution.cli ...` re-imports evolution.config and
+    reads these itself; the parent's monkeypatched module attributes mean
+    nothing to it. Deliberately does not rewrite this process's already-imported
+    config.EVOLUTION_DB_PATH -- that would absolve in-process tests that forget
+    the test_db fixture, and make them share one database. Layer 1 catches those.
+    """
+    env_dir = tmp_path_factory.mktemp("deus_env_isolation")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("DEUS_EVOLUTION_DB", str(env_dir / "evolution.db"))
+        mp.setenv("DEUS_DB", str(env_dir / "memory.db"))
+        yield env_dir
+
+
+# ── Layer 1: refuse a real-DB connect at the moment it happens ────────────────
+
+
+@pytest.fixture(autouse=True)
+def _forbid_real_db_connect(request):
+    """Fail any test that opens a real ~/.deus database.
+
+    Installed by hand, not via the monkeypatch fixture: monkeypatch is
+    function-scoped and shared across a test's fixtures, so monkeypatch.undo()
+    -- the LIA-551 bug itself -- would tear down this guard along with the
+    redirect it backstops.
+    """
+    original = sqlite3.connect
+
+    def guarded(database, *args, **kwargs):
+        if _is_real_db(database):
+            raise RealDatabaseAccess(
+                f"{request.node.nodeid} tried to open the real database "
+                f"{os.fsdecode(database)!r}.\n"
+                "Evolution tests must never touch ~/.deus -- a write there can "
+                "destroy real state (LIA-551 zeroed a genuine failure streak "
+                "this way).\n"
+                "Add the `test_db` fixture, or redirect the path yourself. If "
+                "this fired right after monkeypatch.undo(), that call reversed "
+                "the test_db redirect: use monkeypatch.context() instead."
+            )
+        return original(database, *args, **kwargs)
+
+    sqlite3.connect = guarded
+    try:
+        yield
+    finally:
+        sqlite3.connect = original
+
+
+# ── Per-test database redirect ────────────────────────────────────────────────
 
 
 @pytest.fixture

--- a/evolution/tests/test_db_guard.py
+++ b/evolution/tests/test_db_guard.py
@@ -1,0 +1,214 @@
+"""Regression tests for the real-database guard in conftest.py (LIA-555).
+
+The guard exists because the test suite really did write to the user's live
+~/.deus/evolution.db. These tests prove it fires, prove it survives the specific
+call that caused the original incident, and prove it does not fire on the
+in-memory and tmp paths that ordinary tests use.
+
+Every "must be blocked" case here asserts that the guard raises *before*
+sqlite3 opens anything, so running this file never touches a real database.
+"""
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import evolution.config as config_mod
+from evolution import health
+
+from .conftest import (
+    RealDatabaseAccess,
+    _REAL_DBS,
+    _REAL_EVOLUTION_DB,
+    _REAL_LEGACY_DB,
+    _is_real_db,
+    _same_inode,
+    _target_path,
+)
+
+# The path conftest actually guards. Not hardcoded: an ambient
+# DEUS_EVOLUTION_DB in the developer's shell moves it, and these tests must
+# still describe the real guard rather than a path it no longer covers.
+REAL_EVOLUTION_DB = _REAL_EVOLUTION_DB
+
+
+# ── Layer 1 fires ─────────────────────────────────────────────────────────────
+
+
+def test_connecting_to_the_real_db_fails_the_test():
+    with pytest.raises(RealDatabaseAccess) as exc:
+        sqlite3.connect(str(REAL_EVOLUTION_DB))
+
+    message = str(exc.value)
+    assert str(REAL_EVOLUTION_DB) in message, "the offending path must be named"
+    assert "test_connecting_to_the_real_db_fails_the_test" in message, (
+        "the failing test must be named, so a suite-wide run points at the culprit"
+    )
+
+
+def test_guard_survives_monkeypatch_undo(monkeypatch):
+    """The LIA-551 shape: undo() reverses every patch on this test's monkeypatch
+    instance. If the guard were installed through that same fixture it would be
+    torn down here, which is exactly when it is most needed."""
+    monkeypatch.setattr(config_mod, "EVOLUTION_DB_PATH", Path("/tmp/decoy.db"))
+    monkeypatch.undo()
+
+    with pytest.raises(RealDatabaseAccess):
+        sqlite3.connect(str(REAL_EVOLUTION_DB))
+
+
+def test_mid_test_unredirect_through_production_code_is_caught(test_db, monkeypatch):
+    """The literal LIA-551 bug, end to end.
+
+    undo() reverses test_db's redirect, so health.record_attempt resolves the
+    real EVOLUTION_DB_PATH and would write an OK row into production -- clearing
+    consecutive_failures and first_failed_at. The guard has to stop it inside
+    the production call, not at fixture setup.
+    """
+    health.record_attempt("guard-probe", health.STATUS_OK)  # redirected: fine
+
+    monkeypatch.undo()
+    restored = Path(config_mod.EVOLUTION_DB_PATH).expanduser().resolve()
+    assert restored == _REAL_EVOLUTION_DB, (
+        "precondition: undo() really did restore the production path"
+    )
+
+    # record_attempt wraps its whole body in `except Exception` (health.py:150).
+    # RealDatabaseAccess derives from BaseException precisely so that handler
+    # cannot turn this into a green test with a log line nobody reads.
+    with pytest.raises(RealDatabaseAccess, match="real database"):
+        health.record_attempt("guard-probe", health.STATUS_OK)
+
+
+# ── Alternate spellings of a real path ────────────────────────────────────────
+#
+# str() vs os.fsdecode, URI vs plain, and percent-encoding are all ways the same
+# real path can arrive at sqlite3.connect. A guard that only recognises one of
+# them is a guard with a hole.
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        pytest.param(lambda p: str(p), id="plain-str"),
+        pytest.param(lambda p: p, id="path-object"),
+        pytest.param(lambda p: "~/.deus/evolution.db", id="tilde"),
+        pytest.param(lambda p: os.fsencode(str(p)), id="bytes"),
+        pytest.param(lambda p: f"file:{p}?mode=ro", id="file-uri-with-query"),
+        pytest.param(lambda p: f"file://{p}", id="file-uri-empty-authority"),
+        pytest.param(lambda p: f"file://localhost{p}", id="file-uri-localhost"),
+        pytest.param(
+            lambda p: "file:" + str(p).replace(".db", "%2edb"),
+            id="percent-encoded",
+        ),
+    ],
+)
+def test_every_spelling_of_the_real_path_is_blocked(spelling):
+    assert _is_real_db(spelling(REAL_EVOLUTION_DB)) is True
+
+
+def test_case_different_spelling_is_blocked_on_a_case_insensitive_filesystem():
+    """~/.Deus and ~/.deus are one inode on macOS, so a case-mangled spelling
+    would reach the real file while failing a literal path comparison.
+    os.path.normcase does not help -- it is a no-op on POSIX -- so the guard
+    compares (st_dev, st_ino) as well.
+
+    Skipped where the filesystem really is case-sensitive (CI's ext4), because
+    there the alias is a genuinely different file and must NOT be blocked.
+    """
+    aliased = Path(str(REAL_EVOLUTION_DB).replace("/.deus/", "/.Deus/"))
+    if aliased == REAL_EVOLUTION_DB:
+        pytest.skip("guarded path does not contain a '.deus' segment to re-case")
+    if not aliased.exists():
+        pytest.skip("case-sensitive filesystem: the alias is a different file")
+
+    assert _is_real_db(str(aliased)) is True
+
+
+def test_same_inode_matches_regardless_of_path_spelling(tmp_path, monkeypatch):
+    """Filesystem-independent cover for the inode branch.
+
+    The test above only exercises it on a case-insensitive filesystem, so it
+    skips on CI's ext4. This drives _same_inode directly with two distinct paths
+    reporting one identity, which is what an alias looks like from stat().
+    """
+    left, right = tmp_path / "a.db", tmp_path / "b.db"
+    left.touch()
+    right.touch()
+    assert _same_inode(left, right) is False, "distinct files must not match"
+
+    shared = os.stat_result((0o100644, 4242, 99, 1, 0, 0, 0, 0, 0, 0))
+    monkeypatch.setattr(Path, "stat", lambda self, **kw: shared)
+    assert _same_inode(left, right) is True
+
+
+def test_same_inode_is_false_when_a_path_is_missing(tmp_path):
+    """stat() raises on a path that does not exist -- the CI case, where
+    ~/.deus is absent entirely. The literal comparison still covers it."""
+    existing = tmp_path / "here.db"
+    existing.touch()
+    assert _same_inode(existing, tmp_path / "gone.db") is False
+
+
+def test_the_whole_deus_directory_is_guarded():
+    """Not just the two configured databases -- everything under ~/.deus is real
+    user data."""
+    assert _is_real_db(str(Path("~/.deus/memory_tree.db").expanduser())) is True
+
+
+def test_a_sibling_directory_is_not_confused_for_the_real_one():
+    """Guards against a naive string-prefix check: ~/.deusX is not ~/.deus."""
+    assert _is_real_db(str(Path("~/.deusX/evolution.db").expanduser())) is False
+
+
+# ── No false positives ────────────────────────────────────────────────────────
+
+
+def test_tmp_paths_connect_normally(tmp_path):
+    db = sqlite3.connect(tmp_path / "fine.db")
+    db.execute("CREATE TABLE t (x)")
+    db.close()
+    assert (tmp_path / "fine.db").exists()
+
+
+@pytest.mark.parametrize(
+    "target", [":memory:", "file::memory:?cache=shared", "", None]
+)
+def test_non_filesystem_targets_are_ignored(target):
+    assert _target_path(target) is None
+    assert _is_real_db(target) is False
+
+
+def test_in_memory_databases_still_work():
+    db = sqlite3.connect(":memory:")
+    db.execute("CREATE TABLE t (x)")
+    db.close()
+
+
+# ── Layer 0 ───────────────────────────────────────────────────────────────────
+
+
+def test_subprocess_env_points_away_from_the_real_databases():
+    """A child interpreter re-reads these env vars, so they are what stands
+    between a spawned `python -m evolution.cli ...` and production."""
+    for var in ("DEUS_EVOLUTION_DB", "DEUS_DB"):
+        value = os.environ.get(var)
+        assert value, f"{var} must be set for the whole test session"
+        assert not _is_real_db(value), f"{var} still points at real user data: {value}"
+
+
+def test_guarded_paths_were_snapshotted_before_the_env_was_isolated():
+    """Layer 0 rewrites DEUS_* at session start; the guarded set is captured at
+    conftest import, which happens first. If that order ever inverted, the
+    guarded set would hold the tmp paths and protect nothing."""
+    session_tmp = {
+        Path(os.environ["DEUS_EVOLUTION_DB"]).parent.resolve(),
+        Path(os.environ["DEUS_DB"]).parent.resolve(),
+    }
+    assert _REAL_DBS == {_REAL_EVOLUTION_DB, _REAL_LEGACY_DB}
+    for path in _REAL_DBS:
+        assert path.parent.resolve() not in session_tmp, (
+            f"{path} is a Layer 0 tmp path -- the snapshot ran too late"
+        )
+        assert _is_real_db(str(path)) is True

--- a/evolution/tests/test_signal_pipeline.py
+++ b/evolution/tests/test_signal_pipeline.py
@@ -1,8 +1,13 @@
 """Tests for the has_code column and signal pipeline additions."""
 
 
-def test_has_code_column_migration():
-    """Verify has_code column exists after migration."""
+def test_has_code_column_migration(test_db):
+    """Verify has_code column exists after migration.
+
+    test_db is required: get_storage() resolves EVOLUTION_DB_PATH lazily, so
+    without the redirect this ran the migration against the real
+    ~/.deus/evolution.db on every suite run (LIA-555).
+    """
     from evolution.storage import get_storage
     store = get_storage()
     db = store._connect()

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-15" # auto-bump @1786751042
+last_verified: "2026-08-15" # auto-bump @1786790095
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-15" # auto-bump @1786751042
+last_verified: "2026-08-15" # auto-bump @1786790095
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## The problem was real, not hypothetical

LIA-555 was filed as "nothing *stops* the next test from writing to production." It turns out two tests already were, on every single run.

Found with a `sitecustomize.py` on `PYTHONPATH` wrapping `sqlite3.connect` so it **raises before delegating** — proving the access without performing it — and which CPython loads into every interpreter, so it covers subprocesses that a plain pytest plugin would miss. Exactly two offenders across 834 tests:

| Test | Why it escaped | What it did to production |
| -- | -- | -- |
| `test_signal_pipeline.py::test_has_code_column_migration` | no fixture at all | `get_storage()._connect()` → `mkdir` + `PRAGMA journal_mode=WAL` + full migration on the real DB |
| `test_cli_log_interaction.py::test_main_status_exits_zero` | spawns `python -m evolution.cli status`; the file's autouse fixture patches only the **parent's** module attributes | child re-imports `evolution.config`, resolves the real path |

That is the mechanism behind LIA-551 zeroing a genuine failure streak: `record_attempt(OK)` clears `consecutive_failures` and `first_failed_at`.

## Two layers, because they cover different holes

**Layer 0** points `DEUS_EVOLUTION_DB`/`DEUS_DB` at a session tmp dir, so any spawned interpreter inherits safe paths. This fixes the subprocess offender generally rather than patching one call site. It deliberately does *not* rewrite this process's already-imported `config.EVOLUTION_DB_PATH` — that would absolve in-process tests that forget `test_db` and make them share one database.

**Layer 1** wraps `sqlite3.connect` and fails the test at the moment of use, which is the criterion the ticket cared about: the LIA-551 bug un-redirected the path *mid-test*, so a setup-time check would have missed it. Installed by hand rather than through the `monkeypatch` fixture — that fixture is function-scoped and shared, so `monkeypatch.undo()` (the bug itself) would tear the guard down along with the redirect it backstops.

## The guard is a BaseException, and that is the point

I wrote the end-to-end test first and it **did not fail**. `evolution/health.py:150` wraps `record_attempt` in `except Exception`, which caught the `AssertionError`: the write was correctly blocked, the test passed green, nobody learns.

Non-test `evolution/` has **66** `except Exception` handlers and one `except BaseException` (`providers/embeddings.py:183`) that re-raises anything that is not a timeout. `RealDatabaseAccess(BaseException)` propagates through all of them and pytest still reports a normal failure — the same precedent as `KeyboardInterrupt` and `pytest.skip.Exception`.

A guard against silent failures must not be silenceable by the code it guards.

## Path spellings covered

`str`, `Path`, **bytes** (`os.fsdecode`, because `str(b"/x/y.db")` is `"b'/x/y.db'"` and would never match), `file:` URIs with query strings and percent-escapes, `file://localhost/…`, relative paths, `~`, symlinks, and — via `(st_dev, st_ino)` — **case aliases on case-insensitive filesystems** and hard links. `os.path.normcase` does not help with the case alias; it is a no-op on POSIX, so it does nothing on the only platform where the gap exists.

`~/.deusX/evolution.db` is correctly *not* blocked, so this is not a string-prefix match.

## A third layer was dropped

An mtime snapshot of the real files was in the plan and **the GPT co-gate backend rejected it** after Claude's plan-reviewer had approved it across three rounds. It was right: a snapshot cannot attribute a change to the test process, so a write by a concurrently running Deus service would fail whatever test happened to be running. I had used that exact argument to reject watching WAL sidecars and had not applied it to the main file.

What it would have covered is a writer using neither `sqlite3.connect` nor an inherited environment. A repo-wide grep found none — no `aiosqlite`, no `create_engine`, no `apsw`, no `sqlite3` CLI shellouts.

## Verification

- **858 passed**, 2 skipped. The 1 failure is pre-existing and environmental: `test_judge_registry.py:231` against a local `EVOLUTION_OLLAMA_JUDGE_MODEL`; 26/26 pass at CI's default, where the var is unset.
- **24 new guard tests.** 21 pass + 1 skip under an ambient `DEUS_*` override.
- **Red-green:** reverting only the one-line fixture addition makes the guard fire, naming the test, the path, and the remedy.
- **Independent probe sweep** after the change: zero real-DB access anywhere in the suite.
- **A/B on runtime:** 834 tests unguarded 3.88s vs 858 guarded 4.53s — the delta is the new tests, not guard overhead.
- `~/.deus/evolution.db` and `memory.db` byte-identical (size + mtime) throughout, including during the unguarded baseline run, which was redirected to tmp.

## Note on the extra commit

`chore(patterns): auto-bump drifted patterns` is the repo's own pre-push `drift-check` hook bumping a `last_verified` timestamp; it refuses the push until committed. Not part of this change.

Closes LIA-555

🤖 Generated with [Claude Code](https://claude.com/claude-code)