### PR TITLE
fix(deus-cmd): route the cockpit staleness check through _file_mtime

### DIFF
--- a/deus-cmd.sh
+++ b/deus-cmd.sh
@@ -1394,6 +1394,7 @@ sys.exit(1)
     # the CLI prioritizes the env var over the credentials file.
     [[ "$OSTYPE" == darwin* ]] && launchctl kickstart -k "gui/$(id -u)/com.deus" 2>/dev/null
 
+    # >>> cockpit-staleness
     # Cockpit verdict (LIA-552). Reads the one-line cache the daily healthcheck
     # writes — no interpreter start, no DB, no network, so there is nothing that
     # can hang and no timeout to enforce (neither `timeout` nor `gtimeout` ships
@@ -1408,8 +1409,7 @@ sys.exit(1)
     _cockpit_line="${DEUS_HOME:-$HOME/.deus}/cockpit_health.line"
     _cockpit_max_age=129600
     if [ -r "$_cockpit_line" ]; then
-      # BSD stat (macOS) vs GNU stat (Linux) take different flags.
-      _cockpit_mtime=$(stat -f %m "$_cockpit_line" 2>/dev/null || stat -c %Y "$_cockpit_line" 2>/dev/null)
+      _cockpit_mtime=$(_file_mtime "$_cockpit_line")
       _cockpit_age=$(( $(date +%s) - ${_cockpit_mtime:-0} ))
       _cockpit_verdict=$(head -n 1 "$_cockpit_line" 2>/dev/null)
       if [ -z "$_cockpit_mtime" ]; then
@@ -1428,6 +1428,8 @@ sys.exit(1)
       printf '  cockpit: no healthcheck result on record\n'
     fi
     unset _cockpit_line _cockpit_max_age _cockpit_mtime _cockpit_age _cockpit_verdict
