### PR TITLE
fix(evolution): record batch-judge outcomes instead of returning a bare 0

### DIFF
--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -31,10 +31,25 @@ if __name__ == "__main__" and __package__ is None:
         sys.path.insert(0, _project_root)
     __package__ = "evolution"  # type: ignore
 
+# Must stay BELOW the bootstrap above: a relative import runs before it
+# otherwise, and `python evolution/maintenance.py` — the direct-script form this
+# module's own docstring advertises — dies with "attempted relative import with
+# no known parent package". `python3 -m evolution.maintenance` works either way,
+# which is what makes the broken ordering easy to ship.
+from . import health
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 #: Stale reflection threshold in days.
 ARCHIVE_AFTER_DAYS = 30
+
+# Mirrors evolution/cli.py's _OPTIMIZER_HEALTH_PREFIX convention. Prefixed
+# rather than a flat "evolution.judge" so the remaining LIA-556 sites in this
+# module get sibling components instead of clobbering this row — `component` is
+# the table's primary key, and has_failure("evolution.judge") matches by LIKE
+# prefix, so a rollup still sees all of them.
+_JUDGE_HEALTH_PREFIX = "evolution.judge."
+_BATCH_COMPONENT = _JUDGE_HEALTH_PREFIX + "batch"
 
 #: Maintenance runs at most once per this many interactions.
 MAINTENANCE_INTERACTION_INTERVAL = 25
@@ -180,6 +195,33 @@ def _reflect_single(scored: dict, config: dict) -> bool:
 
 
 def judge_pending_interactions() -> int:
