### PR TITLE
fix(channels): store chat metadata before the message so the first one is not dropped

### DIFF
--- a/patterns/channel-add.md
+++ b/patterns/channel-add.md
@@ -2,7 +2,7 @@
 governs:
   - src/channels
   - packages/
-last_verified: "2026-07-03" # auto-bump @1783088946
+last_verified: "2026-08-20" # auto-bump @1787217743
 test_tasks:
   - "Add a Discord channel with OAuth login"
   - "Add capabilities: logging to a new MCP channel server so notifications are delivered"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786888245
+last_verified: "2026-08-20" # auto-bump @1787217743
 governs:
   - src/
   - evolution/

--- a/src/channels/mcp-adapter-chat-order.test.ts
+++ b/src/channels/mcp-adapter-chat-order.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for #1163 — the first message in a newly registered chat was
+ * silently dropped.
+ *
+ * Two levels, because either alone is insufficient:
+ *
+ *  1. ORDERING at the adapter's surface. `messages.chat_jid` has a foreign key
+ *     onto `chats(jid)`, so the chat row must exist before the message insert.
+ *     The adapter emitted the message first, so the very first message in a
+ *     chat violated the constraint and was lost.
+ *
+ *  2. CONSEQUENCE against a real SQLite database. The ordering assertion alone
+ *     would keep passing if someone dropped the foreign key or disabled the
+ *     pragma; this proves the constraint is genuinely enforced and that the
+ *     wrong order really does lose the row.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+
+const { capturedHandlers } = vi.hoisted(() => ({
+  capturedHandlers: [] as Array<(n: unknown) => void>,
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {}),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(function () {
+    return {
+      callTool: vi.fn().mockResolvedValue({}),
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      setNotificationHandler: function (
+        _schema: unknown,
+        handler: (n: unknown) => void,
+      ) {
+        capturedHandlers.push(handler);
+      },
+    };
+  }),
+}));
+
+const { McpChannelAdapter } = await import('./mcp-adapter.js');
+
+function makeOpts() {
+  return {
+    name: 'test-channel',
+    command: 'node',
+    args: ['server.js'],
+    onMessage: vi.fn(),
+    onReaction: vi.fn(),
+    onChatMetadata: vi.fn(),
+    ownsJid: vi.fn().mockReturnValue(false),
+  };
+}
+
+function incomingMessage(chatId: string) {
+  return {
+    params: {
+      logger: 'incoming_message',
+      data: {
+        id: 'MSG1',
+        chat_id: chatId,
+        sender: 'someone@c.us',
+        sender_name: 'Someone',
+        content: 'first message in a brand new chat',
+        timestamp: '2026-08-20T00:00:00Z',
+        chat_name: 'New Chat',
+        is_group: false,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  capturedHandlers.length = 0;
+});
+
+describe('mcp-adapter chat-before-message ordering (#1163)', () => {
+  it('emits chat metadata BEFORE the message', () => {
+    const opts = makeOpts();
+    new McpChannelAdapter(opts);
+    const handler = capturedHandlers[capturedHandlers.length - 1];
+
+    handler(incomingMessage('brand-new@c.us'));
+
+    expect(opts.onChatMetadata).toHaveBeenCalledTimes(1);
+    expect(opts.onMessage).toHaveBeenCalledTimes(1);
+
+    // The defect: on the unfixed adapter onMessage fired first, so the parent
+    // chats row did not exist yet and the FK insert failed.
+    const metadataOrder = opts.onChatMetadata.mock.invocationCallOrder[0];
+    const messageOrder = opts.onMessage.mock.invocationCallOrder[0];
+    expect(metadataOrder).toBeLessThan(messageOrder);
+  });
+
+  it('still passes chat metadata through unchanged', () => {
+    const opts = makeOpts();
+    new McpChannelAdapter(opts);
+    const handler = capturedHandlers[capturedHandlers.length - 1];
+
+    handler(incomingMessage('brand-new@c.us'));
+
+    // Reordering must change WHEN metadata is recorded, not WHAT.
+    expect(opts.onChatMetadata).toHaveBeenCalledWith(
+      'brand-new@c.us',
+      '2026-08-20T00:00:00Z',
+      'New Chat',
+      'test-channel',
+      false,
+    );
+  });
+
+  it('still delivers the message itself', () => {
+    const opts = makeOpts();
+    new McpChannelAdapter(opts);
+    const handler = capturedHandlers[capturedHandlers.length - 1];
+
+    handler(incomingMessage('existing@c.us'));
+
+    expect(opts.onMessage).toHaveBeenCalledTimes(1);
+    const [jid, msg] = opts.onMessage.mock.calls[0];
+    expect(jid).toBe('existing@c.us');
+    expect(msg.content).toBe('first message in a brand new chat');
+  });
+});
+
+describe('the constraint this ordering exists to satisfy (#1163)', () => {
+  /** Minimal reproduction of the real schema's parent/child relationship. */
+  function freshDb() {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE chats (jid TEXT PRIMARY KEY, name TEXT, last_message_time TEXT);
+      CREATE TABLE messages (
+        id TEXT, chat_jid TEXT, content TEXT,
+        PRIMARY KEY (id, chat_jid),
+        FOREIGN KEY (chat_jid) REFERENCES chats(jid)
+      );
+    `);
+    return db;
+  }
+
+  it('enforces foreign keys by default', () => {
+    const db = freshDb();
+    // SQLite's own default is OFF; better-sqlite3 turns it on. If this ever
+    // changes, the ordering above stops being load-bearing and this test says so.
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+
+  it('LOSES a message inserted before its chat row exists', () => {
+    const db = freshDb();
+
+    expect(() =>
+      db
+        .prepare(
+          'INSERT INTO messages (id, chat_jid, content) VALUES (?, ?, ?)',
+        )
+        .run('MSG1', 'brand-new@c.us', 'hello'),
+    ).toThrow(/FOREIGN KEY constraint failed/);
+
+    expect(db.prepare('SELECT COUNT(*) AS n FROM messages').get()).toEqual({
+      n: 0,
+    });
+  });
+
+  it('stores the message once the chat row exists first', () => {
+    const db = freshDb();
+
+    db.prepare('INSERT INTO chats (jid, name) VALUES (?, ?)').run(
+      'brand-new@c.us',
+      'New Chat',
+    );
+    db.prepare(
+      'INSERT INTO messages (id, chat_jid, content) VALUES (?, ?, ?)',
+    ).run('MSG1', 'brand-new@c.us', 'hello');
+
+    expect(db.prepare('SELECT COUNT(*) AS n FROM messages').get()).toEqual({
+      n: 1,
+    });
+  });
+});

--- a/src/channels/mcp-adapter.ts
+++ b/src/channels/mcp-adapter.ts
@@ -105,9 +105,12 @@ export class McpChannelAdapter implements Channel {
           imageData: meta?.imageData as string | undefined,
         };
 
-        opts.onMessage(chatJid, msg);
-
-        // Also emit chat metadata
+        // Chat metadata MUST be emitted before the message: messages.chat_jid
+        // has a foreign key onto chats(jid) (db.ts), better-sqlite3 enforces
+        // foreign keys by default, and storeMessage does not upsert its parent.
+        // Emitting the message first meant the FIRST message in a newly
+        // registered chat violated the constraint and was lost, with the user
+        // simply seeing no reply (#1163). webhook.ts has always had this order.
         opts.onChatMetadata(
           chatJid,
           msg.timestamp,
@@ -115,6 +118,8 @@ export class McpChannelAdapter implements Channel {
           opts.name,
           data.is_group as boolean | undefined,
         );
+
+        opts.onMessage(chatJid, msg);
       },
     );
   }


### PR DESCRIPTION
Fixes #1163, reported by @Yonatan1203. Their diagnosis was correct in full.

## The bug

`src/channels/mcp-adapter.ts` emitted the inbound message **before** the chat metadata it depends on:

```ts
opts.onMessage(chatJid, msg);   // :108
// Also emit chat metadata
opts.onChatMetadata(...);        // :111
```

`onMessage` → `storeMessage` (`src/index.ts:315`) is a bare insert with no parent upsert (`src/db.ts:504-506`), and `messages.chat_jid` has a foreign key onto `chats(jid)` (`src/db.ts:45`).

The constraint is genuinely enforced — worth confirming, since SQLite's own default is OFF and `src/` never sets the pragma:

```
$ node -e "const D=require('better-sqlite3');console.log(new D(':memory:').pragma('foreign_keys',{simple:true}))"
1
```

better-sqlite3 turns it on. So the **first** message in a newly registered chat violated the FK and was lost — the user simply saw no reply.

### Wider than the report suggested

This is not WhatsApp-specific. Discord, Slack, Outlook, Gmail, Teams, WhatsApp and Telegram all pass their callbacks straight into `McpChannelAdapterOpts` with no ordering logic of their own, so **every MCP-backed channel dropped the first message of every new chat** through this single call site.

## The fix

Move `onChatMetadata` above `onMessage`. `storeChatMetadata` (`db.ts:441-462`) is an `INSERT ... ON CONFLICT DO UPDATE` upsert, so it reliably creates the parent row and is idempotent for existing chats.

`src/channels/webhook.ts` has always had this order (`:227` then `:237`), citing the same constraint in its own comment — so this brings the MCP adapter into line rather than inventing a pattern. The `// Also emit chat metadata` comment framed the call as an afterthought, which is plausibly how the ordering came to be wrong; it now states the constraint.

### Deliberately not hardening `storeMessage`

I considered adding a parent-row upsert inside `storeMessage` and decided against it. Recording the reasoning, since "never lose user data" pulls the other way and a dropped message *is* data loss:

- It duplicates a responsibility `storeChatMetadata` already owns.
- It could create a `chats` row from message fields alone — no name, no channel, no `is_group` — risking a degraded row that later masks the real metadata write.
- It converts a loud FK failure into a silent success, removing the very signal that surfaced this bug.

The reorder makes the FK success path the common path while leaving the constraint as a loud backstop for any future caller that skips `onChatMetadata`. Both gates were asked to challenge this and both independently endorsed it.

## Verification

Red/green pair, reproduced independently by the verification gate rather than taken on my word:

| | metadata before message? |
|---|---|
| **Control** — `origin/main`'s ordering restored | **FAILS**: `expected 4 to be less than 3` |
| **Treatment** — this PR | **passes**, 6/6 |

The tests work at two levels on purpose:

1. **Ordering** at the adapter's surface, via mock invocation order.
2. **Consequence** against a real `better-sqlite3` database — proving the pragma is on, that inserting a message before its chat row throws `FOREIGN KEY constraint failed` and leaves **0** rows, and that it stores once the parent exists.

Level 2 exists because level 1 alone would keep passing if someone dropped the foreign key or disabled the pragma — at which point the ordering would silently stop being load-bearing.

- Full suite: **116 files, 2129 tests**, all pass.
- `npx tsc --noEmit`: clean. `prettier --check`: clean.

Also checked and found clear: the `msg` object (including `msg.timestamp`) is fully constructed before either call, so moving the metadata call earlier introduces no use-before-assign; and the reaction path (`opts.onReaction`) writes no DB row and has no `reactions` table, so it carries no equivalent FK exposure.

## Gates

plan-reviewer co-gate PASS, code-reviewer co-gate PASS, verification-gate SHIP.