+    # <<< cockpit-staleness
+    # The `fi` below closes the PRINT_IDENTITY branch above, not this block.
     fi
     # Launch claude with bypass mode; fall back to normal mode if user declines
     launch_claude() {

--- a/scripts/tests/test_deus_cmd_cockpit_staleness.py
+++ b/scripts/tests/test_deus_cmd_cockpit_staleness.py
@@ -1,0 +1,196 @@
+"""Portability of the cockpit staleness check in `deus-cmd.sh` (#1250).
+
+The block open-coded a `stat -f %m ... || stat -c %Y ...` fallback. On GNU
+coreutils `-f` means "display filesystem status", not "format", so `%m` is read
+as a second FILE operand: the command exits 1 having printed five lines of
+filesystem info to *stdout* (which `2>/dev/null` does not suppress), and the
+fallback then appends the real epoch to that. `_cockpit_mtime` ends up holding
+six lines, so the `[ -z ... ]` guard cannot fire — the value is not empty, just
+wrong.
+
+`deus-cmd.sh`'s shebang is `#!/usr/bin/env zsh`, and zsh treats a malformed
+arithmetic expression as fatal, so the real consequence on Linux is not a bad
+staleness number: the block aborts and everything after it in the command is
+silently lost. A correct `_file_mtime()` helper already existed in the same
+file, used by three other call sites.
+
+The behavioural tests run under zsh ONLY, never bash. This defect is
+specifically zsh-arithmetic-fatal — bash does not abort on the malformed
+expression — so a bash fallback would pass against the broken code. That is not
+hypothetical: `test_deus_cmd_auto_sync_oracle.py` records an earlier revision
+that ran under `bash -c`, silently validated the wrong interpreter, and missed a
+real production bug.
+"""
+
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "deus-cmd.sh"
+
+_HAS_ZSH = shutil.which("zsh") is not None
+_NEEDS_ZSH = pytest.mark.skipif(
+    not _HAS_ZSH,
+    reason="deus-cmd.sh is #!/usr/bin/env zsh; running these under bash would "
+           "validate the wrong interpreter (see module docstring)",
+)
+
+
+def _script_text() -> str:
+    return SCRIPT.read_text()
+
+
+def _extract_cockpit() -> str:
+    m = re.search(
+        r"# >>> cockpit-staleness\n(.*?)# <<< cockpit-staleness",
+        _script_text(),
+        re.DOTALL,
+    )
+    assert m, "cockpit-staleness sentinel markers not found in deus-cmd.sh"
+    return m.group(1)
+
+
+def _extract_file_mtime() -> str:
+    m = re.search(r"(_file_mtime\(\) \{.*?\n\})", _script_text(), re.DOTALL)
+    assert m, "_file_mtime helper not found in deus-cmd.sh"
+    return m.group(1)
+
+
+# ── static: no open-coded stat survives (AC4) ─────────────────────────────────
+#
+# Platform-independent, so this is the assertion that discriminates on a macOS
+# dev host as well as in CI.
+
+
+def test_every_stat_call_lives_inside_the_portable_helper():
+    """Compares by LINE NUMBER, not by substring.
+
+    A substring check would false-pass the moment an open-coded call happened to
+    duplicate a line already inside the helper — and `stat -f %m "$1" 2>/dev/null`
+    is exactly the idiom someone would re-type.
+    """
+    lines = _script_text().splitlines()
+
+    # Line numbers spanned by the helper, so membership is positional.
+    start = next(
+        i for i, ln in enumerate(lines) if ln.startswith("_file_mtime() {")
+    )
+    end = next(i for i in range(start, len(lines)) if lines[i] == "}")
+
+    stat_hits = [
+        (i, ln.strip()) for i, ln in enumerate(lines)
+        if re.search(r"\bstat\s+-[fc]\b", ln)
+    ]
+    assert stat_hits, "expected the helper's own stat calls to be found"
+
+    outside = [(i + 1, ln) for i, ln in stat_hits if not (start <= i <= end)]
+    assert not outside, (
+        "every mtime read must go through _file_mtime; found open-coded "
+        f"stat call(s) at line(s): {outside}"
+    )
+
+
+def test_cockpit_block_calls_the_helper():
+    block = _extract_cockpit()
+    assert '_cockpit_mtime=$(_file_mtime "$_cockpit_line")' in block
+    assert "stat -f" not in block and "stat -c" not in block
+
+
+def test_helper_branches_on_ostype_rather_than_probing_flags():
+    """The bug was a flag probe that guesses wrong on GNU. The helper must keep
+    deciding by platform, not by trying `-f` and falling back."""
+    helper = _extract_file_mtime()
+    assert "$OSTYPE" in helper
+    assert "||" not in helper, "a `-f || -c` probe is the defect this fixes"
+
+
+# ── behavioural: the block actually runs on this platform (AC1/AC2/AC3) ───────
+
+
+def _run_block(tmp_path, *, stub_mtime=None):
+    """Run the real extracted block under zsh, with DEUS_HOME pointed at a temp dir."""
+    parts = [_extract_file_mtime()]
+    if stub_mtime is not None:
+        # Override the helper to force the unreadable-timestamp path (AC3).
+        parts.append(f"_file_mtime() {{ printf '%s' '{stub_mtime}'; }}")
+    parts.append(f'DEUS_HOME="{tmp_path}"')
+    parts.append(_extract_cockpit())
+    return subprocess.run(
+        ["zsh", "-c", "\n".join(parts)],
+        capture_output=True, text=True, timeout=60,
+    )
+
+
+@_NEEDS_ZSH
+def test_fresh_ok_result_is_silent_and_does_not_abort(tmp_path):
+    """AC1: on GNU coreutils this aborted with `bad math expression`."""
+    (tmp_path / "cockpit_health.line").write_text("OK\n")
+
+    r = _run_block(tmp_path)
+
+    assert r.returncode == 0, f"block aborted: {r.stderr}"
+    assert "bad math expression" not in r.stderr
+    assert r.stderr == "", f"unexpected stderr: {r.stderr}"
+    # Quiet when healthy and fresh, or the report becomes noise.
+    assert r.stdout == "", f"unexpected stdout: {r.stdout}"
+
+
+@_NEEDS_ZSH
+def test_stale_result_is_reported(tmp_path):
+    """AC2: the staleness check still does its job — the fix must not silence
+    the very check it lives in."""
+    f = tmp_path / "cockpit_health.line"
+    f.write_text("OK\n")
+    old = time.time() - 200_000  # > 36h
+    import os
+    os.utime(f, (old, old))
+
+    r = _run_block(tmp_path)
+
+    assert r.returncode == 0
+    assert "last result is" in r.stdout and "old" in r.stdout
+
+
+@_NEEDS_ZSH
+def test_non_ok_verdict_is_reported(tmp_path):
+    (tmp_path / "cockpit_health.line").write_text("DEGRADED: scheduler down\n")
+
+    r = _run_block(tmp_path)
+
+    assert r.returncode == 0
+    assert "DEGRADED: scheduler down" in r.stdout
+
+
+@_NEEDS_ZSH
+def test_empty_result_file_is_reported(tmp_path):
+    (tmp_path / "cockpit_health.line").write_text("")
+
+    r = _run_block(tmp_path)
+
+    assert r.returncode == 0
+    assert "empty" in r.stdout
+
+
+@_NEEDS_ZSH
+def test_missing_result_file_is_reported(tmp_path):
+    r = _run_block(tmp_path)
+
+    assert r.returncode == 0
+    assert "no healthcheck result on record" in r.stdout
+
+
+@_NEEDS_ZSH
+def test_unreadable_timestamp_branch_can_fire(tmp_path):
+    """AC3: with the open-coded fallback this branch was unreachable on Linux —
+    the variable held non-empty garbage rather than being empty."""
+    (tmp_path / "cockpit_health.line").write_text("OK\n")
+
+    r = _run_block(tmp_path, stub_mtime="")
+
+    assert r.returncode == 0
+    assert "cannot read healthcheck timestamp" in r.stdout


### PR DESCRIPTION
Closes #1250.

## Problem

The cockpit staleness check open-coded a BSD/GNU `stat` fallback:

```sh
_cockpit_mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null)
```

On GNU coreutils **`stat -f` means "display filesystem status", not "format"**, so `%m` is read as a second FILE operand. The command exits 1 having printed five lines of filesystem info to *stdout* — which `2>/dev/null` does not suppress — and the `||` fallback then appends the real epoch to that same capture. `_cockpit_mtime` ends up holding six lines, so the `[ -z ... ]` guard at the next branch cannot fire: the value is not empty, just wrong.

The correct helper already existed in the same file (`_file_mtime`, branching on `$OSTYPE`), and three other call sites used it. This block was the only outlier in the repo.

## The severity is worse than the issue states

The issue says the bug *"does not kill the script; it corrupts `_cockpit_age`"*, reasoning that `deus-cmd.sh` has no `set -e`. **That assumes bash.** The shebang is `#!/usr/bin/env zsh`, and zsh treats a malformed arithmetic expression as fatal.

Confirmed on `debian:bookworm-slim` (zsh 5.9, GNU coreutils 9.1), running the real block inside a function with neither `set -e` nor `set -u`, matching production:

```
  before: reached the cockpit block
_status_like:7: bad math expression: operand expected at `"/tmp/dh/c...'
final rc=1
```

Neither the rest of the function nor the statement after it ran. So on Linux this is not a wrong staleness number — **the command aborts at the cockpit block and everything after it is silently lost.**

## Fix

```sh
_cockpit_mtime=$(_file_mtime "$_cockpit_line")
```

Plus removal of the now-wrong inline comment, and `# >>> cockpit-staleness` / `# <<< cockpit-staleness` sentinel markers so the tests extract the block the way the `deploy-plan` and `auto-sync` tests already do — rather than by regex against neighbouring prose, including the very comment this change deletes.

## Tests

New `scripts/tests/test_deus_cmd_cockpit_staleness.py`, 9 tests:

- **Static (AC4)** — every `stat -f`/`stat -c` in the file lies within `_file_mtime`'s line range, and the cockpit block calls the helper. Platform-independent, so this is what discriminates on a macOS dev host.
- **Behavioural (AC1/AC2)** — extracts the sentinel region, runs it under `zsh`, and checks the fresh / stale / non-OK / empty / missing cases.
- **AC3** — stubs `_file_mtime` to return empty and confirms the `cannot read healthcheck timestamp` branch fires. That branch is unreachable on Linux today, because the variable holds non-empty garbage rather than being empty.

**zsh only, never a bash fallback.** This defect is specifically zsh-arithmetic-fatal — bash does not abort on the malformed expression — so a bash fallback would pass against the broken code and confirm the issue's own incorrect bash-semantics description. That is not hypothetical: `test_deus_cmd_auto_sync_oracle.py:420-424` records an earlier revision that ran under `bash -c`, *"silently validated the wrong interpreter and missed a real `local path` bug that made an entire code path a no-op in actual production use."* When zsh is absent the tests skip with an explicit reason.

## Verification

Red/green on **real GNU coreutils**, since macOS cannot reach the broken branch at all:

| | with main's line | with the fix |
|---|---|---|
| Linux (zsh 5.9, coreutils 9.1) | **7 of 9 fail** — `bad math expression`, rc 1 | **9/9 pass** |
| macOS | 3 fail (2 static + AC3) | 9/9 pass |

The AC4 guard was also hardened during review: it compared by substring, which would have false-passed an open-coded call whose text duplicated a line already inside the helper — and `stat -f %m "$1" 2>/dev/null` is exactly what someone would re-type. It now compares by line number, and the hole was **proved real** by injecting such a line: the hardened guard fails at line 1412, the substring version passed.

A zsh-absent container gives 3 passed / 6 skipped with explicit reasons — no silent degrade.

**Suite:** `scripts/tests/` is 6 failed / 2399 passed. Those 6 reproduce byte-identically on a pristine `origin/main` worktree (2390 passed there; +9 is exactly the new tests), in `test_deus_cmd_print_identity.py`, `test_sync_agent_skills.py` and `test_warden_review.py` — none touched here.

## Deliberately not included

**#1295** — filed for both halves of the issue's closing note: no `test_deus_cmd_*.py` file runs in CI at all (so these 9 tests, the entire evidence base for this fix, never execute there), and `deus-cmd.sh` is never run on Linux. Recorded there rather than argued here: `shellcheck` would probably **not** have caught this bug — `stat -f %m file` is valid syntax and the defect is semantic — whereas a Linux run would have, cheaply, since `ci.yml:14` already runs `ubuntu-latest`.

Also noted in #1295: `test_warden_review.py`'s three failures **pass in isolation** and fail only in a full-directory run, which is a genuine test-ordering / shared-state bug on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
