### PR TITLE
fix(connectors): give the cliproxy Claude leg a resolvable model id

### DIFF
--- a/connectors/cliproxy/config.yaml
+++ b/connectors/cliproxy/config.yaml
@@ -39,11 +39,37 @@ api-keys:
 
 # Optional safe leg: a real, official Anthropic API key (not OAuth) can be
 # routed through the same proxy for a Claude-family alias if desired.
+#
+# `alias` deliberately EQUALS `name` here — do not "tidy" it into a prettier
+# opaque alias like "opus-planner". The client-facing id must be a real
+# Claude model id, for three separate reasons:
+#
+#   1. Claude Code appends its 1M-context variant marker to any model id it
+#      does not recognise, so an opaque alias reaches the proxy as
+#      "<alias>[1m]". CLIProxyAPI's splitModelThinkingSuffix parses only the
+#      parenthesised `model(value)` form, never brackets, and rejects it with
+#      HTTP 400 "unknown provider". A real id is recognised and the marker is
+#      resolved client-side before the request is sent.
+#   2. An id Claude Code cannot resolve to a real model inherits this
+#      connector's GPT context cap (CLAUDE_CODE_MAX_CONTEXT_TOKENS=272000),
+#      silently throttling a real Claude model. See the case analysis in
+#      connectors/providers/cliproxy_oauth/__init__.py.
+#   3. The id must contain "claude" or "anthropic" to appear in the /model
+#      picker under CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY. A real Claude
+#      id satisfies that for free.
+#
+# An identity mapping is explicitly supported: CLIProxyAPI documents
+# ClaudeModel.Alias as "the client-facing model name that maps to Name", and
+# nothing requires the two to differ.
+#
+# Caveat if you ALSO run a `claude-login` OAuth leg: that leg serves real
+# Claude ids too, so both legs would advertise this same id and the proxy
+# chooses between them. Set `priority` on the preferred leg if you run both.
 claude-api-key:
   - api-key: "REPLACE_WITH_YOUR_REAL_ANTHROPIC_API_KEY"
     models:
       - name: "claude-opus-5"
-        alias: "opus-planner"
+        alias: "claude-opus-5"
 
 # Accepted-risk leg: Codex OAuth-login (run `deus connect setup
 # cliproxy-oauth`, which drives `--codex-login` once to authenticate).

--- a/connectors/providers/cliproxy_oauth/__init__.py
+++ b/connectors/providers/cliproxy_oauth/__init__.py
@@ -260,25 +260,27 @@ class CliproxyOauthConnector(Connector):
             # override correctly. That is the primary, intended path this
             # override exists for.
             #
-            # Known, NOT-fully-covered gap: connectors/cliproxy/config.yaml
-            # also configures `claude-gpt-sol`/`terra`/`luna` picker-
+            # The Claude leg no longer hits case (1). connectors/cliproxy/
+            # config.yaml's `claude-api-key` leg maps its client-facing id
+            # to a REAL Claude model id (`claude-opus-5`, alias == name), so
+            # Claude Code resolves it and applies that model's own context
+            # window rather than inheriting this GPT cap. That was not true
+            # while the leg advertised the opaque alias "opus-planner": a
+            # `/model`-switch to it INCORRECTLY inherited this 272K cap,
+            # artificially throttling a real Claude model. The identity
+            # mapping is load-bearing for that reason and is pinned by a
+            # drift test -- see the config's own comment before changing it.
+            #
+            # Still-open gap: the `claude-gpt-sol`/`terra`/`luna` picker-
             # discovery aliases (deliberately `claude-`-prefixed so
             # CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY surfaces them in
