### PR TITLE
fix(evolution): record the remaining hot-path swallows (LIA-556 sites 2-5)

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -31,6 +31,14 @@ _OPTIMIZER_HEALTH_PREFIX = "evolution.optimizer."
 _REGISTRY_COMPONENT = _OPTIMIZER_HEALTH_PREFIX + "registry"
 _STORAGE_COMPONENT = _OPTIMIZER_HEALTH_PREFIX + "storage"
 
+# Same sibling discipline for the remaining LIA-556 sites in this module. The
+# dispatch components are the OUTERMOST guards — they fire when an inner
+# wrapper could not run at all, so they stay distinct from the inner
+# `evolution.judge.batch` row rather than clobbering it.
+_PRINCIPLES_HEALTH_PREFIX = "evolution.principles."
+_JUDGE_DISPATCH_COMPONENT = "evolution.judge.dispatch"
+_MAINTENANCE_DISPATCH_COMPONENT = "evolution.maintenance.dispatch"
+
 # Allow running as a script (python evolution/cli.py) or module (-m evolution.cli)
 if __name__ == "__main__" and __package__ is None:
     _project_root = str(Path(__file__).parent.parent)
@@ -113,7 +121,10 @@ def cmd_status(group_folder: Optional[str] = None, domain: Optional[str] = None,
                 )
             print("  Details: python evolution/cli.py health")
         elif opt["status"] is None:
-            print("  No active artifacts, and no optimizer run has been recorded yet.")
+            # Print the rollup's own reason rather than a fixed string: it now
+            # distinguishes "nothing recorded at all" from "cycles ran but never
+            # attempted work", which this line used to conflate (LIA-556).
+            print(f"  No active artifacts — {opt['reason']}.")
         else:
             print("  No active artifacts. Optimizer healthy; nothing cleared the ship margin.")
 
@@ -161,8 +172,32 @@ def cmd_get_active_prompt(module: str) -> None:
     print(json.dumps(block or {}))
 
 
+def _clear_dispatch_failure(component: str) -> None:
+    """Clear a dispatch component's failure streak, and only that.
+
+    The two dispatch guards run once per interaction, so recording OK
+    unconditionally would add a health write to every message. `record_attempt`
+    is nonetheless the only thing that resets `consecutive_failures` /
+    `first_failed_at` (`health.py`), so recording nothing at all would make a
+    single transient failure permanent — `has_failure()` feeds `cmd_health`,
+    which the daily cockpit gates on, so one timeout would redden it forever.
+
+    So: read first, write only on the FAILED -> OK transition. Steady state is
+    one indexed SELECT on a small table and zero writes (LIA-556 site 3).
+
+    Best-effort like everything on this path — a lost race just delays the
+    clear by a cycle, and `health.get` already swallows its own errors.
+    """
+    from . import health
+
+    row = health.get(component)
+    if row and row.get("last_status") == health.STATUS_FAILED:
+        health.record_attempt(component, health.STATUS_OK, "recovered")
+
+
 def _maybe_auto_extract_principles(domain_presets: Optional[list] = None) -> None:
     """Auto-trigger principles extraction if enough new data exists."""
+    from . import health
     from .config import PRINCIPLES_COOLDOWN_HOURS
     from .reflexion.principles import extract_principles
     from .storage import get_storage
@@ -179,11 +214,19 @@ def _maybe_auto_extract_principles(domain_presets: Optional[list] = None) -> Non
             if datetime.now(timezone.utc) - last_dt < timedelta(hours=PRINCIPLES_COOLDOWN_HOURS):
                 continue
         # Data-count check + extraction (extract_principles handles its own min_new gate)
+        component = _PRINCIPLES_HEALTH_PREFIX + domain_key
         try:
             extract_principles(domain=domain)
         except Exception as exc:
             log.warning('evolution: principles extraction failed for domain=%s — %s: %s',
                         domain, type(exc).__name__, exc)
