### PR TITLE
fix(setup): refuse to write a CLAUDE.md that still contains placeholders

### DIFF
--- a/patterns/deployment.md
+++ b/patterns/deployment.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-16" # auto-bump @1786874961
+last_verified: "2026-08-20" # auto-bump @1787222734
 governs:
   - package.json
   - tsconfig.json

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-20" # auto-bump @1787217743
+last_verified: "2026-08-20" # auto-bump @1787222734
 governs:
   - src/
   - evolution/

--- a/setup/register-placeholder.test.ts
+++ b/setup/register-placeholder.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for #1165 — a falsy channelFormat left the literal
+ * `{{CHANNEL_FORMAT}}` in a group's CLAUDE.md.
+ *
+ * Why this mattered more than a cosmetic leak: the generated file is read as
+ * instructions by the agent, and `generateClaudeMdFromTemplate` early-returns
+ * when the output already exists ("never overwrite customizations"). So a
+ * corrupted file was PERMANENT — setup would never regenerate it and nothing
+ * surfaced the problem. The fix refuses to write, which keeps the failure
+ * recoverable: fix the input, re-run, and the normal path succeeds.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { generateClaudeMdFromTemplate } = await import('./register.js');
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'deus-register-'));
+});
+
+function writeTemplate(body: string): string {
+  const p = path.join(tmp, 'CLAUDE.md.template');
+  fs.writeFileSync(p, body);
+  return p;
+}
+
+describe('generateClaudeMdFromTemplate placeholder safety (#1165)', () => {
+  it('refuses to write when channelFormat is empty', () => {
+    const tpl = writeTemplate('Reply using {{CHANNEL_FORMAT}} formatting.\n');
+    const out = path.join(tmp, 'groups', 'main', 'CLAUDE.md');
+
+    const wrote = generateClaudeMdFromTemplate(tpl, out, {
+      assistantName: 'Deus',
+      channelFormat: '',
+    });
+
+    expect(wrote).toBe(false);
+    // The defect: previously this file was written containing the literal
+    // placeholder, and could never be regenerated.
+    expect(fs.existsSync(out)).toBe(false);
+  });
+
+  it('refuses to write when channelFormat is absent but the template needs it', () => {
+    const tpl = writeTemplate('Reply using {{CHANNEL_FORMAT}} formatting.\n');
+    const out = path.join(tmp, 'groups', 'main', 'CLAUDE.md');
+
+    const wrote = generateClaudeMdFromTemplate(tpl, out, {
+      assistantName: 'Deus',
+    });
+
+    expect(wrote).toBe(false);
+    expect(fs.existsSync(out)).toBe(false);
+  });
+
+  it('substitutes and writes normally when channelFormat is provided', () => {
+    const tpl = writeTemplate(
+      '{{ASSISTANT_NAME}} replies using {{CHANNEL_FORMAT}} formatting.\n',
+    );
+    const out = path.join(tmp, 'groups', 'main', 'CLAUDE.md');
+
+    const wrote = generateClaudeMdFromTemplate(tpl, out, {
+      assistantName: 'Deus',
+      channelFormat: 'WhatsApp',
+    });
+
+    expect(wrote).toBe(true);
+    const written = fs.readFileSync(out, 'utf-8');
+    expect(written).toBe('Deus replies using WhatsApp formatting.\n');
+    expect(written).not.toContain('{{');
+  });
+
+  it('still generates a template that has no CHANNEL_FORMAT placeholder', () => {
+    // The global template takes no channelFormat and contains no such
+    // placeholder. A naive "require channelFormat" fix would have broken it.
+    const tpl = writeTemplate('{{ASSISTANT_NAME}} is your assistant.\n');
+    const out = path.join(tmp, 'groups', 'global', 'CLAUDE.md');
+
+    const wrote = generateClaudeMdFromTemplate(tpl, out, {
+      assistantName: 'Deus',
+    });
+
+    expect(wrote).toBe(true);
+    expect(fs.readFileSync(out, 'utf-8')).toBe('Deus is your assistant.\n');
+  });
+
+  it('catches any future unsubstituted placeholder, not just CHANNEL_FORMAT', () => {
+    const tpl = writeTemplate('{{ASSISTANT_NAME}} and {{SOME_NEW_TOKEN}}.\n');
+    const out = path.join(tmp, 'groups', 'main', 'CLAUDE.md');
+
+    const wrote = generateClaudeMdFromTemplate(tpl, out, {
+      assistantName: 'Deus',
+      channelFormat: 'WhatsApp',
+    });
+
+    expect(wrote).toBe(false);
+    expect(fs.existsSync(out)).toBe(false);
+  });
+
+  it('leaves an existing CLAUDE.md untouched', () => {
+    const tpl = writeTemplate('Reply using {{CHANNEL_FORMAT}} formatting.\n');
+    const out = path.join(tmp, 'CLAUDE.md');
+    fs.writeFileSync(out, 'customized by hand\n');
+
+    const wrote = generateClaudeMdFromTemplate(tpl, out, {
+      assistantName: 'Deus',
+      channelFormat: 'WhatsApp',
+    });
+
+    expect(wrote).toBe(false);
+    expect(fs.readFileSync(out, 'utf-8')).toBe('customized by hand\n');
+  });
+});

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -80,13 +80,16 @@ const CHANNEL_FORMATS: Record<string, string> = {
  * Generate a CLAUDE.md from a .template file, replacing placeholders.
  * Only writes if the target CLAUDE.md does not already exist (never overwrite customizations).
  */
-function generateClaudeMdFromTemplate(
+export function generateClaudeMdFromTemplate(
   templatePath: string,
   outputPath: string,
   vars: { assistantName: string; channelFormat?: string },
 ): boolean {
   if (fs.existsSync(outputPath)) {
-    logger.info({ file: outputPath }, 'CLAUDE.md already exists, skipping generation');
+    logger.info(
+      { file: outputPath },
+      'CLAUDE.md already exists, skipping generation',
+    );
     return false;
   }
 
@@ -97,8 +100,29 @@ function generateClaudeMdFromTemplate(
 
   let content = fs.readFileSync(templatePath, 'utf-8');
   content = content.replace(/\{\{ASSISTANT_NAME\}\}/g, vars.assistantName);
+  // Substitute only a real value. Substituting a falsy one with '' would
+  // DELETE the placeholder and quietly emit a broken sentence, which the guard
+  // below could no longer detect -- trading a visible corruption for an
+  // invisible one. Leaving it in place lets that guard be the single point of
+  // enforcement (#1165).
   if (vars.channelFormat) {
     content = content.replace(/\{\{CHANNEL_FORMAT\}\}/g, vars.channelFormat);
+  }
+
+  // Never write a template that still carries placeholders. This function
+  // early-returns when the output already exists, so a corrupted file is
+  // PERMANENT -- setup will never regenerate it and nothing reports it.
+  // Refusing to write keeps the failure recoverable: fix the input, re-run,
+  // and the normal path produces a correct file because none exists yet.
+  const leftover = [...content.matchAll(/\{\{[A-Z0-9_]+\}\}/g)].map(
+    (m) => m[0],
+  );
+  if (leftover.length > 0) {
+    logger.error(
+      { file: outputPath, placeholders: [...new Set(leftover)] },
+      'Refusing to write CLAUDE.md with unsubstituted placeholders — fix the inputs and re-run',
+    );
+    return false;
   }
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });


### PR DESCRIPTION
Fixes #1165, reported by @Yonatan1203. One half of their report reproduces; the other doesn't, and I said so publicly when re-filing rather than quietly fixing something else.

- **`{{CHANNEL_FORMAT}}` — real.** Guarded by `if (vars.channelFormat)`, so a falsy value skipped substitution.
- **`{{ASSISTANT_NAME}}` — does not reproduce.** `:99` substitutes it unconditionally.

## Why it mattered

The literal `{{CHANNEL_FORMAT}}` was written into a group's `CLAUDE.md` — a file read as *instructions by the agent*.

It's reachable, not hypothetical. `:54` does `result.channel = (args[++i] || '').toLowerCase()`, so `--channel` as a **trailing argument** makes `args[++i]` undefined and `channel` becomes `''`, overriding the `'whatsapp'` default. `:159` then yields `''`, and the truthiness guard skips substitution. `deus register --group main --channel` produces a corrupted file.

And the corruption was **permanent**: `:88-91` early-returns when the output already exists ("never overwrite customizations"), so setup never regenerates it and nothing surfaces the problem.

## The fix is the write-guard, not the substitution

After templating, any remaining `{{...}}` is logged with its file and name, and **the file is not written**.

That inverts the recoverability, which is the whole argument:

- A corrupted file can never self-heal — the early-return guarantees it.
- A refusal is fixed by correcting the input and re-running, which now succeeds precisely *because* no file exists.

It also generalises: any placeholder added to a template in future is covered without further code.

### Substitution still skips falsy values, deliberately

My first attempt substituted unconditionally with `''`. **My own test caught that as a flaw**: replacing with an empty string *deletes* the placeholder and emits a quietly broken sentence ("Reply using  formatting.") that the guard can no longer detect — trading a visible corruption for an invisible one. Leaving the placeholder in place lets the write-guard be the single point of enforcement.

## Verification

The function had to be exported to be testable, which would have confounded a naive control — every test would fail on main for the wrong reason (import error), not because of behaviour. So the control is **main's logic plus only the export**:

| | result |
|---|---|
| **Control** (main logic + export) | **3 fail / 3 pass** |
| **Treatment** (this PR) | **6 pass** |

- The 3 failures are the bug: files written containing literal placeholders.
- The 3 passes are must-not-regress cases — normal substitution, a template with *no* `{{CHANNEL_FORMAT}}` (the global one, which a naive "require channelFormat" fix would have broken), and an existing file left untouched.

Full suite: **118 files, 2142 tests**. Setup suite 165/165. `tsc --noEmit` and `prettier --check` clean.

## Noted, not fixed

`parseArgs` still accepts an empty `--channel` (`:54`). That's the root cause of this particular route in, and rejecting it would make the corruption unreachable at source. Left out to keep the change scoped, and because the write-guard covers the whole class rather than this one entry point — raised in the plan and the reviewer agreed with the scoping.

## Gates

plan-reviewer co-gate PASS, code-reviewer co-gate PASS, verification-gate marked on the driven evidence above.
