### PR TITLE
fix(setup): stop the skills step deleting the repo's own skill files

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -244,19 +244,42 @@ skills = ['compress', 'resume', 'checkpoint', 'preserve', 'preferences', 'projec
 failed = []
 
 for skill in skills:
-    src = src_base / skill / 'skill.md'
+    src_dir = src_base / skill
+    src = src_dir / 'skill.md'
+    if not src.is_file():
+        failed.append(f'{skill} (no skill.md in repo)')
+        continue
+
     dest_dir = dest_base / skill
-    dest = dest_dir / 'skill.md'
+
+    # deus (deus-cmd.sh _ensure_portable_skills) installs these as DIRECTORY
+    # symlinks into the repo. A file written inside such a link resolves to the
+    # repo's own tracked source, so unlinking it would DELETE that source and
+    # leave a link to nothing. Settle the link itself; never descend into it.
+    if dest_dir.is_symlink():
+        if dest_dir.resolve() == src_dir.resolve():
+            print(f'  ✓ {skill} (already linked)')
+            continue
+        dest_dir.unlink()   # wrong target or dangling: replace the LINK, not its contents
+
     dest_dir.mkdir(parents=True, exist_ok=True)
+    if dest_dir.is_symlink():   # rechecked next to the write, not just at loop top
+        failed.append(f'{skill} (destination is a symlink; refusing to write through it)')
+        continue
+
+    dest = dest_dir / 'skill.md'
     if dest.exists() or dest.is_symlink():
         dest.unlink()
     try:
         dest.symlink_to(src.resolve())
         print(f'  ✓ {skill} (symlink)')
     except OSError:
-        # Windows without Developer Mode — fall back to copy
-        shutil.copy2(src, dest)
-        print(f'  ✓ {skill} (copied — re-run setup after repo updates)')
+        try:
+            # Windows without Developer Mode — fall back to copy
+            shutil.copy2(src, dest)
+            print(f'  ✓ {skill} (copied — re-run setup after repo updates)')
+        except OSError as e:
+            failed.append(f'{skill} ({e})')
 
 if failed:
     print(f'  ✗ failed: {failed}', file=sys.stderr)
@@ -268,6 +291,12 @@ if failed:
 - **Windows (Developer Mode on):** creates symlinks
 - **Windows (Developer Mode off):** falls back to file copy — user must re-run setup after updating the repo
 - Idempotent — safe to re-run anytime
+- **Already dir-symlinked by `deus`?** Reported as `already linked` and left alone.
+  `deus-cmd.sh`'s `_ensure_portable_skills` points `~/.claude/skills/<skill>` at the
+  repo directory itself, so anything written *inside* that path lands on the repo's
+  own tracked file. The step detects this and performs no writes rather than
+  deleting the source it was meant to link to.
+- A skill that fails is reported and skipped; the rest still install.
 
 **If any skill fails:** warn the user and continue — the other skills still install. The commands at `.claude/commands/` (home-mode-only) remain as fallback.
 

--- a/patterns/skill-add.md
+++ b/patterns/skill-add.md
@@ -1,7 +1,7 @@
 ---
 governs:
   - .claude/skills
-last_verified: "2026-08-17" # auto-bump @1786964244
+last_verified: "2026-08-17" # auto-bump @1786967253
 test_tasks:
   - "Create a new skill under .claude/skills/ that fetches recent Gmail threads"
   - "Add a new skill SKILL.md that documents log rotation steps"


### PR DESCRIPTION
Closes LIA-589.

## The bug

`/setup`'s skills step **deleted the repo's own tracked skill files**, then left each skill dead — symlinked to a path that no longer existed. It printed `✓ <skill> (symlink)` for every one and exited 0.

`deus` installs these as **directory** symlinks into the repo (`deus-cmd.sh` `_ensure_portable_skills`, 15 `PORTABLE_SKILLS`), which is the steady state on any machine that has run `deus`:

```
~/.claude/skills/compress -> ~/deus/.claude/skills/compress
```

The installer assumed a real directory and wrote a file inside it:

```python
dest_dir = dest_base / skill          # a SYMLINK to the repo dir
dest     = dest_dir / 'skill.md'      # resolves THROUGH it to the repo's own file
if dest.exists() or dest.is_symlink():
    dest.unlink()                     # deletes the tracked source
dest.symlink_to(src.resolve())        # src was that same file -> broken link
```

Recoverable with `git checkout`, but silent. All 7 skills the step manages.

## The fix

Settle the **link itself** before touching anything inside it, so writing through a directory symlink is unreachable rather than merely discouraged:

- link already pointing at the correct source → `already linked`, **no writes at all** (the steady state)
- link pointing elsewhere, or dangling → `unlink()` the *link* and install fresh
- symlink check repeated adjacent to the write, not only at loop top

Unlinking a symlink never touches its target, so removing the descent removes the only unsafe unlink — and covers a dangling link by construction, which is why the original `exists() or is_symlink()` OR-clause was there.

## Two further defects in the same block

Both contradicted the step's own documented promise ("warn the user and continue — the other skills still install"):

1. **`failed` was never appended to** — initialised, tested, nothing in between. The `✗ failed:` report and `sys.exit(1)` could never fire.
2. **`shutil.copy2` had no handler of its own**, sitting inside `except OSError`, so a failing Windows fallback propagated and aborted every remaining skill.

## Verification — red/green against the shipped block

The test **extracts the installer from this file** rather than a retyped copy, so it exercises what ships.

**Control** (original code, state = pre-existing correct directory symlink):

```
stdout: OK compress (symlink)
rc: 0
repo source still exists: False
CONTROL RESULT: SOURCE DESTROYED
```

**Treatment** — 8/8 states, repo source bytes unchanged in every one:

| # | State | Expected | Result |
|---|---|---|---|
| 1 | dir symlink already correct | `already linked`, no writes | ✓ |
| 2 | dir symlink wrong target | link replaced | ✓ |
| 3 | dir symlink **dangling** | link replaced | ✓ |
| 4 | real dir, empty | symlink created | ✓ |
| 5 | real dir, stale file symlink | replaced | ✓ |
| 6 | repeat over state 1 | idempotent, no writes | ✓ |
| 7 | source missing | in `failed`, rc=1, others processed | ✓ |
| 8 | destination unwritable | in `failed`, rc=1, others processed | ✓ |

Assertions are two-sided — a repo-side check alone cannot see a destination-side break: source `sha256` unchanged, plus `dest.is_symlink()` and `dest.resolve() == src.resolve()`, with directory contents listed via `os.listdir` because `Path.exists()` is fooled by case-insensitive lookup on APFS.

State 1 is the discriminating test: it is the only state that reproduces the bug, and it cannot be reached from an empty `HOME` — which is why this survived.

## Deliberately not here

**No filename or casing change.** An earlier draft canonicalised the destination to `SKILL.md`; review identified a hazard in that, and it was removed rather than guarded. On case-insensitive APFS `SKILL.md` and `skill.md` are **one directory entry**, so a stale-sibling cleanup ordered after the write deletes the symlink just created, and an un-removed old-case entry makes `symlink_to` raise `FileExistsError` — an `OSError` subclass the existing handler would mislabel as "Windows without Developer Mode", permanently downgrading that skill to a copy.

LIA-591 step 4 already owns casing, edits this same block, and now records that hazard as an explicit constraint. Confirmed non-circular: LIA-591 is blocked on this issue; this issue does not depend on it.

Also unchanged: `deus-cmd.sh` (its layout is what is being made safe), the skill list, and `setup/SKILL.md:272`'s fallback sentence (LIA-591's business). Reconciling the two installers' differing lists (15 vs 7) and layouts remains a follow-up.

## Gates

| Gate | claude | gpt | Rounds |
|---|---|---|---|
| plan-reviewer | SHIP | SHIP | 2 |
| code-reviewer | SHIP | SHIP | 1 |
| verification-gate | SHIP | — | 1 |

Round 1 of plan review caught that the fix as drafted carried the casing hazard above, and that the verification matrix asserted only repo-source integrity while three of its states claimed destination outcomes — a destination-side bug would have passed every check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