+            health.record_attempt(component, health.STATUS_FAILED, type(exc).__name__)
+        else:
+            # Recorded on every success, not just on recovery: this path is
+            # already gated by PRINCIPLES_COOLDOWN_HOURS above, so it is not hot
+            # and the OK write is what lets a resolved failure clear its streak
+            # (LIA-556 site 2).
+            health.record_attempt(component, health.STATUS_OK, 'extraction completed')
 
 
 def _maybe_auto_optimize(domain_presets: Optional[list] = None) -> None:
@@ -313,6 +356,8 @@ def _maybe_batch_judge(domain_presets: Optional[list] = None) -> None:
 
 def cmd_log_interaction(json_str: str) -> None:
     """Fire-and-forget logging + deferred batch judge, called by Node.js host."""
+    from . import health
+
     try:
         params = json.loads(json_str)
     except json.JSONDecodeError:
@@ -388,6 +433,11 @@ def cmd_log_interaction(json_str: str) -> None:
         _maybe_batch_judge(domain_presets)
     except Exception as exc:
         log.warning('evolution: batch judge failed — %s: %s', type(exc).__name__, exc)
+        health.record_attempt(
+            _JUDGE_DISPATCH_COMPONENT, health.STATUS_FAILED, type(exc).__name__
+        )
+    else:
+        _clear_dispatch_failure(_JUDGE_DISPATCH_COMPONENT)
 
     # Post-interaction maintenance check (non-blocking, best-effort).
     try:
@@ -395,6 +445,11 @@ def cmd_log_interaction(json_str: str) -> None:
         run_maintenance()
     except Exception as exc:
         log.warning('evolution: maintenance failed — %s: %s', type(exc).__name__, exc)
+        health.record_attempt(
+            _MAINTENANCE_DISPATCH_COMPONENT, health.STATUS_FAILED, type(exc).__name__
+        )
+    else:
+        _clear_dispatch_failure(_MAINTENANCE_DISPATCH_COMPONENT)
 
     # Feedback loop — user_signal: generate reflection for the PREVIOUS interaction.
     if user_signal and session_id:

--- a/evolution/health.py
+++ b/evolution/health.py
@@ -256,10 +256,19 @@ def rollup(prefix: str) -> Dict[str, Any]:
         }
 
     worst = max(rows, key=lambda r: _STATUS_RANK.get(r["last_status"], _RANK_NEVER))
