### PR TITLE
fix(wardens): accept the TRIVIAL bypass the verification-gate advertises

### DIFF
--- a/patterns/hook-change.md
+++ b/patterns/hook-change.md
@@ -3,7 +3,7 @@ governs:
   - .claude/hooks/
   - scripts/codex_warden_hooks.py
   - .claude/settings.json
-last_verified: "2026-08-16"
+last_verified: "2026-08-20" # auto-bump @1787223223
 test_tasks:
   - "Add a PreToolUse gate that blocks a write when the pending content matches a pattern"
   - "Change which tools an existing warden gate fires on"

--- a/scripts/codex_warden_hooks.py
+++ b/scripts/codex_warden_hooks.py
@@ -1644,7 +1644,18 @@ def run_verification_gate(event: dict[str, Any], repo_root: Path) -> int:
     command = tool_input.get("command") if isinstance(tool_input, dict) else ""
     if not isinstance(command, str) or not GIT_COMMIT_RE.search(command):
         return 0
-    if _read_verdict("verified", repo_root) == "SHIP":
+    # TRIVIAL satisfies this gate exactly like SHIP, matching the convention the
+    # backends gate already implements and documents (see the TRIVIAL branch in
+    # _evaluate_backends). This gate used to compare == "SHIP" while its own
+    # block message advertised `mark verified TRIVIAL` -- so following that
+    # instruction printed success, stored "TRIVIAL" verbatim, and then re-blocked
+    # on the next write (#1167).
+    #
+    # This does not widen the bypass. Every constraint on TRIVIAL lives in
+    # mark_warden and is unchanged: refused outright in background sessions,
+    # refused after any blocking verdict, and audit-logged on every use. The
+    # blocking-verdict branch below still declines to advertise it at all.
+    if _read_verdict("verified", repo_root) in ("SHIP", "TRIVIAL"):
         _cc_shadow_observe("verification-gate", config, repo_root, [])
         _cc_mirror_verdicts("verification-gate", config, repo_root)
         return 0

--- a/scripts/tests/test_codex_warden_hooks.py
+++ b/scripts/tests/test_codex_warden_hooks.py
@@ -5633,3 +5633,90 @@ def test_buckets_with_ship_excludes_current_bucket(tmp_path):
     )
 
     assert hooks._buckets_with_ship("code-reviewer", "gpt", repo, current) == []
