### PR TITLE
fix(memory): distinguish an unusable Ollama result from a genuinely empty one

### DIFF
--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-16" # auto-bump @1786888245
+last_verified: "2026-08-20" # auto-bump @1787220472
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/scripts/memory_indexer.py
+++ b/scripts/memory_indexer.py
@@ -2023,8 +2023,11 @@ def _atom_prompt(content: str) -> str:
 def _extract_atoms_ollama(content: str) -> "list[dict] | None":
     """Extract atoms via Ollama (Gemma4). Mirrors _extract_entities_ollama.
 
-    Returns the parsed atom list, or None when Ollama is unreachable (so the
-    caller can fall back to Gemini). Other failures return [] (skip extraction).
+    Returns the parsed atom list on success -- [] meaning "ran successfully and
+    found no atoms". Returns None for ANY failure (unreachable, HTTP error,
+    malformed response, unexpected), so the caller can fall back to Gemini.
+    The two are not interchangeable: only None triggers that fallback, so a
+    failure that returned [] disabled extraction silently (#1166).
     Keyless — this is the path that lets --extract/--add run without a Gemini key.
     """
     import urllib.request  # lazy: only needed when the Ollama path is taken
@@ -2077,20 +2080,38 @@ def _extract_atoms_ollama(content: str) -> "list[dict] | None":
             data = json.loads(resp.read().decode())
         raw = data.get("response", "").strip()
         result = json.loads(raw)
+        # Syntactically valid JSON in the WRONG SHAPE is not a successful empty
+        # extraction -- it is an unusable result, and must reach the fallback
+        # like any other failure. `{}` or `[]` previously fell through to `[]`
+        # here, which claimed success and skipped Gemini (#1166).
+        if not isinstance(result, dict) or not isinstance(result.get("atoms"), list):
+            print(
+                f"  WARN: Ollama atom extraction returned an unexpected shape: {str(result)[:120]}",
+                file=sys.stderr,
+            )
+            return None
         # Cap defensively (prompt asks for 2-5), mirroring the entity path's ceiling.
-        atoms = (result.get("atoms", []) if isinstance(result, dict) else [])[:10]
+        # An empty list here IS a genuine "found nothing" and correctly stays [].
+        atoms = result["atoms"][:10]
         return [a for a in atoms if isinstance(a, dict) and "text" in a and "category" in a]
+    # Return contract (see extract_atoms): None means "no usable result from
+    # Ollama -- try the fallback"; [] means "ran successfully, found no atoms".
+    # Every branch below is the former, so every branch returns None. Returning
+    # [] here used to claim a successful empty extraction, which both hid the
+    # failure AND skipped the Gemini fallback that exists for exactly this --
+    # so pointing DEUS_OLLAMA_ATOM_MODEL at an un-pulled model disabled atom
+    # extraction for the whole run (#1166).
     except urllib.error.HTTPError as exc:
         print(f"  WARN: Ollama atom extraction HTTP {exc.code}: {str(exc)[:120]}", file=sys.stderr)
-        return []
+        return None
     except (ConnectionRefusedError, OSError):
         return None
     except json.JSONDecodeError as exc:
         print(f"  WARN: Ollama atom extraction malformed JSON: {str(exc)[:120]}", file=sys.stderr)
-        return []
+        return None
     except Exception as exc:
         print(f"  WARN: Ollama atom extraction failed: {exc}", file=sys.stderr)
-        return []
+        return None
 
 
 def _extract_atoms_gemini(content: str) -> list[dict]:
@@ -2328,7 +2349,9 @@ def _extract_entities_ollama(content: str) -> "dict | None":
     Returns a dict with the same schema consumed by the DB layer:
       {"entities": [{"name": str, "entity_type": str, "summary": str}],
        "relationships": [{"source": str, "target": str, "rel_type": str}]}
