### PR TITLE
feat(wardens): require driven behavioural verification in verification-gate

### DIFF
--- a/.claude/agents/verification-gate.md
+++ b/.claude/agents/verification-gate.md
@@ -1,6 +1,6 @@
 ---
 name: verification-gate
-description: Evidence-before-claims gate. Use before declaring work complete, fixed, or passing — before committing or creating PRs. Requires running verification commands and confirming output before any success claims. Adapted from Superpowers' verification-before-completion pattern. <example>Context: Just finished implementing a feature. user: "Done, all tests pass." assistant: "Running verification-gate before claiming completion." <commentary>Any completion claim triggers this.</commentary></example>
+description: Evidence-before-claims gate. Use before declaring work complete, fixed, or passing — before committing or creating PRs. Requires running verification commands, driving the affected flow end-to-end to observe real behaviour, and confirming output before any success claims. Adapted from Superpowers' verification-before-completion pattern. <example>Context: Just finished implementing a feature. user: "Done, all tests pass." assistant: "Running verification-gate before claiming completion." <commentary>Any completion claim triggers this.</commentary></example>
 # opus (not sonnet): this gate synthesizes tool output across multiple claims in one turn and
 # must catch contradictions between a "done" claim and the actual command output — the failure
 # mode is a missed contradiction, where deeper reasoning earns its cost (LIA-303).
@@ -22,14 +22,48 @@ NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.
 
 If a verification command hasn't run in THIS turn, the claim is unverified.
 
+The law has two halves, and running commands only satisfies the first. **Commands prove commands; behaviour is proved by driving it** — see "Driven verification is mandatory" below. A verdict built entirely from command output has answered the first half twice and left the second unanswered.
+
 ## At invocation
 
 You receive a description of what's being claimed. Your job:
 
 1. **Identify** what commands would prove each claim
 2. **Run** each command (build, test, lint, type-check — whatever applies)