+
+
+# ── #1167: the gate must accept the bypass it advertises ─────────────────────
+#
+# run_verification_gate compared == "SHIP" while its own block message told the
+# operator to run `mark verified TRIVIAL`. Following that instruction printed
+# success, stored "TRIVIAL" verbatim, and then re-blocked -- a failure that only
+# surfaced on the next write. TRIVIAL satisfies the Claude side exactly like
+# SHIP, which is the convention _evaluate_backends already implements.
+
+
+def test_verification_gate_allows_after_trivial_marker(tmp_path, capsys):
+    """The advertised bypass must actually satisfy the gate (#1167)."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "verification-gate", "TRIVIAL", "config-only", "mark")
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    # The defect: previously this re-blocked despite the mark reporting success.
+    assert capsys.readouterr().out == ""
+
+
+def test_verification_gate_still_allows_after_ship(tmp_path, capsys):
+    """MUST NOT REGRESS: SHIP keeps working."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "verification-gate", "SHIP", "verified", "mark")
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_verification_gate_still_blocks_with_no_verdict(tmp_path, capsys):
+    """MUST NOT REGRESS: absence of a verdict still blocks."""
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    reason = json.loads(capsys.readouterr().out)["hookSpecificOutput"][
+        "permissionDecisionReason"
+    ]
+    assert "no verification-gate approval marker" in reason
+
+
+def test_verification_gate_still_blocks_after_revise(tmp_path, capsys):
+    """MUST NOT REGRESS: a blocking verdict still blocks, and still refuses the bypass.
+
+    This is the case that would matter most if the change were wrong: REVISE must
+    not become bypassable, and the message must not start advertising TRIVIAL.
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    hooks._write_verdict(repo, "verification-gate", "REVISE", "not done", "agent")
+
+    rc = hooks.run_verification_gate(bash_event(repo, "git commit -m test"), repo)
+
+    assert rc == 0
+    reason = json.loads(capsys.readouterr().out)["hookSpecificOutput"][
+        "permissionDecisionReason"
+    ]
+    assert "last verification-gate verdict was REVISE" in reason
+    assert "Trivial bypass is not permitted" in reason
+
+
+def test_marking_trivial_still_refused_in_background_session(tmp_path, monkeypatch, capsys):
+    """MUST NOT REGRESS: bg sessions still cannot record TRIVIAL at all.
+
+    The gate now accepts TRIVIAL, so the constraint that autonomous runs cannot
+    PRODUCE one is what keeps the bypass human-only. If this regresses, the
+    change is wrong.
+    """
+    hooks = load_hooks()
+    repo = git_repo(tmp_path)
+    monkeypatch.setattr(hooks, "_is_bg_session", lambda: True)
+
+    rc = hooks.mark_warden("verified", "TRIVIAL", "config-only", repo)
+
+    assert rc == 2
+    assert "not permitted in background sessions" in capsys.readouterr().err
+    # And nothing was recorded, so the gate cannot then be satisfied by it.
+    assert hooks._read_verdict("verified", repo) is None


### PR DESCRIPTION
Fixes #1167, reported by @Yonatan1203. Their trace was exactly right, including the part that makes it worse than a no-op.

## The bug

`run_verification_gate` passed only on `== "SHIP"` (`:1647`), while its own block message advertised:

```
Trivial-commit bypass (typos, deps, config-only):
  python3 <script> mark verified TRIVIAL "reason"
```

Following that instruction:

1. `mark_warden` accepts `TRIVIAL` (`:3450`), prints `[warden-mark] verified marked as TRIVIAL`, returns **0**.
2. `_write_verdict` (`verdict_store.py:385`) stores `"verdict": verdict` **verbatim** — no normalisation.
3. `_read_verdict` returns `"TRIVIAL"` → `!= "SHIP"` → the gate **re-blocks**.

The mark reports success, so the only way to discover the failure is the next blocked write.

## Which side was wrong

I initially assumed the fix was to stop advertising the bypass — tighten the message rather than loosen the gate. **The codebase settled it the other way.** The sibling backends gate already honours TRIVIAL, and says why (`:2879-2884`):

> `# TRIVIAL is the human trivial-commit bypass (mark_warden accepts SHIP|TRIVIAL and`
> `# writes the literal verdict). It satisfies the Claude side exactly like SHIP — the`
> `# marker-only gates honored it, so the backends gate must too.`

So "TRIVIAL satisfies the Claude side exactly like SHIP" is the stated convention, and `run_verification_gate` was the one place not implementing it. The message was right; the check was wrong.

The fix is one condition:

```python
if _read_verdict("verified", repo_root) in ("SHIP", "TRIVIAL"):
```

## Why this does not weaken the gate

This is the gate every commit in this repo passes through, so the safety argument matters more than the fix.

**Every constraint on TRIVIAL lives in `mark_warden`, and none of it changes:**

- **Refused outright in background sessions** (`:3457-3463`) — returns 2, nothing recorded. Autonomous runs cannot produce a TRIVIAL verdict at all.
- **Refused after any blocking verdict** (`:3466-3476`) — once REVISE/BLOCK is recorded, TRIVIAL is rejected.
- **Audit-logged** — `_write_bypass_log` records every use with session type and reason.
- **The gate's blocking-verdict branch** (`:1657-1664`) still prints `Trivial bypass is not permitted after {last}` and still declines to advertise it. Untouched.

So the gate now accepts exactly what marking already permits a human to record, in exactly the cases it already permits. It closes an inconsistency; it opens no new path.

## Verification

| | result |
|---|---|
| **Control** (`origin/main`) | **1 fail / 20 pass** |
| **Treatment** (this PR) | **21 pass** |

The single control failure is the bug itself — the advertised bypass re-blocking. Everything else passes on **both** sides, which is the point. The four must-not-regress cases:

1. `SHIP` still passes.
2. A missing verdict still blocks, with the same message.
3. **`REVISE` still blocks, and its message still refuses the bypass.** If the change were wrong, this is where it would show.
4. **A background session still cannot record `TRIVIAL` at all** — `mark_warden` returns 2 and `_read_verdict` finds nothing afterwards. Since the gate now accepts TRIVIAL, this constraint is what keeps the bypass human-only.

Full warden hooks suite: **360 passed**.

## Out of scope

Whether the TRIVIAL bypass should exist at all — a policy question. This only makes the advertised behaviour match the actual behaviour.

## Gates

plan-reviewer co-gate PASS, code-reviewer co-gate PASS (asked explicitly to scrutinise for weakening), verification-gate marked on the evidence above.