-    or None when Ollama is not reachable.
+    An empty dict means "ran successfully, found nothing". Returns None for ANY
+    failure (unreachable, HTTP error, malformed response, unexpected), so the
+    caller can fall back to Gemini — only None triggers that fallback (#1166).
     """
     import urllib.request
 
@@ -2387,31 +2410,44 @@ def _extract_entities_ollama(content: str) -> "dict | None":
             data = json.loads(resp.read().decode())
         raw = data.get("response", "").strip()
         result = json.loads(raw)
-        if isinstance(result, dict) and "entities" in result:
-            ents = [
-                e for e in result.get("entities", [])[:10]
-                if isinstance(e, dict)
-                and isinstance(e.get("name"), str) and e["name"]
-                and isinstance(e.get("entity_type"), str)
-            ]
-            rels = [
-                r for r in result.get("relationships", [])[:10]
-                if isinstance(r, dict)
-                and "source" in r and "target" in r and "rel_type" in r
-            ]
-            return {"entities": ents, "relationships": rels}
-        return {"entities": [], "relationships": []}
+        # Wrong-shape response is an unusable result, not a successful empty one
+        # -- same reasoning as the atom path above (#1166). `relationships` stays
+        # optional, as before; only the `entities` envelope is required.
+        if not isinstance(result, dict) or not isinstance(result.get("entities"), list):
+            print(
+                f"  WARN: Ollama entity extraction returned an unexpected shape: {str(result)[:120]}",
+                file=sys.stderr,
+            )
+            return None
+        ents = [
+            e for e in result["entities"][:10]
+            if isinstance(e, dict)
+            and isinstance(e.get("name"), str) and e["name"]
+            and isinstance(e.get("entity_type"), str)
+        ]
+        rels_raw = result.get("relationships")
+        rels = [
+            r for r in (rels_raw if isinstance(rels_raw, list) else [])[:10]
+            if isinstance(r, dict)
+            and "source" in r and "target" in r and "rel_type" in r
+        ]
+        return {"entities": ents, "relationships": rels}
+    # Same return contract as the atom path above (see
+    # extract_entities_and_relations): None means "no usable result -- try the
+    # fallback"; an empty dict means "ran successfully, found nothing". These
+    # branches returned the empty dict, which skipped the Gemini fallback and
+    # silently disabled entity extraction on a bad model id (#1166).
     except urllib.error.HTTPError as exc:
         print(f"  WARN: Ollama entity extraction HTTP {exc.code}: {str(exc)[:120]}", file=sys.stderr)
-        return {"entities": [], "relationships": []}
+        return None
     except (ConnectionRefusedError, OSError):
         return None
     except json.JSONDecodeError as exc:
         print(f"  WARN: Ollama entity extraction malformed JSON: {str(exc)[:120]}", file=sys.stderr)
-        return {"entities": [], "relationships": []}
+        return None
     except Exception as exc:
         print(f"  WARN: Ollama entity extraction failed: {exc}", file=sys.stderr)
-        return {"entities": [], "relationships": []}
+        return None
 
 
 def _extract_entities_and_relations_gemini(content: str) -> dict:

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -4763,3 +4763,220 @@ def test_ensure_client_defers_missing_key_failure(mi, monkeypatch):
     monkeypatch.setattr(mi, "_client", None)
     with pytest.raises(SystemExit):
         mi._ensure_client()
+
+
+# ── #1166: an Ollama failure must be distinguishable from "found nothing" ────
+#
+# The return contract: None means "no usable result -- try the fallback";
+# [] (or an empty dict) means "ran successfully, found nothing". Only None
+# triggers the Gemini fallback in `auto` mode. The failure branches returned the
+# empty value, so a wrong DEUS_OLLAMA_*_MODEL disabled extraction for the whole
+# run AND skipped the fallback that exists for exactly that case.
+
+
+class _FakeHTTPResponse:
+    """Context-manager stand-in for urlopen's response."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def read(self):
+        return self._payload.encode()
+
+
+def _http_error(code=404):
+    import urllib.error
+
+    return urllib.error.HTTPError(
+        "http://localhost:11434/api/generate", code, "Not Found", {}, None
+    )
+
+
+def test_atoms_http_error_returns_none_so_fallback_runs(mi, monkeypatch):
+    """A 404 (e.g. un-pulled model) must not look like a successful empty run."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: (_ for _ in ()).throw(_http_error()),
+    )
+
+    assert mi._extract_atoms_ollama("some content") is None
+
+
+def test_atoms_malformed_json_returns_none(mi, monkeypatch):
+    """A garbage response is not a successful empty extraction either."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "not json at all"}'),
+    )
+
+    assert mi._extract_atoms_ollama("some content") is None
+
+
+def test_atoms_empty_success_still_returns_empty_list(mi, monkeypatch):
+    """MUST NOT REGRESS: a real, successful, empty extraction stays []."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{\\"atoms\\": []}"}'),
+    )
+
+    result = mi._extract_atoms_ollama("some content")
+
+    assert result == []
+    assert result is not None
+
+
+def test_extract_atoms_falls_back_to_gemini_on_http_error(mi, monkeypatch):
+    """The behavioural point: auto mode must reach the fallback on an HTTP failure."""
+    monkeypatch.setattr(mi, "ATOM_PROVIDER", "auto")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: (_ for _ in ()).throw(_http_error()),
+    )
+    called = []
+    monkeypatch.setattr(
+        mi, "_extract_atoms_gemini", lambda c: called.append(c) or [{"text": "x", "category": "y"}]
+    )
+
+    result = mi.extract_atoms("some content")
+
+    assert called, "Gemini fallback was never reached — the HTTP failure was swallowed"
+    assert result == [{"text": "x", "category": "y"}]
+
+
+def test_extract_atoms_does_not_fall_back_on_genuine_empty(mi, monkeypatch):
+    """MUST NOT REGRESS: an honest empty result must not spend a Gemini call."""
+    monkeypatch.setattr(mi, "ATOM_PROVIDER", "auto")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{\\"atoms\\": []}"}'),
+    )
+    called = []
+    monkeypatch.setattr(mi, "_extract_atoms_gemini", lambda c: called.append(c) or [])
+
+    result = mi.extract_atoms("some content")
+
+    assert not called, "fallback ran for a genuinely empty extraction"
+    assert result == []
+
+
+def test_entities_http_error_returns_none_so_fallback_runs(mi, monkeypatch):
+    """The entity path is the atom path's twin and must behave identically."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: (_ for _ in ()).throw(_http_error()),
+    )
+
+    assert mi._extract_entities_ollama("some content") is None
+
+
+def test_extract_entities_falls_back_to_gemini_on_http_error(mi, monkeypatch):
+    """Same behavioural point, entity side."""
+    monkeypatch.setattr(mi, "ENTITY_PROVIDER", "auto")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: (_ for _ in ()).throw(_http_error()),
+    )
+    sentinel = {"entities": [{"name": "n", "entity_type": "t"}], "relationships": []}
+    called = []
+    monkeypatch.setattr(
+        mi,
+        "_extract_entities_and_relations_gemini",
+        lambda c: called.append(c) or sentinel,
+    )
+
+    result = mi.extract_entities_and_relations("some content")
+
+    assert called, "Gemini fallback was never reached on the entity path"
+    assert result == sentinel
+
+
+# ── #1166 (code-review round 1): wrong SHAPE is also "no usable result" ──────
+#
+# Fixing only the exception branches left the success path able to emit the same
+# false signal: syntactically valid JSON in the wrong shape fell through to the
+# empty value, which claims a successful empty extraction and skips the fallback.
+
+
+def test_atoms_wrong_shape_returns_none(mi, monkeypatch):
+    """Valid JSON, wrong envelope -> unusable, not 'found nothing'."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{}"}'),
+    )
+
+    assert mi._extract_atoms_ollama("some content") is None
+
+
+def test_atoms_non_dict_json_returns_none(mi, monkeypatch):
+    """A bare JSON array is not the contract either."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "[]"}'),
+    )
+
+    assert mi._extract_atoms_ollama("some content") is None
+
+
+def test_atoms_wrong_shape_reaches_fallback(mi, monkeypatch):
+    """The behavioural point: a wrong-shape response must reach Gemini."""
+    monkeypatch.setattr(mi, "ATOM_PROVIDER", "auto")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{}"}'),
+    )
+    called = []
+    monkeypatch.setattr(
+        mi, "_extract_atoms_gemini", lambda c: called.append(c) or [{"text": "x", "category": "y"}]
+    )
+
+    result = mi.extract_atoms("some content")
+
+    assert called, "wrong-shape response was swallowed as a successful empty extraction"
+    assert result == [{"text": "x", "category": "y"}]
+
+
+def test_entities_wrong_shape_returns_none(mi, monkeypatch):
+    """Entity twin: same rule."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{}"}'),
+    )
+
+    assert mi._extract_entities_ollama("some content") is None
+
+
+def test_entities_empty_envelope_still_succeeds(mi, monkeypatch):
+    """MUST NOT REGRESS: a well-formed empty envelope is a real empty result."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse(
+            '{"response": "{\\"entities\\": [], \\"relationships\\": []}"}'
+        ),
+    )
+
+    result = mi._extract_entities_ollama("some content")
+
+    assert result == {"entities": [], "relationships": []}
+    assert result is not None
+
+
+def test_entities_relationships_remain_optional(mi, monkeypatch):
+    """MUST NOT REGRESS: relationships was optional before and stays optional."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse(
+            '{"response": "{\\"entities\\": [{\\"name\\": \\"docker\\", \\"entity_type\\": \\"tool\\"}]}"}'
+        ),
+    )
+
+    result = mi._extract_entities_ollama("some content")
+
+    assert result is not None
+    assert [e["name"] for e in result["entities"]] == ["docker"]
+    assert result["relationships"] == []

--- a/scripts/tests/test_memory_indexer.py
+++ b/scripts/tests/test_memory_indexer.py
@@ -5067,3 +5067,53 @@ def test_rerank_happy_path_sorts_by_descending_score(mi, monkeypatch):
     assert result is not None
     assert [a["chunk"] for a in result] == ["high", "low"]
     assert result[0]["_ce_score"] == 0.9
+
+
+# ── #1166 (plan-review round 4): malformed FIELD TYPES, not just wrong envelope ──
+#
+# `{"atoms": "none"}` is a dict containing the expected key, but the value is not
+# a list. Iterating it would filter down to [] and masquerade as a successful
+# empty extraction. The guard checks the field's TYPE, not merely key presence.
+
+
+def test_atoms_non_list_field_returns_none(mi, monkeypatch):
+    """`{"atoms": "none"}` is unusable, not 'found nothing'."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{\\"atoms\\": \\"none\\"}"}'),
+    )
+
+    assert mi._extract_atoms_ollama("some content") is None
+
+
+def test_entities_non_list_field_returns_none(mi, monkeypatch):
+    """Entity twin: `{"entities": "none"}` is unusable too."""
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse('{"response": "{\\"entities\\": \\"none\\"}"}'),
+    )
+
+    assert mi._extract_entities_ollama("some content") is None
+
+
+def test_entities_non_list_relationships_is_tolerated(mi, monkeypatch):
+    """`relationships` is OPTIONAL by contract, so a bad type is treated as absent.
+
+    Deliberately NOT routed to None: the field was already optional before this
+    change (`result.get("relationships", [])`), and a response carrying valid
+    entities is still usable. Documenting the asymmetry so it reads as a decision
+    rather than an oversight.
+    """
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_a, **_k: _FakeHTTPResponse(
+            '{"response": "{\\"entities\\": [{\\"name\\": \\"docker\\", \\"entity_type\\": \\"tool\\"}],'
+            ' \\"relationships\\": \\"none\\"}"}'
+        ),
+    )
+
+    result = mi._extract_entities_ollama("some content")
+
+    assert result is not None
+    assert [e["name"] for e in result["entities"]] == ["docker"]
+    assert result["relationships"] == []

