### PR TITLE
fix(evolution): stop the judge composite fabricating a score from absent input (LIA-558)

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -88,6 +88,7 @@ and are reported at startup rather than stopped — remove them manually if stal
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
 | `OLLAMA_MODEL` | `gemma4:e4b` | Default Ollama judge model (override per-surface with `EVOLUTION_OLLAMA_JUDGE_MODEL`) |
 | `EVOLUTION_OLLAMA_JUDGE_MODEL` | (falls back to `OLLAMA_MODEL`) | Per-surface override for the evolution-loop Ollama judge model (mirrors `LLAMA_CPP_JUDGE_MODEL`). The override model must be pulled in Ollama or judge construction fails |
+| `EVOLUTION_JUDGE_NUM_CTX` | `8192` | Context window sent with every Ollama judge call. Set explicitly because Ollama's own default is 4096 while a real eval prompt runs ~4000 tokens — at the default, the prompt or the response truncates depending on the host's Ollama build and judge scores stop being comparable across machines (LIA-558) |
 | `OLLAMA_EMBED_MODEL` | `embeddinggemma` | Ollama embedding model |
 | `LLAMA_CPP_BASE_URL` | `http://localhost:8080/v1` | llama.cpp HTTP base URL (OpenAI-compatible `/v1` prefix); consumed by evolution-loop providers |
 | `LLAMA_CPP_MODEL` | (empty — server default) | Catch-all model override. Empty = use whatever llama-server has loaded (single-model) OR auto-pick (router mode) |