+    # `status` stays None for a never-attempted worst row, same as for zero rows
+    # — changing that would move _STATUS_RANK precedence and the exit-code
+    # contract. Only the reason distinguishes them, because "nothing has ever
+    # been recorded" and "cycles ran but none ever attempted work" are different
+    # facts and the caller could not previously tell them apart (LIA-556).
+    reason = worst["last_reason"]
+    if worst["last_status"] is None and reason is None:
+        never = sum(1 for r in rows if r["last_status"] is None)
+        reason = f"{never} of {len(rows)} components recorded skips but never attempted work"
     return {
         "component": prefix.rstrip("."),
         "status": worst["last_status"],
-        "reason": worst["last_reason"],
+        "reason": reason,
         "worst_component": worst["component"],
         "consecutive_failures": max(r["consecutive_failures"] or 0 for r in rows),
         "rows": rows,

--- a/evolution/maintenance.py
+++ b/evolution/maintenance.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -50,6 +51,10 @@ ARCHIVE_AFTER_DAYS = 30
 # prefix, so a rollup still sees all of them.
 _JUDGE_HEALTH_PREFIX = "evolution.judge."
 _BATCH_COMPONENT = _JUDGE_HEALTH_PREFIX + "batch"
+
+#: Same sibling discipline for this module's other subsystem (LIA-556 site 5).
+_MAINTENANCE_HEALTH_PREFIX = "evolution.maintenance."
+_COMPACTION_COMPONENT = _MAINTENANCE_HEALTH_PREFIX + "compaction"
 
 #: Maintenance runs at most once per this many interactions.
 MAINTENANCE_INTERACTION_INTERVAL = 25
@@ -98,8 +103,25 @@ def is_maintenance_due(*, interaction_count: Optional[int] = None) -> bool:
     return (interaction_count - stored_count) >= MAINTENANCE_INTERACTION_INTERVAL
 
 
-def _score_single(row: dict, judge) -> dict | None:
-    """Score a single interaction. Returns score info dict or None on failure."""
+def _format_error_kinds(kinds: "Counter[str]") -> str:
+    """Render failure kinds as `TimeoutError x2, schema x1`, worst-first.
+
+    Counts, not a set: two timeouts and one schema miss is a different picture
+    from one of each, and collapsing them would hide which cause dominates.
+    """
+    return ", ".join(f"{kind} x{n}" for kind, n in kinds.most_common())
+
+
+def _score_single(row: dict, judge) -> "tuple[dict | None, str | None]":
+    """Score a single interaction.
+
+    Returns `(score_info, error_kind)`. On success `error_kind` is None; on
+    failure `score_info` is None and `error_kind` names why — `"schema"` for the
+    LIA-580 path, otherwise the exception's class name. The caller folds those
+    kinds into the batch health record, so a wholly failed batch says whether it
+    died of timeouts, schema misses or auth rather than only how many rows fell
+    over (LIA-556 site 4).
+    """
     from .ilog.interaction_log import update_score
     from .persona import digest_for_group
 
@@ -122,7 +144,7 @@ def _score_single(row: dict, judge) -> dict | None:
             log.warning(
                 "evolution: judge schema error for %s — %s", row["id"], result.rationale
             )
-            return None
+            return None, "schema"
         dims = {
             "quality": result.quality,
             "safety": result.safety,
@@ -136,10 +158,10 @@ def _score_single(row: dict, judge) -> dict | None:
             "dims": dims,
             "rationale": result.rationale,
             "is_parse_error": result.is_parse_error,
-        }
+        }, None
     except Exception as exc:
         log.warning("Failed to score interaction %s: %s", row["id"], exc)
-        return None
+        return None, type(exc).__name__
 
 
 def _reflect_single(scored: dict, config: dict) -> bool:
@@ -288,19 +310,25 @@ def _judge_pending_interactions() -> int:
     scored_results = []
     parse_errors = 0
     failed = 0
+    # Kinds are tallied here on the main thread, from what each worker returns,
+    # rather than in a shared accumulator the workers write to — so the pool
+    # needs no locking (LIA-556 site 4).
+    error_kinds: "Counter[str]" = Counter()
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
             pool.submit(_score_single, row, judge): row["id"]
             for row in unjudged
         }
         for future in as_completed(futures):
-            result = future.result()
+            result, error_kind = future.result()
             if result is None:
                 # _score_single swallowed an exception for this row. Counted,
                 # not just skipped: an all-None batch is a broken judge, and
                 # the old bare `continue` made that indistinguishable from a
-                # quiet one.
+                # quiet one. The kind rides along so the health record can name
+                # what went wrong, not merely how often.
                 failed += 1
+                error_kinds[error_kind or "unknown"] += 1
                 continue
             if result["is_parse_error"]:
                 parse_errors += 1
@@ -329,9 +357,14 @@ def _judge_pending_interactions() -> int:
         # Nothing usable came out of a non-empty batch. Keyed on
         # scored_results, never on the return value below: an all-parse-error
         # batch returns nonzero while having produced no usable score at all.
+        # The kinds matter most on this branch: a wholly failed batch is
+        # exactly when the reader needs to know whether it died of timeouts,
+        # schema misses or auth, not merely how many rows fell over.
+        kinds = _format_error_kinds(error_kinds)
         detail = (
             f"{len(unjudged)} unjudged, 0 scored "
-            f"({parse_errors} parse errors, {failed} failed)"
+            f"({parse_errors} parse errors, {failed} failed"
+            f"{': ' + kinds if kinds else ''})"
         )
         health.record_attempt(_BATCH_COMPONENT, health.STATUS_FAILED, detail)
         log.error("evolution: batch judging produced no usable scores — %s", detail)
