### PR TITLE
fix(container): build the image the runtime actually runs

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -7,12 +7,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-IMAGE_NAME="deus-agent"
-TAG="${1:-latest}"
+# Build the image the RUNTIME will actually run. src/config.ts:94 reads
+# CONTAINER_IMAGE (default deus-agent:latest) and container-runner.ts:287 runs
+# it, so a build that ignored CONTAINER_IMAGE produced an image nothing would
+# start -- and made two instances on one host clobber each other's
+# deus-agent:latest (#1164).
+DEFAULT_IMAGE="deus-agent:${1:-latest}"
+IMAGE_REF="${CONTAINER_IMAGE:-$DEFAULT_IMAGE}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
+# Env wins over the positional tag: matching what the runtime will run is the
+# whole point, and a CLI arg that silently diverged from it would reintroduce
+# this bug. Announce the conflict rather than swallowing the argument.
+if [ -n "${CONTAINER_IMAGE:-}" ] && [ -n "${1:-}" ]; then
+  echo "WARN: CONTAINER_IMAGE is set; ignoring tag argument '$1' and building ${CONTAINER_IMAGE}" >&2
+fi
+
 echo "Building Deus agent container image..."
-echo "Image: ${IMAGE_NAME}:${TAG}"
+echo "Image: ${IMAGE_REF}"
 
 # Stage skill agent files for the container build.
 # Each skill with an agent.ts gets its own directory under container/skill-agents/.
@@ -50,14 +62,14 @@ if [ -d ".claude/skills" ]; then
 fi
 
 # Build from project root so Dockerfile can access staged files
-${CONTAINER_RUNTIME} build -t "${IMAGE_NAME}:${TAG}" -f container/Dockerfile .
+${CONTAINER_RUNTIME} build -t "${IMAGE_REF}" -f container/Dockerfile .
 
 # Clean up staging directory
 rm -rf "$STAGING_DIR"
 
 echo ""
 echo "Build complete!"
-echo "Image: ${IMAGE_NAME}:${TAG}"
+echo "Image: ${IMAGE_REF}"
 echo ""
 echo "Test with:"
-echo "  echo '{\"prompt\":\"What is 2+2?\",\"groupFolder\":\"test\",\"chatJid\":\"test@g.us\",\"isMain\":false}' | ${CONTAINER_RUNTIME} run -i ${IMAGE_NAME}:${TAG}"
+echo "  echo '{\"prompt\":\"What is 2+2?\",\"groupFolder\":\"test\",\"chatJid\":\"test@g.us\",\"isMain\":false}' | ${CONTAINER_RUNTIME} run -i ${IMAGE_REF}"

--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786874961
+last_verified: "2026-08-20" # auto-bump @1787222173
 governs:
   - package.json
   - tsconfig.json


### PR DESCRIPTION
Fixes #1164, reported by @Yonatan1203. Their diagnosis was correct, and tracing it turned up a stronger piece of evidence than the report had.

## The bug

`container/build.sh` hardcoded the image name and never read `CONTAINER_IMAGE`:

```sh
IMAGE_NAME="deus-agent"
TAG="${1:-latest}"
...
${CONTAINER_RUNTIME} build -t "${IMAGE_NAME}:${TAG}" -f container/Dockerfile .
```

But `CONTAINER_IMAGE` is load-bearing at runtime:

- `src/config.ts:94-95` — `export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || 'deus-agent:latest'`
- `src/container-runner.ts:287` — `args.push(CONTAINER_IMAGE)`

So the builder and the runner disagreed. Set `CONTAINER_IMAGE` to anything else and the runtime tries to start an image `build.sh` never produced; leave it default on a shared host and two instances both build `deus-agent:latest` and clobber each other — the reported symptom.

**The repo already documented this contract as working.** `scripts/ma-real-e2e.ts:201-205` inspects `CONTAINER_IMAGE` and, when the image is missing, prints:

```
ABORT: image ${CONTAINER_IMAGE} missing. Build it first: ./container/build.sh
```

That instruction could not succeed for any non-default value. The repo told you to run a script that couldn't do what it said.

## The fix

```sh
DEFAULT_IMAGE="deus-agent:${1:-latest}"
IMAGE_REF="${CONTAINER_IMAGE:-$DEFAULT_IMAGE}"
```

with every downstream reference switched to `$IMAGE_REF`, including the echoed run/test hints so they name the image actually built.

**`CONTAINER_IMAGE` wins over the positional tag argument**, and the conflict is announced rather than swallowed:

```
WARN: CONTAINER_IMAGE is set; ignoring tag argument 'v2' and building deus-agent-b:9
```

Env-wins is the right precedence *specifically here*: the entire point is to match what `container-runner.ts` will run, and that comes from the environment. A CLI argument that silently diverged from the runtime would reintroduce this exact class of bug.

## Verification

There's no shell test harness in this repo, but the script is drivable without building anything — `CONTAINER_RUNTIME` is already parameterised (`:12`), so substituting `echo` prints the real build command. That's the actual script and the actual argument construction, not a simulation.

| `CONTAINER_IMAGE=deus-agent-b:9` | build target |
|---|---|
| **Control** (`origin/main`) | `build -t deus-agent:latest` — **env ignored** |
| **Treatment** (this PR) | `build -t deus-agent-b:9` |

All four paths checked:

```
unset                  -> build -t deus-agent:latest
unset + tag arg 'v2'   -> build -t deus-agent:v2
CONTAINER_IMAGE set    -> build -t deus-agent-b:9
both set               -> WARN ... + build -t deus-agent-b:9
```

`bash -n` clean. With `CONTAINER_IMAGE` unset, behaviour is unchanged, so existing single-instance users see no difference.

## Gates

plan-reviewer co-gate PASS, code-reviewer co-gate PASS, verification-gate marked on the driven evidence above.
