### PR TITLE
fix(evolution): stop compaction fabricating a record from an absent response

### DIFF
--- a/evolution/storage/provider.py
+++ b/evolution/storage/provider.py
@@ -388,7 +388,17 @@ class StorageProvider(ABC):
 
     @abstractmethod
     def get_compactable_interactions(self, days: int, limit: int = 50) -> list[dict]:
-        """Fetch scored interactions older than N days with long prompt text, eligible for compaction."""
+        """Fetch scored interactions older than N days with long prompt text, eligible for compaction.
+
+        Interactions with no response text are excluded. Compaction summarises an
+        interaction with an LLM and the summary replaces the prompt permanently,
+        so a blank response yields a confabulated record rather than a compacted
+        one (LIA-564). Implementations must exclude them during selection, not
+        after, so rejected rows cannot occupy slots under `limit`.
+
+        "Blank" means what Python's ``str.strip()`` means, Unicode whitespace
+        included — not just ASCII space.
+        """
         ...
 
     @abstractmethod

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -29,6 +29,20 @@ log = logging.getLogger(__name__)
 # corrupted/poisoned DB row can't sneak a payload through DROP TABLE.
 _SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# Whitespace set for the compaction selector's TRIM: every codepoint Python's
+# str.strip() removes, so the SQL check matches it exactly. SQLite's
+# one-argument TRIM strips ASCII space only, which would let a tab- or
+# NBSP-only response read as non-empty. Kept as a literal because deriving it
+# means scanning 1.1M codepoints at import; test_compaction_ws_matches_python
+# asserts it stays in sync.
+_COMPACTION_WS = (
+    "\u0009\u000a\u000b\u000c\u000d\u001c"
+    "\u001d\u001e\u001f\u0020\u0085\u00a0"
+    "\u1680\u2000\u2001\u2002\u2003\u2004"
+    "\u2005\u2006\u2007\u2008\u2009\u200a"
+    "\u2028\u2029\u202f\u205f\u3000"
+)
+
 # Allow-list for update_interaction(**fields). Each entry must correspond to a
 # column on `interactions` that the rest of the codebase legitimately writes
 # after initial insert. Adding a new entry is intentional — never widen this
@@ -1134,6 +1148,14 @@ class SQLiteStorageProvider(StorageProvider):
     # ── Compaction & batch judging ──────────────────────────────────────────
 
     def get_compactable_interactions(self, days: int, limit: int = 50) -> list[dict]:
+        # Rows with no response text are excluded: the summary permanently
+        # replaces the prompt, so a blank "Assistant:" section gets confabulated
+        # into the record. Filtered in SQL so no caller can bypass it and
+        # rejected rows never consume a LIMIT slot (LIA-564).
+        #
+        # Binding order is load-bearing and only half-safe: swapping ws with
+        # limit raises, but swapping it with days makes datetime() return NULL
+        # and the query silently returns zero rows.
         db = self._connect()
         rows = db.execute(
             """
@@ -1143,10 +1165,12 @@ class SQLiteStorageProvider(StorageProvider):
               AND LENGTH(prompt) > 300
               AND eval_suite != 'maintenance'
               AND group_folder != '__maintenance__'
+              AND response IS NOT NULL
+              AND TRIM(response, ?) != ''
             ORDER BY timestamp ASC
             LIMIT ?
             """,
-            (f"-{days}", limit),
+            (f"-{days}", _COMPACTION_WS, limit),
         ).fetchall()
         db.close()
         return [dict(r) for r in rows]

--- a/evolution/tests/test_storage_provider.py
+++ b/evolution/tests/test_storage_provider.py
@@ -977,6 +977,85 @@ class TestSQLiteCompactionAndBatchJudge:
         assert len(results) == 1
         assert results[0]["id"] == "cmp1"
 
