### PR TITLE
fix(evolution): record a skipped principles extraction as a skip, not STATUS_OK

### DIFF
--- a/evolution/cli.py
+++ b/evolution/cli.py
@@ -216,17 +216,33 @@ def _maybe_auto_extract_principles(domain_presets: Optional[list] = None) -> Non
         # Data-count check + extraction (extract_principles handles its own min_new gate)
         component = _PRINCIPLES_HEALTH_PREFIX + domain_key
         try:
-            extract_principles(domain=domain)
+            result = extract_principles(domain=domain)
         except Exception as exc:
             log.warning('evolution: principles extraction failed for domain=%s — %s: %s',
                         domain, type(exc).__name__, exc)
             health.record_attempt(component, health.STATUS_FAILED, type(exc).__name__)
         else:
-            # Recorded on every success, not just on recovery: this path is
-            # already gated by PRINCIPLES_COOLDOWN_HOURS above, so it is not hot
-            # and the OK write is what lets a resolved failure clear its streak
-            # (LIA-556 site 2).
-            health.record_attempt(component, health.STATUS_OK, 'extraction completed')
+            # Three outcomes, not two. "Did not raise" is not "did work", and
+            # conflating them let a skip clear a real FAILED streak (#1248).
+            if result is None:
+                # Returned before the single generate() call — either the
+                # min_new data-count gate or the <3-usable-examples gate. No
+                # LLM call, no cooldown consumed, nothing attempted. record_skip
+                # touches only last_skipped_at, so it is structurally incapable
+                # of clearing a streak or overwriting a diagnostic cause.
+                health.record_skip(component)
+            elif not result.strip():
+                # The generate() call DID happen: extract_principles returns its
+                # text only after _record_extraction has already run, so the
+                # cooldown and the tokens are spent. Producing nothing is a
+                # failed attempt, not a skip.
+                health.record_attempt(component, health.STATUS_FAILED, 'empty generation')
+            else:
+                # Recorded on every success, not just on recovery: this path is
+                # already gated by PRINCIPLES_COOLDOWN_HOURS above, so it is not hot
+                # and the OK write is what lets a resolved failure clear its streak
+                # (LIA-556 site 2).
+                health.record_attempt(component, health.STATUS_OK, 'extraction completed')
 
 
 def _maybe_auto_optimize(domain_presets: Optional[list] = None) -> None:

--- a/evolution/health.py
+++ b/evolution/health.py
@@ -164,14 +164,20 @@ def record_skip(component: str) -> None:
     record: it can neither flip the status nor overwrite the diagnostic cause.
     Both were real bugs before this shape.
 
-    Deliberately takes no `reason` argument. There is exactly one skip path
-    (the below-threshold early return in cli.py), so the explanation is
-    constant and derivable from the threshold config. Storing it in a column
-    was tried and produced three further defects — `rollup()` reads
-    `last_reason` only and would have reported None for a skip-only component;
-    the column needed an ALTER TABLE that every reader would execute, adding
-    DDL lock exposure on a concurrently-written file; and it deviated from
-    patterns/eval-change.md. The field is simply not written.
+    Deliberately takes no `reason` argument, and callers must not grow one.
+    Every skip site is an early return from its own explicit gate, so the gate
+    condition IS the explanation and it is constant per site — derivable from
+    the config or the query that guards it, never varying call to call. Current
+    sites, illustrative rather than exhaustive: the below-threshold return in
+    `_maybe_auto_optimize` (cli.py), the empty-queue return in
+    `judge_pending_interactions` (maintenance.py), and the `min_new` and
+    usable-examples gates reached through `_maybe_auto_extract_principles`
+    (cli.py). Storing a reason in a column was tried and produced three further
+    defects — `rollup()` reads `last_reason` only and would have reported None
+    for a skip-only component; the column needed an ALTER TABLE that every
+    reader would execute, adding DDL lock exposure on a concurrently-written
+    file; and it deviated from patterns/eval-change.md. The field is simply not
+    written.
 
     On the INSERT branch `last_status` is left as SQL NULL, so a
     never-attempted component is never confused with a healthy one.

--- a/evolution/tests/test_evolution_silent_swallows.py
+++ b/evolution/tests/test_evolution_silent_swallows.py
@@ -56,7 +56,10 @@ def test_principles_success_records_ok_and_self_heals(test_db, principles):
     cli._maybe_auto_extract_principles(["coding"])
     assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is True
 
