### PR TITLE
feat(skills): add the verify skill — run it AND contrast it against a control

### DIFF
--- a/.claude/skills/verify/PROVENANCE.md
+++ b/.claude/skills/verify/PROVENANCE.md
@@ -1,0 +1,138 @@
+# Provenance — `verify`
+
+Locally authored. Converges two predecessor skills and replaces both.
+
+## What it replaces
+
+| Predecessor | What it contributed | Status |
+|---|---|---|
+| Claude Code's bundled `/verify` | Runtime observation: build, launch, drive the affected flow, capture evidence. Verdicts PASS/FAIL/BLOCKED/SKIP. **No control requirement.** | Cannot be removed — it ships inside the CLI itself rather than as a file on disk. Shadowed by this skill, which wins the by-name lookup. |
+| `verify-this` | Falsifiable claim, baseline vs treatment, artefact comparison. Verdicts VERIFIED / NOT VERIFIED / INCONCLUSIVE. **Agnostic about where measurement happens,** so it accepted unit-test evidence. | Removed 2026-08-16. Was a verbatim copy of `cursor-team-kit/skills/verify-this/SKILL.md` from `cursor/plugins`, pinned commit `2a8044425c7bddf429c3bdedf3ab61e791d34d65`, SHA-256 `c1c7b27c1133085bd3409c601ea12b6e6f61b4b23debcd52bc248fc01907e7de`. |
+
+Neither was a complete verification alone. The bundled skill could not separate
+"the change caused this" from "it was already so." `verify-this` demanded the
+contrast but tolerated measuring somewhere other than the software a user meets.
+Here both are mandatory, and a missing control downgrades the verdict to
+INCONCLUSIVE rather than being silently dropped.
+
+## Licence — how this became publishable
+
+An earlier revision of this file claimed the prose was "newly written rather than
+copied." **That claim was wrong, and it had never been measured.** A word-sequence
+comparison against the bundled skill's own wording found **181 shared 12-word
+sequences, 7.1% of the file at 12-grams and 13.7% at 8-grams**. That is
+derivative expression, not merely shared methodology, and it made the file
+unpublishable.
+
+The current text was then rewritten clean-room and re-measured:
+
+| Compared against | 12-gram | 10-gram | 8-gram | 6-gram |
+|---|---|---|---|---|
+| bundled `/verify` (before rewrite) | 181 | 248 | 348 | 489 |
+| bundled `/verify` (after rewrite) | **0** | **0** | **0** | 4 |
+| `verify-this` | **0** | **0** | **0** | **0** |
+
+The four surviving 6-grams are generic technical English ("at one of the rows
+above", "only the one in the diff"). Re-measure before any future edit that
+borrows phrasing from either predecessor.
+
+What is retained from both is **method**, which is not ownable: exercise the real
+surface, contrast against a control, probe the adjacent cases, report a verdict
+from a fixed rubric. What was removed is expression.
+
+**On structural similarity, asked and answered.** Word-sequence overlap is not the
+only theory of copying; shared structure, sequence and organisation is another.
+Answered honestly: this skill and the bundled one do share part of a skeleton —
+establish scope, find the surface, get the software running, drive it, capture,
+report, map to a verdict. That order is the functional order of the underlying
+task rather than an authored arrangement: you cannot drive software before you can
+run it, or compare captures before you have taken them. The steps that carry this
+skill's actual thesis are additions, not rearrangements — fixing a falsifiable
+claim with its refutation condition up front, capturing a control as its own
+gated step, comparing as its own step, and a five-way verdict ladder decided on
+evidence standing. The residual similarity is task order, which no one owns; it is
+recorded here rather than left implied.
+
+`verify-this` was never the constraint — at zero shared 8-grams, this skill took
+its idea and none of its words. `cursor/plugins` publishes no licence (no
+`LICENSE` at the repo root, GitHub API reports `license: null`), so its
+expression could not have been redistributed; its methodology always could.
+
+## Layout
+
+```
+verify/
+├── SKILL.md                    the protocol — always loaded on invocation
+├── PROVENANCE.md               this file — never linked from SKILL.md, so never loaded
+└── reference/
+    ├── surfaces.md             per-surface driving mechanics and what to capture
+    ├── control.md              obtaining a control, state that leaks between runs
+    └── measurement.md          performance and non-deterministic methodology
+```
+
+No `scripts/` directory, deliberately. An earlier draft put the §2 scope logic in
+`scripts/scope.sh`; two things ruled that out. This repository excludes
+`.claude/skills/*/scripts/` from version control by design — community skill
+templates ship documentation, not private implementations — so the file would
+never have reached a clone, leaving the body pointing at something absent. And
+more fundamentally, a skill installed at user scope runs inside arbitrary
+projects, so it must not depend on a file that exists in only one of them. The
+logic is inlined instead, which is portable and self-contained.
+
+Progressive disclosure is deliberate, following the bundled `/verify` and `/run`,
+which both ship `examples/*.md` rather than inlining them. The body carries what
+every run needs — the claim, the contrast, the verdict rubric, the report. The
+reference files carry what only some runs reach: you are on exactly one surface
+out of seven, so six of those sections would be dead weight in context. §8
+(probes) is deliberately **not** disclosed, because every run probes, and it is
+the step most likely to be skipped.
+
+Launching the software is delegated to the bundled `/run` skill rather than
+reimplemented. `/run` is model-invocable (unlike `/verify`) and already ships six
+per-project-type recipes.
+
+§2's command block was exercised before shipping, first as a script and then in
+its inlined form, against a clean tree with a remote and against a repository with
+no remote plus uncommitted and untracked work. Testing caught a real defect in the
+first inlined draft: chaining the base-ref fallbacks with `||` does not work,
+because a pipeline's exit status is its last command's, so `base=$(git
+symbolic-ref … | sed …)` reports success even when `git` failed and left the
+variable empty. It now tests emptiness explicitly.
+
+## Why the bundled skill could not simply be invoked
+
+Model invocation of the bundled skill sits behind a runtime feature flag, observed
+off in the CLI build current at the time of writing. While it is off, that skill
+is user-invocable only: it does not appear in the model-facing skill list and the
+`Skill` tool refuses it, so an agent can neither reach it nor be told to. `/commit`
+behaves the same way.
+
+Because this is a gated rollout rather than a fixed property, it may switch on in
+a later release — at which point the bundled skill becomes model-invocable too,
+but this skill still shadows it by name.
+
+This skill carries a `description` and no `disable-model-invocation`, so it **is**
+model-invocable: reachable as `Skill(skill="verify")`.
+
+## Precedence
+
+- A **project-level** `.claude/skills/verify/SKILL.md` would shadow this one. §4
+  therefore directs cold-start recipes to `verifier-<surface>/` instead. An
+  earlier revision wrote them to `verify/`, which meant the first successful cold
+  start in any repository silently replaced this protocol with a bare build
+  recipe — no claim, no control, no probe, no rubric. That path also did not
+  match §4's own `verifier-*` search, so the skill could not find what it had
+  told a previous session to write.
+- Do not add a second `verify` skill elsewhere under `~/.claude/skills/`; the
+  by-name lookup resolves to one winner and a duplicate makes it ambiguous which
+  ran.
+
+## Not done yet
+
+`context: fork` (with `background: false` and `effort: high`) would run this in a
+separate context from the work under review. The fields exist in this CLI build,
+and the argument is that the verdict is otherwise produced by the same agent that
+did the work and wants to be finished. It is unshipped because it changes the
+execution model and has not been exercised on a real change — precisely the kind
+of unverified claim this skill exists to refuse. Test it, watch the first two
+runs, then decide.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: verify
+description: "Prove or disprove that a change does what it claims, by exercising it at its real user-facing surface and comparing a control capture against a treatment capture. Use before committing or handing off a nontrivial behavioural change, for bug-fix reproduction, manual QA or smoke testing, acceptance-criteria checks, or when asked to show evidence that something works. Covers any change something outside it can observe — including a public type or API signature, whose surface is the compiler as an external consumer meets it. Skip only when nothing observes the change at all: prose, comments, or tests alone."
+---
+
+# Verify
+
+A verification stands on two legs. Remove either one and it is not a verification.
+
+- **Observation at the real surface.** The claim is exercised where a user meets
+  it, and what the software actually emitted is captured.
+- **A controlled contrast.** A second capture, from the unchanged state,
+  measured identically — so the difference is attributable to the change and
+  not to the weather.
+
+One leg alone has a name. A treatment capture with no control is a demo. A
+control/treatment pair measured somewhere other than the real surface is a
+laboratory result about code nobody runs.
+
+## What does not count
+
+Three substitutes, each of which feels like evidence and is not:
+
+1. **Suites and typecheckers.** They re-assert what someone already wrote down.
+   They cannot speak to a claim nobody has encoded yet — which is precisely the
+   claim under verification. Read a test as a specification if it helps; then go
+   exercise the software.
+2. **Calling the changed function directly.** Reaching past the public boundary
+   to invoke an internal and printing the result is a test you authored moments
+   ago, graded by its author. The function behaved as written; reading it told
+   you that. Nothing that ships was exercised.
+3. **Narrating the diff.** A description of what changed is a claim awaiting
+   verification, never its discharge.
+
+## 1. Fix the claim, and fix what would refute it
+
+Two sentences, written **before** anything is measured, and not revised
+afterwards:
+
+> **Claim.** Under `<condition>`, at `<surface>`, `<observable>` `<holds>`.
+> **Refuted if.** `<the specific observation that would end this as a failure>`.
+
+Worked examples:
+
+> Claim: invoked with an empty `--from`, the CLI exits non-zero and names the
+> flag in its message. Refuted if: it exits 0, or the message omits `--from`.
+
+> Claim: the twelfth request inside a minute receives 429 carrying
+> `Retry-After`. Refuted if: a twelfth request succeeds, or the header is
+> absent or unparseable.
+
+> Claim: p95 cold start on this host is at or under 400 ms across 10 trials.
+> Refuted if: p95 exceeds 400 ms, or the trials scatter too widely to place it.
+
+The refutation sentence is the whole point of writing this down. Fixing the
+failure condition in advance is what stops the bar from drifting to wherever the
+output happened to land. Quote it verbatim in the report.
+
+**Where the claim comes from.** Intended behaviour is owned by the request, the
+issue, or the acceptance criteria — not by the diff. The diff is authoritative
+only about what changed. Where the two disagree, that disagreement is the
+finding. If no external statement of intent exists, derive the claim from the
+diff and label it **inferred**: you may then verify that the observed change is
+real, but you may not present it as proof the software does what was wanted.
+
+Unmeasurable claims ("cleaner", "more robust", "better structured") carry no
+refutation condition and so cannot be verified. Obtain a measurable one, or ask;
+if you cannot ask — you are running as a subagent — report INCONCLUSIVE naming
+the claim you could not pin down.
+
+## 2. Establish scope
+
+Resolve the real base branch first, then measure from the merge base. A branch may
+be many commits, and the change may not be committed at all:
+
+```bash
+# The base is the PR's own, else whatever the remote calls its default.
+# Test emptiness rather than chaining with ||: a pipeline's exit status is the
+# LAST command's, so `base=$(git ... | sed ...)` succeeds even when git failed.
+base=$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null)
+[ -n "$base" ] || base=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
+
+# A named base is authoritative: use it, fetch it, or stop. Never substitute a
+# trunk for a base you were actually told — that compares a different branch.
+ref=""
+if [ -n "$base" ]; then
+  for c in "origin/$base" "$base"; do
+    git rev-parse --verify -q "$c" >/dev/null 2>&1 && { ref="$c"; break; }
+  done
+  if [ -z "$ref" ] && git fetch -q origin "$base" 2>/dev/null; then
+    git rev-parse --verify -q FETCH_HEAD >/dev/null 2>&1 && ref=FETCH_HEAD
+  fi
+else
+  # Only with no base named anywhere is a conventional trunk a fair guess.
+  for c in origin/main main origin/master master; do
+    git rev-parse --verify -q "$c" >/dev/null 2>&1 && { ref="$c"; break; }
+  done
+fi
+
+mb=""
+[ -n "$ref" ] && mb=$(git merge-base HEAD "$ref" 2>/dev/null)
+
+if [ -z "$mb" ]; then
+  echo "STOP: could not resolve base '${base:-unnamed}' (tried '${ref:-nothing}')."
+  echo "Ask which branch to compare against; do not guess one."
+else
+  git rev-list --count "$mb"..HEAD            # how many commits
+  git --no-pager diff --stat "$mb"..HEAD      # committed work
+  git --no-pager diff --stat HEAD             # staged + unstaged
+  git ls-files --others --exclude-standard    # untracked — also part of the change
+  git rev-parse "$mb" HEAD                    # the two SHAs, for the report
+fi
+```
+
+**If it prints STOP, stop.** An unresolved base is not a scope of zero commits —
+it is an unknown scope, and continuing past it reports an empty diff for a change
+that may be substantial. Repositories built on `master`, or with no remote and a
+differently-named trunk, land here legitimately: ask which branch to compare
+against rather than guessing.
+
+Two traps those commands exist to avoid. **`@{u}` is the wrong base:** an upstream
+is usually the remote copy of this same branch, so diffing against it hides every
+commit already pushed. **`git diff HEAD` is not the whole change:** it omits
+untracked files, so a newly added file is invisible in it.
+
+Carry both SHAs and whether the tree was dirty into the report — those are what
+let someone else reproduce the comparison. A large diff that truncates goes to a
+file you then read. No repository → the scope is whatever the requester named; ask
+if they did not.
+
+## 3. Locate the surface
+
+The surface is wherever something outside the change first observes it. Pick the
+row; the mechanics live in [reference/surfaces.md](reference/surfaces.md).
+
+| The change surfaces at | Observe by |
+|---|---|
+| A terminal (CLI, TUI) | issuing the command, capturing the screen |
+| A socket (server, API) | sending the request, capturing the whole response |
+| A window (GUI, web) | driving it headless, then **looking at** the screenshot |
+| A package boundary | consuming the published export as an outside caller would |
+| A compiler | compiling an external consumer against the shipped declarations |
+| An agent (prompt, role spec) | running the agent, capturing what it did |
+| A CI runner | triggering the real event, then confirming the run's head SHA is yours — a manual dispatch defaults to the default branch and can grade a different version of the workflow |
+
+**Internals are not surfaces.** Every internal has a caller, and following the
+callers terminates at one of the rows above. The observable behaviour of a
+commit-blocking hook is not what its function returns — it is whether the commit
+is refused when you type it.
+
+**Nothing observes it → SKIP,** one line saying why. Prose, comments, and
+declarations that emit nothing and that no consumer compiles against qualify. A
+diff of only tests qualifies too: those are the author's evidence, and re-running
+them re-runs CI. Where a diff carries both source and tests, verify the source.
+
+Do not stretch SKIP to cover a change you merely found inconvenient to reach. A
+public type with no runtime emission still has the compiler as its surface, and
+an external consumer that fails to compile before and succeeds after is a real
+control/treatment pair.
+
+## 4. Obtain a handle on the software
+
+Getting the software built and running is `/run`'s subject, not this one. Invoke
+it. It already knows the per-project-type recipes and will find a project skill
+that supersedes them.
+
+Before falling back to anything generic, look for what this repository has
+already committed — at its root and at every directory level the diff touches,
+because within a multi-package tree whatever makes a given package runnable
+tends to be stored next to it:
+
+```bash
+ls .claude/skills/
+ls <each-touched-dir>/.claude/skills/
+```
+
+A `verifier-*` skill matching your surface is the repository's own
+evidence-capture protocol; prefer it, because a reviewer can replay what it
+records. Mismatched surface, try the next. Where it misdirects you over plumbing that
+has nothing to do with what you are checking, it has rotted — say so, and never
+let its decay become the change's verdict.
+
+Nothing to lean on, and `/run` cannot get there either? Timebox the cold start
+to roughly fifteen minutes, then report **BLOCKED** with the exact point of
+failure.
+
+If a cold start did succeed, write the recipe down **after reporting** —
+`.claude/skills/verifier-<surface>/SKILL.md`, beside the code it applies to.
+Commands, worthwhile flows, traps; nothing more. Amend an existing one only where
+it misled you.
+
+Two rules about that file. **Never write during a verification** — a new file
+lands in the very diff being measured, and for a prompt or config change it can
+alter the behaviour under observation. And **never name it `verify`**: a
+project-scope skill of that name shadows this one, so the next run would load a
+build recipe stripped of the claim, the control, the probe, and the verdicts —
+strictly worse than having nothing. The `verifier-` prefix is also what the
+search above actually matches.
+
+## 5. Capture the control
+
+Skipped more often than any other step, and the reason unfounded PASSes ship.
+How to obtain one, what to record before starting the treatment, and the state
+that leaks between runs: [reference/control.md](reference/control.md).
+
+**Name the contrast before measuring it.** Old-breaks-new-works is one shape
+among several, and assuming it universally rejects correct work:
+
+| The change claims | Its contrast |
+|---|---|
+| A defect removed, a capability added | control violates the claim; treatment satisfies it |
+| Behaviour preserved (refactor, swap, migration) | the two agree, inside a margin you state |
+| Failures made rarer | the **rate** over repeated trials falls — one clean control run refutes nothing |
+| Better performance | named statistic across enough trials to separate the distributions |
+| Depth of defence | the guard is reached under an injected fault that otherwise masks it |
+| Wider compatibility | previously-working environments still work **and** the newly-targeted one flips |
+
+Where the control contradicts the contrast you named, that is information, not a
+stop sign: confirm you are reaching the changed path at all, and that the
+measurement could detect the effect if it were there. Then either re-state the
+contrast or report what you actually found.
+
+**Measure both sides the same way** — same invocation, same inputs, same
+environment, same warm-up. A control obtained differently is not a control; it is
+a second variable wearing one's coat.
+
+**Do not let measuring the control disturb what the treatment needs.** Quotas,
+rate-limit counters, one-shot migrations, caches, seeded rows, and
+first-invocation warm-up all persist across runs — consume the counter while
+measuring the control and the 429 you then attribute to the fix was your own
+doing. Re-seed between runs, keep the two builds separate, and say what you
+reset. The full list, and the countermeasures, are in
+[reference/control.md](reference/control.md).
+
+**Control genuinely unobtainable?** Say so and report INCONCLUSIVE, unless the
+change is purely additive — then the absence *is* the control, and it is
+capturable: the unrecognised flag, the 404, the compile error naming the missing
+export. Assert an absence and you have asserted, not verified.
+
+## 6. Drive the treatment
+
+Shortest route that puts the changed lines into execution. Then read your own
+plan back: if every step builds, typechecks, or runs a suite, you have planned a
+CI re-run. Replace one of them with something an observer at the surface could
+witness, or report BLOCKED.
+
+Go through the interface, never around it. Components passing in isolation says
+nothing about the joins, and joins are where this fails. Where users press a
+button, press the button.
+
+Stochastic surface — agents, concurrency, anything network-adjacent — is not
+settled by one run each. Fix inputs and scoring in advance, run the pair
+repeatedly, and report trials and rates ([reference/measurement.md](reference/measurement.md)).
+One fortunate control failure beside one fortunate treatment success is a fully
+compliant false PASS.
+
+**Prove you reached the changed code.** A control that fails and a treatment
+that passes is also consistent with two different environments, or a stale
+build, or a cache. Keep something that could only come from the new path: a log
+line it alone emits, a version string, an error only it raises. Without that
+receipt the pair is circumstantial.
+
+**Irreversible operations** — deleting, publishing, sending, writing outside the
+workspace — do not get driven live without a dry-run or a disposable target.
+Exercise what is safe, then name the path you left alone. A required destructive
+effect you never exercised is BLOCKED or INCONCLUSIVE, never PASS.
+
+## 7. Compare
+
+Set the two captures beside each other as artefacts — exit statuses, response
+bodies, screen dumps, images, trial series. Not as your recollection, which is
+not evidence.
+
+Numbers carry four figures: control, treatment, difference, and the threshold
+from §1. Two samples cannot distinguish a real effect from cache warming,
+thermal drift, or a noisy neighbour — if the difference does not clear the
+spread, it has not been shown. Declare the statistic and trial count before
+collecting, alternate which side runs first, and keep cold and warm trials
+apart: [reference/measurement.md](reference/measurement.md).
+
+Name the confounds you can think of — carried-over state, unrelated commits
+riding along in the treatment, an environment that shifted between captures —
+rather than waiting to be asked. Where the treatment contains changes beyond the
+one claimed, either isolate the target or say plainly that the verdict covers
+the whole branch.
+
+## 8. Probe the edges
+
+Confirming the claim is the first half. The claim is what the author already
+believed; your value is what they had not thought to check.
+
+You know exactly what moved, so push on what sits beside it, at the same surface:
+
+- **A new flag or option** — empty, doubled, contradicted, misspelt (does the
+  error name it?)
+- **A new route or handler** — wrong verb, malformed body, absent required
+  field, oversized payload
+- **A reworked error path** — the neighbouring errors it did *not* touch: did
+  the rework reach them, or only the one in the diff?
+- **Anything interactive** — interrupt mid-operation, resize, paste rubbish,
+  hammer a key, escape at the wrong moment
+- **Anything stateful** — twice in a row, on top of stale state, from two
+  sessions at once
+
+Choose what the change points at; this is not a list to exhaust. **At least one
+probe, and its result, always.** One that finds nothing still earns its line —
+recording that empty `--from` produces a clean `error: --from requires a value`
+and exit 2 tells the author what is now known to hold, which a bare PASS cannot.
+
+A probe that misbehaves gets re-run against the control before it can drive a
+FAIL. Identical misbehaviour on both sides is pre-existing, and pre-existing is a
+finding, not a regression.
+
+## Evidence discipline
+
+What was captured is evidence; what you remember is not. Something surprising
+appears — capture it, record it, and decide whether it belongs to the change or
+the environment. Breakage you did not cause is still a finding.
+
+Isolate shared state: private tmux socket, port 0, a fresh temporary directory.
+The host is not yours alone.
+
+Artefacts on disk are optional, one directory per claim, holding the claim, the
+two captures, and the verdict. Where they would contain credentials, personal
+data, prompts, or images of private material, keep the minimum inline and leave
+the rest unwritten unless the requester agrees.
+
+**Evidence has to arrive.** A path is evidence only to someone who can open it.
+Screen dumps and response bodies travel inside the report; a bare path works only
+where the reader shares your filesystem. On a remote surface with a file-sending
+tool available, send the images and say in the report what was sent.
+
+## Report
+
+Inline, in the final message:
+
+```text
+## Verification: <what changed, one line>
+**Verdict:** PASS | FAIL | INCONCLUSIVE | BLOCKED | SKIP
+**Claim:** <verbatim from §1>
+**Refuted if:** <verbatim from §1 — unchanged since>
+**Scope:** <base SHA>..<head SHA>, <n> commits, <clean|dirty tree>
+**Handle:** <verifier or run skill used, or cold start; what was launched>
+**Reached the changed code:** <the receipt — log line, version, unique error>
+
+### Control vs treatment
+| | Control (<ref>) | Treatment (<ref>) |
+|---|---|---|
+| <observable> | <artefact> | <artefact> |
+<numeric claims add difference + threshold + trial count>
+
+### Steps
+Things done to running software, and what came back. Building, installing and
+checking out are preparation, not steps.
+1. ✅/❌/⚠️/🔍 <what was done> → <what was observed>
+   <the software's own output>
+
+### Findings
+<What stood out. Bugs, and also friction, surprises, whatever a newcomer would
+stumble over. The bar is low: a pause while exercising the software earns a
+line. It has to be your pause, from running it — relaying a red check or
+someone else's comment is not an observation. Claim/diff disagreements,
+pre-existing breakage and environment notes belong here. Every probe gets a
+line, including the ones that held. Lead with ⚠️ where the reader should stop
+and look.>
+```
+
+🔍 marks a probe. **A report with no 🔍 cannot be PASS** — it is an incomplete
+verification, whatever the happy path showed.
+
+## Verdicts
+
+Decide on the evidence's standing, not on how confident you feel. In order:
+
+1. Treatment unreachable → **BLOCKED**
+2. Nothing observes the change → **SKIP**
+3. Either capture untrustworthy → **INCONCLUSIVE**
+4. Trustworthy captures meet the named contrast → **PASS**, else → **FAIL**
+
+- **PASS** — software exercised at its surface, trustworthy captures satisfy the
+  §5 contrast, the refutation condition did not occur, and at least one probe is
+  recorded.
+- **FAIL** — exercised, captures trusted, and the contrast is not met: wrong
+  direction, short of threshold, collateral breakage, or intent and diff
+  disagreeing about the very observable claimed.
+- **INCONCLUSIVE** — it ran, but the evidence cannot bear a verdict: no valid
+  control, noise larger than the difference, environments that drifted apart,
+  state carried between runs, a measurement that failed. **Name what would
+  settle it** — the access, data, trial count, or rerun that decides. Without
+  that sentence this is an abandoned verification wearing a verdict's clothes,
+  and it is the exit an agent takes when it would rather be finished.
+- **BLOCKED** — the treatment could not be reached at all: build broken,
+  dependency absent, nothing would start. Says nothing about the change. A
+  *control* you cannot obtain is INCONCLUSIVE (§5), not this. Do not claim it
+  before searching the skills beside the touched code, where the unlock usually
+  is. Say where it stopped.
+- **SKIP** — nothing observes the change. One line why.
+
+**Nothing partial passes, but partial does not automatically mean FAIL** — route
+it by the same ladder. Where several claims are in scope: any one of them validly
+falsified makes the whole thing FAIL. Where none was falsified but one was never
+measured, the aggregate is INCONCLUSIVE, or BLOCKED if that one's surface could
+not be reached at all — and name which claim is outstanding. Only an author
+placing a claim outside the scope removes it from the count.
+
+**Ambiguity never resolves upward into a PASS.** Sound captures falling short is
+FAIL, stated plainly. Unsound captures is INCONCLUSIVE with the settling step
+named. A shipped false PASS costs far more than another look — and downgrading a
+real defect to INCONCLUSIVE to avoid delivering the news is the same failure in
+the other direction.

--- a/.claude/skills/verify/reference/control.md
+++ b/.claude/skills/verify/reference/control.md
@@ -1,0 +1,112 @@
+# The control capture — obtaining one, and keeping it honest
+
+Loaded on demand from `SKILL.md` §5.
+
+## Acquiring the unchanged state
+
+Ranked by how little they disturb what you are measuring.
+
+**A second worktree at the base ref.** The default. Both states exist at once,
+each with its own build output, and your working tree is never touched.
+
+```bash
+ctl=$(mktemp -d)                       # unique per run
+git worktree add "$ctl" "$mb"          # $mb — the merge base §2 already resolved
+# build inside "$ctl" with its OWN install/build step, then capture
+git worktree remove --force "$ctl"     # when finished, before reporting
+```
+
+Three requirements, and the reasons they are not optional:
+
+- **Use `$mb` from §2, don't re-derive it.** §2 may have resolved the base through
+  a local ref or a targeted fetch; recomputing against `origin/<base>` here can
+  fail on a repository whose scope resolved perfectly well, blocking the control
+  capture for no reason. One resolution, one SHA, reused.
+- **A fresh directory per run, removed afterwards.** Git keeps worktrees
+  registered, so a fixed path makes a second or concurrent run fail there — and if
+  that failure goes unnoticed, the next command captures a stale control from an
+  earlier run. `git worktree list` shows what is still registered.
+- **Build separately in each.** A shared build directory or module cache hands the
+  control the treatment's artefacts. A shared build directory, a shared `node_modules`, or a
+shared compiler cache silently gives the control the treatment's artefacts, which
+is the failure mode most likely to manufacture a false PASS — the two runs agree
+because they were, in the part that matters, the same binary.
+
+**A behaviour flag.** Where the change sits behind one, flip it. Cheapest
+possible pair and it holds every other variable fixed. Confirm the flag actually
+gates the changed path rather than only its entry point.
+
+**An existing documented reproduction.** The issue's own steps. Note that these
+supply a *recipe*, not an artefact: unless you run them yourself, at a known
+revision, in your environment, you have inherited someone else's evidence. Run
+them.
+
+**`git stash`.** Available, and the one to be careful with: nothing about a
+verification reminds you to restore it. If you stash, restore before reporting —
+and prefer a worktree, which cannot leave the user's uncommitted work parked
+somewhere they did not put it.
+
+## Before you begin the treatment
+
+Four things recorded, or the comparison is not reproducible:
+
+1. the control's revision (a SHA, not "main")
+2. the exact invocation, identical to the one the treatment will get
+3. the initial state — seed, fixture, database snapshot, cache condition
+4. the raw artefact the control produced
+
+Only then start the treatment. Where you cannot hold all four, the honest
+destination is INCONCLUSIVE; discovering afterwards that the control was never
+captured properly is how a verification quietly becomes a demo.
+
+## State that carries between runs
+
+The confound this file exists for. Measuring the control can consume the very
+condition the treatment needs, and the resulting difference looks exactly like a
+working change:
+
+- **Counters and quotas** — rate limits, retry budgets, per-window allowances.
+  Exhaust the window measuring the control and the treatment's 429 is yours, not
+  the code's.
+- **One-shot transitions** — migrations, first-run setup, lazy initialisation,
+  "create if absent". The second run takes a different path by design.
+- **Caches at every level** — filesystem, DNS, HTTP, compiler, module resolution,
+  connection pools. A cold control against a warm treatment is a cache
+  measurement wearing a performance claim's clothes.
+- **Seeded data** — rows the control run wrote, consumed, or locked.
+- **Ambient conditions** — a background job, a laptop that thermally throttled
+  during the first run, a neighbour saturating the disk.
+
+Countermeasures: re-seed or restore between runs; separate worktrees and build
+outputs; alternate which side runs first, or randomise it, so any ordering effect
+shows up as noise instead of as your result; and where you cannot isolate a piece
+of state, say in the report which one and why.
+
+## The receipt
+
+A control that violates the claim beside a treatment that satisfies it is also
+consistent with: two different builds, two different environments, a stale
+artefact, or never having reached the changed lines at all.
+
+So keep something only the new path could have produced — a log line unique to
+it, a version string, an error only it raises, a marker you added and then
+removed. Cheap to obtain, and it converts a circumstantial pair into a causal
+one.
+
+## When there is genuinely no "before"
+
+For a purely additive change the absence *is* the control, and it is capturable
+rather than merely assertable:
+
+| Added | The control's artefact |
+|---|---|
+| A flag | the old binary rejecting it — unrecognised-option error, non-zero status |
+| A route | the old server's 404 |
+| An export | the old package failing to compile or import it, error naming the member |
+| A subcommand | the old entrypoint's usage message, which does not list it |
+
+Capture that. "It did not exist before" written as prose is an assertion; the
+error message proving it is evidence.
+
+Where the old state cannot even be built, say so and report INCONCLUSIVE. Never
+present a treatment-only run as a verification.

--- a/.claude/skills/verify/reference/measurement.md
+++ b/.claude/skills/verify/reference/measurement.md
@@ -1,0 +1,70 @@
+# Measuring things that vary
+
+Loaded on demand from `SKILL.md` §7, for two cases the single-run pattern cannot
+settle: performance claims, and any surface whose output differs between
+identical runs.
+
+## Performance
+
+Declare four things **before** collecting anything. Choosing them afterwards is
+how a measurement becomes a justification.
+
+1. **The metric** — wall clock to first byte, wall clock to exit, peak RSS,
+   allocations. Name the boundary precisely: "startup" is not a metric until you
+   say what event ends it.
+2. **The statistic** — median, p95, mean. Not "it looked faster." Tail claims
+   need tail statistics; a median improvement can hide a worse p99, and for
+   anything user-facing the tail is usually what was actually complained about.
+3. **The threshold** — the number from the claim, and what counts as clearing it.
+4. **How many trials, decided in advance.** Otherwise you stop when the numbers
+   look right, which guarantees they eventually will.
+
+Then collect:
+
+- **Separate cold from warm.** They are different claims. A cold-start number
+  needs the caches actually cold each trial — which usually means resetting
+  something between them, not just running the command again.
+- **Alternate or randomise the order.** Control-then-treatment ten times in a row
+  lets machine drift — thermal, background load, page cache filling — masquerade
+  as your effect.
+- **Keep every sample**, or a full summary with a spread. A pair of single
+  numbers cannot distinguish a real change from ordinary variance.
+- **Say what else was running.** A build in another window is a confound.
+
+**The decision rule:** if the difference does not clearly exceed the spread of
+the samples, it has not been demonstrated. Overlapping distributions are
+INCONCLUSIVE with the trial count named, never a PASS narrated as "slightly
+faster." Two samples per side is not a measurement; it is two anecdotes.
+
+## Non-deterministic behaviour
+
+Agents, concurrency, network calls, retry and timeout logic, anything seeded by
+time or randomness: one run per side proves nothing, because one lucky control
+failure beside one lucky treatment success satisfies every other rule in this
+skill while being pure noise.
+
+Fix in advance:
+
+- **The inputs** — the exact prompt, request sequence, or seed set. Reused
+  verbatim on both sides.
+- **The scoring rule** — what makes a single trial a success. Written down before
+  you see any output, so it cannot bend.
+- **The trial count**, matched across control and treatment.
+
+Then report **rates, not verdicts on individual runs**: "control 2/20, treatment
+19/20" is evidence; "it worked when I tried it" is not. Hold the model, the
+runtime, and the configuration fixed, and say which ones you could not hold.
+
+**A claim stated deterministically that only holds sometimes is FAIL,** not a
+qualified pass. "Always returns 429 after the eleventh request" is refuted by a
+twelfth request that succeeds once in twenty. If the true claim is statistical,
+the claim in §1 should have said so — and rewriting it after seeing the output is
+exactly what the pre-declared refutation condition exists to prevent.
+
+## Both at once
+
+Performance measured on a stochastic surface needs both disciplines: pre-declared
+statistic *and* pre-declared trial count, with the order alternated. This is
+where an under-powered comparison is most likely to look convincing, because
+there are two independent sources of variance and only one of them is visible in
+the numbers you chose to print.

--- a/.claude/skills/verify/reference/surfaces.md
+++ b/.claude/skills/verify/reference/surfaces.md
@@ -1,0 +1,170 @@
+# Surfaces — how to reach one and what to keep
+
+Loaded on demand from `SKILL.md` §3. Find your row, drive it, keep the artefact
+named under "Capture". Everything here assumes you already have the software
+running (see `SKILL.md` §4 — that is `/run`'s job, not this file's).
+
+## Terminal — CLI
+
+Run the real entrypoint as a user would, not `node ./src/thing.js`.
+
+```bash
+<entrypoint> <the subcommand the diff touches> ; echo "exit=$?"
+```
+
+**Capture:** the full stdout/stderr *and* the exit status. A status alone hides
+the message; a message alone hides whether the shell saw failure. Both, always —
+"exits non-zero and says why" is two observables.
+
+Note stderr and stdout separately when the claim concerns one of them
+(`2>/dev/null` to prove a message went to stderr rather than stdout).
+
+## Terminal — TUI / interactive
+
+Drive it inside a private tmux server so you never touch the host's sessions.
+
+```bash
+sk="verify-$$"                                    # socket + session unique to this run
+tmux -L "$sk" new-session -d -s "$sk" -x 120 -y 40 '<entrypoint>'
+
+ready=""
+for _ in $(seq 60); do                            # ~30s ceiling
+  tmux -L "$sk" has-session -t "$sk" 2>/dev/null || break
+  tmux -L "$sk" capture-pane -p -t "$sk" | grep -q '<the ready marker>' && { ready=1; break; }
+  sleep 0.5
+done
+
+tmux -L "$sk" capture-pane -p -t "$sk" 2>/dev/null   # capture either way
+[ -n "$ready" ] && tmux -L "$sk" send-keys -t "$sk" '<the navigation>' && sleep 0.5 \
+  && tmux -L "$sk" capture-pane -p -t "$sk"
+tmux -L "$sk" kill-session -t "$sk" 2>/dev/null      # this run's session only
+```
+
+Four requirements. Adapt the shape freely; these are what make it trustworthy:
+
+- **A socket and session name unique per run.** A fixed pair collides with a
+  concurrent verification or a stale session from an interrupted one, and then
+  `new-session` fails while the following commands happily capture *someone else's*
+  session — evidence for the wrong software.
+- **`kill-session`, never `kill-server`.** On a shared socket, `kill-server` ends
+  every session on it, including another verification's.
+- **Bound the wait, and check the process is alive.** A program that dies at
+  startup otherwise leaves you looping instead of reporting BLOCKED. Both are real
+  outcomes; only one is a hang.
+- **Capture the pane on the failure path too.** What it printed before dying is
+  the most useful evidence available, and never becoming ready is a BLOCKED verdict
+  that still needs evidence attached.
+
+Poll for a ready marker rather than sleeping a fixed interval, and say which string
+means ready. Fix the geometry with `-x`/`-y`; some interfaces hide
+content at narrow widths, and a capture that differs between control and
+treatment only because the pane was a different size is a confound, not a
+finding.
+
+**Capture:** the pane dump. `-e` keeps escape sequences when colour is the
+claim; `-J` rejoins wrapped lines when the wrap is getting in the way.
+
+## Socket — server / API
+
+Launch in the background, wait for the port rather than for a duration, then hit
+the specific route the diff touches.
+
+```bash
+<launch> &
+pid=$!
+
+up=""
+for _ in $(seq 60); do                                   # ~30s ceiling
+  kill -0 "$pid" 2>/dev/null || { echo "server exited before listening"; break; }
+  curl -sf -o /dev/null "http://127.0.0.1:<port>/<health>" && { up=1; break; }
+  sleep 0.5
+done
+
+if [ -z "$up" ]; then
+  # Kill BEFORE waiting: a server that is alive but never healthy would make a
+  # bare `wait` block forever, defeating the ceiling above.
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  echo "never came up — BLOCKED; the launch output is the evidence"
+else
+  curl -sS -D - -o body.txt "http://127.0.0.1:<port>/<the changed route>"
+  kill "$pid" 2>/dev/null
+fi
+```
+
+Same requirements as the TUI loop, plus one specific to a backgrounded process:
+**kill before `wait`.** An unbounded `until curl ...` never returns against a server
+that crashed at startup, and a bare `wait` never returns against one that is alive
+but permanently unhealthy — both convert a legitimate BLOCKED into a stalled
+session. Bind to a per-run port too (or port 0 and read back what was assigned):
+a fixed port collides with a concurrent run, and you may end up measuring its
+server rather than yours.
+
+Bind port 0 (or a per-run port) when anything else on the host might be
+listening; two runs racing for one port is a confound that looks like flakiness.
+
+**Capture:** status line, the headers that carry the claim, and the body. A
+claim about `Retry-After` is not evidenced by a status code, and "returns 429"
+is not evidenced by a body that happens to mention rate limits.
+
+## Pixels — GUI / web
+
+Drive headless, then **open the screenshot and look at it.** An all-white frame
+is a failed launch that a passing script will happily report as success, and no
+amount of exit-status checking catches it.
+
+Read the rendered text too, not only the image — an accessibility snapshot or a
+text extraction proves the content is present rather than merely that pixels
+were drawn.
+
+**Capture:** the image, plus whatever text you extracted. Both control and
+treatment at the same viewport.
+
+## Package boundary — library / SDK
+
+Consume the built, packaged artefact the way an outside caller would: import the
+public entry, never a deep path into the source tree. Where the packaging step
+itself can drop an export, install the packed tarball into a scratch directory
+and import from there — that catches an export missing from the manifest, which
+importing from the working tree cannot.
+
+**Capture:** the sample program and its output, verbatim.
+
+## Compiler — build-time API
+
+A public type with no runtime emission still has a real surface: the compiler,
+as experienced by a consumer outside the package. Write the smallest external
+consumer that exercises the changed declaration, and compile it against the
+*shipped* declarations in both states.
+
+**Capture:** the compiler's own diagnostics. Control failing to compile with an
+error naming the missing member, and treatment compiling clean, is a proper
+control/treatment pair.
+
+## The agent — prompt, role spec, gate spec
+
+The surface is the agent's behaviour, not the text you edited. Run it on an
+input that reaches the changed instruction and record what it did.
+
+Where the change is meant to *stop* something, the observable is the refusal
+under the condition that should trigger it — and the corresponding
+non-interference when it should not. Both halves: a gate that blocks everything
+satisfies its own claim while being useless.
+
+**Capture:** the transcript, or the artefact the agent produced. Where a
+decision is logged, the log line.
+
+## The runner — CI workflow
+
+Trigger the event the change actually concerns. A manual dispatch does not
+reproduce push, pull-request, or scheduled semantics, nor their permissions and
+payloads, and by default it targets the repository's default branch — so a
+dispatch can silently exercise a different version of the workflow than the one
+you changed.
+
+Pass the ref explicitly, then confirm the run's head SHA before you believe it.
+Where the real event cannot be reproduced before merge, that is BLOCKED or
+INCONCLUSIVE — not an excuse to grade the default branch's CI and call it
+verified.
+
+**Capture:** the run's identity (SHA, event, workflow file version) plus the log
+region that shows the changed behaviour.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ renaming a repo-owned skill, update this table in the same change.
 | `/teach` | Teach a skill or concept over multiple sessions (stateful teaching workspace) |
 | `/update-skills` | Update installed skill branches from upstream |
 | `/use-local-whisper` | Switch voice transcription to local whisper.cpp |
+| `/verify` | Prove or disprove that a change works by exercising it at its real surface and comparing a control capture against a treatment capture |
 | `/wardens` | View, toggle, and configure warden quality gates |
 | `/wayfinder` | Chart a large effort as decision tickets on the issue tracker; resolve them one at a time |
 | `/writing-great-skills` | Reference for authoring predictable skills — leading words, progressive disclosure |

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-15" # auto-bump @1786825669
+last_verified: "2026-08-17" # auto-bump @1786964244
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
## What

Adds `.claude/skills/verify/` — a model-invocable skill that proves or disproves that a change does what it claims — plus its `AGENTS.md` registry row.

## Why

A verification needs two legs, and each predecessor had exactly one.

| Predecessor | Had | Lacked |
|---|---|---|
| Claude Code's bundled `/verify` | drives the software at its real surface | **no control** — a PASS cannot separate "the change caused this" from "it was already so" |
| third-party `verify-this` | falsifiable claim, control vs treatment | **agnostic about where** — accepted unit-test evidence about code nobody runs |

Both are now mandatory. An unobtainable control downgrades the verdict to INCONCLUSIVE rather than being silently dropped.

## What the protocol adds beyond either

- **A refutation condition fixed before measuring**, quoted verbatim in the report, so the bar cannot drift to wherever the output happened to land.
- **A contrast table.** Old-breaks/new-works is one shape of six: refactors claim equivalence within a margin, reliability fixes compare failure *rates*, performance compares distributions on a named statistic, defence-in-depth needs an injected fault, compatibility expansion needs both halves. The previous single rule rejected correct work in five of those six cases.
- **A receipt that the changed code executed.** Control-fails/treatment-passes is also consistent with a stale build, a warm cache, or two different environments.
- **Verdicts decided on evidence standing**, via an ordered ladder — and INCONCLUSIVE must name what would settle it, otherwise it is the exit an agent takes when it would rather be finished.
- **State that leaks between runs, named explicitly.** Consume a rate-limit counter while measuring the control and the treatment's 429 is your own doing, not the fix's.

## Structure

Progressive disclosure, following the bundled `/verify` and `/run`, which both ship reference files rather than inlining them:

```
verify/
├── SKILL.md              protocol — always loaded (~360 lines, under the 500-line ceiling)
├── PROVENANCE.md         derivation; never linked from SKILL.md, so never loaded
└── reference/
    ├── surfaces.md       per-surface driving mechanics + what counts as a capture
    ├── control.md        control acquisition, leaking state, the receipt
    └── measurement.md    performance + non-deterministic methodology
```

You are on one surface of seven, so six of those sections would be dead weight in context. **Probes stay inline deliberately** — every run probes, and it is the step most likely to be skipped. Launching the software is delegated to the bundled `/run` (which *is* model-invocable) rather than reimplemented.

No `scripts/` directory: `.gitignore:132` excludes skill scripts by design, and a user-scope skill must not depend on a file that exists in only one repository. The scope logic is inlined instead.

## Licensing — measured, not assumed

`~/deus` is public, so the text must not be derivative of either predecessor's expression. Measured by n-gram overlap:

| vs bundled `/verify` | 12-gram | 10-gram | 8-gram | 6-gram |
|---|---|---|---|---|
| first draft | 181 | 248 | 348 | 489 |
| after clean-room rewrite | **0** | **0** | **0** | 4 |

| vs `verify-this` | 12-gram | 8-gram | 6-gram |
|---|---|---|---|
| | **0** | **0** | **0** |

The first draft was genuinely unpublishable. `verify-this` was never a constraint — zero shared 8-grams means this took its method and none of its words, and method is not ownable. The four surviving 6-grams are generic technical English.

**Structural similarity answered too**, not just word sequences: the two skills share part of a skeleton (scope → surface → handle → drive → capture → report → verdict), which is the functional order of the task — you cannot drive software before you can run it. The steps carrying this skill's thesis are additions. Recorded in `PROVENANCE.md` rather than left implied.

## Verification

Every executable path was driven against real repositories and processes, and **driving it found three defects that reading had missed**:

1. A pipeline's exit status masking a failed base resolution (`base=$(git … | sed …)` reports success when `git` failed), leaving the base empty.
2. A known base silently substituted by a trunk — a PR targeting `release` would have been compared against `main` whenever `release` wasn't fetched.
3. A `wait` that blocked forever against a server that was alive but permanently unhealthy, defeating the readiness ceiling.

States exercised:

| Path | Result |
|---|---|
| base: remote present / no remote / known-present / unnamed | resolves correctly |
| base: trunk named neither `main` nor `master` | **STOP**, not "0 commits" |
| base: known but not fetched | **STOP**, not silent `main` fallback |
| control worktree: create → capture → remove, then repeat | clean, no leftover registration |
| readiness: program dies at startup | terminates **0s**, reports BLOCKED |
| readiness: alive but never healthy | terminates at ceiling (**3s**, not 300s) |
| tmux: two concurrent runs | no cross-talk; each captured only its own output |
| tmux: bystander session during cleanup | survives (`kill-session`, not `kill-server`) |

## Gates

| Gate | claude | gpt | Rounds |
|---|---|---|---|
| plan-reviewer | SHIP | SHIP | 2 |
| code-reviewer | SHIP | SHIP | 5 |
| ai-eng-warden | SHIP | SHIP | 1 |
| verification-gate | SHIP | — | 1 |

Findings narrowed monotonically across the code-review rounds: licence and sequencing → self-contradictions → shell edge cases → **regressions introduced by the previous round's fixes** → concurrency isolation. Two rounds caught defects created while fixing the round before, which is the case for not self-certifying. Round 5 hit the round-count circuit breaker, so the recipes were re-scoped — normative requirements as prose, shell as adaptable illustration — retiring the recurring defect class rather than patching instance six.

## Follow-up, deliberately not in this PR

`context: fork` (with `background: false`, `effort: high`) would run the skill in a context separate from the work under review — the verdict is otherwise produced by the same agent that did the work and wants to be finished. The fields exist in the current CLI build, but this changes the execution model and has not been exercised on a real change. Shipping an unverified execution-model change is what this skill exists to refuse. Recorded in `PROVENANCE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
