### PR TITLE
docs(examples): pin multi-model subagents to a real Claude model id

### DIFF
--- a/examples/multi-model-cliproxyapi/README.md
+++ b/examples/multi-model-cliproxyapi/README.md
@@ -78,6 +78,23 @@ mapped it to in `config.yaml`.
    `plan-writer` / `implementer` / `reviewer-sol` / `reviewer-opus` available
    as pinned-model subagent types via the `Agent` tool.
 
+   **Pin subagents to a real model id, never to a gateway alias.** The Claude
+   agents here pin `claude-opus-5`, not the `opus-planner` alias defined in
+   `config.yaml`, and that difference is deliberate — do not "tidy" it into
+   matching the alias. Claude Code appends its 1M-context variant marker to a
+   model id it does not recognise, and a gateway alias is such an id, so the
+   pin reaches the proxy as `opus-planner[1m]`. CLIProxyAPI's
+   `splitModelThinkingSuffix` parses only the parenthesised `model(value)`
+   form, not brackets, and rejects it:
+
+   ```
+   [claude-code:unrecognized_model] {"model":"opus-planner[1m]","query_source":"agent:custom:reviewer-opus"}
+   -> HTTP 400  "unknown provider for model opus-planner[1m]"
+   ```
+
+   Only the subagent-pin path is affected — the `/model` switching in step 8
+   takes an alias fine.
+
 ## Verify the files themselves before relying on them
 
 ```

--- a/examples/multi-model-cliproxyapi/agents/plan-writer.md
+++ b/examples/multi-model-cliproxyapi/agents/plan-writer.md
@@ -1,7 +1,7 @@
 ---
 name: plan-writer
 description: Drafts implementation plans. Pinned to Opus 5 regardless of the session's current default model — use for the planning phase of the multi-model workflow.
-model: opus-planner
+model: claude-opus-5
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/examples/multi-model-cliproxyapi/agents/reviewer-opus.md
+++ b/examples/multi-model-cliproxyapi/agents/reviewer-opus.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer-opus
 description: Reviews a diff. One of two required reviewers in the multi-model workflow — pinned to Opus 5. Pair with reviewer-sol; both must approve.
-model: opus-planner
+model: claude-opus-5
 tools: Read, Grep, Glob, Bash
 ---
 


### PR DESCRIPTION
Fixes stale guidance in `examples/multi-model-cliproxyapi/`: two Claude subagents pinned the `opus-planner` gateway alias, which is a live footgun for anyone following the example.

## The defect

Claude Code appends its 1M-context variant marker to a model id it does **not** recognise. A gateway alias is such an id, so the pin reaches the proxy suffixed. CLIProxyAPI's `splitModelThinkingSuffix` (`internal/client/claude/models/models.go:84-90`) parses only the parenthesised `model(value)` form, never brackets, and rejects it:

```
[claude-code:unrecognized_model] {"model":"opus-planner[1m]","query_source":"agent:custom:reviewer-opus"}
-> HTTP 400  "unknown provider for model opus-planner[1m]"
```

Reproduced against the live gateway today. An agent pinned to the **real** id `claude-opus-5` succeeds instead, with its own `modelUsage` entry and no error in the gateway log.

## Changes

- `agents/reviewer-opus.md`, `agents/plan-writer.md` — `model: opus-planner` → `model: claude-opus-5`
- `README.md` — a caution at step 9, where the reader is told to copy these files, explaining why the pins deliberately differ from the alias in `config.yaml` so they are not later "tidied" into matching

## Deliberately unchanged

- **`config.yaml:41` `alias: "opus-planner"`** — aliasing is a legitimate gateway feature the example partly exists to teach, and the alias is not itself broken. Only *pinning a subagent to it* is.
- **`README.md:73` `/model opus-planner`** — interactive `/model` switching was never observed to fail. The confirmed trigger is the subagent-pin path (`query_source: agent:custom:…`). Changing it would be speculation past the evidence.

## Verification

Ran the example's own two stated checks and read the output:

```
python3 -c "import yaml; yaml.safe_load(open('config.yaml'))"   -> OK

agents/implementer.md     model=luna-max        required-fields=OK
agents/plan-writer.md     model=claude-opus-5   required-fields=OK
agents/reviewer-opus.md   model=claude-opus-5   required-fields=OK
agents/reviewer-sol.md    model=sol             required-fields=OK
```

Also confirmed the replacement id is real rather than invented — `claude-opus-5` is present with `owned_by: anthropic` in the live gateway's `/v1/models` listing — and that a CommonMark scan finds no broken inline code spans in the edited README.

Doc-only; no runtime code path touched.

Refs LIA-584

🤖 Generated with [Claude Code](https://claude.com/claude-code)