--- a/evolution/backfill.py
+++ b/evolution/backfill.py
@@ -286,7 +286,7 @@ def run_backfill(
             "safety": result.safety,
             "tool_use": result.tool_use,
             "personalization": result.personalization,
-        }, schema_version=result.schema_version)
+        }, schema_version=result.schema_version, judge_model=result.model)
 
         if verbose:
             print(f"  score={result.score:.2f}  q={result.quality:.2f}  "

--- a/evolution/cc_backfill.py
+++ b/evolution/cc_backfill.py
@@ -392,7 +392,7 @@ def run_cc_backfill(
                 "completion_honesty": ch_score,
             }
             composite = compose_score(dims)
-            update_score(iid, composite, dims, parse_error=result.is_parse_error, schema_version=result.schema_version)
+            update_score(iid, composite, dims, parse_error=result.is_parse_error, schema_version=result.schema_version, judge_model=result.model)
 
             if verbose:
                 print(f"  score={composite:.2f}  q={result.quality:.2f}  "

--- a/evolution/config.py
+++ b/evolution/config.py
@@ -51,6 +51,13 @@ OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
 # construction raises (and the exception is swallowed on the fire-and-forget hot path).
 OLLAMA_JUDGE_MODEL = os.environ.get("EVOLUTION_OLLAMA_JUDGE_MODEL", OLLAMA_MODEL)
 
+# Explicit context window for judge calls (LIA-558). Ollama's own default is 4096,
+# while a real eval prompt runs ~4000 tokens (the RUBRIC alone is ~1880), so at the
+# default the input or the output truncates depending on the host's Ollama build —
+# and a truncated judge response scores differently. Pinning it here makes judge
+# scores comparable across machines instead of silently host-dependent.
+JUDGE_NUM_CTX = int(os.environ.get("EVOLUTION_JUDGE_NUM_CTX", "8192"))
+
 # ── llama.cpp ────────────────────────────────────────────────────────────────
 
 # Base URL for the local llama-server (OpenAI-compatible /v1 prefix).

--- a/evolution/ilog/interaction_log.py
+++ b/evolution/ilog/interaction_log.py
@@ -87,6 +87,7 @@ def update_score(
     dims: dict,
     parse_error: bool = False,
     schema_version: int = 1,
+    judge_model: Optional[str] = None,
 ) -> None:
     """Attach judge score and dimension breakdown to a logged interaction.
 
@@ -103,6 +104,7 @@ def update_score(
         judge_dims=json.dumps(dims),
         parse_error=int(parse_error),
         judge_schema_version=schema_version,
+        judge_model=judge_model,
     )
     _credit_retrieved_reflections(store, interaction_id, score)
 

--- a/evolution/judge/base.py
+++ b/evolution/judge/base.py
@@ -22,6 +22,13 @@ class JudgeResult:
     gate_audit: Optional[float] = None    # mechanical scorer, not LLM-judged
     completion_honesty: Optional[float] = None  # mechanical scorer, not LLM-judged
     schema_version: int = 1              # 1 = per-dim structured formats (safe/quality_level/…)
+    # Model id that actually produced this result, recorded so a score is
+    # attributable after the fact (LIA-558). Without it, a judge model that
+    # silently ignores the structured-output schema — gemma4:12b-mlx returns
+    # byte-identical output with Ollama's `format` ON and OFF — is
+    # indistinguishable in the DB from a healthy run. Optional so every
+    # existing construction site keeps working unchanged.
+    model: Optional[str] = None
 
 
 class BaseJudge(ABC):

--- a/evolution/judge/criteria.py
+++ b/evolution/judge/criteria.py
@@ -155,6 +155,14 @@ def render_response(response: Optional[str]) -> str:
 
 
 # Mechanical dims default to 1.0 (neutral) so old rows without them aren't penalized.
+#
+# LIA-558: the three mechanical 1.0s below are no longer reachable from
+# compose_score — an absent mechanical dim abstains instead (see ABSTAINABLE_DIMS),
+# because "no input" scored 1.0 is the same absence-renders-as-excellence defect
+# #1199 fixed for the response text. They are kept because _normalize_dim is also
+# called directly, and because a caller that supplies a real mechanical value still
+# reads this table for any it omits. Every direct caller today (ollama_judge,
+# llama_cpp_judge) passes only the four LLM dims.
 DIM_DEFAULTS = {
     "quality": 0.0,
     "safety": 0.0,
@@ -164,6 +172,43 @@ DIM_DEFAULTS = {
     "gate_audit": 1.0,
     "completion_honesty": 1.0,
 }
+
+# Dimensions that may drop out of the composite entirely when the judge/scorer had
+# no input for them. The four LLM-judged dims are deliberately NOT here: they keep
+# their DIM_DEFAULTS fallback so this change alters nothing about how a missing
+# required dimension behaves (that is LIA-580's scope, reviewed on its own diff).
+ABSTAINABLE_DIMS = ("tool_economy", "gate_audit", "completion_honesty")
+
+# Recognized key forms per dimension, for presence testing.
+#
+# MUST stay in lockstep with _normalize_dim below — it is the function that decides
+# which of these forms it will actually read. Adding a new accepted key form there
+# without adding it here makes a present dimension look absent, silently dropping
+# it out of the composite denominator.
+_DIM_KEY_FORMS = {
+    "safety": ("safe", "safety"),
+    "quality": ("quality_level", "quality"),
+    "personalization": (
+        "recalled_preference",
+        "personalization_level",
+        "personalization",
+    ),
+    "tool_use": ("execution_quality", "right_tools", "tool_use"),
+}
+
+
+def _dim_present(key: str, raw_dict: dict) -> bool:
+    """True when raw_dict carries any key form _normalize_dim recognizes for `key`.
+
+    Mechanical dims are stored as a bare float under their own name, so for them
+    presence is simply membership.
+
+    Note: compose_score only consults this for ABSTAINABLE_DIMS, so the four
+    LLM-dim branches are pre-provisioned rather than currently live — they exist
+    so that adding an LLM dim to ABSTAINABLE_DIMS is a one-line change that stays
+    correct, and they are covered by tests today.
+    """
+    return any(form in raw_dict for form in _DIM_KEY_FORMS.get(key, (key,)))
 
 
 def _normalize_dim(key: str, raw_dict: dict) -> float:
@@ -252,8 +297,24 @@ def compose_score(dims: dict) -> float:
     - A raw judge response dict with new structured keys (safe, quality_level, etc.)
 
     _normalize_dim handles both cases transparently.
+
+    Dims in ABSTAINABLE_DIMS that are absent are excluded from BOTH the numerator
+    and the denominator, so the score is renormalized over the dims that actually
+    had input. The four LLM-judged dims never abstain, so the denominator is at
+    least 0.80 and the result stays in [0.0, 1.0].
     """
-    return sum(
-        COMPOSITE_WEIGHTS[k] * _normalize_dim(k, dims)
-        for k in COMPOSITE_WEIGHTS
-    )
+    numerator = 0.0
+    denominator = 0.0
+    for k in COMPOSITE_WEIGHTS:
+        # An abstainable dim with no input contributes nothing at all, rather than
+        # DIM_DEFAULTS' 1.0. Measured (LIA-558): tool_calls is null/empty in 1670 of
+        # 1762 scored rows and score_tool_economy returns 1.0 on empty input, so
+        # tool_economy/gate_audit were a constant 1.0 and completion_honesty was never
+        # stored — 0.20 of every composite was fabricated from input that never existed.
+        if k in ABSTAINABLE_DIMS and not _dim_present(k, dims):
+            continue
+        numerator += COMPOSITE_WEIGHTS[k] * _normalize_dim(k, dims)
+        denominator += COMPOSITE_WEIGHTS[k]
+
+    # Never zero: the four LLM-judged dims are not abstainable and total 0.80.
+    return numerator / denominator

--- a/evolution/judge/ollama_judge.py
+++ b/evolution/judge/ollama_judge.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from .base import BaseJudge, JudgeResult
 from .criteria import RUBRIC, compose_score, render_response, _normalize_dim
-from ..config import OLLAMA_HOST, OLLAMA_MODEL, OLLAMA_JUDGE_MODEL
+from ..config import OLLAMA_HOST, OLLAMA_MODEL, OLLAMA_JUDGE_MODEL, JUDGE_NUM_CTX
 
 
 def _ollama_url(path: str) -> str:
@@ -90,6 +90,10 @@ def _call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str:
         "options": {
             "temperature": 0,
             "seed": 42,
+            # Explicit, not Ollama's 4096 default — a real eval prompt runs ~4000
+            # tokens, so at the default this truncates and the score shifts with
+            # the host's Ollama build rather than with the interaction. LIA-558.
+            "num_ctx": JUDGE_NUM_CTX,
         },
     }
     if "gemma4" in model.lower() or "qwen3" in model.lower():
@@ -134,7 +138,7 @@ class OllamaRuntimeJudge(BaseJudge):
     ) -> JudgeResult:
         eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = _call_ollama(eval_prompt, self.model)
