### PR TITLE
fix(whatsapp): actually reconnect after a retriable close so pairing can complete

### DIFF
--- a/scripts/tests/whatsapp-auth-reconnect.test.ts
+++ b/scripts/tests/whatsapp-auth-reconnect.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for #1162 — whatsapp-auth never reconnected after a
+ * retriable close, so pairing-code auth could never succeed.
+ *
+ * These assert the BEHAVIOUR that was broken (a retriable close tears down and
+ * actually invokes a reconnect, and stays bounded), not merely that the reason
+ * is classified as retriable — classification alone would pass on the buggy
+ * code too and prove nothing.
+ *
+ * Reason 515 ("restart required") always follows a successful pairing, which is
+ * why it is the case that matters most here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createConnectionUpdateHandler } from '../whatsapp-auth.js';
+
+/** Build a `connection.update` payload for a close with the given status code. */
+function close(statusCode: number) {
+  return {
+    connection: 'close',
+    lastDisconnect: { error: { output: { statusCode } } },
+  };
+}
+
+function makeDeps(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    reconnect: vi.fn(),
+    teardown: vi.fn(),
+    fail: vi.fn(),
+    succeed: vi.fn(),
+    ...overrides,
+  } as {
+    reconnect: ReturnType<typeof vi.fn>;
+    teardown: ReturnType<typeof vi.fn>;
+    fail: ReturnType<typeof vi.fn>;
+    succeed: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('whatsapp-auth reconnect (#1162)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('reconnects after a 515 restart-required close', () => {
+    const deps = makeDeps();
+    const handler = createConnectionUpdateHandler({
+      ...deps,
+      maxRetries: 3,
+      retryState: { count: 0 },
+    });
+
+    handler(close(515));
+
+    // The defect: on the unfixed code nothing ever called reconnect().
+    expect(deps.reconnect).toHaveBeenCalledTimes(1);
+    expect(deps.fail).not.toHaveBeenCalled();
+  });
+
+  it('tears the dead socket down before reconnecting', () => {
+    const order: string[] = [];
+    const deps = makeDeps({
+      teardown: vi.fn(() => order.push('teardown')),
+      reconnect: vi.fn(() => order.push('reconnect')),
+    });
+    const handler = createConnectionUpdateHandler({
+      ...deps,
+      maxRetries: 3,
+      retryState: { count: 0 },
+    });
+
+    handler(close(515));
+
+    // Listener accumulation across attempts is the #305 failure mode.
+    expect(order).toEqual(['teardown', 'reconnect']);
+  });
+
+  it('stays bounded: stops reconnecting once retries are exhausted', () => {
+    const deps = makeDeps();
+    // ONE shared retry state across attempts — this is what production does, and
+    // it is the reason the counter cannot live inside the handler: each reconnect
+    // builds a fresh socket and a fresh handler.
+    const retryState = { count: 0 };
+    const attempt = () =>
+      createConnectionUpdateHandler({ ...deps, maxRetries: 3, retryState });
+
+    attempt()(close(515));
+    attempt()(close(515));
+    attempt()(close(515));
+
+    expect(deps.fail).toHaveBeenCalledTimes(1);
+    expect(deps.fail.mock.calls[0][0]).toContain('retries exhausted');
+    // Bound preserved: the third close failed instead of reconnecting again.
+    expect(deps.reconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('never reconnects on a logged-out close', () => {
+    const deps = makeDeps();
+    const handler = createConnectionUpdateHandler({
+      ...deps,
+      maxRetries: 3,
+      retryState: { count: 0 },
+    });
+
+    handler(close(401));
+
+    expect(deps.reconnect).not.toHaveBeenCalled();
+    expect(deps.fail).toHaveBeenCalledTimes(1);
+    expect(deps.fail.mock.calls[0][0]).toContain('logged_out');
+  });
+
+  it('never reconnects on a 405 rejection', () => {
+    const deps = makeDeps();
+    const handler = createConnectionUpdateHandler({
+      ...deps,
+      maxRetries: 3,
+      retryState: { count: 0 },
+    });
+
+    handler(close(405));
+
+    expect(deps.reconnect).not.toHaveBeenCalled();
+    expect(deps.fail).toHaveBeenCalledTimes(1);
+    expect(deps.fail.mock.calls[0][0]).toContain('405');
+  });
+
+  it('single-flights overlapping close events', () => {
+    const deps = makeDeps();
+    const handler = createConnectionUpdateHandler({ ...deps, maxRetries: 10 });
+
+    handler(close(515));
+    handler(close(515));
+    handler(close(515));
+
+    // One handler instance == one socket == at most one scheduled reconnect.
+    expect(deps.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports success on an open connection', () => {
+    const deps = makeDeps();
+    const handler = createConnectionUpdateHandler({
+      ...deps,
+      maxRetries: 3,
+      retryState: { count: 0 },
+    });
+
+    handler({ connection: 'open' });
+
+    expect(deps.succeed).toHaveBeenCalledTimes(1);
+    expect(deps.fail).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/whatsapp-auth.ts
+++ b/scripts/whatsapp-auth.ts
@@ -38,7 +38,114 @@ if (usePairingCode && !phone) {
 }
 
 const MAX_RETRIES = 3;
-let retryCount = 0;
+
+/** Delay before a reconnect attempt. Short and fixed, not exponential: a human is
+ *  waiting to enter a pairing code within its validity window. The daemon's
+ *  ReconnectController (packages/mcp-whatsapp) is deliberately NOT reused here —
+ *  its 60s cap and stability timer are tuned for a long-lived socket, not a
+ *  bounded interactive tool. */
+const RECONNECT_DELAY_MS = 2000;
+
+/** Reason 515 is "restart required" and ALWAYS follows a successful pairing, so
+ *  this is the one disconnect that must reconnect rather than terminate. */
+const RESTART_REQUIRED = 515;
+
+type ConnectionUpdateLike = {
+  connection?: string;
+  lastDisconnect?: { error?: unknown } | undefined;
+  qr?: string;
+};
+
+/** Retry bookkeeping shared across reconnect attempts.
+ *
+ *  Must live OUTSIDE the handler: each reconnect builds a fresh socket and a
+ *  fresh handler, so a per-handler counter would reset every attempt and the
+ *  MAX_RETRIES bound would never be reached. Injectable so tests get isolation
+ *  instead of sharing one module-global counter across cases. */
+export interface RetryState {
+  count: number;
+}
+
+const sharedRetryState: RetryState = { count: 0 };
+
+export interface ConnectionHandlerDeps {
+  /** Re-run the connect flow. The defect this fixes was that nothing called it. */
+  reconnect: () => void;
+  /** Drop the dead socket's listeners before reconnecting (avoids the
+   *  MaxListenersExceeded accumulation documented in #305). */
+  teardown: () => void;
+  /** Terminal failure. Production exits 1. */
+  fail: (message: string) => void;
+  /** Terminal success. */
+  succeed: (userId: string | undefined) => void;
+  /** Handle a QR frame (render, or request a pairing code). */
+  onQr?: (qr: string) => void;
+  maxRetries?: number;
+  /** Defaults to the process-wide counter; tests pass their own. */
+  retryState?: RetryState;
+}
+
+/**
+ * Build the `connection.update` handler with its side effects injected.
+ *
+ * Extracted so the reconnect behaviour is assertable without a live socket:
+ * the production wiring passes real effects, tests pass fakes and check that a
+ * retriable close actually tears down and reconnects, and that it stays bounded.
+ */
+export function createConnectionUpdateHandler(deps: ConnectionHandlerDeps) {
+  const maxRetries = deps.maxRetries ?? MAX_RETRIES;
+  const retries = deps.retryState ?? sharedRetryState;
+  let reconnecting = false; // single-flight: overlapping closes must not stack
+
+  return function handleConnectionUpdate(update: ConnectionUpdateLike): void {
+    const { connection, lastDisconnect, qr } = update;
+
+    if (qr && deps.onQr) deps.onQr(qr);
+
+    if (connection === 'close') {
+      const reason = (
+        lastDisconnect?.error as { output?: { statusCode?: number } }
+      )?.output?.statusCode;
+
+      if (reason === DisconnectReason.loggedOut) {
+        deps.fail('AUTH_STATUS: failed (logged_out)');
+        return;
+      }
+      if (reason === 405) {
+        deps.fail(
+          `AUTH_STATUS: failed (error ${reason} — WhatsApp rejected the connection)\n` +
+            'This usually means the baileys protocol version is outdated.\n' +
+            'Try: rm -rf store/auth/ and re-run authentication.',
+        );
+        return;
+      }
+
+      if (reconnecting) return; // a reconnect is already scheduled for this socket
+      retries.count++;
+      if (retries.count >= maxRetries) {
+        deps.fail(
+          `AUTH_STATUS: failed (${retries.count} retries exhausted, last reason: ${reason})`,
+        );
+        return;
+      }
+
+      reconnecting = true;
+      console.error(
+        `Connection closed (reason: ${reason}${
+          reason === RESTART_REQUIRED ? ' — restart required after pairing' : ''
+        }), retrying (${retries.count}/${maxRetries})...`,
+      );
+      // The bug: main() was never re-invoked here, so the process simply exited.
+      deps.teardown();
+      deps.reconnect();
+      return;
+    }
+
+    if (connection === 'open') {
+      deps.succeed(undefined);
+    }
+  };
+}
 
 async function main() {
   fs.mkdirSync(AUTH_DIR, { recursive: true });
@@ -63,16 +170,17 @@ async function main() {
 
   let pairingCodeRequested = false;
 
-  sock.ev.on('connection.update', (update) => {
-    const { connection, lastDisconnect, qr } = update;
-
-    if (qr) {
+  const handler = createConnectionUpdateHandler({
+    onQr: (qr) => {
       // Write QR data to file for external rendering (browser, image, etc.)
       fs.mkdirSync(path.dirname(QR_DATA_PATH), { recursive: true });
       fs.writeFileSync(QR_DATA_PATH, qr);
 
-      // Request pairing code on first qr event (socket is now ready)
-      if (usePairingCode && !pairingCodeRequested) {
+      // Request pairing code on first qr event (socket is now ready).
+      // `state.creds.registered` guard: after a 515 the creds ARE registered, so
+      // the reconnect must go straight to connecting rather than asking for a
+      // second code the user cannot use.
+      if (usePairingCode && !pairingCodeRequested && !state.creds.registered) {
         pairingCodeRequested = true;
         sock
           .requestPairingCode(phone!)
@@ -86,6 +194,7 @@ async function main() {
           });
         return; // Skip QR instructions when using pairing code
       }
+      if (usePairingCode) return;
 
       qrcode.generate(qr, { small: true });
       console.log(`\nQR data written to ${QR_DATA_PATH}`);
@@ -93,50 +202,44 @@ async function main() {
       console.log(
         'Open WhatsApp > Settings > Linked Devices > Link a Device\n',
       );
-    }
-
-    if (connection === 'close') {
-      const reason = (
-        lastDisconnect?.error as { output?: { statusCode?: number } }
-      )?.output?.statusCode;
-
-      if (reason === DisconnectReason.loggedOut) {
-        console.error('AUTH_STATUS: failed (logged_out)');
-        cleanup();
-        process.exit(1);
-      } else if (reason === 405) {
-        console.error(
-          `AUTH_STATUS: failed (error ${reason} — WhatsApp rejected the connection)`,
-        );
-        console.error(
-          'This usually means the baileys protocol version is outdated.',
-        );
-        console.error('Try: rm -rf store/auth/ and re-run authentication.');
-        cleanup();
-        process.exit(1);
-      } else {
-        retryCount++;
-        if (retryCount >= MAX_RETRIES) {
-          console.error(
-            `AUTH_STATUS: failed (${retryCount} retries exhausted, last reason: ${reason})`,
-          );
+    },
+    teardown: () => {
+      // Drop the dead socket's listeners before reconnecting, so attempts do not
+      // accumulate handlers bound to a closed socket (#305's failure mode).
+      sock.ev.removeAllListeners('connection.update');
+      sock.ev.removeAllListeners('creds.update');
+      try {
+        sock.end(undefined);
+      } catch {}
+    },
+    reconnect: () => {
+      // main() re-reads creds from disk via useMultiFileAuthState, so the
+      // reconnect picks up the post-pairing registered state. That re-read is
+      // what lets the 515 restart actually complete authentication.
+      setTimeout(() => {
+        main().catch((err) => {
+          console.error('Auth failed:', err);
           cleanup();
           process.exit(1);
-        }
-        console.error(
-          `Connection closed (reason: ${reason}), retrying (${retryCount}/${MAX_RETRIES})...`,
-        );
-      }
-    } else if (connection === 'open') {
+        });
+      }, RECONNECT_DELAY_MS);
+    },
+    fail: (message) => {
+      console.error(message);
+      cleanup();
+      process.exit(1);
+    },
+    succeed: () => {
       const id = sock.user?.id?.split(':')[0] || 'unknown';
       console.log(`\nAUTH_STATUS: authenticated`);
       console.log(`Phone: ${id}`);
       console.log('WhatsApp authentication successful!');
       cleanup();
       setTimeout(() => process.exit(0), 200);
-    }
+    },
   });
 
+  sock.ev.on('connection.update', handler);
   sock.ev.on('creds.update', saveCreds);
 }
 
@@ -146,8 +249,16 @@ function cleanup() {
   } catch {}
 }
 
-main().catch((err) => {
-  console.error('Auth failed:', err);
-  cleanup();
-  process.exit(1);
-});
+// Import-safe: only start authenticating when this file is executed directly.
+// Without this guard, importing the module (e.g. from a test reaching
+// createConnectionUpdateHandler) would start a live authentication attempt.
+const isDirectRun =
+  !!process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error('Auth failed:', err);
+    cleanup();
+    process.exit(1);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
       'src/**/*.test.ts',
       'setup/**/*.test.ts',
       'scripts/spikes/**/*.test.ts',
+      // TypeScript tests for standalone scripts/ tools. scripts/tests/ is
+      // otherwise Python (test_*.py), so the *.test.ts suffix keeps the two
+      // suites from colliding and lets `npx vitest run` (the required `ci`
+      // check) gate them.
+      'scripts/tests/**/*.test.ts',
       // deus-v2-cmd.mjs (LIA-434) lives at repo root, mirroring deus-cmd.sh /
       // scripts/migrate.mjs's build-free top-level placement — its test needs
       // an explicit entry since it's outside the globs above.


### PR DESCRIPTION
Fixes #1162, reported by @Yonatan1203. Their diagnosis was correct in full and is what this implements.

## The bug

`scripts/whatsapp-auth.ts` logged `retrying (N/MAX)` on a retriable disconnect but never actually reconnected. `main()` was invoked exactly once at module load (`:149`), so after a close the socket was dead, the event loop drained, and the process exited **0**.

That is fatal rather than cosmetic because **reason 515 ("restart required") always follows a successful pairing**. The one disconnect that must be retried was the one that ended the process — leaving a half-registered `store/auth/creds.json` (`registered: true`, no key material) that WhatsApp then revokes with 401. Net effect: **pairing-code auth could never succeed through this script.** Nothing retried it externally either; the only callers are `.claude/skills/add-whatsapp/SKILL.md:99,125,328,336`, which invoke it directly.

## The fix

The retriable branch now tears the dead socket down and re-invokes `main()` after a short fixed delay. `main()` re-reads creds from disk via `useMultiFileAuthState`, which is precisely what lets the post-515 registered state complete the handshake.

Supporting changes, each with a reason:

- **Teardown before reconnect.** Removes the closed socket's `connection.update` / `creds.update` listeners and ends it, so attempts don't accumulate handlers bound to a dead socket — the `MaxListenersExceeded` failure mode behind #305.
- **Injectable `RetryState`.** The retry counter must outlive a handler, because each reconnect builds a fresh socket *and* a fresh handler; a per-handler counter would reset every attempt and the `MAX_RETRIES` bound would never be reached. Injectable so tests get isolation rather than sharing one module global.
- **Single-flight latch**, so overlapping `close` events schedule at most one reconnect.
- **Import-safe module.** The top-level `main()` call is now guarded by a direct-execution check — importing this module previously started a live authentication attempt, which made the behaviour untestable.
- **No second pairing code.** Gated on `state.creds.registered`, since after a 515 the creds already are registered and a fresh code would be unusable.
- `loggedOut` and `405` remain immediately terminal, unchanged.

### Why not `ReconnectController`

`packages/mcp-whatsapp/src/reconnect-backoff.ts` is the repo's established reconnect primitive, so reusing it was the obvious first instinct. Rejected deliberately: it is tuned for a long-lived daemon (exponential backoff to a **60s** cap, stability timer, epoch cancellation) whereas this is a bounded, interactive, ≤3-attempt tool with a human waiting to type a pairing code inside its validity window. Root `package.json` also has no `workspaces` key and no `scripts/` file currently imports from `packages/mcp-*`, so it would additionally introduce a module-resolution failure mode into the exact tool people run when auth is already broken.

## Verification

A red/green pair, not just a passing test:

| | 515 close → `reconnect` invoked? |
|---|---|
| **Control** — pre-fix branch transcribed verbatim from `git show origin/main:scripts/whatsapp-auth.ts` | **0 times → FAILS** |
| **Treatment** — this PR | **1 time → passes**, 7/7 |

The 7 cases cover: 515 reconnects; teardown ordered before reconnect; boundedness (3rd close fails with `retries exhausted` and does **not** reconnect again); `loggedOut` never reconnects; `405` never reconnects; overlapping closes single-flight to one reconnect; `open` → success.

- Full suite: **116 files, 2130 tests**, all pass.
- `npx tsc --noEmit`: exit 0.
- `prettier --check`: clean.

The verification-gate independently re-derived this rather than accepting my word — it wrote its own transcription of `origin/main`'s branch and reproduced the same control failure.

## Not proven, stated plainly

**No live end-to-end pairing against WhatsApp's servers was driven.** That is credential-bound and needs a real handset and phone number. What is proven is the mechanism that was broken: a retriable close now tears down and invokes a bounded reconnect, and `main()` re-reads creds. I'd rather say that than imply the live flow was exercised.

One further gap, disclosed: the `state.creds.registered` guard lives inline in `main()`'s `onQr` callback rather than in the extracted factory, so it is hand-traced but not unit-tested. It is a single boolean; the verification-gate judged it low-risk and non-blocking.

## Incidental

`scripts/**` TypeScript tests were outside the vitest `include` globs (`scripts/tests/` is otherwise Python), so the new test would neither run nor be CI-gated. Added `scripts/tests/**/*.test.ts`, following the existing precedent in that file for an explicit documented entry.

## Gates

plan-reviewer co-gate PASS (round 2 — round 1 REVISE correctly caught that the module wasn't import-safe and that testing pure classification would prove nothing), code-reviewer co-gate PASS, verification-gate SHIP.