@@ -339,11 +372,13 @@ def _judge_pending_interactions() -> int:
         # OK attests to scoring only. Reflection counts ride along in the
         # reason so a wholly failed pass 2 is visible, but they do not set the
         # status: reflection health is its own concern (LIA-556 follow-up).
+        kinds = _format_error_kinds(error_kinds)
         health.record_attempt(
             _BATCH_COMPONENT,
             health.STATUS_OK,
             f"{len(scored_results)} scored, {parse_errors} parse errors, "
-            f"{failed} failed, {reflected}/{len(needs_reflection)} reflections",
+            f"{failed} failed{': ' + kinds if kinds else ''}, "
+            f"{reflected}/{len(needs_reflection)} reflections",
         )
 
     return len(scored_results) + parse_errors
@@ -555,8 +590,26 @@ def compact_old_interactions() -> int:
         from .generative.provider import GenerativeRegistry
         provider = GenerativeRegistry.default().resolve()
         can_generate = provider.is_available()
-    except Exception:
-        pass
+    except Exception as exc:
+        # Was a bare `except: pass`. On failure `can_generate` stays False and
+        # compaction silently degrades to plain truncation — forever, with no
+        # log and no record (LIA-556 site 5).
+        log.warning(
+            "evolution: generative provider probe failed, compaction will "
+            "truncate instead of summarize — %s: %s", type(exc).__name__, exc
+        )
+        health.record_attempt(
+            _COMPACTION_COMPONENT, health.STATUS_FAILED, type(exc).__name__
+        )
+    else:
+        # OK only on a clean probe. `is_available() == False` is a legitimate
+        # "no generative backend configured" state, not a failure, and it
+        # cannot reach the except branch — it is a plain assignment above.
+        health.record_attempt(
+            _COMPACTION_COMPONENT,
+            health.STATUS_OK,
+            f"generative provider {'available' if can_generate else 'not configured'}",
+        )
 
     compacted = 0
     for row in compactable:

