### PR TITLE
chore(git): ignore the warden ephemera that keep surfacing as strays (LIA-562)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,14 @@ dist/
 .claude/worktree-markers/
 # Co-gate backend verdict markers (user-local; per-role @<backend>)
 .claude/.*@*
-# Co-gate loop backups (timestamped runtime ephemera)
-.claude/.co-gate-loop-*.bak-*
+# Co-gate loop counters + their timestamped backups (per-role runtime ephemera)
+.claude/.co-gate-loop-*
+# Per-role cross-review context files + their timestamped backups. The
+# plan-reviewer one is already matched by .claude/.plan-*.md below, but only
+# incidentally, and that pattern misses every .bak- copy.
+.claude/.*-cross-review.md*
+# Warden memo, rebuilt on every gated edit
+.claude/.warden-memo.md
 # Plan revise log + scratch plan docs (host-local working notes)
 .claude/plan-revise-log.jsonl
 .claude/.plan-*.md


### PR DESCRIPTION
Five files written by the warden hooks were never gitignored, so they surface as untracked strays after every gated edit. `.claude/.warden-memo.md` appeared three times in one session, which is what prompted the ticket.

## Verified unignored before the change

`git check-ignore -v` matched **nothing** for:

| File | Written by |
|---|---|
| `.claude/.warden-memo.md` | rebuilt on every gated edit |
| `.claude/.co-gate-loop-<role>.json` | per-role co-gate loop counter |
| `.claude/.code-reviewer-cross-review.md` | co-gate cross-review context |
| `.claude/.ai-eng-warden-cross-review.md` | co-gate cross-review context |
| `.claude/.<role>-cross-review.md.bak-<ts>` | timestamped backups (10 were sitting in the main checkout) |

## Two gaps, not one

The ticket names only the memo. Probing the full ephemera list from `run_session_init` found two distinct holes:

1. Line 27 covered only `.co-gate-loop-*.bak-*` — the *backup* — and never the live counter. Widened to `.co-gate-loop-*`.
2. `.claude/.plan-*.md` matched `.plan-reviewer-cross-review.md` only **incidentally** (it happens to start with `.plan-`), missing the code-reviewer and ai-eng-warden files entirely, plus every `.bak-` copy since those don't end in `.md`. `.claude/.*-cross-review.md*` covers all of them.

Every listed file is already treated as session ephemera — `run_session_init` in `scripts/codex_warden_hooks.py` deletes each one on every session start. They were simply never added to `.gitignore`.

## Safety, checked in both directions

A broadened glob's one real risk is silently ignoring something tracked:

- `git ls-files` shows **no `.claude` dotfile is tracked at all**.
- Grepping `git ls-files` against the three new patterns returns **empty**.
- `git ls-files -i -c` output is unchanged — the only tracked-but-ignored entries are pre-existing `.claude/skills/*` matches from lines 124-127, unrelated to this change.

After the change, all seven probed paths resolve to a rule.

`drift_check.py --all` and `flag_lint.py` both pass (run after committing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)