### PR TITLE
docs(patterns): add hook-change pattern for authoring gates

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -16,6 +16,7 @@
 | memory / startup-gate | `patterns/general-code.md` | `docs/decisions/INDEX.md` (mandatory) |
 | env-var-add | `patterns/deployment.md` | `docs/ENVIRONMENT.md` |
 | monitor-watch | `patterns/monitor-resilience.md` | — |
+| hook-change | `patterns/hook-change.md` | `docs/SDK_DEEP_DIVE.md` (hook input/output types) |
 | general-code (fallback) | `patterns/general-code.md` | — |
 
 ## Precedence

--- a/patterns/INDEX.md
+++ b/patterns/INDEX.md
@@ -11,5 +11,6 @@
 | `patterns/cross-platform.md` | Any code that touches paths, signals, shells, or env vars | `docs/CROSS_PLATFORM.md` (CI-enforced violations only) |
 | `patterns/security-review.md` | IPC, mounts, credentials, container boundary | `docs/SECURITY.md` |
 | `patterns/documentation.md` | Adding or editing docs, ADRs, research write-ups | `docs/decisions/INDEX.md`, `docs/ARCHITECTURE.md` |
+| `patterns/hook-change.md` | Authoring hooks and warden gates in `.claude/hooks/` + `codex_warden_hooks.py` | `docs/SDK_DEEP_DIVE.md` hook types |
 | `patterns/general-code.md` | Catch-all: branch, tests, commits, ADR gate | `docs/CONTRIBUTING-AI.md` core rules |
 | `patterns/monitor-resilience.md` | monitor-watch: fleet merge, CI gate, bg session watch | — |

--- a/patterns/hook-change.md
+++ b/patterns/hook-change.md
@@ -1,0 +1,89 @@
+---
+governs:
+  - .claude/hooks/
+  - scripts/codex_warden_hooks.py
+  - .claude/settings.json
+last_verified: "2026-08-16"
+test_tasks:
+  - "Add a PreToolUse gate that blocks a write when the pending content matches a pattern"
+  - "Change which tools an existing warden gate fires on"
+  - "Make a hook emit an advisory message instead of blocking"
+---
+# Pattern: hook-change
+
+Authoring hooks and warden gates. For co-gate *operation* — verdict buckets, marker routing,
+backend marking — see `.claude/rules/orchestration-rules.md` instead; this file is about writing
+the hook, not running the gate.
+
+The hook input/output **types** are already documented at `docs/SDK_DEEP_DIVE.md:465,509`. Read
+those first; this file records only what they do not cover.
+
+## PreToolUse receives the pending content
+
+`tool_input` carries the tool's actual arguments, so a gate can refuse a write based on **what is
+about to be written**, not merely which file is touched:
+
+| Tool | Keys available at PreToolUse |
+|------|------------------------------|
+| `Edit` | `file_path`, `old_string`, `new_string`, `replace_all` |
+| `Write` | `file_path`, `content` |
+| `Bash` | `command`, `description` |
+
+This is what makes a content-matching gate possible at all — e.g. refusing a test file whose
+`new_string` introduces a call that would corrupt a production database.
+
+**Caveat, stated because it matters:** the official hook documentation does not enumerate
+`tool_input` keys per tool. The table above is confirmed from real tool calls observed in a live
+session, not from a published contract. Before shipping a gate that depends on a content key, log
+`tool_input` from one real invocation and confirm the key is present.
+
+`_event_paths` (`scripts/codex_warden_hooks.py:375`) reads only `file_path` and `command` today —
+its silence about the content keys reflects what existing gates needed, not what is available.
+
+## Blocking versus advising is one JSON key
+
+Two helpers, same file, entirely different force:
+
+- `_block_pre_tool` (`scripts/codex_warden_hooks.py:451`) emits `permissionDecision: deny`. The
+  harness refuses the tool call; the action never happens.
+- `_warn_post_tool` (`:463`) emits `systemMessage`. Text appears and nothing is stopped.
+
+A rule is only strict if it reaches the first one. Text injected into context — by any mechanism,
+however prominently worded — is advisory, and a hook that merely warns is a reminder no matter
+what the message says.
+
+Note the event constraint: only `PreToolUse` can deny. `PostToolUse` runs after the write, so a
+check there can catch and report but never prevent. When prevention is not available, reading the
+file from disk at `PostToolUse` still works — the file exists by then.
+
+## Which tools a gate fires on is a regex in settings.json
+
+Hooks are registered per event in `.claude/settings.json`, and each entry carries a `matcher` —
+a regex over the **tool name**, not the file path:
+
+| Matcher | Gates registered under it |
+|---------|---------------------------|
+| `Write\|Edit\|MultiEdit\|apply_patch\|ExitPlanMode` | plan-review-gate, tdd-test-lock |
+| `ExitPlanMode\|Task\|Agent` | plan-mode-invalidator, codegraph-cite-check |
+| `Write\|apply_patch` | placement-guard |
+| `Bash` | code-review-gate, ai-eng-gate, verification-gate, admin-merge-gate, format-check |
+
+To change what a gate fires on, edit its matcher — adding a tool there is what makes the hook
+receive that tool's events at all. Note the consequence for the Bash group: those gates see
+*every* Bash call and must decide relevance themselves from the command text, which is why the
+commit gate string-matches `git commit` rather than being scoped by the harness.
+
+Path-based selectivity is the hook's own job, not the matcher's — see `_managed_paths` and
+`_event_paths` in `scripts/codex_warden_hooks.py`.
+
+## The block reason is written for the model, not the user
+
+`permissionDecisionReason` is fed back to the agent as feedback so it can adjust; it is not
+surfaced to the user as an explanation. Write it as an instruction — *"use `monkeypatch.context()`
+instead; `undo()` reverts the `test_db` redirect"* — rather than as prose describing the problem
+to a human.
+
+Same evidentiary caveat as the key table above: this came from a documentation search, not from a
+line in this repo, and nothing under `docs/` states the audience split. Treat it as well-founded
+but unconfirmed locally — if a gate message ever needs to reach the user, verify before relying on
+this.


