### PR TITLE
feat(cogate): refuse to record a Claude verdict a GPT model produced

### DIFF
--- a/scripts/cogate.py
+++ b/scripts/cogate.py
@@ -29,7 +29,8 @@ and runs the GPT half.
 Exit codes (typed, agent-native — see scripts/_exit_codes.py):
     0  SUCCESS        co-gate will PASS (Claude accepted AND GPT SHIP; or --skip-gpt + accepted)
     2  USAGE_ERROR    bad arguments, or the Claude mark was REFUSED (e.g. bg-session TRIVIAL,
-                      or a TRIVIAL bypass after a prior REVISE/BLOCK) — GPT is NOT run
+                      or a TRIVIAL bypass after a prior REVISE/BLOCK), or the Claude half
+                      would run on a known non-Anthropic model (LIA-560) — GPT is NOT run
     5  INTERNAL_ERROR a recorded verdict is REVISE/BLOCK — the gate will BLOCK
     4/5/7             GPT COULD_NOT_RUN (auth/internal/rate): the gate fails OPEN (non-blocking),
                       but this exits non-zero + warns LOUDLY so the operator sees GPT did not run
@@ -48,6 +49,7 @@ import codex_warden  # noqa: E402  (the GPT half is its main(), invoked in-proce
 import codex_warden_hooks as whooks  # noqa: E402  (mark_warden, bucket resolution, readback)
 from _agent_io import agent_output, is_agent_context  # noqa: E402
 from _exit_codes import INTERNAL_ERROR, SUCCESS, USAGE_ERROR  # noqa: E402
+from warden_review import model_family  # noqa: E402  (Claude-half model-family guard, LIA-560)
 from warden_review.constants import BACKEND_GPT, store_key  # noqa: E402
 from warden_hooks.verdict_store import _fresh_entry, _read_verdicts  # noqa: E402
 
@@ -122,6 +124,19 @@ def main(argv: list[str] | None = None) -> int:
             bucket = _verdicts_path(marker_root)
         except Exception:  # pragma: no cover — display-only
             bucket = None
+
+    # 1b) Refuse to record a "claude" verdict that a non-Claude model would produce (LIA-560).
+    #     In a gateway session the roles' `model: sonnet` pin resolves through
+    #     ANTHROPIC_DEFAULT_SONNET_MODEL, which may name a GPT model — the co-gate would then
+    #     print `claude: SHIP` for GPT-reviewed-by-GPT. Checked BEFORE the mark so a block
+    #     records nothing and burns no GPT call. Only ever blocks on positive evidence; every
+    #     other outcome warns and proceeds. See model_family.py for why that asymmetry matters.
+    family_verdict, family_msg = model_family.check_claude_half(args.role, wt)
+    if family_verdict == model_family.BLOCK:
+        sys.stderr.write(family_msg + "\n")
+        return USAGE_ERROR
+    if family_msg:
+        sys.stderr.write(family_msg + "\n")
 
     # 2) Mark the Claude verdict into that bucket. mark_warden enforces the bg-session TRIVIAL
     #    refusal + the post-REVISE/BLOCK guard for free; a non-zero return means REFUSED.