-            # the /model picker) and a separate real-Claude-model leg
-            # (`claude-api-key` -> "opus-planner", for `opus-planner`).
-            # `opus-planner` itself is NOT `claude-`-prefixed and Claude
-            # Code cannot resolve that opaque proxy alias to a real Claude
-            # model -- so it hits case (1) too, meaning if a user ever
-            # `/model`-switches to `opus-planner` mid-session, it
-            # INCORRECTLY inherits this 272K cap (a real Claude model
-            # artificially throttled). Conversely, the `claude-gpt-*`
-            # picker-discovery aliases hit case (3) -- this override does
-            # NOT apply to them at all, so a user reaching a GPT model via
-            # the /model picker (rather than subagent dispatch) gets NO
+            # the /model picker) hit case (3) -- this override does NOT
+            # apply to them at all, so a user reaching a GPT model via the
+            # /model picker (rather than subagent dispatch) gets NO
             # correction and is exposed to the original silent-wrong-
-            # threshold problem this override exists to fix. Both gaps are
+            # threshold problem this override exists to fix. That gap is
             # scoped to manual /model-switching only, not the primary
-            # dispatched-subagent path, and are not fixed by this override
+            # dispatched-subagent path, and is not fixed by this override
             # -- Claude Code has no mechanism to resolve an opaque proxy
             # alias to its real upstream model or context window.
             "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "272000",
@@ -292,9 +294,9 @@ class CliproxyOauthConnector(Connector):
             # this one launch only. Session-wide, with no per-subagent
             # override (Claude Code has no such mechanism) -- so any
             # portion of the session using a real Claude model (e.g.
-            # `opus-planner`) also auto-compacts more eagerly than the
+            # `claude-opus-5`) also auto-compacts more eagerly than the
             # user's global default would, independent of the context-
-            # window gaps documented above.
+            # window gap documented above.
             "DEUS_CONNECT_SETTINGS_JSON": '{"autoCompactEnabled": true}',
         }
 
@@ -363,9 +365,9 @@ class CliproxyOauthSetupHandler(ConnectorSetupHandler):
             # placeholder claude-api-key block entirely rather than
             # carrying REPLACE_WITH_YOUR_REAL_ANTHROPIC_API_KEY through into
             # the real config. CLIProxyAPI would register that sentinel as
-            # a live provider leg, and a later `/model opus-planner` (or
-            # whatever alias it maps to) would 401 for a reason nothing
-            # surfaces.
+            # a live provider leg, and a later `/model claude-opus-5` (or
+            # whatever id that leg advertises) would 401 for a reason
+            # nothing surfaces.
             placeholder.pop("claude-api-key", None)
         model_map = values["model_map"]
         placeholder["deus-model-map"] = model_map

--- a/connectors/tests/test_registry.py
+++ b/connectors/tests/test_registry.py
@@ -489,6 +489,49 @@ class TestCliproxyOauthWriteConfig:
             )
 
 
