### PR TITLE
fix(security): fail closed when the sender allowlist is corrupt (LIA-447)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786868688
+last_verified: "2026-08-16" # auto-bump @1786869765
 governs:
   - src/
   - evolution/

--- a/patterns/security-review.md
+++ b/patterns/security-review.md
@@ -5,7 +5,7 @@ governs:
   - src/ipc.ts
   - src/sender-allowlist.ts
   - src/mount-security.ts
-last_verified: "2026-07-17" # auto-bump @1784304895
+last_verified: "2026-08-16" # reviewed against LIA-447 (src/sender-allowlist.ts fail-closed)
 test_tasks:
   - "Add a new mount in src/container-mounter.ts for per-group config files"
   - "Update src/mount-security.ts to permit reading a new credential path"

--- a/src/sender-allowlist.test.ts
+++ b/src/sender-allowlist.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { logger } from './logger.js';
 import {
   isSenderAllowed,
   isTriggerAllowed,
@@ -28,6 +29,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Total spy isolation: without this, an assertion throwing before a manual
+  // mockRestore() would leak the spy into later spy-based tests and inflate
+  // their call counts, turning one failure into a confusing cascade.
+  vi.restoreAllMocks();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -79,29 +84,118 @@ describe('loadSenderAllowlist', () => {
     expect(cfg.chats['group-a'].mode).toBe('drop');
   });
 
-  it('returns allow-all on invalid JSON', () => {
+  // A config file that EXISTS but cannot be trusted must deny, not widen to
+  // allow-all. These four cases previously asserted the opposite (fail-open).
+  it('denies all senders on invalid JSON', () => {
     const p = cfgPath();
     fs.writeFileSync(p, '{ not valid json }}}');
     const cfg = loadSenderAllowlist(p);
-    expect(cfg.default.allow).toBe('*');
+    expect(cfg.default.allow).toEqual([]);
+    expect(isSenderAllowed('any-chat', 'alice', cfg)).toBe(false);
   });
 
-  it('returns allow-all on invalid schema', () => {
+  it('denies all senders on invalid schema', () => {
     const p = writeConfig({ default: { oops: true } });
     const cfg = loadSenderAllowlist(p);
-    expect(cfg.default.allow).toBe('*');
+    expect(cfg.default.allow).toEqual([]);
+    expect(isSenderAllowed('any-chat', 'alice', cfg)).toBe(false);
   });
 
-  it('rejects non-string allow array items', () => {
+  it('denies all senders when allow array items are not strings', () => {
     const p = writeConfig({
       default: { allow: [123, null, true], mode: 'trigger' },
       chats: {},
     });
     const cfg = loadSenderAllowlist(p);
-    expect(cfg.default.allow).toBe('*'); // falls back to default
+    expect(cfg.default.allow).toEqual([]);
+    expect(isSenderAllowed('any-chat', 'alice', cfg)).toBe(false);
   });
 
-  it('skips invalid per-chat entries', () => {
+  // `null` parses successfully, so without a root guard the loader would read
+  // `.default` off null and THROW on the per-message path — a crash, not just a
+  // fail-open.
+  it.each(['null', '[]', '42', '"a string"'])(
+    'denies (and does not throw) when the config root is %s',
+    (raw) => {
+      const p = cfgPath();
+      fs.writeFileSync(p, raw);
+      const cfg = loadSenderAllowlist(p);
+      expect(cfg.default.allow).toEqual([]);
+      expect(isSenderAllowed('any-chat', 'alice', cfg)).toBe(false);
+    },
+  );
+
+  // A malformed chats container must not silently collapse to an empty map —
+  // that would delete the operator's per-chat restrictions and fall through to
+  // the permissive default.
+  it('denies when chats is present but not an object', () => {
+    const p = writeConfig({
+      default: { allow: '*', mode: 'trigger' },
+      chats: 'oops',
+    });
+    const cfg = loadSenderAllowlist(p);
+    expect(cfg.default.allow).toEqual([]);
+    expect(isSenderAllowed('some-chat', 'alice', cfg)).toBe(false);
+  });
+
+  // Guards the "log suppression, NOT a config cache" property. Without this,
+  // adding a mount-security-style process-lifetime cache — exactly what the
+  // comment in sender-allowlist.ts warns against — passes every other test.
+  // The loader must stay uncached so editing the file takes effect on the very
+  // next message, with no restart.
+  it('re-reads the file on every call rather than caching a good config', () => {
+    const p = writeConfig({ default: { allow: ['alice'], mode: 'trigger' } });
+    expect(isSenderAllowed('c', 'alice', loadSenderAllowlist(p))).toBe(true);
+    expect(isSenderAllowed('c', 'bob', loadSenderAllowlist(p))).toBe(false);
+
+    // Operator edits the file: the change must be picked up immediately.
+    writeConfig({ default: { allow: ['bob'], mode: 'trigger' } });
+    expect(isSenderAllowed('c', 'bob', loadSenderAllowlist(p))).toBe(true);
+    expect(isSenderAllowed('c', 'alice', loadSenderAllowlist(p))).toBe(false);
+  });
+
+  // The other direction of the same property: a corrupt file self-heals once
+  // fixed, without a restart.
+  it('recovers from a corrupt config as soon as it is repaired', () => {
+    const p = cfgPath();
+    fs.writeFileSync(p, '{ broken beyond repair');
+    expect(loadSenderAllowlist(p).default.allow).toEqual([]);
+
+    writeConfig({ default: { allow: '*', mode: 'trigger' } });
+    expect(loadSenderAllowlist(p).default.allow).toBe('*');
+  });
+
+  it('accepts a config with no chats key at all', () => {
+    const p = writeConfig({ default: { allow: ['alice'], mode: 'trigger' } });
+    const cfg = loadSenderAllowlist(p);
+    expect(cfg.chats).toEqual({});
+    expect(isSenderAllowed('some-chat', 'alice', cfg)).toBe(true);
+    expect(isSenderAllowed('some-chat', 'mallory', cfg)).toBe(false);
+  });
+
+  it('denies an unreadable (non-ENOENT) config instead of allowing all', () => {
+    // A directory where a file is expected reproduces a non-ENOENT read error
+    // (EISDIR) without depending on chmod semantics, which vary by platform and
+    // do not apply when running as root.
+    const p = cfgPath();
+    fs.mkdirSync(p);
+    const cfg = loadSenderAllowlist(p);
+    expect(cfg.default.allow).toEqual([]);
+    expect(isSenderAllowed('any-chat', 'alice', cfg)).toBe(false);
+  });
+
+  // The deny-all fallback must never use 'drop' mode: shouldDropMessage() true
+  // routes to a branch in src/index.ts that returns BEFORE storing the message,
+  // so a deny-all in drop mode would silently destroy inbound messages.
+  it('deny-all fallback uses trigger mode so no message is ever dropped', () => {
+    const p = cfgPath();
+    fs.writeFileSync(p, 'not json at all');
+    const cfg = loadSenderAllowlist(p);
+    expect(cfg.default.mode).toBe('trigger');
+    expect(shouldDropMessage('any-chat', cfg)).toBe(false);
+  });
+
+  it('denies an invalid per-chat entry rather than dropping it', () => {
     const p = writeConfig({
       default: { allow: '*', mode: 'trigger' },
       chats: {
@@ -111,7 +205,72 @@ describe('loadSenderAllowlist', () => {
     });
     const cfg = loadSenderAllowlist(p);
     expect(cfg.chats['good']).toBeDefined();
-    expect(cfg.chats['bad']).toBeUndefined();
+    // Previously deleted, which let getEntry() fall through to the permissive
+    // default and WIDEN access past what the operator wrote for this chat.
+    expect(cfg.chats['bad']).toEqual({ allow: [], mode: 'trigger' });
+    expect(isSenderAllowed('bad', 'alice', cfg)).toBe(false);
+    expect(isSenderAllowed('good', 'alice', cfg)).toBe(true);
+  });
+
+  it('returns a copy so callers cannot mutate shared module state', () => {
+    const p = cfgPath();
+    fs.writeFileSync(p, 'still not json');
+    const first = loadSenderAllowlist(p);
+    (first.default.allow as string[]).push('injected');
+    const second = loadSenderAllowlist(p);
+    expect(second.default.allow).toEqual([]);
+  });
+
+  it('reports a broken config once per distinct file state, not per read', () => {
+    const p = cfgPath();
+    fs.writeFileSync(p, '{ broken');
+    const errSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    loadSenderAllowlist(p);
+    loadSenderAllowlist(p);
+    loadSenderAllowlist(p);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+
+    // A genuinely different broken state must be reported again.
+    fs.writeFileSync(p, '{ broken differently');
+    loadSenderAllowlist(p);
+    expect(errSpy).toHaveBeenCalledTimes(2);
+
+    errSpy.mockRestore();
+  });
+
+  it('dedupes an unreadable config on its error code', () => {
+    const p = cfgPath();
+    fs.mkdirSync(p); // EISDIR on every read
+    const errSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    loadSenderAllowlist(p);
+    loadSenderAllowlist(p);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+
+    errSpy.mockRestore();
+  });
+
+  // A file that goes missing resets the suppression, so the SAME broken content
+  // reappearing later is reported again rather than silently swallowed.
+  it('re-reports identical broken content after the file disappears', () => {
+    const p = cfgPath();
+    const broken = '{ vanishing act';
+    fs.writeFileSync(p, broken);
+    const errSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    loadSenderAllowlist(p);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+
+    fs.rmSync(p);
+    const gone = loadSenderAllowlist(p);
+    expect(gone.default.allow).toBe('*'); // absent == feature off
+
+    fs.writeFileSync(p, broken);
+    loadSenderAllowlist(p);
+    expect(errSpy).toHaveBeenCalledTimes(2);
+
+    errSpy.mockRestore();
   });
 });
 

--- a/src/sender-allowlist.ts
+++ b/src/sender-allowlist.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import fs from 'fs';
 
 import { SENDER_ALLOWLIST_PATH } from './config.js';
@@ -14,11 +15,82 @@ export interface SenderAllowlistConfig {
   logDenied: boolean;
 }
 
+/**
+ * Returned when NO config file exists — the feature is simply not configured,
+ * so every sender is allowed. Absent must stay distinct from corrupt.
+ */
 const DEFAULT_CONFIG: SenderAllowlistConfig = {
   default: { allow: '*', mode: 'trigger' },
   chats: {},
   logDenied: true,
 };
+
+/**
+ * Returned when a config file EXISTS but cannot be trusted. Deny rather than
+ * widen to allow-all: the operator wrote a restriction and a typo must not
+ * discard it.
+ */
+const DENY_ALL_CONFIG: SenderAllowlistConfig = {
+  // mode is 'trigger' and NEVER 'drop': a true shouldDropMessage() routes to a
+  // branch in src/index.ts that returns BEFORE storing, so a deny-all in drop
+  // mode would silently destroy inbound messages. Deny the privileged action
+  // (agent invocation), never retention. Safe for the operator because every
+  // trigger-gating call site short-circuits on isControlGroup / is_from_me
+  // first — see src/message-orchestrator.ts.
+  default: { allow: [], mode: 'trigger' },
+  chats: {},
+  logDenied: true,
+};
+
+/** Substituted for a single per-chat entry that failed validation. */
+const DENY_ALL_ENTRY: ChatAllowlistEntry = { allow: [], mode: 'trigger' };
+
+/**
+ * The single most-recently-logged config-file state — path plus either a
+ * content hash or the read-error code — so a broken file is reported once
+ * rather than on every read. The path is part of the key because the key
+ * identifies a FILE's state, not merely a failure kind.
+ *
+ * One slot, not a seen-set: alternating between two broken files would re-log
+ * each time. Harmless in production, where the path is a single constant.
+ */
+// Deliberately a log-suppression key, NOT a config cache: the loader stays
+// uncached so fixing the file takes effect on the next message with no restart.
+// Unlike mount-security.ts's loadMountAllowlist, which caches for the process
+// lifetime — do not "align" them without preserving that self-healing property.
+let lastReportedState: string | null = null;
+
+/**
+ * True at most once per distinct config-file state. Call once per load and
+ * gate every problem log for that load on the result, so one broken file
+ * produces one complete report rather than a partial one per read.
+ */
+function shouldReport(stateKey: string): boolean {
+  if (stateKey === lastReportedState) return false;
+  lastReportedState = stateKey;
+  return true;
+}
+
+function cloneEntry(entry: ChatAllowlistEntry): ChatAllowlistEntry {
+  return {
+    allow: Array.isArray(entry.allow) ? [...entry.allow] : entry.allow,
+    mode: entry.mode,
+  };
+}
+
+/** Defensive copy so callers can never mutate a shared module-level config. */
+function cloneConfig(cfg: SenderAllowlistConfig): SenderAllowlistConfig {
+  const chats: Record<string, ChatAllowlistEntry> = {};
+  for (const [jid, entry] of Object.entries(cfg.chats)) {
+    chats[jid] = cloneEntry(entry);
+  }
+  return { default: cloneEntry(cfg.default), chats, logDenied: cfg.logDenied };
+}
+
+/** A non-null, non-array object — the only shape a config or chats map may take. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 function isValidEntry(entry: unknown): entry is ChatAllowlistEntry {
   if (!entry || typeof entry !== 'object') return false;
@@ -39,50 +111,104 @@ export function loadSenderAllowlist(
   try {
     raw = fs.readFileSync(filePath, 'utf-8');
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return DEFAULT_CONFIG;
-    logger.warn(
-      { err, path: filePath },
-      'sender-allowlist: cannot read config',
-    );
-    return DEFAULT_CONFIG;
+    const code = (err as NodeJS.ErrnoException).code;
+    // No file at all: the feature is not configured, so allow everyone. This is
+    // the ONLY path that may widen access on failure.
+    if (code === 'ENOENT') {
+      lastReportedState = null;
+      return cloneConfig(DEFAULT_CONFIG);
+    }
+    // The file exists but we cannot read it (EACCES, EISDIR, I/O error). We do
+    // not know what it says, so we must not assume it said "allow everyone".
+    if (shouldReport(`${filePath}:read:${code ?? 'unknown'}`)) {
+      logger.error(
+        { err, path: filePath },
+        'sender-allowlist: config exists but cannot be read — denying all senders until it is readable',
+      );
+    }
+    return cloneConfig(DENY_ALL_CONFIG);
   }
+
+  // Key the log suppression on the file's exact contents, so a broken file is
+  // reported once and re-reported the moment it actually changes.
+  const report = shouldReport(
+    `${filePath}:${crypto.createHash('sha1').update(raw).digest('hex')}`,
+  );
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
-    logger.warn({ path: filePath }, 'sender-allowlist: invalid JSON');
-    return DEFAULT_CONFIG;
+  } catch (err: unknown) {
+    if (report) {
+      logger.error(
+        { err, path: filePath },
+        'sender-allowlist: invalid JSON — denying all senders until it is fixed',
+      );
+    }
+    return cloneConfig(DENY_ALL_CONFIG);
   }
 
-  const obj = parsed as Record<string, unknown>;
+  // `null`, an array and a scalar are all valid JSON but not a config object.
+  // Guard before any property access: reading `.default` off null would throw
+  // out of this function, on the per-message path.
+  if (!isPlainObject(parsed)) {
+    if (report) {
+      logger.error(
+        { path: filePath },
+        'sender-allowlist: config root is not an object — denying all senders until it is fixed',
+      );
+    }
+    return cloneConfig(DENY_ALL_CONFIG);
+  }
+
+  const obj = parsed;
 
   if (!isValidEntry(obj.default)) {
-    logger.warn(
-      { path: filePath },
-      'sender-allowlist: invalid or missing default entry',
-    );
-    return DEFAULT_CONFIG;
+    if (report) {
+      logger.error(
+        { path: filePath },
+        'sender-allowlist: invalid or missing default entry — denying all senders until it is fixed',
+      );
+    }
+    return cloneConfig(DENY_ALL_CONFIG);
+  }
+
+  // A present-but-malformed `chats` container means the operator's per-chat
+  // restrictions are unreadable. Collapsing it to an empty map would silently
+  // delete them and fall through to `default`, so treat it as untrustworthy.
+  // Absent is fine — it simply means no per-chat overrides.
+  if (obj.chats !== undefined && !isPlainObject(obj.chats)) {
+    if (report) {
+      logger.error(
+        { path: filePath },
+        'sender-allowlist: chats is not an object — denying all senders until it is fixed',
+      );
+    }
+    return cloneConfig(DENY_ALL_CONFIG);
   }
 
   const chats: Record<string, ChatAllowlistEntry> = {};
-  if (obj.chats && typeof obj.chats === 'object') {
-    for (const [jid, entry] of Object.entries(
-      obj.chats as Record<string, unknown>,
-    )) {
+  if (isPlainObject(obj.chats)) {
+    for (const [jid, entry] of Object.entries(obj.chats)) {
       if (isValidEntry(entry)) {
-        chats[jid] = entry;
+        chats[jid] = cloneEntry(entry);
       } else {
-        logger.warn(
-          { jid, path: filePath },
-          'sender-allowlist: skipping invalid chat entry',
-        );
+        // Deny this chat rather than dropping the entry. A dropped entry falls
+        // through to `cfg.default` in getEntry(), which would WIDEN access past
+        // what the operator explicitly wrote for this chat.
+        chats[jid] = cloneEntry(DENY_ALL_ENTRY);
+        if (report) {
+          logger.error(
+            { jid, path: filePath },
+            'sender-allowlist: invalid chat entry — denying that chat until it is fixed',
+          );
+        }
       }
     }
   }
 
   return {
-    default: obj.default as ChatAllowlistEntry,
+    default: cloneEntry(obj.default),
     chats,
     logDenied: obj.logDenied !== false,
   };


### PR DESCRIPTION
First slice of LIA-447's silent-failure audit for the TypeScript host path.

## The defect

`src/sender-allowlist.ts` returned the **allow-everyone** default whenever its config file existed but could not be trusted. A typo in a hand-edited JSON file silently converted a restrictive allowlist into an open one.

The worst of the paths: a malformed **per-chat** entry was *deleted*, so `getEntry()` fell through to the permissive default — erasing a restriction the operator had explicitly written, rather than holding it.

## The fix

Every untrustworthy path now returns a deny-all config:

| Path | Before | After |
|---|---|---|
| non-ENOENT read error (EACCES, EISDIR, I/O) | allow-` * ` | deny-all |
| invalid JSON | allow-` * ` | deny-all |
| root is `null` / array / scalar | **threw a TypeError** out of the per-message loader | deny-all |
| invalid `default` entry | allow-` * ` | deny-all |
| `chats` present but not an object | collapsed to an empty map, dropping every per-chat restriction | deny-all |
| one malformed chat entry | entry deleted → fell through to default | that chat denied |

**ENOENT is unchanged** and still returns allow-all — an absent file means the feature is not configured, and that must stay distinct from a corrupt one.

## Two load-bearing details

**The deny-all config uses `mode: 'trigger'`, never `'drop'`.** `shouldDropMessage()` returning true routes to a branch in `src/index.ts` that returns *before* the message is stored, so failing closed into drop mode would silently **destroy inbound messages**. Fail closed on the privileged action, never on retention.

**Denying cannot lock the operator out.** Every trigger-gating call site short-circuits on `isControlGroup` or `is_from_me` before consulting the allowlist, so the control group and the operator's own messages keep working in every group while the file is broken. Verified at all five call sites.

## Logging

Errors are deduped on the file's *state* — its path plus a content hash, or the read-error code — because the loader is reached from six call sites, several times per message. This is log suppression only, deliberately **not** a config cache: the loader stays uncached so fixing the file takes effect on the next message with no restart. Two tests guard that property, because a comment alone did not.

## Consistency

Aligns this control with its sibling in the same config directory: `loadMountAllowlist` (`src/mount-security.ts`) already fails closed on a missing-or-invalid file. Two allowlists in `~/.config/deus/` previously had opposite failure semantics.

## Severity — stated plainly

**No live exposure.** `~/.config/deus/sender-allowlist.json` does not exist on this host, and all four rows in `registered_groups` bypass the allowlist anyway (three have `is_main=1`; `webhook-sandbox-test` has `requires_trigger=0`). This is a latent defect in shipped, wired-up code — worth fixing as correctness *before* the feature is first used, not a live hole.

Consequently there is **no runtime surface to verify against**; unit tests are the only available evidence, which is why test quality got extra attention.

## Verification

- `sender-allowlist.test.ts`: **19 → 33 tests**. The four that asserted the fail-open are inverted; the ENOENT test is preserved verbatim.
- Full suite **2123 passing** (115 files), `tsc --noEmit` exit 0, `npx eslint . --max-warnings 220` exit 0 (131 warnings, 0 errors — one *below* the pre-change baseline).
- `drift_check.py --all` and `flag_lint.py` both run **after** committing (they diff `base...HEAD`, so a pre-commit run proves nothing): ALL CHECKS PASSED.
- Mutation-tested: reverting the deny-all fails 11 tests; adding the forbidden config cache fails the new self-healing guard where it previously passed all 31.

Review gates caught four real defects in this change during development, including the `JSON.parse('null')` TypeError and a test of mine that passed only because of neighbouring test order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)