+    # ── LIA-564: an interaction with no response text must never be selected ──
+    # The summary permanently replaces the prompt, so a blank "Assistant:"
+    # section gets confabulated into the record.
+
+    def test_compaction_ws_matches_python(self):
+        """The TRIM set must stay identical to what str.strip() removes.
+
+        It is a literal for import speed, so nothing keeps it in sync
+        automatically — if a future Python adds a whitespace codepoint, this
+        fails rather than silently reopening the gap.
+        """
+        import sys
+
+        from evolution.storage.providers.sqlite import _COMPACTION_WS
+
+        derived = "".join(
+            chr(c) for c in range(sys.maxunicode + 1) if chr(c).isspace()
+        )
+        assert _COMPACTION_WS == derived
+
+    @pytest.mark.parametrize(
+        "blank, label",
+        [("", "empty"), (" ", "space"), ("\t", "tab"), ("\n", "newline"),
+         ("\r\n", "crlf"), ("  \t\n ", "mixed"),
+         ("\u00a0", "nbsp"), ("\u2028", "line_sep"), ("\u3000", "ideographic"),
+         ("\u00a0\t\u2003", "unicode_mixed")],
+    )
+    def test_get_compactable_skips_blank_responses(self, sqlite_provider, blank, label):
+        # tab/newline are the cases one-argument TRIM would have let through;
+        # the Unicode ones are what an ASCII-only char set would have missed.
+        sqlite_provider.log_interaction(
+            prompt="x" * 400, response=blank, group_folder="g",
+            timestamp="2020-01-01T00:00:00Z", interaction_id=f"blank_{label}",
+        )
+        sqlite_provider.update_interaction(f"blank_{label}", judge_score=0.8)
+
+        assert sqlite_provider.get_compactable_interactions(days=7) == []
+
+    def test_get_compactable_skips_null_response(self, sqlite_provider):
+        # Already-compacted rows: compact_interaction NULLs the response and
+        # leaves a <=500-char summary as the prompt, so without this they get
+        # re-summarised into a summary of a summary.
+        sqlite_provider.log_interaction(
+            prompt="s" * 400, response=None, group_folder="g",
+            timestamp="2020-01-01T00:00:00Z", interaction_id="already_compacted",
+        )
+        sqlite_provider.update_interaction("already_compacted", judge_score=0.8)
+
+        assert sqlite_provider.get_compactable_interactions(days=7) == []
+
+    def test_get_compactable_still_selects_padded_real_content(self, sqlite_provider):
+        # Over-exclusion control: this passes without the guard too, so it is not
+        # coverage of the fix. It earns its place as the only test here that
+        # catches a days/ws binding swap — that makes datetime() return NULL and
+        # the query select nothing, which every `== []` assertion above would
+        # happily accept.
+        sqlite_provider.log_interaction(
+            prompt="x" * 400, response="  a genuine answer  ", group_folder="g",
+            timestamp="2020-01-01T00:00:00Z", interaction_id="padded",
+        )
+        sqlite_provider.update_interaction("padded", judge_score=0.8)
+
+        results = sqlite_provider.get_compactable_interactions(days=7)
+        assert [r["id"] for r in results] == ["padded"]
+
+    def test_get_compactable_selects_content_padded_with_unicode_whitespace(
+        self, sqlite_provider
+    ):
+        # The full-Unicode TRIM set must strip padding without eating the content
+        # it surrounds — the over-broad failure the widened set could introduce.
+        sqlite_provider.log_interaction(
+            prompt="x" * 400, response="\u00a0real answer\u3000", group_folder="g",
+            timestamp="2020-01-01T00:00:00Z", interaction_id="uni_padded",
+        )
+        sqlite_provider.update_interaction("uni_padded", judge_score=0.8)
+
+        results = sqlite_provider.get_compactable_interactions(days=7)
+        assert [r["id"] for r in results] == ["uni_padded"]
+
     def test_get_compactable_skips_short_prompts(self, sqlite_provider):
         sqlite_provider.log_interaction(
             prompt="short", response="r", group_folder="g",

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-16" # auto-bump @1786829394
+last_verified: "2026-08-16" # auto-bump @1786848780
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786829394
+last_verified: "2026-08-16" # auto-bump @1786848780
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## The defect

`compact_interaction` replaces an interaction's prompt with an LLM summary and NULLs the response:

```sql
UPDATE interactions SET prompt = ?, response = NULL WHERE id = ?
```

That is intended. What isn't: for a row with **no response text**, the summarisation prompt renders a blank `Assistant:` section, and the model — asked to "Preserve WHY it scored well/poorly … outcome success" — confabulates what the agent did. **That fabrication becomes the permanent record**, and the original prompt is gone.

## It was armed, and the next batch was entirely fabrication

Measured read-only against the live DB, using the selector's exact filters:

| | before | after |
| -- | --: | --: |
| rows eligible for compaction | **1136** | **202** |
| composition of the next 50-row batch | **50/50 `response IS NULL`** | 50/50 real content |

Not "eventually reaches bad rows" — under `ORDER BY timestamp ASC` the oldest go first, and those are the already-compacted ones. The very next maintenance run would have re-summarised 50 existing summaries from nothing: a second-generation fabrication overwriting a first.

Maintenance fires at `interaction_count - stored_count >= 25`; the sentinel held 1761 against a table of 1770, so **16 more logged interactions** away.

Of the excluded rows: **884** are strictly empty and **50** are `NULL` — the latter previously-compacted, 37 sitting exactly at the 500-char `summary.strip()[:500]` cap and 13 between 388 and 496.

## The fix

Two lines in the selector, excluding during selection rather than at the caller — so no second caller can bypass it and rejected rows never consume a slot under the `LIMIT`.

**The whitespace set is every codepoint Python's `str.strip()` removes, not just ASCII.** One-argument `TRIM` strips ASCII space alone, so a tab- or NBSP-only response would have survived it — the same class of blank the guard exists to catch. An earlier revision used the ASCII set and documented the Unicode gap as accepted; the GPT co-gate rejected that, correctly, since the method's own docstring promises exclusion *during selection*. Closing it properly turned out to be 29 codepoints with **zero disagreements** against `str.strip()`, while content that merely *contains* NBSP or U+2028 still selects.

Kept as a literal for import speed (deriving it means scanning 1.1M codepoints), with `test_compaction_ws_matches_python` asserting it stays identical to the runtime-derived set. Written as `\uXXXX` escapes — invisible characters in source are unreviewable, and one of them was a raw U+2028, which Python's `splitlines()` treats as a line terminator.

**The widened set changes zero rows today, and that is the point.** Measured: the ASCII-only predicate selects 202 and the 29-codepoint predicate selects the same 202 — the extra codepoints exclude nothing currently in the table, and no row today passes the ASCII predicate while being empty under Python's `str.strip()`. So this is not a count improvement; it is an invariant. A reviewer reproducing the before/after with the ASCII set alone will get the same 202 and should not read the extra codepoints as unmotivated: the claim being defended is *no row can pass the SQL predicate and fail a Python emptiness check*, which is what makes the caller-side filter unnecessary and the guard's contract honest.

## Verification

**886 tests pass** in `evolution/tests`. The verification gate mutation-tested the new tests on a temp copy:

| mutation | outcome |
| -- | -- |
| drop the TRIM clause | killed (10 failures) |
| ASCII-only whitespace set | killed (5) |
| swap the ws/days binding | killed (3) |
| drop one codepoint (U+3000) | killed (2) |
| one-argument TRIM | killed (8) |
| drop `response IS NOT NULL` | survived — behaviourally redundant, kept for explicitness |

Binding order is load-bearing and only half-safe, which the code comment records: swapping ws with `limit` raises, but swapping it with `days` makes `datetime()` return NULL and the query **silently** returns zero rows. The two positive-control tests are the only ones that catch that, since every `== []` assertion accepts an empty result.

**One pre-existing failure is unrelated:** `test_judge_registry.py::test_default_model_reads_from_config` asserts a hardcoded `gemma4:e4b` while `default_model` returns `OLLAMA_JUDGE_MODEL`. It fails on any machine with `EVOLUTION_OLLAMA_JUDGE_MODEL` set; CI does not set it. Confirmed by subprocess with the var removed, and the file is untouched here.

## Scope

Phase 1 of 2, and it closes 100% of the measured exposure on its own — zero rows pass the SQL predicate while failing a Python `strip()`.

Phase 2 was originally a caller-side Python parity filter. It largely dissolved: with SQL at exact parity there is nothing left for it to catch, and the starvation defect the co-gate raised against it (rejected rows permanently occupying the head of the queue under `LIMIT 50`) cannot arise, because no fetch-then-reject step remains.

Not touched: `compact_interaction`'s own `response = NULL` behaviour, `taste_profile.py`, and the transport defect that produces the empty responses — all owned elsewhere.

Empty and NULL rows become permanently exempt from compaction, so their prompts are retained indefinitely. Accepted: a retained prompt beats a fabricated one, and `_truncation_fallback` is fabrication-free if those rows ever need compacting.

## Review

Five plan-review rounds, four code-review rounds, one verification round, and a co-gate REVISE that forced the re-scope. Every round found something real — including four factual errors of mine and a stale git index that would have shipped round-1 content.

Part of LIA-564, phase 1 of 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