-    principles(lambda domain=None: None)  # recovered
+    # Recovered. The stub must return generated TEXT, not None: None is the
+    # return of a skip that never reached the LLM, and a skip is precisely what
+    # must NOT clear a streak (see the skip tests below).
+    principles(lambda domain=None: _GENERATED)
     cli._maybe_auto_extract_principles(["coding"])
 
     row = health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")
@@ -74,6 +77,7 @@ def test_one_broken_domain_does_not_taint_a_healthy_one(test_db, monkeypatch):
     def selective(domain=None):
         if domain == "coding":
             raise RuntimeError("boom")
+        return _GENERATED
 
     monkeypatch.setattr("evolution.reflexion.principles.extract_principles", selective)
     cli._maybe_auto_extract_principles(["coding", "study"])
@@ -82,6 +86,169 @@ def test_one_broken_domain_does_not_taint_a_healthy_one(test_db, monkeypatch):
         == health.STATUS_FAILED
     assert health.get(cli._PRINCIPLES_HEALTH_PREFIX + "study")["last_status"] \
         == health.STATUS_OK
+
+
+# ── Site 2, continued: a skip is not an attempt (#1248) ───────────────────────
+#
+# `extract_principles` returns None on two ordinary paths, BOTH of which return
+# before the single `generate()` call: the `min_new` data-count gate
+# (principles.py:71-76) and the "<3 usable examples once empty responses are
+# filtered" gate (principles.py:94-95). Neither did any work, so neither is an
+# attempt — and because record_attempt(OK) is the only write that zeroes
+# `consecutive_failures` and nulls `first_failed_at`, recording one as OK
+# laundered a live FAILED streak into a clean bill of health.
+#
+# The two gate tests drive the REAL `extract_principles` with only its data
+# sources stubbed, so they are pinned to the actual early-return sites rather
+# than to a hand-made stub that merely agrees with them.
+
+_GENERATED = "1. Answer the question asked.\n2. Cite the file you changed."
+
+
+@pytest.fixture
+def real_extraction(monkeypatch):
+    """Run the real `extract_principles`, with only its data sources stubbed.
+
+    `principles.py` binds `get_storage` and `get_recent` at MODULE level, so
+    these patch the names in that module rather than at their definition sites
+    — patching `evolution.storage.get_storage` alone would not be seen here (it
+    is seen in cli.py only because cli.py imports it inside the function body).
+
+    Returns a setter taking `new_count` (what the min_new gate compares) and
+    `rows` (what `get_recent` yields for both the best and worst queries).
+    """
+    def _wire(new_count, rows=(), generated=_GENERATED):
+        store = type("S", (), {
+            "get_last_extraction": lambda self, d: None,
+            "count_new_scored": lambda self, since_timestamp=None, domain=None: new_count,
+            "record_extraction": lambda self, **kw: None,
+        })()
+        monkeypatch.setattr("evolution.storage.get_storage", lambda *a, **k: store)
+        monkeypatch.setattr("evolution.reflexion.principles.get_storage",
+                            lambda *a, **k: store)
+        monkeypatch.setattr("evolution.reflexion.principles.get_recent",
+                            lambda **kw: list(rows))
+        monkeypatch.setattr("evolution.reflexion.principles.generate",
+                            lambda *a, **k: generated)
+        monkeypatch.setattr("evolution.reflexion.principles.save_reflection",
+                            lambda **kw: None)
+    return _wire
+
+
+def _row(response="a real answer"):
+    return {"prompt": "p", "response": response, "judge_score": 0.9}
+
+
+def test_min_new_gate_records_a_skip_not_ok(test_db, real_extraction):
+    """AC1: below the min_new threshold, nothing ran — so nothing is recorded
+    as having run."""
+    real_extraction(new_count=0)  # default min_new is 5
+
+    cli._maybe_auto_extract_principles(["coding"])
+
+    row = health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")
+    assert row["last_status"] != health.STATUS_OK, \
+        "a below-threshold skip must not be recorded as a successful extraction"
+    assert row["last_status"] is None, "a skip must not invent a status at all"
+    assert row["last_skipped_at"] is not None, "the skip itself must be recorded"
+
+
+def test_usable_examples_gate_records_a_skip_not_ok(test_db, real_extraction):
+    """AC2: past min_new, but the empty-response filter leaves <3 usable rows.
+
+    Four rows in, three of them response-less: `response_supports_reflection`
+    drops those, leaving 1 + 1 = 2 < 3. Still no LLM call, still not an attempt.
+    """
+    rows = [_row(), _row(""), _row(None), _row("   ")]
+    real_extraction(new_count=99, rows=rows)
+
+    cli._maybe_auto_extract_principles(["coding"])
+
+    row = health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")
+    assert row["last_status"] != health.STATUS_OK, \
+        "an insufficient-examples skip must not be recorded as a successful extraction"
+    assert row["last_status"] is None
+    assert row["last_skipped_at"] is not None
+
+
+@pytest.mark.parametrize("gate,new_count,rows", [
+    ("min_new", 0, ()),
+    ("usable_examples", 99, (_row(), _row(""), _row(None))),
+])
+def test_a_skip_does_not_clear_a_live_failure_streak(
+    test_db, real_extraction, gate, new_count, rows,
+):
+    """AC3: the actual bug. A real FAILED streak must survive both skip paths.
+
+    Parametrised over both gates because they are separate `return None` sites
+    and a fix that caught only one would still launder the other.
+    """
+    component = cli._PRINCIPLES_HEALTH_PREFIX + "coding"
+    health.record_attempt(component, health.STATUS_FAILED, "no API key")
+    health.record_attempt(component, health.STATUS_FAILED, "no API key")
+    before = health.get(component)
+    assert before["consecutive_failures"] == 2
+
+    real_extraction(new_count=new_count, rows=rows)
+    cli._maybe_auto_extract_principles(["coding"])
+
+    after = health.get(component)
+    assert after["last_status"] == health.STATUS_FAILED, f"{gate} skip cleared the status"
+    assert after["consecutive_failures"] == 2, f"{gate} skip reset the streak counter"
+    assert after["last_reason"] == "no API key", f"{gate} skip overwrote the diagnostic cause"
+    assert after["first_failed_at"] == before["first_failed_at"], \
+        f"{gate} skip moved the start of the streak"
+    assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is True, \
+        f"{gate} skip hid an unresolved failure from the cockpit gate"
+
+
+def test_empty_generation_records_failed_not_skipped(test_db, principles):
+    """AC4: the third case, and the easy one to miss.
+
+    `extract_principles` returns the generation text AFTER `_record_extraction`
+    has already run, so an empty string means the LLM call really happened and
+    consumed both its cooldown and its tokens. That is a failed attempt — not a
+    skip, and certainly not an OK.
+    """
+    principles(lambda domain=None: "   \n  ")
+
+    cli._maybe_auto_extract_principles(["coding"])
+
+    row = health.get(cli._PRINCIPLES_HEALTH_PREFIX + "coding")
+    assert row["last_status"] == health.STATUS_FAILED
+    assert row["last_reason"] == "empty generation"
+    assert row["consecutive_failures"] == 1
+
+
+def test_a_real_extraction_still_clears_a_streak(test_db, real_extraction):
+    """AC5: the LIA-556 intent is preserved — self-heal still works, but now
+    only for an extraction that actually produced output."""
+    component = cli._PRINCIPLES_HEALTH_PREFIX + "coding"
+    health.record_attempt(component, health.STATUS_FAILED, "no API key")
+    assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is True
+
+    real_extraction(new_count=99, rows=[_row(), _row(), _row()])
+    cli._maybe_auto_extract_principles(["coding"])
+
+    row = health.get(component)
+    assert row["last_status"] == health.STATUS_OK
+    assert row["last_reason"] == "extraction completed"
+    assert row["consecutive_failures"] == 0
+    assert row["first_failed_at"] is None
+    assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is False
+
+
+def test_skip_only_history_is_never_attempted_not_healthy(test_db, real_extraction):
+    """AC6: a component that has never extracted anything must not report as
+    healthy — to `rollup()` or to anything reading it."""
+    real_extraction(new_count=0)
+    cli._maybe_auto_extract_principles(["coding"])
+
+    roll = health.rollup(cli._PRINCIPLES_HEALTH_PREFIX)
+    assert roll["status"] is None, "never-attempted must not surface as OK"
+    assert "never attempted" in roll["reason"]
+    # ...and it is still not a failure, so it must not trip the cockpit gate.
+    assert health.has_failure(cli._PRINCIPLES_HEALTH_PREFIX) is False
 
 
 # ── Site 3: the outermost dispatch guards ─────────────────────────────────────

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-20" # auto-bump @1787220472
+last_verified: "2026-08-20" # auto-bump @1787228084
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-20" # auto-bump @1787222734
+last_verified: "2026-08-20" # auto-bump @1787228084
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
Closes #1248.