--- a/scripts/tests/test_memory_indexer_ner.py
+++ b/scripts/tests/test_memory_indexer_ner.py
@@ -210,7 +210,7 @@ def test_ollama_returns_none_on_os_error(mi_auto):
     assert result is None
 
 
-def test_ollama_returns_empty_on_json_decode_error(mi_auto, capsys):
+def test_ollama_returns_none_on_json_decode_error(mi_auto, capsys):
     bad_body = json.dumps({"response": "not json at all"}).encode()
     resp = MagicMock()
     resp.read.return_value = bad_body
@@ -220,28 +220,28 @@ def test_ollama_returns_empty_on_json_decode_error(mi_auto, capsys):
     with patch("urllib.request.urlopen", return_value=resp):
         result = mi_auto._extract_entities_ollama("text")
 
-    assert result == {"entities": [], "relationships": []}
+    assert result is None  # #1166: a failure is not a successful empty result
     captured = capsys.readouterr()
     assert "WARN" in captured.err
     assert "malformed JSON" in captured.err
 
 
-def test_ollama_returns_empty_on_http_error(mi_auto, capsys):
+def test_ollama_returns_none_on_http_error(mi_auto, capsys):
     with patch("urllib.request.urlopen",
                side_effect=urllib.error.HTTPError(None, 404, "Not Found", {}, None)):
         result = mi_auto._extract_entities_ollama("text")
 