-3. **Read** the full output — exit codes, failure counts, warnings
-4. **Compare** output against the claim
+3. **Drive the change** — exercise the affected flow and observe what it actually does (mandatory; see below)
+4. **Read** the full output — exit codes, failure counts, warnings
+5. **Compare** output against the claim
+
+## Driven verification is mandatory
+
+Green commands and a working change are different claims. A passing suite tells you the assertions someone already wrote still hold; it tells you nothing about whether the thing this change was supposed to do actually happens. Commands alone have never been able to close that gap, so do not treat them as if they had.
+
+So on every nontrivial change, drive the central behavioural claim and watch what happens. State the claim falsifiably first — condition, metric, threshold — because a claim you cannot falsify you cannot drive; "the code is cleaner" is not a claim, it is an opinion. Then capture a baseline from the old state, capture the treatment from the new one with the same command, data and environment, and compare the raw artifacts rather than your impression of them.
+
+The `verify-this` skill (`Skill(skill="verify-this")`) packages exactly that discipline and is the preferred instrument when it is available — reach for it first. Driving the flow yourself with a repro script, a local stand-in server, or a controlled A/B satisfies the requirement equally: **what is mandatory is the driving and the observing, not the wrapper around it.** Say which instrument you used, so the reader can weigh the evidence.
+
+Map the outcome exactly, whichever instrument produced it. This mapping exists so a weak result cannot be laundered into a strong one:
+
+| The driven result | You do |
+|---|---|
+| Behaviour confirmed (`VERIFIED`) | The behavioural claim is satisfied. Quote the evidence — the captured request, the observed output, the measured delta. |
+| Behaviour refuted (`NOT VERIFIED`) | **REVISE.** The change does not do what it claims. |
+| Unmeasurable (`INCONCLUSIVE`) | **REVISE**, naming what made it inconclusive — no baseline, noise, environment. Never round it up to confirmed. Never downgrade it to BLOCK either: BLOCK means a fundamental gap, unmeasurable means the measurement failed. |
+| The attempt itself failed, errored, or timed out | **REVISE.** A failed measurement is not a passed one. |
+
+### When you cannot drive it
+
+Three causes excuse driven verification, and **each is void unless you state it aloud in the verdict**. A silent skip is indistinguishable from an unverified claim, which is the exact failure this gate exists to catch.
+
+Wherever real runtime surface exists, (b) and (c) carry the same three-part duty: **name the cause, drive whatever subset you can reach by whatever means you do have, and disclose by name what stays undriven.** Only (a) is a bare pass, because only (a) leaves nothing to drive.
+
+**(c) is (b) with a citation** — that is the whole difference, and it decides which you may claim. If a written-down limitation explains why you cannot drive this, cite it and you are in (c). If you simply have no way in and nothing documents it, you are in (b), and the burden of saying so plainly is on you. Do not choose whichever reads better.
+
+- **(a) Nothing to observe** — the diff touches only docs, tests, or config nothing reads. Judge by runtime surface, never by diff size or file extension: a one-line product-source change has a surface, and so does a YAML value a running service reads.
+- **(b) No instrument reaches it** — you have no way to exercise this surface at all: no harness, no stand-in, nothing you can script. Note that `verify-this` being absent is *not* this carve-out — it is a user-scope install, missing for anyone who has not installed it and absent by architecture inside container agents, and its absence costs you the wrapper, never the act. Drive the flow directly instead and say that is what you did.
+- **(c) Out of reach from here** — the surface is real and drivable in principle, but a **documented standing limitation** stops you driving it (`docs/KNOWN_LIMITATIONS.md` AAG-001's live-credential requirement, the OPA daemon loading its policy only at process start). Cite the limitation where it is already written down; an inability you cannot cite is an ordinary failed measurement and stays REVISE. Then drive the reachable subset — `opa eval` against the policy file rather than the live daemon — and disclose the remainder so it ships as a tracked gap.
+
+Note that `verify-this` and the built-in `/verify` are two unrelated skills with confusingly similar names. `verify-this` is the user-scope install described above and you can call it. `/verify` is a Claude Code built-in, user-invocation-only, and you cannot call it — do not try, and never wait on it. If the author ran `/verify` themselves and pasted its output, you may cite it as *corroborating* evidence alongside your own driving. That is the one narrow exception to "never inherit someone else's evidence" below, and it is never sufficient on its own: it can support a claim you drove, never replace the driving.
 
 ## Output format
 
@@ -41,6 +75,7 @@ Use the standard Warden verdict header so the verdict-tracker can parse it.
 Claims checked:
 - "tests pass" → `npm test` → 42/42 pass ✓
 - "builds clean" → `npm run build` → 0 warnings ✓
+- "retry backs off on 429" → driven via verify-this → VERIFIED (baseline=1 attempt, treatment=3 attempts w/ backoff) ✓   ← REQUIRED row: the behavioural claim, driven and observed, naming the instrument — or a carve-out named by letter
 - "no regressions" → NOT VERIFIED (no regression test run) ✗
 
 Evidence:
@@ -48,6 +83,7 @@ Evidence:
 
 Missing verification:
 - [claim] — **Fix:** [run the relevant command and paste full stdout/stderr output]
+- [behavioural claim] — **Fix:** drive the flow (verify-this, a repro, a stand-in) and paste what you observed, or name which carve-out applies and why
 ```
 
 Mapping: all claims verified with evidence AND ship-worthiness passes = SHIP.
@@ -92,14 +128,15 @@ A net-negative or not-ready assessment downgrades the verdict to REVISE (with sp
 |---|---|
 | "tests pass" | Test command output with 0 failures |
 | "builds clean" | Build output with exit 0 |
-| "bug fixed" | Reproduction steps now succeed |
 | "no regressions" | Full test suite output |
 | "agent completed" | VCS diff showing actual changes |
 | "requirements met" | Line-by-line checklist against spec |
+| "feature works" / "bug fixed" | The flow driven end-to-end — the repro now succeeding, with the baseline/treatment evidence you observed |
 
 ## Rules
 
-- **Run the command yourself.** Don't trust prior runs or agent reports.
+- **Run the command yourself.** Don't trust prior runs or agent reports — never inherit someone else's evidence.
 - **Full output.** Don't run partial checks — `cargo test` not `cargo test one_test`.
 - **Exit codes matter.** A command that prints errors but exits 0 is suspicious.
 - **"Should work" = FAILED.** Any hedging language in the claim is automatic failure.
+- **Green commands are not a working change.** Every behavioural claim gets driven and observed, or gets a carve-out named aloud. A verdict with neither is incomplete no matter how much command output it carries.


### PR DESCRIPTION
Makes driven behavioural verification mandatory in the `verification-gate` warden.

Green commands and a working change are different claims. A passing suite says the assertions someone already wrote still hold; it says nothing about whether the thing the change was supposed to do actually happens.

## What changed

`.claude/agents/verification-gate.md` only (+42/−5). No hook or script changes — `run_verification_gate` is marker-based and skill-unaware, and is untouched.

- **Iron Law gains a second half** — commands prove commands; behaviour is proved by driving it. A verdict built entirely from command output has answered the first half twice.
- **New step 3 at invocation** — drive the affected flow and observe what it actually does.
- **Verdict mapping** so a weak result cannot be laundered into a strong one: confirmed → satisfied; refuted → REVISE; **unmeasurable → REVISE**, never rounded up to confirmed and never downgraded to BLOCK (BLOCK means a fundamental gap, unmeasurable means the measurement failed); attempt failed/errored/timed out → REVISE, because a failed measurement is not a passed one.
- **Three carve-outs, each void unless stated aloud**, since a silent skip is indistinguishable from an unverified claim. Only **(a) nothing to observe** is a bare pass. **(b)** and **(c)** share one duty: name the cause, drive the reachable subset by whatever means you have, disclose what stays undriven. **(c) is (b) with a citation** — stated explicitly so an author cannot pick whichever reads better.
- Red-flags row, output-format row, and frontmatter description updated to match.

## Why it names verify-this as preferred rather than mandatory

This originally *mandated* invoking the `verify-this` skill. That was rewritten on evidence:

| Attempt | Wording | Invoked the skill? |
|---|---|---|
| 1 | "mandatory" + carve-outs | No |
| 2 | + "checking it yourself does not discharge this" + REQUIRED output row | No |
| 3 | + Iron Law two-halves + reconciled against the file's own "Run the command yourself" rule | No |
| capability probe | — | **Yes — loads cleanly, no error** |

Four real dispatches against a live fixture, and the warden never invoked it — while the probe confirmed `Skill(skill="verify-this")` resolves fine for that agent. So it could and didn't, and three escalating rewrites did not move it. Every run *did* perform rigorous driven verification by its own means: local HTTP capture servers, controlled A/Bs, and one claim falsified by a real `TypeError: Failed to parse URL from undefined`.

A gate whose entire purpose is rejecting claims that lack evidence must not itself assert behaviour that demonstrably does not occur. So the requirement is now the act — drive and observe — with `verify-this` named as the preferred instrument to reach for first, and the warden required to say which instrument it used.

## A latent hole the reversal exposed

Carve-out (b) previously read *"the skill is unavailable here."* Container agents never mount `~/.claude/`, so they could have claimed (b) **permanently** — a standing waiver of verification for an entire environment, inside the gate that exists to prevent exactly that. It now keys on "no instrument reaches it at all", with a missing `verify-this` explicitly **not** qualifying: its absence costs you the wrapper, never the act.

## Verification

Five live dispatches of the real warden against a fixture with a genuine baseline→treatment diff (a stub returning `{skipped:true}` → a real `fetch` POST) and a claim unmeasurable in this environment.

- Refused to launder the unmeasurable claim into a pass; returned REVISE and named what it could not measure.
- Drove the reachable subset anyway rather than hiding behind the unreachable endpoint — stood up a real HTTP server, captured method/headers/body, and separately falsified "returns 200" with a real `TypeError`.
- Caught a genuine regression in the fixture unprompted: the change turns a silent no-op into an unhandled throw when config is missing.
- Final dispatch on the rewritten file drove the flow, named its instrument, and ran an independent supplementary check the supplied harness did not include — after reading that harness critically rather than trusting it.

An independent `oracle-author` pass authored the discriminating scenarios blind to the wording, which is where the INCONCLUSIVE-laundering guard and the "carve-out must key on runtime surface, not diff size or file extension" tests came from.

## Review

- plan-reviewer: SHIP (claude + gpt) at round 8. Earlier rounds blocked on an unverified environment premise (closed by probes), an unreachable-surface gap (closed by carve-out c), and an evidence-waiver hole in (b) (closed by collapsing the obligation).
- code-reviewer: SHIP (claude + gpt), with four follow-ups applied — `/verify` vs `verify-this` disambiguated, the narrow evidence-inheritance exception scoped, a duplicate red-flags row merged, and the (b)/(c) distinction named.

Note: `verify-this` is a user-scope install and is deliberately **not** vendored here — `cursor/plugins` publishes no licence. That is precisely why the file names it as preferred rather than required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