+class TestTrackedConfigClaudeLegAlias:
+    """The `claude-api-key` leg's client-facing id must be a real Claude
+    model id, not an opaque alias -- enforced here because nothing else
+    enforces it and the failure modes are both silent.
+
+    An id Claude Code cannot resolve (a) reaches the proxy carrying the
+    1M-context variant marker, which CLIProxyAPI's splitModelThinkingSuffix
+    rejects with "unknown provider" (it parses only the parenthesised
+    `model(value)` form), and (b) inherits this connector's GPT context cap
+    of 272K, silently throttling a real Claude model. Both were live while
+    the leg advertised "opus-planner". The identity mapping is the fix, so
+    it is load-bearing rather than cosmetic.
+    """
+
+    def test_claude_leg_alias_is_the_real_model_id(self):
+        import connectors.providers.cliproxy_oauth as mod
+
+        cfg = yaml.safe_load(mod.TRACKED_CONFIG.read_text())
+        legs = cfg.get("claude-api-key") or []
+        assert legs, "tracked template lost its claude-api-key leg"
+
+        for leg in legs:
+            models = leg.get("models") or []
+            assert models, "claude-api-key leg has no models[] entries"
+            for entry in models:
+                name, alias = entry["name"], entry["alias"]
+                assert alias == name, (
+                    f"claude-api-key alias {alias!r} must equal its upstream "
+                    f"name {name!r} -- an opaque alias is unresolvable to "
+                    f"Claude Code, so it is rejected when the 1M-context "
+                    f"marker is appended and it silently inherits the 272K "
+                    f"GPT context cap"
+                )
+                # Independent of the identity check above: the id must also
+                # survive the gateway-discovery filter, which requires
+                # "claude" or "anthropic" in the id to list it in /model.
+                assert "claude" in alias or "anthropic" in alias, (
+                    f"claude-api-key alias {alias!r} would not appear in the "
+                    f"/model picker under "
+                    f"CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"
+                )
+
+
 class TestTrackedConfigPickerDiscoveryAliases:
     """Regression coverage for a documentation-only invariant that has no
     other enforcement: each claude-gpt-* picker-discovery alias's `name`


### PR DESCRIPTION
Follow-on to #1214, which fixed the same footgun in `examples/`. This is the **shipped template** that `deus connect setup cliproxy-oauth` copies into every new user's `config.local.yaml`, so it matters more.

## The problem

```yaml
claude-api-key:
  - api-key: "REPLACE_WITH_YOUR_REAL_ANTHROPIC_API_KEY"
    models:
      - name: "claude-opus-5"
        alias: "opus-planner"      # <- opaque; Claude Code cannot resolve it
```

Two silent failures follow from that one string:

1. **Rejected outright.** Claude Code appends its 1M-context variant marker to any id it does not recognise, so the request reaches the proxy as `opus-planner[1m]`. CLIProxyAPI's `splitModelThinkingSuffix` parses only the parenthesised `model(value)` form, never brackets → `HTTP 400 unknown provider`. Reproduced against the live gateway (LIA-584).
2. **A real Claude model throttled to 272K.** An unresolvable id inherits this connector's GPT context cap. This was already documented in our own source as a *"Known, NOT-fully-covered gap"* — `cliproxy_oauth/__init__.py` spelled out that a `/model`-switch to `opus-planner` "INCORRECTLY inherits this 272K cap (a real Claude model artificially throttled)".

## The change

Identity mapping — `alias` == `name` == `claude-opus-5`:

- Recognised, so the variant marker is resolved client-side and never reaches the proxy.
- Resolvable, so the model's own context window applies instead of the GPT cap.
- Still contains `claude`, so it keeps appearing in the `/model` picker under `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`.

Legality read from CLIProxyAPI source rather than assumed: `ClaudeModel.Alias` is documented as *"the client-facing model name that maps to Name"* (`internal/config/config_types.go`), and the only alias normalization (`SanitizeOAuthModelAlias`) applies to `oauth-model-alias`, a different block.

Also updates the provider comments, which described the gap as live and used `opus-planner` as a running example, and adds a drift test mirroring the two tracked-template drift tests already in `test_registry.py`.

## Verification

- **The new test discriminates** — not merely passes. Reverting the alias to `opus-planner` makes it fail with the expected assertion; the file was then restored and re-confirmed. A guard that passes either way would be worthless.
- **Regression control at the same base**: clean tree `50 passed`, with the diff `51 passed` — delta exactly the one added test, no failures on either side.
- Template still parses, yielding `[{name: claude-opus-5, alias: claude-opus-5}]`.
- `grep` confirms no non-comment `opus-planner` value remains in `connectors/`; the three surviving mentions are deliberate historical prose explaining why the identity mapping is load-bearing.

## Blast radius

**Existing installs are unaffected** — their `config.local.yaml` is already written and is not rewritten by this change. Only new setups get the corrected template.

One caveat is documented in the config comment rather than engineered around: if a user also runs a `claude-login` OAuth leg, both legs advertise the same real id and the proxy chooses between them. `ClaudeKey.Priority` is the intended lever, and the template ships only one Claude leg.

Refs LIA-584

🤖 Generated with [Claude Code](https://claude.com/claude-code)