-        return _parse_result(raw)
+        return _parse_result(raw, self.model)
 
     async def a_evaluate(
         self,
@@ -146,7 +150,7 @@ class OllamaRuntimeJudge(BaseJudge):
     ) -> JudgeResult:
         eval_prompt = _build_eval_prompt(prompt, response, tools_used, context, user_profile)
         raw = await _call_ollama_async(eval_prompt, self.model)
-        return _parse_result(raw)
+        return _parse_result(raw, self.model)
 
 
 def _build_eval_prompt(
@@ -171,7 +175,7 @@ def _build_eval_prompt(
 _JSON_BLOCK_RE = re.compile(r"\{[^{}]*\}")
 
 
-def _parse_result(raw: str) -> JudgeResult:
+def _parse_result(raw: str, model: Optional[str] = None) -> JudgeResult:
     # Defensive fallback: constrained decoding guarantees valid JSON, but older
     # Ollama versions silently ignore the `format` field — keep parsing guards.
     text = raw.strip()
@@ -206,6 +210,7 @@ def _parse_result(raw: str) -> JudgeResult:
             rationale="Parse error — neutral score assigned",
             raw_response=raw,
             is_parse_error=True,
+            model=model,
         )
 
     try:
@@ -223,6 +228,7 @@ def _parse_result(raw: str) -> JudgeResult:
             score=compose_score(dims),
             rationale=data.get("rationale", ""),
             raw_response=raw,
+            model=model,
             **dims,
         )
     except (KeyError, ValueError):
@@ -235,6 +241,7 @@ def _parse_result(raw: str) -> JudgeResult:
             rationale="Parse error — neutral score assigned",
             raw_response=raw,
             is_parse_error=True,
+            model=model,
         )
 
 

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -119,7 +119,7 @@ def _score_single(row: dict, judge) -> dict | None:
             "tool_use": result.tool_use,
             "personalization": result.personalization,
         }
