### PR TITLE
fix(scripts): forward --bump through drift_check's --all branch (LIA-472)

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1490,15 +1490,23 @@ def check_codegraph_db_schema(project_root: Path) -> int:
     return 0
 
 
-def check_all(project_root: Path, base_ref: str | None = None) -> int:
+def check_all(
+    project_root: Path, base_ref: str | None = None, bump: bool = False
+) -> int:
     """Run every fast check in sequence and aggregate exit codes.
 
     Runs: drift (main), paths, adr, test_tasks, coverage. The worst exit code
     wins. Coverage is informational (always returns 0) so it contributes only
     its report, never a failure.
+
+    `bump` is forwarded to the drift sub-check so `--all --bump` actually
+    touches drifted pattern files. Before this existed the CLI's `elif` chain
+    matched `--all` first and dropped `--bump` silently, which made the tool's
+    own "Run with --bump" remediation a no-op when combined with `--all`.
+    Defaults to False so CI's `--all --base ...` stays non-mutating.
     """
     print("=== drift (mtime) ===")
-    drift_rc = main(base_ref=base_ref)
+    drift_rc = main(base_ref=base_ref, bump=bump)
     print("\n=== paths ===")
     paths_rc = check_paths(project_root)
     print("\n=== index completeness ===")
@@ -2314,7 +2322,10 @@ if __name__ == "__main__":
     elif args.validate is not None:
         sys.exit(check_validate(PROJECT_ROOT, args.validate or None))
     elif args.all:
-        sys.exit(check_all(PROJECT_ROOT, base_ref=drift_base))
+        # `--bump` must be forwarded here, not just handled by the standalone
+        # `elif args.bump` branch below: this branch matches first when both
+        # flags are passed, so without this the combination is a silent no-op.
+        sys.exit(check_all(PROJECT_ROOT, base_ref=drift_base, bump=args.bump))
     elif args.coverage:
         sys.exit(check_coverage(PROJECT_ROOT))
     elif args.paths:

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1341,3 +1341,63 @@ class TestCodegraphDbSchema:
         out = capsys.readouterr().out
         assert "FAIL" in out
         assert "qualified_name" in out
+
+
+class TestCheckAllBumpForwarding:
+    """check_all must forward `bump` to the drift sub-check (LIA-472).
+
+    Before the fix, the CLI's `elif` chain matched `--all` before `--bump`, and
+    `check_all` had no `bump` parameter at all -- so `--all --bump` silently did
+    nothing. These tests pin the forwarding, and that the default stays False so
+    CI's `--all --base ...` invocation remains non-mutating.
+    """
+
+    def _setup(self, tmp_path, monkeypatch):
+        """Minimal valid tree (mirrors TestCheckContradictions.test_not_in_check_all)
+        so check_all's other sub-checks don't sys.exit before we can observe the
+        forwarding, plus a spy replacing drift_check.main. Returns the call log.
+        """
+        _make_pattern_tree(tmp_path, {
+            "demo.md": "---\ngoverns:\n  - src/\nlast_verified: \"2026-04-09\"\n"
+                       "test_tasks:\n  - \"do a thing\"\n  - \"do b\"\n  - \"do c\"\n---\nbody\n"
+        })
+        (tmp_path / "src").mkdir()
+        (tmp_path / "docs").mkdir()
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+
+        calls: list[dict] = []
+
+        def fake_main(base_ref=None, bump=False):
+            calls.append({"base_ref": base_ref, "bump": bump})
+            return 0
+
+        monkeypatch.setattr(drift_check, "main", fake_main)
+        return calls
+
+    def test_forwards_bump_true(self, tmp_path, monkeypatch, capsys):
+        calls = self._setup(tmp_path, monkeypatch)
+
+        drift_check.check_all(tmp_path, bump=True)
+
+        capsys.readouterr()
+        assert len(calls) == 1
+        assert calls[0]["bump"] is True
+
+    def test_defaults_to_no_bump(self, tmp_path, monkeypatch, capsys):
+        """Omitting bump must not mutate -- this is what keeps CI safe."""
+        calls = self._setup(tmp_path, monkeypatch)
+
+        drift_check.check_all(tmp_path)
+
+        capsys.readouterr()
+        assert len(calls) == 1
+        assert calls[0]["bump"] is False
+
+    def test_bump_composes_with_base_ref(self, tmp_path, monkeypatch, capsys):
+        """`--all --base <ref> --bump` must forward both, not one or the other."""
+        calls = self._setup(tmp_path, monkeypatch)
+
+        drift_check.check_all(tmp_path, base_ref="origin/main", bump=True)
+
+        capsys.readouterr()
+        assert calls[0] == {"base_ref": "origin/main", "bump": True}


