### PR TITLE
fix(evolution): count schema errors against the judge composite ranking

### DIFF
--- a/evolution/benchmark_judge.py
+++ b/evolution/benchmark_judge.py
@@ -96,6 +96,12 @@ class ModelResult:
         return self.parse_errors / self.total if self.total else 0.0
 
     @property
+    def schema_error_rate(self) -> float:
+        # Same denominator as parse_error_rate: `total` is incremented once per
+        # interaction, so the two rates are fractions of the same attempted set.
+        return self.schema_errors / self.total if self.total else 0.0
+
+    @property
     def avg_latency(self) -> float:
         return statistics.mean(self.latencies) if self.latencies else 0.0
 
@@ -551,12 +557,18 @@ def print_comparison(results: list[ModelResult], trivial_baselines: Optional[dic
         print("\nNo results to compare.")
         return
 
-    # Sort by composite: correlation (40%) + inverse MAE (30%) + inverse parse rate (30%)
+    # Sort by composite: correlation (40%) + inverse MAE (30%) + inverse error rate (30%)
     def composite(r: ModelResult) -> float:
         corr = max(r.pearson, 0)
         mae_score = max(0, 1 - r.mae)
-        parse_score = 1 - r.parse_error_rate
-        return 0.4 * corr + 0.3 * mae_score + 0.3 * parse_score
+        # Both counters mean "the judge returned no valid, complete assessment",
+        # so they are penalised symmetrically — additive rather than an
+        # eligibility gate, which would need a threshold no evidence supports.
+        # Additive is only safe because the two are disjoint per record: a
+        # schema error's rationale can never contain "Parse error", and the
+        # except-branch parse error continues before the schema check (#1245).
+        error_score = max(0.0, 1 - r.parse_error_rate - r.schema_error_rate)
+        return 0.4 * corr + 0.3 * mae_score + 0.3 * error_score
 
     ranked = sorted(results, key=composite, reverse=True)
 
@@ -576,7 +588,7 @@ def print_comparison(results: list[ModelResult], trivial_baselines: Optional[dic
     print("BENCHMARK RESULTS (ranked by composite score)")
     print(f"{'='*80}")
     header = f"{'Rank':<5} {'Model':<25} {'Pearson':>8} {'Spearman':>9} " \
-             f"{'MAE':>6} {'ParseErr':>9} {'Latency':>8} {'Composite':>10}"
+             f"{'MAE':>6} {'ParseErr':>9} {'SchemaErr':>10} {'Latency':>8} {'Composite':>10}"
     if log_len_r is not None:
         header += f" {'Δ vs log-len':>13}"
     print(header)
@@ -588,11 +600,26 @@ def print_comparison(results: list[ModelResult], trivial_baselines: Optional[dic
         row = (
             f"{i+1:<5} {r.model:<25} {r.pearson:>8.3f} {r.spearman:>9.3f} "
             f"{r.mae:>6.3f} {r.parse_errors:>4}/{r.total:<4} "
+            # The cause of a schema demotion, in the compact table rather than
+            # only in the verbose per-model summary (#1245).
+            f"{r.schema_errors:>5}/{r.total:<4} "
             f"{r.avg_latency:>7.1f}s {comp:>9.3f}"
         )
         if log_len_r is not None:
             row += f" {r.pearson - log_len_r:>+13.3f}"
         print(row + marker)
+
+    if not ranked[0].scores:
+        # Every record was dropped before entering a statistic, so this model's
+        # correlation and MAE are not measurements. Ranking cannot catch this on
+        # its own — with one candidate there is nothing to prefer over it — and
+        # recommending it would emit an `export OLLAMA_MODEL=` line for a judge
+        # that never returned a valid assessment (#1245).
+        print(f"\nNo winner: {ranked[0].model} has no usable records "
+              f"({ranked[0].schema_errors} schema / {ranked[0].parse_errors} parse "
+              f"errors out of {ranked[0].total}). Fix the judge output before "
+              f"trusting any ranking above.")
+        return
 
     print(f"\n*** Winner: {ranked[0].model}")
 

--- a/evolution/tests/test_benchmark_judge_fixture.py
+++ b/evolution/tests/test_benchmark_judge_fixture.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from evolution import benchmark_judge as bj
+from evolution.judge.base import schema_error_result
 
 
 # ── metrics ──────────────────────────────────────────────────────────────────
@@ -280,3 +281,222 @@ def test_print_comparison_with_trivial_baselines(capsys):
     out = capsys.readouterr().out
     assert "Trivial baselines" in out and "log-length r=0.300" in out
     assert "Δ vs log-len" in out
+
+
+# ── schema errors reach the ranking (#1245) ──────────────────────────────────
+#
+# Schema-invalid records leave the sample entirely (`continue` before both
+# appends), so a model that keeps omitting a required dimension has its
+# correlation and MAE computed only on the subset it answered validly, while
+# `parse_error_rate` — the ranking's only error term — stays untouched. It
+# therefore collects the full error-free weight, and omitting a dimension is
+# REWARDED relative to answering it badly. This ranking selects the judge that
+# grades everything downstream, so the failure is self-reinforcing.
+
+
+def _mr(model, *, scores, truth, total, parse_errors=0, schema_errors=0):
+    mr = bj.ModelResult(model=model)
+    mr.scores = list(scores)
+    mr.ground_truth = list(truth)
+    mr.total = total
+    mr.parse_errors = parse_errors
+    mr.schema_errors = schema_errors
+    return mr
+
+
+def _printed_composite(out, model):
+    """Read a model's Composite value back off the ranked table.
+
+    `composite` is a closure inside `print_comparison` with no importable name,
+    so the printed table is the observable surface — which is also what a human
+    acts on. The rank-1 row carries a trailing ` ***` winner marker, so tokens
+    are filtered before taking the last numeric field.
+    """
+    row = next(line for line in out.splitlines()
+               if f" {model} " in line and line.strip()[0].isdigit())
+    return float([t for t in row.split() if t != "***"][-1])
+
+
+def test_schema_errors_demote_an_otherwise_equivalent_model(capsys):
+    """AC1: identical stats, but one model kept omitting a required dimension."""
+    clean = _mr("clean", scores=[0.1, 0.5, 0.9], truth=[0.2, 0.4, 0.8], total=10)
+    dirty = _mr("dirty", scores=[0.1, 0.5, 0.9], truth=[0.2, 0.4, 0.8], total=10,
+                schema_errors=5)
+
+    bj.print_comparison([dirty, clean])  # deliberately passed worst-first
+    out = capsys.readouterr().out
+
+    assert out.index("clean") < out.index("dirty"), \
+        "a model with a high schema-error rate must rank below an equivalent clean one"
+    assert "*** Winner: clean" in out
+
+
+def test_a_flattering_subset_does_not_beat_an_honest_full_sample(capsys):
+    """AC1, the scenario the issue is actually about — and the one that inverts
+    the incentive.
+
+    `skimmer` answered only 3 of 10 records and schema-errored the other 7, so
+    its correlation and MAE are computed on the 3 it happened to get right,
+    while its parse-error rate stays 0 and it collects the full error-free
+    weight. `honest` answered all 10 with slightly looser agreement. On main the
+    skimmer wins, so omitting a required dimension is rewarded relative to
+    answering it badly — and this ranking picks the judge that grades
+    everything downstream.
+    """
+    skimmer = _mr("skimmer", scores=[0.2, 0.5, 0.8], truth=[0.2, 0.5, 0.8],
+                  total=10, schema_errors=7)
+    honest = _mr("honest",
+                 scores=[0.15, 0.3, 0.45, 0.5, 0.55, 0.6, 0.7, 0.8, 0.85, 0.95],
+                 truth=[0.2, 0.35, 0.4, 0.55, 0.5, 0.65, 0.75, 0.75, 0.9, 0.9],
+                 total=10)
+
+    bj.print_comparison([skimmer, honest])
+    out = capsys.readouterr().out
+
+    assert _printed_composite(out, "honest") > _printed_composite(out, "skimmer"), \
+        "a model that skipped 7 of 10 records must not outrank one that answered all 10"
+    assert "*** Winner: honest" in out
+
+
+def test_all_schema_errors_cannot_win(capsys):
+    """AC2, comparative half: a model that never returned a valid assessment
+    must not be recommended over one that did."""
+    broken = _mr("broken", scores=[], truth=[], total=8, schema_errors=8)
+    ok = _mr("ok", scores=[0.1, 0.5, 0.9], truth=[0.2, 0.4, 0.8], total=8)
+
+    bj.print_comparison([broken, ok])
+    out = capsys.readouterr().out
+
+    assert "*** Winner: ok" in out
+    assert "*** Winner: broken" not in out
+
+
+def test_all_schema_errors_not_recommended_even_when_sole_candidate(capsys):
+    """AC2, degenerate half — the case ranking alone cannot fix.
+
+    With one candidate there is nothing to rank it against, so the formula
+    cannot demote it: it is `ranked[0]` at composite 0.0 and the tool would
+    still print a winner AND an `export OLLAMA_MODEL=` line, which is active
+    advice to adopt a judge that never produced a valid assessment.
+    """
+    broken = _mr("broken", scores=[], truth=[], total=8, schema_errors=8)
+
+    bj.print_comparison([broken])
+    out = capsys.readouterr().out
+
+    assert "*** Winner:" not in out, "a judge with no usable records must not be a winner"
+    assert "export OLLAMA_MODEL=" not in out, \
+        "must not advise adopting a judge that never returned a valid assessment"
+    assert "no usable records" in out.lower()
+
+
+def test_ranked_table_shows_the_schema_error_count(capsys):
+    """AC4: the compact table a human scans must show the cause of a demotion.
+
+    Before this change the only error column was ParseErr, so a schema-demoted
+    model showed no reason at all in the ranked table.
+    """
+    dirty = _mr("dirty", scores=[0.1, 0.5, 0.9], truth=[0.2, 0.4, 0.8], total=10,
+                schema_errors=5)
+
+    bj.print_comparison([dirty])
+    out = capsys.readouterr().out
+
+    assert "SchemaErr" in out, "the ranked table needs a schema-error column"
+    assert "5/10" in out, "the schema-error count must appear in the ranked row"
+
+
+def test_no_schema_errors_leaves_the_composite_unchanged(capsys):
+    """AC5: unchanged output for any run that has no schema errors.
+
+    The new term is `max(0.0, 1 - parse_rate - schema_rate)`; with
+    schema_errors == 0 and parse_errors <= total the clamp is a no-op, so this
+    reduces exactly to the old `1 - parse_error_rate`. Asserted numerically
+    against the pre-change formula rather than against golden text.
+    """
+    mr = _mr("m", scores=[0.1, 0.5, 0.9], truth=[0.2, 0.4, 0.8], total=10,
+             parse_errors=2)
+
+    expected = (0.4 * max(mr.pearson, 0)
+                + 0.3 * max(0, 1 - mr.mae)
+                + 0.3 * (1 - mr.parse_error_rate))
+
+    bj.print_comparison([mr])
+    out = capsys.readouterr().out
+
+    assert abs(_printed_composite(out, "m") - expected) < 5e-4, \
+        f"composite changed for a run with no schema errors: " \
+        f"{_printed_composite(out, 'm')} vs {expected}"
+
+
+def test_schema_error_rate_property():
+    assert _mr("m", scores=[], truth=[], total=8, schema_errors=2).schema_error_rate == 0.25
+    assert bj.ModelResult(model="m").schema_error_rate == 0.0, "no division by zero at total=0"
+
+
+# ── the counters are disjoint per record (AC3) ───────────────────────────────
+
+
+@dataclass
+class _ParseRes:
+    """A record the rationale-substring check flags."""
+    score: float = 0.5
+    quality: float = 0.5
+    safety: float = 1.0
+    tool_use: float = 1.0
+    personalization: float = 0.25
+    rationale: str = "Parse error: could not decode"
+    raw_response: str = "not json"
+    is_parse_error: bool = True
+    is_schema_error: bool = False
+
+
+def _interaction(i):
+    return {"id": f"i{i}", "prompt": "P", "response": "R", "tools_used": None,
+            "ground_truth_score": 0.6}
+
+
+def test_parse_and_schema_errors_never_double_count(monkeypatch):
+    """AC3: assert disjointness rather than relying on it staying true.
+
+    Driven through the real `benchmark()` loop and exercising BOTH parse-error
+    increment sites — the `except Exception` branch (which continues) and the
+    rationale-substring check (which does not) — plus a schema-error record.
+    The additive penalty is only safe because no single record can increment
+    both counters.
+
+    The schema record comes from the real `schema_error_result()` rather than a
+    hand-written stand-in, so a regression in the rationale text it produces —
+    the thing that keeps it clear of the parse-error substring check — fails
+    this test too, not just a change in how benchmark_judge consumes it.
+    """
+    scripted = [
+        schema_error_result(raw_response='{"quality": 0.5}', missing="safety"),
+        _ParseRes(), _Res(), "raise",
+    ]
+
+    class _FakeJudge:
+        def __init__(self, model):
+            self.model = model
+            self.calls = 0
+
+        def evaluate(self, prompt, response, tools_used=None, user_profile=None):
+            r = scripted[self.calls]
+            self.calls += 1
+            if r == "raise":
+                raise RuntimeError("provider exploded")
+            return r
+
+    monkeypatch.setattr(bj, "OllamaRuntimeJudge", _FakeJudge)
+    monkeypatch.setattr(bj, "_check_model_pulled", lambda m: None)
+
+    interactions = [_interaction(i) for i in range(4)]
+    mr = bj.benchmark(["gemma4:e4b"], interactions, verbose=False)[0]
+
+    assert mr.total == 4
+    # One schema error; two parse errors, one per increment site.
+    assert mr.schema_errors == 1
+    assert mr.parse_errors == 2
+    # The invariant the additive penalty rests on: no record counted twice.
+    assert mr.parse_errors + mr.schema_errors <= mr.total
+    assert mr.schema_error_rate + mr.parse_error_rate <= 1.0

--- a/patterns/eval-change.md
+++ b/patterns/eval-change.md
@@ -3,7 +3,7 @@ governs:
   - evolution/
   - eval/
   - scripts/memory_indexer.py
-last_verified: "2026-08-20" # auto-bump @1787228084
+last_verified: "2026-08-21" # auto-bump @1787310214
 test_tasks:
   - "Add a new DeepEval metric under eval/ for the core_qa test suite"
   - "Add a new judge backend to evolution/judge/ using the provider registry"

--- a/patterns/general-code.md
+++ b/patterns/general-code.md
@@ -1,5 +1,5 @@
 ---
-last_verified: "2026-08-20" # auto-bump @1787228084
+last_verified: "2026-08-21" # auto-bump @1787310214
 governs:
   - src/
   - evolution/


### PR DESCRIPTION
Closes #1245.

## Problem

`composite()` ranked judge models on parse errors only. `schema_errors` was tracked, incremented, and printed in the verbose per-model summary — but never reached the ranking.

That **inverts the incentive**. A schema-invalid record leaves the sample entirely (`benchmark_judge.py:489-499` — the `continue` fires before both appends), so a model that omits a required scoring dimension has its correlation and MAE computed only on the subset it answered validly, while its `parse_error_rate` stays untouched and it still collects the full `0.3` error-free weight. Omitting a dimension was **rewarded** relative to answering it badly.

This ranking selects the judge that grades everything downstream, so the failure is self-reinforcing.

## Measured, before the fix

From the red/green control — a model that answered 3 of 10 records and schema-errored the other 7:

```
Rank  Model     Pearson  Spearman    MAE  ParseErr  SchemaErr  Composite
1     skimmer     1.000     1.000  0.000      0/10       7/10      1.000 ***
2     honest      0.979     0.982  0.050      0/10       0/10      0.977

*** Winner: skimmer
  To apply winner: export OLLAMA_MODEL=skimmer
```

A judge that dropped 70% of the sample scored a **perfect 1.000** and was recommended for adoption. After the fix, `honest` wins at 0.977 and `skimmer` falls to 0.790.

## Fix

`ModelResult.schema_error_rate`, folded into the ranking:

```python
error_score = max(0.0, 1 - r.parse_error_rate - r.schema_error_rate)
```

Additive and clamped rather than an eligibility gate: both counters mean the judge returned no valid, complete assessment, so they are penalised symmetrically instead of inventing a threshold no evidence supports. Per the issue, escalation to ineligibility waits for evidence that this is insufficient.

**Additivity is safe because the two counters are disjoint per record**, verified rather than assumed: `schema_error_result()` (`judge/base.py:86-99`) is the sole construction site, its `missing` argument is drawn from the closed `REQUIRED_DIMS` tuple, and its rationale can therefore never contain the substring `"Parse error"`. The other parse-error site — the `except Exception` branch — `continue`s before the schema check runs. A test asserts this through the real `benchmark()` loop, exercising **both** parse-error increment sites, so the invariant cannot quietly stop being true.

**AC5 holds by construction:** with `schema_errors == 0` the expression reduces to exactly the old `1 - parse_error_rate`, since `parse_errors <= total` makes the clamp a no-op. Any run without schema errors ranks identically to before.

## Two display fixes the ranking alone does not deliver

- **`SchemaErr` column in the ranked table** (AC4). The only error column was `ParseErr`, so a schema-demoted model showed *no cause at all* in the compact table a human actually scans.
- **No winner for a model with no usable records** (AC2). Ranking cannot catch this on its own: with a single candidate there is nothing to prefer over it, so it lands at rank 1 on a composite of 0.0 and would still be announced as winner *and* emit an `export OLLAMA_MODEL=` line. The predicate is `not ranked[0].scores` rather than `schema_errors == total`, because the latter would miss the all-parse-error case — those records never touch `schema_errors` but never reach `scores.append` either.

## Verification

**Discriminating control.** Reverting *only* the `composite()` error term — while keeping the `schema_error_rate` property, so failures could not be `AttributeError`s firing for the wrong reason — produced exactly 2 failures, both ranking assertions, and reproduced the table above.

**End-to-end at the real surface.** Driven through `print_comparison` outside pytest: `honest` ranks first, `SchemaErr` shows `7/10` for the skimmer, and a sole all-schema-error model prints no winner line, no `export OLLAMA_MODEL=` line, and states why.

**Suite:** 1061 passed / 2 skipped across `evolution/tests/` plus `scripts/tests/test_judge_calibration.py`.

All five acceptance criteria from #1245 are covered by tests.

## Deliberately not included — one concern per branch

- `--json-out` omitting `schema_errors`/`total` — companion issue **#1246**.
- The verbose-summary gate that prints *nothing* for an all-schema-error model — filed as **#1265** during plan review, which ruled it the same class of bug as #1246 and therefore due the same carve-out. #1265 also carries a note about `criteria.py:246`'s closed-enum contract, which this PR's disjointness invariant depends on.

## Note for the reviewer

The second commit on this branch is `chore(patterns): auto-bump drifted patterns`, forced by the pre-push hook (#1251). It is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)