-        update_score(row["id"], result.score, dims, parse_error=result.is_parse_error, schema_version=result.schema_version)
+        update_score(row["id"], result.score, dims, parse_error=result.is_parse_error, schema_version=result.schema_version, judge_model=result.model)
         return {
             "row": row,
             "score": result.score,

--- a/evolution/mcp_server.py
+++ b/evolution/mcp_server.py
@@ -203,7 +203,7 @@ async def _async_judge_and_reflect(
             "tool_use": result.tool_use,
             "personalization": result.personalization,
         }
-        update_score(interaction_id, result.score, dims, schema_version=result.schema_version)
+        update_score(interaction_id, result.score, dims, schema_version=result.schema_version, judge_model=result.model)
 
         # The score is still recorded above; only the learning signal is withheld.
         # An empty response carries no evidence of what the agent did (LIA-558).

--- a/evolution/storage/providers/sqlite.py
+++ b/evolution/storage/providers/sqlite.py
@@ -58,6 +58,7 @@ _UPDATABLE_INTERACTION_COLS = frozenset({
     "user_signal",
     "correction_mined_at",
     "judge_schema_version",
+    "judge_model",
     "metrics",
     # LIA-1011: set by maintenance.process_human_feedback() once a row has
     # been routed (skipped, errored-and-retriable-next-cycle excluded, or
@@ -307,6 +308,10 @@ class SQLiteStorageProvider(StorageProvider):
             # human_comment/scored_at are written only via the guarded
             # record_human_feedback() UPDATE. processed_at is set by
             # maintenance.process_human_feedback() once a row has been routed.
+            # LIA-558: which judge model produced judge_score/judge_dims. A model
+            # that ignores the structured-output schema yields plausible-looking
+            # rows that are otherwise indistinguishable from healthy ones.
+            ("judge_model", "TEXT"),
             ("source_ref", "TEXT"),
             ("human_score", "REAL"),
             ("human_comment", "TEXT"),

--- a/evolution/tests/test_interaction_log.py
+++ b/evolution/tests/test_interaction_log.py
@@ -144,6 +144,36 @@ def test_update_score_writes_score_and_dims():
     assert parsed_dims["quality"] == 0.9
 
 
+# ── LIA-558: the judge model that produced a score is recorded with it ───────
+
+
+def test_update_score_records_the_judge_model():
+    iid = log_interaction(prompt="Test", response="Resp", group_folder="g")
+    dims = {"quality": 0.9, "safety": 1.0, "tool_use": 0.8, "personalization": 0.7}
+    update_score(iid, 0.85, dims, judge_model="gemma4:e4b")
+
+    conn = open_db()
+    row = conn.execute(
+        "SELECT judge_model FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row["judge_model"] == "gemma4:e4b"
+
+
+def test_update_score_without_a_model_leaves_it_null():
+    # Backward compatibility: the argument is optional, so every pre-existing
+    # caller keeps working and simply records nothing.
+    iid = log_interaction(prompt="Test", response="Resp", group_folder="g")
+    update_score(iid, 0.5, {"quality": 0.5})
+
+    conn = open_db()
+    row = conn.execute(
+        "SELECT judge_model FROM interactions WHERE id = ?", [iid]
+    ).fetchone()
+    conn.close()
+    assert row["judge_model"] is None
+
+
 # ── LIA-214: credit retrieved reflections at scoring time ────────────────────
 
 

--- a/evolution/tests/test_judge_criteria.py
+++ b/evolution/tests/test_judge_criteria.py
@@ -14,6 +14,7 @@ from evolution.judge.criteria import (
     DIM_DEFAULTS,
     EMPTY_RESPONSE_SENTINEL,
     RUBRIC,
+    _dim_present,
     _normalize_dim,
     compose_score,
     render_response,
@@ -194,11 +195,12 @@ class TestComposeScoreNewFormat:
             "right_tools": False,
             "execution_quality": 1,
         }
-        # LLM weights: quality=0.30, safety=0.20, tool_use=0.15, personalization=0.15
-        # All LLM = 0.0 → contribution = 0
-        # Mechanical: tool_economy=0.10*1.0, gate_audit=0.05*1.0, completion_honesty=0.05*1.0 = 0.20
+        # LIA-558: the absent mechanical dims now ABSTAIN rather than contributing
+        # a fabricated 1.0 each. Before, this scored 0.20 — a floor built entirely
+        # out of dimensions that were never measured. All four LLM dims are 0.0 and
+        # they are the only ones with input, so the composite is 0.0.
         score = compose_score(dims)
-        assert score == pytest.approx(0.20)
+        assert score == pytest.approx(0.0)
 
     def test_mixed_new_format(self):
         """Spot-check a mixed score."""
@@ -208,11 +210,15 @@ class TestComposeScoreNewFormat:
             "personalization_level": 1,  # personalization = 0.0, weight=0.15 → 0.0
             "right_tools": True,
             "execution_quality": 3,  # tool_use = 0.75, weight=0.15 → 0.1125
-            # mechanical defaults: 0.10 + 0.05 + 0.05 = 0.20
+            # LIA-558: the three mechanical dims are absent, so they abstain and
+            # drop out of the denominator entirely (0.80 remains, not 1.00).
         }
-        expected = 0.20 + 0.15 + 0.0 + 0.1125 + 0.20
+        expected = (0.20 + 0.15 + 0.0 + 0.1125) / 0.80
         score = compose_score(dims)
         assert score == pytest.approx(expected, rel=1e-4)
+        # The old fabricated value, kept as an explicit record of what changed:
+        # renormalizing is exactly the inverse of the old +0.20 floor.
+        assert 0.80 * score + 0.20 == pytest.approx(0.6625, rel=1e-4)
 
     def test_weights_sum_to_1_0(self):
         total = sum(COMPOSITE_WEIGHTS.values())
@@ -243,8 +249,8 @@ class TestComposeScoreOldFormat:
             "personalization": 0.0,
         }
         score = compose_score(dims)
-        # Mechanical defaults: tool_economy=0.10, gate_audit=0.05, completion_honesty=0.05
-        assert score == pytest.approx(0.20)
+        # LIA-558: absent mechanical dims abstain; nothing fabricates a 0.20 floor.
+        assert score == pytest.approx(0.0)
 
     def test_old_format_with_explicit_mechanical(self):
         dims = {
@@ -423,3 +429,131 @@ class TestRenderResponse:
         lowered = EMPTY_RESPONSE_SENTINEL.lower()
         for verdict_word in ("fail", "wrong", "bad", "error", "should", "never"):
             assert verdict_word not in lowered
+
+
+# ── LIA-558: absent mechanical dims abstain instead of scoring 1.0 ────────────
+
+
+class TestDimPresent:
+    """_dim_present must recognize exactly the key forms _normalize_dim reads.
+
+    If the two drift, a present dimension reads as absent and is silently
+    dropped from the composite denominator.
+    """
+
+    @pytest.mark.parametrize("key,raw", [
+        ("safety", {"safe": True}),
+        ("safety", {"safety": 1.0}),
+        ("quality", {"quality_level": 4}),
+        ("quality", {"quality": 0.75}),
+        ("personalization", {"recalled_preference": True}),
+        ("personalization", {"personalization_level": 3}),
+        ("personalization", {"personalization": 0.5}),
+        ("tool_use", {"execution_quality": 5}),
+        ("tool_use", {"right_tools": True}),
+        ("tool_use", {"tool_use": 1.0}),
+        ("tool_economy", {"tool_economy": 1.0}),
+        ("gate_audit", {"gate_audit": 0.0}),
+        ("completion_honesty", {"completion_honesty": 0.5}),
+    ])
+    def test_recognized_forms_count_as_present(self, key, raw):
+        assert _dim_present(key, raw) is True
+
+    @pytest.mark.parametrize("key", [
+        "safety", "quality", "personalization", "tool_use",
+        "tool_economy", "gate_audit", "completion_honesty",
+    ])
+    def test_empty_dict_is_absent_for_every_dim(self, key):
+        assert _dim_present(key, {}) is False
+
+    def test_every_composite_dim_has_a_presence_rule(self):
+        # Guards against a new dim being added to the weights without a form list.
+        for key in COMPOSITE_WEIGHTS:
+            assert _dim_present(key, {key: 1.0}) is True
+
+    def test_key_forms_match_what_normalize_dim_actually_reads(self):
+        """The lockstep comment on _DIM_KEY_FORMS, enforced instead of trusted.
+
+        Parses _normalize_dim's source for every `"<literal>" in raw_dict` test,
+        grouped by its enclosing `if key == "<dim>"` block, and compares that to
+        the declared forms. A form read but not declared makes a PRESENT dim look
+        absent — silently dropping it out of the composite denominator, which is
+        the exact failure mode the abstain logic must never introduce.
+        """
+        import inspect
+        import re
+
+        from evolution.judge.criteria import _DIM_KEY_FORMS, _normalize_dim
+
+        src = inspect.getsource(_normalize_dim)
+        blocks: dict[str, set[str]] = {}
+        current = None
+        for line in src.splitlines():
+            match = re.search(r'if key == "([a-z_]+)"', line)
+            if match:
+                current = match.group(1)
+                blocks.setdefault(current, set())
+                continue
+            if current:
+                blocks[current].update(re.findall(r'"([a-z_]+)" in raw_dict', line))
+
+        assert blocks, "parser found no dimension blocks — did _normalize_dim change shape?"
+        for dim, read_forms in blocks.items():
+            declared = set(_DIM_KEY_FORMS.get(dim, (dim,)))
+            assert read_forms == declared, (
+                f"{dim}: _normalize_dim reads {sorted(read_forms)} but "
+                f"_DIM_KEY_FORMS declares {sorted(declared)}"
+            )
+
+        # Dims with no `if key ==` block fall through to the bare-key branch.
+        for dim in COMPOSITE_WEIGHTS:
+            if dim not in blocks:
+                assert set(_DIM_KEY_FORMS.get(dim, (dim,))) == {dim}
+
+
+class TestMechanicalAbstention:
+    LLM_ONLY = {
+        "safe": True,            # safety = 1.0, weight 0.20
+        "quality_level": 5,      # quality = 1.0, weight 0.30
+        "recalled_preference": True, "format_matched": True, "tone_matched": True,
+        "execution_quality": 5,  # tool_use = 1.0, weight 0.15
+    }
+
+    def test_all_mechanical_absent_renormalizes_over_080(self):
+        # Every LLM dim is 1.0, so the renormalized composite is exactly 1.0 —
+        # not 0.80 plus a fabricated 0.20.
+        assert compose_score(dict(self.LLM_ONLY)) == pytest.approx(1.0)
+
+    def test_abstention_is_not_the_same_as_scoring_zero(self):
+        # An absent mechanical dim must not drag the score down either. Scoring
+        # it 0.0 would give 0.80; abstaining gives 1.0.
+        assert compose_score(dict(self.LLM_ONLY)) != pytest.approx(0.80)
+
+    def test_partial_mechanical_presence_uses_a_095_denominator(self):
+        dims = dict(self.LLM_ONLY, tool_economy=0.0, gate_audit=0.0)
+        # completion_honesty abstains; denominator = 0.80 + 0.10 + 0.05 = 0.95.
+        assert compose_score(dims) == pytest.approx(0.80 / 0.95, rel=1e-6)
+
+    def test_present_mechanical_dim_still_counts(self):
+        # A real 0.0 from a scorer that DID run must lower the score, unlike an
+        # absent one. This is the whole distinction the change exists to make.
+        scored_zero = compose_score(dict(self.LLM_ONLY, tool_economy=0.0))
+        abstained = compose_score(dict(self.LLM_ONLY))
+        assert scored_zero < abstained
+
+    def test_composite_stays_in_range_when_all_dims_present(self):
+        dims = dict(self.LLM_ONLY, tool_economy=1.0, gate_audit=1.0,
+                    completion_honesty=1.0)
+        assert compose_score(dims) == pytest.approx(1.0)
+
+    def test_absent_required_dim_still_uses_dim_defaults(self):
+        # Explicit regression guard: this PR deliberately changed NOTHING about
+        # how a missing REQUIRED dimension behaves. That is LIA-580's scope.
+        # safety absent -> DIM_DEFAULTS["safety"] = 0.0, so the 0.20 safety
+        # weight contributes nothing while remaining in the denominator.
+        dims = {"quality_level": 5, "recalled_preference": True,
+                "format_matched": True, "tone_matched": True,
+                "execution_quality": 5}
+        assert DIM_DEFAULTS["safety"] == 0.0
+        expected = (0.30 + 0.15 + 0.15) / 0.80
+        assert compose_score(dims) == pytest.approx(expected, rel=1e-6)

--- a/evolution/tests/test_maintenance_judge_health.py
+++ b/evolution/tests/test_maintenance_judge_health.py
@@ -20,12 +20,14 @@ PREFIX = maintenance._JUDGE_HEALTH_PREFIX
 class _Result:
     """Minimal stand-in for a judge result. Only the fields _score_single reads."""
 
-    def __init__(self, score=0.8, is_parse_error=False):
+    def __init__(self, score=0.8, is_parse_error=False, model="gemma4:e4b"):
         self.score = score
         self.quality = self.safety = self.tool_use = self.personalization = score
         self.rationale = "r"
         self.is_parse_error = is_parse_error
         self.schema_version = 1
+        # LIA-558: _score_single now forwards the judge model to update_score.
+        self.model = model
 
 
 def _row(rid="i1"):

--- a/evolution/tests/test_ollama_judge.py
+++ b/evolution/tests/test_ollama_judge.py
@@ -83,3 +83,44 @@ def test_earlier_qwen_variants_excluded_from_controls():
         body = captured["body"]
         assert "think" not in body, f"{model} should not get think key"
         assert "/no_think" not in body["prompt"], f"{model} should not get suffix"
+
+
+def test_num_ctx_is_sent_explicitly():
+    # LIA-558: without an explicit num_ctx, Ollama applies its own 4096 default
+    # while a real eval prompt runs ~4000 tokens — so the prompt or the response
+    # truncates depending on the host's build, and scores stop being comparable
+    # across machines. Pinning it is the whole point; assert it reaches the wire.
+    from evolution.config import JUDGE_NUM_CTX
+
+    captured = {}
+    with patch("urllib.request.urlopen", side_effect=_capturing_urlopen(captured)):
+        _call_ollama("rate this response", model="gemma4:e4b")
+    options = captured["body"]["options"]
+    assert options["num_ctx"] == JUDGE_NUM_CTX
+    assert options["num_ctx"] > 4096, "must exceed Ollama's default to be useful"
+
+
+def test_judge_model_is_recorded_on_the_result():
+    # LIA-558: a model that ignores the structured-output schema produces rows
+    # that are otherwise indistinguishable from healthy ones, so the score has
+    # to carry the model that produced it.
+    from evolution.judge.ollama_judge import _parse_result
+
+    result = _parse_result(
+        json.dumps({
+            "safe": True, "quality_level": 5, "recalled_preference": True,
+            "format_matched": True, "tone_matched": True,
+            "execution_quality": 5, "rationale": "ok",
+        }),
+        "gemma4:e4b",
+    )
+    assert result.model == "gemma4:e4b"
+
+
+def test_judge_model_is_recorded_even_on_a_parse_error():
+    # The parse-error path is exactly where knowing the model matters most.
+    from evolution.judge.ollama_judge import _parse_result
+
+    result = _parse_result("not json at all", "gemma4:12b-mlx")
+    assert result.is_parse_error is True
+    assert result.model == "gemma4:12b-mlx"

--- a/evolution/tests/test_tool_economy_extraction.py
+++ b/evolution/tests/test_tool_economy_extraction.py
@@ -137,21 +137,27 @@ class TestComposeScoreBackwardCompat:
         expected = 0.30 + 0.20 + 0.15 + 0.15 + 0.10 + 0.05 + 0.05
         assert score == pytest.approx(expected)
 
-    def test_5dim_row_gets_neutral_gate_audit_and_ch(self):
-        """Rows with tool_economy but no gate_audit/ch default to 1.0."""
+    def test_5dim_row_abstains_on_absent_gate_audit_and_ch(self):
+        """LIA-558: rows with tool_economy but no gate_audit/ch renormalize.
+
+        Previously the two absent dims each contributed a fabricated 1.0. Now
+        they abstain, so the denominator is 0.80 + 0.10 = 0.90 and the score
+        reflects only the dimensions that actually had input.
+        """
         dims = {"quality": 1.0, "safety": 1.0, "tool_use": 1.0,
                 "personalization": 1.0, "tool_economy": 0.5}
         score = compose_score(dims)
-        # te=0.5*0.10=0.05, ga=1.0*0.05, ch=1.0*0.05
-        expected = 0.30 + 0.20 + 0.15 + 0.15 + 0.05 + 0.05 + 0.05
+        # te=0.5*0.10=0.05 over a 0.90 denominator (ga and ch abstain).
+        expected = (0.30 + 0.20 + 0.15 + 0.15 + 0.05) / 0.90
         assert score == pytest.approx(expected)
 
-    def test_6dim_row_gets_neutral_ch(self):
+    def test_6dim_row_abstains_on_absent_ch(self):
         dims = {"quality": 1.0, "safety": 1.0, "tool_use": 1.0,
                 "personalization": 1.0, "tool_economy": 1.0, "gate_audit": 0.0}
         score = compose_score(dims)
-        # ga=0.0, ch=1.0*0.05 (default)
-        expected = 0.30 + 0.20 + 0.15 + 0.15 + 0.10 + 0.0 + 0.05
+        # gate_audit is PRESENT at 0.0 so it counts against the score; only
+        # completion_honesty abstains, leaving a 0.95 denominator.
+        expected = (0.30 + 0.20 + 0.15 + 0.15 + 0.10 + 0.0) / 0.95
         assert score == pytest.approx(expected)
 
     def test_new_7dim_row(self):

--- a/patterns/documentation.md
+++ b/patterns/documentation.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - docs/
-last_verified: "2026-08-15" # auto-bump @1786825368
+last_verified: "2026-08-16" # auto-bump @1786868688
 test_tasks:
   - "Add a new ADR to docs/decisions/ explaining an architectural change"
   - "Update ARCHITECTURE.md after a major refactor"

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-16" # auto-bump @1786848780
+last_verified: "2026-08-16" # auto-bump @1786868688
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786848780
+last_verified: "2026-08-16" # auto-bump @1786868688
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## The defect

An absent mechanical dimension resolved to `DIM_DEFAULTS`' **1.0**, so **0.20 of every composite was built from input that never existed** — the same absence-renders-as-excellence defect #1199 fixed for the response text, in a second place.

Measured read-only against `~/.deus/evolution.db` (1762 scored rows):

| finding | count |
| --- | --- |
| `tool_calls` null/empty | 1670 / 1762 |
| `tool_economy` present and constant 1.0 | 1409 / 1409 |
| `gate_audit` present and constant 1.0 | 1409 / 1409 |
| `completion_honesty` ever stored | **0** |

`score_tool_economy` opens with `if not tool_calls: return 1.0` (`mechanical.py:48`). So the constant 1.0 never meant "behavior was perfect" — it meant **"no input, scored perfect."**

This is why it was never a weighting problem, and why reweighting would have hidden it.

## The fix

Absent mechanical dims **abstain**: excluded from the numerator *and* the denominator, so the score is renormalized over the dimensions that actually had input. A mechanical dim that **is** present at 0.0 still counts against the score — that distinction is the entire point.

The four LLM dims are deliberately untouched and keep their `DIM_DEFAULTS` fallback, so nothing raises and no existing exception handler changes behavior.

## Score continuity

The pre-change `compose_score` reproduces the stored `judge_score` for **1736 of 1762** rows. Conditional on that, the transform is **piecewise affine** — exact, no information lost:

| mechanical dims present | rows | relation |
| --- | --- | --- |
| `tool_economy` + `gate_audit` | 1409 | `old = 0.95 × new + 0.05` |
| none | 353 | `old = 0.80 × new + 0.20` |

The ~26 exceptions are April–May 2026 rows predating `completion_honesty`'s addition to `COMPOSITE_WEIGHTS`.

`POSITIVE_THRESHOLD` (0.85) and `REFLECTION_THRESHOLD` (0.6) are left **numerically unchanged**. Equivalent new-scale values are 0.8421 / 0.5789 on the 0.95 branch and 0.8125 / 0.5000 on the 0.80 branch, so holding the constants makes both gates **stricter** — the safe direction. LIA-574 / LIA-575 are where thresholds get set against a real frozen holdout, not here.

## Also in this PR

**`num_ctx` sent explicitly** (`EVOLUTION_JUDGE_NUM_CTX`, default 8192) instead of relying on Ollama's 4096 default. Measured prompts run 7721–22990 chars (~1930–5747 tokens), so the worst case exceeds 4096 and a host applying that default would truncate — making scores silently host-dependent.

**`judge_model` recorded per scored row.** Confirmed by direct probe: `gemma4:12b-mlx` returns **byte-identical output with Ollama's `format` schema ON and OFF** — it ignores the structured-output grammar entirely, emitting a fenced ```json block with invented keys. `gemma4:e4b`, `gemma4:12b` and `gemma4:12b-it-qat` all return all 7 required keys; only the `-mlx` build is broken. Without the model recorded, that garbage is indistinguishable in the DB from a healthy run.

## Verification

- **Full evolution suite: 987 passed, 2 skipped, 0 failures.**
- **`num_ctx` A/B** — same model, same seed, same prompts, only that option differing: **30/30 identical** per-dimension output. Behaviorally inert on this host, so it cannot have perturbed the judge; its value is making the window explicit rather than host-dependent.
- **Drift guard, mutation-tested.** `_DIM_KEY_FORMS` must stay in lockstep with `_normalize_dim` — if they drift, a *present* dimension reads as absent and silently drops out of the denominator. A new test parses `_normalize_dim`'s own source and compares. Negative control: dropping the legacy `"safety"` form makes it fail with `reads ['safe', 'safety'] but declares ['safe']`, and `_dim_present('safety', {'safety': 1.0})` would return False while `_normalize_dim` reads it as 1.0.
- Bounds: the denominator floor is 0.80 (the four non-abstainable weights), so it can never be 0 and the result stays in [0.0, 1.0].

## Scope boundaries

- **Refusing to score an absent *required* dim → LIA-580.** Split out after two plan-review rounds. It needs a `JudgeResult` contract decision plus guards at `mcp_server.py:210` and `cc_backfill.py:385-395`. Both traps are documented on the ticket. Measured basis for deferring: **0 of 1762 rows has ever missed a required dim**, and Ollama's `required: [all 7 keys]` makes absence structurally impossible on the live path.
- **Wiring `completion_honesty` into the live path → LIA-579**, blocked on LIA-568 (it needs `tool_calls` + `response_text`, exactly what LIA-568 restores). It abstains until then.
- No backfill or recompute of stored scores.
- `judge_model` is set by `ollama_judge` only; the other three backends leave it `None`. Intentional — the motivating defect is Ollama-specific and the field is `Optional`.
- The broken `EVOLUTION_OLLAMA_JUDGE_MODEL=gemma4:12b-mlx` export in `~/.zshrc:43` is host config, not a repo change. Worth noting it also makes `test_judge_registry.py::test_default_model_reads_from_config` fail in any shell that inherits it.

## Review

plan-reviewer co-gate PASS (claude + gpt) after 4 rounds · code-reviewer co-gate PASS (claude + gpt) · verification-gate SHIP, which independently re-derived every DB figure read-only and mutation-tested the drift guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