## Problem

`_maybe_auto_extract_principles` (`evolution/cli.py`) recorded `health.STATUS_OK` on every call that did not raise — including calls where `extract_principles` skipped before doing any work. `STATUS_OK` is the only write that zeroes `consecutive_failures` and nulls `first_failed_at`, so a skip laundered a genuine `FAILED` streak into a clean bill of health with nothing having been fixed. Health data actively lied.

`extract_principles` returns `None` on two ordinary paths, **both before the single `generate()` call**: the `min_new` data-count gate (`principles.py:71-76`) and the "<3 usable examples once empty responses are filtered" gate (`principles.py:94-95`).

## Fix

Capture the return value and route three ways:

| return | recorded as | why |
|---|---|---|
| `None` | `record_skip()` | no LLM call happened — not an attempt |
| empty / whitespace | `STATUS_FAILED` `'empty generation'` | the call **did** happen; text is returned only after `_record_extraction` runs, so cooldown and tokens are spent |
| non-empty | `STATUS_OK` | unchanged — preserves the LIA-556 self-heal intent |

`record_skip` already existed (`health.py:158`) and two sibling call sites already used it correctly. This was the one that did not.

## Also in this PR

`record_skip`'s docstring claimed *"There is exactly one skip path (the below-threshold early return in cli.py)."* That was **already false before this change** — `maintenance.py:297` is an empty-queue skip in a different file — and this PR adds two more. A "one → two" recount would have landed still-inaccurate, so the brittle count is replaced by the invariant it stood in for: each site's own gate condition is the reason, which is exactly why the function takes no `reason` argument. Sites are now listed as examples so the prose does not re-rot. No behaviour change.

