### PR TITLE
fix(patterns): stop the last_verified auto-bump destroying human annotations

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -481,11 +481,7 @@ def main(base_ref: str | None = None, bump: bool = False) -> int:
             for r in drifted_patterns:
                 p = PROJECT_ROOT / "patterns" / r["pattern"]
                 text = p.read_text()
-                updated = re.sub(
-                    r'(last_verified:\s*)"?\d{4}-\d{2}-\d{2}"?.*',
-                    rf'\g<1>"{today}" # auto-bump @{ts}',
-                    text,
-                )
+                updated = _rewrite_last_verified(text, today, ts)
                 if updated != text:
                     p.write_text(updated)
                     print(f"  bumped {r['pattern']} → {today}")
@@ -617,6 +613,40 @@ def parse_adr(adr_path: Path) -> dict | None:
     scopes = [_normalize_path(s) for s in scope_raw.split(",") if s.strip()]
 
     return {"date": date_match.group(1), "scopes": scopes}
+
+
+#: Splits an already-bumped tail into the machine stamp and anything this
+#: function previously preserved, so a re-bump restamps without re-wrapping.
+_AUTO_BUMP_TAIL = re.compile(r'#\s*auto-bump\s*@\d+\s*(?:\|\s*(?P<kept>.*?))?\s*$')
+
+
+def _rewrite_last_verified(text: str, today: str, ts: int) -> str:
+    """Stamp `last_verified:` with `today`, keeping any human note on that line.
+
+    A kept note carries the date it described, since this also moves the date —
+    otherwise the note would read as a review nobody performed (#1251).
+    Idempotent: pre-push bumps constantly, so a tail written here is restamped
+    rather than wrapped again.
+    """
+    def _replace(m: re.Match) -> str:
+        old_date, tail = m.group("date"), m.group("tail").strip()
+        kept = None
+        if tail:
+            already = _AUTO_BUMP_TAIL.fullmatch(tail)
+            if already:
+                kept = (already.group("kept") or "").strip() or None
+            else:
+                # A bare "#" carries nothing worth pinning a date to.
+                note = tail.lstrip("#").strip()
+                kept = f"{old_date}: {note}" if note else None
+        stamp = f"# auto-bump @{ts}"
+        return f'{m.group("key")}"{today}" {stamp}' + (f" | {kept}" if kept else "")
+
+    return re.sub(
+        r'(?P<key>last_verified:\s*)"?(?P<date>\d{4}-\d{2}-\d{2})"?(?P<tail>.*)',
+        _replace,
+        text,
+    )
 
 
 def parse_last_verified(pattern_path: Path) -> str | None:

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -1401,3 +1401,169 @@ class TestCheckAllBumpForwarding:
 
         capsys.readouterr()
         assert calls[0] == {"base_ref": "origin/main", "bump": True}