--- a/evolution/tests/test_evolution_silent_swallows.py
+++ b/evolution/tests/test_evolution_silent_swallows.py
@@ -1,0 +1,234 @@
+"""Health recording for LIA-556 sites 2, 3 and 5, plus the rollup ambiguity.
+
+Each of these sites swallowed an exception into a `log.warning` — or, at site 5,
+into nothing at all — so a persistently broken subsystem was indistinguishable
+from a quiet one. These tests pin each failure to a durable record, and pin the
+self-heal, because `record_attempt(OK)` is the only thing that clears a streak:
+a component that records FAILED and never OK is a one-way door, and
+`has_failure()` feeds the gate the daily cockpit reads.
+"""
+import pytest
+
+from evolution import cli, health, maintenance
+
+# Imported for its side effect, before any fixture below patches
+# `evolution.storage.get_storage`. `interaction_log` binds `get_storage` at
+# MODULE level (`evolution/ilog/interaction_log.py:11`), so whichever test first
+# triggers its import captures whatever `get_storage` is at that moment — and a
+# stub captured there survives monkeypatch teardown for the rest of the process,
+# breaking unrelated tests later in the run. Importing it here means the real
+# function is what gets bound.
+from evolution.ilog import interaction_log as _interaction_log  # noqa: F401
+
+
+# ── Site 2: principles extraction, per domain ─────────────────────────────────
+
+
+@pytest.fixture
+def principles(monkeypatch):
+    """Wire _maybe_auto_extract_principles so nothing real is touched.
+
+    Returns a setter taking the extract callable; the store reports no prior
+    extraction, so the cooldown never short-circuits the call under test.
+    """
+    def _wire(extract):
+        store = type("S", (), {"get_last_extraction": lambda self, d: None})()
+        monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: store)
+        monkeypatch.setattr("evolution.reflexion.principles.extract_principles", extract)
+    return _wire
+
+
+def test_principles_failure_records_per_domain(test_db, principles):
+    principles(lambda domain=None: (_ for _ in ()).throw(RuntimeError("no key")))
+
+    cli._maybe_auto_extract_principles(["coding"])
+
+    row = health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "RuntimeError" in row["last_reason"]
+    # The cross-domain pass runs too and fails the same way.
+    assert health.get(cli._PRINCIPLES_HEALTH_PREFIX + "cross-domain")["last_status"] \
+        == health.STATUS_FAILED
+
+
+def test_principles_success_records_ok_and_self_heals(test_db, principles):
+    principles(lambda domain=None: (_ for _ in ()).throw(RuntimeError("no key")))
+    cli._maybe_auto_extract_principles(["coding"])
+    assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is True
+
+    principles(lambda domain=None: None)  # recovered
+    cli._maybe_auto_extract_principles(["coding"])
+
+    row = health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")
+    assert row["last_status"] == health.STATUS_OK
+    assert row["consecutive_failures"] == 0
+    assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is False
+
+
+def test_one_broken_domain_does_not_taint_a_healthy_one(test_db, monkeypatch):
+    """Per-domain components, so a dead domain is visible without reddening the
+    domains that still work."""
+    store = type("S", (), {"get_last_extraction": lambda self, d: None})()
+    monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: store)
+
+    def selective(domain=None):
+        if domain == "coding":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("evolution.reflexion.principles.extract_principles", selective)
+    cli._maybe_auto_extract_principles(["coding", "study"])
+
+    assert health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")["last_status"] \
+        == health.STATUS_FAILED
+    assert health.get(cli._PRINCIPLES_HEALTH_PREFIX + "study")["last_status"] \
+        == health.STATUS_OK
+
+
+# ── Site 3: the outermost dispatch guards ─────────────────────────────────────
+
+
+def test_clear_dispatch_failure_writes_only_on_transition(test_db, monkeypatch):
+    """This runs once per interaction, so the steady state must not write.
+
+    Read first, write only on FAILED -> OK; otherwise every message would cost a
+    health write.
+    """
+    component = cli._JUDGE_DISPATCH_COMPONENT
+    writes = []
+    real = health.record_attempt
+    monkeypatch.setattr(
+        health, "record_attempt",
+        lambda c, s, r=None: (writes.append((c, s)), real(c, s, r))[1],
+    )
+
+    # No row at all: nothing to clear, so nothing written.
+    cli._clear_dispatch_failure(component)
+    assert writes == []
+
+    real(component, health.STATUS_OK, "fine")
+    writes.clear()
+    # Already OK: still nothing written.
+    cli._clear_dispatch_failure(component)
+    assert writes == []
+
+    real(component, health.STATUS_FAILED, "boom")
+    writes.clear()
+    # FAILED -> OK: exactly one write, and the streak is cleared.
+    cli._clear_dispatch_failure(component)
+    assert writes == [(component, health.STATUS_OK)]
+    row = health.get(component)
+    assert row["last_status"] == health.STATUS_OK
+    assert row["consecutive_failures"] == 0
+
+
+def test_dispatch_components_are_siblings_not_the_batch_row(test_db):
+    """The dispatch guards fire when the inner wrapper could not run at all, so
+    they must not clobber the inner component's row.
+
+    Both prefixes are asserted against `maintenance`'s own constants rather than
+    re-stated as literals. `cli.py` declares its component names independently —
+    importing `maintenance` at cli's module level would load it on a path
+    Node.js calls once per interaction — so this test is what keeps the two
+    declarations from silently drifting apart on a rename.
+    """
+    assert cli._JUDGE_DISPATCH_COMPONENT != maintenance._BATCH_COMPONENT
+    assert cli._JUDGE_DISPATCH_COMPONENT.startswith(maintenance._JUDGE_HEALTH_PREFIX)
+    assert cli._MAINTENANCE_DISPATCH_COMPONENT.startswith(
+        maintenance._MAINTENANCE_HEALTH_PREFIX
+    )
+    assert cli._MAINTENANCE_DISPATCH_COMPONENT != maintenance._COMPACTION_COMPONENT
+
+
+# ── Site 5: the compaction generative probe ───────────────────────────────────
+
+
+@pytest.fixture
+def compactable(monkeypatch):
+    """One compactable row, so compact_old_interactions reaches the probe."""
+    store = type("S", (), {
+        "get_compactable_interactions": lambda self, days=0, limit=50: [
+            {"id": "i1", "prompt": "p", "response": "r"}
+        ],
+        "update_interaction": lambda self, *a, **k: None,
+    })()
+    monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: store)
+
+
+def test_probe_exception_is_logged_and_recorded(test_db, compactable, monkeypatch):
+    """Was a bare `except: pass` — compaction silently degraded to truncation
+    forever, with no log and no record."""
+    monkeypatch.setattr(
+        "evolution.generative.provider.GenerativeRegistry.default",
+        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("no provider"))),
+    )
+
+    maintenance.compact_old_interactions()
+
+    row = health.get(maintenance._COMPACTION_COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "RuntimeError" in row["last_reason"]
+
+
+def test_unconfigured_provider_is_not_a_failure(test_db, compactable, monkeypatch):
+    """`is_available() == False` is a legitimate "no backend configured" state.
+    Recording it FAILED would cry wolf on every install without one."""
+    provider = type("P", (), {"is_available": lambda self: False})()
+    monkeypatch.setattr(
+        "evolution.generative.provider.GenerativeRegistry.default",
+        staticmethod(lambda: type("R", (), {"resolve": lambda self: provider})()),
+    )
+
+    maintenance.compact_old_interactions()
+
+    row = health.get(maintenance._COMPACTION_COMPONENT)
+    assert row["last_status"] == health.STATUS_OK
+    assert "not configured" in row["last_reason"]
+
+
+def test_compaction_component_self_heals(test_db, compactable, monkeypatch):
+    monkeypatch.setattr(
+        "evolution.generative.provider.GenerativeRegistry.default",
+        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("boom"))),
+    )
+    maintenance.compact_old_interactions()
+    assert health.get(maintenance._COMPACTION_COMPONENT)["last_status"] \
+        == health.STATUS_FAILED
+
+    provider = type("P", (), {"is_available": lambda self: True})()
+    monkeypatch.setattr(
+        "evolution.generative.provider.GenerativeRegistry.default",
+        staticmethod(lambda: type("R", (), {"resolve": lambda self: provider})()),
+    )
+    maintenance.compact_old_interactions()
+
+    row = health.get(maintenance._COMPACTION_COMPONENT)
+    assert row["last_status"] == health.STATUS_OK
+    assert row["consecutive_failures"] == 0
+
+
+# ── rollup(): zero rows vs recorded-but-never-attempted ───────────────────────
+
+
+def test_rollup_distinguishes_no_records_from_never_attempted(test_db):
+    """Both return status None, so only the reason can tell them apart — and
+    cmd_status printed one fixed string for both."""
+    empty = health.rollup("evolution.nothing.")
+    assert empty["status"] is None
+    assert empty["reason"] == "no health records"
+
+    health.record_skip("evolution.skipped.alpha")
+    skipped = health.rollup("evolution.skipped.")
+
+    assert skipped["status"] is None, "a skip must not invent a status"
+    assert skipped["reason"] != empty["reason"], "the two cases must be distinguishable"
+    assert "never attempted" in skipped["reason"]
+
+
+def test_rollup_reason_survives_a_real_failure(test_db):
+    """The new branch must not shadow a genuine FAILED reason."""
+    health.record_skip("evolution.mixed.alpha")
+    health.record_attempt("evolution.mixed.beta", health.STATUS_FAILED, "real cause")
+
+    roll = health.rollup("evolution.mixed.")
+    assert roll["status"] == health.STATUS_FAILED
+    assert roll["reason"] == "real cause"

