### PR TITLE
fix(memory): let the cross-encoder reranker degrade instead of crashing

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-16" # auto-bump @1786888245
+last_verified: "2026-08-20" # auto-bump @1787218639
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -1341,9 +1341,24 @@ def _rrf_fuse(
 def _rerank_cross_encoder(query: str, candidates: list[dict]) -> list[dict] | None:
     """Rerank atom candidates using a cross-encoder. Returns None on failure."""
     global _cross_encoder
-    from sentence_transformers import CrossEncoder
-    if _cross_encoder is None:
-        _cross_encoder = CrossEncoder(RERANKER_MODEL)
+    # Import AND construction live inside the guard, not just .predict() below.
+    # sentence_transformers is optional, and CrossEncoder(...) additionally
+    # reaches for a model cache, so both are ordinary failure modes on a fresh
+    # or minimal install. With them outside the guard, --query died instead of
+    # degrading to unreranked results, contradicting this function's own
+    # documented contract (#1169). Exception, not ImportError: a missing/corrupt
+    # model cache, a network fetch, or a torch init error are none of them
+    # ImportError, and each crashed the same way.
+    try:
+        from sentence_transformers import CrossEncoder
+        if _cross_encoder is None:
+            _cross_encoder = CrossEncoder(RERANKER_MODEL)
+    except Exception as exc:
+        print(
+            f"  WARN: cross-encoder unavailable, skipping rerank: {str(exc)[:120]}",
+            file=sys.stderr,
+        )
+        return None
     pairs = [(query, a["chunk"] or "") for a in candidates]
     try:
         scores = _cross_encoder.predict(pairs).tolist()

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -4763,3 +4763,92 @@ def test_ensure_client_defers_missing_key_failure(mi, monkeypatch):
     monkeypatch.setattr(mi, "_client", None)
     with pytest.raises(SystemExit):
         mi._ensure_client()
+
+
+# ── #1169: the reranker must degrade, not crash ──────────────────────────────
+#
+# `_rerank_cross_encoder` documents "Returns None on failure", and both call
+# sites act on that (`if reranked is not None: ...`). But the import and the
+# CrossEncoder construction used to sit OUTSIDE the try, so the two most likely
+# failures on a fresh install -- the optional dep being absent, and the model
+# cache being missing -- propagated out of --query instead of degrading.
+
+
+def _reset_cross_encoder(mod):
+    """Clear the module-level singleton so each case starts cold."""
+    mod._cross_encoder = None
+
+
+def test_rerank_returns_none_when_sentence_transformers_missing(mi, monkeypatch):
+    """A missing optional dependency degrades instead of crashing (#1169)."""
+    _reset_cross_encoder(mi)
+    # Force the import to fail deterministically, so the test does not depend on
+    # whether this machine happens to have sentence_transformers installed.
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+
+    result = mi._rerank_cross_encoder("q", [{"chunk": "a"}, {"chunk": "b"}])
+
+    assert result is None
+
+
+def test_rerank_returns_none_when_model_construction_fails(mi, monkeypatch):
+    """A model-cache/torch failure is not an ImportError -- it must degrade too."""
+    _reset_cross_encoder(mi)
+
+    class _Boom:
+        def __init__(self, *_a, **_k):
+            raise OSError("model cache missing")
+
+    stub = types.ModuleType("sentence_transformers")
+    stub.CrossEncoder = _Boom
+    monkeypatch.setitem(sys.modules, "sentence_transformers", stub)
+
+    result = mi._rerank_cross_encoder("q", [{"chunk": "a"}])
+
+    assert result is None
+
+
+def test_rerank_returns_none_when_predict_fails(mi, monkeypatch):
+    """Pre-existing behaviour preserved: a predict failure still returns None."""
+    _reset_cross_encoder(mi)
+
+    class _PredictBoom:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def predict(self, _pairs):
+            raise RuntimeError("inference exploded")
+
+    stub = types.ModuleType("sentence_transformers")
+    stub.CrossEncoder = _PredictBoom
+    monkeypatch.setitem(sys.modules, "sentence_transformers", stub)
+
+    result = mi._rerank_cross_encoder("q", [{"chunk": "a"}])
+
+    assert result is None
+
+
+def test_rerank_happy_path_sorts_by_descending_score(mi, monkeypatch):
+    """The fix must not disturb a working reranker."""
+    _reset_cross_encoder(mi)
+
+    class _Scores:
+        def tolist(self):
+            return [0.1, 0.9]
+
+    class _Working:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def predict(self, _pairs):
+            return _Scores()
+
+    stub = types.ModuleType("sentence_transformers")
+    stub.CrossEncoder = _Working
+    monkeypatch.setitem(sys.modules, "sentence_transformers", stub)
+
+    result = mi._rerank_cross_encoder("q", [{"chunk": "low"}, {"chunk": "high"}])
+
+    assert result is not None
+    assert [a["chunk"] for a in result] == ["high", "low"]
+    assert result[0]["_ce_score"] == 0.9


### PR DESCRIPTION
Fixes #1169, reported by @Yonatan1203. Their diagnosis was correct: the contract was already right, only the guard placement was wrong.

## The bug

```python
def _rerank_cross_encoder(query, candidates) -> list[dict] | None:
    """Rerank atom candidates using a cross-encoder. Returns None on failure."""
    global _cross_encoder
    from sentence_transformers import CrossEncoder      # :1344  outside the try
    if _cross_encoder is None:
        _cross_encoder = CrossEncoder(RERANKER_MODEL)   # :1346  outside the try
    pairs = [...]
    try:
        scores = _cross_encoder.predict(pairs).tolist()
    except Exception:
        return None
```

The `try` covered only `.predict()`. The import and the model construction sat outside it, so on a machine without the optional dependency — or without the reranker model cached — the exception propagated out of a function whose own docstring promises `Returns None on failure`.

`--query` is the memory-retrieval entry point, and `RERANKER_ENABLED` defaults on, so retrieval **died** where it was designed to degrade. The failure lands hardest exactly where it's least expected: a fresh or minimal install.

The degrade path was already fully built and simply unreachable for the two most likely failure modes — both call sites handle `None` correctly (`:1690` and `:4426-4434`).

## The fix

Move the import and construction inside the guard, warn on stderr, return `None`. The existing `except Exception: return None` around `.predict()` is untouched.

Two deliberate choices:

- **`Exception`, not `ImportError`.** A missing or corrupt model cache, a network fetch, or a torch init error are none of them `ImportError` and each crashed identically. Narrowing to `ImportError` would fix the reported case and leave its neighbours broken.
- **Warn rather than degrade silently.** Matches the `str(exc)[:120]` stderr convention already used at four other sites in this file. A silently-disabled reranker is its own smaller version of the problem reported in #1166.

## Verification

Red/green pair, driven by the verification gate independently as well as by me:

| case | control (`origin/main`) | treatment |
|---|---|---|
| `sentence_transformers` missing | **`ModuleNotFoundError`** at `:1344` | returns `None` |
| `CrossEncoder(...)` construction fails | **`OSError`** at `:1346` | returns `None` |
| `.predict()` fails | returns `None` | returns `None` |
| happy path | reranks | reranks, sorted descending |

The third row is the useful one: it passes on **both** sides, which is the evidence that the pre-existing guard was preserved rather than altered. A fix that changed it would show up here.

- `pytest scripts/tests/test_memory_indexer.py` → **288 passed** (CI already runs this file).
- Ran with `-p no:cacheprovider`, since the module under test was being edited.

Also confirmed, rather than assumed: when `None` is returned, both call sites fall back to the already-sorted results rather than dropping them — site 1 leaves `atom_results` intact (the slice was never reassigned into it), site 2 has an explicit `else: sorted_atoms = sorted_atoms[:k]`. "Degrades" really does mean unreranked results, not missing ones.

## Gates

plan-reviewer co-gate PASS, code-reviewer co-gate PASS, verification-gate SHIP.

One process note for the record: during verification the gate's own `git checkout origin/main -- <file>` (run for the control) also unstaged the fix. It caught that, reconstructed and re-staged it, and I independently diffed the staged blob against a copy I had taken before verification began — byte-identical — then re-ran the tests myself before committing.
