### PR TITLE
fix(evolution): stop the judge reading an absent response as evidence

### DIFF
--- a/evolution/backfill.py
+++ b/evolution/backfill.py
@@ -29,7 +29,7 @@ from .config import REFLECTION_THRESHOLD, MAX_REFLECTIONS_TO_GENERATE
 from .ilog.interaction_log import log_interaction, update_score
 from .storage import get_storage
 from .judge import make_runtime_judge
-from .reflexion.generator import generate_reflection
+from .reflexion.generator import generate_reflection, response_supports_reflection
 from .reflexion.store import save_reflection
 
 SESSIONS_DIR = Path(__file__).parent.parent / "data" / "sessions"
@@ -293,8 +293,10 @@ def run_backfill(
                   f"s={result.safety:.2f}  t={result.tool_use:.2f}  "
                   f"p={result.personalization:.2f}")
 
-        # Generate reflection(s) for low-scoring interactions
-        if result.score < REFLECTION_THRESHOLD:
+        # Generate reflection(s) for low-scoring interactions. An empty response
+        # records no evidence of what the agent did, so a judge-driven reflection
+        # would assert something the interaction cannot support (LIA-558).
+        if result.score < REFLECTION_THRESHOLD and response_supports_reflection(pair["response"]):
             try:
                 dims = {
                     "quality": result.quality,

--- a/evolution/cc_backfill.py
+++ b/evolution/cc_backfill.py
@@ -326,7 +326,11 @@ def run_cc_backfill(
             print("Logging interactions without scores. Run maintenance to judge later.")
             judge = None
 
-    from .reflexion.generator import generate_reflection, generate_positive_reflection
+    from .reflexion.generator import (
+        generate_reflection,
+        generate_positive_reflection,
+        response_supports_reflection,
+    )
     from .reflexion.store import save_reflection
     from .judge.mechanical import score_tool_economy, score_gate_audit, score_completion_honesty
     from .judge.criteria import compose_score
@@ -396,8 +400,10 @@ def run_cc_backfill(
                       f"p={result.personalization:.2f}  te={te_score:.2f}  "
                       f"ga={ga_score:.2f}  ch={ch_score:.2f}")
 
-            # Generate reflections
-            if not result.is_parse_error:
+            # Generate reflections. The response guard is hoisted above the
+            # corrective/positive split on purpose: an empty response supports
+            # neither verdict, so BOTH branches must be withheld (LIA-558).
+            if not result.is_parse_error and response_supports_reflection(pair["response"]):
                 if composite < REFLECTION_THRESHOLD:
                     try:
                         content, category = generate_reflection(

--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -7,7 +7,10 @@ Each LLM-judged dimension uses a structured format to reduce bimodal scoring:
 - tool_use: Likert execution_quality (1-5)
 
 _normalize_dim() converts each raw dict into a 0.0–1.0 float for compose_score.
+render_response() is the shared seam every prompt builder uses to interpolate an
+agent response, so an absent one can never render as a blank section.
 """
+from typing import Optional
 
 # ── RUBRIC COUPLING WARNING — read before editing any dimension below ─────────
 # This RUBRIC is ONE shared prompt: the judge scores ALL four dimensions
@@ -126,6 +129,30 @@ COMPOSITE_WEIGHTS = {
     "gate_audit": 0.05,
     "completion_honesty": 0.05,
 }
+
+# Rendered in place of an absent agent response: a blank "**Agent response:**"
+# section makes the judge confabulate success from the instructions above it
+# (gemma4:e4b, temp 0 — empty scored 5/5, the literal "Done." scored 1/5).
+# Wording is load-bearing, not cosmetic: a more emphatic variant read as a
+# verdict and mis-scored a case where silence was the instruction. Full
+# measurement in LIA-558.
+EMPTY_RESPONSE_SENTINEL = "(the agent returned an empty response — no text at all)"
+
+
+def render_response(response: Optional[str]) -> str:
+    """Render an agent response for inclusion in a judge or reflection prompt.
+
+    Returns the response unchanged — byte-identical, including any leading or
+    trailing whitespace around real content — or EMPTY_RESPONSE_SENTINEL when
+    there is nothing to show. Whitespace-only counts as nothing.
+
+    Every prompt builder that interpolates a stored response goes through here so
+    the rule lives in one place; see LIA-558 for the measurement.
+    """
+    if response is None or not response.strip():
+        return EMPTY_RESPONSE_SENTINEL
+    return response
+
 
 # Mechanical dims default to 1.0 (neutral) so old rows without them aren't penalized.
 DIM_DEFAULTS = {

--- a/evolution/judge/gemini_judge.py
+++ b/evolution/judge/gemini_judge.py
@@ -18,7 +18,7 @@ from ..config import (
     load_api_key,
 )
 from .base import BaseJudge, JudgeResult
-from .criteria import RUBRIC, compose_score, _normalize_dim
+from .criteria import RUBRIC, compose_score, render_response, _normalize_dim
 
 _client = None
 
@@ -144,7 +144,7 @@ def _build_eval_prompt(
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")
-    parts.append(f"**Agent response:**\n{response}\n")
+    parts.append(f"**Agent response:**\n{render_response(response)}\n")
     if strict_json:
         parts.append(
             "\nIMPORTANT: Respond with ONLY a valid JSON object. "

--- a/evolution/judge/llama_cpp_judge.py
+++ b/evolution/judge/llama_cpp_judge.py
@@ -20,7 +20,7 @@ import urllib.error
 from typing import Optional
 
 from .base import BaseJudge, JudgeResult
-from .criteria import RUBRIC, compose_score, _normalize_dim
+from .criteria import RUBRIC, compose_score, render_response, _normalize_dim
 from ..config import LLAMA_CPP_BASE_URL, LLAMA_CPP_JUDGE_MODEL
 
 
@@ -149,7 +149,7 @@ def _build_eval_prompt(
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")
-    parts.append(f"**Agent response:**\n{response}\n")
+    parts.append(f"**Agent response:**\n{render_response(response)}\n")
     return "\n".join(parts)
 
 

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -13,7 +13,7 @@ import urllib.error
 from typing import Optional
 
 from .base import BaseJudge, JudgeResult
-from .criteria import RUBRIC, compose_score, _normalize_dim
+from .criteria import RUBRIC, compose_score, render_response, _normalize_dim
 from ..config import OLLAMA_HOST, OLLAMA_MODEL, OLLAMA_JUDGE_MODEL
 
 
@@ -164,7 +164,7 @@ def _build_eval_prompt(
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")
-    parts.append(f"**Agent response:**\n{response}\n")
+    parts.append(f"**Agent response:**\n{render_response(response)}\n")
     return "\n".join(parts)
 
 

--- a/evolution/judge/openai_judge.py
+++ b/evolution/judge/openai_judge.py
@@ -93,7 +93,7 @@ from ..config import (
     OPENAI_JUDGE_MODEL,
 )
 from .base import BaseJudge, JudgeResult
-from .criteria import RUBRIC, compose_score, _normalize_dim
+from .criteria import RUBRIC, compose_score, render_response, _normalize_dim
 
 _RESPONSE_SCHEMA = {
     "type": "object",
@@ -519,7 +519,7 @@ def _build_eval_prompt(
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")
-    parts.append(f"**Agent response:**\n{response}\n")
+    parts.append(f"**Agent response:**\n{render_response(response)}\n")
     if strict_json:
         parts.append(
             "\nIMPORTANT: Respond with ONLY a valid JSON object. "

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -133,14 +133,35 @@ def _score_single(row: dict, judge) -> dict | None:
 
 
 def _reflect_single(scored: dict, config: dict) -> bool:
-    """Generate reflection(s) for a scored interaction. Returns True on success."""
+    """Generate reflection(s) for a scored interaction.
+
+    Returns True on success or skip, False on generation failure. The skip case
+    guards the data-integrity invariant (no reflection persisted from an absent
+    response), not a counting one — a caller that wants an honest reflected/total
+    tally must filter empties out beforehand, as the batch path does.
+    """
     from .config import MAX_REFLECTIONS_TO_GENERATE
     from .metrics import parse_metrics
-    from .reflexion.generator import generate_reflection, generate_positive_reflection
+    from .reflexion.generator import (
+        generate_reflection,
+        generate_positive_reflection,
+        response_supports_reflection,
+    )
     from .reflexion.store import save_reflection
 
     row = scored["row"]
     metrics = parse_metrics(row.get("metrics"))
+
+    # Defence in depth: the only caller already filters these out of
+    # needs_reflection so the health denominator stays honest, but this path is
+    # judge-score-driven and an empty response supports neither a corrective nor
+    # a positive reflection, so a future caller must not be able to reintroduce
+    # one (LIA-558). True means "handled without error". The human-score path
+    # elsewhere in this module is deliberately exempt — there a person supplied
+    # the evidence.
+    if not response_supports_reflection(row.get("response")):
+        return True
+
     try:
         if scored["score"] < config["reflection_threshold"]:
             generated_contents: set[str] = set()
@@ -233,6 +254,7 @@ def _judge_pending_interactions() -> int:
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from .config import REFLECTION_THRESHOLD, POSITIVE_THRESHOLD
     from .judge import make_runtime_judge
+    from .reflexion.generator import response_supports_reflection
     from .storage import get_storage
 
     store = get_storage()
@@ -275,11 +297,16 @@ def _judge_pending_interactions() -> int:
             else:
                 scored_results.append(result)
 
-    # Pass 2: Reflect in parallel for interactions that need it
+    # Pass 2: Reflect in parallel for interactions that need it. Empty-response
+    # rows are excluded HERE rather than skipped inside _reflect_single so the
+    # {reflected}/{len(needs_reflection)} health detail below keeps an honest
+    # denominator — a pass that reflected nothing must not read "N/N" (LIA-558,
+    # preserving the visibility LIA-556 added).
     needs_reflection = [
         s for s in scored_results
-        if s["score"] < config["reflection_threshold"]
-        or s["score"] >= config["positive_threshold"]
+        if (s["score"] < config["reflection_threshold"]
+            or s["score"] >= config["positive_threshold"])
+        and response_supports_reflection(s["row"].get("response"))
     ]
     reflected = 0
     if needs_reflection:

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -36,7 +36,7 @@ except ImportError:
 
 from .judge import make_runtime_judge
 from .ilog.interaction_log import log_interaction, update_score
-from .reflexion.generator import generate_reflection
+from .reflexion.generator import generate_reflection, response_supports_reflection
 from .reflexion.retriever import format_reflections_block, get_reflections
 from .reflexion.store import increment_helpful, save_reflection
 
@@ -205,7 +205,9 @@ async def _async_judge_and_reflect(
         }
         update_score(interaction_id, result.score, dims, schema_version=result.schema_version)
 
-        if result.score < REFLECTION_THRESHOLD:
+        # The score is still recorded above; only the learning signal is withheld.
+        # An empty response carries no evidence of what the agent did (LIA-558).
+        if result.score < REFLECTION_THRESHOLD and response_supports_reflection(response):
             generated_contents: set[str] = set()
             for _ in range(MAX_REFLECTIONS_TO_GENERATE):
                 content, category = generate_reflection(

--- a/evolution/reflexion/generator.py
+++ b/evolution/reflexion/generator.py
@@ -9,6 +9,28 @@ import re
 from typing import Optional
 
 from ..generative import generate
+from ..judge.criteria import render_response
+
+
+def response_supports_reflection(response: Optional[str]) -> bool:
+    """Whether an interaction's response can support a claim about agent behaviour.
+
+    False when the response is absent or whitespace-only. Such an interaction
+    records no evidence of what the agent did: nothing distinguishes "ran and
+    correctly stayed silent" from "never ran". Callers whose trigger is the
+    JUDGE's own score must not generate a reflection from one — asserting either
+    failure or excellence would be unsupported (LIA-558).
+
+    Callers triggered by a HUMAN signal are exempt and deliberately do not call
+    this: there a person supplied the evidence, so the reflection is grounded
+    even when the stored response is empty.
+
+    Retire this once execution evidence (tool calls, exit status, a completion
+    marker) is recorded alongside the response — at that point the record can
+    answer the question and the judge should be allowed to.
+    """
+    return bool((response or "").strip())
+
 
 _REFLECTION_PROMPT = """Analyze this low-scoring AI interaction and extract an actionable lesson.
 
@@ -59,7 +81,7 @@ def generate_reflection(
     """
     formatted = _REFLECTION_PROMPT.format(
         prompt=prompt[:1500],
-        response=(response or "")[:1500],
+        response=render_response(response)[:1500],
         tools=", ".join(tools_used or []) or "none",
         score=score,
         dims=json.dumps(dims or {}),
@@ -110,7 +132,7 @@ def generate_positive_reflection(
     """
     formatted = _POSITIVE_PROMPT.format(
         prompt=prompt[:1500],
-        response=(response or "")[:1500],
+        response=render_response(response)[:1500],
         tools=", ".join(tools_used or []) or "none",
         score=score,
         dims=json.dumps(dims or {}),

--- a/evolution/reflexion/principles.py
+++ b/evolution/reflexion/principles.py
@@ -14,7 +14,9 @@ from typing import Optional
 
 from ..generative import generate
 from ..ilog.interaction_log import get_recent
+from ..judge.criteria import render_response
 from ..storage import get_storage
+from .generator import response_supports_reflection
 from .store import save_reflection
 
 
@@ -81,6 +83,14 @@ def extract_principles(
         max_score=0.5, limit=top_k, eval_suite=None, domain=domain,
     )
 
+    # Drop rows with no response BEFORE the count check below. An absent response
+    # is neither an exemplar nor a cautionary case — nothing in the record says
+    # whether the agent ran (LIA-558). Filtering after the check would let an
+    # all-empty pool satisfy the count and generate principles from "(none)",
+    # which is worse than the confabulation this guards against.
+    best = [ix for ix in best if response_supports_reflection(ix.get("response"))]
+    worst = [ix for ix in worst if response_supports_reflection(ix.get("response"))]
+
     if len(best) + len(worst) < 3:
         return None
 
@@ -91,7 +101,7 @@ def extract_principles(
             parts.append(
                 f"[{i}] Score: {score}\n"
                 f"  Prompt: {ix['prompt'][:200]}\n"
-                f"  Response: {(ix.get('response') or '')[:200]}"
+                f"  Response: {render_response(ix.get('response'))[:200]}"
             )
         return "\n\n".join(parts) if parts else "(none)"
 

--- a/evolution/tests/test_empty_response_handling.py
+++ b/evolution/tests/test_empty_response_handling.py
@@ -1,0 +1,260 @@
+"""LIA-558: an absent agent response must not be read as evidence.
+
+Two halves, both regression-critical:
+
+1. Every prompt builder renders an absent response explicitly, and renders a
+   present one byte-identically. The byte-identity assertion is what makes it
+   safe to skip a fixture re-measurement: if the prompt for a non-empty response
+   is unchanged, its score cannot move.
+
+2. Reflection paths whose trigger is the JUDGE's own score withhold the learning
+   signal for an absent response. Paths triggered by a HUMAN signal do not — a
+   person supplied the evidence there.
+"""
+import pytest
+
+from evolution.judge.criteria import (
+    RUBRIC,
+    EMPTY_RESPONSE_SENTINEL,
+    render_response,
+)
+from evolution.judge.ollama_judge import _build_eval_prompt as ollama_build
+from evolution.judge.gemini_judge import _build_eval_prompt as gemini_build
+from evolution.judge.llama_cpp_judge import _build_eval_prompt as llama_build
+from evolution.judge.openai_judge import _build_eval_prompt as openai_build
+from evolution.training.build_judge_lora_dataset import build_eval_prompt as lora_build
+from evolution.reflexion.generator import response_supports_reflection
+
+
+def _call(build, prompt, response):
+    """Call a builder with no tools and no context.
+
+    All five accept (prompt, response, tools_used, context) positionally — the
+    judge builders require the last two, the LoRA builder defaults them — so one
+    call shape covers every builder without swallowing a real TypeError.
+    """
+    return build(prompt, response, None, None)
+
+
+ALL_BUILDERS = [
+    pytest.param(ollama_build, id="ollama"),
+    pytest.param(gemini_build, id="gemini"),
+    pytest.param(llama_build, id="llama_cpp"),
+    pytest.param(openai_build, id="openai"),
+    pytest.param(lora_build, id="lora_dataset"),
+]
+
+
+# ── Half 1: every builder renders an absent response explicitly ───────────────
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+@pytest.mark.parametrize("absent", [None, "", "   ", "\n\t "])
+def test_every_builder_marks_an_absent_response(build, absent):
+    out = _call(build, "Do the thing.", absent)
+    assert EMPTY_RESPONSE_SENTINEL in out
+    # And never leaves the section blank, which is the actual defect.
+    assert "**Agent response:**\n\n" not in out
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_every_builder_passes_a_real_response_through(build):
+    out = _call(build, "Do the thing.", "the thing is done, here is the output")
+    assert "the thing is done, here is the output" in out
+    assert EMPTY_RESPONSE_SENTINEL not in out
+
+
+# ── The regression test that removes the need for a fixture re-measurement ────
+# Frozen literal, assembled by hand rather than by calling render_response, so
+# the assertion cannot go tautological if render_response itself regresses.
+
+
+def _frozen(prompt, response):
+    """The prompt as it was constructed before this change, assembled by hand.
+
+    Not built via render_response, so the assertion cannot go tautological if
+    render_response itself regresses.
+    """
+    return "\n".join([
+        RUBRIC,
+        "\n## Interaction to evaluate\n",
+        f"**User prompt:**\n{prompt}\n",
+        f"**Agent response:**\n{response}\n",
+    ])
+
+
+# Parametrised across all five builders rather than frozen once for ollama: with
+# no tools, context or profile they must emit the SAME bytes, so a single literal
+# pins each builder AND proves they still agree with each other — the "same shape
+# as the production judge eval prompt" promise build_judge_lora_dataset.py makes.
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_non_empty_prompt_is_byte_identical_to_the_pre_change_construction(build):
+    prompt, response = "What is 2+2?", "4"
+    assert _call(build, prompt, response) == _frozen(prompt, response)
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_byte_identity_holds_with_whitespace_padded_content(build):
+    # The one case a naive `response.strip()` implementation would break.
+    prompt, response = "Echo it.", "  padded  "
+    assert _call(build, prompt, response) == _frozen(prompt, response)
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_absent_response_prompt_is_byte_identical_across_builders(build):
+    # The empty case pinned the same way, so no builder can drift to a different
+    # marker or a different placement without failing here.
+    assert _call(build, "Do the thing.", "") == _frozen(
+        "Do the thing.", EMPTY_RESPONSE_SENTINEL
+    )
+
+
+# ── Half 2: the judge-driven reflection guard ─────────────────────────────────
+
+
+@pytest.mark.parametrize("absent", [None, "", "   ", "\n\t "])
+def test_absent_response_does_not_support_a_reflection(absent):
+    assert response_supports_reflection(absent) is False
+
+
+@pytest.mark.parametrize("present", ["x", " x ", "Done.", EMPTY_RESPONSE_SENTINEL])
+def test_present_response_supports_a_reflection(present):
+    # Including the sentinel itself: if an agent really emitted that text, it is
+    # a response and the guard must not swallow it.
+    assert response_supports_reflection(present) is True
+
+
+@pytest.mark.parametrize(
+    "fn_name, score",
+    [("generate_reflection", 0.1), ("generate_positive_reflection", 0.95)],
+    ids=["corrective_template", "positive_template"],
+)
+def test_generator_prompts_mark_an_absent_response(monkeypatch, fn_name, score):
+    """Human-signal paths still reach the generator with an empty response.
+
+    The human's trigger stays authoritative — this asserts the generator is NOT
+    guarded — but it must not be handed a blank `Assistant:` section to
+    confabulate from. Both templates, since both are reachable from a human path
+    (thumbs-down and thumbs-up respectively).
+    """
+    from evolution.reflexion import generator as gen
+
+    seen = {}
+
+    def fake_generate(prompt, model=None):
+        seen["prompt"] = prompt
+        return "1. Some lesson learned about the interaction."
+
+    monkeypatch.setattr(gen, "generate", fake_generate)
+    content, _category = getattr(gen, fn_name)(
+        prompt="Do the thing.", response="", score=score
+    )
+
+    # It generated — the human path is not suppressed.
+    assert content
+    # And it saw the marker, not a blank section.
+    assert EMPTY_RESPONSE_SENTINEL in seen["prompt"]
+    assert "Assistant: \n" not in seen["prompt"]
+
+
+def test_extract_principles_skips_when_every_candidate_is_empty(monkeypatch):
+    """The pool filter must run BEFORE the `< 3` count check.
+
+    Filtering afterwards would let an all-empty pool satisfy the count, render
+    "(none)", and store principles hallucinated from nothing — worse than the
+    defect being fixed.
+    """
+    from evolution.reflexion import principles as pr
+
+    rows = [
+        {"id": f"i{i}", "prompt": "p" * 50, "response": "", "judge_score": 0.9}
+        for i in range(5)
+    ]
+    monkeypatch.setattr(pr, "get_recent", lambda **kw: rows)
+    monkeypatch.setattr(pr, "_count_new_scored", lambda domain: 999)
+
+    called = {"generate": 0, "saved": 0}
+
+    def fake_generate(prompt, model=None):
+        called["generate"] += 1
+        # Digit-prefixed so it WOULD be stored — principles.py keeps only lines
+        # whose first character isdigit(). A non-digit mock would make this test
+        # pass for the wrong reason.
+        return "1. A principle that should never be extracted from nothing."
+
+    monkeypatch.setattr(pr, "generate", fake_generate)
+    monkeypatch.setattr(pr, "save_reflection", lambda **kw: called.__setitem__("saved", called["saved"] + 1))
+
+    assert pr.extract_principles(force=True) is None
+    assert called["generate"] == 0
+    assert called["saved"] == 0
+
+
+def test_reflect_single_skips_an_empty_response_without_calling_the_generator(monkeypatch):
+    """Defence in depth behind the caller-side filter.
+
+    The batch path filters empties out of needs_reflection so the health
+    denominator stays honest; this guard stops a future caller reintroducing one.
+    """
+    from evolution import maintenance as mt
+
+    called = {"n": 0}
+
+    def boom(**kw):
+        called["n"] += 1
+        raise AssertionError("generator must not be reached for an empty response")
+
+    monkeypatch.setattr("evolution.reflexion.generator.generate_reflection", boom)
+    monkeypatch.setattr("evolution.reflexion.generator.generate_positive_reflection", boom)
+
+    def scored_with(response, score):
+        return {
+            "row": {"id": "x", "prompt": "p", "response": response, "metrics": None},
+            "score": score,
+            "dims": {},
+            "rationale": "r",
+        }
+
+    config = {"reflection_threshold": 0.6, "positive_threshold": 0.85}
+
+    assert mt._reflect_single(scored_with("   ", score=0.05), config) is True
+    assert called["n"] == 0
+
+    # BOTH polarities. Guarding only the corrective half would half-apply the
+    # rule: a blank response supports "this was exemplary" no better than it
+    # supports "this failed", and 305 live rows currently clear 0.85.
+    assert mt._reflect_single(scored_with("", score=0.95), config) is True
+    assert called["n"] == 0
+
+    # Positive control: without it this test would pass even if the monkeypatch
+    # never intercepted, since the assertion is that nothing was called. A real
+    # response must reach the (exploding) generator — on each polarity.
+    assert mt._reflect_single(scored_with("a real answer", score=0.05), config) is False
+    assert called["n"] == 1
+    assert mt._reflect_single(scored_with("a real answer", score=0.95), config) is False
+    assert called["n"] == 2
+
+
+def test_extract_principles_still_runs_on_real_responses(monkeypatch, test_db):
+    """The guard must not disable principle extraction outright.
+
+    Takes test_db because a successful extraction records its own bookkeeping —
+    the conftest guard correctly refuses to let that reach ~/.deus.
+    """
+    from evolution.reflexion import principles as pr
+
+    rows = [
+        {"id": f"i{i}", "prompt": "p" * 50, "response": f"a real answer {i}", "judge_score": 0.9}
+        for i in range(5)
+    ]
+    monkeypatch.setattr(pr, "get_recent", lambda **kw: rows)
+    monkeypatch.setattr(pr, "_count_new_scored", lambda domain: 999)
+
+    saved = []
+    monkeypatch.setattr(pr, "generate", lambda prompt, model=None: "1. A real principle.")
+    monkeypatch.setattr(pr, "save_reflection", lambda **kw: saved.append(kw))
+
+    assert pr.extract_principles(force=True) is not None
+    assert len(saved) == 1

--- a/evolution/tests/test_judge_criteria.py
+++ b/evolution/tests/test_judge_criteria.py
@@ -12,9 +12,11 @@ import pytest
 from evolution.judge.criteria import (
     COMPOSITE_WEIGHTS,
     DIM_DEFAULTS,
+    EMPTY_RESPONSE_SENTINEL,
     RUBRIC,
     _normalize_dim,
     compose_score,
+    render_response,
 )
 
 
@@ -370,3 +372,54 @@ class TestHardenedQualityRubric:
     def test_brevity_protective_high_anchor(self):
         # Guards against overcorrection — terse-but-complete must stay a 5.
         assert "brevity is not a defect when the task is genuinely complete" in RUBRIC
+
+
+# ── render_response: an absent response must never render as a blank section ──
+# LIA-558. A bare "**Agent response:**" followed by nothing reads to the judge as
+# nothing worth noting, and it confabulates success from the instructions above.
+# Measured on gemma4:e4b at temperature 0: an empty response scored 5/5 while the
+# literal string "Done." scored 1/5.
+
+
+class TestRenderResponse:
+    def test_none_renders_sentinel(self):
+        assert render_response(None) == EMPTY_RESPONSE_SENTINEL
+
+    def test_empty_string_renders_sentinel(self):
+        assert render_response("") == EMPTY_RESPONSE_SENTINEL
+
+    @pytest.mark.parametrize(
+        "blank", [" ", "\t", "\n", "\r\n", "   \n\t  ", " ", "  "]
+    )
+    def test_whitespace_only_renders_sentinel(self, blank):
+        # Includes non-breaking and thin/em spaces: str.strip() covers the
+        # Unicode whitespace classes, and a response of only those carries no
+        # more evidence than "".
+        assert render_response(blank) == EMPTY_RESPONSE_SENTINEL
+
+    def test_real_response_passes_through_byte_identical(self):
+        assert render_response("hello world") == "hello world"
+
+    def test_surrounding_whitespace_on_real_content_is_preserved(self):
+        # Only wholly-blank responses are replaced; padding around real content
+        # must survive untouched, or non-empty prompts would not be byte-stable.
+        assert render_response("  hi  ") == "  hi  "
+        assert render_response("\n\nresult\n") == "\n\nresult\n"
+
+    def test_response_equal_to_sentinel_passes_through(self):
+        # Collision case: an agent may legitimately emit the sentinel text. The
+        # check keys on emptiness, never on the sentinel, so it is returned
+        # unchanged rather than mistaken for an absent response.
+        assert render_response(EMPTY_RESPONSE_SENTINEL) == EMPTY_RESPONSE_SENTINEL
+
+    def test_response_containing_sentinel_passes_through(self):
+        text = f"I nearly replied {EMPTY_RESPONSE_SENTINEL}, but here is the answer."
+        assert render_response(text) == text
+
+    def test_sentinel_reads_as_a_fact_not_a_verdict(self):
+        # Wording is load-bearing, not cosmetic: a more emphatic variant ("no
+        # response — the agent produced no output at all") lost an
+        # instructed-silence case by reading as a judgement rather than a fact.
+        lowered = EMPTY_RESPONSE_SENTINEL.lower()
+        for verdict_word in ("fail", "wrong", "bad", "error", "should", "never"):
+            assert verdict_word not in lowered

--- a/evolution/training/build_judge_lora_dataset.py
+++ b/evolution/training/build_judge_lora_dataset.py
@@ -38,7 +38,13 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from evolution.judge.criteria import RUBRIC, COMPOSITE_WEIGHTS, DIM_DEFAULTS, compose_score
+from evolution.judge.criteria import (
+    RUBRIC,
+    COMPOSITE_WEIGHTS,
+    DIM_DEFAULTS,
+    compose_score,
+    render_response,
+)
 from evolution.storage import get_storage
 from evolution.training._provenance import git_sha, git_dirty, sha256_file
 
@@ -60,7 +66,10 @@ def build_eval_prompt(prompt: str, response: str, tools_used=None, context=None)
     parts.append(f"**User prompt:**\n{prompt}\n")
     if tools_used:
         parts.append(f"**Tools used:** {', '.join(tools_used)}\n")
-    parts.append(f"**Agent response:**\n{response}\n")
+    # No-op in practice — is_chat_interaction() already filters empty responses
+    # out of the dataset. Routed through the shared seam anyway so this builder
+    # keeps its promise of matching the production judge prompt byte for byte.
+    parts.append(f"**Agent response:**\n{render_response(response)}\n")
     return "\n".join(parts)
 
 

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-15" # auto-bump @1786792800
+last_verified: "2026-08-16" # auto-bump @1786829394
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-15" # auto-bump @1786817018; also LIA-491 (container instance scoping)
+last_verified: "2026-08-16" # auto-bump @1786829394
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## The defect

An empty agent response rendered as a blank `**Agent response:**` section, and the judge confabulated success from the instructions above it.

Measured on `gemma4:e4b` at temperature 0, over 3 tasks where the agent produced nothing:

| rendering | quality | exec | correct |
| -- | -- | -- | --: |
| blank section (current) | [5,5,5] | [5,5,5] | **0/3** |
| explicit marker | [1,1,1] | [1,1,1] | **3/3** |

An empty response scored **5/5** while the literal string `"Done."` scored **1/5**. In the live DB, **308** empty-response rows are stored at `quality = 1.0` and **305** clear `POSITIVE_THRESHOLD` — the loop has been crediting "produced nothing" as exemplary, and **863 of 1994 stored reflections (43%)** derive from an empty-response interaction.

This is prompt construction, not model capability: a 5-condition run shows the judge separates correct (5.0) / partial (2.0) / hollow `"Done."` (1.0) cleanly. Only the empty case inverts.

## The change

Two halves of one rule: **an absent response must not be read as evidence.**

**Render it explicitly.** `criteria.py` gains `EMPTY_RESPONSE_SENTINEL` and `render_response()`, the shared seam for every prompt builder that interpolates a stored response — the four judges, the LoRA dataset builder, and both reflection-generator templates. A non-empty response passes through byte-identical.

**Withhold the learning signal.** `response_supports_reflection()` guards the six judge-score-driven reflection paths, **both polarities** — a blank response supports neither "this failed" nor "this was exemplary". `extract_principles` filters its best/worst pools *before* the count check, so an all-empty pool cannot satisfy the count and generate principles from `"(none)"`. The four human-signal paths are deliberately exempt: there a person supplied the evidence.

## Why the guard is right, and why it's temporary

Two independent reviewers blocked an earlier version of this for asserting failure on runs that may have succeeded silently. They were right: the record cannot distinguish "ran and correctly stayed silent" from "never ran". I measured three renderings that tell the judge outright that no execution record exists — all three scored identically, because no renderer recovers missing evidence.

So the score is recorded honestly and the *claim* is withheld. `response_supports_reflection`'s docstring names its own retirement condition: once execution evidence (tool calls, exit status, a completion marker) is logged, delete it.

## Why no fixture re-measurement

`RUBRIC` is untouched, so the coupling rule at `criteria.py:12-24` does not fire. For non-empty responses the built prompt is asserted byte-identical to a hand-assembled frozen literal across all five builders — if the prompt cannot change, the score cannot move. A full 4-dimension re-measure is impossible regardless: no Gemini-labelled fixture is committed and `GEMINI_API_KEY` is absent from the authoring session.

## Tests

**939 passed, 2 skipped.** 53 tests in the new file. The verification gate proved they discriminate by mutation:

| mutation | tests that failed |
| -- | --: |
| `render_response` strips padding | 5 |
| guard predicate forced True | 6 |
| templates interpolate raw | 2 |

**One pre-existing failure is unrelated to this diff:** `test_judge_registry.py::test_default_model_reads_from_config` asserts a hardcoded `gemma4:e4b` while `default_model` returns `OLLAMA_JUDGE_MODEL`. It fails on any machine with `EVOLUTION_OLLAMA_JUDGE_MODEL` set; CI does not set it. Confirmed three ways (stash to pre-change tree, subprocess without the var, and the file is untouched here).

## Deliberately out of scope, ticketed

- **LIA-564** (priority 1) — compaction summarises a blank `Assistant:` section and the fabrication *overwrites the prompt permanently*. **884 rows eligible now**, 16 logged interactions from firing.
- `taste_profile.py` — judge-score-driven but not a reflection producer, manual-only, writes outside this repo.
- The runtime transport defect that makes 903 of 905 rows empty in the first place, and cleanup of the 863 already-contaminated reflections — both owned by other sessions.

## Review

Six plan-review rounds, two code-review rounds, two verification rounds, co-gate PASS on both backends. Every round found something real; five were my own errors, including a missed positive-reflection branch and a mis-classified producer.

Refs: LIA-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)