--- a/evolution/tests/test_maintenance_judge_health.py
+++ b/evolution/tests/test_maintenance_judge_health.py
@@ -283,3 +283,83 @@ def test_the_direct_script_entry_point_still_works():
         f"direct-script entry point broken:\n{result.stderr}"
     )
     assert "attempted relative import" not in result.stderr
+
+
+# ── LIA-556 site 4: failure KINDS, not just counts ────────────────────────────
+
+
+def test_failed_batch_names_the_exception_kinds(test_db, wire):
+    """A wholly failed batch is exactly when the reader needs to know whether it
+    died of timeouts, schema misses or auth — the count alone cannot say."""
+    def boom(**kw):
+        raise TimeoutError("judge timed out")
+
+    wire([_row("a"), _row("b")], evaluate=boom)
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_FAILED
+    assert "TimeoutError x2" in row["last_reason"], row["last_reason"]
+
+
+def test_mixed_kinds_are_counted_separately(test_db, wire):
+    """Two DISTINCT kinds, so a set-based implementation that collapsed
+    `TimeoutError x1, TimeoutError x1` into `x1` would pass a single-kind test
+    and fail this one."""
+    seen = {"n": 0}
+
+    def mixed(**kw):
+        seen["n"] += 1
+        if seen["n"] == 1:
+            raise TimeoutError("slow")
+        if seen["n"] == 2:
+            raise ValueError("bad")
+        r = _Result()
+        r.is_schema_error = True
+        return r
+
+    wire([_row("a"), _row("b"), _row("c")], evaluate=mixed)
+    maintenance.judge_pending_interactions()
+
+    reason = health.get(COMPONENT)["last_reason"]
+    assert "TimeoutError x1" in reason, reason
+    assert "ValueError x1" in reason, reason
+    assert "schema x1" in reason, reason
+
+
+def test_partial_failure_still_records_ok(test_db, wire):
+    """The bar stays where site 1 put it: >=1 usable score is OK, however many
+    rows fell over. An earlier design tripped on any single failed row, which
+    would have reddened the prefix the cockpit gates on for one flaky call."""
+    seen = {"n": 0}
+
+    def one_bad(**kw):
+        seen["n"] += 1
+        if seen["n"] == 1:
+            raise TimeoutError("slow")
+        return _Result()
+
+    wire([_row("a"), _row("b")], evaluate=one_bad)
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_OK, row["last_reason"]
+    assert "TimeoutError x1" in row["last_reason"], row["last_reason"]
+
+
+def test_batch_component_self_heals_after_failure(test_db, wire, monkeypatch):
+    """record_attempt(OK) is the only thing that clears a streak, so a component
+    that records FAILED but never OK is a one-way door."""
+    wire([_row()])
+    monkeypatch.setattr("evolution.judge.make_runtime_judge",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    maintenance.judge_pending_interactions()
+    assert health.get(COMPONENT)["last_status"] == health.STATUS_FAILED
+
+    wire([_row()])  # judge healthy again
+    maintenance.judge_pending_interactions()
+
+    row = health.get(COMPONENT)
+    assert row["last_status"] == health.STATUS_OK
+    assert row["consecutive_failures"] == 0
+    assert health.has_failure(PREFIX) is False

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-16" # auto-bump @1786872877
+last_verified: "2026-08-16" # auto-bump @1786888245
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786874961
+last_verified: "2026-08-16" # auto-bump @1786888245
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
## What

Four more places in the evolution hot path where an exception became a log line nobody reads, plus a `rollup()` ambiguity that printed the same sentence for two different states. Site 1 shipped in #1192; this finishes the ticket's list.

**The ticket's line numbers had drifted**, so every site was re-located by reading — the bare `except: pass` is at `maintenance.py:551`, not the `:445` the ticket cites.

| site | before | after |
| -- | -- | -- |
| principles extraction | `except: log.warning` per domain | records `evolution.principles.<domain>` OK/FAILED |
| the two dispatch guards | `except: log.warning` | FAILED on exception; clears a streak only when one exists |
| `_score_single` | returned `None`, cause discarded | returns `(result, error_kind)`; kinds ride the existing batch record |
| compaction probe | **bare `except: pass`, no log at all** | logs and records `evolution.maintenance.compaction` |
| `rollup()` | `status: None` for two different states | reason distinguishes them; `cmd_status` prints it |

## Two designs that came from three REVISE rounds

Both defects were mine, both in site 4, and both were **health components harder to clear than to trip**:

1. **First revision:** components recorded FAILED and never OK. `record_attempt(OK)` is the only thing that clears a streak, so one transient timeout would have pinned `has_failure()` — which the daily cockpit gates on — permanently. Every component here now has a reachable OK path *and a test that drives it*.
2. **Second revision:** the replacement went FAILED on any 1 of up to 50 concurrently-scored rows and cleared only on a spotless batch, while the sibling beside it heals on any success. One flaky call would have reddened the whole prefix. **A detector that cries wolf is its own silent failure**, so the component is gone entirely and the exception kinds ride the existing record, which already heals on the right bar.

The failed branch is where kinds matter most: knowing 48 rows fell over says nothing; knowing they were all `TimeoutError` says everything.

## Hot-path discipline

The dispatch guards run **once per interaction**, so recording OK unconditionally would add a health write to every message. They read first and write only on the FAILED→OK transition — steady state is one indexed SELECT and zero writes. There's a test that counts the writes.

An unconfigured generative provider records **OK**, not FAILED: "no backend configured" is a configuration, not a fault, and alarming on it would train the reader to ignore the alarm.

## Verification

- **1027 pass.** The single failure is pre-existing and environment-dependent — `EVOLUTION_OLLAMA_JUDGE_MODEL` is set on this host and consumed at `config.py:52`. (I earlier attributed it to `OLLAMA_MODEL`, which is **not set**; corrected on LIA-552.)
- **Three mutation checks**, each reverted after, confirming the tests discriminate rather than merely pass:
  - a `set`-based kind formatter collapses `TimeoutError x2` → `x1` — caught
  - recording FAILED when `is_available()` is False — caught
  - making the dispatch clear write unconditionally — caught
- The verification gate independently drove every claim live through `cmd_log_interaction` and re-ran all three mutations.
- `drift_check.py --all` → ALL CHECKS PASSED.

### One discrepancy, resolved rather than waved through

I claimed removing the test file's `interaction_log` pre-import reproduces a specific cross-test `AttributeError`. The verification gate **could not reproduce it** running the file alone or the full suite.

Both are correct. I proved the mechanism directly with a standalone probe — patch `get_storage`, import `interaction_log` fresh, undo the patch, and the module still holds the stub:

```
captured the stub at import time : True
STILL the stub after teardown    : True
```

So the mechanism is real and the pytest manifestation is **ordering-dependent**: it appears with the specific two-test invocation (how the code-reviewer originally found it) and not when something else imports the module first. That is precisely why it's dangerous — it would surface later under CI sharding or `-k` as a confusing failure in innocent code.

Root cause is pre-existing and filed as **LIA-587**, with removal of this workaround in its acceptance criteria.

## Gates

plan-reviewer SHIP (round 4), code-reviewer SHIP (round 2), verification-gate SHIP. All co-gated claude+gpt, all PASS. Round 1 of code review found the cross-test contamination *by executing two tests together* — reading wouldn't have surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