Two existing tests encoded the buggy contract — they stubbed `extract_principles` to return `None` and asserted `STATUS_OK`. Both now use a text-returning stub, which is what the assertion was always trying to express.

## Verification

**Red/green control.** With **only** `evolution/cli.py` reverted to `main` (tests and docstring change kept in place), exactly 6 of the new tests fail, and every failure is a health-status assertion — no import, collection, or fixture errors:

```
test_min_new_gate_records_a_skip_not_ok                          assert 'OK' != 'OK'
test_usable_examples_gate_records_a_skip_not_ok                  assert 'OK' != 'OK'
test_a_skip_does_not_clear_a_live_failure_streak[min_new]        assert 'OK' == 'FAILED'
test_a_skip_does_not_clear_a_live_failure_streak[usable_examples] assert 'OK' == 'FAILED'
test_empty_generation_records_failed_not_skipped                 assert 'OK' == 'FAILED'
test_skip_only_history_is_never_attempted_not_healthy            assert 'OK' is None
```

The AC1/AC2 tests drive the **real** `extract_principles` with only its data sources stubbed, so they are pinned to the actual early-return sites rather than to a stub that merely agrees with them.

**End-to-end, outside pytest.** A live `FAILED` streak survives a skip (`consecutive_failures` stays 2, `last_status` FAILED, `last_reason` intact), and a real extraction still clears it (0 / OK) — confirming the fix did not simply disable the self-heal.

**Suite.** `evolution/tests/` — 1035 passed, 2 skipped.

All six acceptance criteria from #1248 are covered by tests.

## Known gap, deliberately out of scope

A generation that is non-empty but contains no digit-led lines stores zero reflections yet still returns truthy text, so it records `OK` for a run that persisted nothing. Closing this requires `extract_principles` to report *what it stored* — a change to its contract, not to health accounting. Filed separately rather than bundled here.

## Notes for the reviewer

- The second commit on this branch is `chore(patterns): auto-bump drifted patterns`, forced by the pre-push hook (#1251). It is not part of this change.
- `evolution/tests/test_judge_registry.py::test_default_model_reads_from_config` fails on a host that exports `EVOLUTION_OLLAMA_JUDGE_MODEL`; it passes with the var unset and is unrelated to this diff. Latent env-dependent test, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)