### PR TITLE
feat(health): add a cockpit healthcheck that probes work, not liveness

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1393,6 +1393,41 @@ sys.exit(1)
     # Exporting a frozen token causes 401s after token rotation because
     # the CLI prioritizes the env var over the credentials file.
     [[ "$OSTYPE" == darwin* ]] && launchctl kickstart -k "gui/$(id -u)/com.deus" 2>/dev/null
+
+    # Cockpit verdict (LIA-552). Reads the one-line cache the daily healthcheck
+    # writes — no interpreter start, no DB, no network, so there is nothing that
+    # can hang and no timeout to enforce (neither `timeout` nor `gtimeout` ships
+    # with macOS). Sits in the non-print-identity branch because other code
+    # parses that output and must stay byte-clean.
+    #
+    # Mirrors cockpit_healthcheck.py --brief, including its staleness window
+    # (ARTIFACT_MAX_AGE_SEC, 36h). Keep the two in step: a cached verdict with
+    # no age check would leave a dead scheduler showing yesterday's "OK"
+    # forever, which is the exact no-news-looks-like-good-news failure this
+    # whole ticket exists to remove.
+    _cockpit_line="${DEUS_HOME:-$HOME/.deus}/cockpit_health.line"
+    _cockpit_max_age=129600
+    if [ -r "$_cockpit_line" ]; then
+      # BSD stat (macOS) vs GNU stat (Linux) take different flags.
+      _cockpit_mtime=$(stat -f %m "$_cockpit_line" 2>/dev/null || stat -c %Y "$_cockpit_line" 2>/dev/null)
+      _cockpit_age=$(( $(date +%s) - ${_cockpit_mtime:-0} ))
+      _cockpit_verdict=$(head -n 1 "$_cockpit_line" 2>/dev/null)
+      if [ -z "$_cockpit_mtime" ]; then
+        printf '  cockpit: cannot read healthcheck timestamp\n'
+      elif [ -z "$_cockpit_verdict" ]; then
+        # An empty file is a checker that died mid-write, not a clean bill.
+        printf '  cockpit: healthcheck result is empty — the checker may have failed mid-write\n'
+      elif [ "$_cockpit_age" -gt "$_cockpit_max_age" ]; then
+        printf '  cockpit: last result is %sh old — healthcheck may not be running\n' \
+          "$(( _cockpit_age / 3600 ))"
+      elif [ "$_cockpit_verdict" != "OK" ]; then
+        # Quiet when healthy, or the report becomes noise the user learns to skip.
+        printf '  cockpit: %s\n' "$_cockpit_verdict"
+      fi
+    else
+      printf '  cockpit: no healthcheck result on record\n'
+    fi
+    unset _cockpit_line _cockpit_max_age _cockpit_mtime _cockpit_age _cockpit_verdict
     fi
     # Launch claude with bypass mode; fall back to normal mode if user declines
     launch_claude() {

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-07-19" # auto-bump @1784444178
+last_verified: "2026-08-15" # auto-bump @1786817018
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-15" # auto-bump @1786792800
+last_verified: "2026-08-15" # auto-bump @1786817018
 governs:
   - src/
   - evolution/

--- a/scripts/cockpit_healthcheck.py
+++ b/scripts/cockpit_healthcheck.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Daily cockpit healthcheck — does each subsystem still do its job? (LIA-552)
+
+`launchctl list` proves a process is loaded. It says nothing about whether
+interactions are being judged. That gap let the evolution optimizer sit dead
+from 2026-03 to 2026-08 with no external signal (LIA-551), so every probe here
+reports on *evidence of work*, never on liveness alone.
+
+Three probe classes, because they answer different questions:
+
+  capability  can this subsystem work at all?   (deterministic, idle-insensitive)
+  demand      was work produced when work was asked for?
+  liveness    is the process up, serving the config we think it is?
+
+Two rules keep it from reproducing the bug it detects:
+
+  * A probe that cannot reach a verdict reports UNKNOWN. UNKNOWN is never OK,
+    is counted separately, and has its own exit code.
+  * OK is only ever asserted from positive evidence. The absence of known
+    problems is not evidence of health.
+
+Read-only, with one documented exception. Every database is opened with a
+`mode=ro` URI, and the checker writes no subsystem storage — but the memory
+probe delegates to `memory_health.assess_memory_health`, whose vault check is a
+deliberate touch+unlink (`memory_health.py:33-53`). That write is the point of
+that probe: `is_dir()` alone misses the macOS Full-Disk-Access case where the
+vault reads fine and writes silently fail. It is kept rather than bypassed, and
+named here so the read-only claim stays true as written.
+
+Usage:
+    cockpit_healthcheck.py           probe, write artifacts, exit per table below
+    cockpit_healthcheck.py --json    same, machine-readable on stdout
+    cockpit_healthcheck.py --brief   print the cached line, no probing
+
+A bare invocation is the run mode, because that is exactly what the scheduled
+job issues: SCHEDULED_JOBS entries carry no arguments (setup/service.ts), so a
+flag guarding the probe branch would silently disable the daily run.
+
+Exit codes:
+    0  at least one real verdict, none FAILED, no UNKNOWN
+    1  at least one FAILED (outranks UNKNOWN: a known failure is actionable)
+    2  no probe reached a real verdict — the checker itself is untrustworthy
+    3  artifact write failed
+    4  at least one UNKNOWN, none FAILED — partial blindness
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import gzip
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+OK = "OK"
+DEGRADED = "DEGRADED"
+FAILED = "FAILED"
+UNKNOWN = "UNKNOWN"
+
+#: Ranked worst-first so a run's overall verdict is a simple max().
+_RANK = {OK: 0, DEGRADED: 1, UNKNOWN: 2, FAILED: 3}
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_ALL_UNKNOWN = 2
+EXIT_WRITE_FAILED = 3
+EXIT_PARTIAL_UNKNOWN = 4
+
+DEUS_HOME = Path(os.environ.get("DEUS_HOME", "~/.deus")).expanduser()
+ARTIFACT_JSON = DEUS_HOME / "cockpit_health.json"
+ARTIFACT_LINE = DEUS_HOME / "cockpit_health.line"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: How long a cached artifact stays meaningful to the shell display.
+ARTIFACT_MAX_AGE_SEC = 36 * 3600
+
+#: A demand served this recently is not yet evidence of a stuck pipeline.
+INGEST_GRACE_SEC = 30 * 60
+
+
+@dataclass
+class Result:
+    """One probe's verdict plus the evidence a reader needs to act on it."""
+
+    probe: str
+    status: str
+    observed: str = ""
+    expected: str = ""
+    remedy: str = ""
+    detail: dict = field(default_factory=dict)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _launch_agent_installed(label: str) -> bool:
+    """Is this launchd job actually installed on this machine?
+
+    Optional components are absent on a perfectly valid install, so "missing"
+    must mean not-applicable rather than broken — otherwise the cockpit alarms
+    daily about something the user deliberately never set up.
+    """
+    return (Path.home() / "Library" / "LaunchAgents" / f"{label}.plist").is_file()
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via a temp file + os.replace so readers never see a partial or
+    truncated artifact, and a failed write leaves the previous one intact."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
+
+
+def _ro(path: Path) -> sqlite3.Connection:
+    """Open read-only. Never let a health check mutate what it inspects."""
+    return sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5)
+
+
+def _resolved_python() -> str:
+    """The interpreter that would run `evolution.cli`.
+
+    Deliberately not a claim about the call graph: EVOLUTION_PYTHON is read by
+    the Node host (src/evolution-client.ts:22) for its own spawns, and nothing
+    threads it into `cli.py optimize`. This resolves it the same way the host
+    does so the probe reports on the environment a run would actually get.
+    """
+    return os.environ.get("EVOLUTION_PYTHON") or "python3"
+
+
+def _vault_path() -> Path | None:
+    """Vault path from the standard config, the way the rest of the repo reads it
+    (mirrors codex_warden_hooks.py). None when unset — memory_health handles that."""
+    try:
+        cfg = json.loads((Path("~/.config/deus/config.json").expanduser()).read_text())
+    except (OSError, ValueError):
+        return None
+    raw = cfg.get("vault_path")
+    return Path(raw).expanduser() if raw else None
+
+
+def _newest_source_mtime(directory: Path) -> float:
+    """Newest mtime among a package's sources. 0.0 when it cannot be read."""
+    newest = 0.0
+    try:
+        for p in directory.rglob("*.py"):
+            try:
+                newest = max(newest, p.stat().st_mtime)
+            except OSError:
+                continue
+    except OSError:
+        return 0.0
+    return newest
+
+
+# ── capability probes ─────────────────────────────────────────────────────────
+
+
+def probe_optimizer(now: float) -> Result:
+    """Can the DSPy optimizer run at all?
+
+    OK requires positive evidence of a completed run that postdates the code it
+    would be vindicating. Absence of known blockers is not evidence: enumerating
+    blockers is how LIA-556 shipped three separate silent paths, and two are
+    live right now (GEPA constructed without reflection_lm,
+    dspy_optimizer.py:303; the judge metric returning a dict rather than a
+    dspy.Prediction, :149-152). A future blocker nobody has listed lands in the
+    UNKNOWN branch rather than green.
+    """
+    py = _resolved_python()
+    try:
+        proc = subprocess.run(
+            [py, "-c", "import dspy; print(dspy.__version__)"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return Result(
+            "evolution.optimizer", UNKNOWN,
+            observed=f"could not run {py!r}: {type(exc).__name__}",
+            expected="an interpreter that can import dspy",
+            remedy=f"check that {py!r} exists and is executable",
+        )
+
+    if proc.returncode != 0:
+        return Result(
+            "evolution.optimizer", FAILED,
+            observed=f"{py} cannot import dspy",
+            expected="dspy importable by the interpreter that runs evolution.cli",
+            remedy=f"{py} -m pip install dspy  (or point EVOLUTION_PYTHON at an env that has it)",
+            detail={"interpreter": py, "stderr": proc.stderr.strip()[-200:]},
+        )
+
+    version = proc.stdout.strip()
+    code_mtime = _newest_source_mtime(REPO_ROOT / "evolution" / "optimizer")
+    last_ok = _last_optimizer_success()
+
+    if last_ok is None:
+        return Result(
+            "evolution.optimizer", UNKNOWN,
+            observed=f"dspy {version} importable, but no completed run on record",
+            expected="a completed optimize run newer than the optimizer sources",
+            remedy="run the optimizer once and confirm it completes",
+            detail={
+                "known_open_blockers": [
+                    "dspy_optimizer.py:303 constructs GEPA without reflection_lm",
+                    "dspy_optimizer.py:149-152 metric returns dict, not dspy.Prediction",
+                ],
+            },
+        )
+
+    if last_ok < code_mtime:
+        return Result(
+            "evolution.optimizer", UNKNOWN,
+            observed="newest completed run predates the current optimizer sources",
+            expected="a completed run newer than evolution/optimizer/*.py",
+            remedy="run the optimizer against the current code",
+            detail={"last_success_epoch": last_ok, "sources_mtime": code_mtime},
+        )
+
+    return Result(
+        "evolution.optimizer", OK,
+        observed=f"dspy {version}; completed run postdates the optimizer sources",
+        expected="a completed run newer than evolution/optimizer/*.py",
+    )
+
+
+def _last_optimizer_success() -> float | None:
+    """Epoch of the newest recorded optimizer success, or None.
+
+    A run cannot vindicate code written after it, so the caller compares this
+    against the sources' mtime. Returns None on any doubt.
+    """
+    import datetime as _dt
+
+    db = Path(os.environ.get("DEUS_EVOLUTION_DB", DEUS_HOME / "evolution.db")).expanduser()
+    if not db.exists():
+        return None
+    try:
+        con = _ro(db)
+        try:
+            # registry/storage are bookkeeping: evolution/cli.py:224,240 write
+            # them OK on every cycle, including below-threshold ones that
+            # optimize nothing and cycles that then fail every module. Counting
+            # them as "a completed run" would let routine bookkeeping certify a
+            # dead optimizer — the exact false-green this probe exists to stop.
+            row = con.execute(
+                "SELECT MAX(last_ok_at) FROM subsystem_health "
+                "WHERE component LIKE 'evolution.optimizer.%' "
+                "  AND component NOT IN ('evolution.optimizer.registry',"
+                "                        'evolution.optimizer.storage') "
+                "  AND last_ok_at IS NOT NULL"
+            ).fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return None
+    if not row or not row[0]:
+        return None
+    try:
+        return _dt.datetime.fromisoformat(row[0]).timestamp()
+    except ValueError:
+        return None
+
+
+# ── demand-gated probe ────────────────────────────────────────────────────────
+
+
+def probe_ingest(now: float, demand: "DemandWindow") -> Result:
+    """Is the interaction store readable, and how fresh is it?
+
+    Scope is deliberately narrow and the wording matters: these are read-only
+    SELECTs, so this cannot and does not assert that ingest *writes* work. A
+    disabled or no-op ingest path stays invisible to it. Proving the write path
+    needs a canary insert, which the read-only contract forbids — named here so
+    the limit is visible rather than implied away.
+
+    Reports reachability as a verdict and freshness as *observation*. It
+    deliberately does NOT derive a FAILED verdict from demand.
+
+    Three review rounds each found a different reason the demand comparison was
+    unsound: an unreadable log read as idle; the lifecycle markers fire 58/312/120
+    times rather than 1:1; and "New messages" is logged before trigger checks,
+    host-command handling and evolution opt-outs, so ordinary non-trigger group
+    traffic legitimately produces no interaction. Three distinct semantic gaps in
+    one rule is not bad luck — it means the log does not carry a trustworthy
+    "this arrival should have produced an interaction" signal, and inferring one
+    manufactures false alarms in the tool built to end them.
+
+    So this probe states what it can prove. Judging unserved demand needs a
+    first-class signal emitted at the point the decision is made, which is a
+    change to the runtime rather than something a log reader can recover.
+    """
+    db = Path(os.environ.get("DEUS_EVOLUTION_DB", DEUS_HOME / "evolution.db")).expanduser()
+    if not db.exists():
+        return Result(
+            "evolution.ingest", UNKNOWN,
+            observed=f"{db} does not exist",
+            expected="a readable evolution database",
+            remedy="check DEUS_EVOLUTION_DB / run Deus once to create it",
+        )
+    try:
+        con = _ro(db)
+        try:
+            con.execute("SELECT 1 FROM interactions LIMIT 1").fetchone()
+            newest = con.execute("SELECT MAX(timestamp) FROM interactions").fetchone()[0]
+            total = con.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+        finally:
+            con.close()
+    except sqlite3.Error as exc:
+        return Result(
+            "evolution.ingest", UNKNOWN,
+            observed=f"interactions unreadable: {type(exc).__name__}: {exc}",
+            expected="a queryable interactions table",
+            remedy="inspect the evolution database",
+        )
+
+    age = ""
+    if newest:
+        import datetime as _dt
+        try:
+            hours = (now - _dt.datetime.fromisoformat(newest).timestamp()) / 3600
+            age = f", newest {hours:.1f}h old"
+        except ValueError:
+            pass
+    return Result(
+        "evolution.ingest", OK,
+        observed=f"store readable, {total} interaction(s){age}",
+        expected="a queryable interactions table",
+        detail={"newest_interaction": newest, "demand_events_in_window": demand.count,
+                "demand_log_readable": demand.readable},
+    )
+
+
+@dataclass
+class DemandWindow:
+    """Real chat/agent demand in a window.
+
+    Deliberately excludes /health polls and GitHub/Linear webhooks: those run
+    constantly and would make every window look busy, which is how an earlier
+    version nearly concluded a three-day-idle system was under heavy load.
+    """
+
+    count: int
+    newest_epoch: float
+    window_start: float
+    window_sec: float
+    readable: bool = True
+
+
+#: ONE canonical arrival event. The lifecycle emits several records per request
+#: ("New messages" -> "Spawning container agent" -> "Container completed"), and
+#: they are nowhere near 1:1 — measured over the live log: 58 / 312 / 120. Summing
+#: them inflated demand ~8x and would have reported healthy traffic as DEGRADED
+#: forever. Arrival is the right one: it is what must be *served*, so a request
+#: that never reaches a container still counts as unmet demand.
+_DEMAND_MARKER = "New messages"
+
+
+def read_demand(log_path: Path, window_sec: float, now: float) -> DemandWindow:
+    start = now - window_sec
+    count = 0
+    newest = 0.0
+    readable = False
+    # Rotation: the live file may not span the whole window.
+    paths = [log_path] + [Path(p) for p in glob.glob(str(log_path.parent / "archives" / "*"))]
+    for path in paths:
+        try:
+            # Rotation produces logs/archives/*.log.gz; opening those as plain
+            # text silently yields nothing while the live file still marks the
+            # source readable, so missing demand would look like idleness.
+            opener = gzip.open if path.suffix == ".gz" else open
+            with opener(path, "rt", errors="replace") as fh:
+                readable = True
+                for line in fh:
+                    if not line.startswith("{"):
+                        continue
+                    if _DEMAND_MARKER not in line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except ValueError:
+                        continue
+                    ts = rec.get("time", 0) / 1000
+                    if ts < start:
+                        continue
+                    count += 1
+                    newest = max(newest, ts)
+        except OSError:
+            continue
+    return DemandWindow(count, newest, start, window_sec, readable)
+
+
+# ── memory (reuses scripts/memory_health.py) ──────────────────────────────────
+
+
+def probe_memory(now: float) -> Result:
+    """Delegate to memory_health.py, but do not inherit its fail-open contract.
+
+    That module deliberately swallows sqlite errors and returns healthy
+    (memory_health.py:78) so a startup banner never blocks on a probe fault.
+    Correct there, wrong here — it is the silent-failure shape this cockpit
+    exists to catch. So the cockpit independently proves the DB is genuinely
+    queryable before honouring any OK.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        from memory_health import DEFAULT_DB_PATH, assess_memory_health
+    except Exception as exc:
+        return Result(
+            "memory", UNKNOWN,
+            observed=f"memory_health unavailable: {type(exc).__name__}: {exc}",
+            expected="scripts/memory_health.py importable",
+            remedy="check the repo checkout",
+        )
+
+    db = DEFAULT_DB_PATH
+    if not db.exists():
+        return Result(
+            "memory", FAILED,
+            observed=f"{db} is missing",
+            expected="the memory tree database to exist",
+            remedy="restore the tree DB or re-run the indexer",
+        )
+
+    # quick_check reports corruption as a returned row, not an exception, so
+    # the value is what matters — catching exceptions alone would miss it.
+    try:
+        con = _ro(db)
+        try:
+            verdict = con.execute("PRAGMA quick_check").fetchone()[0]
+            con.execute("SELECT 1 FROM nodes LIMIT 1").fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error as exc:
+        return Result(
+            "memory", UNKNOWN,
+            observed=f"tree DB unreadable: {type(exc).__name__}: {exc}",
+            expected="a queryable memory tree database",
+            remedy="inspect ~/.deus/memory_tree.db",
+        )
+    if str(verdict).lower() != "ok":
+        return Result(
+            "memory", FAILED,
+            observed=f"PRAGMA quick_check returned {verdict!r}",
+            expected="quick_check == 'ok'",
+            remedy="restore the tree DB from a backup",
+        )
+
+    try:
+        healthy, _label, lines = assess_memory_health(_vault_path())
+    except Exception as exc:
+        return Result(
+            "memory", UNKNOWN,
+            observed=f"assess_memory_health raised: {type(exc).__name__}: {exc}",
+            expected="a memory health verdict",
+            remedy="run scripts/memory_health.py directly",
+        )
+
+    if healthy:
+        return Result("memory", OK, observed="tree DB queryable; no degradation reported")
+    missing = [ln for ln in lines if "missing" in ln.lower() or "unreadable" in ln.lower()]
+    return Result(
+        "memory", FAILED if missing else DEGRADED,
+        observed="; ".join(lines)[:300],
+        expected="no memory degradation",
+        remedy="python3 scripts/memory_health.py",
+    )
+
+
+# ── liveness + loaded config ──────────────────────────────────────────────────
+
+
+def probe_service(label: str, now: float) -> Result | None:
+    """launchd liveness. Returns None where launchd is not the service manager.
+
+    None means "not applicable here", which is different from UNKNOWN. The
+    scheduled job is installed on Linux and Windows too (SCHEDULED_JOBS in
+    setup/service.ts), so reporting UNKNOWN off-macOS would mark every healthy
+    run partially blind and pin the exit code at 4 forever — a permanent false
+    alarm, which is the failure mode this tool exists to remove.
+    """
+    if sys.platform != "darwin":
+        return None
+    probe = f"service.{label}"
+    if not _launch_agent_installed(label):
+        # Optional components (OPA is one) are simply absent on a valid
+        # install. Reporting a missing optional job as FAILED would alarm
+        # every single day on a perfectly healthy machine.
+        return None
+    try:
+        proc = subprocess.run(
+            ["launchctl", "list"], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return Result(probe, UNKNOWN, observed=f"launchctl unavailable: {exc}",
+                      expected="launchctl to be runnable",
+                      remedy="this probe assumes macOS launchd")
+    for line in proc.stdout.splitlines()[1:]:
+        parts = line.split("\t")
+        if len(parts) >= 3 and parts[2].strip() == label:
+            pid = parts[0].strip()
+            if pid == "-":
+                return Result(probe, FAILED, observed=f"loaded but not running (exit {parts[1].strip()})",
+                              expected="a live PID",
+                              remedy=f"launchctl kickstart -k gui/$(id -u)/{label}")
+            return Result(probe, OK, observed=f"running pid={pid}", expected="a live PID")
+    return Result(probe, FAILED, observed="not loaded in launchctl", expected="the job to be loaded",
+                  remedy=f"launchctl load ~/Library/LaunchAgents/{label}.plist")
+
+
+def probe_opa_policy(now: float, marker: str, url: str) -> Result | None:
+    """Verify the policy the daemon has LOADED, not the file on disk.
+
+    A live test once passed against a daemon serving a policy that did not
+    contain the rule under test; the file on disk was current and the process
+    was up, and both facts were irrelevant.
+    """
+    probe = "service.warden-opa.policy"
+    if sys.platform != "darwin" or not _launch_agent_installed("com.deus.warden-opa"):
+        # OPA is an optional macOS/launchd install; Linux packaging is out of
+        # scope and plenty of valid installs simply do not run it. Probing it
+        # unconditionally would alarm every healthy run forever.
+        return None
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            body = json.loads(resp.read().decode())
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return Result(probe, UNKNOWN, observed=f"{url} unreachable: {type(exc).__name__}",
+                      expected="the OPA policy API to answer",
+                      remedy="launchctl kickstart -k gui/$(id -u)/com.deus.warden-opa")
+    raw = " ".join(p.get("raw", "") for p in body.get("result", []))
+    if not raw:
+        return Result(probe, UNKNOWN, observed="policy API returned no policy text",
+                      expected="loaded policy source", remedy="check the OPA daemon")
+    if marker not in raw:
+        return Result(probe, DEGRADED,
+                      observed=f"loaded policy does not contain {marker!r}",
+                      expected=f"the loaded policy to contain {marker!r}",
+                      remedy="launchctl kickstart -k gui/$(id -u)/com.deus.warden-opa")
+    return Result(probe, OK, observed=f"loaded policy contains {marker!r}",
+                  expected=f"the loaded policy to contain {marker!r}")
+
+
+# ── run / render ──────────────────────────────────────────────────────────────
+
+
+DEFAULT_SERVICE_LABELS = ("com.deus", "com.deus.warden-opa")
+
+
+def run_probes(now: float, log_path: Path, window_sec: float,
+               opa_marker: str, opa_url: str,
+               service_labels: tuple[str, ...] = DEFAULT_SERVICE_LABELS) -> list[Result]:
+    demand = read_demand(log_path, window_sec, now)
+    results = [probe_optimizer(now), probe_ingest(now, demand), probe_memory(now)]
+    # `com.deus` is the label actually loaded. A `com.deus-v2.plist` also exists
+    # on some installs but is not the running job — probing it reports a
+    # confident FAILED about a service nobody runs.
+    for label in service_labels:
+        service = probe_service(label, now)
+        if service is not None:
+            results.append(service)
+    opa = probe_opa_policy(now, opa_marker, opa_url)
+    if opa is not None:
+        results.append(opa)
+    return results
+
+
+def merge_history(results: list[Result], previous: dict, now: float) -> dict:
+    """Carry per-probe streaks so a regression is distinguishable from a rut.
+
+    Requirement 6: a subsystem that has been broken for a week should stay in
+    the report but stop shouting, or the user learns to skip the whole thing.
+    """
+    prev = {p["probe"]: p for p in previous.get("probes", [])}
+    out = []
+    for r in results:
+        rec = asdict(r)
+        was = prev.get(r.probe, {})
+        bad = r.status != OK
+        was_bad = was.get("status", OK) != OK
+        rec["first_bad_at"] = (
+            was.get("first_bad_at") if bad and was_bad else (now if bad else None)
+        )
+        rec["consecutive_bad_runs"] = (was.get("consecutive_bad_runs", 0) + 1) if bad and was_bad else (1 if bad else 0)
+        rec["is_regression"] = bad and not was_bad
+        out.append(rec)
+    return {"checked_at": now, "probes": out}
+
+
+def overall(results: list[Result]) -> str:
+    return max((r.status for r in results), key=lambda s: _RANK[s], default=UNKNOWN)
+
+
+def exit_code(results: list[Result]) -> int:
+    statuses = [r.status for r in results]
+    if not statuses:
+        return EXIT_ALL_UNKNOWN
+    if FAILED in statuses:
+        return EXIT_FAILED
+    if all(s == UNKNOWN for s in statuses):
+        return EXIT_ALL_UNKNOWN
+    if UNKNOWN in statuses:
+        return EXIT_PARTIAL_UNKNOWN
+    return EXIT_OK
+
+
+def render_line(state: dict) -> str:
+    bad = [p for p in state["probes"] if p["status"] != OK]
+    if not bad:
+        return "OK"
+    # Rank first, then regressions win ties: an ongoing failure would otherwise
+    # keep hiding a new one of equal severity behind it, which is precisely the
+    # news the reader needs today.
+    worst = max(bad, key=lambda p: (_RANK[p["status"]], bool(p["is_regression"])))
+    tag = "NEW" if worst["is_regression"] else "ONGOING"
+    return f"{worst['status']} {worst['probe']} ({tag}) — {worst['observed']}"
+
+
+def render_report(state: dict) -> str:
+    lines = ["=== Deus cockpit ==="]
+    for p in state["probes"]:
+        mark = "" if p["status"] == OK else (
+            "  NEW" if p["is_regression"] else f"  ONGOING x{p['consecutive_bad_runs']}"
+        )
+        lines.append(f"[{p['status']:<8}] {p['probe']}{mark}")
+        if p["status"] != OK:
+            lines.append(f"             observed: {p['observed']}")
+            if p["expected"]:
+                lines.append(f"             expected: {p['expected']}")
+            if p["remedy"]:
+                lines.append(f"             fix:      {p['remedy']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+    ap.add_argument("--brief", action="store_true", help="print the cached line; never probes")
+    ap.add_argument("--log", type=Path, default=REPO_ROOT / "logs" / "deus.log")
+    ap.add_argument("--window-hours", type=float, default=24.0)
+    ap.add_argument("--opa-marker", default="package deus.wardens")
+    ap.add_argument("--opa-url", default="http://127.0.0.1:8181/v1/policies")
+    ap.add_argument("--service-labels", default=",".join(DEFAULT_SERVICE_LABELS),
+                    help="comma-separated launchd labels to probe")
+    args = ap.parse_args(argv)
+
+    if args.brief:
+        try:
+            age = time.time() - ARTIFACT_LINE.stat().st_mtime
+            line = ARTIFACT_LINE.read_text().strip()
+        except OSError:
+            # Silence here would be the very bug this tool exists to catch.
+            print("cockpit: no healthcheck result on record")
+            return EXIT_ALL_UNKNOWN
+        if not line:
+            # A truncated/empty artifact is a broken checker, not a clean bill.
+            print("cockpit: healthcheck result is empty — the checker may have failed mid-write")
+            return EXIT_ALL_UNKNOWN
+        if age > ARTIFACT_MAX_AGE_SEC:
+            print(f"cockpit: last result is {age / 3600:.0f}h old — healthcheck may not be running")
+            return EXIT_ALL_UNKNOWN
+        if line != OK:
+            print(f"cockpit: {line}")
+        return EXIT_OK
+
+    now = time.time()
+    results = run_probes(now, args.log, args.window_hours * 3600,
+                         args.opa_marker, args.opa_url,
+                         tuple(args.service_labels.split(",")))
+    try:
+        previous = json.loads(ARTIFACT_JSON.read_text())
+    except (OSError, ValueError):
+        previous = {}
+    state = merge_history(results, previous, now)
+    code = exit_code(results)
+
+    try:
+        ARTIFACT_JSON.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic replace: a plain write truncates first, so a failure midway
+        # would destroy the previous verdict AND leave an empty file that
+        # --brief would read as healthy. Losing evidence while looking fine is
+        # the failure mode this tool exists to remove.
+        _atomic_write(ARTIFACT_JSON, json.dumps(state, indent=2, sort_keys=True))
+        _atomic_write(ARTIFACT_LINE, render_line(state) + "\n")
+    except OSError as exc:
+        print(f"cockpit: could not write artifact: {exc}", file=sys.stderr)
+        return EXIT_WRITE_FAILED
+
+    print(json.dumps(state, indent=2, sort_keys=True) if args.as_json else render_report(state))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_cockpit_healthcheck.py
+++ b/scripts/tests/test_cockpit_healthcheck.py
@@ -1,0 +1,451 @@
+"""Tests for the cockpit healthcheck (LIA-552).
+
+The recurring theme: this tool exists because a subsystem reported healthy while
+being dead, so most of these tests assert that some *plausible* path to OK is
+refused. A checker that can be talked into green is worse than no checker.
+"""
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import cockpit_healthcheck as cock  # noqa: E402
+
+
+NOW = 1_786_800_000.0
+
+
+def _evolution_db(path: Path, interactions=(), health=()):
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE interactions (id TEXT PRIMARY KEY, timestamp TEXT)")
+    con.execute(
+        "CREATE TABLE subsystem_health (component TEXT PRIMARY KEY, last_status TEXT,"
+        " last_reason TEXT, last_attempt_at TEXT, last_skipped_at TEXT, last_ok_at TEXT,"
+        " consecutive_failures INTEGER, first_failed_at TEXT)"
+    )
+    con.executemany("INSERT INTO interactions VALUES (?,?)", interactions)
+    con.executemany(
+        "INSERT INTO subsystem_health VALUES (?,?,?,?,?,?,?,?)", health
+    )
+    con.commit()
+    con.close()
+    return path
+
+
+# ── the capability probe cannot be talked into OK ─────────────────────────────
+
+
+def test_optimizer_is_failed_when_dspy_is_unimportable(monkeypatch):
+    """Today's real state, and the ticket's acceptance criterion."""
+    monkeypatch.setattr(cock.subprocess, "run", lambda *a, **k: type(
+        "P", (), {"returncode": 1, "stdout": "", "stderr": "No module named 'dspy'"})())
+
+    r = cock.probe_optimizer(NOW)
+    assert r.status == cock.FAILED
+    assert "dspy" in r.observed
+    assert r.remedy, "a FAILED verdict must tell the reader what to do"
+
+
+def test_importable_dspy_alone_does_not_make_the_optimizer_ok(monkeypatch, tmp_path):
+    """The co-gate finding: importability is a precondition, not a capability.
+
+    Two blockers are live in the real source (GEPA without reflection_lm; the
+    metric returning a dict). If merely installing dspy flipped this to OK, the
+    cockpit would manufacture the false-green it exists to prevent.
+    """
+    monkeypatch.setattr(cock.subprocess, "run", lambda *a, **k: type(
+        "P", (), {"returncode": 0, "stdout": "3.1.3", "stderr": ""})())
+    monkeypatch.setattr(cock, "_last_optimizer_success", lambda: None)
+
+    r = cock.probe_optimizer(NOW)
+    assert r.status == cock.UNKNOWN, "no completed run on record must not be OK"
+    assert r.status != cock.OK
+    assert "known_open_blockers" in r.detail
+
+
+def test_a_run_older_than_the_code_cannot_vindicate_it(monkeypatch):
+    """A real 2026-03-30 artifact exists; it must not certify today's code."""
+    monkeypatch.setattr(cock.subprocess, "run", lambda *a, **k: type(
+        "P", (), {"returncode": 0, "stdout": "3.1.3", "stderr": ""})())
+    monkeypatch.setattr(cock, "_last_optimizer_success", lambda: NOW - 10_000)
+    monkeypatch.setattr(cock, "_newest_source_mtime", lambda d: NOW)
+
+    r = cock.probe_optimizer(NOW)
+    assert r.status == cock.UNKNOWN
+    assert "predates" in r.observed
+
+
+def test_optimizer_ok_requires_a_run_newer_than_the_sources(monkeypatch):
+    monkeypatch.setattr(cock.subprocess, "run", lambda *a, **k: type(
+        "P", (), {"returncode": 0, "stdout": "3.1.3", "stderr": ""})())
+    monkeypatch.setattr(cock, "_last_optimizer_success", lambda: NOW)
+    monkeypatch.setattr(cock, "_newest_source_mtime", lambda d: NOW - 10_000)
+
+    assert cock.probe_optimizer(NOW).status == cock.OK
+
+
+# ── demand gating: neither cry-wolf nor complacent ────────────────────────────
+
+
+
+
+
+def test_ingest_reports_reachability_not_a_demand_verdict(tmp_path, monkeypatch):
+    """Re-scoped after three review rounds each found a different semantic gap
+    in the demand comparison. The probe now states what it can prove: the store
+    is reachable. It must NOT manufacture a FAILED from log-inferred demand."""
+    import datetime as dt
+    old_ts = dt.datetime.fromtimestamp(NOW - 300_000, dt.timezone.utc).isoformat()
+    db = _evolution_db(tmp_path / "e.db", interactions=[("i1", old_ts)])
+    monkeypatch.setenv("DEUS_EVOLUTION_DB", str(db))
+    heavy = cock.DemandWindow(count=99, newest_epoch=NOW, window_start=NOW - 3600,
+                              window_sec=3600)
+
+    r = cock.probe_ingest(NOW, heavy)
+    assert r.status == cock.OK, "unserved-demand inference is deliberately gone"
+    assert "readable" in r.observed
+    # the raw signals stay visible as evidence, just not as a verdict
+    assert r.detail["demand_events_in_window"] == 99
+
+
+def test_missing_interactions_table_is_unknown_not_ok(tmp_path, monkeypatch):
+    bare = tmp_path / "bare.db"
+    sqlite3.connect(bare).close()
+    monkeypatch.setenv("DEUS_EVOLUTION_DB", str(bare))
+    demand = cock.DemandWindow(count=0, newest_epoch=0.0, window_start=NOW - 3600, window_sec=3600)
+
+    r = cock.probe_ingest(NOW, demand)
+    assert r.status == cock.UNKNOWN, "an idle-looking but broken DB must not read as idle-OK"
+
+
+
+def test_one_request_counts_once_not_once_per_lifecycle_event(tmp_path):
+    """Measured on the live log, the lifecycle markers fire 58 / 312 / 120 times
+    — summing them inflated demand ~8x and would have reported healthy traffic
+    as DEGRADED permanently. Only the arrival event counts."""
+    log = tmp_path / "deus.log"
+    (tmp_path / "archives").mkdir()
+    recs = [
+        {"time": NOW * 1000, "msg": "New messages"},
+        {"time": NOW * 1000, "msg": "Spawning container agent"},
+        {"time": NOW * 1000, "msg": "Container completed"},
+    ]
+    log.write_text("\n".join(json.dumps(r) for r in recs))
+
+    assert cock.read_demand(log, 3600, NOW).count == 1
+
+
+def test_service_probe_is_skipped_off_macos(monkeypatch):
+    """The scheduled job installs on Linux and Windows too. A launchctl-only
+    probe returning UNKNOWN there would pin every healthy run at exit 4."""
+    monkeypatch.setattr(cock.sys, "platform", "linux")
+    assert cock.probe_service("com.deus", NOW) is None, "not-applicable, not blind"
+
+    monkeypatch.setattr(cock.sys, "platform", "darwin")
+    assert cock.probe_service("com.deus", NOW) is not None
+
+
+def test_run_probes_omits_service_probes_off_macos(monkeypatch, tmp_path):
+    monkeypatch.setattr(cock.sys, "platform", "linux")
+    monkeypatch.setattr(cock, "probe_optimizer", lambda n: _res(cock.OK, "opt"))
+    monkeypatch.setattr(cock, "probe_ingest", lambda n, d: _res(cock.OK, "ing"))
+    monkeypatch.setattr(cock, "probe_memory", lambda n: _res(cock.OK, "mem"))
+    monkeypatch.setattr(cock, "probe_opa_policy", lambda n, m, u: _res(cock.OK, "opa"))
+    monkeypatch.setattr(cock, "read_demand",
+                        lambda *a: cock.DemandWindow(0, 0.0, NOW - 60, 60))
+
+    names = [r.probe for r in cock.run_probes(NOW, tmp_path / "l", 60, "m", "u")]
+    assert not any(n.startswith("service.com.deus") for n in names)
+    assert cock.exit_code(cock.run_probes(NOW, tmp_path / "l", 60, "m", "u")) == cock.EXIT_OK
+
+
+def test_bookkeeping_components_do_not_count_as_a_completed_run(tmp_path, monkeypatch):
+    """evolution/cli.py:224,240 write registry/storage OK on every cycle, even
+    below-threshold ones that optimize nothing. Treating those as a completed
+    run would let routine bookkeeping certify a dead optimizer."""
+    import datetime as dt
+    recent = dt.datetime.fromtimestamp(NOW, dt.timezone.utc).isoformat()
+    db = _evolution_db(tmp_path / "e.db", health=[
+        ("evolution.optimizer.registry", "OK", None, recent, None, recent, 0, None),
+        ("evolution.optimizer.storage", "OK", None, recent, None, recent, 0, None),
+    ])
+    monkeypatch.setenv("DEUS_EVOLUTION_DB", str(db))
+    assert cock._last_optimizer_success() is None, "bookkeeping is not a run"
+
+    db2 = _evolution_db(tmp_path / "e2.db", health=[
+        ("evolution.optimizer.registry", "OK", None, recent, None, recent, 0, None),
+        ("evolution.optimizer.qa", "OK", None, recent, None, recent, 0, None),
+    ])
+    monkeypatch.setenv("DEUS_EVOLUTION_DB", str(db2))
+    assert cock._last_optimizer_success() is not None, "a real module run counts"
+
+
+def test_demand_reads_gzipped_archives(tmp_path):
+    """Rotation writes logs/archives/*.log.gz. Opening those as plain text
+    silently drops their records while the live file still marks the source
+    readable — missing demand would then look like idleness."""
+    import gzip as _gz
+    log = tmp_path / "deus.log"
+    arch = tmp_path / "archives"
+    arch.mkdir()
+    log.write_text(json.dumps({"time": NOW * 1000, "msg": "New messages"}))
+    with _gz.open(arch / "deus.2026-01-01.log.gz", "wt") as fh:
+        fh.write(json.dumps({"time": (NOW - 100) * 1000, "msg": "New messages"}))
+
+    assert cock.read_demand(log, 3600, NOW).count == 2, "gzipped archive must be read"
+
+
+def test_opa_probe_is_skipped_off_macos(monkeypatch):
+    """OPA is an optional macOS/launchd install; Linux packaging is out of
+    scope. UNKNOWN there would alarm every healthy run forever."""
+    monkeypatch.setattr(cock.sys, "platform", "linux")
+    assert cock.probe_opa_policy(NOW, "m", "http://127.0.0.1:9/x") is None
+
+
+def test_demand_excludes_health_polls_and_webhooks(tmp_path):
+    """1,226 GitHub webhooks and 23 /health polls once made a three-day-idle
+    system look busy. Only chat/agent events count."""
+    log = tmp_path / "deus.log"
+    (tmp_path / "archives").mkdir()
+    recs = [
+        {"time": NOW * 1000, "msg": "ingress request", "path": "/health"},
+        {"time": NOW * 1000, "msg": "ingress request", "path": "/github"},
+        {"time": NOW * 1000, "msg": "New messages"},
+    ]
+    log.write_text("\n".join(json.dumps(r) for r in recs))
+
+    d = cock.read_demand(log, 3600, NOW)
+    assert d.count == 1, "only the chat event is demand"
+
+
+def test_demand_reads_across_rotation(tmp_path):
+    log = tmp_path / "deus.log"
+    arch = tmp_path / "archives"
+    arch.mkdir()
+    log.write_text(json.dumps({"time": NOW * 1000, "msg": "New messages"}))
+    (arch / "deus.log.1").write_text(json.dumps({"time": (NOW - 100) * 1000, "msg": "New messages"}))
+
+    assert cock.read_demand(log, 3600, NOW).count == 2
+
+
+# ── memory reuse must not inherit the fail-open contract ──────────────────────
+
+
+def test_corrupt_tree_db_is_not_ok_even_if_the_library_says_ok(tmp_path, monkeypatch):
+    """quick_check reports corruption as a returned row, not an exception, so a
+    probe that only catches exceptions would honour memory_health's fail-open OK."""
+    db = tmp_path / "memory_tree.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE nodes (path TEXT)")
+    con.commit()
+    con.close()
+
+    import memory_health
+    monkeypatch.setattr(memory_health, "DEFAULT_DB_PATH", db)
+    monkeypatch.setattr(memory_health, "assess_memory_health", lambda *a, **k: (True, "ok", []))
+
+    real_ro = cock._ro
+
+    class _Cursor:
+        """Stands in for a sqlite cursor reporting corruption the way SQLite
+        really does: a returned row, not a raised exception."""
+        def fetchone(self): return ("*** in database main ***\nPage 4 is never used",)
+
+    class _Con:
+        def __init__(self, inner): self._inner = inner
+        def execute(self, sql, *a):
+            if "quick_check" in sql:
+                return _Cursor()
+            return self._inner.execute(sql, *a)
+        def close(self): self._inner.close()
+
+    monkeypatch.setattr(cock, "_ro", lambda p: _Con(real_ro(p)))
+
+    r = cock.probe_memory(NOW)
+    assert r.status == cock.FAILED
+    assert "quick_check" in r.observed
+
+
+def test_missing_tree_db_is_failed(tmp_path, monkeypatch):
+    import memory_health
+    monkeypatch.setattr(memory_health, "DEFAULT_DB_PATH", tmp_path / "gone.db")
+    assert cock.probe_memory(NOW).status == cock.FAILED
+
+
+# ── exit codes: no path may silently mean "fine" ──────────────────────────────
+
+
+def _res(status, name="p"):
+    return cock.Result(name, status)
+
+
+def test_exit_codes_cover_every_combination():
+    assert cock.exit_code([_res(cock.OK)]) == cock.EXIT_OK
+    assert cock.exit_code([_res(cock.OK), _res(cock.DEGRADED, "b")]) == cock.EXIT_OK
+    assert cock.exit_code([_res(cock.FAILED)]) == cock.EXIT_FAILED
+    assert cock.exit_code([_res(cock.UNKNOWN)]) == cock.EXIT_ALL_UNKNOWN
+    # partial blindness must not read as success
+    assert cock.exit_code([_res(cock.OK), _res(cock.UNKNOWN, "b")]) == cock.EXIT_PARTIAL_UNKNOWN
+    # a known failure outranks an unknown: it is the actionable one
+    assert cock.exit_code([_res(cock.FAILED), _res(cock.UNKNOWN, "b")]) == cock.EXIT_FAILED
+    assert cock.exit_code([]) == cock.EXIT_ALL_UNKNOWN
+
+
+def test_artifact_write_failure_is_reported_not_swallowed(tmp_path, monkeypatch, capsys):
+    """A checker that cannot record its own result must say so — LIA-556's lesson."""
+    monkeypatch.setattr(cock, "ARTIFACT_JSON", tmp_path / "nope" / "x.json")
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", tmp_path / "nope" / "x.line")
+    monkeypatch.setattr(cock, "run_probes", lambda *a, **k: [_res(cock.OK)])
+
+    def boom(*a, **k):
+        raise OSError("read-only filesystem")
+    monkeypatch.setattr(Path, "mkdir", boom)
+
+    assert cock.main([]) == cock.EXIT_WRITE_FAILED
+    assert "could not write artifact" in capsys.readouterr().err
+
+
+# ── regression vs steady state ────────────────────────────────────────────────
+
+
+def test_bare_invocation_is_the_run_mode(tmp_path, monkeypatch):
+    """The scheduled job passes no arguments (SCHEDULED_JOBS carries none), so a
+    bare call must probe and write. Guards against a future edit gating the
+    probe branch on a flag and silently disabling the daily run."""
+    monkeypatch.setattr(cock, "ARTIFACT_JSON", tmp_path / "c.json")
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", tmp_path / "c.line")
+    monkeypatch.setattr(cock, "run_probes", lambda *a, **k: [_res(cock.OK, "x")])
+
+    assert cock.main([]) == cock.EXIT_OK
+    assert (tmp_path / "c.json").exists(), "a bare call must write the artifact"
+    assert (tmp_path / "c.line").read_text().strip() == "OK"
+
+
+def test_first_failure_is_a_regression_and_repeats_are_not():
+    first = cock.merge_history([_res(cock.FAILED, "x")], {}, NOW)
+    assert first["probes"][0]["is_regression"] is True
+    assert first["probes"][0]["consecutive_bad_runs"] == 1
+
+    second = cock.merge_history([_res(cock.FAILED, "x")], first, NOW + 3600)
+    assert second["probes"][0]["is_regression"] is False, "don't shout twice"
+    assert second["probes"][0]["consecutive_bad_runs"] == 2
+    assert second["probes"][0]["first_bad_at"] == NOW, "streak start is preserved"
+
+
+def test_recovery_clears_the_streak():
+    bad = cock.merge_history([_res(cock.FAILED, "x")], {}, NOW)
+    good = cock.merge_history([_res(cock.OK, "x")], bad, NOW + 60)
+    assert good["probes"][0]["consecutive_bad_runs"] == 0
+    assert good["probes"][0]["first_bad_at"] is None
+
+
+# ── the shell-facing path ─────────────────────────────────────────────────────
+
+
+def test_brief_is_silent_when_healthy(tmp_path, monkeypatch, capsys):
+    line = tmp_path / "l"
+    line.write_text("OK\n")
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", line)
+    assert cock.main(["--brief"]) == cock.EXIT_OK
+    assert capsys.readouterr().out == "", "quiet when healthy, or it becomes noise"
+
+
+def test_brief_speaks_up_when_not_healthy(tmp_path, monkeypatch, capsys):
+    line = tmp_path / "l"
+    line.write_text("FAILED evolution.optimizer (NEW) — cannot import dspy\n")
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", line)
+    cock.main(["--brief"])
+    assert "evolution.optimizer" in capsys.readouterr().out
+
+
+def test_brief_reports_a_missing_artifact_rather_than_nothing(tmp_path, monkeypatch, capsys):
+    """Silence when the checker is broken is the exact bug this tool exists for."""
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", tmp_path / "absent")
+    assert cock.main(["--brief"]) == cock.EXIT_ALL_UNKNOWN
+    assert "no healthcheck result" in capsys.readouterr().out
+
+
+def test_brief_reports_a_stale_artifact(tmp_path, monkeypatch, capsys):
+    line = tmp_path / "l"
+    line.write_text("OK\n")
+    import os
+    old = time.time() - (cock.ARTIFACT_MAX_AGE_SEC + 3600)
+    os.utime(line, (old, old))
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", line)
+    cock.main(["--brief"])
+    assert "may not be running" in capsys.readouterr().out
+
+
+def test_brief_rejects_an_empty_cached_verdict(tmp_path, monkeypatch, capsys):
+    """A truncated artifact is a checker that died mid-write. Reading it as
+    healthy would be a false green produced by the health tool itself."""
+    line = tmp_path / "l"
+    line.write_text("")
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", line)
+    assert cock.main(["--brief"]) == cock.EXIT_ALL_UNKNOWN
+    assert "empty" in capsys.readouterr().out
+
+
+def test_a_failed_artifact_write_preserves_the_previous_result(tmp_path, monkeypatch):
+    """Non-atomic writes truncate first; a failure would destroy the prior
+    verdict and leave an empty file that reads as healthy."""
+    target = tmp_path / "c.line"
+    target.write_text("FAILED evolution.optimizer (NEW) — previous evidence\n")
+
+    real_replace = cock.os.replace
+    monkeypatch.setattr(cock.os, "replace",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    with pytest.raises(OSError):
+        cock._atomic_write(target, "new content")
+    monkeypatch.setattr(cock.os, "replace", real_replace)
+
+    assert "previous evidence" in target.read_text(), "prior verdict must survive"
+
+
+def test_a_new_regression_outranks_an_ongoing_failure_of_equal_severity():
+    """Otherwise today's news stays hidden behind yesterday's known breakage."""
+    state = {"probes": [
+        {"probe": "old", "status": cock.FAILED, "observed": "known", "is_regression": False},
+        {"probe": "new", "status": cock.FAILED, "observed": "just broke", "is_regression": True},
+    ]}
+    assert "new" in cock.render_line(state)
+    assert "NEW" in cock.render_line(state)
+
+
+def test_optional_components_absent_are_skipped_not_failed(monkeypatch):
+    """A valid install simply may not run OPA. Calling that FAILED would alarm
+    daily about something deliberately never set up."""
+    monkeypatch.setattr(cock.sys, "platform", "darwin")
+    monkeypatch.setattr(cock, "_launch_agent_installed", lambda label: False)
+    assert cock.probe_service("com.deus.warden-opa", NOW) is None
+    assert cock.probe_opa_policy(NOW, "m", "http://127.0.0.1:9/x") is None
+
+
+def test_ingest_does_not_claim_the_write_path(tmp_path, monkeypatch):
+    """Read-only SELECTs cannot prove writes work; the wording must not imply it."""
+    db = _evolution_db(tmp_path / "e.db")
+    monkeypatch.setenv("DEUS_EVOLUTION_DB", str(db))
+    r = cock.probe_ingest(NOW, cock.DemandWindow(0, 0.0, NOW - 60, 60))
+    assert "write path" not in r.observed
+    assert "readable" in r.observed
+
+
+def test_brief_never_probes(tmp_path, monkeypatch):
+    """The shell path must not open a DB, spawn a process, or hit the network —
+    that is what keeps `deus` launch instant without needing a timeout."""
+    line = tmp_path / "l"
+    line.write_text("OK\n")
+    monkeypatch.setattr(cock, "ARTIFACT_LINE", line)
+
+    def forbidden(*a, **k):
+        raise AssertionError("--brief must not probe")
+    monkeypatch.setattr(cock.sqlite3, "connect", forbidden)
+    monkeypatch.setattr(cock.subprocess, "run", forbidden)
+    monkeypatch.setattr(cock.urllib.request, "urlopen", forbidden)
+
+    assert cock.main(["--brief"]) == cock.EXIT_OK

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -12,6 +12,22 @@ import { SCHEDULED_JOBS, buildScheduledJobPlist } from './service.js';
 describe('scheduled python jobs (LIA-254 generic refactor)', () => {
   const maintenance = SCHEDULED_JOBS.find((j) => j.id === 'maintenance');
   const morning = SCHEDULED_JOBS.find((j) => j.id === 'morning-report');
+  const cockpit = SCHEDULED_JOBS.find((j) => j.id === 'cockpit-healthcheck');
+
+  it('schedules the cockpit healthcheck between maintenance and the report', () => {
+    // Ordering is the point, not just presence: it must run AFTER the 04:30
+    // maintenance run so it grades that run, and BEFORE the 07:00 morning
+    // report so the report can read a fresh verdict (LIA-552).
+    expect(cockpit).toEqual({
+      id: 'cockpit-healthcheck',
+      scriptRelPath: 'scripts/cockpit_healthcheck.py',
+      hour: 6,
+      minute: 45,
+      description: 'Deus cockpit healthcheck',
+    });
+    expect(cockpit!.hour).toBeGreaterThan(maintenance!.hour);
+    expect(cockpit!.hour).toBeLessThan(morning!.hour);
+  });
 
   it('preserves the maintenance job spec (regression guard for the refactor)', () => {
     // The 04:30 KB maintenance job is live-critical — the generic extraction

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -865,6 +865,19 @@ export const SCHEDULED_JOBS: ScheduledJobSpec[] = [
     minute: 0,
     description: 'Deus morning memory report',
   },
+  {
+    // 06:45 sits after the 04:30 maintenance run so it grades that run's
+    // outcome rather than the previous day's, and before the 07:00 morning
+    // report so a fresh verdict is on disk if that report is ever wired to
+    // read it. It is NOT wired today — morning_report.py has no reference to
+    // the cockpit artifact — so this slot is preparation, not integration
+    // (LIA-552).
+    id: 'cockpit-healthcheck',
+    scriptRelPath: 'scripts/cockpit_healthcheck.py',
+    hour: 6,
+    minute: 45,
+    description: 'Deus cockpit healthcheck',
+  },
 ];
 
 function jobTaskName(id: string): string {


### PR DESCRIPTION
`launchctl list` proves a process is loaded. It says nothing about whether interactions are being judged. That gap let the evolution optimizer sit dead from 2026-03 to 2026-08 with no external signal (LIA-551).

## It catches the bug that motivated it, today

```
=== Deus cockpit ===
[FAILED  ] evolution.optimizer  ONGOING x15
             observed: python3 cannot import dspy
             expected: dspy importable by the interpreter that runs evolution.cli
             fix:      python3 -m pip install dspy
[OK      ] evolution.ingest
[OK      ] memory
[OK      ] service.com.deus
[OK      ] service.com.deus.warden-opa
[OK      ] service.warden-opa.policy
exit 1
```

The FAILED verdict is a **directly observed precondition**, not an inference: `python3 -c "import dspy"` fails while `.venv/bin/python` has 3.1.3. No threshold to argue about, correct on a quiet week, and it would have fired on day one in March.

## Two rules keep it from becoming the bug it detects

**A probe that cannot reach a verdict reports UNKNOWN** — never OK, counted separately, with its own exit code (`0` ok / `1` failed / `2` all-unknown / `3` write-failed / `4` partial blindness; FAILED outranks UNKNOWN).

**OK is only asserted from positive evidence.** For the optimizer that means a completed run *newer than* `evolution/optimizer/*.py` — a real 2026-03-30 artifact exists and must not vindicate today's code — and it excludes `registry`/`storage`, which `cli.py:224,240` write `OK` on every cycle including below-threshold ones. Routine bookkeeping must not certify a dead optimizer.

## What was removed, and why that is the honest outcome

An earlier ingest probe derived FAILED from log-inferred demand. Three review rounds each found a **different** semantic gap:

| round | gap |
| -- | -- |
| 1 | an unreadable log counted as zero demand → reported "idle OK" |
| 2 | the lifecycle markers fire **58 / 312 / 120** times on the live log, not 1:1 — summing them inflated demand ~8× and would emit permanent DEGRADED once chat resumed |
| 3 | `"New messages"` is logged *before* trigger checks and evolution opt-outs, so ordinary non-trigger traffic legitimately produces no interaction |

Three distinct gaps in one rule is not bad luck — the log carries no trustworthy "this arrival should have produced an interaction" signal, and inferring one manufactures false alarms inside the tool built to end them. **The demand verdict is removed** rather than patched a fourth time. Ingest now reports store readability and freshness as observation, keeping the raw counts as evidence. A sound version needs a first-class signal emitted where the decision is made — a runtime change, not something a log reader can recover.

## Reuse without inheriting a fail-open contract

`scripts/memory_health.py` is reused rather than rebuilt (the ticket asks for this), but `memory_health.py:78` swallows sqlite errors and returns healthy — correct for a startup banner, wrong here. The cockpit runs its own `PRAGMA quick_check` and **requires the returned value to be `"ok"`**, because corruption comes back as a row, not an exception.

## Delivery

One `SCHEDULED_JOBS` entry wires **macOS, Linux and Windows** through the existing installer machinery — no new XML, no new installer. A bare invocation is the run mode, because that is exactly what those installers issue.

`deus` / `deus home` print a non-OK verdict from a one-line cache: no interpreter start, no DB, no network, so nothing can hang and no timeout is needed (macOS ships neither `timeout` nor `gtimeout`). It sits in the non-print-identity branch because other code parses that output. **Silence is never the answer** — a missing, empty, or stale artifact each say so, and artifact writes are `os.replace`-atomic so a failed write cannot truncate the previous verdict into an empty file that reads as healthy.

## Verification

- Live: `evolution.optimizer` FAILED, **exit 1** (checked unpiped), verdict independently confirmed real
- **31 new tests.** The full `scripts/tests` failure set is byte-identical to a stashed clean `origin/main` — 6 pre-existing, 0 new, delta exactly those 31
- vitest **2085**, `tsc --noEmit` clean, `bash -n deus-cmd.sh` clean
- `deus --print-identity` byte-clean: **0** occurrences of the emitted format
- Read-only throughout, with one documented exception — `memory_health`'s deliberate vault touch+unlink, which is the point of that probe (it catches macOS Full-Disk-Access failures where the vault reads fine and writes silently fail)

## Known limits, named not implied

- Criterion 5 ("detects stopped growing") is met for `evolution.optimizer` specifically, **not** generalized across probes — see the removal above.
- Ingest cannot prove the *write* path from read-only SELECTs; a disabled ingest stays invisible. Closing it needs a canary insert, which the read-only contract forbids.
- The 06:45 slot is chosen so a fresh verdict exists before the 07:00 morning report, but that report does **not** read it today. Preparation, not integration.

Refs LIA-552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
