### PR TITLE
fix(container): scope orphan cleanup to this install's containers (LIA-491)

### DIFF
--- a/.claude/skills/convert-to-apple-container/SKILL.md
+++ b/.claude/skills/convert-to-apple-container/SKILL.md
@@ -12,6 +12,12 @@ This skill switches Deus's container runtime from Docker to Apple Container (mac
 - Mount syntax: `-v path:path:ro` → `--mount type=bind,source=...,target=...,readonly`
 - Startup check: `docker info` → `container system status` (with auto-start)
 - Orphan detection: `docker ps --filter` → `container ls --format json`
+  - **Preserve the instance-suffix scoping (LIA-491).** `cleanupOrphans()` only
+    stops containers whose name ends in this install's `-i<8hex>` stamp; names
+    without a stamp are warned about, never stopped. Dropping that partition
+    during the port silently restores the old host-wide sweep, in which a second
+    daemon kills the first's live containers. The stamp is a plain name suffix,
+    so it survives any listing format — only the parsing needs porting.
 - Build script default: `docker` → `container`
 - Dockerfile entrypoint: `.env` shadowing via `mount --bind` inside the container (Apple Container only supports directory mounts, not file mounts like Docker's `/dev/null` overlay)
 - Container runner: main-group containers start as root for `mount --bind`, then drop privileges via `setpriv`

--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,11 @@ CONTAINER_TIMEOUT=1800000
 MAX_CONCURRENT_CONTAINERS=5
 IDLE_TIMEOUT=1800000
 CONTAINER_MAX_OUTPUT_SIZE=10485760
+# Scopes startup orphan-cleanup so this daemon only stops its OWN containers
+# (LIA-491). Defaults to a hash of the install path, which is already distinct
+# per install — only set this if two daemons share one working copy. The value
+# is hashed, not used verbatim, so any string works.
+# DEUS_INSTANCE_ID=
 
 # === Credential Proxy ===
 CREDENTIAL_PROXY_PORT=3001

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -53,6 +53,23 @@ All variables are set in `.env` at the project root. Copy `.env.example` to get 
 | `MAX_CONCURRENT_CONTAINERS` | `5` | Max parallel agent containers |
 | `IDLE_TIMEOUT` | `1800000` | Idle container shutdown timeout in ms |
 | `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` | Max output size per container in bytes (10 MB) |
+| `DEUS_INSTANCE_ID` | derived from the install path | Identifies this install so orphan cleanup only stops its *own* containers (LIA-491) |
+
+### `DEUS_INSTANCE_ID`
+
+Every container is named with a trailing `-i<8hex>` stamp, and startup orphan
+cleanup only stops containers carrying **this** install's stamp. Without it a
+second daemon on the same host would stop live containers belonging to the
+first, killing conversations mid-flight.
+
+The default derives from the install directory, which is stable across restarts
+(so a crashed run's orphans are still reaped) and distinct between installs (so
+concurrent daemons leave each other alone). **You only need to set this if two
+daemons deliberately share one working copy** — otherwise leave it unset.
+
+The value is **hashed, not used verbatim**, so any string works; it just has to
+differ between instances. Containers created before this existed carry no stamp
+and are reported at startup rather than stopped — remove them manually if stale.
 
 ## Credential Proxy
 

--- a/patterns/cross-platform.md
+++ b/patterns/cross-platform.md
@@ -3,7 +3,7 @@ governs:
   - src/platform.ts
   - src/cross-platform.test.ts
   - src/config.ts
-last_verified: "2026-06-19" # auto-bump @1781878010
+last_verified: "2026-08-15" # reviewed against LIA-491 (src/config.ts deusInstanceId)
 test_tasks:
   - "Add a new HOME directory lookup in src/ that must go through src/platform.ts"
   - "Add a shell command helper under src/ that works on macOS, Linux, and Windows"

--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -1,9 +1,9 @@
 ---
-last_verified: "2026-07-13" # auto-bump @1783974759
+last_verified: "2026-08-15" # reviewed against LIA-491 (src/container-runner.ts naming)
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-07-13" # auto-bump @1783974759
+last_verified: "2026-08-15" # reviewed against LIA-491 (src/container-runner.ts naming)
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-15" # reviewed against docs/decisions/deus-v2-archival.md
+last_verified: "2026-08-15" # reviewed against LIA-491 (docs/ENVIRONMENT.md)
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-15" # auto-bump @1786792800
+last_verified: "2026-08-15" # reviewed against LIA-491 (container instance scoping)
 governs:
   - src/
   - evolution/

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-13" # auto-bump @1786611349
+last_verified: "2026-08-15" # reviewed against LIA-491 (apple-container skill note)
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 
-import { STORE_DIR, GROUPS_DIR, DATA_DIR } from './config.js';
+import {
+  STORE_DIR,
+  GROUPS_DIR,
+  DATA_DIR,
+  deusInstanceId,
+  resetDeusInstanceIdCache,
+} from './config.js';
 
 describe('config paths', () => {
   it('STORE_DIR is an absolute path ending with store', () => {
@@ -26,5 +32,62 @@ describe('config paths', () => {
     const segments = STORE_DIR.split(path.sep);
     // Check that 'store' appears only as the last segment, not fused into another
     expect(segments[segments.length - 1]).toBe('store');
+  });
+});
+
+describe('deusInstanceId (LIA-491)', () => {
+  const original = process.env.DEUS_INSTANCE_ID;
+
+  beforeEach(() => {
+    resetDeusInstanceIdCache();
+    delete process.env.DEUS_INSTANCE_ID;
+  });
+
+  afterEach(() => {
+    resetDeusInstanceIdCache();
+    if (original === undefined) delete process.env.DEUS_INSTANCE_ID;
+    else process.env.DEUS_INSTANCE_ID = original;
+  });
+
+  it('defaults to a stable 8-hex digest when no override is set', () => {
+    const first = deusInstanceId();
+    expect(first).toMatch(/^[0-9a-f]{8}$/);
+    // Memoised: repeated calls agree.
+    expect(deusInstanceId()).toBe(first);
+    // And stable across a cache reset, since it derives from PROJECT_ROOT.
+    resetDeusInstanceIdCache();
+    expect(deusInstanceId()).toBe(first);
+  });
+
+  it('lets DEUS_INSTANCE_ID override the default', () => {
+    const fallback = deusInstanceId();
+    resetDeusInstanceIdCache();
+    process.env.DEUS_INSTANCE_ID = 'sandbox';
+    const overridden = deusInstanceId();
+    expect(overridden).toMatch(/^[0-9a-f]{8}$/);
+    expect(overridden).not.toBe(fallback);
+  });
+
+  it('hashes the override rather than using it verbatim', () => {
+    // A verbatim value would be illegal in a container name and could inject
+    // regex metacharacters into the ownership matcher.
+    process.env.DEUS_INSTANCE_ID = 'Not/A*Valid.Name$^[]';
+    expect(deusInstanceId()).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic for the same override', () => {
+    process.env.DEUS_INSTANCE_ID = 'sandbox';
+    const a = deusInstanceId();
+    resetDeusInstanceIdCache();
+    const b = deusInstanceId();
+    expect(a).toBe(b);
+  });
+
+  it('distinguishes two different overrides', () => {
+    process.env.DEUS_INSTANCE_ID = 'sandbox-a';
+    const a = deusInstanceId();
+    resetDeusInstanceIdCache();
+    process.env.DEUS_INSTANCE_ID = 'sandbox-b';
+    expect(deusInstanceId()).not.toBe(a);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import path from 'path';
 
 import {
@@ -53,6 +54,42 @@ export const SENDER_ALLOWLIST_PATH = path.join(
 export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+
+let cachedInstanceId: string | undefined;
+
+/**
+ * Stable identifier for THIS Deus installation, used to scope container
+ * ownership so one daemon never stops another's containers (LIA-491).
+ *
+ * The identity must be stable across restarts (orphan cleanup reaps containers
+ * left by a previous *crashed* run of this same daemon) yet distinct between
+ * concurrently-running installs. `PROJECT_ROOT` has both properties: launchd
+ * gives each install its own `WorkingDirectory`. `DEUS_INSTANCE_ID` (LIA-491)
+ * is the escape hatch for two daemons deliberately sharing one working copy.
+ *
+ * The resolved value is always hashed rather than used verbatim, so an
+ * arbitrary override can never contain regex metacharacters that would widen
+ * the ownership matcher, nor characters illegal in a container name.
+ *
+ * Resolved lazily rather than at module scope so the value isn't frozen before
+ * overrides settle, and so tests can reset the cache. (Not for side-effect
+ * reasons — this module already calls `readEnvFile` at import.)
+ */
+export function deusInstanceId(): string {
+  if (cachedInstanceId !== undefined) return cachedInstanceId;
+  // LIA-491: process.env wins over .env, matching the convention in checks.ts.
+  const raw =
+    process.env.DEUS_INSTANCE_ID?.trim() ||
+    readEnvFile(['DEUS_INSTANCE_ID']).DEUS_INSTANCE_ID?.trim() ||
+    PROJECT_ROOT;
+  cachedInstanceId = createHash('sha256').update(raw).digest('hex').slice(0, 8);
+  return cachedInstanceId;
+}
+
+/** Test-only: clear the memoised instance id. */
+export function resetDeusInstanceIdCache(): void {
+  cachedInstanceId = undefined;
+}
 
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'deus-agent:latest';

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -7,6 +7,7 @@ import {
   vi,
   afterEach,
 } from 'vitest';
+import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 import path from 'path';
@@ -34,6 +35,7 @@ vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/deus-test-data',
   DEUS_CONTEXT_FILE_MAX_CHARS: '12345',
   DEUS_OPENAI_MODEL: 'gpt-test-model',
+  deusInstanceId: () => 'a1b2c3d4',
   GROUPS_DIR: '/tmp/deus-test-groups',
   HOME_DIR: '/tmp/deus-test-home',
   IDLE_TIMEOUT: 1800000, // 30min
@@ -2477,5 +2479,53 @@ describe('readAvailableTools (LIA-154)', () => {
   it('returns [] when the JSON is not an array', () => {
     fsMocked.readFileSync.mockReturnValue(JSON.stringify({ tools: ['Bash'] }));
     expect(readAvailableTools(logsDir, 'g-1')).toEqual([]);
+  });
+});
+
+// --- container naming / instance stamping (LIA-491) ---
+
+describe('container name instance stamping', () => {
+  /** Run the agent once and return the `--name` value handed to spawn. */
+  async function nameForFolder(folder: string): Promise<string> {
+    vi.mocked(spawn).mockClear();
+    fakeProc = createFakeProcess();
+    void runContainerAgent(
+      { ...testGroup, folder },
+      testInput,
+      () => {},
+      async () => {},
+    );
+    // spawn happens after async mount/token setup, so wait for the call.
+    for (let i = 0; i < 100 && !vi.mocked(spawn).mock.calls.length; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    const args = vi.mocked(spawn).mock.calls[0][1] as string[];
+    return args[args.indexOf('--name') + 1];
+  }
+
+  beforeEach(() => {
+    fakeProc = createFakeProcess();
+  });
+
+  it('stamps the container name with this instance id as a suffix', async () => {
+    const name = await nameForFolder('test-group');
+    // deusInstanceId is mocked to 'a1b2c3d4' in this file's config mock.
+    expect(name).toMatch(/^deus-test-group-\d+-ia1b2c3d4$/);
+  });
+
+  it('stays within the 63-char limit for a maximum-length folder', async () => {
+    // GROUP_FOLDER_PATTERN allows up to 64 chars; Apple Container caps
+    // container ids at 63.
+    const name = await nameForFolder('a'.repeat(64));
+    expect(name.length).toBeLessThanOrEqual(63);
+    expect(name).toMatch(/-ia1b2c3d4$/);
+  });
+
+  it('keeps long folders sharing a prefix distinct via a digest of the full name', async () => {
+    // Both share the first 27 chars, so plain truncation would collide.
+    const a = await nameForFolder(`${'x'.repeat(30)}-alpha`);
+    const b = await nameForFolder(`${'x'.repeat(30)}-beta`);
+    const stripTimestamp = (n: string) => n.replace(/-\d+-i[0-9a-f]{8}$/, '');
+    expect(stripTimestamp(a)).not.toBe(stripTimestamp(b));
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -5,6 +5,7 @@
  * Mount assembly lives in container-mounter.ts.
  */
 import { ChildProcess, execFile, spawn } from 'child_process';
+import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -22,6 +23,7 @@ import {
   CREDENTIAL_PROXY_PORT,
   DEUS_CONTEXT_FILE_MAX_CHARS,
   DEUS_OPENAI_MODEL,
+  deusInstanceId,
   IDLE_TIMEOUT,
   LLAMA_CPP_AGENT_MODEL,
   LLAMA_CPP_MODEL,
@@ -470,7 +472,23 @@ export async function runContainerAgent(
     input.ipcRunKey,
   );
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
-  const containerName = `deus-${safeName}-${Date.now()}`;
+  // Apple Container rejects names over 63 chars. Fixed overhead is
+  // `deus-`(5) + `-`(1) + a 13-digit timestamp + `-i`(2) + 8 hex = 29, leaving
+  // 34 for the group segment. Long names keep a digest of the FULL folder so
+  // two folders sharing a prefix still get distinct names; short names are
+  // left untouched so the common case reads exactly as before (LIA-491).
+  const namePart =
+    safeName.length <= 34
+      ? safeName
+      : `${safeName.slice(0, 27)}-${createHash('sha256')
+          .update(safeName)
+          .digest('hex')
+          .slice(0, 6)}`;
+  // The instance id is a SUFFIX, not a prefix: group folders may legally begin
+  // with `i` + 8 hex chars, so a prefix could not be told apart from a legacy
+  // name. Legacy names always end in timestamp digits, so they can never match
+  // the `-i<8hex>` suffix (LIA-491).
+  const containerName = `deus-${namePart}-${Date.now()}-i${deusInstanceId()}`;
   const containerArgs = buildContainerArgs(
     mounts,
     containerName,

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -136,12 +136,18 @@ describe('ensureContainerRuntimeRunning', () => {
 
 // --- cleanupOrphans ---
 
-describe('cleanupOrphans', () => {
-  it('stops orphaned deus containers', () => {
-    // docker ps returns container names, one per line
-    mockExecFileSync.mockReturnValueOnce('deus-group1-111\ndeus-group2-222\n');
+// Instance ids are always 8 lowercase hex (see config.deusInstanceId).
+const MINE = 'a1b2c3d4';
+const THEIRS = '99887766';
 
-    cleanupOrphans();
+describe('cleanupOrphans', () => {
+  it('stops orphaned deus containers stamped with this instance', () => {
+    // docker ps returns container names, one per line
+    mockExecFileSync.mockReturnValueOnce(
+      `deus-group1-111-i${MINE}\ndeus-group2-222-i${MINE}\n`,
+    );
+
+    cleanupOrphans(MINE);
 
     // ps call + 2 stop calls, all via execFileSync
     expect(mockExecFileSync).toHaveBeenCalledTimes(3);
@@ -154,25 +160,77 @@ describe('cleanupOrphans', () => {
     expect(mockExecFileSync).toHaveBeenNthCalledWith(
       2,
       CONTAINER_RUNTIME_BIN,
-      ['stop', '-t', '1', 'deus-group1-111'],
+      ['stop', '-t', '1', `deus-group1-111-i${MINE}`],
       { stdio: 'pipe', timeout: 15000 },
     );
     expect(mockExecFileSync).toHaveBeenNthCalledWith(
       3,
       CONTAINER_RUNTIME_BIN,
-      ['stop', '-t', '1', 'deus-group2-222'],
+      ['stop', '-t', '1', `deus-group2-222-i${MINE}`],
       { stdio: 'pipe', timeout: 15000 },
     );
     expect(logger.info).toHaveBeenCalledWith(
-      { count: 2, names: ['deus-group1-111', 'deus-group2-222'] },
+      {
+        count: 2,
+        names: [`deus-group1-111-i${MINE}`, `deus-group2-222-i${MINE}`],
+      },
       'Stopped orphaned containers',
+    );
+  });
+
+  it('leaves containers belonging to another live instance alone (LIA-491)', () => {
+    mockExecFileSync.mockReturnValueOnce(
+      `deus-mine-1-i${MINE}\ndeus-theirs-2-i${THEIRS}\n`,
+    );
+
+    cleanupOrphans(MINE);
+
+    // ps + exactly one stop: only ours.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      2,
+      CONTAINER_RUNTIME_BIN,
+      ['stop', '-t', '1', `deus-mine-1-i${MINE}`],
+      { stdio: 'pipe', timeout: 15000 },
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      { count: 1, names: [`deus-mine-1-i${MINE}`] },
+      'Stopped orphaned containers',
+    );
+  });
+
+  it('warns about unstamped pre-LIA-491 containers without stopping them', () => {
+    mockExecFileSync.mockReturnValueOnce('deus-legacy-111\n');
+
+    cleanupOrphans(MINE);
+
+    // ps only — nothing stopped.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { count: 1, names: ['deus-legacy-111'] },
+      expect.stringContaining('unstamped'),
+    );
+  });
+
+  it('does not treat a group folder that looks like an instance id as a stamp', () => {
+    // A folder legally named `iabcdef12-...` produces this legacy name. It must
+    // be classified as unstamped, not mistaken for another instance (LIA-491).
+    mockExecFileSync.mockReturnValueOnce('deus-iabcdef12-mygroup-111\n');
+
+    cleanupOrphans(MINE);
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { count: 1, names: ['deus-iabcdef12-mygroup-111'] },
+      expect.stringContaining('unstamped'),
     );
   });
 
   it('does nothing when no orphans exist', () => {
     mockExecFileSync.mockReturnValueOnce('');
 
-    cleanupOrphans();
+    cleanupOrphans(MINE);
 
     expect(mockExecFileSync).toHaveBeenCalledTimes(1);
     expect(logger.info).not.toHaveBeenCalled();
@@ -183,7 +241,7 @@ describe('cleanupOrphans', () => {
       throw new Error('docker not available');
     });
 
-    cleanupOrphans(); // should not throw
+    cleanupOrphans(MINE); // should not throw
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
@@ -192,8 +250,11 @@ describe('cleanupOrphans', () => {
   });
 
   it('continues stopping remaining containers when one stop fails', () => {
-    // ps call returns two orphans
-    mockExecFileSync.mockReturnValueOnce('deus-a-1\ndeus-b-2\n');
+    // ps call returns two orphans, both stamped as ours so both are eligible —
+    // this test's subject is partial-failure recovery, not ownership.
+    mockExecFileSync.mockReturnValueOnce(
+      `deus-a-1-i${MINE}\ndeus-b-2-i${MINE}\n`,
+    );
     // First stop fails
     mockExecFileSync.mockImplementationOnce(() => {
       throw new Error('already stopped');
@@ -201,11 +262,11 @@ describe('cleanupOrphans', () => {
     // Second stop succeeds
     mockExecFileSync.mockReturnValueOnce('');
 
-    cleanupOrphans(); // should not throw
+    cleanupOrphans(MINE); // should not throw
 
     expect(mockExecFileSync).toHaveBeenCalledTimes(3);
     expect(logger.info).toHaveBeenCalledWith(
-      { count: 2, names: ['deus-a-1', 'deus-b-2'] },
+      { count: 2, names: [`deus-a-1-i${MINE}`, `deus-b-2-i${MINE}`] },
       'Stopped orphaned containers',
     );
   });

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -4,6 +4,7 @@
  */
 import { execFileSync } from 'child_process';
 
+import { deusInstanceId } from './config.js';
 import { FatalError } from './errors/index.js';
 import { logger } from './logger.js';
 import { detectProxyBindHost, hostGatewayArgs } from './platform.js';
@@ -115,26 +116,55 @@ export function ensureContainerRuntimeRunning(): void {
   });
 }
 
-/** Kill orphaned Deus containers from previous runs. */
-export function cleanupOrphans(): void {
+/** Trailing `-i<8hex>` instance stamp written by container-runner (LIA-491). */
+const INSTANCE_SUFFIX_RE = /-i([0-9a-f]{8})$/;
+
+/**
+ * Kill orphaned Deus containers left by a previous run OF THIS INSTALL.
+ *
+ * Runs on every daemon startup, so it must never touch containers belonging to
+ * a different, concurrently-running daemon — doing so killed live conversations
+ * (LIA-491). Ownership is decided by the `-i<8hex>` suffix each container is
+ * named with; anything not stamped with THIS install's id is left alone.
+ */
+export function cleanupOrphans(instanceId: string = deusInstanceId()): void {
   try {
     const output = execFileSync(
       CONTAINER_RUNTIME_BIN,
       ['ps', '--filter', 'name=deus-', '--format', '{{.Names}}'],
       { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
     );
-    const orphans = output.trim().split('\n').filter(Boolean);
-    for (const name of orphans) {
+    const names = output.trim().split('\n').filter(Boolean);
+
+    const mine: string[] = [];
+    const unstamped: string[] = [];
+    for (const name of names) {
+      const stamp = INSTANCE_SUFFIX_RE.exec(name)?.[1];
+      if (stamp === instanceId) mine.push(name);
+      else if (stamp === undefined) unstamped.push(name);
+      // else: stamped by another live install — never ours to stop.
+    }
+
+    for (const name of mine) {
       try {
         stopContainerSync(name);
       } catch {
         /* already stopped */
       }
     }
-    if (orphans.length > 0) {
+    if (mine.length > 0) {
       logger.info(
-        { count: orphans.length, names: orphans },
+        { count: mine.length, names: mine },
         'Stopped orphaned containers',
+      );
+    }
+    // Containers created before LIA-491 carry no stamp. Stopping them would
+    // reintroduce the cross-install sweep this fix removes (an older build's
+    // live containers are also unstamped), so surface them instead of guessing.
+    if (unstamped.length > 0) {
+      logger.warn(
+        { count: unstamped.length, names: unstamped },
+        'Found unstamped Deus containers from a pre-LIA-491 build — not stopping them; remove manually if they are stale',
       );
     }
   } catch (err) {


### PR DESCRIPTION
## The bug

`cleanupOrphans()` ran on **every daemon startup**, listed every container matching `name=deus-`, and stopped all of them — with no scoping to the daemon that started them. A second daemon anywhere on the host (a sandbox, a test run, a dev instance) would stop **live production containers mid-conversation**.

## The fix

Containers now carry the install's identity as a **name suffix** (`deus-<name>-<ts>-i<8hex>`), and cleanup partitions what it finds three ways:

| Bucket | Action |
|---|---|
| Own stamp | stop (a genuine orphan of ours) |
| Another install's stamp | skip — never ours to stop |
| No stamp (pre-LIA-491) | **warn, never stop** |

**Monotonically risk-reducing**: the stop-set is a strict subset of what was swept before, so no input can now stop a container the old code would have spared.

## Design decisions, and why

**Suffix, not prefix.** `GROUP_FOLDER_PATTERN` legally permits a folder named `iabcdef12-mygroup`, which produces `deus-iabcdef12-mygroup-<ts>` — a prefix scheme cannot tell that apart from a real stamp, and would misfile it as "another live instance": never reaped, never warned. Legacy names always end in timestamp digits, so they can never match `-i<8hex>` at the *end*. A test pins this exact case.

**Warn, don't stop, for unstamped containers.** Stopping them would reintroduce the very cross-install sweep being removed, since an older build's *live* containers are also unstamped. Ignoring them silently would leak a container with no signal.

**63-char cap** for Apple Container. Folders over 34 chars keep a digest of the **full** folder name rather than being blindly truncated, so two folders sharing a prefix stay distinct; shorter folders are untouched and read exactly as before. Math is exact: `5 + 34 + 1 + 13 + 2 + 8 = 63`.

**`deusInstanceId()` lives in `config.ts`**, not `container-runtime.ts` — the Apple Container conversion replaces the latter wholesale, so identity logic there would be silently lost. The conversion skill now records that the scoping must be preserved when porting.

**Identity is hashed, never verbatim**, so a `DEUS_INSTANCE_ID` override can't inject regex metacharacters into the ownership matcher or characters illegal in a container name — and a typo can't break startup.

## Verification

- **115 files / 2095 tests pass**; `npx tsc --noEmit` clean — both re-run *after* lint-staged's reformatting, on the committed content.
- `drift_check.py --all --base origin/main` and `flag_lint.py --base origin/main` both exit 0, run **post-commit** where they're actually meaningful.
- Two existing `cleanupOrphans` tests seeded unstamped names and asserted they were stopped; both rewritten to keep exercising their original subjects (notably the partial-failure recovery case), not gutted.

## Review

Five plan-review rounds (twelve findings, all source-verified) and three verification rounds. Two findings are worth recording because they'd have shipped silently:

1. **The drift check was reporting `ALL CHECKS PASSED` while examining zero files.** `_changed_files_since` uses a three-dot `base...HEAD` **commit** diff, which is empty pre-commit — so every governed-file check was skipped. Verified, then worked around: because this branch had zero commits, `git diff --cached` was byte-identical to the future `origin/main...HEAD`, so `flag_lint`'s real `scan()` could be run against the staged bytes for a genuine answer.
2. **Five patterns needed bumping, not two.** Two review rounds each missed one. The full audit — replicating `_file_in_changed_set` across all 11 patterns × every changed path — was then run independently three times and converged on the same five.

**Pre-existing defect found, not fixed here:** `patterns/debugging.md` has a duplicate `last_verified` key. `parse_last_verified` reads only the first, so the second can silently rot — almost certainly an auto-bump artifact that may affect other pattern files. Both copies were updated so neither is stale, but the underlying bug deserves its own ticket rather than scope-creeping this one.

Rescued from the archived deus-v2 project and verified to reproduce here — see `docs/decisions/deus-v2-archival.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)