### PR TITLE
chore(patterns): drop the duplicate last_verified key in debugging.md (LIA-561)

### DIFF
--- a/patterns/debugging.md
+++ b/patterns/debugging.md
@@ -3,7 +3,6 @@ last_verified: "2026-08-15" # reviewed against LIA-491 (src/container-runner.ts 
 governs:
   - src/container-runner.ts
   - src/message-orchestrator.ts
-last_verified: "2026-08-15" # reviewed against LIA-491 (src/container-runner.ts naming)
 test_tasks:
   - "Messages from a Telegram group arrive but the agent never responds"
   - "A container exits with code 137 instead of returning a result"


### PR DESCRIPTION
`patterns/debugging.md` declared `last_verified` **twice** — lines 2 and 6, byte-identical. Line 6 is removed; line 2 is kept, because that is the one the tooling reads.

## Why it mattered

Nothing changes today, but the duplicate was a live trap: **the two readers disagree about which one wins.**

| Reader | Resolves to |
|---|---|
| `parse_last_verified` (`scripts/drift_check.py`) — `re.search(..., MULTILINE)` | the **FIRST** match → line 2 |
| Any YAML parser — duplicate keys are last-wins | the **LAST** value → line 6 |

Both confirmed directly rather than assumed:

```
yaml on duplicate keys -> LAST
regex first-match      -> FIRST
```

The values are identical right now, so the split is invisible. But updating one occurrence and not the other would have made the drift check and any YAML consumer **silently disagree** about when this pattern was last verified — the exact shape of bug that is expensive to find later.

## Verified after the change

- `parse_last_verified` imported and called directly: still returns `2026-08-15`.
- `yaml.safe_load` on the frontmatter: valid, with `last_verified`, `governs` and `test_tasks` all intact and `governs` unchanged.
- `drift_check.py --all` and `flag_lint.py` pass (run after committing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)