### PR TITLE
fix(ci): pin npm 11.6.2 so test-agent-runner can pass at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,13 +262,37 @@ jobs:
         if: steps.filter.outputs.agent-runner == 'true'
         with:
           node-version: 20
-      - name: Test agent-runner
+      # node 20 ships npm 10.8.2, and the whole npm 10.x line crashes with
+      # "Cannot read properties of null (reading 'edgesOut')" on the
+      # `npm install --no-save` step below. Reproduced against main's OWN
+      # agent-runner lockfile (no PR content involved) on 10.8.2, 10.9.4 and
+      # 10.9.7; 11.x is unaffected. npm 11 supports node 20 (engines:
+      # ^20.17.0 || >=22.9.0), so this pins the fix without moving node.
+      # Pinned exactly, not `npm@11`: the npm 10 bug survived three patch
+      # releases before anyone caught it, so bump this deliberately. See #1228.
+      - name: Pin npm 11.6.2 (node 20's bundled npm 10.x crashes on --no-save)
+        if: steps.filter.outputs.agent-runner == 'true'
+        run: npm i -g npm@11.6.2
+
+      # The next three steps were previously one step holding all three
+      # commands. The log's group header is derived from the run script's first
+      # line (the real job logged `##[group]Run npm ci`), so the crash below
+      # appeared under a group reading "npm ci" and was misread as a corrupt
+      # lockfile for two weeks. Split so each command logs under its own name.
+      - name: Install agent-runner dependencies
         if: steps.filter.outputs.agent-runner == 'true'
         working-directory: container/agent-runner
-        run: |
-          npm ci
-          # vitest isn't a declared dep (the container Dockerfile installs devDeps
-          # into the runtime image), so declaring it would bloat the agent image.
-          # Install ephemerally, pinned to the root's version (see root package-lock).
-          npm install --no-save vitest@4.1.8
-          npx vitest run
+        run: npm ci
+
+      # vitest isn't a declared dep (the container Dockerfile installs devDeps
+      # into the runtime image), so declaring it would bloat the agent image.
+      # Install ephemerally, pinned to the root's version (see root package-lock).
+      - name: Install vitest (ephemeral, not saved)
+        if: steps.filter.outputs.agent-runner == 'true'
+        working-directory: container/agent-runner
+        run: npm install --no-save vitest@4.1.8
+
+      - name: Run agent-runner tests
+        if: steps.filter.outputs.agent-runner == 'true'
+        working-directory: container/agent-runner
+        run: npx vitest run


### PR DESCRIPTION
Fixes the required `test-agent-runner` check, which has been **red by construction** since 4 August — it cannot pass for any change under `container/agent-runner/`. It currently blocks four dependabot PRs that between them clear every open `npm audit` advisory in the agent runner: #1120 and #1126 (high), #1147 and #1175 (moderate).

## `npm ci` was never the problem

The old step was named `Test agent-runner` but ran three commands in one `run:` block. In the real failing job (run 32024278032, job 95370251513) `npm ci` **succeeds** — `added 103 packages, and audited 104 packages in 3s`. The `Cannot read properties of null (reading 'edgesOut')` crash comes from the next command, `npm install --no-save vitest@4.1.8`.

The log's group header is taken from the run script's first line — the real job logged `##[group]Run npm ci` — so the failure was displayed under a heading reading `npm ci` and was read as a corrupt dependabot lockfile for two weeks. It isn't one.

## Root cause: the npm 10.x line

Reproduced against `main`'s **own** agent-runner lockfile, with no PR content involved:

| npm | `npm ci` | `npm install --no-save vitest@4.1.8` |
|---|---|---|
| 10.8.2 (bundled with node 20) | OK | **crash** |
| 10.9.4 | OK | **crash** |
| 10.9.7 | OK | **crash** |
| 11.6.2 | OK | passes |

The job pins `node-version: 20`, which ships npm 10.8.2 — hence the permanent red. It reads as intermittent only because the job is path-filtered, so it is skipped on nearly every PR and runs only on the ones it then blocks.

## Verification

A controlled A/B inside a `node:20` container, i.e. the exact node/npm the runner uses:

```
control   (node v20.20.2, npm 10.8.2):
  npm ci                              -> added 103 packages, audited 104 in 9s
  npm install --no-save vitest@4.1.8  -> npm error Cannot read properties of null (reading 'edgesOut')
                                         ^ byte-identical to the real CI log

treatment (node v20.20.2, npm 11.6.2):
  npm ci                              -> OK
  npm install --no-save vitest@4.1.8  -> OK
  npx vitest run                      -> Test Files 24 passed (24) / Tests 250 passed (250)
```

`npm view npm@11.6.2 engines` → `{ node: '^20.17.0 || >=22.9.0' }`, satisfied by the runner's node 20.20.2 — so npm 11 runs on node 20 and the node version does not need to move.

## The change

- Adds a `npm i -g npm@11.6.2` step. **Exact pin, not floating `npm@11`** — the npm 10 regression survived three patch releases before anyone caught it, so a floating major re-exposes the same misdiagnosable failure mode.
- Splits the single `run:` block into three named steps (deps / vitest / test run) so a future failure logs under the command that actually failed. The required check context is job-level (`test-agent-runner`), confirmed against branch protection, so splitting steps does not affect it.

## Note on this PR's own CI

`test-agent-runner` will be **skipped** here — the path filter requires `container/agent-runner/**` to change and this PR touches only the workflow. That is structural to a path-filtered job. The live exercise is the four blocked PRs: each gets `gh pr update-branch` after this merges (required anyway under strict branch protection, and it creates a new head commit that triggers a fresh run against the corrected workflow), and their **new** check conclusion is what gets confirmed before they merge.

Rollback is `git revert` — single file, single job, no state.

Closes #1228
