### PR TITLE
chore(eval): bump stale judge model default to claude-sonnet-5

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -44,7 +44,7 @@ The judge model scores agent responses. Configured in `judge_model.py`.
 | 1 | GeminiJudge | `GEMINI_API_KEY` in `.env` |
 | 2 | ClaudeProxyJudge (fallback) | Credential proxy on localhost:3001. Currently blocked by Anthropic OAuth auth issue. |
 
-Override the judge model name with `DEEPEVAL_JUDGE_MODEL` (default: `claude-sonnet-4-5`).
+Override the judge model name with `DEEPEVAL_JUDGE_MODEL` (default: `claude-sonnet-5`).
 
 ## Concurrency
 
@@ -106,7 +106,7 @@ Convention: `test_{name}.py` loads `datasets/{name}.jsonl`. The warmup fixture a
 | `DEUS_EVAL_CONCURRENT` | auto | Parallel warmup workers |
 | `CREDENTIAL_PROXY_PORT` | `3001` | Credential proxy port |
 | `GEMINI_API_KEY` | (none) | For GeminiJudge |
-| `DEEPEVAL_JUDGE_MODEL` | `claude-sonnet-4-5` | Judge model name override |
+| `DEEPEVAL_JUDGE_MODEL` | `claude-sonnet-5` | Judge model name override |
 
 ## Architecture Notes
 

--- a/eval/judge_model.py
+++ b/eval/judge_model.py
@@ -43,4 +43,4 @@ def make_judge(model: Optional[str] = None) -> DeepEvalBaseLLM:
     except NoProviderAvailableError:
         # Last resort: Claude proxy (kept for legacy compatibility)
         from evolution.judge.providers.claude_proxy import ClaudeProxyJudge
-        return ClaudeProxyJudge(model=model or os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5"))
+        return ClaudeProxyJudge(model=model or os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-5"))

--- a/evolution/judge/providers/claude_proxy.py
+++ b/evolution/judge/providers/claude_proxy.py
@@ -8,7 +8,7 @@ from ..base import BaseJudge, JudgeResult
 from ..provider import JudgeProvider
 
 PROXY_BASE_URL = os.environ.get("CREDENTIAL_PROXY_URL", "http://localhost:3001")
-CLAUDE_JUDGE_MODEL = os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-4-5")
+CLAUDE_JUDGE_MODEL = os.environ.get("DEEPEVAL_JUDGE_MODEL", "claude-sonnet-5")
 
 
 class ClaudeProxyRuntimeJudge(BaseJudge):

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-16" # auto-bump @1786872877
+last_verified: "2026-08-16" # auto-bump @1786884902
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786874961
+last_verified: "2026-08-16" # auto-bump @1786884902
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
Replaces **#1087**, which carried the identical change but became unmergeable. Opened fresh off current `main`.

## The change

`claude-sonnet-4-5` → `claude-sonnet-5`, four lines across three files:

- `eval/judge_model.py` — the last-resort fallback's `DEEPEVAL_JUDGE_MODEL` default
- `evolution/judge/providers/claude_proxy.py` — module-level `CLAUDE_JUDGE_MODEL` default
- `eval/README.md` — the documented default, in prose and in the env-var table

The value is surfaced as the judge's reported model name (`claude_proxy.py` returns `CLAUDE_JUDGE_MODEL`), so a stale default misattributes any score that path produces.

`DEEPEVAL_JUDGE_MODEL` still takes precedence at both code sites — the `os.environ.get` wrapper is untouched — so any deployment pinning it explicitly is unaffected.

## Scope, stated honestly

This is the **last-resort fallback** judge, reached only when `JudgeRegistry` raises `NoProviderAvailableError`, and its runtime `evaluate()` returns fixed neutral scores rather than calling a model. Live judging is Ollama → Gemini → Claude. So this is staleness hygiene, **not** a correctness fix.

## Why a new branch instead of fixing #1087

#1087 was `CONFLICTING`/`DIRTY`, but its only conflict was two auto-generated `last_verified:` stamps in `patterns/*.md` — the three substantive files merged clean. Resolving in place produces a merge commit staging 200+ files (everything `main` brought in over six days) for a 4-line change, which is the documented mid-merge review hazard where the co-gate can REVISE on unrelated already-merged content. Rebasing would have needed a force-push.

So: fresh branch, deliberately **without** carrying over the generated-stamp churn. (The pre-push drift hook then generated its own current stamps, as it does on any `eval/`-touching branch.)

## Verification

- `grep` confirms no `claude-sonnet-4-5` remains in the three files, and that `os.environ.get("DEEPEVAL_JUDGE_MODEL", …)` still wraps both code defaults.
- Imported the module live: `CLAUDE_JUDGE_MODEL == claude-sonnet-5`.
- **Regression control at the same base**: judge/provider suite is `1 failed, 510 passed` both *with* the diff and on a stashed clean tree — identical test, identical assertion (`gemma4:12b-mlx` vs `gemma4:e4b`, a pre-existing `EVOLUTION_OLLAMA_JUDGE_MODEL` host-profile mismatch). Delta attributable to this change: zero.
- `claude-sonnet-5` confirmed real — present and `owned_by: anthropic` in the live gateway's `/v1/models` listing.

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)