### PR DESCRIPTION
Documentation only. 91 added lines across three files, no code.

## What this captures

Three hook-authoring facts verified today that had no home:

1. **PreToolUse carries the pending content** — `Edit` has `new_string`, `Write` has `content`, `Bash` has `command`. This is what makes a content-matching gate possible rather than path-only: a gate can refuse a write based on what is about to be written.
2. **Blocking vs advising is one JSON key** — `_block_pre_tool` (`codex_warden_hooks.py:451`) emits `permissionDecision: deny`; `_warn_post_tool` (`:463`) emits `systemMessage`. Only `PreToolUse` can deny.
3. **The block reason is fed to the model, not the user** — so it should read as an instruction to the agent, not an explanation to a human.

Plus the `matcher` mechanism: which tools a gate fires on is a regex over the **tool name** in `.claude/settings.json`, with the four live matcher groups tabulated.

## Why a new pattern file

No existing pattern governs hook code. `general-code.md` covers `src/`, `evolution/`, `setup/`; `debugging.md` covers two `src/` files; grep for `PreToolUse` across `patterns/` returned nothing. Writing these into an existing pattern would file them where they never surface when someone edits a hook.

They also can't go in `.claude/rules/orchestration-rules.md` — the harness warned it has crossed a hard limit (42.7k against 40.0k chars). `patterns/` is hook-retrieved by task type rather than always-loaded, which is the correct tier for this class of content.

## Evidence caveats are in the file, not omitted

The `tool_input` key table is derived from **live tool calls, not a published contract** — the official docs don't enumerate per-tool keys, which review confirmed by grepping `SDK_DEEP_DIVE.md`. The file says so and tells the reader to log one real invocation before depending on a content key. Fact 3 carries the same caveat, at the same evidence tier.

Hook input/output *types* already exist at `docs/SDK_DEEP_DIVE.md:465,509` and are referenced rather than restated.

## What review caught, and it was the important part

The first version registered the pattern **only** in `patterns/INDEX.md` — which turns out to be drift-check bookkeeping, not the routing table. `CLAUDE.md` names `.mex/ROUTER.md` as the task-type selection mechanism, and it had no `hook-change` row.

So the file would have been indexed, drift-checked, and **unreachable**: a session authoring a hook would have fallen back to `general-code.md` and never loaded it. A capability built and left disconnected — and the plan text had named ROUTER.md as the mechanism, so the wiring was described and then not done.

Now registered in both surfaces.

Second catch, same family: omitting `last_verified` makes `parse_last_verified` return `None`, which permanently skips the file in the ADR-staleness check — while `--all` still exits 0. A silent, permanent exemption. Now set.

## Verification

`python3 scripts/drift_check.py --all` → `ALL CHECKS PASSED`, exit 0, with `hook-change.md | OK`. Routing confirmed present exactly once in each of `.mex/ROUTER.md` and `patterns/INDEX.md`.

Review independently verified every citation lands exactly — `codex_warden_hooks.py:375/451/463` on `_event_paths`/`_block_pre_tool`/`_warn_post_tool`, and `SDK_DEEP_DIVE.md:465/509` inside the hook type blocks.

Plan review and code review both to SHIP, co-gate PASS across claude and gpt on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