--- a/scripts/tests/test_cogate_family_guard.py
+++ b/scripts/tests/test_cogate_family_guard.py
@@ -1,0 +1,252 @@
+"""Tests for the co-gate Claude-half model-family guard (LIA-560 defect 3).
+
+No network: every test injects ``fetch``. The invariant these pin — and the reason several
+of them exist at all — is that there is exactly ONE hard-BLOCK condition. Rounds 3 and 4 of
+this feature's plan review each regressed by quietly adding a second one, so
+``test_block_is_exhaustive`` asserts the property directly rather than trusting review.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from warden_review import model_family as mf  # noqa: E402
+
+GATEWAY = "http://localhost:8317"
+CLOAKED_LUNA = "claude-fable-5-dd-xam-anul"      # -> luna-max   (GPT)
+CLOAKED_OPUS = "claude-fable-5-dd-rennalp-supo"  # -> opus-planner (real Claude)
+
+
+def _listing(*entries):
+    """Build a fetch stub returning an OpenAI-shaped listing."""
+    def fetch(url, api_key, timeout):
+        assert url.startswith(GATEWAY), url
+        return {"data": [{"id": i, "owned_by": o, "object": "model"} for i, o in entries]}
+    return fetch
+
+
+def _raises(exc=ConnectionError("gateway down")):
+    def fetch(url, api_key, timeout):
+        raise exc
+    return fetch
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A repo root with a `sonnet`-pinned agent file, like the real co-gated roles."""
+    agents = tmp_path / ".claude" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "code-reviewer.md").write_text(
+        "---\nname: code-reviewer\nmodel: sonnet\n---\nbody\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _env(**over):
+    env = {"ANTHROPIC_BASE_URL": GATEWAY, "ANTHROPIC_API_KEY": "k",
+           "ANTHROPIC_DEFAULT_SONNET_MODEL": CLOAKED_LUNA}
+    env.update(over)
+    return env
+
+
+# ── decode / normalise ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(("cloaked", "plain"), [
+    (CLOAKED_LUNA, "luna-max"),
+    ("claude-fable-5-dd-los", "sol"),
+    (CLOAKED_OPUS, "opus-planner"),
+])
+def test_decode_round_trips_known_ids(cloaked, plain):
+    assert mf.decode_model_id(cloaked) == plain
+
+
+def test_decode_leaves_plain_and_real_claude_ids_alone():
+    assert mf.decode_model_id("luna-max") == "luna-max"
+    assert mf.decode_model_id("claude-opus-5") == "claude-opus-5"
+
+
+def test_decode_preserves_thinking_suffix():
+    """The round-3 blocking bug: reversing the suffix along with the base garbles the id."""
+    assert mf.decode_model_id(f"{CLOAKED_LUNA}(high)") == "luna-max(high)"
+    assert mf.decode_model_id("claude-opus-5(high)") == "claude-opus-5(high)"
+
+
+def test_strip_variant_suffix():
+    assert mf.strip_variant_suffix("opus-planner[1m]") == "opus-planner"
+    assert mf.strip_variant_suffix("opus-planner") == "opus-planner"
+
+
+# ── alias resolution ────────────────────────────────────────────────────────────────
+
+def test_alias_pin_resolves_through_env(repo):
+    pin, resolved, source = mf.resolve_claude_half_model("code-reviewer", repo, _env())
+    assert (pin, resolved, source) == ("sonnet", CLOAKED_LUNA, "ANTHROPIC_DEFAULT_SONNET_MODEL")
+
+
+def test_explicit_pin_used_verbatim(repo):
+    (repo / ".claude" / "agents" / "r.md").write_text(
+        "---\nname: r\nmodel: opus-planner\n---\n", encoding="utf-8")
+    pin, resolved, _ = mf.resolve_claude_half_model("r", repo, _env())
+    assert (pin, resolved) == ("opus-planner", "opus-planner")
+
+
+def test_missing_pin_falls_back_to_anthropic_model(repo):
+    (repo / ".claude" / "agents" / "nopin.md").write_text("---\nname: nopin\n---\n", encoding="utf-8")
+    pin, resolved, source = mf.resolve_claude_half_model(
+        "nopin", repo, _env(ANTHROPIC_MODEL="claude-opus-5"))
+    assert pin is None and resolved == "claude-opus-5" and "ANTHROPIC_MODEL" in source
+
+
+# ── the decision table ──────────────────────────────────────────────────────────────
+
+def test_ok_when_no_gateway(repo):
+    """First-party API: the Claude half really is Claude, no check needed."""
+    verdict, msg = mf.check_claude_half("code-reviewer", repo, _env(ANTHROPIC_BASE_URL=""),
+                                        fetch=_raises())
+    assert verdict == mf.OK and msg == ""
+
+
+def test_ok_for_anthropic_owner(repo):
+    verdict, _ = mf.check_claude_half(
+        "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL=CLOAKED_OPUS),
+        fetch=_listing(("opus-planner", "anthropic")))
+    assert verdict == mf.OK
+
+
+def test_ok_is_case_insensitive(repo):
+    verdict, _ = mf.check_claude_half(
+        "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL=CLOAKED_OPUS),
+        fetch=_listing(("opus-planner", "Anthropic")))
+    assert verdict == mf.OK
+
+
+def test_blocks_the_measured_defect(repo):
+    """The whole point: sonnet -> a cloaked GPT id -> owned_by openai."""
+    verdict, msg = mf.check_claude_half("code-reviewer", repo, _env(),
+                                        fetch=_listing(("luna-max", "openai")))
+    assert verdict == mf.BLOCK
+    assert "luna-max" in msg and "openai" in msg
+
+
+def test_blocks_plain_id_spelling_too(repo):
+    verdict, _ = mf.check_claude_half(
+        "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL="luna-max"),
+        fetch=_listing(("luna-max", "openai")))
+    assert verdict == mf.BLOCK
+
+
+def test_block_owner_match_is_case_insensitive(repo):
+    verdict, _ = mf.check_claude_half("code-reviewer", repo, _env(),
+                                      fetch=_listing(("luna-max", "OpenAI")))
+    assert verdict == mf.BLOCK
+
+
+def test_block_message_carries_all_three_escapes(repo):
+    """The R6 mitigation for the relabelling-proxy residual — asserted, not just documented."""
+    _, msg = mf.check_claude_half("code-reviewer", repo, _env(),
+                                  fetch=_listing(("luna-max", "openai")))
+    assert "code-reviewer" in msg and "sonnet" in msg
+    assert CLOAKED_LUNA in msg and "luna-max" in msg
+    assert GATEWAY in msg
+    assert "ANTHROPIC_DEFAULT_SONNET_MODEL" in msg
+    assert "non-gateway session" in msg
+    assert "rename that section" in msg
+
+
+def test_unknown_owner_label_warns_not_blocks(repo):
+    """A relabelling proxy may front a REAL Claude model — must never hard-block."""
+    for label in ("litellm", "corporate", "acme-platform-team"):
+        verdict, msg = mf.check_claude_half("code-reviewer", repo, _env(),
+                                            fetch=_listing(("luna-max", label)))
+        assert verdict == mf.WARN, label
+        assert "UNVERIFIED" in msg
+
+
+def test_absent_from_listing_warns_not_blocks(repo):
+    """A delisted model may be mid-cooldown and genuinely Claude (round-4 finding)."""
+    verdict, msg = mf.check_claude_half(
+        "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL=CLOAKED_OPUS),
+        fetch=_listing(("something-else", "openai")))
+    assert verdict == mf.WARN and "cooldown" in msg
+
+
+def test_real_claude_cloaked_id_with_failing_fetch_does_not_block(repo):
+    """The exact round-3 counter-example: real Claude + transient blip must not hard-block."""
+    verdict, _ = mf.check_claude_half(
+        "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL=CLOAKED_OPUS),
+        fetch=_raises())
+    assert verdict == mf.WARN
+
+
+def test_fetch_failure_never_blocks_any_id(repo):
+    for model in (CLOAKED_LUNA, CLOAKED_OPUS, "luna-max", "claude-opus-5"):
+        verdict, _ = mf.check_claude_half(
+            "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL=model), fetch=_raises())
+        assert verdict == mf.WARN, model
+
+
+def test_malformed_payloads_warn_and_do_not_crash(repo):
+    for body in ({}, {"data": "nope"}, [], {"data": [None, 7, {"no_id": 1}]}, "text"):
+        verdict, _ = mf.check_claude_half("code-reviewer", repo, _env(),
+                                          fetch=lambda u, k, t, b=body: b)
+        assert verdict == mf.WARN
+
+
+def test_unset_resolution_env_warns(repo):
+    verdict, msg = mf.check_claude_half(
+        "code-reviewer", repo, _env(ANTHROPIC_DEFAULT_SONNET_MODEL=""), fetch=_raises())
+    assert verdict == mf.WARN and "unset" in msg
+
+
+def test_user_agent_is_not_claude_cli():
+    """A claude-cli UA flips the gateway to the cloaked shape, per isAnthropicModelsRequest."""
+    assert not mf._USER_AGENT.startswith("claude-cli")
+
+
+def test_block_is_exhaustive(repo):
+    """The ONLY BLOCK path is: listed model + known non-Anthropic owner.
+
+    Pins the design principle so a future edit cannot quietly add a second hard-block, which
+    is how two earlier revisions regressed.
+    """
+    cases = [
+        (_env(ANTHROPIC_BASE_URL=""), _raises()),                            # no gateway
+        (_env(), _raises()),                                                 # fetch fails
+        (_env(), _listing(("other", "openai"))),                             # absent
+        (_env(), _listing(("luna-max", "litellm"))),                         # unknown owner
+        (_env(), _listing(("luna-max", "anthropic"))),                       # anthropic
+        (_env(ANTHROPIC_DEFAULT_SONNET_MODEL=""), _listing(("x", "openai"))),  # unset
+        (_env(), lambda u, k, t: {"data": "malformed"}),                     # malformed
+    ]
+    for env, fetch in cases:
+        verdict, _ = mf.check_claude_half("code-reviewer", repo, env, fetch=fetch)
+        assert verdict in (mf.OK, mf.WARN), (env, verdict)
+
+    verdict, _ = mf.check_claude_half("code-reviewer", repo, _env(),
+                                      fetch=_listing(("luna-max", "openai")))
+    assert verdict == mf.BLOCK
+
+
+# ── integration: the guard must short-circuit cogate.main() ─────────────────────────
+
+def test_cogate_short_circuits_before_marking_or_running_gpt(monkeypatch, repo):
+    """A BLOCK must record no verdict and burn no GPT call — unit tests alone can't show this."""
+    import cogate
+
+    called = {"mark": 0, "gpt": 0}
+    monkeypatch.setattr(cogate.whooks, "mark_warden",
+                        lambda *a, **k: called.__setitem__("mark", called["mark"] + 1) or 0)
+    monkeypatch.setattr(cogate.codex_warden, "main",
+                        lambda *a, **k: called.__setitem__("gpt", called["gpt"] + 1) or 0)
+    monkeypatch.setattr(cogate.model_family, "check_claude_half",
+                        lambda *a, **k: (cogate.model_family.BLOCK, "BLOCK: nope"))
+
+    rc = cogate.main(["--role", "code-reviewer", "--claude-verdict", "SHIP",
+                      "--claude-reason", "r", "--worktree-root", str(repo)])
+
+    assert rc == 2
+    assert called == {"mark": 0, "gpt": 0}

--- a/scripts/warden_review/model_family.py
+++ b/scripts/warden_review/model_family.py
@@ -1,0 +1,240 @@
+"""Guard: refuse to record a Claude co-gate verdict that a non-Claude model produced.
+
+LIA-560 defect 3. In a gateway session (``ANTHROPIC_BASE_URL`` pointing at a local
+CLIProxyAPI), the three co-gated roles all pin ``model: sonnet``, which resolves through
+``ANTHROPIC_DEFAULT_SONNET_MODEL``. If that variable names a GPT model, the "Claude half"
+of the co-gate *is* a GPT model — and ``cogate.py`` still prints ``claude: SHIP``. Measured:
+a ``haiku``-pinned subagent answered with no separate ``modelUsage`` entry at all; its usage
+folded into the GPT orchestrator's. The co-gate reported a cross-family guarantee it was not
+providing, silently.
+
+Design principle, arrived at over several review rounds and worth preserving verbatim:
+**there is exactly ONE hard-BLOCK condition — the resolved model is present in a
+successfully parsed gateway listing AND its ``owned_by`` is a label that unambiguously
+denotes a non-Anthropic provider.** Every other outcome is OK or a loud WARN that fails
+open. Two earlier designs were rejected for violating that principle:
+
+* Blocking on "``owned_by`` != anthropic" hard-blocks a *real* Claude model served through a
+  relabelling proxy (an ``openai-compatibility`` section's owner is ``compat.Name``, an
+  arbitrary operator-chosen string — ``service_models.go:726``).
+* Blocking on "absent from the listing" hard-blocks a *real* Claude model that is merely
+  mid-cooldown: ``modelRegistrationAvailability`` (``internal/registry/model_registry.go``)
+  drops a registration from ``/v1/models`` entirely while any client is suspended for a
+  non-quota reason (401/402/403/404), for 30 minutes to 12 hours. Absence is not evidence.
+
+``owned_by`` is only partly gateway-verified: CLIProxyAPI hardcodes it for its first-party
+sections (claude-api-key -> ``anthropic``, codex OAuth -> ``openai``, vertex/gemini ->
+``google``, xai -> ``xai``), but for the generic ``openai-compatibility:`` passthrough it is
+that arbitrary config label. Hence the known-owner allowlist rather than a not-equal test,
+and hence the rename escape in the block message.
+
+CLIProxyAPI citations pinned to commit ecc9aa72b32f34b680d03b0724b531a21ae74472.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.request
+from pathlib import Path
+
+#: CLIProxyAPI cloaks any model id that does not already start with ``claude-`` as this
+#: prefix plus the id reversed (``EnsureClaudeModelIDPrefix``, models.go:50). Used here ONLY
+#: to normalise an id back to its real name for the listing lookup — never as evidence of a
+#: model's family. The gateway's genuine Anthropic model is aliased ``opus-planner``, which
+#: cloaks to ``claude-fable-5-dd-rennalp-supo``, so the prefix says nothing about provenance.
+CLOAK_PREFIX = "claude-fable-5-dd-"
+
+#: Owner labels that unambiguously denote a non-Anthropic model family. Matched
+#: case-insensitively. Deliberately an allowlist: an unrecognised label (``litellm``,
+#: ``corporate``, a team name) may well front a real Claude model, so it must not block.
+KNOWN_NON_ANTHROPIC_OWNERS = frozenset({
+    "openai", "google", "xai", "meta", "mistral", "deepseek",
+    "moonshot", "qwen", "zhipu", "minimax", "cohere",
+})
+
+ANTHROPIC_OWNER = "anthropic"
+
+#: Agent-frontmatter ``model:`` aliases and the env var each resolves through.
+ALIAS_ENV = {
+    "sonnet": "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "opus": "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "haiku": "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "fable": "ANTHROPIC_DEFAULT_FABLE_MODEL",
+}
+
+OK = "OK"
+WARN = "WARN"
+BLOCK = "BLOCK"
+
+_TIMEOUT = 10.0
+#: Any UA that does not start with ``claude-cli``. ``isAnthropicModelsRequest``
+#: (server_routes.go:554-559) selects the cloaked Anthropic shape on an ``Anthropic-Version``
+#: header OR a ``claude-cli`` User-Agent prefix, so omitting the header alone is NOT enough
+#: to guarantee the plain-id OpenAI shape this guard reads.
+_USER_AGENT = "deus-cogate-family-guard"
+
+_VARIANT_SUFFIX_RE = re.compile(r"\[[^\[\]]*\]$")
+
+
+def strip_variant_suffix(model_id: str) -> str:
+    """Drop a trailing bracketed variant marker such as ``[1m]``.
+
+    A Claude Code *client* convention (the CLI's 1M-context marker), not a CLIProxyAPI one —
+    the gateway rejects ``opus-planner[1m]`` with "unknown provider" (LIA-560 defect 2).
+    Normalisation only: this guard's inputs are operator-set config strings, which should
+    never carry it. Cheap insurance for the listing lookup, not load-bearing.
+    """
+    return _VARIANT_SUFFIX_RE.sub("", model_id.strip())
+
+
+def _split_thinking_suffix(model_id: str) -> tuple[str, str | None]:
+    """Split a trailing ``(value)`` thinking-suffix, mirroring ``splitModelThinkingSuffix``."""
+    if not model_id.endswith(")"):
+        return model_id, None
+    open_at = model_id.rfind("(")
+    if open_at <= 0:
+        return model_id, None
+    return model_id[:open_at], model_id[open_at + 1:-1]
+
+
+def decode_model_id(model_id: str) -> str:
+    """Undo CLIProxyAPI's cloaking, mirroring ``ResolveClaudeModelIDPrefix`` (models.go:59).
+
+    Order matters and is copied from the reference: split the ``(value)`` thinking-suffix
+    FIRST, then strip the prefix and reverse the base, then re-attach the suffix. Reversing
+    a string that still carries its suffix produces a garbled id that matches nothing.
+    An id without the prefix is returned unchanged, suffix intact.
+    """
+    base, suffix = _split_thinking_suffix(model_id)
+    if not base.startswith(CLOAK_PREFIX):
+        return model_id
+    encoded = base[len(CLOAK_PREFIX):]
+    if not encoded:
+        return model_id
+    resolved = encoded[::-1]
+    return f"{resolved}({suffix})" if suffix is not None else resolved
+
+
+def _agent_model_pin(role: str, repo_root: Path) -> str | None:
+    """Read the ``model:`` pin from a role's agent frontmatter, if present."""
+    path = Path(repo_root) / ".claude" / "agents" / f"{role}.md"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines()[:40]:
+        if line.startswith("model:"):
+            return line.split(":", 1)[1].strip() or None
+    return None
+
+
+def resolve_claude_half_model(role, repo_root, env) -> tuple[str | None, str | None, str]:
+    """Resolve which model id the in-session Claude half will actually run on.
+
+    Returns ``(pin, resolved_id, source)``. An alias pin resolves through its
+    ``ANTHROPIC_DEFAULT_*`` env var; a non-alias pin is used verbatim; no pin at all falls
+    back to ``ANTHROPIC_MODEL``.
+    """
+    pin = _agent_model_pin(role, Path(repo_root))
+    if pin is None:
+        return None, env.get("ANTHROPIC_MODEL") or None, "ANTHROPIC_MODEL (no agent pin)"
+    alias = pin.lower()
+    if alias in ALIAS_ENV:
+        var = ALIAS_ENV[alias]
+        return pin, env.get(var) or None, var
+    return pin, pin, f"{role}.md model: pin"
+
+
+def _http_get(url: str, api_key: str, timeout: float) -> dict:
+    req = urllib.request.Request(
+        url,
+        headers={"x-api-key": api_key, "User-Agent": _USER_AGENT},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - operator-set URL
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def gateway_owner(base_url, api_key, model_id, timeout=_TIMEOUT, fetch=_http_get):
+    """Return ``(found, owner)`` for ``model_id`` from the gateway's OpenAI-shaped listing.
+
+    The OpenAI shape is requested deliberately: its ids are PLAIN, so the lookup does not
+    depend on the cloaking transform. (Both shapes carry ``owned_by``; neither carries a
+    usable provenance discriminator, so ``owned_by`` is all there is.) Raises on any
+    transport or parse failure — callers treat that as "learned nothing", never as evidence.
+
+    ``fetch`` is injected by tests; this is the only function here that touches the network.
+    """
+    url = base_url.rstrip("/") + "/v1/models?limit=1000"
+    body = fetch(url, api_key, timeout)
+    entries = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(entries, list):
+        raise ValueError("gateway /v1/models did not return a data list")
+    wanted = decode_model_id(strip_variant_suffix(model_id))
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("id") == wanted:
+            owner = entry.get("owned_by")
+            return True, (owner if isinstance(owner, str) else None)
+    return False, None
+
+
+def _block_message(role, pin, raw_id, decoded_id, owner, base_url, source) -> str:
+    shown = raw_id if raw_id == decoded_id else f"{raw_id}\n               -> {decoded_id}"
+    return (
+        "BLOCK: co-gate cannot record a Claude verdict.\n\n"
+        f"  role:        {role}\n"
+        f"  agent pin:   {pin or '(none)'}\n"
+        f"  resolves to: {shown} (owned_by: {owner})\n"
+        f"  via:         {source}\n"
+        f"  gateway:     {base_url}\n\n"
+        "The Claude half would run on a non-Anthropic model, so 'claude: SHIP'\n"
+        "would be false — the co-gate would report cross-family review it is not\n"
+        "providing.\n\n"
+        "Fix one of:\n"
+        f"  - point {source} at a Claude model\n"
+        "  - run the co-gate from a non-gateway session\n"
+        "  - if this is an openai-compatibility passthrough whose section name\n"
+        "    collides with a provider label, rename that section"
+    )
+
+
+def check_claude_half(role, repo_root, env=None, timeout=_TIMEOUT, fetch=_http_get):
+    """Decide whether the Claude co-gate half may be recorded. Returns ``(verdict, message)``.
+
+    ``BLOCK`` only on positive evidence (listed model, known non-Anthropic owner). Everything
+    else is ``OK`` or ``WARN``; a WARN never stops the co-gate.
+    """
+    env = os.environ if env is None else env
+    base_url = (env.get("ANTHROPIC_BASE_URL") or "").strip()
+    if not base_url:
+        return OK, ""
+
+    pin, raw_id, source = resolve_claude_half_model(role, repo_root, env)
+    if not raw_id:
+        return WARN, (f"[cogate] {source} is unset, so the Claude half's model could not be "
+                      f"resolved against {base_url}; cross-family review is UNVERIFIED.")
+
+    api_key = env.get("ANTHROPIC_API_KEY") or ""
+    decoded = decode_model_id(strip_variant_suffix(raw_id))
+    try:
+        found, owner = gateway_owner(base_url, api_key, raw_id, timeout, fetch)
+    except Exception as exc:  # noqa: BLE001 - any failure means we learned nothing
+        return WARN, (f"[cogate] could not read {base_url}/v1/models ({exc}); the Claude "
+                      f"half's model ({decoded}) is UNVERIFIED. Proceeding.")
+
+    if not found:
+        return WARN, (f"[cogate] {decoded} is not in {base_url}'s model listing — it may be "
+                      "mid-cooldown rather than absent, so this is not treated as proof. "
+                      "Cross-family review is UNVERIFIED. Proceeding.")
+
+    if owner and owner.strip().lower() == ANTHROPIC_OWNER:
+        return OK, ""
+
+    if owner and owner.strip().lower() in KNOWN_NON_ANTHROPIC_OWNERS:
+        return BLOCK, _block_message(role, pin, raw_id, decoded, owner, base_url, source)
+
+    return WARN, (f"[cogate] {decoded} is served by {base_url} under owner "
+                  f"{owner!r}, which does not identify a model family — the Claude half is "
+                  "UNVERIFIED. Proceeding.")


### PR DESCRIPTION
## Summary

Closes the LIA-560 defect-3 gap: in a gateway session, `scripts/cogate.py` recorded and printed `claude: SHIP` when the Claude half had actually run on a GPT model.

All three co-gated warden roles pin `model: sonnet`, which resolves through `ANTHROPIC_DEFAULT_SONNET_MODEL`. Point that at a GPT model — as `claude-multi` does — and the co-gate reports cross-family review it is not providing, silently. Measured during investigation: a `haiku`-pinned subagent answered correctly with **no separate `modelUsage` entry at all**, its usage folded into the GPT orchestrator's.

The guard resolves the role's pin through its alias env var, decodes any CLIProxyAPI-cloaked id, and looks the model up in the gateway's listing. It runs *before* the Claude mark, so a block records no verdict and burns no GPT call.

## The design invariant

**Exactly one hard-block condition:** the model is present in a successfully parsed listing AND its `owned_by` is a label that unambiguously denotes a non-Anthropic provider. Everything else warns and fails open.

Two narrower-looking designs were rejected in review for violating it:

- `owned_by != "anthropic"` → block would hard-block a **real Claude model** behind a relabelling proxy (an `openai-compatibility` section's owner is `compat.Name`, an arbitrary operator string).
- "absent from listing" → block would hard-block a **real Claude model** that is merely mid-cooldown — CLIProxyAPI's `modelRegistrationAvailability` delists a registration whose client is suspended for a non-quota reason, for 30 min to 12 h.

`test_block_is_exhaustive` pins the invariant directly, because two review rounds regressed by quietly adding a second block path.

## Block message

Names the role, pin, resolved id (cloaked and decoded), owner and gateway, and lists all three escapes — including renaming an `openai-compatibility` section whose label collides with a provider name, which is the one residual false-positive path.

## Test plan

- `scripts/tests/test_cogate_family_guard.py` — 25 tests, no network (`fetch` injected). Covers the decode against the pinned upstream algorithm including the `(value)` suffix case, alias resolution, every decision-table row, malformed payloads, the exhaustiveness invariant, the block-message content, and an integration test asserting a block reaches neither `mark_warden` nor `codex_warden.main`.
- **Live gateway probe:** real config → `BLOCK` naming `claude-fable-5-dd-xam-anul -> luna-max (owned_by: openai)`. Non-gateway session → `('OK', '')`.
- **Regression control:** full suite at this branch (3811 passed) vs the *same base commit* with no diff (3786 passed) — delta exactly 25, failure sets byte-identical. The 7 pre-existing failures are unrelated and reproduce on a clean tree.

Wardens: plan-reviewer SHIP, code-reviewer SHIP, verification-gate SHIP — each co-gated PASS across the Claude and GPT backends. The GPT backend caught two real defects the Claude reviewer had approved, which is the case for this guard existing.

Refs LIA-560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)