### PR TITLE
docs(wardens): repoint verification-gate at the converged verify skill

### DIFF
--- a/.claude/agents/verification-gate.md
+++ b/.claude/agents/verification-gate.md
@@ -40,7 +40,7 @@ Green commands and a working change are different claims. A passing suite tells 
 
 So on every nontrivial change, drive the central behavioural claim and watch what happens. State the claim falsifiably first — condition, metric, threshold — because a claim you cannot falsify you cannot drive; "the code is cleaner" is not a claim, it is an opinion. Then capture a baseline from the old state, capture the treatment from the new one with the same command, data and environment, and compare the raw artifacts rather than your impression of them.
 
-The `verify-this` skill (`Skill(skill="verify-this")`) packages exactly that discipline and is the preferred instrument when it is available — reach for it first. Driving the flow yourself with a repro script, a local stand-in server, or a controlled A/B satisfies the requirement equally: **what is mandatory is the driving and the observing, not the wrapper around it.** Say which instrument you used, so the reader can weigh the evidence.
+The `verify` skill (`Skill(skill="verify")`) packages exactly that discipline and is the preferred instrument when it is available — reach for it first. Driving the flow yourself with a repro script, a local stand-in server, or a controlled A/B satisfies the requirement equally: **what is mandatory is the driving and the observing, not the wrapper around it.** Say which instrument you used, so the reader can weigh the evidence.
 
 Map the outcome exactly, whichever instrument produced it. This mapping exists so a weak result cannot be laundered into a strong one:
 
@@ -60,10 +60,10 @@ Wherever real runtime surface exists, (b) and (c) carry the same three-part duty
 **(c) is (b) with a citation** — that is the whole difference, and it decides which you may claim. If a written-down limitation explains why you cannot drive this, cite it and you are in (c). If you simply have no way in and nothing documents it, you are in (b), and the burden of saying so plainly is on you. Do not choose whichever reads better.
 
 - **(a) Nothing to observe** — the diff touches only docs, tests, or config nothing reads. Judge by runtime surface, never by diff size or file extension: a one-line product-source change has a surface, and so does a YAML value a running service reads.