### PR DESCRIPTION
## The bug

`scripts/drift_check.py --all --bump` silently did nothing.

The CLI dispatch is an `elif` chain that matches `args.all` before `args.bump`, and `check_all` had **no `bump` parameter at all** — it called `main(base_ref=base_ref)` without it, even though `main` has supported `bump` all along.

No error, no warning. That matters because the remediation the tool itself prints is *"Run with --bump to touch drifted patterns"* — so a developer appending `--bump` to the same `--all` invocation got silence and reasonably concluded the bump was broken.

## The fix

Make the flags **compose** rather than merely warning about the combination (the ticket's preferred option):

- `check_all` gains `bump: bool = False` and forwards it to `main`.
- The `--all` branch passes `bump=args.bump`.
- The standalone `elif args.bump` branch is untouched and still handles `--bump` alone.

**The default stays `False` so CI's `--all --base ...` invocation remains non-mutating** — CI must never self-modify. A dedicated test pins that.

**Deliberately not reordering the elif chain.** That would change which single check runs for other flag combinations — a materially larger blast radius than this bug warrants.

## Verification

- **117 tests pass** (114 pre-existing + 3 new), pycache cleared first per repo rule.
- **Red-green proven, not asserted**: the pre-fix module was executed directly in a scratch process and `check_all(tmp, bump=True)` produced a real `TypeError: unexpected keyword argument 'bump'`.
- `drift_check.py --all` and `--all --bump` both exit 0.
- **No pattern bump owed** — only `patterns/eval-change.md` governs anything under `scripts/`, and specifically `scripts/memory_indexer.py`, not `drift_check.py`. Verified by parsing every pattern's `governs:` list.

### Disclosed coverage limitation

A live mtime-drift bump was **not** exercised end-to-end: inside a linked worktree `drift_check` auto-selects merge-base mode, so no drift exists to bump. Both reviewers judged this acceptable, and the verification-gate confirmed it on stronger grounds than originally argued — **no test in the suite calls `main()` directly at all**, so the live bump-writing logic is a pre-existing coverage gap this PR neither created nor is obligated to close. Both edges of the actual forwarding regression are covered.

## Review

Unanimous SHIP from both co-gate backends at every gate (plan-review, code-review, verification), zero blocking findings.

This landed via a deliberate **re-scope**: it was originally planned alongside LIA-491 (container orphan-cleanup scoping), and three review rounds produced findings against LIA-491 every time while LIA-472 was confirmed correct by both backends in all three — six clean confirmations. Per the round-count circuit breaker, the converged fix was split out and shipped rather than looping. Reviewers independently confirmed the split is genuine (no shared files or behavior), not a way around a REVISE. **LIA-491 is not abandoned** — it gets its own plan and branch, carrying nine accumulated findings forward.

One `comment-discipline` finding was **declined**: the elif-ordering history appears both in the `check_all` docstring and in an inline comment at the dispatch. Both code-review backends rated it informational, and the verification-gate judged the decline defensible on inspection — they aren't literal duplication, and each guards a distinct future-regression path (the docstring documents the contract; the inline comment warns an editor against dropping the kwarg on the mistaken belief that the `elif args.bump` branch below already covers it, which is exactly the shape of this bug).

Rescued from the archived deus-v2 project and verified to reproduce here — see `docs/decisions/deus-v2-archival.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)