+
+
+# ── the bump must not destroy human annotations (#1251) ───────────────────────
+#
+# pre-push bumps on every drifted push, and the rewrite replaced the whole tail
+# of the `last_verified:` line — destroying any human note. Preserving the text
+# alone is not enough: the date moves too, so the note must stay pinned to the
+# date it described rather than appear to describe today's bump.
+
+_TODAY = "2026-08-21"
+_TS = 1787310214
+
+
+class TestRewriteLastVerified:
+    def test_plain_line_is_unchanged_in_form(self):
+        """AC3: a line with no comment behaves exactly as before the fix."""
+        out = drift_check._rewrite_last_verified(
+            'last_verified: "2026-05-16"\n', _TODAY, _TS,
+        )
+        assert out == f'last_verified: "{_TODAY}" # auto-bump @{_TS}\n'
+
+    def test_unquoted_date_is_still_handled(self):
+        out = drift_check._rewrite_last_verified(
+            "last_verified: 2026-05-16\n", _TODAY, _TS,
+        )
+        assert out == f'last_verified: "{_TODAY}" # auto-bump @{_TS}\n'
+
+    def test_existing_auto_bump_is_restamped(self):
+        out = drift_check._rewrite_last_verified(
+            'last_verified: "2026-08-20" # auto-bump @1787222734\n', _TODAY, _TS,
+        )
+        assert out == f'last_verified: "{_TODAY}" # auto-bump @{_TS}\n'
+
+    def test_human_annotation_survives(self):
+        """AC1: the whole point. The note is kept, pinned to its own date."""
+        out = drift_check._rewrite_last_verified(
+            'last_verified: "2026-08-15" # reviewed against LIA-491 (src/x.ts)\n',
+            _TODAY, _TS,
+        )
+        assert "reviewed against LIA-491 (src/x.ts)" in out
+        assert f'last_verified: "{_TODAY}"' in out
+        # The note describes the OLD date's review, not today's bump.
+        assert "2026-08-15: reviewed against LIA-491" in out
+
+    @pytest.mark.parametrize("original", [
+        # AC2, widened: the issue names only debugging.md, but three pattern
+        # files carry a live annotation. Copied verbatim from the real files.
+        'last_verified: "2026-08-15" # reviewed against LIA-491 (src/container-runner.ts naming)',
+        'last_verified: "2026-08-15" # reviewed against LIA-491 (src/config.ts deusInstanceId)',
+        'last_verified: "2026-08-16" # reviewed against LIA-447 (src/sender-allowlist.ts fail-closed)',
+    ])
+    def test_every_live_annotation_in_the_repo_survives(self, original):
+        note = original.split("# ", 1)[1]
+        old_date = original.split('"')[1]
+
+        out = drift_check._rewrite_last_verified(original + "\n", _TODAY, _TS)
+
+        assert note in out, "the human note must survive verbatim"
+        assert f"{old_date}: {note}" in out, "and stay attached to the date it described"
+        assert f'last_verified: "{_TODAY}"' in out
+
+    def test_repeated_bumps_do_not_grow_the_line(self):
+        """This line is rewritten on nearly every push, so a naive re-append
+        would nest without bound."""
+        line = 'last_verified: "2026-08-15" # reviewed against LIA-491 (src/x.ts)\n'
+
+        once = drift_check._rewrite_last_verified(line, _TODAY, _TS)
+        twice = drift_check._rewrite_last_verified(once, "2026-09-01", 1789000000)
+        thrice = drift_check._rewrite_last_verified(twice, "2026-09-02", 1789100000)
+
+        assert twice.count("reviewed against LIA-491") == 1
+        assert thrice.count("reviewed against LIA-491") == 1
+        assert thrice.count("auto-bump") == 1
+        # Only the date and stamp move; the preserved segment is byte-stable.
+        assert twice.split("|", 1)[1] == thrice.split("|", 1)[1]
+        assert '2026-08-15: reviewed against LIA-491 (src/x.ts)' in thrice
+
+    def test_bare_hash_tail_is_not_pinned_to_a_date(self):
+        """A comment marker with no content has nothing worth preserving, and
+        must not leave a dangling `<date>: `."""
+        out = drift_check._rewrite_last_verified(
+            'last_verified: "2026-08-15" #\n', _TODAY, _TS,
+        )
+        assert out == f'last_verified: "{_TODAY}" # auto-bump @{_TS}\n'
+
+    def test_empty_preserved_segment_does_not_double_wrap(self):
+        """Degenerate form only this tool could write."""
+        out = drift_check._rewrite_last_verified(
+            'last_verified: "2026-08-20" # auto-bump @1787222734 |\n', _TODAY, _TS,
+        )
+        assert out.count("auto-bump") == 1
+        assert out.count("|") <= 1
+        assert f'last_verified: "{_TODAY}"' in out
+
+    def test_only_the_last_verified_line_is_touched(self):
+        text = (
+            "---\n"
+            'last_verified: "2026-08-15" # reviewed against LIA-491 (src/x.ts)\n'
+            "governs:\n"
+            "  - src/container-runner.ts\n"
+            "---\n"
+            "\n"
+            "# Debugging\n"
+            "Body text mentioning 2026-08-15 should not move.\n"
+        )
+        out = drift_check._rewrite_last_verified(text, _TODAY, _TS)
+
+        assert "Body text mentioning 2026-08-15 should not move." in out
+        assert "  - src/container-runner.ts\n" in out
+        assert out.count("last_verified:") == 1
+
+
+class TestBumpEndToEnd:
+    """AC4: the drift check still detects and reports drift — the fix must not
+    be reached by weakening the check."""
+
+    def _setup(self, tmp_path, monkeypatch, front_matter):
+        (tmp_path / "patterns").mkdir()
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "x.ts").write_text("export const x = 1;\n")
+        (tmp_path / "patterns" / "INDEX.md").write_text(
+            "| pattern |\n|---|\n| `patterns/debugging.md` |\n"
+        )
+        p = tmp_path / "patterns" / "debugging.md"
+        p.write_text(
+            "---\n"
+            f"{front_matter}\n"
+            "governs:\n"
+            "  - src/x.ts\n"
+            "---\n"
+            "\nBody.\n"
+        )
+
+        monkeypatch.setattr(drift_check, "PROJECT_ROOT", tmp_path)
+        # The governed file is newer than the pattern → DRIFTED. Both times come
+        # from the same helper, so the fake keys off the path rather than
+        # returning one constant.
+        monkeypatch.setattr(
+            drift_check, "_git_commit_time",
+            lambda path, root: 1000.0 if path.name == "debugging.md" else 2000.0,
+        )
+        return p
+
+    def test_bump_reports_drift_and_preserves_the_annotation(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        p = self._setup(
+            tmp_path, monkeypatch,
+            'last_verified: "2026-08-15" # reviewed against LIA-491 (src/x.ts)',
+        )
+
+        rc = drift_check.main(bump=True)
+        out = capsys.readouterr().out
+
+        assert "DRIFTED" in out, "the drift check must still report drift"
+        assert rc == 0, "--bump resolves the drift it just reported"
+        assert "reviewed against LIA-491 (src/x.ts)" in p.read_text(), \
+            "the annotation must survive a real end-to-end bump"
+
+    def test_bump_still_stamps_a_plain_line(self, tmp_path, monkeypatch, capsys):
+        p = self._setup(tmp_path, monkeypatch, 'last_verified: "2026-05-16"')
+
+        drift_check.main(bump=True)
+        capsys.readouterr()
+
+        assert "# auto-bump @" in p.read_text()


### PR DESCRIPTION
Closes #1251.

## Problem

`.husky/pre-push` runs `drift_check.py --bump` on every push where drift is detected. Its rewrite matched `.*` from the date to end-of-line and kept only the key, so **any human note on that line was overwritten** with a bare `# auto-bump @<ts>` — recoverable only from a commit whose message is the generic `chore(patterns): auto-bump drifted patterns`.

## The issue undercounts the damage

It says *"There is a live instance in the repo right now"*, naming `patterns/debugging.md`. **There are three**, all at risk today:

| file:line | annotation |
|---|---|
| `patterns/debugging.md:2` | `reviewed against LIA-491 (src/container-runner.ts naming)` |
| `patterns/cross-platform.md:6` | `reviewed against LIA-491 (src/config.ts deusInstanceId)` |
| `patterns/security-review.md:8` | `reviewed against LIA-447 (src/sender-allowlist.ts fail-closed)` |

Each records *why* a pattern was re-verified and against what. AC2 names only `debugging.md`, so implementing it literally would have left two-thirds of the live data loss in place. The tests cover all three, as parametrised fixtures copied verbatim from the real files.

## Measured, on the real files

Driving both the old and new rewrite over the actual file contents:

```
patterns/debugging.md
  before : last_verified: "2026-08-15" # reviewed against LIA-491 (src/container-runner.ts naming)
  main   : last_verified: "2026-08-21" # auto-bump @1787310214
  fixed  : last_verified: "2026-08-21" # auto-bump @1787310214 | 2026-08-15: reviewed against LIA-491 (...)

SUMMARY: main destroys 3/3 annotations; the fix preserves 3/3.
```

## Why preservation alone would be wrong

The bump also **moves the date**. Carrying `reviewed against LIA-491` onto today's date would leave the file asserting a review nobody performed — trading lost data for a false claim, the same genre of defect as #1248. A kept note is therefore pinned to the date it actually described, and the machine stamp stays so machine-set and human-set remain distinguishable.

## Idempotency is load-bearing, not incidental

This line is rewritten on nearly every push, so a naive re-append would nest without bound. A tail this code already wrote is recognised and restamped rather than re-wrapped. Three successive bumps on real content:

```
bump 1: ... "2026-08-21" # auto-bump @1787310214 | 2026-08-15: reviewed against LIA-491 (...)
bump 2: ... "2026-09-01" # auto-bump @1789000000 | 2026-08-15: reviewed against LIA-491 (...)
bump 3: ... "2026-09-02" # auto-bump @1789100000 | 2026-08-15: reviewed against LIA-491 (...)

line length 123 -> 123 -> 123, note count 1
```

## Also in this PR

The rewrite moves out of `main()` into `_rewrite_last_verified(text, today, ts)`. It had **zero test coverage** while inline, in a 1400-line test file — which is how this shipped. A pure `str -> str` function is directly testable, and behaviour for a line with no comment is byte-identical to before (AC3).

The replacement is passed to `re.sub` as a **function** rather than a template string, so backslash sequences in a preserved note are not interpreted as group references. The old string-template form would have been vulnerable to exactly that.

## Verification

**Discriminating control.** Reverting only the function's *body* to main's one-liner — keeping the name and signature, so failures could not be `AttributeError`s firing for the wrong reason — produced 6 failures, every one a plain `AssertionError` about the note surviving.

**Real surface.** Driven against the three live files outside pytest: main drops the note 3/3, the fix keeps it 3/3 pinned to its original date. The real pattern files were never modified.

**Reader unaffected.** `parse_last_verified` still returns the correct date from the new format — confirmed by driving it, not by inspection.

**Suite.** `scripts/tests/test_drift_check.py`: 130 passed (13 new).

## Note on the wider suite

`scripts/tests/` reports 6 failures. I verified these are **pre-existing on `origin/main`**, not introduced here: a pristine `6b1a2b02` worktree running the identical command produces a byte-identical failure set (2377 passed there vs 2389 here — the difference is exactly the 13 new tests). They live in `test_deus_cmd_print_identity.py`, `test_sync_agent_skills.py` and `test_warden_review.py`, none of which this diff touches.

Worth surfacing separately: `test_warden_review.py`'s three failures **pass in isolation** and fail only in a full-directory run, so there is a genuine test-ordering / shared-state bug on main. Not this PR's to fix, but it should not stay invisible.

## Deliberately not included — one concern per branch

- **Anchoring the rewrite regex to line start.** Plan-reviewer ruled this scope creep; verified a no-op on all 13 current pattern files. Filed as **#1267**.
- **Recovering annotations already destroyed.** Five files (`deployment.md`, `documentation.md`, `hook-change.md`, `skill-add.md`, `channel-add.md`) now carry a bare `# auto-bump @<ts>`; whatever tail they once had was overwritten before this fix lands. No AC asks for recovery and it is not this fix's regression to undo — recoverable via `git log -p -- patterns/<file>.md` if ever needed.
- **Directions 2, 3 and 4 from the issue** (stop scheduled bumping / a `.gitattributes` merge driver / a generated sidecar). Direction 1 stops the data loss; it does not address the merge-conflict half, nor the deeper point that a machine-stamped `last_verified` still does not mean anyone re-verified anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