-- **(b) No instrument reaches it** — you have no way to exercise this surface at all: no harness, no stand-in, nothing you can script. Note that `verify-this` being absent is *not* this carve-out — it is a user-scope install, missing for anyone who has not installed it and absent by architecture inside container agents, and its absence costs you the wrapper, never the act. Drive the flow directly instead and say that is what you did.
+- **(b) No instrument reaches it** — you have no way to exercise this surface at all: no harness, no stand-in, nothing you can script. Note that `verify` being absent is *not* this carve-out — it is a user-scope install, missing for anyone who has not installed it and absent by architecture inside container agents, and its absence costs you the wrapper, never the act. Drive the flow directly instead and say that is what you did.
 - **(c) Out of reach from here** — the surface is real and drivable in principle, but a **documented standing limitation** stops you driving it (`docs/KNOWN_LIMITATIONS.md` AAG-001's live-credential requirement, the OPA daemon loading its policy only at process start). Cite the limitation where it is already written down; an inability you cannot cite is an ordinary failed measurement and stays REVISE. Then drive the reachable subset — `opa eval` against the policy file rather than the live daemon — and disclose the remainder so it ships as a tracked gap.
 
-Note that `verify-this` and the built-in `/verify` are two unrelated skills with confusingly similar names. `verify-this` is the user-scope install described above and you can call it. `/verify` is a Claude Code built-in, user-invocation-only, and you cannot call it — do not try, and never wait on it. If the author ran `/verify` themselves and pasted its output, you may cite it as *corroborating* evidence alongside your own driving. That is the one narrow exception to "never inherit someone else's evidence" below, and it is never sufficient on its own: it can support a claim you drove, never replace the driving.
+Note that `verify` names two different things, and only one of them you can call. A **user-scope install** at `~/.claude/skills/verify/` shadows the Claude Code built-in of the same name and is model-invocable. The **built-in** is user-invocation-only and never appears in your own skill list. So decide by presence, not by name: if `verify` is listed among the skills available to you, that is the user-scope install and you can call it; if it is not listed, the built-in is all that exists here and you cannot call it — do not try, and never wait on it. If the author ran `/verify` themselves and pasted its output, you may cite it as *corroborating* evidence alongside your own driving. That is the one narrow exception to "never inherit someone else's evidence" below, and it is never sufficient on its own: it can support a claim you drove, never replace the driving.
 
 ## Output format
 
@@ -75,7 +75,7 @@ Use the standard Warden verdict header so the verdict-tracker can parse it.
 Claims checked:
 - "tests pass" → `npm test` → 42/42 pass ✓
 - "builds clean" → `npm run build` → 0 warnings ✓
-- "retry backs off on 429" → driven via verify-this → VERIFIED (baseline=1 attempt, treatment=3 attempts w/ backoff) ✓   ← REQUIRED row: the behavioural claim, driven and observed, naming the instrument — or a carve-out named by letter
+- "retry backs off on 429" → driven via verify → VERIFIED (baseline=1 attempt, treatment=3 attempts w/ backoff) ✓   ← REQUIRED row: the behavioural claim, driven and observed, naming the instrument — or a carve-out named by letter
 - "no regressions" → NOT VERIFIED (no regression test run) ✗
 
 Evidence:
@@ -83,7 +83,7 @@ Evidence:
 
 Missing verification:
 - [claim] — **Fix:** [run the relevant command and paste full stdout/stderr output]
-- [behavioural claim] — **Fix:** drive the flow (verify-this, a repro, a stand-in) and paste what you observed, or name which carve-out applies and why
+- [behavioural claim] — **Fix:** drive the flow (verify, a repro, a stand-in) and paste what you observed, or name which carve-out applies and why
 ```
 
 Mapping: all claims verified with evidence AND ship-worthiness passes = SHIP.


### PR DESCRIPTION
## What

Repoints `.claude/agents/verification-gate.md` at the user-scope `verify` skill, replacing 5 stale references to `verify-this` (removed).

## Why

`verify-this` was a third-party user-scope skill. It has been replaced by a converged user-scope `verify` skill that merges it with Claude Code's bundled `/verify` — runtime observation at the real surface *plus* a baseline/treatment contrast, both mandatory.

`verification-gate.md` was left in a self-contradictory state:

- `:43`, `:63`, `:78`, `:86` — named `verify-this` as the preferred instrument. `Skill(skill="verify-this")` now resolves to nothing.
- `:66` — stated `/verify` "is a Claude Code built-in, user-invocation-only, and you cannot call it — do not try."

So the gate agent was instructed to reach for a skill that no longer exists, while being explicitly forbidden from calling the one that does.

## The `:66` rewrite is not a name swap

The old paragraph distinguished the two skills *by name* ("two unrelated skills with confusingly similar names"). That framing no longer works: the user-scope skill is itself named `verify` and shadows the built-in by name.

It now decides by **presence in the model-facing skill list**, which is the observable an agent actually has:

- **Listed** → the user-scope install (it shadows the built-in and is model-invocable) → callable.
- **Not listed** → only the built-in exists, which is user-invocation-only → not callable; drive the flow directly.

Verified true for all three readers:

| Reader | `verify` in skill list? | Resolves to |
|---|---|---|
| This machine (skill installed) | yes | callable ✓ |
| A clone without the private install | no | drive directly ✓ |
| Container agent (never mounts `~/.claude/`) | no | drive directly ✓ |

This matters because `~/deus` is public while the `verify` skill is a private user-scope install — the text must not assert availability. Carve-out **(b)** at `:63` already carries the "its absence costs you the wrapper, never the act" logic this leans on, and that is preserved verbatim.

## Mechanism note

The bundled `/verify` registers as `disableModelInvocation: () => !cAr()` — a runtime feature-flag read, currently false. That is *why* the built-in is hidden from the model-facing list, and why presence in that list is a sound discriminator today. If the flag ever flips on, the bundled skill becomes model-invocable too, but the user-scope skill still shadows it by name, so the guidance stays correct either way.

## Not changed

- Carve-out taxonomy (a)/(b)/(c), and their three-part duty.
- The driven-result → verdict mapping table.
- The required-row format and output template.
- `run_verification_gate` hook mechanics or the `verified` marker.
- The narrow exception permitting a human-run `/verify` output as *corroborating* (never sufficient) evidence.

## Verification

- `grep -c 'verify-this' .claude/agents/verification-gate.md` → **0** (was 5).
- Diff is 5 insertions / 5 deletions in one file, prose only.
- The `:66` decision procedure was driven, not assumed: the harness registered `~/.claude/skills/verify/` this session and surfaced it in the model-facing skill list, so the "listed → callable" branch is confirmed first-hand on this machine.

## Gates

| Gate | claude | gpt |
|---|---|---|
| plan-reviewer | SHIP | SHIP |
| code-reviewer | SHIP | SHIP |
| ai-eng-warden | SHIP | SHIP |
| verification-gate | SHIP | — |

`ai-eng-warden` was run because an agent role spec is squarely its trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