-    assert result == {"entities": [], "relationships": []}
+    assert result is None  # #1166: a failure is not a successful empty result
     captured = capsys.readouterr()
     assert "WARN" in captured.err
     assert "HTTP 404" in captured.err
 
 
-def test_ollama_returns_empty_on_unexpected_error(mi_auto, capsys):
+def test_ollama_returns_none_on_unexpected_error(mi_auto, capsys):
     with patch("urllib.request.urlopen", side_effect=ValueError("unexpected")):
         result = mi_auto._extract_entities_ollama("text")
 
-    assert result == {"entities": [], "relationships": []}
+    assert result is None  # #1166: a failure is not a successful empty result
     captured = capsys.readouterr()
     assert "WARN" in captured.err
 
@@ -288,6 +288,9 @@ def test_provider_ollama_strict_returns_empty_when_not_reachable(mi_ollama, caps
             result = mi_ollama.extract_entities_and_relations("some content")
 
     mock_gemini.assert_not_called()
+    # The PUBLIC function still returns an empty dict here, deliberately: with
+    # provider=ollama there is no fallback to reach, so it warns and degrades.
+    # Only the INTERNAL _extract_entities_ollama returns None (#1166).
     assert result == {"entities": [], "relationships": []}
     captured = capsys.readouterr()
     assert "WARN" in captured.err


### PR DESCRIPTION
Fixes #1166, reported by @Yonatan1203. Their conclusion — that extraction gets silently disabled — is right. The mechanism is different from the one they described, and worse.

## Correcting the report first

Two specifics in the issue are inaccurate, and I'd rather say so than quietly fix something else:

- **Not hardcoded.** `:2035` and `:2337` read `DEUS_OLLAMA_ATOM_MODEL` / `DEUS_OLLAMA_ENTITY_MODEL`; `gemma4:e4b` is only the default.
- **Not silent.** The `HTTPError` branch already printed a stderr `WARN`.

## The actual defect

`extract_atoms` uses the return value as a three-state signal:

| return | meaning | Gemini fallback runs? |
|---|---|---|
| `None` | Ollama gave no usable result | **yes** |
| `[]` | Ollama ran fine, found no atoms | no |

Every failure path returned `[]`. So pointing the model env var at an un-pulled model didn't just disable atom extraction for the whole run — **it also skipped the fallback that exists for exactly that failure.** `_extract_entities_ollama` has the identical shape and the identical caller.

## What changed

Two classes of false success, found in two review rounds:

1. **Exception branches** — `HTTPError`, `JSONDecodeError`, generic `Exception` returned the empty value. Now `None`. (`ConnectionRefusedError`/`OSError` already did; untouched.)
2. **The success path** — this one I missed, and the code-reviewer co-gate caught it. Syntactically valid JSON in the wrong shape (`{}`, a bare array) fell through to `[]`, producing the same false signal one layer up. A response that doesn't match the contract now returns `None` too.

Preserved deliberately:

- A well-formed envelope with no items is a *real* empty result — still `[]`, still no fallback call.
- `relationships` remains optional on the entity side.
- **Per-item filtering is unchanged.** An envelope with 2 valid atoms and 1 malformed one still returns the 2. Routing that to `None` would fall back and risk duplicates for what is ordinary model noise. Flagged in the plan rather than decided silently; both gates endorsed leaving it.

Both docstrings still documented the *removed* contract verbatim. They now state it accurately — leaving them would perpetuate exactly the ambiguity that caused this bug.

## Verification

Two red/green controls against `origin/main`, both reproduced independently by the verification gate:

| control | result on main |
|---|---|
| exception paths (7 tests) | **5 fail** — incl. `Gemini fallback was never reached — the HTTP failure was swallowed`, both twins |
| shape paths (6 tests) | **4 fail** — incl. `wrong-shape response was swallowed as a successful empty extraction` |

In both, the must-not-regress cases **pass on main too** — that's the point: they prove the legitimate `[]` path survived.

- Treatment: 13/13 scoped tests pass. Full suite **297 passed**.
- `provider="ollama"` (no fallback configured) still degrades to an empty result rather than raising — driven directly, since returning `None` more often could plausibly have changed that.
- The new `WARN` cannot itself raise: `result` comes from `json.loads`, which only yields types with an exception-free `__str__`.

## Gates

plan-reviewer co-gate PASS (2 rounds), code-reviewer co-gate PASS (2 rounds — round 1 REVISE found the success-path gap and was adopted in full), verification-gate SHIP.
