### PR TITLE
fix(ingress): make the ngrok pre-flight honour its fail-closed contract (LIA-447)

### DIFF
--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786869765
+last_verified: "2026-08-16" # auto-bump @1786870085
 governs:
   - src/
   - evolution/

--- a/src/ingress/tunnel.test.ts
+++ b/src/ingress/tunnel.test.ts
@@ -1,5 +1,155 @@
+import http from 'http';
+import type { AddressInfo } from 'net';
 import { describe, it, expect } from 'vitest';
-import { buildNgrokArgs, extractPublicUrl } from './tunnel.js';
+import {
+  buildNgrokArgs,
+  classifyProbeError,
+  extractPublicUrl,
+  probeNgrokApi,
+} from './tunnel.js';
+
+/** Serve one fixed body on loopback, and return its URL plus a close handle. */
+async function serveOnce(
+  body: string,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/api/tunnels`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+// The regression this guards: an HTTP response whose body does not parse used
+// to resolve as "port free", which let a second ngrok launch into the session
+// conflict the pre-flight exists to prevent.
+describe('probeNgrokApi', () => {
+  it('reports occupied when something answers with valid JSON', async () => {
+    const s = await serveOnce(
+      JSON.stringify({
+        tunnels: [{ proto: 'https', public_url: 'https://x' }],
+      }),
+    );
+    try {
+      const probe = await probeNgrokApi(s.url);
+      expect(probe.state).toBe('occupied');
+      expect(
+        extractPublicUrl(probe.state === 'occupied' ? probe.api : null),
+      ).toBe('https://x');
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('reports occupied — NOT free — when the responder returns unparseable JSON', async () => {
+    const s = await serveOnce('<html>definitely not json</html>');
+    try {
+      const probe = await probeNgrokApi(s.url);
+      expect(probe.state).toBe('occupied');
+      expect(probe.state === 'occupied' && probe.api).toBeNull();
+    } finally {
+      await s.close();
+    }
+  });
+
+  // A peer that sends headers then resets used to resolve null, which the
+  // pre-flight read as "free". It must now never be "free". Whether it lands on
+  // 'occupied' or 'indeterminate' depends on whether the buffered headers were
+  // flushed before the reset, and both fail closed — so assert the invariant
+  // that matters rather than a timing-dependent state.
+  it('never reports free when the peer resets mid-response', async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': '9999',
+      });
+      res.write('{"tunnels":');
+      res.socket?.destroy();
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const { port } = server.address() as AddressInfo;
+    try {
+      const probe = await probeNgrokApi(`http://127.0.0.1:${port}/api/tunnels`);
+      expect(probe.state).not.toBe('free');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 5000);
+
+  // The probe budget must be ABSOLUTE. A socket-inactivity timeout would be
+  // reset by every chunk, so a responder that streams forever without ending
+  // would hang the pre-flight — and with it, startup.
+  it('settles under an absolute deadline when the responder never ends', async () => {
+    const timers: NodeJS.Timeout[] = [];
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      // Keep dribbling data so an inactivity timer would never fire.
+      const t = setInterval(() => res.write('{"keep":"going"}'), 50);
+      timers.push(t as unknown as NodeJS.Timeout);
+      res.on('close', () => clearInterval(t));
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const { port } = server.address() as AddressInfo;
+    try {
+      const started = Date.now();
+      const probe = await probeNgrokApi(`http://127.0.0.1:${port}/api/tunnels`);
+      expect(probe.state).not.toBe('free');
+      expect(Date.now() - started).toBeLessThan(4000);
+    } finally {
+      timers.forEach(clearInterval);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 8000);
+
+  it('reports free only when nothing is listening', async () => {
+    // Bind then immediately release, so the port is known-unused and refuses.
+    const s = await serveOnce('{}');
+    const url = s.url;
+    await s.close();
+    const probe = await probeNgrokApi(url);
+    expect(probe.state).toBe('free');
+  });
+});
+
+// The :4040 pre-flight is a fail-closed check, so "free" must mean proof of an
+// absent listener — not merely "the request did not succeed". NGROK_API is a
+// literal IPv4 loopback with no DNS, so an unoccupied port refuses immediately.
+describe('classifyProbeError', () => {
+  it('treats ECONNREFUSED as proof the port is free', () => {
+    expect(classifyProbeError('ECONNREFUSED')).toEqual({ state: 'free' });
+  });
+
+  it('does not treat a reset connection as free — a live listener can reset', () => {
+    const probe = classifyProbeError('ECONNRESET');
+    expect(probe.state).toBe('indeterminate');
+  });
+
+  it.each(['EPIPE', 'ECONNABORTED', 'EHOSTUNREACH', 'ETIMEDOUT'])(
+    'does not treat %s as free',
+    (code) => {
+      expect(classifyProbeError(code).state).toBe('indeterminate');
+    },
+  );
+
+  it('does not treat an error with no code as free', () => {
+    expect(classifyProbeError(undefined).state).toBe('indeterminate');
+  });
+
+  it('explains which error made the result indeterminate', () => {
+    const probe = classifyProbeError('ECONNRESET');
+    expect(probe.state === 'indeterminate' && probe.detail).toContain(
+      'ECONNRESET',
+    );
+  });
+});
 
 describe('buildNgrokArgs', () => {
   it('builds the base http args', () => {

--- a/src/ingress/tunnel.ts
+++ b/src/ingress/tunnel.ts
@@ -68,25 +68,121 @@ export function extractPublicUrl(api: unknown): string | null {
   return https?.public_url ?? any?.public_url ?? null;
 }
 
-/** GET ngrok's local API; resolves null if nothing is listening on :4040. */
-function fetchTunnelsApi(): Promise<unknown> {
+/** Absolute wall-clock budget for the whole :4040 probe. */
+const PROBE_TIMEOUT_MS = 1500;
+
+/** Body bytes to buffer before giving up on parsing (ngrok's payload is tiny). */
+const MAX_PROBE_BODY_BYTES = 1024 * 1024;
+
+/**
+ * Outcome of probing :4040. Only `free` permits starting our own ngrok — the
+ * pre-flight is a fail-closed check, so anything short of proof that the port
+ * is unoccupied must block.
+ */
+export type PortProbe =
+  | { state: 'free' }
+  | { state: 'occupied'; api: unknown }
+  | { state: 'indeterminate'; detail: string };
+
+/**
+ * Classify a failed request to ngrok's local API. Pure, so the fail-closed
+ * policy is unit-testable without a socket.
+ *
+ * NGROK_API is a literal IPv4 loopback address with no DNS lookup, so a port
+ * with no listener answers ECONNREFUSED essentially immediately. That makes
+ * ECONNREFUSED the ONLY evidence that the port is genuinely free. Every other
+ * error code means something engaged with the socket and then failed (e.g. a
+ * live listener that accepts and then resets), which is not proof of absence.
+ */
+export function classifyProbeError(code: string | undefined): PortProbe {
+  if (code === 'ECONNREFUSED') return { state: 'free' };
+  return {
+    state: 'indeterminate',
+    detail: `request failed with ${code ?? 'an unknown error'}`,
+  };
+}
+
+/**
+ * Probe ngrok's local API on :4040.
+ *
+ * Any HTTP response at all means something is listening — including one whose
+ * body does not parse, which previously read as "free" and let a second ngrok
+ * launch into a session conflict.
+ */
+export function probeNgrokApi(apiUrl: string = NGROK_API): Promise<PortProbe> {
   return new Promise((resolve) => {
-    const req = http.get(NGROK_API, (res) => {
+    // Response headers are all the pre-flight actually needs: if anything
+    // answered, the port is taken. The body is only read so the post-spawn URL
+    // poll can reuse this probe.
+    let sawHeaders = false;
+    let settled = false;
+    // Assigned below, once `req` exists; `finish` only reads it at call time.
+    let deadline: NodeJS.Timeout | undefined = undefined;
+
+    /** Once headers arrived the port is occupied, whatever happened next. */
+    const givenHeaders = (detail: string): PortProbe =>
+      sawHeaders
+        ? { state: 'occupied', api: null }
+        : { state: 'indeterminate', detail };
+
+    const finish = (probe: PortProbe): void => {
+      if (settled) return;
+      settled = true;
+      if (deadline) clearTimeout(deadline);
+      req.destroy();
+      resolve(probe);
+    };
+
+    const req = http.get(apiUrl, (res) => {
+      sawHeaders = true;
       const chunks: Buffer[] = [];
-      res.on('data', (c) => chunks.push(c));
+      let bytes = 0;
+      res.on('data', (c: Buffer) => {
+        bytes += c.length;
+        if (bytes > MAX_PROBE_BODY_BYTES) {
+          // Occupied beyond doubt — we simply cannot use this body.
+          finish({ state: 'occupied', api: null });
+          return;
+        }
+        chunks.push(c);
+      });
       res.on('end', () => {
         try {
-          resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8')));
+          finish({
+            state: 'occupied',
+            api: JSON.parse(Buffer.concat(chunks).toString('utf-8')),
+          });
         } catch {
-          resolve(null);
+          // A response that is not JSON still proves the port is taken.
+          finish({ state: 'occupied', api: null });
         }
       });
+      // An unhandled 'error' on the response would otherwise throw.
+      const aborted = (): void =>
+        finish(givenHeaders('response aborted before the body completed'));
+      res.on('error', aborted);
+      res.on('aborted', aborted);
     });
-    req.on('error', () => resolve(null));
-    req.setTimeout(1500, () => {
-      req.destroy();
-      resolve(null);
-    });
+
+    req.on('error', (err: NodeJS.ErrnoException) =>
+      finish(
+        sawHeaders
+          ? { state: 'occupied', api: null }
+          : classifyProbeError(err.code),
+      ),
+    );
+    // 'close' always fires once the request finishes, for any reason.
+    req.on('close', () =>
+      finish(givenHeaders('connection closed before a usable response')),
+    );
+
+    // An ABSOLUTE deadline, deliberately not req.setTimeout: that one measures
+    // socket INACTIVITY, so a peer streaming chunks forever would keep resetting
+    // it while 'end'/'aborted'/'error'/'close' never fire — hanging the
+    // pre-flight, and with it startup.
+    deadline = setTimeout(() => {
+      finish(givenHeaders(`no usable response within ${PROBE_TIMEOUT_MS}ms`));
+    }, PROBE_TIMEOUT_MS);
   });
 }
 
@@ -95,8 +191,10 @@ const sleep = (ms: number): Promise<void> =>
 
 /**
  * Start ngrok and resolve once the public URL is known. Fails CLOSED:
- *  - a foreign ngrok already on :4040 (e.g. the legacy launchd agent) → throw
+ *  - anything already answering on :4040 (e.g. the legacy launchd agent) → throw
  *    with an actionable unload hint, rather than silently sharing the session;
+ *  - :4040 not provably free — a timeout, or any request error other than
+ *    ECONNREFUSED → throw, since only a refused connection proves no listener;
  *  - ngrok binary missing (ENOENT) → throw;
  *  - URL not resolved within the timeout → throw.
  * Supervises a single restart on unexpected exit (not on an auth-error exit).
@@ -105,12 +203,21 @@ export async function startTunnel(deps: TunnelDeps): Promise<TunnelHandle> {
   const timeoutMs = deps.startTimeoutMs ?? 15_000;
 
   // Pre-flight: detect a foreign ngrok holding :4040 (free tier = 1 session).
-  const existing = await fetchTunnelsApi();
-  if (existing !== null) {
+  // Fail closed — proceed only on positive proof that the port is free.
+  const probe = await probeNgrokApi();
+  if (probe.state === 'occupied') {
     throw new Error(
-      'ingress-tunnel: ngrok API already responding on :4040 — another ngrok ' +
-        'is running. Stop it first (macOS launchd: launchctl unload ' +
+      'ingress-tunnel: something is already responding on :4040 — another ngrok ' +
+        'is likely running. Stop it first (macOS launchd: launchctl unload ' +
         '~/Library/LaunchAgents/com.deus.ngrok.plist; Linux/WSL: kill $(pgrep ngrok)).',
+    );
+  }
+  if (probe.state === 'indeterminate') {
+    throw new Error(
+      `ingress-tunnel: could not confirm :4040 is free (${probe.detail}). ` +
+        'Refusing to start a second ngrok, because a free loopback port refuses ' +
+        'the connection immediately — anything else suggests a process is holding it. ' +
+        'Check what owns :4040 (macOS/Linux: lsof -nP -iTCP:4040 -sTCP:LISTEN).',
     );
   }
 
@@ -154,7 +261,13 @@ export async function startTunnel(deps: TunnelDeps): Promise<TunnelHandle> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     await sleep(500);
-    const url = extractPublicUrl(await fetchTunnelsApi());
+    // Here we want the payload if our own ngrok has come up yet, so anything
+    // other than a parsed response simply means "not ready, keep polling".
+    // This is deliberately NOT the fail-closed reading used by the pre-flight.
+    const probed = await probeNgrokApi();
+    const url = extractPublicUrl(
+      probed.state === 'occupied' ? probed.api : null,
+    );
     if (url) {
       logger.info({ url }, 'ingress-tunnel: tunnel up');
       return {


### PR DESCRIPTION
Second slice of LIA-447's silent-failure audit. Independent of #1205 — both branch off `origin/main`.

## The defect

`startTunnel`'s own docstring promised:

> Fails CLOSED: a foreign ngrok already on :4040 → throw with an actionable unload hint, rather than silently sharing the session

But `fetchTunnelsApi` collapsed **three distinct outcomes into `null`** — connection error, timeout, and an HTTP response whose body would not parse — and the pre-flight threw only on a non-null result. A non-JSON responder holding `:4040` therefore passed as *"port free"*, and a second ngrok was spawned into exactly the session conflict the check exists to prevent.

## The fix

The probe now returns a discriminated result:

| Outcome | When |
|---|---|
| `free` | **only** when the request fails with `ECONNREFUSED` |
| `occupied` | any HTTP response at all — parseable body or not |
| `indeterminate` | the timeout, and any other request error code |

**Only `ECONNREFUSED` proves absence.** `NGROK_API` is a literal IPv4 loopback with no DNS lookup, so an unoccupied port refuses immediately. Every other error means something engaged the socket and then failed — a live listener can accept and then reset, which must not read as "nothing is listening".

## The probe always settles, under an *absolute* deadline

`req.setTimeout` measures socket **inactivity**, so a peer that streams chunks forever would keep resetting it while `end`, `aborted`, `error` and `close` never fire — hanging the pre-flight, and with it startup. Replaced with a single absolute deadline, plus:

- a 1 MiB body cap
- a request `close` backstop (it always fires once the request finishes, for any reason)
- response `error`/`aborted` handling — an unhandled response `error` would otherwise throw

Since **headers alone prove occupancy**, the deadline/abort/cap paths resolve `occupied` when headers were seen and `indeterminate` otherwise. Both fail closed for the pre-flight, and the `api: null` they carry keeps the post-spawn URL poll correct, where it simply means *"not ready, keep polling"* — that caller deliberately does **not** inherit the fail-closed reading.

## Blast radius of a false positive

Bounded and already handled: `startTunnel`'s throw is caught and logged at `src/index.ts`, so the worst case is *no tunnel this boot, with a clear reason* — which is precisely the behaviour the docstring already promised. Each non-free outcome throws its own message so the operator can tell which happened.

## Severity — stated plainly

**Latent.** `INGRESS_TUNNEL_ENABLED` defaults off (`src/config.ts`), so there is no live exposure and no runtime surface to verify against; unit tests are the only available evidence.

## Verification

- `tunnel.test.ts`: **7 → 20 tests**, including a real `http.createServer` responder that streams without ever ending, asserting the probe settles well inside the timeout — something the old inactivity timer could never have done.
- The new pure `classifyProbeError` matches the module header's own note that conflict detection is one of the unit-tested pure helpers.
- Full suite **2109 passing** (115 files), `tsc --noEmit` exit 0, `eslint --max-warnings 220` exit 0 (0 errors).
- `drift_check.py --all` and `flag_lint.py` run **after** committing: ALL CHECKS PASSED.
- Mutation-tested: reverting the parse branch to `free` fails the unparseable-body test.

Three of this change's defects were caught by review gates rather than by me — the timeout-as-free classification, the `req.on('error')`-is-not-ECONNREFUSED distinction, and the inactivity-timeout hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)