+    """Judge unjudged interactions, recording the outcome to subsystem_health.
+
+    Classifies every outcome in one place so a failure is never mistaken for
+    "nothing to do" -- both used to return 0 with nothing durable written
+    (LIA-556).
+
+    Guarantee, and its limit: any failure that leaves the health DB writable
+    produces exactly one FAILED row. A failure that also takes out the health
+    DB -- it is the same evolution.db -- produces only a log.error, because
+    health.record_attempt swallows its own errors by design. Detecting that
+    case needs an out-of-process staleness probe; LIA-552 owns it.
+    """
+    try:
+        return _judge_pending_interactions()
+    except Exception as exc:
+        # Catches the paths enumerated during review (storage read, judge
+        # construction) and, more to the point, any a later edit adds.
+        # Exception rather than BaseException: a KeyboardInterrupt is not a
+        # judge failure, and the test suite's real-DB guard (LIA-555) is a
+        # BaseException precisely so it escapes handlers like this one.
+        detail = f"{type(exc).__name__}: {exc}"
+        health.record_attempt(_BATCH_COMPONENT, health.STATUS_FAILED, detail)
+        log.error("evolution: batch judging failed — %s", detail, exc_info=True)
+        return 0
+
+
+def _judge_pending_interactions() -> int:
     """
     Judge unjudged interactions using a two-pass parallel approach:
       Pass 1: Score all interactions concurrently (GPU-bound)
@@ -196,13 +238,12 @@ def judge_pending_interactions() -> int:
     store = get_storage()
     unjudged = store.get_unjudged_interactions(limit=50)
     if not unjudged:
+        # A skip, not an attempt: record_skip touches only last_skipped_at, so
+        # an idle cycle cannot launder a live failure into looking healthy.
+        health.record_skip(_BATCH_COMPONENT)
         return 0
 
-    try:
-        judge = make_runtime_judge()
-    except Exception as exc:
-        log.warning("Could not create judge for batch judging: %s", exc)
-        return 0
+    judge = make_runtime_judge()
 
     config = {
         "reflection_threshold": REFLECTION_THRESHOLD,
@@ -214,6 +255,7 @@ def judge_pending_interactions() -> int:
     # Pass 1: Score all in parallel
     scored_results = []
     parse_errors = 0
+    failed = 0
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
             pool.submit(_score_single, row, judge): row["id"]
@@ -222,6 +264,11 @@ def judge_pending_interactions() -> int:
         for future in as_completed(futures):
             result = future.result()
             if result is None:
+                # _score_single swallowed an exception for this row. Counted,
+                # not just skipped: an all-None batch is a broken judge, and
+                # the old bare `continue` made that indistinguishable from a
+                # quiet one.
+                failed += 1
                 continue
             if result["is_parse_error"]:
                 parse_errors += 1
@@ -234,9 +281,33 @@ def judge_pending_interactions() -> int:
         if s["score"] < config["reflection_threshold"]
         or s["score"] >= config["positive_threshold"]
     ]
+    reflected = 0
     if needs_reflection:
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            list(pool.map(lambda s: _reflect_single(s, config), needs_reflection))
+            reflected = sum(
+                pool.map(lambda s: _reflect_single(s, config), needs_reflection)
+            )
+
+    if not scored_results:
+        # Nothing usable came out of a non-empty batch. Keyed on
+        # scored_results, never on the return value below: an all-parse-error
+        # batch returns nonzero while having produced no usable score at all.
+        detail = (
+            f"{len(unjudged)} unjudged, 0 scored "
+            f"({parse_errors} parse errors, {failed} failed)"
+        )
+        health.record_attempt(_BATCH_COMPONENT, health.STATUS_FAILED, detail)
+        log.error("evolution: batch judging produced no usable scores — %s", detail)
+    else:
+        # OK attests to scoring only. Reflection counts ride along in the
+        # reason so a wholly failed pass 2 is visible, but they do not set the
+        # status: reflection health is its own concern (LIA-556 follow-up).
+        health.record_attempt(
+            _BATCH_COMPONENT,
+            health.STATUS_OK,
+            f"{len(scored_results)} scored, {parse_errors} parse errors, "
+            f"{failed} failed, {reflected}/{len(needs_reflection)} reflections",
+        )
 
     return len(scored_results) + parse_errors
 

--- a/evolution/tests/test_maintenance_judge_health.py
+++ b/evolution/tests/test_maintenance_judge_health.py
@@ -1,0 +1,281 @@
+"""Health recording for the batch judge (LIA-556 site 1).
+
+Before this, judge_pending_interactions() returned 0 for "nothing pending",
+"the judge would not construct", and "every row failed to score" alike, writing
+nothing durable for any of them. These tests pin each outcome to a distinct
+health record, and pin the one case the design deliberately cannot cover.
+"""
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from evolution import health, maintenance
+
+COMPONENT = maintenance._BATCH_COMPONENT
+PREFIX = maintenance._JUDGE_HEALTH_PREFIX
+
+
+class _Result:
+    """Minimal stand-in for a judge result. Only the fields _score_single reads."""
+
+    def __init__(self, score=0.8, is_parse_error=False):
+        self.score = score
+        self.quality = self.safety = self.tool_use = self.personalization = score
+        self.rationale = "r"
+        self.is_parse_error = is_parse_error
+        self.schema_version = 1
+
+
+def _row(rid="i1"):
+    return {"id": rid, "prompt": "p", "response": "r", "group_folder": None,
+            "tools_used": None}
+
+
+@pytest.fixture
+def wire(monkeypatch):
+    """Wire the batch judge's collaborators so no network or real DB is touched.
+
+    Returns a setter so each test states only what it varies.
+    """
+    def _wire(rows, evaluate=None, reflect=True):
+        store = type("S", (), {"get_unjudged_interactions": lambda self, limit=50: list(rows)})()
+        monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: store)
+        judge = type("J", (), {"evaluate": staticmethod(evaluate or (lambda **kw: _Result()))})()
+        monkeypatch.setattr("evolution.judge.make_runtime_judge", lambda *a, **k: judge)
+        monkeypatch.setattr("evolution.ilog.interaction_log.update_score",
+                            lambda *a, **k: None)
+        monkeypatch.setattr("evolution.persona.digest_for_group", lambda *a, **k: "")
+        monkeypatch.setattr(maintenance, "_reflect_single", lambda s, c: reflect)
+        return store
+    return _wire
+
+
+# ── Failure is distinguishable from "nothing to do" ───────────────────────────
+
+
+def test_judge_construction_failure_records_failed(test_db, wire, monkeypatch):
+    wire([_row()])
+    monkeypatch.setattr("evolution.judge.make_runtime_judge",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no model")))
+
+    assert maintenance.judge_pending_interactions() == 0, "hot path must not raise"
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "RuntimeError" in row["last_reason"]
+    assert "no model" in row["last_reason"]
+
+
+def test_a_recorded_failure_reaches_has_failure(test_db, wire, monkeypatch):
+    """The row needs a consumer, or it is just another thing nobody reads."""
+    wire([_row()])
+    monkeypatch.setattr("evolution.judge.make_runtime_judge",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    maintenance.judge_pending_interactions()
+
+    assert health.has_failure(PREFIX) is True
+    assert health.has_failure() is True
+
+
+def test_storage_read_failure_records_failed(test_db, wire, monkeypatch):
+    """get_unjudged_interactions sat outside every guard: a locked DB escaped
+    to a log.warning two frames up and wrote no health row at all."""
+    broken = type("S", (), {
+        "get_unjudged_interactions":
+            lambda self, limit=50: (_ for _ in ()).throw(OSError("database is locked"))
+    })()
+    monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: broken)
+
+    assert maintenance.judge_pending_interactions() == 0
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "database is locked" in row["last_reason"]
+
+
+def test_empty_queue_records_a_skip_not_an_attempt(test_db, wire):
+    wire([])
+    assert maintenance.judge_pending_interactions() == 0
+
+    row = health.get(COMPONENT)
+    assert row["last_skipped_at"] is not None
+    assert row["last_status"] is None, "a skip must not claim an attempt happened"
+
+
+def test_an_idle_cycle_cannot_launder_a_live_failure(test_db, wire):
+    """The property record_skip exists for: a quiet cycle after a real failure
+    must leave the failure standing."""
+    health.record_attempt(COMPONENT, health.STATUS_FAILED, "earlier breakage")
+
+    wire([])
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert row["last_reason"] == "earlier breakage"
+    assert health.has_failure(PREFIX) is True
+    # Without this the test passes vacuously: "the failure survived" is equally
+    # true of "record_skip fired" and "the idle path did nothing at all".
+    # Caught by mutation-testing the verification gate ran.
+    assert row["last_skipped_at"] is not None, "the idle cycle must still record a skip"
+
+
+# ── The false-OK paths, one test each ─────────────────────────────────────────
+
+
+def test_every_row_raising_records_failed_not_ok(test_db, wire):
+    """_score_single swallows per-row exceptions and returns None, so a judge
+    that constructs fine but fails every call used to look like a quiet batch."""
+    def explode(**kw):
+        raise RuntimeError("inference failed")
+    wire([_row("a"), _row("b")], evaluate=explode)
+
+    assert maintenance.judge_pending_interactions() == 0
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "0 scored" in row["last_reason"]
+    assert "2 failed" in row["last_reason"]
+
+
+def test_every_row_a_parse_error_records_failed_despite_nonzero_return(test_db, wire):
+    """The status must key on scored_results, never the return value: this
+    batch produced nothing usable yet returns a nonzero count."""
+    wire([_row("a"), _row("b")], evaluate=lambda **kw: _Result(is_parse_error=True))
+
+    returned = maintenance.judge_pending_interactions()
+    assert returned == 2, "precondition: the return value looks productive here"
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "2 parse errors" in row["last_reason"]
+
+
+def test_partial_failure_stays_ok_with_the_count_recorded(test_db, wire):
+    """No invented degradation threshold -- but the damage is on the record."""
+    calls = {"n": 0}
+
+    def flaky(**kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _Result(score=0.5)
+        raise RuntimeError("inference failed")
+
+    wire([_row("a"), _row("b"), _row("c")], evaluate=flaky)
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_OK
+    assert "1 scored" in row["last_reason"]
+    assert "2 failed" in row["last_reason"]
+
+
+def test_a_successful_batch_records_ok_and_clears_the_streak(test_db, wire):
+    health.record_attempt(COMPONENT, health.STATUS_FAILED, "earlier breakage")
+    wire([_row("a")], evaluate=lambda **kw: _Result(score=0.5))
+
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_OK
+    assert row["consecutive_failures"] == 0
+    assert health.has_failure(PREFIX) is False
+
+
+def test_failed_and_nothing_to_do_are_distinguishable(test_db, wire, monkeypatch):
+    """LIA-556's acceptance criterion, stated directly: both return 0, and the
+    health rows must not agree."""
+    wire([])
+    maintenance.judge_pending_interactions()
+    idle = dict(health.get(COMPONENT))
+
+    wire([_row()])  # must precede the override: wire() sets a working judge
+    monkeypatch.setattr("evolution.judge.make_runtime_judge",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    maintenance.judge_pending_interactions()
+    broken = dict(health.get(COMPONENT))
+
+    assert idle["last_status"] != broken["last_status"]
+    assert broken["last_status"] == health.STATUS_FAILED
+
+
+def test_a_wholly_failed_reflection_pass_is_visible_but_does_not_flip_status(
+    test_db, wire
+):
+    """OK attests to scoring, not reflection -- but pass 2's booleans are no
+    longer discarded, so a dead reflection pass shows up on the row."""
+    wire([_row("a")], evaluate=lambda **kw: _Result(score=0.1), reflect=False)
+
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_OK
+    assert "0/1 reflections" in row["last_reason"]
+
+
+# ── The guarantee, and its limit ──────────────────────────────────────────────
+
+
+def test_the_wrapper_covers_a_path_no_test_enumerates(test_db, wire, monkeypatch):
+    """The point of the wrapper is paths nobody thought of, so test that rather
+    than one more specific branch."""
+    monkeypatch.setattr(
+        maintenance, "_judge_pending_interactions",
+        lambda: (_ for _ in ()).throw(ValueError("something nobody predicted")),
+    )
+
+    assert maintenance.judge_pending_interactions() == 0
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "something nobody predicted" in row["last_reason"]
+
+
+def test_a_health_db_that_is_also_down_records_nothing_by_design(
+    test_db, wire, monkeypatch
+):
+    """Documents the limit rather than asserting a guarantee the code cannot
+    deliver: health writes go to the same evolution.db, and record_attempt
+    swallows its own errors, so the failure that takes out the DB takes out its
+    own record too. Detecting that needs an out-of-process staleness probe
+    (LIA-552)."""
+    broken = type("S", (), {
+        "get_unjudged_interactions":
+            lambda self, limit=50: (_ for _ in ()).throw(OSError("database is locked"))
+    })()
+    monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: broken)
+    # Model what a locked health DB actually does. record_attempt wraps its own
+    # body in `except Exception: log.error(...)` (health.py:150), so it returns
+    # normally having written nothing -- it does not raise. An earlier draft of
+    # this test made it raise instead, which no real failure produces and which
+    # only proved the wrapper propagates a thing that cannot happen.
+    monkeypatch.setattr(health, "record_attempt", lambda *a, **k: None)
+
+    assert maintenance.judge_pending_interactions() == 0
+    assert health.get(COMPONENT) is None, (
+        "no durable record survives when the health DB is the thing that failed"
+    )
+
+
+def test_the_direct_script_entry_point_still_works():
+    """maintenance.py supports `python evolution/maintenance.py`, via a
+    __package__ bootstrap its module docstring advertises.
+
+    A relative import placed above that bootstrap breaks it with
+    "attempted relative import with no known parent package" — which is exactly
+    what adding the health import did on the first attempt. No existing test
+    caught it, because `python -m evolution.maintenance` and a plain
+    `import evolution.maintenance` both keep working. This runs the form that
+    actually breaks.
+    """
+    script = pathlib.Path(maintenance.__file__)
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"direct-script entry point broken:\n{result.stderr}"
+    )
+    assert "attempted relative import" not in result.stderr

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-15" # auto-bump @1786790559
+last_verified: "2026-08-15" # auto-bump @1786792800
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-15" # auto-bump @1786790559
+last_verified: "2026-08-15" # auto-bump @1786792800
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
Site 1 of the five swallow sites in LIA-556. The other four stay open — deliberately, since the ticket itself records that every scope expansion in LIA-551 introduced a new defect.

## What was silent

`judge_pending_interactions()` returned `0` for three completely different situations and wrote nothing durable for any:

| situation | before |
| -- | -- |
| no unjudged rows | `return 0` |
| judge would not construct | `log.warning`, `return 0` |
| every row failed to score | `return 0` |

A persistently broken judge therefore means `count_scored_since` never grows, so auto-optimize is never even attempted — the ticket's point that this silences the half of the loop that currently *works*.

## What it records now

Each outcome gets a distinct row under `evolution.judge.batch`:

| situation | after |
| -- | -- |
| no unjudged rows | `record_skip` |
| anything raises | `FAILED` + exception type |
| rows existed, 0 scored | `FAILED` + parse-error and failure counts |
| rows scored | `OK` + counts |

## Structure, not enumeration

Plan review found **three separate silent paths in this one function** — every row raising inside `_score_single`, every row a parse error, and a completely unguarded storage read whose escape `cli.py:387-390` swallowed. Rather than patch a fourth, a thin wrapper classifies every outcome in one place, covering paths a later edit introduces too.

**The status keys on `not scored_results`, never the return value.** `return len(scored_results) + parse_errors` is *nonzero* for an all-parse-error batch, so keying off it would write `OK` for a judge whose output is unusable on every single row. A test asserts FAILED *and* a nonzero return for that case, so it fails against that implementation.

## What this cannot do

Stated in the docstring rather than assumed away: `health.record_attempt` swallows its own errors (`health.py:150`) and writes to the same `evolution.db`. A failure that also takes out that DB leaves only a `log.error`. That is not fixable inside this function — a record living in the resource that failed cannot survive it failing. **LIA-552's out-of-process staleness probe is the right detector** and owns that case. A test pins the limitation rather than asserting a guarantee the code cannot deliver.

## Import placement is load-bearing

`from . import health` sits **below** the `__package__` bootstrap. Above it, `python evolution/maintenance.py` — the direct-script form this module's own docstring advertises — dies with `attempted relative import with no known parent package`. `python -m evolution.maintenance` and a plain `import` both keep working, which is exactly what makes the wrong order easy to ship; it passed my first check for that reason. Caught by the GPT co-gate backend after the Claude reviewer had SHIPped it. A subprocess test now covers the form that breaks.

## Behaviour change, flagged not buried

A storage-read failure used to propagate and abort the rest of `run_maintenance`. It now records FAILED and continues, so compaction and reflection archiving still run. This matches the module's existing best-effort shape (`cli.py:213-230` does the same) and the ticket's instruction that exceptions are never re-raised on this path. `cli.py:306`'s path is unchanged — `cli.py:387-390` already swallowed it.

## Verification

- **872 passed**, 2 skipped. The 1 failure is pre-existing and environmental (`test_judge_registry.py:231` vs a local `EVOLUTION_OLLAMA_JUDGE_MODEL`; 26/26 at CI's default, where it is unset).
- **14 new tests.** Mutation-tested with the constants kept and only the behaviour reverted: **13 of 14 fail**. The one that passed vacuously was found by the verification gate and strengthened.
- **Entry-point regression red-green** against a deliberately broken copy.
- **Read path end-to-end**: `evolution.cli health --json` lists `evolution.judge.batch` and exits **1**, so it drives LIA-551's non-zero exit with no read-path change.
- Independent probe sweep: **zero** real-DB access. Both live DBs byte-identical throughout.

Refs LIA-556

🤖 Generated with [Claude Code](https://claude.com/claude-code)